### PR TITLE
Expose obs-gateway-router as LoadBalancer on port 22893

### DIFF
--- a/deployments/quick-start/k3d-config.yaml
+++ b/deployments/quick-start/k3d-config.yaml
@@ -25,8 +25,12 @@ ports:
   - port: 21893:21893
     nodeFilters:
       - loadbalancer
-  # Observability Gateway (LoadBalancer service on port 22893)
+  # Observability Gateway HTTP (LoadBalancer service on port 22893)
   - port: 22893:22893
+    nodeFilters:
+      - loadbalancer
+  # Observability Gateway HTTPS (LoadBalancer service on port 22894)
+  - port: 22894:22894
     nodeFilters:
       - loadbalancer
   # Control Plane uses port range 8xxx

--- a/deployments/values/api-platform-operator-full-config.yaml
+++ b/deployments/values/api-platform-operator-full-config.yaml
@@ -475,12 +475,12 @@ data:
           pullPolicy: Always
         imagePullSecrets: []
         service:
-          type: ClusterIP
+          type: LoadBalancer
           annotations: {}
           labels: {}
           ports:
-            http: 8080
-            https: 8443
+            http: 22893
+            https: 22894
             admin: 9901
         deployment:
           enabled: true


### PR DESCRIPTION
## Summary

- Changes observability gateway router service from `ClusterIP` to `LoadBalancer`
- Exposes HTTP on port 22893 and HTTPS on port 22894
- Adds port 22894 mapping to k3d-config.yaml for HTTPS access

This fixes the issue where `http://localhost:22893/otel` was inaccessible after running quick-start because the router service was only available within the cluster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTPS endpoint for Observability Gateway on port 22894

* **Configuration**
  * Gateway and router services now configured for external access via LoadBalancer
  * Updated gateway and router service ports to 22893 (HTTP) and 22894 (HTTPS)
  * Observability Gateway HTTP endpoint now available on port 22893

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->