### PR TITLE
Skip buildpack cache pre-population in quick-start

### DIFF
--- a/deployments/single-cluster/values-bp.yaml
+++ b/deployments/single-cluster/values-bp.yaml
@@ -10,6 +10,10 @@ global:
     registry:
       # k3d registry endpoint
       endpoint: host.k3d.internal:10082
+    # Disable buildpack cache pre-population to reduce installation time
+    # First agent build will pull buildpacks on-demand
+    buildpackCache:
+      enabled: false
 
 # Registry service configuration
 registry:


### PR DESCRIPTION
## Summary
- Disables buildpack cache pre-population during Build Plane installation to reduce installation time

## Problem
- The `push-buildpack-cache-images` job pulls and pushes multiple large buildpack images
- This can take 10+ minutes and cause Build Plane installation to timeout
- Similar fix was applied in PR #147 but was lost during refactoring, and the helm chart value path has since changed

## Solution
Add `--set global.defaultResources.buildpackCache.enabled=false` to the Build Plane helm install

## Impact
- Build Plane installation time reduced significantly
- First agent build will pull buildpacks on-demand (acceptable trade-off for quick-start)
- Subsequent builds are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to modify buildpack cache handling behavior. Buildpacks are now fetched on-demand rather than pre-populated during installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->