### PR TITLE
Update trace retrieval API to increase fetch limit

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       # - OPENSEARCH_URL=http://host.docker.internal:9200
       - OBSERVER_URL=http://host.docker.internal:8085
       - AMP_VERSION=v0.1.0
+      - TRACE_OBSERVER_URL=http://host.docker.internal:9098
     volumes:
       # Mount source code for hot-reloading
       - ../agent-manager-service:/app
@@ -76,7 +77,7 @@ services:
       - AUTH_BASE_URL=null
       - SIGN_IN_REDIRECT_URL=null
       - SIGN_OUT_REDIRECT_URL=null
-      - API_BASE_URL=http://localhost:8080
+      - API_BASE_URL=http://localhost:9000
       - DISABLE_AUTH=true
       - OBS_API_BASE_URL=http://localhost:9098
     volumes:

--- a/traces-observer-service/README.MD
+++ b/traces-observer-service/README.MD
@@ -126,19 +126,18 @@ curl --location 'http://localhost:9098/api/v1/traces?serviceName=sample-app&star
 
 ### 2. Get trace spans - `GET /api/v1/trace`
 
-Retrieves all spans for a specific trace ID and service.
+Retrieves all spans for a specific trace ID and component. Returns up to 10,000 spans without pagination.
 
 **Query Parameters:**
 
 - `traceId` (required) - The trace ID to retrieve spans for
-- `serviceName` (required) - Name of the service
-- `sortOrder` (optional) - Sort order for spans: `asc` or `desc` (default: `asc` - chronological)
-- `limit` (optional) - Maximum number of spans to return (default: 100)
+- `componentUid` (required) - The component unique identifier
+- `environmentUid` (required) - The environment unique identifier
 
 **Example request:**
 
 ```bash
-curl --location 'http://localhost:9098/api/v1/trace?traceId=21a29d5d24837ca724b8751494e70a95&serviceName=langchain-docker-app&sortOrder=asc&limit=100'
+curl --location 'http://localhost:9098/api/v1/trace?traceId=21a29d5d24837ca724b8751494e70a95&componentUid=default-component&environmentUid=default-environment'
 ```
 
 **Response (200):**

--- a/traces-observer-service/handlers/handlers.go
+++ b/traces-observer-service/handlers/handlers.go
@@ -56,8 +56,6 @@ type TraceByIdAndServiceRequest struct {
 	TraceID        string `json:"traceId"`
 	ComponentUid   string `json:"componentUid"`
 	EnvironmentUid string `json:"environmentUid"`
-	SortOrder      string `json:"sortOrder,omitempty"`
-	Limit          int    `json:"limit,omitempty"`
 }
 
 // ErrorResponse represents an error response
@@ -171,34 +169,11 @@ func (h *Handler) GetTraceByIdAndService(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Parse sortOrder (default: desc)
-	sortOrder := query.Get("sortOrder")
-	if sortOrder == "" {
-		sortOrder = "desc"
-	}
-	if sortOrder != "asc" && sortOrder != "desc" {
-		h.writeError(w, http.StatusBadRequest, "sortOrder must be 'asc' or 'desc'")
-		return
-	}
-
-	// Parse limit (default: 100 for spans)
-	limit := 100
-	if limitStr := query.Get("limit"); limitStr != "" {
-		parsedLimit, err := strconv.Atoi(limitStr)
-		if err != nil || parsedLimit <= 0 {
-			h.writeError(w, http.StatusBadRequest, "limit must be a positive integer")
-			return
-		}
-		limit = parsedLimit
-	}
-
 	// Build query parameters
 	params := opensearch.TraceByIdAndServiceParams{
 		TraceID:        traceID,
 		ComponentUid:   componentUid,
 		EnvironmentUid: environmentUid,
-		SortOrder:      sortOrder,
-		Limit:          limit,
 	}
 
 	// Execute query

--- a/traces-observer-service/openapi.yaml
+++ b/traces-observer-service/openapi.yaml
@@ -26,7 +26,7 @@ paths:
       tags:
         - traces
       summary: Get a single trace by trace ID
-      description: Retrieves detailed span information for a specific trace
+      description: Retrieves all span information for a specific trace without pagination. Returns up to 10,000 spans.
       operationId: getTrace
       parameters:
         - name: traceId

--- a/traces-observer-service/opensearch/queries.go
+++ b/traces-observer-service/opensearch/queries.go
@@ -167,18 +167,6 @@ func BuildTraceByIdAndServiceQuery(params TraceByIdAndServiceParams) map[string]
 		})
 	}
 
-	// Set default limit if not provided
-	limit := params.Limit
-	if limit == 0 {
-		limit = 10000 // Get all spans for the trace by default
-	}
-
-	// Set default sort order
-	sortOrder := params.SortOrder
-	if sortOrder == "" {
-		sortOrder = "asc"
-	}
-
 	// Build the complete query
 	query := map[string]interface{}{
 		"query": map[string]interface{}{
@@ -186,14 +174,7 @@ func BuildTraceByIdAndServiceQuery(params TraceByIdAndServiceParams) map[string]
 				"must": mustConditions,
 			},
 		},
-		"size": limit,
-		"sort": []map[string]interface{}{
-			{
-				"startTime": map[string]string{
-					"order": sortOrder,
-				},
-			},
-		},
+		"size": 10000,
 	}
 
 	return query

--- a/traces-observer-service/opensearch/types.go
+++ b/traces-observer-service/opensearch/types.go
@@ -34,8 +34,6 @@ type TraceByIdAndServiceParams struct {
 	TraceID        string
 	ComponentUid   string
 	EnvironmentUid string
-	SortOrder      string
-	Limit          int
 }
 
 // Span represents a single trace span


### PR DESCRIPTION
## Purpose

> Update the trace retrieval API to allow fetching up to 10,000 spans per trace without pagination. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified trace retrieval: returns up to 10,000 spans and is not paginated.

* **Refactor**
  * Replaced serviceName with componentUid and environmentUid for trace lookups; removed sortOrder and limit parameters for simpler behavior.

* **Chores**
  * Updated deployment environment settings and the console API base URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->