### PR TITLE
Switch python base image to ECR Public to avoid Docker Hub rate limits

### DIFF
--- a/python-instrumentation-provider/Dockerfile
+++ b/python-instrumentation-provider/Dockerfile
@@ -4,7 +4,7 @@
 ARG PYTHON_VERSION=3.11
 
 ############### STAGE 1 — BUILD INSTRUMENTATION PACKAGES ###############
-FROM python:${PYTHON_VERSION}-slim AS otel-tracing
+FROM public.ecr.aws/docker/library/python:${PYTHON_VERSION}-slim AS otel-tracing
 
 # Set the working directory where all instrumentation-related build files will be stored.
 WORKDIR /instrumentation
@@ -19,7 +19,7 @@ COPY sitecustomize.py packages/sitecustomize.py
 ############### STAGE 2 — FINAL RUNTIME IMAGE ###############
 # Create final OpenLLMetry image
 ARG PYTHON_VERSION=3.11
-FROM python:${PYTHON_VERSION}-slim
+FROM public.ecr.aws/docker/library/python:${PYTHON_VERSION}-slim
 WORKDIR /instrumentations
 
 # Copy the built instrumentation packages from the builder stage.


### PR DESCRIPTION
## Summary
- Switches `python:${PYTHON_VERSION}-slim` base images in `python-instrumentation-provider/Dockerfile` to `public.ecr.aws/docker/library/python:${PYTHON_VERSION}-slim`
- Fixes CI build failures caused by Docker Hub's unauthenticated pull rate limit (429 Too Many Requests)
- ECR Public mirrors the same official images without rate limits
