### PR TITLE
Skip release note creation for RC releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,7 @@ jobs:
         build-python-instrumentation-provider-images,
         package-charts,
       ]
+    if: ${{ !contains(inputs.target-release, '-rc') }}
     runs-on:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:


### PR DESCRIPTION
## Summary
- Added an `if` condition to the `create-release` job in the release pipeline to skip GitHub release note creation when the `target-release` version contains the `-rc<Number>` postfix (e.g., `0.0.1-rc1`, `1.2.3-rc10`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the release workflow to conditionally skip the Create Release step for versions containing a release candidate suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->