### PR TITLE
Fix quick-start port mappings and agent manager API connectivity

### DIFF
--- a/deployments/helm-charts/wso2-amp-build-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-build-extension/values.yaml
@@ -15,7 +15,7 @@ global:
   agentManagerService:
     # -- The base URL of the agent manager service
     # Use host.k3d.internal for k3d or host.docker.internal for Docker Desktop/Kind to access host machine
-    url: "http://host.k3d.internal:8080"
+    url: "http://host.k3d.internal:9000"
     apiKeyHeader: "X-API-Key"
     # -- API Key for agent manager authentication
     # Provide it during installation with:


### PR DESCRIPTION
## Summary
- Fix Build Plane registry port mapping in k3d configuration
- Fix agent manager API port in Build Extension Helm values

## Problem
1. The quick-start installation was hanging during Build Plane setup because the registry at `host.k3d.internal:10082` was not accessible from within the k3d cluster
2. After the API port was changed from 8080 to 9000 (commit 17a14f1), the Build Extension Helm chart was not updated, causing Argo workflows to fail with: "Failed to connect to host.k3d.internal port 8080 after 1 ms: Could not connect to server"

## Changes
1. **k3d-config.yaml**: Added port mapping `10082:5000` for Build Plane registry LoadBalancer service
2. **wso2-amp-build-extension/values.yaml**: Updated agent manager service URL from port 8080 to 9000

## Testing
After these changes, the quick-start container should:
- Successfully install the Build Plane without hanging
- Allow Argo workflows to connect to the agent manager API successfully

## Related Commits
- Builds on 17a14f1 (Fix quick-start service accessibility and port conflicts)
- Completes the port migration for agent manager API from 8080 to 9000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal service communication configuration to use port 9000 instead of port 8080.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->