### PR TITLE
Remove traces-observer service from docker compose

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -89,24 +89,6 @@ services:
     depends_on:
       - agent-manager-service
 
-  #add traces observer service
-  traces-observer-service:
-    build:
-      context: ../traces-observer-service
-      dockerfile: Dockerfile.dev
-    container_name: traces-observer-service
-    ports:
-      - "9098:9098"
-    environment:
-      - TRACES_OBSERVER_PORT=9098
-      - OPENSEARCH_ADDRESS=http://host.docker.internal:9200
-      - OPENSEARCH_USERNAME=admin
-      - OPENSEARCH_PASSWORD=ThisIsTheOpenSearchPassword1
-    networks:
-      - agent-manager
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-
 volumes:
   postgres_data:
   console_node_modules:


### PR DESCRIPTION
Removed the traces-observer-service from the Docker Compose configuration as the observability functionality is handled by the traces-observer-service (provided by the helm chart) running on OpenChoreo Observability plane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the traces-observer-service from the deployment configuration, including all associated build context, container settings, ports, environment variables, volumes, networks, and host configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->