### PR TITLE
Update AMP Instrumentation package API key header and make trace attributes optional

### DIFF
--- a/libs/amp-instrumentation/.gitignore
+++ b/libs/amp-instrumentation/.gitignore
@@ -28,3 +28,5 @@ htmlcov/
 # Development
 *.log
 .DS_Store
+
+.venv

--- a/libs/amp-instrumentation/README.md
+++ b/libs/amp-instrumentation/README.md
@@ -31,7 +31,12 @@ First, register your agent at the [WSO2 AI Agent Management Platform](https://gi
 ```bash
 export AMP_OTEL_ENDPOINT="https://amp-otel-endpoint.com" # AMP OTEL endpoint
 export AMP_AGENT_API_KEY="your-agent-api-key" # Agent-specific key generated after registration
-export AMP_TRACE_ATTRIBUTES="trace-attributes-set" # Custom key-value pairs for trace metadata
+```
+
+Optionally, you can set custom trace attributes:
+
+```bash
+export AMP_TRACE_ATTRIBUTES="environment-uid=env,component-uid=comp" # Optional: Custom key-value pairs for trace metadata
 ```
 
 ### 3. Run Your Application

--- a/libs/amp-instrumentation/tests/test_initialization.py
+++ b/libs/amp-instrumentation/tests/test_initialization.py
@@ -68,4 +68,4 @@ class TestInitializeInstrumentation:
         # Verify Traceloop was initialized
         assert mock_traceloop.initialized is True
         assert mock_traceloop.init_kwargs["api_endpoint"] == "https://otel.example.com"
-        assert mock_traceloop.init_kwargs["headers"]["x-api-key"] == "test-key"
+        assert mock_traceloop.init_kwargs["headers"]["x-amp-api-key"] == "test-key"


### PR DESCRIPTION
## Purpose
> Update the API key header to `x-amp-api-key` and make the trace attributes optional to enhance flexibility in configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource attributes configuration is now optional.
  * Added initialization success logging.

* **Documentation**
  * Enhanced documentation for custom trace attributes with dedicated section and examples.

* **Chores**
  * Updated development environment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->