### PR TITLE
Override OTel Collector configMap to disable trace sampling

### DIFF
--- a/deployments/scripts/setup-openchoreo.sh
+++ b/deployments/scripts/setup-openchoreo.sh
@@ -164,13 +164,17 @@ echo "7️⃣  Installing OpenChoreo Observability Plane..."
 if helm status openchoreo-observability-plane -n openchoreo-observability-plane &>/dev/null; then
     echo "⏭️  Observability Plane already installed, skipping..."
 else
-    echo "   This includes OpenSearch"
+    echo "   This may take up to 15 minutes..."
+    kubectl create namespace openchoreo-observability-plane --dry-run=client -o yaml | kubectl apply -f -
+
+    kubectl apply -f $1/deployments/values/oc-collector-configmap.yaml -n openchoreo-observability-plane
+
     helm install openchoreo-observability-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \
-    --version 0.7.0 \
-    --namespace openchoreo-observability-plane \
-    --create-namespace \
-    --values https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.7/install/k3d/single-cluster/values-op.yaml \
-    --set opentelemetryCollectorCustomizations.tailSampling.spansPerSecond=100000
+        --version 0.7.0 \
+        --namespace openchoreo-observability-plane \
+        --create-namespace \
+        --values https://raw.githubusercontent.com/openchoreo/openchoreo/release-v0.7/install/k3d/single-cluster/values-op.yaml \
+        --set opentelemetry-collector.configMap.existingName=amp-opentelemetry-collector-config
 fi
 
 echo "⏳ Waiting for OpenSearch pods to be ready..."

--- a/deployments/scripts/setup-openchoreo.sh
+++ b/deployments/scripts/setup-openchoreo.sh
@@ -164,11 +164,11 @@ echo "7️⃣  Installing OpenChoreo Observability Plane..."
 if helm status openchoreo-observability-plane -n openchoreo-observability-plane &>/dev/null; then
     echo "⏭️  Observability Plane already installed, skipping..."
 else
-    echo "   This may take up to 15 minutes..."
+    echo "   Creating OpenChoreo Observability Plane namespace..."
     kubectl create namespace openchoreo-observability-plane --dry-run=client -o yaml | kubectl apply -f -
-
+    echo "   Applying Custom OpenTelemetry Collector configuration..."
     kubectl apply -f $1/deployments/values/oc-collector-configmap.yaml -n openchoreo-observability-plane
-
+    echo "   Installing Observability Plane Helm chart..."
     helm install openchoreo-observability-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \
         --version 0.7.0 \
         --namespace openchoreo-observability-plane \

--- a/deployments/values/oc-collector-configmap.yaml
+++ b/deployments/values/oc-collector-configmap.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amp-opentelemetry-collector-config
+  namespace: openchoreo-observability-plane 
+data:
+  relay: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    exporters:
+      opensearch:
+        http:
+          auth:
+            authenticator: basicauth/opensearch
+          endpoint: https://opensearch.openchoreo-observability-plane.svc.cluster.local:9200
+          tls:
+            insecure_skip_verify: true
+        sending_queue:
+          num_consumers: 5
+          queue_size: 1000
+          sizer: items
+        traces_index: "otel-traces"
+        traces_index_time_format: "yyyy-MM-dd"
+
+    extensions:
+      basicauth/opensearch:
+        client_auth: 
+          username: admin
+          password: ThisIsTheOpenSearchPassword1
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+  
+    processors:
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+
+        extract:
+          labels:
+            - key: openchoreo.dev/component-uid
+              tag_name: openchoreo.dev/component-uid
+            - key: openchoreo.dev/environment-uid
+              tag_name: openchoreo.dev/environment-uid
+            - key: openchoreo.dev/project-uid
+              tag_name: openchoreo.dev/project-uid
+            
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.namespace.name
+            - k8s.node.name
+
+    service:
+      extensions: [basicauth/opensearch, health_check]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [k8sattributes]
+          exporters: [opensearch]


### PR DESCRIPTION
## Purpose
Override the default OpenChoreo OpenTelemetry Collector configuration to disable trace sampling, ensuring complete trace data collection for AI agent observability.

## Goals
Collect 100% of traces without sampling for comprehensive AI agent monitoring usecases

## Approach
Created a custom ConfigMap (oc-collector-configmap.yaml) containing OpenTelemetry Collector configuration without sampling processors
Updated the [setup-openchoreo.sh] script to:
  - Apply the custom ConfigMap before Helm installation
  - Override the default collector configuration using --set opentelemetry-collector.configMap.existingName=amp-opentelemetry-collector-config

    The custom ConfigMap includes:
    
    - OTLP receivers (gRPC/HTTP)
    - OpenSearch exporter with authentication
    - k8sattributes processor for extracting OpenChoreo labels and Kubernetes metadata
    - No sampling processors (key change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced OpenChoreo Observability Plane setup with explicit namespace creation and configuration management
  * Updated OpenTelemetry Collector configuration to include receivers, exporters, processors, and Kubernetes attribute extraction
  * Improved Helm deployment workflow with pre-install configuration steps and updated deployment verification process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->