### PR TITLE
Disable build cache pre-population

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -32,8 +32,6 @@ runs:
         tags: ${{ inputs.registry }}/${{ inputs.registry-org }}/${{ inputs.image-name }}:${{ inputs.tag }}
         build-args: |
           VERSION=${{ inputs.tag }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
 
     - name: Log image details
       run: |


### PR DESCRIPTION
## Summary
- Disable buildpack cache pre-population in quick-start to reduce installation time (first agent build will pull buildpacks on-demand)
- Disable Docker build cache in release workflow - the GHA cache was misconfigured with all matrix jobs sharing the same cache scope, causing each image build to overwrite the previous one's cache


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Docker image build configuration in CI/CD workflows to streamline the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->