### PR TITLE
Fix quickstart install stalling on completed Job pods

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -204,7 +204,7 @@ helm_install_idempotent() {
     fi
 }
 
-# Wait for pods to be ready
+# Wait for pods to be ready (excludes Succeeded/Completed pods like Jobs)
 wait_for_pods() {
     local namespace=$1
     local timeout=$2
@@ -213,12 +213,12 @@ wait_for_pods() {
     log_info "Waiting for pods in ${namespace} to be ready (timeout: ${timeout}s)..."
 
     if [ -n "$selector" ]; then
-        kubectl wait --for=condition=Ready pod -l "${selector}" -n "${namespace}" --timeout="${timeout}s" || {
+        kubectl wait --for=condition=Ready pod -l "${selector}" --field-selector=status.phase!=Succeeded -n "${namespace}" --timeout="${timeout}s" || {
             log_warning "Some pods may still be starting (non-fatal)"
             return 0
         }
     else
-        kubectl wait --for=condition=Ready pod --all -n "${namespace}" --timeout="${timeout}s" || {
+        kubectl wait --for=condition=Ready pod --all --field-selector=status.phase!=Succeeded -n "${namespace}" --timeout="${timeout}s" || {
             log_warning "Some pods may still be starting (non-fatal)"
             return 0
         }


### PR DESCRIPTION
## Summary
- The quickstart `wait_for_pods` function uses `kubectl wait --for=condition=Ready pod --all`, which includes completed Job pods (e.g. `cluster-gateway-ca-extractor`). These pods have `phase=Succeeded` and `Ready=False`, so the wait hangs for the full 600s timeout before continuing.
- Adds `--field-selector=status.phase!=Succeeded` to exclude completed pods from the readiness check.

## Test plan
- [ ] Run quickstart install and verify step 5 (OpenChoreo Control Plane) completes without a 10-minute stall
- [ ] Verify all subsequent steps install correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pod readiness validation in the quick-start installation process. The system now properly excludes completed pods when determining deployment readiness, ensuring more accurate and reliable installation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->