### PR TITLE
Make evaluation-job image config-driven

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -18,6 +18,11 @@
     {
       "name": "amp-quick-start",
       "dir": "deployments/quick-start"
+    },
+    {
+      "name": "amp-evaluation-monitor",
+      "dir": "evaluation-job",
+      "context": "."
     }
   ],
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,8 @@ jobs:
           IMAGES=$(jq -c --arg base "$CHARTS_BASE_PATH" '[.images[] | {
             name: .name,
             "service-dir": .dir,
-            dockerfile: (.dir + "/Dockerfile")
+            dockerfile: (.dir + "/Dockerfile"),
+            context: (.context // "")
           }]' "$CONFIG_FILE")
 
           # Expand charts configuration (add resolved paths)
@@ -278,6 +279,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           registry-org: ${{ env.REGISTRY_ORG }}
           tag: v${{ inputs.target-release }}
+          context: ${{ matrix.image.context }}
 
   build-python-instrumentation-provider-images:
     name: Build Instrumentation Provider Python ${{ matrix.python-version }}
@@ -316,44 +318,10 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
 
-  build-evaluation-job-image:
-    name: Build amp-evaluation-job
-    needs: prepare-release
-    runs-on:
-      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: amp/v${{ inputs.target-release }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push amp-evaluation-monitor
-        uses: ./.github/actions/build-docker-image
-        with:
-          service-dir: evaluation-job
-          image-name: amp-evaluation-monitor
-          registry: ${{ env.REGISTRY }}
-          registry-org: ${{ env.REGISTRY_ORG }}
-          tag: v${{ inputs.target-release }}
-          context: .  # Root context required: Dockerfile copies from both libs/amp-evaluation/ and evaluation-job/
-
   package-charts:
     name: Package ${{ matrix.chart.name }}
     needs:
-      [load-config, build-images, build-python-instrumentation-provider-images, build-evaluation-job-image]
+      [load-config, build-images, build-python-instrumentation-provider-images]
     runs-on:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
@@ -399,7 +367,6 @@ jobs:
         prepare-release,
         build-images,
         build-python-instrumentation-provider-images,
-        build-evaluation-job-image,
         package-charts,
       ]
     if: ${{ !contains(inputs.target-release, '-rc') }}


### PR DESCRIPTION
## Summary

- Moves `amp-evaluation-monitor` from a standalone hardcoded job into the config-driven `images` matrix in `release-config.json`
- Adds optional `context` field to the image config schema (needed because the evaluation-job Dockerfile copies from `libs/amp-evaluation/`, requiring root build context)
- Removes the standalone `build-evaluation-job-image` job and its references from downstream dependencies

This resolves the structural inconsistency where `build-evaluation-job-image` was the only build job that bypassed `load-config` and wasn't driven by `release-config.json`.

### Before
```
prepare-release → load-config → ┬─ build-images ─────────────────────┐
                 │               └─ build-python-instrumentation ─────┼─ package-charts → create-release
                 └──────────── build-evaluation-job-image ────────────┘
```

### After
```
prepare-release → load-config → ┬─ build-images (includes evaluation-monitor) ─┐
                                 └─ build-python-instrumentation ───────────────┼─ package-charts → create-release
```

## Changes

| File | Change |
|------|--------|
| `.github/release-config.json` | Added `amp-evaluation-monitor` entry with `"context": "."` |
| `.github/workflows/release.yml` | Updated `load-config` jq to pass through `context` field |
| `.github/workflows/release.yml` | Updated `build-images` to forward `context` to action |
| `.github/workflows/release.yml` | Removed standalone `build-evaluation-job-image` job |
| `.github/workflows/release.yml` | Removed `build-evaluation-job-image` from `package-charts` and `create-release` needs |

## Notes

- The `context: "."` override is needed because `evaluation-job/Dockerfile` does `COPY libs/amp-evaluation/...` from a sibling directory. The Dockerfile itself has a comment: *"This is temporary until amp-evaluation is published to PyPI."* Once the SDK is published, this override can be removed.
- The `build-docker-image` action already supports the `context` input and falls back to `./<service-dir>` when empty, so images without a `context` field are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image build configuration by adding per-image context support, enabling customized build contexts for different container images.
  * Streamlined the release workflow by consolidating evaluation job image building and simplifying build pipeline dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->