### PR TITLE
Add API Key Generation to the Setup Agent dialog in Console

### DIFF
--- a/console/workspaces/libs/api-client/src/apis/agents.ts
+++ b/console/workspaces/libs/api-client/src/apis/agents.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -27,6 +27,10 @@ import {
   ListAgentsPathParams,
   ListAgentsQuery,
   CreateAgentRequest,
+  GenerateAgentTokenPathParams,
+  GenerateAgentTokenQuery,
+  TokenRequest,
+  TokenResponse,
 } from "@agent-management-platform/types";
 
 export async function listAgents(
@@ -111,4 +115,36 @@ export async function deleteAgent(
     `/agents/${encodeURIComponent(agentName)}`;
   const res = await httpDELETE(url, { token });
   if (!res.ok) throw await res.json();
+}
+
+export async function generateAgentToken(
+  params: GenerateAgentTokenPathParams,
+  body?: TokenRequest,
+  query?: GenerateAgentTokenQuery,
+  getToken?: () => Promise<string>,
+): Promise<TokenResponse> {
+  const { orgName = "default", projName = "default", agentName } = params;
+
+  if (!agentName) {
+    throw new Error("agentName is required");
+  }
+
+  const search = query
+    ? Object.fromEntries(
+        Object.entries(query)
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          .filter(([_, v]) => v !== undefined)
+          .map(([k, v]) => [k, String(v)])
+      )
+    : undefined;
+
+  const token = getToken ? await getToken() : undefined;
+  const url =
+    `${SERVICE_BASE}/orgs/${encodeURIComponent(orgName)}` +
+    `/projects/${encodeURIComponent(projName)}` +
+    `/agents/${encodeURIComponent(agentName)}/token`;
+  
+  const res = await httpPOST(url, body || {}, { searchParams: search, token });
+  if (!res.ok) throw await res.json();
+  return res.json();
 }

--- a/console/workspaces/libs/api-client/src/hooks/agents.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agents.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,7 +17,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createAgent, deleteAgent, getAgent, listAgents } from "../apis";
+import { createAgent, deleteAgent, getAgent, listAgents, generateAgentToken } from "../apis";
 import {
   AgentListResponse,
   AgentResponse,
@@ -27,6 +27,10 @@ import {
   GetAgentPathParams,
   ListAgentsPathParams,
   ListAgentsQuery,
+  GenerateAgentTokenPathParams,
+  GenerateAgentTokenQuery,
+  TokenRequest,
+  TokenResponse,
 } from "@agent-management-platform/types";
 import { useAuthHooks } from "@agent-management-platform/auth";
 
@@ -75,4 +79,15 @@ export function useDeleteAgent() {
             queryClient.invalidateQueries({ queryKey: ['agents'] });
         },
     });
+}
+
+export function useGenerateAgentToken() {
+  const { getToken } = useAuthHooks();
+  return useMutation<
+    TokenResponse,
+    unknown,
+    { params: GenerateAgentTokenPathParams; body?: TokenRequest; query?: GenerateAgentTokenQuery }
+  >({
+    mutationFn: ({ params, body, query }) => generateAgentToken(params, body, query, getToken),
+  });
 }

--- a/console/workspaces/libs/types/src/api/agents.ts
+++ b/console/workspaces/libs/types/src/api/agents.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -75,5 +75,23 @@ export type CreateAgentPathParams = OrgProjPathParams;
 export type GetAgentPathParams = AgentPathParams;
 export type DeleteAgentPathParams = AgentPathParams;
 export type ListAgentsQuery = ListQuery;
+
+// Agent Token
+export interface TokenRequest {
+  expires_in?: string; // Go duration format (e.g., "720h" for 30 days, "8760h" for 1 year)
+}
+
+export interface TokenResponse {
+  token: string;
+  expires_at: number; // Unix timestamp
+  issued_at: number; // Unix timestamp
+  token_type: string; // "Bearer"
+}
+
+export interface GenerateAgentTokenPathParams extends AgentPathParams {}
+
+export interface GenerateAgentTokenQuery {
+  environment?: string;
+}
 
 

