### PR TITLE
Add ballerina trace parsing

### DIFF
--- a/console/workspaces/pages/traces/src/subComponents/spanDetails/Overview.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/spanDetails/Overview.tsx
@@ -97,7 +97,7 @@ const MessageList = memo(function MessageList({
     if (!showEmptyMessage) {
       return null;
     }
-    
+
     return (
       <Box data-testid={testId}>
         <Typography variant="h6" sx={{ mb: 2 }}>
@@ -258,12 +258,6 @@ export function Overview({ ampAttributes }: OverviewProps) {
 
   const hasContent = inputMessages.length > 0 || outputMessages.length > 0;
 
-  // Check if this is a span type that should have input/output
-  const shouldHaveInputOutput = useMemo(() => {
-    const { kind } = ampAttributes || {};
-    return kind === 'llm' || kind === 'tool' || kind === 'agent' || kind === 'embedding';
-  }, [ampAttributes]);
-
   const getRoleColor = useCallback((role: string) => {
     switch (role) {
       case "system":
@@ -308,7 +302,7 @@ export function Overview({ ampAttributes }: OverviewProps) {
           <Typography variant="h6">Description</Typography>
           <Card variant="outlined">
             <CardContent>
-              <Typography 
+              <Typography
                 variant="body2"
                 sx={{
                   whiteSpace: "pre-wrap",
@@ -327,7 +321,7 @@ export function Overview({ ampAttributes }: OverviewProps) {
           <Typography variant="h6">System Prompt</Typography>
           <Card variant="outlined">
             <CardContent>
-              <Typography 
+              <Typography
                 variant="body2"
                 sx={{
                   whiteSpace: "pre-wrap",
@@ -346,14 +340,14 @@ export function Overview({ ampAttributes }: OverviewProps) {
         messages={inputMessages}
         getRoleColor={getRoleColor}
         data-testid="input-messages"
-        showEmptyMessage={shouldHaveInputOutput && name !== undefined}
+        showEmptyMessage={false}
       />
       <MessageList
         title="Output Messages"
         messages={outputMessages}
         getRoleColor={getRoleColor}
         data-testid="output-messages"
-        showEmptyMessage={shouldHaveInputOutput && name !== undefined}
+        showEmptyMessage={false}
       />
     </Stack>
   );

--- a/traces-observer-service/opensearch/types.go
+++ b/traces-observer-service/opensearch/types.go
@@ -94,13 +94,14 @@ type RetrieverData struct {
 
 // AgentData contains agent execution span information
 type AgentData struct {
-	Name         string           `json:"name,omitempty"`         // Agent name (from gen_ai.agent.name)
-	Tools        []ToolDefinition `json:"tools,omitempty"`        // Available tools for the agent (from gen_ai.agent.tools)
-	Model        string           `json:"model,omitempty"`        // Model used by the agent (from gen_ai.request.model)
-	Framework    string           `json:"framework,omitempty"`    // Agent framework (from gen_ai.system, e.g., "strands-agents")
-	SystemPrompt string           `json:"systemPrompt,omitempty"` // System prompt for the agent
-	MaxIter      int              `json:"maxIter,omitempty"`      // Maximum iterations for the agent (from crewai.agent.max_iter)
-	TokenUsage   *LLMTokenUsage   `json:"tokenUsage,omitempty"`   // Token usage details (aggregated from agent execution)
+	Name           string           `json:"name,omitempty"`           // Agent name (from gen_ai.agent.name)
+	Tools          []ToolDefinition `json:"tools,omitempty"`          // Available tools for the agent (from gen_ai.agent.tools)
+	Model          string           `json:"model,omitempty"`          // Model used by the agent (from gen_ai.request.model)
+	Framework      string           `json:"framework,omitempty"`      // Agent framework (from gen_ai.system, e.g., "strands-agents")
+	SystemPrompt   string           `json:"systemPrompt,omitempty"`   // System prompt for the agent
+	MaxIter        int              `json:"maxIter,omitempty"`        // Maximum iterations for the agent (from crewai.agent.max_iter)
+	TokenUsage     *LLMTokenUsage   `json:"tokenUsage,omitempty"`     // Token usage details (aggregated from agent execution)
+	ConversationID string           `json:"conversationId,omitempty"` // Conversation ID (from gen_ai.conversation.id)
 }
 
 // CrewAITaskData contains CrewAI task execution span information


### PR DESCRIPTION
## Purpose
We need to add improve trace-view support for Ballerina. 

https://github.com/wso2/ai-agent-management-platform/issues/179

## Summary
This pull request introduces several improvements and fixes to both the frontend and backend components related to span details and trace processing. The most significant changes are in the Go backend (`traces-observer-service/opensearch/process.go`), which now handles more flexible input types and adds robust logging for better traceability and debugging. The frontend (`Overview.tsx`) was simplified to always hide empty message placeholders.

### Backend improvements:

#### Robust attribute extraction and type handling

* Added helper functions `extractIntValue` and `extractFloatValue` to safely extract integer and float values from span attributes, supporting multiple types (int, float, string). This makes token and temperature extraction more reliable across different data sources.
* Updated token usage and temperature extraction logic to use these helpers, ensuring correct parsing regardless of input type. [[1]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1L167-R173) [[2]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R469-R556)

#### Enhanced agent and message extraction

* Improved agent attribute extraction to prefer OTEL attributes (`gen_ai.input.messages`, `gen_ai.output.messages`) and fall back to Traceloop attributes only if OTEL ones are missing. Also, conversation ID extraction was added. [[1]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R242-R262) [[2]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R284-R288)
* Added more robust OTEL message parsing with recursive JSON parsing to handle deeply stringified or nested message formats, and improved logging for parsing failures or skipped messages. [[1]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R767-R941) [[2]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R1073-R1086)

#### Tool definition extraction

* Enhanced tool definition extraction to support Ballerina format (`gen_ai.input.tools`) in addition to OTEL and Traceloop formats, and improved error handling/logging for malformed tool definitions. [[1]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R1214-L1034) [[2]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R1243-R1258) [[3]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1L333-R364) [[4]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R374-R375)

#### Logging and debugging

* Introduced extensive `slog` debug and warning logs throughout message, tool, and input/output extraction functions to aid troubleshooting and provide visibility into parsing decisions and failures. [[1]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R21-R23) [[2]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1L333-R364) [[3]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R374-R375) [[4]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R648-R667) [[5]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R696-R735) [[6]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R767-R941) [[7]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R1073-R1086) [[8]](diffhunk://#diff-bf0227c44672ef2fb883676d51d560ad0ef1e0b087f1fbe85d768789fe9d2be1R1243-R1258)

### Frontend simplification (`Overview.tsx`):

* Removed logic for conditionally showing empty message placeholders and now always hides them, simplifying the UI and reducing confusion for span types without input/output. [[1]](diffhunk://#diff-99ad0e506e81716ccf0480d46cf6bc3f5ca462d117b5483608dca537068c3060L261-L266) [[2]](diffhunk://#diff-99ad0e506e81716ccf0480d46cf6bc3f5ca462d117b5483608dca537068c3060L349-R350)


