### PR TITLE
Optimize quick-start: Skip buildpack cache pre-population

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -496,7 +496,8 @@ helm_install_idempotent \
     "${BUILD_CI_NS}" \
     "${TIMEOUT_BUILD_PLANE}" \
     --version "${OPENCHOREO_VERSION}" \
-    --values "https://raw.githubusercontent.com/openchoreo/openchoreo/${OC_RELEASE}/install/k3d/single-cluster/values-bp.yaml"
+    --values "https://raw.githubusercontent.com/openchoreo/openchoreo/${OC_RELEASE}/install/k3d/single-cluster/values-bp.yaml" \
+    --set prePushBuildpackImages=false
 
 # Register Build Plane
 log_info "Registering Build Plane..."


### PR DESCRIPTION
## Summary
Skips buildpack cache pre-population in quick-start installation to dramatically reduce installation time and prevent timeout failures.

## Problem
- Build Plane installation was **failing** after 10-minute timeout
- `push-buildpack-cache-images` job took **15+ minutes**
- Total installation time: **18+ minutes** (and failing at Step 5/7)

## Solution
Add `--set prePushBuildpackImages=false` to Build Plane helm install

## Impact
- ✅ Build Plane: **10+ min (failed) → 1-2 min (success)**
- ✅ Overall installation: **18+ min (failed) → ~8-10 min (complete)**
- ✅ Fixes installation failure

## Trade-off
First agent build will pull buildpacks on-demand (acceptable for quick-start). Subsequent builds are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Build Plane Helm installation configuration to disable pre-pushing of buildpack images during deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->