### PR TITLE
Add contributing guidelines documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,10 @@
 
 This document establishes guidelines for using GitHub Discussions and Issues for technical conversations about the AI Agent Management Platform.
 
-## Repository
+## Getting Started
 
-| Repository | Visibility | Purpose |
-|------------|------------|---------|
-| [wso2/ai-agent-management-platform](https://github.com/wso2/ai-agent-management-platform) | **Public** | Open source version, default location for discussions and issues |
-
-### Contribution Policy
-
-- **All welcome**: Discussions and issues from the community are encouraged
-- **Open collaboration**: Feature ideas, bug reports, and design proposals are all welcome
-- **Security issues**: Please report security vulnerabilities to security@wso2.com as per the [WSO2 Security Reporting Guidelines](https://security.docs.wso2.com/en/latest/security-reporting/report-security-issues/)
+- Discussions, issues, feature ideas, bug reports, and design proposals from the community are welcome
+- For security vulnerabilities, please report to security@wso2.com as per the [WSO2 Security Reporting Guidelines](https://security.docs.wso2.com/en/latest/security-reporting/report-security-issues/)
 
 ## Discussion Categories
 


### PR DESCRIPTION
## Summary
- Adds CONTRIBUTING.md with guidelines for using GitHub Discussions and Issues
- Documents the feature lifecycle from idea to implementation
- Includes design proposal template sections and labels
- Provides contribution policy with security reporting guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured Contributing Guidelines with clearer, discussion- and category-driven workflow.
  * Replaced PR-centric steps with a Discussion-first process and a Starting a Discussion workflow.
  * Added discussion category table and decision guidance for when to use Discussions vs Issues.
  * Introduced lifecycle stages (Idea → Design Proposal → Implementation Tracking) and Proposal Labels for status tracking.
  * Removed legacy community, licensing, and generic help sections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->