### PR TITLE
Fix auth hooks causing infinite loading on console

### DIFF
--- a/console/workspaces/libs/auth/src/asgardio/hooks/authHooks.ts
+++ b/console/workspaces/libs/auth/src/asgardio/hooks/authHooks.ts
@@ -21,29 +21,37 @@ import { useQuery } from '@tanstack/react-query';
 import { UserInfo } from '../../types';
 
 export const useAuthHooks = () => {
-  const { 
-      signIn, 
+  const {
+      signIn,
       signOut,
       getIDToken,
-      getBasicUserInfo,
+      getDecodedIDToken,
       isAuthenticated,
       trySignInSilently,
     } = useAuthContext() ?? {};
 
   const { data: userInfo , isLoading: isLoadingUserInfo } = useQuery({
-    queryKey: ['auth', 'userInfo', getBasicUserInfo],
+    queryKey: ['auth', 'userInfo'],
     queryFn: async () => {
-      return getBasicUserInfo()
+      const idToken = await getDecodedIDToken();
+      return {
+        sub: idToken.sub,
+        username: idToken.preferred_username || idToken.email || idToken.sub,
+        displayName: idToken.name,
+        email: idToken.email,
+        givenName: idToken.given_name,
+        familyName: idToken.family_name,
+      };
     },
-    enabled: !!getBasicUserInfo,
+    enabled: !!getDecodedIDToken,
   });
 
   const {
       data: isAuthenticatedState,
       isLoading: isLoadingIsAuthenticated,
-      refetch: refetchIsAuthenticated 
+      refetch: refetchIsAuthenticated
     } = useQuery({
-    queryKey: ['isAuthenticated',isAuthenticated],
+    queryKey: ['isAuthenticated'],
     queryFn: () => {
       return isAuthenticated();
     },


### PR DESCRIPTION
## Summary

- Replaces `getBasicUserInfo` with `getDecodedIDToken` for extracting user info, since Thunder does not expose a userinfo endpoint (the Asgardeo SDK's `getBasicUserInfo` calls `/userinfo` which Thunder doesn't implement)
- Removes function references (`getBasicUserInfo`, `isAuthenticated`) from React Query keys — Asgardeo returns new function references on each context re-render, causing React Query to treat every render as a brand-new query and reset `isLoading` back to `true` indefinitely, leaving `Protected.tsx` stuck displaying `<FullPageLoader />`

## Root cause

The `2b0bc4e` commit ("Configure Thunder for the UI") introduced a regression by reverting the `getDecodedIDToken` fix from `b15bcd9` and adding `getBasicUserInfo` to the query key. This caused two compounding issues:
1. `queryKey: ['auth', 'userInfo', getBasicUserInfo]` — infinite re-query loop
2. `queryKey: ['isAuthenticated', isAuthenticated]` — `isLoadingIsAuthenticated` never settles to `false`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal authentication query mechanisms for improved efficiency in user data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->