### PR TITLE
Add crew ai task type spans rich view

### DIFF
--- a/console/workspaces/libs/types/src/api/traces.ts
+++ b/console/workspaces/libs/types/src/api/traces.ts
@@ -111,12 +111,18 @@ export interface AgentData {
   tokenUsage?: LLMTokenUsage;
 }
 
+export interface CrewAITaskData {
+  name?: string;
+  description?: string;
+  tools?: ToolDefinition[];
+}
+
 export interface AmpAttributes {
   kind: string;
   input?: PromptMessage[] | string[] | string;
   output?: PromptMessage[] | string;
   status?: SpanStatus;
-  data?: LLMData | ToolData | EmbeddingData | RetrieverData | AgentData;
+  data?: LLMData | ToolData | EmbeddingData | RetrieverData | AgentData | CrewAITaskData;
 }
 
 export interface Span {

--- a/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
+++ b/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
@@ -42,6 +42,7 @@ import {
   Search,
   ArrowUpDown,
   Bot,
+  ClipboardCheck,
 } from '@wso2/oxygen-ui-icons-react';
 
 interface TraceExplorerProps {
@@ -107,6 +108,12 @@ export function SpanIcon({ span }: { span: Span }) {
       return (
         <Box color="warning.main">
           <Bot size={16} />
+        </Box>
+      );
+    case 'crewaitask':
+      return (
+        <Box sx={{ color: '#9C27B0' }}>
+          <ClipboardCheck size={16} />
         </Box>
       );
     case 'chain':

--- a/console/workspaces/pages/traces/src/subComponents/SpanDetailsPanel.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/SpanDetailsPanel.tsx
@@ -17,7 +17,7 @@
  */
 
 import { Chip, Divider, Stack, Tab, Tabs, Typography } from "@wso2/oxygen-ui";
-import { Span, LLMData, AgentData, ToolDefinition, ToolData } from "@agent-management-platform/types";
+import { Span, LLMData, AgentData, ToolDefinition, ToolData, CrewAITaskData } from "@agent-management-platform/types";
 import { BasicInfoSection } from "./spanDetails/BasicInfoSection";
 import { AttributesSection } from "./spanDetails/AttributesSection";
 import { useEffect, useState } from "react";
@@ -61,6 +61,14 @@ function hasOverviewContent(span: Span): boolean {
   if (kind === 'tool' && data) {
     const toolData = data as ToolData;
     if (toolData.name) {
+      return true;
+    }
+  }
+  
+  // Check for CrewAI task name or description
+  if (kind === 'crewaitask' && data) {
+    const taskData = data as CrewAITaskData;
+    if (taskData.name || taskData.description) {
       return true;
     }
   }

--- a/console/workspaces/pages/traces/src/subComponents/spanDetails/Overview.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/spanDetails/Overview.tsx
@@ -26,7 +26,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Info } from "@wso2/oxygen-ui-icons-react";
-import { AmpAttributes, PromptMessage, ToolData, AgentData } from "@agent-management-platform/types";
+import { AmpAttributes, PromptMessage, ToolData, AgentData, CrewAITaskData } from "@agent-management-platform/types";
 import { memo, useCallback, useMemo } from "react";
 
 interface OverviewProps {
@@ -193,6 +193,17 @@ export function Overview({ ampAttributes }: OverviewProps) {
       return (data as ToolData).name;
     } else if (kind === 'agent' && data) {
       return (data as AgentData).name;
+    } else if (kind === 'crewaitask' && data) {
+      return (data as CrewAITaskData).name;
+    }
+    return undefined;
+  }, [ampAttributes]);
+
+  // Extract description for CrewAI tasks
+  const taskDescription = useMemo(() => {
+    const { kind, data } = ampAttributes || {};
+    if (kind === 'crewaitask' && data) {
+      return (data as CrewAITaskData).description;
     }
     return undefined;
   }, [ampAttributes]);
@@ -248,6 +259,25 @@ export function Overview({ ampAttributes }: OverviewProps) {
           <Card variant="outlined">
             <CardContent>
               <Typography variant="body2">{name}</Typography>
+            </CardContent>
+          </Card>
+        </Stack>
+      )}
+
+      {taskDescription && (
+        <Stack>
+          <Typography variant="h6">Description</Typography>
+          <Card variant="outlined">
+            <CardContent>
+              <Typography 
+                variant="body2"
+                sx={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}
+              >
+                {taskDescription}
+              </Typography>
             </CardContent>
           </Card>
         </Stack>

--- a/traces-observer-service/opensearch/types.go
+++ b/traces-observer-service/opensearch/types.go
@@ -103,6 +103,13 @@ type AgentData struct {
 	TokenUsage   *LLMTokenUsage   `json:"tokenUsage,omitempty"`   // Token usage details (aggregated from agent execution)
 }
 
+// CrewAITaskData contains CrewAI task execution span information
+type CrewAITaskData struct {
+	Name        string           `json:"name,omitempty"`        // Task name (from crewai.task.name)
+	Description string           `json:"description,omitempty"` // Task description (from crewai.task.description)
+	Tools       []ToolDefinition `json:"tools,omitempty"`       // Available tools for the task (from crewai.task.tools)
+}
+
 // SpanStatus represents the execution status of a span
 type SpanStatus struct {
 	Error     bool   `json:"error"`               // Whether the span has an error
@@ -180,14 +187,15 @@ type TraceStatus struct {
 type SpanType string
 
 const (
-	SpanTypeLLM       SpanType = "llm"       // LLM/Chat completion operations
-	SpanTypeEmbedding SpanType = "embedding" // Embedding generation operations
-	SpanTypeTool      SpanType = "tool"      // Tool/Function calls
-	SpanTypeRetriever SpanType = "retriever" // Vector DB retrieval operations
-	SpanTypeRerank    SpanType = "rerank"    // Reranking operations
-	SpanTypeAgent     SpanType = "agent"     // Agent orchestration
-	SpanTypeChain     SpanType = "chain"     // Generic tasks/workflows
-	SpanTypeUnknown   SpanType = "unknown"   // Unknown/unclassified spans
+	SpanTypeLLM        SpanType = "llm"        // LLM/Chat completion operations
+	SpanTypeEmbedding  SpanType = "embedding"  // Embedding generation operations
+	SpanTypeTool       SpanType = "tool"       // Tool/Function calls
+	SpanTypeRetriever  SpanType = "retriever"  // Vector DB retrieval operations
+	SpanTypeRerank     SpanType = "rerank"     // Reranking operations
+	SpanTypeAgent      SpanType = "agent"      // Agent orchestration
+	SpanTypeChain      SpanType = "chain"      // Generic tasks/workflows
+	SpanTypeCrewAITask SpanType = "crewaitask" // CrewAI task operations
+	SpanTypeUnknown    SpanType = "unknown"    // Unknown/unclassified spans
 )
 
 // TokenUsage represents aggregated token usage from GenAI spans


### PR DESCRIPTION


https://github.com/wso2/ai-agent-management-platform/issues/40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CrewAI task visualization in the trace explorer with distinctive iconography.
  * Overview tab now displays CrewAI task details including name, description, and associated tools.
  * Enhanced trace processing to properly identify and render CrewAI task spans.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->