### PR TITLE
Fix Build Plane registry port mapping in quick-start

### DIFF
--- a/deployments/quick-start/k3d-config.yaml
+++ b/deployments/quick-start/k3d-config.yaml
@@ -25,6 +25,10 @@ ports:
   - port: 21893:21893
     nodeFilters:
       - loadbalancer
+  # Build Plane Registry (LoadBalancer service on port 5000 -> host port 10082)
+  - port: 10082:5000
+    nodeFilters:
+      - loadbalancer
 options:
   k3s:
     extraArgs:


### PR DESCRIPTION
## Summary

- Adds missing port mapping for Build Plane registry (10082:5000) to k3d configuration
- Fixes helm install hanging during quick-start Build Plane installation

## Problem

The helm install for OpenChoreo Build Plane gets stuck indefinitely during quick-start installation. The `push-buildpack-cache-images` job cannot connect to the registry at `host.k3d.internal:10082`.

### Root Cause

The Build Plane Helm chart (values-bp.yaml) configures the registry endpoint as `host.k3d.internal:10082`:

```yaml
global:
  defaultResources:
    registry:
      endpoint: "host.k3d.internal:10082"
```

However, the k3d-config.yaml was missing the port mapping to expose the LoadBalancer service port 5000 on host port 10082. This caused the push-buildpack-cache-images job to fail with:

```
Registry not ready yet (attempt X/60), retrying in 5s...
Target registry: host.k3d.internal:10082
```

## Solution

Added the missing port mapping in `deployments/quick-start/k3d-config.yaml`:

```yaml
# Build Plane Registry (LoadBalancer service on port 5000 -> host port 10082)
- port: 10082:5000
  nodeFilters:
    - loadbalancer
```

## Related Issues

Resolves the issue where helm install for Build Plane gets stuck during quick-start installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Build Plane Registry is now accessible on port 10082 through the load balancer in quick-start deployment configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->