--- a/console/workspaces/pages/overview/src/AgentOverview/ExternalAgentOverview.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/ExternalAgentOverview.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -65,7 +65,7 @@ export const ExternalAgentOverview = () => {
 
 
   const agentInstrumentationUrl = globalConfig.instrumentationUrl || "http://localhost:21893";
-  const apiKey = "8e3c1f4a-9b7d-4c2f-92a6-5d8f3b1c27e0";
+  const apiKey = "ey***";
 
   const handleSetupAgent = (environmentId: string) => {
     setSelectedEnvironmentId(environmentId);
@@ -141,6 +141,10 @@ export const ExternalAgentOverview = () => {
         onClose={() => setSearchParams({})}
         traceAttributes={`environment-uid=${selectedEnvironmentId},component-uid=${agent?.uuid}`}
         agentId={agentId ?? ""}
+        orgName={orgId ?? "default"}
+        projName={projectId ?? "default"}
+        agentName={agentId ?? ""}
+        environment={sortedEnvironmentList?.find((env: Environment) => env.uuid === selectedEnvironmentId)?.name}
         instrumentationUrl={agentInstrumentationUrl}
         apiKey={apiKey}
       />

--- a/console/workspaces/pages/overview/src/AgentOverview/InstrumentationDrawer.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/InstrumentationDrawer.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,6 +19,8 @@
 import { Box, Typography } from "@wso2/oxygen-ui";
 import { Settings } from "@wso2/oxygen-ui-icons-react";
 import { SetupStep } from "./SetupStep";
+import { TokenGenerationStep } from "./TokenGenerationStep";
+import { useState } from "react";
 import {
   DrawerWrapper,
   DrawerHeader,
@@ -29,6 +31,10 @@ interface InstrumentationDrawerProps {
   open: boolean;
   onClose: () => void;
   agentId: string;
+  orgName: string;
+  projName: string;
+  agentName: string;
+  environment?: string;
   instrumentationUrl: string;
   apiKey: string;
   traceAttributes: string;
@@ -37,10 +43,19 @@ interface InstrumentationDrawerProps {
 export const InstrumentationDrawer = ({
   open,
   onClose,
+  orgName,
+  projName,
+  agentName,
+  environment,
   instrumentationUrl,
   apiKey,
   traceAttributes,
 }: InstrumentationDrawerProps) => {
+  const [generatedApiKey, setGeneratedApiKey] = useState<string | null>(null);
+  
+  // Use generated key if available, otherwise use the passed apiKey
+  const effectiveApiKey = generatedApiKey || apiKey;
+
   return (
     <DrawerWrapper open={open} onClose={onClose} maxWidth={700}>
       <DrawerHeader
@@ -67,18 +82,26 @@ export const InstrumentationDrawer = ({
             fieldId="install"
             description="Provides the ability to instrument your agent and export traces."
           />
-          <SetupStep
+          <TokenGenerationStep
             stepNumber={2}
+            orgName={orgName}
+            projName={projName}
+            agentName={agentName}
+            environment={environment}
+            onTokenGenerated={setGeneratedApiKey}
+          />
+          <SetupStep
+            stepNumber={3}
             title="Set environment variables"
             code={`export AMP_OTEL_ENDPOINT="${instrumentationUrl}"
-export AMP_AGENT_API_KEY="${apiKey}"
+export AMP_AGENT_API_KEY="${effectiveApiKey}"
 export AMP_TRACE_ATTRIBUTES="${traceAttributes}"`}
             language="bash"
             fieldId="env"
             description="Sets the agent endpoint and agent-specific API key so traces can be exported securely."
           />
           <SetupStep
-            stepNumber={3}
+            stepNumber={4}
             title="Run Agent with Instrumentation Enabled"
             code="amp-instrument <run_command>"
             language="bash"

--- a/console/workspaces/pages/overview/src/AgentOverview/InstrumentationDrawer.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/InstrumentationDrawer.tsx
@@ -106,7 +106,7 @@ export AMP_TRACE_ATTRIBUTES="${traceAttributes}"`}
             code="amp-instrument <run_command>"
             language="bash"
             fieldId="run"
-            description="Look at the code-block in the screenshot, that way we can give a default command but also tell in a comment that user should replace it with what makes sense for them."
+            description="Replace <run_command> with your agent's start command. For example: amp-instrument python app.py"
           />
         </Box>
       </DrawerContent>

--- a/console/workspaces/pages/overview/src/AgentOverview/TokenGenerationStep.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/TokenGenerationStep.tsx
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useState } from "react";
+import { Box, Typography, Button, Select, MenuItem, CircularProgress } from "@wso2/oxygen-ui";
+import { CodeBlock } from "@agent-management-platform/shared-component";
+import { useGenerateAgentToken } from "@agent-management-platform/api-client";
+
+interface TokenGenerationStepProps {
+  stepNumber: number;
+  orgName: string;
+  projName: string;
+  agentName: string;
+  environment?: string;
+  onTokenGenerated: (token: string) => void;
+}
+
+const DURATION_OPTIONS = [
+  { label: "30 days", value: "720h" },
+  { label: "90 days", value: "2160h" },
+  { label: "6 months", value: "4320h" },
+  { label: "1 year", value: "8760h" },
+  { label: "2 years", value: "17520h" },
+];
+
+export const TokenGenerationStep = ({
+  stepNumber,
+  orgName,
+  projName,
+  agentName,
+  environment,
+  onTokenGenerated,
+}: TokenGenerationStepProps) => {
+  const [duration, setDuration] = useState<string>("8760h"); // Default to 1 year
+  const [generatedToken, setGeneratedToken] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const generateTokenMutation = useGenerateAgentToken();
+
+  const handleGenerateToken = async () => {
+    setError(null);
+    
+    try {
+      const result = await generateTokenMutation.mutateAsync({
+        params: { orgName, projName, agentName },
+        body: { expires_in: duration },
+        query: environment ? { environment } : undefined,
+      });
+      
+      setGeneratedToken(result.token);
+      onTokenGenerated(result.token);
+    } catch (err) {
+      console.error("Failed to generate token:", err);
+      setError("Failed to generate token. Please try again.");
+    }
+  };
+
+  const displayToken = generatedToken || "ey***";
+  const codeSnippet = `API Key="${displayToken}"`;
+
+  return (
+    <Box display="flex" gap={1} flexDirection="column">
+      <Box display="flex" alignItems="center" gap={1} justifyContent="space-between">
+        <Box display="flex" alignItems="center" gap={1}>
+          <Box
+            sx={{
+              gap: 2,
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              bgcolor: (theme) => theme.palette.primary.main,
+              color: "primary.contrastText",
+              fontWeight: 600,
+            }}
+          >
+            <Typography variant="body2" fontWeight={600}>
+              {stepNumber}
+            </Typography>
+          </Box>
+          <Typography variant="body1">Generate API Key</Typography>
+        </Box>
+
+        <Box display="flex" gap={1} alignItems="center">
+          <Typography variant="body2" color="textSecondary">
+            Token Duration
+          </Typography>
+          <Select
+            value={duration}
+            onChange={(e) => setDuration(e.target.value as string)}
+            size="small"
+            disabled={!!generatedToken || generateTokenMutation.isPending}
+            sx={{ minWidth: 100 }}
+          >
+            {DURATION_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+
+          <Button
+            variant="contained"
+            onClick={handleGenerateToken}
+            disabled={!!generatedToken || generateTokenMutation.isPending}
+            startIcon={generateTokenMutation.isPending ? <CircularProgress size={16} /> : undefined}
+            size="small"
+          >
+            {generateTokenMutation.isPending ? "Generating..." : generatedToken ? "Generated" : "Generate"}
+          </Button>
+        </Box>
+      </Box>
+
+      <Box display="flex" flexDirection="column" gap={1}>
+        {error && (
+          <Typography variant="body2" color="error">
+            {error}
+          </Typography>
+        )}
+
+        <CodeBlock code={codeSnippet} language="bash" fieldId="api-key" />
+
+        <Typography variant="body2" color="textSecondary">
+          {generatedToken
+            ? "Token generated successfully. Copy it now as you won't be able to see it again."
+            : "Generate a token to authenticate your traces."}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Purpose
Resolves #230 , Related to #54

> Adds API key generation functionality to the Setup Agent dialog in the console UI, allowing users to generate authentication tokens directly from the interface.

## Goals
> Enable users to generate agent authentication tokens from the UI for secure trace ingestion
Provide a user-friendly interface for selecting token duration and viewing the generated key
Automatically populate environment variables with the generated token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent API token generation: Create API keys directly from the agent setup interface with configurable expiration durations (30 days to 2 years).
  * Environment-scoped tokens: Generate tokens for specific environments as needed.
  * Secure token display: Generated API keys are presented in a dedicated code block for easy integration into agent instrumentation setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->