### PR TITLE
Add major version git tags to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,6 @@ jobs:
           fi
           git tag -a "$MAJOR_TAG" -m "Latest release for major version $MAJOR_VERSION"
           git push origin "$MAJOR_TAG"
-          echo "major_tag=$MAJOR_TAG" >> $GITHUB_OUTPUT
-          echo "major_version=$MAJOR_VERSION" >> $GITHUB_OUTPUT
           echo "✅ Created/updated major version tag: $MAJOR_TAG"
         shell: bash
 


### PR DESCRIPTION
## Summary
- Updates the release workflow to create/update a major version tag (e.g., `amp/v1`) alongside the full version tag (e.g., `amp/v1.2.3`)
- This floating tag always points to the latest release within that major version
- Enables GitHub-hosted documentation links to automatically reference the latest docs for a major version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to automatically create and manage major version tags alongside standard release tags, including automatic detection and update of existing tags with status notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->