### PR TITLE
Add Historical Range display in View Monitor page

### DIFF
--- a/console/workspaces/pages/eval/src/ViewMonitor.Component.tsx
+++ b/console/workspaces/pages/eval/src/ViewMonitor.Component.tsx
@@ -19,6 +19,7 @@
 import React, { useMemo } from "react";
 import { PageLayout } from "@agent-management-platform/views";
 import {
+  Chip,
   CircularProgress,
   Grid,
   IconButton,
@@ -101,6 +102,7 @@ export const ViewMonitorComponent: React.FC = () => {
       "Selected period",
     [timeRange],
   );
+
   const commonParams = useMemo(
     () => ({
       monitorName: monitorId ?? "",
@@ -134,6 +136,21 @@ export const ViewMonitorComponent: React.FC = () => {
 
   const isLoading = isMonitorLoading || isScoresMainLoading;
   const isRefetching = isMonitorRefetching || isScoresMainRefetching;
+
+  const isHistorical = monitorData?.type === "past";
+
+  const historicalRangeLabel = useMemo(() => {
+    if (!isHistorical) return null;
+    const fmt = (iso?: string) =>
+      iso
+        ? new Date(iso).toLocaleDateString(undefined, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          })
+        : "—";
+    return `${fmt(monitorData?.traceStart)} – ${fmt(monitorData?.traceEnd)}`;
+  }, [isHistorical, monitorData?.traceStart, monitorData?.traceEnd]);
 
   // ── raw evaluator arrays ─────────────────────────────────────────────────
   const evaluators = useMemo(() => scoresMain?.evaluators ?? [], [scoresMain]);
@@ -323,26 +340,34 @@ export const ViewMonitorComponent: React.FC = () => {
             )}
             actions={
               <Stack direction="row" spacing={1} alignItems="center">
-                <Select
-                  size="small"
-                  variant="outlined"
-                  value={timeRange}
-                  onChange={(e) =>
-                    handleTimeRangeChange(e.target.value as TraceListTimeRange)
-                  }
-                  startAdornment={
-                    <InputAdornment position="start">
-                      <Clock size={16} />
-                    </InputAdornment>
-                  }
-                  sx={{ minWidth: 140 }}
-                >
-                  {MONITOR_TIME_RANGE_OPTIONS.map((opt) => (
-                    <MenuItem key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </MenuItem>
-                  ))}
-                </Select>
+                {isHistorical ? (
+                  <Chip
+                    icon={<Clock size={14} />}
+                    label={historicalRangeLabel}
+                    variant="outlined"
+                  />
+                ) : (
+                  <Select
+                    size="small"
+                    variant="outlined"
+                    value={timeRange}
+                    onChange={(e) =>
+                      handleTimeRangeChange(e.target.value as TraceListTimeRange)
+                    }
+                    startAdornment={
+                      <InputAdornment position="start">
+                        <Clock size={16} />
+                      </InputAdornment>
+                    }
+                    sx={{ minWidth: 140 }}
+                  >
+                    {MONITOR_TIME_RANGE_OPTIONS.map((opt) => (
+                      <MenuItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                )}
                 <IconButton
                   size="small"
                   onClick={handleRefresh}


### PR DESCRIPTION
## Purpose
This pull request enhances the `ViewMonitorComponent` in the evaluation workspace by improving how historical monitors are displayed. The main change is the addition of a clear visual indicator and label for historical monitor periods, making it easier for users to distinguish between historical and current monitors.

**User interface improvements for historical monitors:**

* Added a `Chip` component with a clock icon and a formatted date range label to indicate when a monitor is historical, replacing the time range selector in this case. (`ViewMonitor.Component.tsx`)
* Introduced logic to determine if a monitor is historical (`isHistorical`) and to format and display the historical date range (`historicalRangeLabel`). (`ViewMonitor.Component.tsx`)
* Updated the UI to conditionally show either the historical range chip or the time range selector, depending on the monitor type. (`ViewMonitor.Component.tsx`)

**Component and dependency updates:**

* Imported the `Chip` component to support the new historical monitor UI. (`ViewMonitor.Component.tsx`)

**Minor refactor:**

* Added a small whitespace for readability in the memoized label code. (`ViewMonitor.Component.tsx`)

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added historical mode support to the monitor view, displaying the date range for past monitor data.
  * Replaced the time-range selector with a date-range label when viewing historical monitors, providing better context for past data analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->