### PR TITLE
Update Traces Observer API

### DIFF
--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -40,7 +40,7 @@ func NewTracingController(osClient *opensearch.Client) *TracingController {
 
 // GetTraceOverviews retrieves unique trace IDs with root span information
 func (s *TracingController) GetTraceOverviews(ctx context.Context, params opensearch.TraceQueryParams) (*opensearch.TraceOverviewResponse, error) {
-	log.Printf("Getting trace overviews for component: %s, project: %s, environment: %s", params.ComponentUid, params.ProjectUid, params.EnvironmentUid)
+	log.Printf("Getting trace overviews for component: %s, environment: %s", params.ComponentUid, params.EnvironmentUid)
 
 	// Set defaults
 	if params.Limit == 0 {
@@ -147,7 +147,7 @@ func (s *TracingController) GetTraceOverviews(ctx context.Context, params opense
 
 // GetTraceByIdAndService retrieves spans for a specific trace ID and component UID
 func (s *TracingController) GetTraceByIdAndService(ctx context.Context, params opensearch.TraceByIdAndServiceParams) (*opensearch.TraceResponse, error) {
-	log.Printf("Getting trace for traceID: %s, component: %s, project: %s, environment: %s", params.TraceID, params.ComponentUid, params.ProjectUid, params.EnvironmentUid)
+	log.Printf("Getting trace for traceID: %s, component: %s, environment: %s", params.TraceID, params.ComponentUid, params.EnvironmentUid)
 
 	// Build query
 	query := opensearch.BuildTraceByIdAndServiceQuery(params)
@@ -175,10 +175,10 @@ func (s *TracingController) GetTraceByIdAndService(ctx context.Context, params o
 	spans := opensearch.ParseSpans(response)
 
 	if len(spans) == 0 {
-		return nil, fmt.Errorf("no spans found for traceID: %s, component: %s, project: %s, environment: %s", params.TraceID, params.ComponentUid, params.ProjectUid, params.EnvironmentUid)
+		return nil, fmt.Errorf("no spans found for traceID: %s, component: %s, environment: %s", params.TraceID, params.ComponentUid, params.EnvironmentUid)
 	}
 
-	log.Printf("Retrieved %d spans for traceID: %s, component: %s, project: %s, environment: %s", len(spans), params.TraceID, params.ComponentUid, params.ProjectUid, params.EnvironmentUid)
+	log.Printf("Retrieved %d spans for traceID: %s, component: %s, environment: %s", len(spans), params.TraceID, params.ComponentUid, params.EnvironmentUid)
 
 	return &opensearch.TraceResponse{
 		Spans:      spans,

--- a/traces-observer-service/handlers/handlers.go
+++ b/traces-observer-service/handlers/handlers.go
@@ -41,25 +41,21 @@ func NewHandler(controllers *controllers.TracingController) *Handler {
 
 // TraceRequest represents the request body for getting traces
 type TraceRequest struct {
-	ComponentUid    string `json:"componentUid"`
-	ProjectUid      string `json:"projectUid"`
-	EnvironmentUid  string `json:"environmentUid"`
-	OrganizationUid string `json:"organizationUid,omitempty"`
-	StartTime       string `json:"startTime"`
-	EndTime         string `json:"endTime"`
-	Limit           int    `json:"limit,omitempty"`
-	SortOrder       string `json:"sortOrder,omitempty"`
+	ComponentUid   string `json:"componentUid"`
+	EnvironmentUid string `json:"environmentUid"`
+	StartTime      string `json:"startTime"`
+	EndTime        string `json:"endTime"`
+	Limit          int    `json:"limit,omitempty"`
+	SortOrder      string `json:"sortOrder,omitempty"`
 }
 
 // TraceByIdAndServiceRequest represents the request body for getting traces by ID and component
 type TraceByIdAndServiceRequest struct {
-	TraceID         string `json:"traceId"`
-	ComponentUid    string `json:"componentUid"`
-	ProjectUid      string `json:"projectUid"`
-	EnvironmentUid  string `json:"environmentUid"`
-	OrganizationUid string `json:"organizationUid,omitempty"`
-	SortOrder       string `json:"sortOrder,omitempty"`
-	Limit           int    `json:"limit,omitempty"`
+	TraceID        string `json:"traceId"`
+	ComponentUid   string `json:"componentUid"`
+	EnvironmentUid string `json:"environmentUid"`
+	SortOrder      string `json:"sortOrder,omitempty"`
+	Limit          int    `json:"limit,omitempty"`
 }
 
 // ErrorResponse represents an error response
@@ -79,15 +75,11 @@ func (h *Handler) GetTraceOverviews(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projectUid := query.Get("projectUid") // Optional
-
 	environmentUid := query.Get("environmentUid")
 	if environmentUid == "" {
 		h.writeError(w, http.StatusBadRequest, "environmentUid is required")
 		return
 	}
-
-	organizationUid := query.Get("organizationUid") // Optional
 
 	startTime := query.Get("startTime")
 	endTime := query.Get("endTime")
@@ -126,15 +118,13 @@ func (h *Handler) GetTraceOverviews(w http.ResponseWriter, r *http.Request) {
 
 	// Build query parameters
 	params := opensearch.TraceQueryParams{
-		ComponentUid:    componentUid,
-		ProjectUid:      projectUid,
-		EnvironmentUid:  environmentUid,
-		OrganizationUid: organizationUid,
-		StartTime:       startTime,
-		EndTime:         endTime,
-		Limit:           limit,
-		Offset:          offset,
-		SortOrder:       sortOrder,
+		ComponentUid:   componentUid,
+		EnvironmentUid: environmentUid,
+		StartTime:      startTime,
+		EndTime:        endTime,
+		Limit:          limit,
+		Offset:         offset,
+		SortOrder:      sortOrder,
 	}
 
 	// Execute query
@@ -167,15 +157,11 @@ func (h *Handler) GetTraceByIdAndService(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	projectUid := query.Get("projectUid") // Optional
-
 	environmentUid := query.Get("environmentUid")
 	if environmentUid == "" {
 		h.writeError(w, http.StatusBadRequest, "environmentUid is required")
 		return
 	}
-
-	organizationUid := query.Get("organizationUid") // Optional
 
 	// Parse sortOrder (default: desc)
 	sortOrder := query.Get("sortOrder")
@@ -200,13 +186,11 @@ func (h *Handler) GetTraceByIdAndService(w http.ResponseWriter, r *http.Request)
 
 	// Build query parameters
 	params := opensearch.TraceByIdAndServiceParams{
-		TraceID:         traceID,
-		ComponentUid:    componentUid,
-		ProjectUid:      projectUid,
-		EnvironmentUid:  environmentUid,
-		OrganizationUid: organizationUid,
-		SortOrder:       sortOrder,
-		Limit:           limit,
+		TraceID:        traceID,
+		ComponentUid:   componentUid,
+		EnvironmentUid: environmentUid,
+		SortOrder:      sortOrder,
+		Limit:          limit,
 	}
 
 	// Execute query

--- a/traces-observer-service/openapi.yaml
+++ b/traces-observer-service/openapi.yaml
@@ -43,13 +43,6 @@ paths:
           schema:
             type: string
             example: "default-component"
-        - name: projectUid
-          in: query
-          required: false
-          description: The project unique identifier (optional)
-          schema:
-            type: string
-            example: "default-project"
         - name: environmentUid
           in: query
           required: true
@@ -114,13 +107,6 @@ paths:
           schema:
             type: string
             example: "default-component"
-        - name: projectUid
-          in: query
-          required: false
-          description: The project unique identifier (optional)
-          schema:
-            type: string
-            example: "default-project"
         - name: environmentUid
           in: query
           required: true

--- a/traces-observer-service/opensearch/queries.go
+++ b/traces-observer-service/opensearch/queries.go
@@ -78,29 +78,11 @@ func BuildTraceQuery(params TraceQueryParams) map[string]interface{} {
 		})
 	}
 
-	// Add project UID filter
-	if params.ProjectUid != "" {
-		mustConditions = append(mustConditions, map[string]interface{}{
-			"term": map[string]interface{}{
-				"resource.openchoreo.dev/project-uid": params.ProjectUid,
-			},
-		})
-	}
-
 	// Add environment UID filter
 	if params.EnvironmentUid != "" {
 		mustConditions = append(mustConditions, map[string]interface{}{
 			"term": map[string]interface{}{
 				"resource.openchoreo.dev/environment-uid": params.EnvironmentUid,
-			},
-		})
-	}
-
-	// Add organization UID filter (optional)
-	if params.OrganizationUid != "" {
-		mustConditions = append(mustConditions, map[string]interface{}{
-			"term": map[string]interface{}{
-				"resource.openchoreo.dev/organization-uid": params.OrganizationUid,
 			},
 		})
 	}
@@ -176,29 +158,11 @@ func BuildTraceByIdAndServiceQuery(params TraceByIdAndServiceParams) map[string]
 		})
 	}
 
-	// Add project UID filter
-	if params.ProjectUid != "" {
-		mustConditions = append(mustConditions, map[string]interface{}{
-			"term": map[string]interface{}{
-				"resource.openchoreo.dev/project-uid": params.ProjectUid,
-			},
-		})
-	}
-
 	// Add environment UID filter
 	if params.EnvironmentUid != "" {
 		mustConditions = append(mustConditions, map[string]interface{}{
 			"term": map[string]interface{}{
 				"resource.openchoreo.dev/environment-uid": params.EnvironmentUid,
-			},
-		})
-	}
-
-	// Add organization UID filter (optional)
-	if params.OrganizationUid != "" {
-		mustConditions = append(mustConditions, map[string]interface{}{
-			"term": map[string]interface{}{
-				"resource.openchoreo.dev/organization-uid": params.OrganizationUid,
 			},
 		})
 	}

--- a/traces-observer-service/opensearch/types.go
+++ b/traces-observer-service/opensearch/types.go
@@ -20,26 +20,22 @@ import "time"
 
 // TraceQueryParams holds parameters for trace queries
 type TraceQueryParams struct {
-	ComponentUid     string
-	ProjectUid       string
-	EnvironmentUid   string
-	OrganizationUid  string
-	StartTime        string
-	EndTime          string
-	Limit            int
-	Offset           int
-	SortOrder        string
+	ComponentUid   string
+	EnvironmentUid string
+	StartTime      string
+	EndTime        string
+	Limit          int
+	Offset         int
+	SortOrder      string
 }
 
 // TraceByIdAndServiceParams holds parameters for querying by both traceId and componentUid
 type TraceByIdAndServiceParams struct {
-	TraceID          string
-	ComponentUid     string
-	ProjectUid       string
-	EnvironmentUid   string
-	OrganizationUid  string
-	SortOrder        string
-	Limit            int
+	TraceID        string
+	ComponentUid   string
+	EnvironmentUid string
+	SortOrder      string
+	Limit          int
 }
 
 // Span represents a single trace span


### PR DESCRIPTION
## Purpose
Remove projectUid and organizationUid from traces-observer-service

This PR simplifies the trace querying mechanism by removing `projectUid` and `organizationUid` parameters, focusing solely on component and environment-based filtering for trace retrieval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed projectUid and organizationUid parameters from trace retrieval endpoints (GET /trace and GET /traces).
  * Trace filtering now relies exclusively on component and environment identifiers.
  * Updated query parameter structures and logging for the simplified trace context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->