### PR TITLE
Update Single Cluster installation with HTTPS trace ingestion instructions

### DIFF
--- a/deployments/scripts/port-forward.sh
+++ b/deployments/scripts/port-forward.sh
@@ -53,18 +53,23 @@ echo "🔑 Forwarding Thunder IDP Service (8090)..."
 kubectl port-forward -n amp-thunder svc/amp-thunder-extension-service 8090:8090 &
 
 # Port forward Observability Gateway
-echo "🌐 Forwarding Observability Gateway (22893)..."
-kubectl port-forward -n openchoreo-data-plane svc/obs-gateway-gateway-router 22893:8080 &
+echo "🌐 Forwarding Observability Gateway HTTP (22893)..."
+kubectl port-forward -n openchoreo-data-plane svc/obs-gateway-gateway-router 22893:22893 &
+
+# Port forward Observability Gateway
+echo "🌐 Forwarding Observability Gateway HTTPS (22894)..."
+kubectl port-forward -n openchoreo-data-plane svc/obs-gateway-gateway-router 22894:22894 &
 
 
 echo ""
 echo "✅ Port forwarding active:"
 echo "   Thunder IDP Service:        http://localhost:8090"
-echo "   Observer Service API:       http://localhost:8085"
-echo "   Traces Observer Service:    http://localhost:9098"
-echo "   OpenSearch:                 http://localhost:9200"
-echo "   OpenTelemetry Collector:    http://localhost:21893"
-echo "   Observability Gateway:      http://localhost:22893"
+echo "   Observer Service API: http://localhost:8085"
+echo "   OpenSearch:           http://localhost:9200"
+echo "   Traces Observer Service:      http://localhost:9098"
+echo "   Observability Gateway:       http://localhost:22893/otel"
+echo "   Observability Gateway (HTTPS):       https://localhost:22894/otel"
+echo "   OpenSearch Dashboard: http://localhost:5601"
 
 echo ""
 echo "💡 Keep this terminal open. Press Ctrl+C to stop."

--- a/deployments/scripts/setup-openchoreo.sh
+++ b/deployments/scripts/setup-openchoreo.sh
@@ -296,7 +296,7 @@ echo "🔟 Applying Gateway Operator Configuration..."
 echo "   Creating local development config..."
 cp "${SCRIPT_DIR}/../values/api-platform-operator-full-config.yaml" "${SCRIPT_DIR}/../values/api-platform-operator-local-config.yaml"
 # Update JWKS URI for local development
-sed -i '' 's|http://agent-manager-service.wso2-amp.svc.cluster.local:9000/auth/external/jwks.json|http://host.docker.internal:9000/auth/external/jwks.json|g' "${SCRIPT_DIR}/../values/api-platform-operator-local-config.yaml"
+sed -i '' 's|http://amp-api.wso2-amp.svc.cluster.local:9000/auth/external/jwks.json|http://host.docker.internal:9000/auth/external/jwks.json|g' "${SCRIPT_DIR}/../values/api-platform-operator-local-config.yaml"
 kubectl apply -f "${SCRIPT_DIR}/../values/api-platform-operator-local-config.yaml"
 echo "✅ Gateway configuration applied"
 echo ""

--- a/docs/install/single-cluster.md
+++ b/docs/install/single-cluster.md
@@ -332,8 +332,14 @@ kubectl port-forward -n wso2-amp svc/amp-console 3000:3000 &
 # Agent Manager API (port 8080)
 kubectl port-forward -n wso2-amp svc/amp-api 9000:9000 &
 
-# OTel Collector (port 21893)
-kubectl port-forward -n openchoreo-observability-plane svc/otel-collector 21893:21893 &
+# Port forward Observability Gateway
+echo "🌐 Forwarding Observability Gateway HTTP (22893)..."
+kubectl port-forward -n openchoreo-data-plane svc/obs-gateway-gateway-router 22893:22893 &
+
+# Port forward Observability Gateway
+echo "🌐 Forwarding Observability Gateway HTTPS (22894)..."
+kubectl port-forward -n openchoreo-data-plane svc/obs-gateway-gateway-router 22894:22894 &
+
 
 ```
 
@@ -343,7 +349,23 @@ After port forwarding is set up:
 
 - **Console**: http://localhost:3000
 - **API**: http://localhost:9000
-- **OpenTelemetry Collector**: http://localhost:21893
+- **Observabliity Gateway**: http://localhost:22893/otel
+- **Observability Gateway (HTTPS)** https://localhost:22894/otel
+
+### Handling Self-Signed Certificate Issues (HTTPS)
+
+If you need to use the HTTPS endpoint for OTEL exporters and encounter self-signed certificate issues, you can extract and use the certificate authority (CA) certificate from the cluster:
+
+```bash
+# Extract the CA certificate from the Kubernetes secret
+kubectl get secret obs-gateway-gateway-controller-tls \
+  -n openchoreo-data-plane \
+  -o jsonpath='{.data.ca\.crt}' | base64 --decode > ca.crt
+
+# Export the certificate path for OTEL exporters (use absolute path to the ca.crt file)
+export OTEL_EXPORTER_OTLP_CERTIFICATE=$(pwd)/ca.crt
+```
+
 
 ## Custom Configuration
 


### PR DESCRIPTION
## Purpose
> Enhance the single cluster installation documentation by adding instructions for HTTPS trace ingestion and updating port forwarding commands for the Observability Gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with Observability Gateway HTTP (22893) and HTTPS (22894) port-forwarding, revised access URLs, added OpenSearch Dashboard link, and guidance for handling self-signed certificates.

* **Chores**
  * Updated Observability Gateway port mappings, labels, and related configuration references; removed previous collector URL entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->