### PR TITLE
Update Quick Start link to use major version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Deploy WSO2 AI Agent Management Platform on Kubernetes using our Helm charts:
 
 ## Getting Started
 
-For installation instructions and a step-by-step guide, see the [Quick Start Guide](docs/quick-start.md).
+For installation instructions and a step-by-step guide, see the [Quick Start Guide](https://github.com/wso2/ai-agent-management-platform/blob/amp/v0/docs/quick-start.md).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Updates the Quick Start Guide link in README to point to the `amp/v0` tag
- This ensures users always see documentation that matches the latest v0.x.x release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start Guide link in the Getting Started section to use a direct GitHub URL for improved accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->