### PR TITLE
Improve evaluation job logging and LLM judge retry prompt

### DIFF
--- a/evaluation-job/main.py
+++ b/evaluation-job/main.py
@@ -98,6 +98,7 @@ def configure_logging() -> None:
     handler.setFormatter(JsonFormatter(datefmt="%Y-%m-%dT%H:%M:%S"))
     logging.basicConfig(level=logging.INFO, handlers=[handler])
     logging.getLogger(__name__).setLevel(level)
+    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
 
 
 def parse_args() -> argparse.Namespace:
@@ -588,7 +589,8 @@ def main() -> None:
 
         # Log results
         logger.info(
-            "Evaluation complete traces_evaluated=%d duration=%.1fs status=%s",
+            "Evaluation complete: %d evaluator(s), %d trace(s), duration=%.1fs, status=%s",
+            len(evaluator_instances),
             result.traces_evaluated,
             result.duration_seconds,
             "SUCCESS" if result.success else "FAILED",
@@ -596,17 +598,26 @@ def main() -> None:
 
         if result.scores:
             for name, summary in result.scores.items():
+                passed = summary.count - (summary.skipped_count or 0)
+                agg_info = ""
                 agg_scores = summary.aggregated_scores
                 if "mean" in agg_scores:
-                    logger.info("Evaluator score %s mean=%.3f", name, agg_scores["mean"])
+                    agg_info = " mean=%.3f" % agg_scores["mean"]
                 elif agg_scores:
                     first_key = next(iter(agg_scores))
+                    agg_info = " %s=%s" % (first_key, agg_scores[first_key])
+
+                if summary.skipped_count and summary.skipped_count > 0:
                     logger.info(
-                        "Evaluator score %s %s=%s",
+                        "  %s: %d/%d passed (%d skipped)%s",
                         name,
-                        first_key,
-                        agg_scores[first_key],
+                        passed,
+                        summary.count,
+                        summary.skipped_count,
+                        agg_info,
                     )
+                else:
+                    logger.info("  %s: %d/%d passed%s", name, passed, summary.count, agg_info)
 
                 # Log skip reasons with unique reason breakdown
                 if summary.skipped_count and summary.skipped_count > 0:
@@ -620,12 +631,6 @@ def main() -> None:
                             continue
                         skip_reason_counts[reason] = skip_reason_counts.get(reason, 0) + 1
 
-                    logger.warning(
-                        "Evaluator %s skipped %d/%d evaluation(s)",
-                        name,
-                        summary.skipped_count,
-                        summary.count,
-                    )
                     for reason, count in skip_reason_counts.items():
                         logger.warning("  %s: %d skip(s) — reason: %s", name, count, reason)
 

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -624,8 +624,10 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
             retry_ctx = ""
             if last_error and attempt > 0:
                 retry_ctx = (
-                    f"\n\n[Previous response was invalid: {last_error}. "
-                    f"Please respond with valid JSON matching the format above.]"
+                    f"\n\n[IMPORTANT: Your previous response was invalid: {last_error}. "
+                    f"You MUST respond with ONLY a JSON object containing exactly two fields:\n"
+                    f'{{"explanation": "<your analysis>", "score": <float between 0.0 and 1.0>}}\n'
+                    f"The 'score' MUST be a top-level numeric field in the JSON, NOT embedded in the explanation text.]"
                 )
 
             try:

--- a/libs/amp-evaluation/src/amp_evaluation/runner.py
+++ b/libs/amp-evaluation/src/amp_evaluation/runner.py
@@ -318,6 +318,7 @@ class BaseRunner(ABC):
 
         for evaluator in self._evaluators:
             try:
+                logger.debug("Running evaluator '%s' on trace %s", evaluator.name, trace.trace_id)
                 # run() returns List[EvaluatorScore] already enriched with span identity
                 evaluator_scores = evaluator(trace, task)
 
@@ -361,10 +362,20 @@ class BaseRunner(ABC):
         )
 
         scores_by_evaluator: Dict[str, List[EvaluatorScore]] = {e.name: [] for e in self._evaluators}
+        total_traces = len(traces)
+        evaluator_names = [e.name for e in self._evaluators]
+        logger.info(
+            "Starting evaluation: %d trace(s) x %d evaluator(s) %s",
+            total_traces,
+            len(self._evaluators),
+            evaluator_names,
+        )
 
-        for trace in traces:
+        for idx, trace in enumerate(traces, 1):
             task = tasks.get(trace.trace_id) if tasks else None
             trial_id = trial_info.get(trace.trace_id) if trial_info else None
+
+            logger.info("Evaluating trace %d/%d trace_id=%s", idx, total_traces, trace.trace_id)
 
             try:
                 trace_scores = self.evaluate_trace(trace, task, trial_id=trial_id)


### PR DESCRIPTION
## Summary
- Suppress noisy LiteLLM INFO/DEBUG logs from evaluation job output
- Add progress logging in the evaluation runner (trace-by-trace progress with evaluator list)
- Improve the overall run summary to show per-evaluator pass/skip counts with aggregation scores
- Improve LLM-as-judge retry prompt to reduce score parsing failures

Resolves #473
  
## Test plan
- [x] Run evaluation job with multiple evaluators and verify log output shows progress and summary
- [x] Verify LiteLLM debug/info logs are suppressed
- [x] Verify skip reason breakdown appears for evaluators with skipped traces
- [x] Verify LLM judge retry prompt produces valid JSON more reliably