### PR TITLE
Improve evaluator list UX and fix tag handling

### DIFF
--- a/agent-manager-service/models/custom_evaluator.go
+++ b/agent-manager-service/models/custom_evaluator.go
@@ -62,26 +62,7 @@ func (ce *CustomEvaluator) ToEvaluatorResponse() *EvaluatorResponse {
 		provider = CustomProviderLLMJudge
 	}
 
-	// Build auto-tags from type, then append user-defined tags (deduped)
-	var autoTags []string
-	if ce.Type == CustomEvaluatorTypeCode {
-		autoTags = []string{"code"}
-	} else {
-		autoTags = []string{"llm-judge"}
-	}
-
-	seen := make(map[string]struct{}, len(autoTags)+len(ce.Tags))
-	tags := make([]string, 0, len(autoTags)+len(ce.Tags))
-	for _, t := range autoTags {
-		seen[t] = struct{}{}
-		tags = append(tags, t)
-	}
-	for _, t := range ce.Tags {
-		if _, exists := seen[t]; !exists {
-			seen[t] = struct{}{}
-			tags = append(tags, t)
-		}
-	}
+	tags := ce.Tags
 
 	// For llm_judge evaluators, prepend base config params that the user hasn't overridden.
 	configSchema := ce.ConfigSchema

--- a/console/apps/webapp/public/prompts/writing-evaluators.md
+++ b/console/apps/webapp/public/prompts/writing-evaluators.md
@@ -1,8 +1,16 @@
 # Writing Custom Evaluators — AI Copilot Reference
 
-> This guide is auto-generated from the AMP evaluation SDK.
-> It contains the framework conventions, data models, templates, and rules
-> needed to write custom evaluators.
+> This is the complete reference for writing AMP custom evaluators.
+> It contains all conventions, data models, templates, and rules needed.
+> Read the section matching your evaluator type (Code or LLM-Judge) and level (trace, agent, or llm).
+
+## Table of Contents
+
+- [Code Evaluators](#code-evaluators) — [Trace](#code-template--trace-level-trace) · [Agent](#code-template--agent-level-agenttrace) · [LLM](#code-template--llm-level-llmspan)
+- [LLM-Judge Evaluators](#llm-judge-evaluators) — [Trace](#llm-judge-template--trace-level-trace) · [Agent](#llm-judge-template--agent-level-agenttrace) · [LLM](#llm-judge-template--llm-level-llmspan)
+- [Supporting Data Models](#supporting-data-models) — Span types, agent steps, messages, metrics
+- [EvalResult](#evalresult)
+- [Common Mistakes](#common-mistakes)
 
 ## Overview
 
@@ -74,7 +82,7 @@ def my_evaluator(
 
 - `trace.input`: `str` — User input / query
 - `trace.output`: `str` — Agent output / final response
-- `trace.spans`: `List[amp_evaluation.trace.models.LLMSpan | amp_evaluation.trace.models.ToolSpan | amp_evaluation.trace.models.RetrieverSpan | amp_evaluation.trace.models.AgentSpan | amp_evaluation.trace.models.ChainSpan]` — All execution spans ordered by start time
+- `trace.spans`: `List[LLMSpan | ToolSpan | RetrieverSpan | AgentSpan | ChainSpan]` — All execution spans ordered by start time
 - `trace.metrics`: `TraceMetrics` — Aggregated performance metrics
 - `trace.format_evidence()`: `str` — Format tool results and retrieved documents for LLM-friendly display.
 - `trace.format_spans()`: `str` — Render the full span tree using parent_span_id hierarchy.
@@ -235,7 +243,7 @@ Scoring Rubric:
 
 - `trace.input`: `str` — User input / query
 - `trace.output`: `str` — Agent output / final response
-- `trace.spans`: `List[amp_evaluation.trace.models.LLMSpan | amp_evaluation.trace.models.ToolSpan | amp_evaluation.trace.models.RetrieverSpan | amp_evaluation.trace.models.AgentSpan | amp_evaluation.trace.models.ChainSpan]` — All execution spans ordered by start time
+- `trace.spans`: `List[LLMSpan | ToolSpan | RetrieverSpan | AgentSpan | ChainSpan]` — All execution spans ordered by start time
 - `trace.metrics`: `TraceMetrics` — Aggregated performance metrics
 - `trace.format_evidence()`: `str` — Format tool results and retrieved documents for LLM-friendly display.
 - `trace.format_spans()`: `str` — Render the full span tree using parent_span_id hierarchy.
@@ -340,6 +348,159 @@ Scoring Rubric:
 - `llm_span.get_system_messages()`: `List[SystemMessage]` — Get system messages only.
 - `llm_span.get_tool_messages()`: `List[ToolMessage]` — Get tool result messages only.
 - `llm_span.get_user_messages()`: `List[UserMessage]` — Get user messages only.
+
+## Supporting Data Models
+
+These types appear as fields or return values in the main evaluator input types above. Refer to them when writing evaluators that inspect spans, steps, messages, or metrics.
+
+### Span Types
+
+**AgentSpan**
+
+- `agentSpan.name`: `str` — Name of the agent
+- `agentSpan.framework`: `str` — Framework (crewai, langchain, openai_agents, etc.)
+- `agentSpan.model`: `str` — LLM model used by the agent
+- `agentSpan.system_prompt`: `str` — System prompt / instructions
+- `agentSpan.available_tools`: `List[ToolDefinition]` — Tools available to the agent
+- `agentSpan.max_iterations`: `int | None` — Maximum iterations allowed
+- `agentSpan.input`: `str` — Agent input
+- `agentSpan.output`: `str` — Agent output
+- `agentSpan.metrics`: `AgentMetrics` — Agent performance metrics
+
+**ChainSpan**
+
+
+
+**RetrieverSpan**
+
+- `retrieverSpan.query`: `str` — Retrieval query
+- `retrieverSpan.documents`: `List[RetrievedDoc]` — Retrieved documents
+- `retrieverSpan.vector_db`: `str` — Vector database used
+- `retrieverSpan.top_k`: `int` — Number of documents requested
+- `retrieverSpan.metrics`: `RetrieverMetrics` — Retrieval performance metrics
+
+**ToolSpan**
+
+- `toolSpan.name`: `str` — Tool name
+- `toolSpan.arguments`: `Dict[str, Any]` — Arguments passed to the tool
+- `toolSpan.result`: `Any` — Execution result
+
+### Agent Step Types
+
+**LLMReasoningStep**
+
+- `lLMReasoningStep.content`: `str` — LLM response text
+- `lLMReasoningStep.tool_calls`: `List[ToolCallInfo]` — Tool calls requested by the LLM
+- `lLMReasoningStep.is_response`: `bool` — True if this is a final response (no tool calls requested).
+
+**ToolExecutionStep**
+
+- `toolExecutionStep.tool_name`: `str` — Name of the tool
+- `toolExecutionStep.tool_input`: `Dict[str, Any] | None` — Input passed to the tool
+- `toolExecutionStep.tool_output`: `Any | None` — Output returned by the tool
+- `toolExecutionStep.content`: `str` — What was fed back to the LLM
+- `toolExecutionStep.error`: `str | None` — Error message if failed
+- `toolExecutionStep.duration_ms`: `float | None` — Execution duration in milliseconds
+- `toolExecutionStep.nested_traces`: `List[LLMSpan | AgentTrace]` — Nested LLM calls or sub-agent traces
+
+**UserInputStep**
+
+- `userInputStep.content`: `str` — User message content
+
+### Message Types
+
+**AssistantMessage**
+
+- `assistantMessage.content`: `str` — Response text
+- `assistantMessage.tool_calls`: `List[ToolCall]` — Tool calls requested
+
+**SystemMessage**
+
+- `systemMessage.content`: `str` — System prompt text
+
+**ToolMessage**
+
+- `toolMessage.content`: `str` — Tool result text
+- `toolMessage.tool_call_id`: `str` — ID of the originating tool call
+
+**UserMessage**
+
+- `userMessage.content`: `str` — User input text
+
+### Metrics
+
+**AgentMetrics**
+
+- `agentMetrics.duration_ms`: `float` — Span duration in milliseconds
+- `agentMetrics.error`: `bool` — Whether an error occurred
+- `agentMetrics.error_type`: `str | None` — Error type if an error occurred
+- `agentMetrics.error_message`: `str | None` — Error message if an error occurred
+- `agentMetrics.token_usage`: `TokenUsage` — Token usage breakdown
+
+**LLMMetrics**
+
+- `lLMMetrics.duration_ms`: `float` — Span duration in milliseconds
+- `lLMMetrics.error`: `bool` — Whether an error occurred
+- `lLMMetrics.error_type`: `str | None` — Error type if an error occurred
+- `lLMMetrics.error_message`: `str | None` — Error message if an error occurred
+- `lLMMetrics.token_usage`: `TokenUsage` — Token usage breakdown
+- `lLMMetrics.time_to_first_token_ms`: `float | None` — Time to first token in milliseconds
+
+**RetrieverMetrics**
+
+- `retrieverMetrics.duration_ms`: `float` — Span duration in milliseconds
+- `retrieverMetrics.error`: `bool` — Whether an error occurred
+- `retrieverMetrics.error_type`: `str | None` — Error type if an error occurred
+- `retrieverMetrics.error_message`: `str | None` — Error message if an error occurred
+- `retrieverMetrics.documents_retrieved`: `int` — Number of documents retrieved
+
+**TokenUsage**
+
+- `tokenUsage.input_tokens`: `int` — Number of input tokens
+- `tokenUsage.output_tokens`: `int` — Number of output tokens
+- `tokenUsage.total_tokens`: `int` — Total tokens (input + output)
+- `tokenUsage.cache_read_tokens`: `int` — Cached prompt tokens (if supported)
+
+**ToolMetrics**
+
+- `toolMetrics.duration_ms`: `float` — Span duration in milliseconds
+- `toolMetrics.error`: `bool` — Whether an error occurred
+- `toolMetrics.error_type`: `str | None` — Error type if an error occurred
+- `toolMetrics.error_message`: `str | None` — Error message if an error occurred
+
+**TraceMetrics**
+
+- `traceMetrics.total_duration_ms`: `float` — Total trace duration in milliseconds
+- `traceMetrics.token_usage`: `TokenUsage` — Aggregated token usage across all LLM calls
+- `traceMetrics.error_count`: `int` — Number of spans with errors
+- `traceMetrics.has_errors`: `bool` — Check if any errors occurred in the trace.
+
+### Other
+
+**RetrievedDoc**
+
+- `retrievedDoc.id`: `str` — Document identifier
+- `retrievedDoc.content`: `str` — Document content
+- `retrievedDoc.score`: `float` — Relevance score
+- `retrievedDoc.metadata`: `Dict[str, Any]` — Document metadata
+
+**ToolCall**
+
+- `toolCall.id`: `str` — Unique tool call identifier
+- `toolCall.name`: `str` — Name of the tool
+- `toolCall.arguments`: `Dict[str, Any]` — Arguments passed to the tool
+
+**ToolCallInfo**
+
+- `toolCallInfo.id`: `str` — Unique tool call identifier
+- `toolCallInfo.name`: `str` — Name of the tool
+- `toolCallInfo.arguments`: `Dict[str, Any]` — Arguments passed
+
+**ToolDefinition**
+
+- `toolDefinition.name`: `str` — Tool name
+- `toolDefinition.description`: `str` — Tool description
+- `toolDefinition.parameters`: `str` — JSON schema of parameters
 
 ### EvalResult
 

--- a/console/workspaces/pages/eval/scripts/generate-evaluator-models.sh
+++ b/console/workspaces/pages/eval/scripts/generate-evaluator-models.sh
@@ -257,10 +257,10 @@ lines.append('')
 # ---------------------------------------------------------------------------
 
 lines.append('// ---------------------------------------------------------------------------')
-lines.append('// AI Copilot prompts (short, copy-paste prompts per type/level)')
+lines.append('// AI Copilot prompt template (single template, resolved at runtime)')
 lines.append('// ---------------------------------------------------------------------------')
 lines.append('')
-lines.append(f'export const AI_COPILOT_PROMPTS: Record<"code" | "llm_judge", Record<EvaluatorLevel, string>> = {json.dumps(schema["ai_copilot_prompts"], indent=2)};')
+lines.append(f'export const AI_COPILOT_PROMPT_TEMPLATE: string = {json.dumps(schema["ai_copilot_prompt_template"])};')
 lines.append('')
 lines.append('')
 

--- a/console/workspaces/pages/eval/src/EvalEvaluators.Component.tsx
+++ b/console/workspaces/pages/eval/src/EvalEvaluators.Component.tsx
@@ -164,291 +164,313 @@ export const EvalEvaluatorsComponent: React.FC = () => {
 
   return (
     <>
-    <PageLayout
-      title="Evaluators"
-      disableIcon
-      actions={
-        <Button
-          variant="contained"
-          component={Link}
-          to={generatePath(
-            evaluatorsRouteMap.children.create.path,
-            routeParams,
+      <PageLayout
+        title="Evaluators"
+        disableIcon
+        actions={
+          <Button
+            variant="contained"
+            component={Link}
+            to={generatePath(
+              evaluatorsRouteMap.children.create.path,
+              routeParams,
+            )}
+            startIcon={<Plus />}
+            color="primary"
+          >
+            Create Evaluator
+          </Button>
+        }
+      >
+        <Stack spacing={2}>
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            justifyContent="space-between"
+            flexWrap="wrap"
+            useFlexGap
+          >
+            <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+              {sourceFilterOptions.map((option) => (
+                <Chip
+                  key={option.value}
+                  label={option.label}
+                  variant={
+                    sourceFilter === option.value ? "filled" : "outlined"
+                  }
+                  color={sourceFilter === option.value ? "primary" : "default"}
+                  onClick={() => {
+                    setSourceFilter(option.value);
+                    setPage(0);
+                  }}
+                />
+              ))}
+            </Stack>
+            <SearchBar
+              placeholder="Search evaluators"
+              size="small"
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value);
+                debouncedSetSearch(event.target.value);
+              }}
+              disabled={isLoading}
+            />
+          </Stack>
+
+          {evaluatorsError && (
+            <Alert severity="error">
+              {evaluatorsError instanceof Error
+                ? evaluatorsError.message
+                : "Failed to load evaluators"}
+            </Alert>
           )}
-          startIcon={<Plus />}
-          color="primary"
-        >
-          Create Evaluator
-        </Button>
-      }
-    >
-      <Stack spacing={2}>
-        <Stack
-          direction="row"
-          spacing={1}
-          alignItems="center"
-          justifyContent="space-between"
-          flexWrap="wrap"
-          useFlexGap
-        >
-          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-            {sourceFilterOptions.map((option) => (
-              <Chip
-                key={option.value}
-                label={option.label}
-                variant={sourceFilter === option.value ? "filled" : "outlined"}
-                color={sourceFilter === option.value ? "primary" : "default"}
-                onClick={() => {
-                  setSourceFilter(option.value);
-                  setPage(0);
-                }}
-              />
-            ))}
-          </Stack>
-          <SearchBar
-            placeholder="Search evaluators"
-            size="small"
-            value={search}
-            onChange={(event) => {
-              setSearch(event.target.value);
-              debouncedSetSearch(event.target.value);
-            }}
-            disabled={isLoading}
-          />
-        </Stack>
 
-        {evaluatorsError && (
-          <Alert severity="error">
-            {evaluatorsError instanceof Error
-              ? evaluatorsError.message
-              : "Failed to load evaluators"}
-          </Alert>
-        )}
+          {isLoading && (
+            <Stack direction="row" gap={1}>
+              <Skeleton variant="rounded" height={180} width="100%" />
+              <Skeleton variant="rounded" height={180} width="100%" />
+              <Skeleton variant="rounded" height={180} width="100%" />
+              <Skeleton variant="rounded" height={180} width="100%" />
+            </Stack>
+          )}
 
+          {!isLoading &&
+            !evaluatorsError &&
+            evaluators.length === 0 &&
+            !search.trim() && (
+              <ListingTable.Container sx={{ my: 3 }}>
+                <ListingTable.EmptyState
+                  illustration={<CircleIcon size={64} />}
+                  title="No evaluators yet"
+                  description="Create a custom evaluator or browse built-in evaluators."
+                />
+              </ListingTable.Container>
+            )}
 
-        {isLoading && (
-          <Stack direction="row" gap={1}>
-            <Skeleton variant="rounded" height={180} width="100%" />
-            <Skeleton variant="rounded" height={180} width="100%" />
-            <Skeleton variant="rounded" height={180} width="100%" />
-            <Skeleton variant="rounded" height={180} width="100%" />
-          </Stack>
-        )}
-
-        {!isLoading &&
-          !evaluatorsError &&
-          evaluators.length === 0 &&
-          !search.trim() && (
+          {evaluators.length === 0 && !isLoading && search.trim() && (
             <ListingTable.Container sx={{ my: 3 }}>
               <ListingTable.EmptyState
-                illustration={<CircleIcon size={64} />}
-                title="No evaluators yet"
-                description="Create a custom evaluator or browse built-in evaluators."
+                illustration={<SearchIcon size={64} />}
+                title="No evaluators match your search"
+                description="Try a different keyword or clear the search filter."
               />
             </ListingTable.Container>
           )}
 
-        {evaluators.length === 0 && !isLoading && search.trim() && (
-          <ListingTable.Container sx={{ my: 3 }}>
-            <ListingTable.EmptyState
-              illustration={<SearchIcon size={64} />}
-              title="No evaluators match your search"
-              description="Try a different keyword or clear the search filter."
-            />
-          </ListingTable.Container>
-        )}
-
-        {evaluators.length > 0 && (
-          <SectionErrorBoundary fallbackMessage="Failed to render evaluator list. Click Retry to try again.">
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: {
-                xs: "repeat(auto-fill, minmax(260px, 1fr))",
-                md: "repeat(auto-fill, minmax(300px, 1fr))",
-              },
-              gap: 2,
-            }}
-          >
-            {evaluators.map((evaluator) => (
+          {evaluators.length > 0 && (
+            <SectionErrorBoundary fallbackMessage="Failed to render evaluator list. Click Retry to try again.">
               <Box
-                key={evaluator.identifier}
-                role="button"
-                tabIndex={0}
-                onClick={() =>
-                  navigate(
-                    generatePath(evaluatorsRouteMap.children.view.path, {
-                      ...routeParams,
-                      evaluatorId: evaluator.identifier,
-                    }),
-                  )
-                }
-                onKeyDown={(e) => {
-                  if (e.target !== e.currentTarget) return;
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    navigate(
-                      generatePath(evaluatorsRouteMap.children.view.path, {
-                        ...routeParams,
-                        evaluatorId: evaluator.identifier,
-                      }),
-                    );
-                  }
-                }}
                 sx={{
-                  border: 1,
-                  borderColor: "divider",
-                  borderRadius: 2,
-                  p: 0,
-                  display: "flex",
-                  flexDirection: "column",
-                  cursor: "pointer",
-                  "&:hover": {
-                    borderColor: "primary.main",
-                    boxShadow: 1,
+                  display: "grid",
+                  gridTemplateColumns: {
+                    xs: "repeat(auto-fill, minmax(260px, 1fr))",
+                    md: "repeat(auto-fill, minmax(300px, 1fr))",
                   },
+                  gap: 2,
                 }}
               >
-                <CardHeader
-                  title={
-                    <Stack direction="column" spacing={1}>
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <Typography
-                          variant="h6"
-                          textOverflow="ellipsis"
-                          overflow="hidden"
-                          whiteSpace="nowrap"
-                          maxWidth="70%"
-                        >
-                          {evaluator.displayName}
-                        </Typography>
-                        <Chip
-                          label={getSourceLabel(evaluator)}
-                          size="small"
-                          variant="outlined"
-                          color={getSourceColor(evaluator)}
-                        />
-                        {evaluator.level && (
-                          <Chip
-                            label={
-                              evaluator.level.charAt(0).toUpperCase() +
-                              evaluator.level.slice(1)
-                            }
-                            size="small"
-                            variant="outlined"
-                          />
-                        )}
-                      </Stack>
-                      {(() => {
-                        const tags = evaluator.tags ?? [];
-                        return tags.length > 0 ? (
+                {evaluators.map((evaluator) => (
+                  <Box
+                    key={evaluator.identifier}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() =>
+                      navigate(
+                        generatePath(evaluatorsRouteMap.children.view.path, {
+                          ...routeParams,
+                          evaluatorId: evaluator.identifier,
+                        }),
+                      )
+                    }
+                    onKeyDown={(e) => {
+                      if (e.target !== e.currentTarget) return;
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        navigate(
+                          generatePath(evaluatorsRouteMap.children.view.path, {
+                            ...routeParams,
+                            evaluatorId: evaluator.identifier,
+                          }),
+                        );
+                      }
+                    }}
+                    sx={{
+                      border: 1,
+                      borderColor: "divider",
+                      borderRadius: 2,
+                      p: 0,
+                      display: "flex",
+                      flexDirection: "column",
+                      cursor: "pointer",
+                      overflow: "hidden",
+                      "&:hover": {
+                        borderColor: "primary.main",
+                        boxShadow: 1,
+                      },
+                    }}
+                  >
+                    <CardHeader
+                      sx={{
+                        overflow: "hidden",
+                        "& .MuiCardHeader-content": { overflow: "hidden" },
+                      }}
+                      title={
+                        <Stack direction="column" spacing={1}>
                           <Stack
                             direction="row"
                             spacing={1}
                             alignItems="center"
+                            sx={{ minWidth: 0, overflow: "hidden" }}
                           >
-                            {tags.slice(0, 3).map((tag) => (
+                            <Tooltip
+                              title={evaluator.displayName}
+                              placement="top"
+                            >
+                              <Typography
+                                variant="h6"
+                                textOverflow="ellipsis"
+                                overflow="hidden"
+                                whiteSpace="nowrap"
+                                sx={{ flexShrink: 1, minWidth: 0 }}
+                              >
+                                {evaluator.displayName}
+                              </Typography>
+                            </Tooltip>
+                            <Chip
+                              label={getSourceLabel(evaluator)}
+                              size="small"
+                              variant="outlined"
+                              color={getSourceColor(evaluator)}
+                              sx={{ flexShrink: 0 }}
+                            />
+                            {evaluator.level && (
                               <Chip
-                                key={tag}
+                                label={
+                                  evaluator.level.charAt(0).toUpperCase() +
+                                  evaluator.level.slice(1)
+                                }
                                 size="small"
-                                label={tag}
                                 variant="outlined"
+                                color="primary"
+                                sx={{ flexShrink: 0 }}
                               />
-                            ))}
-                            {tags.length > 3 && (
-                              <Tooltip title={tags.join(", ")} placement="top">
-                                <Typography
-                                  variant="caption"
-                                  color="text.secondary"
-                                >
-                                  {`+${tags.length - 3} more`}
-                                </Typography>
-                              </Tooltip>
                             )}
                           </Stack>
-                        ) : null;
-                      })()}
-                    </Stack>
-                  }
-                />
-                <CardContent sx={{ flexGrow: 1 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    {evaluator.description}
-                  </Typography>
-                </CardContent>
-                {!evaluator.isBuiltin && (
-                  <Stack
-                    direction="row"
-                    justifyContent="flex-end"
-                    spacing={1}
-                    px={2}
-                    pb={1}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Button
-                      size="small"
-                      variant="text"
-                      startIcon={<EditIcon size={14} />}
-                      onClick={() =>
-                        navigate(
-                          generatePath(
-                            evaluatorsRouteMap.children.view.path,
-                            {
-                              ...routeParams,
-                              evaluatorId: evaluator.identifier,
-                            },
-                          ),
-                          { state: { edit: true } },
-                        )
+                          {(() => {
+                            const tags = evaluator.tags ?? [];
+                            return tags.length > 0 ? (
+                              <Stack
+                                direction="row"
+                                spacing={1}
+                                alignItems="center"
+                              >
+                                {tags.slice(0, 3).map((tag) => (
+                                  <Chip
+                                    key={tag}
+                                    size="small"
+                                    label={tag}
+                                    variant="outlined"
+                                  />
+                                ))}
+                                {tags.length > 3 && (
+                                  <Tooltip
+                                    title={tags.join(", ")}
+                                    placement="top"
+                                  >
+                                    <Typography
+                                      variant="caption"
+                                      color="text.secondary"
+                                    >
+                                      {`+${tags.length - 3} more`}
+                                    </Typography>
+                                  </Tooltip>
+                                )}
+                              </Stack>
+                            ) : null;
+                          })()}
+                        </Stack>
                       }
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      size="small"
-                      variant="text"
-                      color="error"
-                      startIcon={<Trash size={14} />}
-                      onClick={() => handleDelete(evaluator)}
-                    >
-                      Delete
-                    </Button>
-                  </Stack>
-                )}
+                    />
+                    <CardContent sx={{ flexGrow: 1 }}>
+                      <Typography variant="caption" color="text.secondary">
+                        {evaluator.description}
+                      </Typography>
+                    </CardContent>
+                    {!evaluator.isBuiltin && (
+                      <Stack
+                        direction="row"
+                        justifyContent="flex-end"
+                        spacing={1}
+                        px={2}
+                        pb={1}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Button
+                          size="small"
+                          variant="text"
+                          startIcon={<EditIcon size={14} />}
+                          onClick={() =>
+                            navigate(
+                              generatePath(
+                                evaluatorsRouteMap.children.view.path,
+                                {
+                                  ...routeParams,
+                                  evaluatorId: evaluator.identifier,
+                                },
+                              ),
+                              { state: { edit: true } },
+                            )
+                          }
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          size="small"
+                          variant="text"
+                          color="error"
+                          startIcon={<Trash size={14} />}
+                          onClick={() => handleDelete(evaluator)}
+                        >
+                          Delete
+                        </Button>
+                      </Stack>
+                    )}
+                  </Box>
+                ))}
               </Box>
-            ))}
-          </Box>
-          </SectionErrorBoundary>
-        )}
+            </SectionErrorBoundary>
+          )}
 
-        {totalItems > rowsPerPage && (
-          <TablePagination
-            component="div"
-            count={totalItems}
-            page={page}
-            rowsPerPage={rowsPerPage}
-            onPageChange={(_event, newPage) => setPage(newPage)}
-            onRowsPerPageChange={(event) => {
-              const next = parseInt(event.target.value, 10);
-              setRowsPerPage(next);
-              setPage(0);
-            }}
-            rowsPerPageOptions={[6, 12, 24]}
-          />
-        )}
-      </Stack>
-    </PageLayout>
-    <Snackbar
-      open={!!deleteError}
-      autoHideDuration={6000}
-      onClose={resetDeleteError}
-      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-    >
-      <Alert onClose={resetDeleteError} severity="error">
-        {(deleteError as { message?: string })?.message ||
-          "Failed to delete evaluator"}
-      </Alert>
-    </Snackbar>
+          {totalItems > rowsPerPage && (
+            <TablePagination
+              component="div"
+              count={totalItems}
+              page={page}
+              rowsPerPage={rowsPerPage}
+              onPageChange={(_event, newPage) => setPage(newPage)}
+              onRowsPerPageChange={(event) => {
+                const next = parseInt(event.target.value, 10);
+                setRowsPerPage(next);
+                setPage(0);
+              }}
+              rowsPerPageOptions={[6, 12, 24]}
+            />
+          )}
+        </Stack>
+      </PageLayout>
+      <Snackbar
+        open={!!deleteError}
+        autoHideDuration={6000}
+        onClose={resetDeleteError}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert onClose={resetDeleteError} severity="error">
+          {(deleteError as { message?: string })?.message ||
+            "Failed to delete evaluator"}
+        </Alert>
+      </Snackbar>
     </>
   );
 };

--- a/console/workspaces/pages/eval/src/ViewEvaluator.Component.tsx
+++ b/console/workspaces/pages/eval/src/ViewEvaluator.Component.tsx
@@ -182,7 +182,10 @@ function registerEditorProviders(monaco: Monaco) {
   };
 
   return [
-    monaco.languages.registerCompletionItemProvider("python", completionProvider),
+    monaco.languages.registerCompletionItemProvider(
+      "python",
+      completionProvider,
+    ),
     monaco.languages.registerHoverProvider("python", hoverProvider),
     monaco.languages.registerCompletionItemProvider(
       LLM_JUDGE_LANG,
@@ -324,7 +327,14 @@ function formatDefault(value: unknown): string {
   return String(value);
 }
 
-const PARAM_TYPES = ["string", "integer", "float", "boolean", "array", "enum"] as const;
+const PARAM_TYPES = [
+  "string",
+  "integer",
+  "float",
+  "boolean",
+  "array",
+  "enum",
+] as const;
 
 const emptyParam = (): EvaluatorConfigParam => ({
   key: "",
@@ -405,11 +415,7 @@ function EditableConfigParams({
 
   return (
     <Box>
-      <Stack
-        direction="row"
-        justifyContent="space-between"
-        alignItems="center"
-      >
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
         <Box>
           <Typography variant="subtitle2" gutterBottom>
             Configuration Parameters
@@ -441,7 +447,13 @@ function EditableConfigParams({
             }}
           >
             <Stack spacing={1}>
-              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                flexWrap="wrap"
+                useFlexGap
+              >
                 <TextField
                   placeholder="Key"
                   size="small"
@@ -474,10 +486,13 @@ function EditableConfigParams({
                 <TextField
                   placeholder="Default"
                   size="small"
-                  value={param.default !== undefined ? String(param.default) : ""}
+                  value={
+                    param.default !== undefined ? String(param.default) : ""
+                  }
                   onChange={(e) =>
                     updateParam(idx, {
-                      default: e.target.value === "" ? undefined : e.target.value,
+                      default:
+                        e.target.value === "" ? undefined : e.target.value,
                     })
                   }
                   sx={{ flex: 1.5, minWidth: 100 }}
@@ -486,7 +501,9 @@ function EditableConfigParams({
                   placeholder="Description"
                   size="small"
                   value={param.description}
-                  onChange={(e) => updateParam(idx, { description: e.target.value })}
+                  onChange={(e) =>
+                    updateParam(idx, { description: e.target.value })
+                  }
                   sx={{ flex: 3, minWidth: 150 }}
                 />
                 <FormControlLabel
@@ -494,7 +511,9 @@ function EditableConfigParams({
                     <Checkbox
                       size="small"
                       checked={!!param.required}
-                      onChange={(e) => updateParam(idx, { required: e.target.checked })}
+                      onChange={(e) =>
+                        updateParam(idx, { required: e.target.checked })
+                      }
                     />
                   }
                   label="Required"
@@ -514,7 +533,10 @@ function EditableConfigParams({
                     value={param.min !== undefined ? param.min : ""}
                     onChange={(e) =>
                       updateParam(idx, {
-                        min: e.target.value === "" ? undefined : Number(e.target.value),
+                        min:
+                          e.target.value === ""
+                            ? undefined
+                            : Number(e.target.value),
                       })
                     }
                     sx={{ flex: 1 }}
@@ -526,7 +548,10 @@ function EditableConfigParams({
                     value={param.max !== undefined ? param.max : ""}
                     onChange={(e) =>
                       updateParam(idx, {
-                        max: e.target.value === "" ? undefined : Number(e.target.value),
+                        max:
+                          e.target.value === ""
+                            ? undefined
+                            : Number(e.target.value),
                       })
                     }
                     sx={{ flex: 1 }}
@@ -653,7 +678,7 @@ export const ViewEvaluatorComponent: React.FC = () => {
 
   const evaluatorsRouteMap = agentId
     ? absoluteRouteMap.children.org.children.projects.children.agents.children
-      .evaluation.children.evaluators
+        .evaluation.children.evaluators
     : absoluteRouteMap.children.org.children.projects.children.evaluators;
 
   const routeParams = agentId
@@ -697,7 +722,12 @@ export const ViewEvaluatorComponent: React.FC = () => {
     if (!evaluator) return;
     // For LLM judge, the API response prepends base config params (model, temperature, etc.)
     // Strip them so the user only edits their custom params.
-    const baseKeys = new Set(["model", "temperature", "max_tokens", "max_retries"]);
+    const baseKeys = new Set([
+      "model",
+      "temperature",
+      "max_tokens",
+      "max_retries",
+    ]);
     const configSchema = evaluator.configSchema
       ? evaluator.type === "llm_judge"
         ? evaluator.configSchema.filter((p) => !baseKeys.has(p.key))
@@ -771,7 +801,6 @@ export const ViewEvaluatorComponent: React.FC = () => {
     }
   }, []);
 
-   
   const handleEditorDidMount = useCallback(
     (editor: any, monaco: Monaco) => {
       editorRef.current = editor;
@@ -823,7 +852,9 @@ export const ViewEvaluatorComponent: React.FC = () => {
         backLabel="Back to Evaluators"
         disableIcon
       >
-        <Alert severity="error">Failed to load evaluator. Please try again.</Alert>
+        <Alert severity="error">
+          Failed to load evaluator. Please try again.
+        </Alert>
       </PageLayout>
     );
   }
@@ -886,6 +917,7 @@ export const ViewEvaluatorComponent: React.FC = () => {
               }
               variant="outlined"
               size="small"
+              color="primary"
             />
           </Stack>
         ) : undefined
@@ -955,6 +987,7 @@ export const ViewEvaluatorComponent: React.FC = () => {
               }
               variant="outlined"
               size="small"
+              color="primary"
             />
           </Stack>
         )}
@@ -1038,10 +1071,10 @@ export const ViewEvaluatorComponent: React.FC = () => {
                   onChange={
                     isEditing
                       ? (value) =>
-                        setEditValues((prev) => ({
-                          ...prev,
-                          source: value ?? "",
-                        }))
+                          setEditValues((prev) => ({
+                            ...prev,
+                            source: value ?? "",
+                          }))
                       : undefined
                   }
                   beforeMount={handleEditorBeforeMount}

--- a/console/workspaces/pages/eval/src/generated/evaluator-models.generated.ts
+++ b/console/workspaces/pages/eval/src/generated/evaluator-models.generated.ts
@@ -3135,21 +3135,10 @@ export const LLM_JUDGE_VARIABLES: Record<EvaluatorLevel, LLMJudgeLevelInfo> = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// AI Copilot prompts (short, copy-paste prompts per type/level)
+// AI Copilot prompt template (single template, resolved at runtime)
 // ---------------------------------------------------------------------------
 
-export const AI_COPILOT_PROMPTS: Record<"code" | "llm_judge", Record<EvaluatorLevel, string>> = {
-  "code": {
-    "trace": "Write a custom code evaluator (trace-level) for the AMP evaluation framework.\n\nThe evaluator is a Python function that receives a `Trace` object and returns an `EvalResult`.\n\n## What it should evaluate\n[Describe your evaluation criteria here]\n\n## Framework reference\nFollow the conventions and data models described in:\n{{GUIDE_URL}}",
-    "agent": "Write a custom code evaluator (agent-level) for the AMP evaluation framework.\n\nThe evaluator is a Python function that receives a `AgentTrace` object and returns an `EvalResult`.\n\n## What it should evaluate\n[Describe your evaluation criteria here]\n\n## Framework reference\nFollow the conventions and data models described in:\n{{GUIDE_URL}}",
-    "llm": "Write a custom code evaluator (llm-level) for the AMP evaluation framework.\n\nThe evaluator is a Python function that receives a `LLMSpan` object and returns an `EvalResult`.\n\n## What it should evaluate\n[Describe your evaluation criteria here]\n\n## Framework reference\nFollow the conventions and data models described in:\n{{GUIDE_URL}}"
-  },
-  "llm_judge": {
-    "trace": "Write a custom LLM-judge evaluator prompt (trace-level) for the AMP evaluation framework.\n\nThe evaluator is a prompt template string (not Python code). Use {trace.*} expressions to access Trace fields. Python f-string expressions are supported inside curly braces.\n\n## What it should evaluate\n[Describe your evaluation criteria here]\n\n## Framework reference\nFollow the conventions and data models described in:\n{{GUIDE_URL}}",
-    "agent": "Write a custom LLM-judge evaluator prompt (agent-level) for the AMP evaluation framework.\n\nThe evaluator is a prompt template string (not Python code). Use {agent_trace.*} expressions to access AgentTrace fields. Python f-string expressions are supported inside curly braces.\n\n## What it should evaluate\n[Describe your evaluation criteria here]\n\n## Framework reference\nFollow the conventions and data models described in:\n{{GUIDE_URL}}",
-    "llm": "Write a custom LLM-judge evaluator prompt (llm-level) for the AMP evaluation framework.\n\nThe evaluator is a prompt template string (not Python code). Use {llm_span.*} expressions to access LLMSpan fields. Python f-string expressions are supported inside curly braces.\n\n## What it should evaluate\n[Describe your evaluation criteria here]\n\n## Framework reference\nFollow the conventions and data models described in:\n{{GUIDE_URL}}"
-  }
-};
+export const AI_COPILOT_PROMPT_TEMPLATE: string = "Write a custom {{TYPE}} {{LEVEL}} evaluator. It should evaluate:\n[Describe scenario]\n\n## Evaluator details\n- **Name**: {{EVALUATOR_NAME}}\n- **Description**: {{EVALUATOR_DESCRIPTION}}\n\nAlways refer to this framework reference: {{GUIDE_URL}}";
 
 
 // ---------------------------------------------------------------------------

--- a/console/workspaces/pages/eval/src/subComponents/EvaluatorDetailsDrawer.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/EvaluatorDetailsDrawer.tsx
@@ -425,7 +425,7 @@ export function EvaluatorDetailsDrawer({
   const [savedConfig, setSavedConfig] = useState<Record<string, unknown>>({});
   const { addConfirmation } = useConfirmationDialog();
 
-  const isLlmJudge = Boolean(evaluator?.tags?.includes("llm-judge"));
+  const isLlmJudge = evaluator?.type === "llm_judge";
   const isShowLLMProviderConfigs =
     isLlmJudge && onLLMProviderConfigsChange && llmProviders.length > 0;
 

--- a/console/workspaces/pages/eval/src/subComponents/EvaluatorForm.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/EvaluatorForm.tsx
@@ -49,14 +49,17 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import { Link } from "react-router-dom";
 import Editor, { type Monaco } from "@monaco-editor/react";
-import type { EvaluatorConfigParam, EvaluatorLevel } from "@agent-management-platform/types";
+import type {
+  EvaluatorConfigParam,
+  EvaluatorLevel,
+} from "@agent-management-platform/types";
 import {
   DataModelReferenceDrawer,
   type ReferenceTypeKey,
 } from "./DataModelReferenceDrawer";
 import { SectionErrorBoundary } from "./SectionErrorBoundary";
 import {
-  AI_COPILOT_PROMPTS,
+  AI_COPILOT_PROMPT_TEMPLATE,
   LLM_JUDGE_BASE_CONFIG_SCHEMA,
   LLM_JUDGE_TEMPLATES,
   LLM_JUDGE_VARIABLES,
@@ -71,10 +74,34 @@ import {
 // AI copilot prompt helper
 // ---------------------------------------------------------------------------
 
-function resolveAiPrompt(type: string, level: EvaluatorLevel): string {
-  const raw = AI_COPILOT_PROMPTS[type as "code" | "llm_judge"]?.[level] ?? "";
+const _TYPE_LABELS: Record<string, string> = {
+  code: "code",
+  llm_judge: "LLM-judge",
+};
+const _LEVEL_LABELS: Record<string, string> = {
+  trace: "trace-level",
+  agent: "agent-level",
+  llm: "llm-level",
+};
+
+function resolveAiPrompt(
+  type: string,
+  level: EvaluatorLevel,
+  displayName: string,
+  description: string,
+): string {
   const guideUrl = `${window.location.origin}/prompts/writing-evaluators.md`;
-  return raw.replace("{{GUIDE_URL}}", guideUrl);
+  return AI_COPILOT_PROMPT_TEMPLATE.replace(
+    "{{TYPE}}",
+    _TYPE_LABELS[type] ?? type,
+  )
+    .replace("{{LEVEL}}", _LEVEL_LABELS[level] ?? level)
+    .replace("{{GUIDE_URL}}", guideUrl)
+    .replace("{{EVALUATOR_NAME}}", displayName || "[add name here]")
+    .replace(
+      "{{EVALUATOR_DESCRIPTION}}",
+      description || "[add description here]",
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -172,7 +199,10 @@ function registerEditorProviders(monaco: Monaco) {
 
   // Register for both Python (code evaluator) and LLM judge prompt language
   return [
-    monaco.languages.registerCompletionItemProvider("python", completionProvider),
+    monaco.languages.registerCompletionItemProvider(
+      "python",
+      completionProvider,
+    ),
     monaco.languages.registerHoverProvider("python", hoverProvider),
     monaco.languages.registerCompletionItemProvider(
       LLM_JUDGE_LANG,
@@ -393,11 +423,41 @@ const PYTHON_TYPE_MAP: Record<string, string> = {
 };
 
 const PYTHON_KEYWORDS = new Set([
-  "False","None","True","and","as","assert","async","await",
-  "break","class","continue","def","del","elif","else","except",
-  "finally","for","from","global","if","import","in","is",
-  "lambda","nonlocal","not","or","pass","raise","return","try",
-  "while","with","yield",
+  "False",
+  "None",
+  "True",
+  "and",
+  "as",
+  "assert",
+  "async",
+  "await",
+  "break",
+  "class",
+  "continue",
+  "def",
+  "del",
+  "elif",
+  "else",
+  "except",
+  "finally",
+  "for",
+  "from",
+  "global",
+  "if",
+  "import",
+  "in",
+  "is",
+  "lambda",
+  "nonlocal",
+  "not",
+  "or",
+  "pass",
+  "raise",
+  "return",
+  "try",
+  "while",
+  "with",
+  "yield",
 ]);
 
 const VALID_PY_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -439,10 +499,7 @@ export function validateParamKeys(
   return undefined;
 }
 
-function formatParamDefault(
-  value: unknown,
-  type: string,
-): string {
+function formatParamDefault(value: unknown, type: string): string {
   if (value === undefined || value === "") return "";
   if (type === "string" || type === "enum") return `"${escapePyString(value)}"`;
   if (type === "boolean") {
@@ -456,7 +513,8 @@ function buildParamExpression(param: EvaluatorConfigParam): string {
   const args: string[] = [];
   const defVal = formatParamDefault(param.default, param.type);
   if (defVal) args.push(`default=${defVal}`);
-  if (param.description) args.push(`description="${escapePyString(param.description)}"`);
+  if (param.description)
+    args.push(`description="${escapePyString(param.description)}"`);
   if (param.required) args.push("required=True");
   if (param.min !== undefined) args.push(`min=${param.min}`);
   if (param.max !== undefined) args.push(`max=${param.max}`);
@@ -608,10 +666,17 @@ const defaultValues: EvaluatorFormValues = {
   level: "trace",
   source: generateCodeHeader("trace", []) + "\n" + DEFAULT_CODE_BODY.trace,
   configSchema: [],
-  tags: [],
+  tags: ["code"],
 };
 
-const PARAM_TYPES = ["string", "integer", "float", "boolean", "array", "enum"] as const;
+const PARAM_TYPES = [
+  "string",
+  "integer",
+  "float",
+  "boolean",
+  "array",
+  "enum",
+] as const;
 
 // Reusable card selector matching the InputInterface pattern from agent creation.
 interface OptionCardProps {
@@ -622,7 +687,13 @@ interface OptionCardProps {
   onClick?: () => void;
 }
 
-const OptionCard = ({ label, description, selected, disabled, onClick }: OptionCardProps) => (
+const OptionCard = ({
+  label,
+  description,
+  selected,
+  disabled,
+  onClick,
+}: OptionCardProps) => (
   <Form.CardButton
     onClick={disabled ? undefined : onClick}
     selected={selected}
@@ -634,10 +705,14 @@ const OptionCard = ({ label, description, selected, disabled, onClick }: OptionC
     }}
   >
     <Form.CardContent sx={{ height: "100%" }}>
-      <Box display="flex" flexDirection="row" alignItems="center" height="100%" gap={1}>
-        <Box>
-          {selected ? <CheckCircle size={16} /> : <Circle size={16} />}
-        </Box>
+      <Box
+        display="flex"
+        flexDirection="row"
+        alignItems="center"
+        height="100%"
+        gap={1}
+      >
+        <Box>{selected ? <CheckCircle size={16} /> : <Circle size={16} />}</Box>
         <Divider orientation="vertical" flexItem />
         <Box>
           <Typography variant="h6">{label}</Typography>
@@ -760,7 +835,13 @@ export function EvaluatorForm({
 
     setValues((prev) => ({ ...prev, source: newSource }));
     sourceRef.current = newSource;
-  }, [values.configSchema, values.level, values.type, values.source, initialValues]);
+  }, [
+    values.configSchema,
+    values.level,
+    values.type,
+    values.source,
+    initialValues,
+  ]);
 
   // Re-validate when level or type changes
   useEffect(() => {
@@ -785,7 +866,6 @@ export function EvaluatorForm({
     }
   }, []);
 
-   
   const handleEditorDidMount = useCallback(
     (editor: any, monaco: Monaco) => {
       editorRef.current = editor;
@@ -830,11 +910,29 @@ export function EvaluatorForm({
   const handleTypeChange = useCallback(
     (newType: "code" | "llm_judge") => {
       updateField("type", newType);
+
+      // Swap the type tag: remove the old one, add the new one
+      const oldTag = newType === "code" ? "llm-judge" : "code";
+      const newTag = newType === "code" ? "code" : "llm-judge";
+      const filtered = values.tags.filter(
+        (t) => t.toLowerCase() !== oldTag.toLowerCase(),
+      );
+      if (!filtered.some((t) => t.toLowerCase() === newTag.toLowerCase())) {
+        filtered.unshift(newTag);
+      }
+      updateField("tags", filtered);
+
       if (!initialValues) {
         if (newType === "code") {
           try {
-            const header = generateCodeHeader(values.level, values.configSchema);
-            updateField("source", header + "\n" + DEFAULT_CODE_BODY[values.level]);
+            const header = generateCodeHeader(
+              values.level,
+              values.configSchema,
+            );
+            updateField(
+              "source",
+              header + "\n" + DEFAULT_CODE_BODY[values.level],
+            );
           } catch {
             // Invalid param keys — skip; error surfaces on submit.
           }
@@ -843,7 +941,13 @@ export function EvaluatorForm({
         }
       }
     },
-    [initialValues, values.level, values.configSchema, updateField],
+    [
+      initialValues,
+      values.level,
+      values.configSchema,
+      values.tags,
+      updateField,
+    ],
   );
 
   const handleLevelChange = useCallback(
@@ -1241,7 +1345,12 @@ export function EvaluatorForm({
                     multiline
                     rows={8}
                     fullWidth
-                    value={resolveAiPrompt(values.type, values.level)}
+                    value={resolveAiPrompt(
+                      values.type,
+                      values.level,
+                      values.displayName,
+                      values.description,
+                    )}
                     InputProps={{
                       readOnly: true,
                       sx: { fontFamily: "monospace", fontSize: "0.8rem" },
@@ -1251,18 +1360,33 @@ export function EvaluatorForm({
                           sx={{ alignSelf: "flex-start", mt: 1, mr: -0.5 }}
                         >
                           <Tooltip
-                            title={aiPromptCopied ? "Copied!" : "Copy to clipboard"}
+                            title={
+                              aiPromptCopied ? "Copied!" : "Copy to clipboard"
+                            }
                             placement="top"
                           >
                             <IconButton
                               size="small"
                               onClick={() => {
-                                navigator.clipboard.writeText(
-                                  resolveAiPrompt(values.type, values.level),
-                                ).then(() => {
-                                  setAiPromptCopied(true);
-                                  setTimeout(() => setAiPromptCopied(false), 2000);
-                                }).catch(() => { /* clipboard unavailable */ });
+                                navigator.clipboard
+                                  .writeText(
+                                    resolveAiPrompt(
+                                      values.type,
+                                      values.level,
+                                      values.displayName,
+                                      values.description,
+                                    ),
+                                  )
+                                  .then(() => {
+                                    setAiPromptCopied(true);
+                                    setTimeout(
+                                      () => setAiPromptCopied(false),
+                                      2000,
+                                    );
+                                  })
+                                  .catch(() => {
+                                    /* clipboard unavailable */
+                                  });
                               }}
                             >
                               {aiPromptCopied ? (
@@ -1340,214 +1464,267 @@ export function EvaluatorForm({
           </Form.Section>
 
           <SectionErrorBoundary fallbackMessage="Config params section failed to render. Click Retry to try again.">
-          <Form.Section>
-            <Stack direction="row" justifyContent="space-between" alignItems="center">
-              <Box>
-                <Form.Header>Config Params</Form.Header>
-                <Typography variant="caption" color="text.secondary">
-                  {values.type === "code"
-                    ? "Params are passed as keyword arguments to your function (e.g. threshold: float = 0.5)."
-                    : "Params are available as {key} placeholders in your prompt template."}
-                </Typography>
-              </Box>
-              <Button
-                size="small"
-                variant="outlined"
-                onClick={() =>
-                  updateField("configSchema", [...values.configSchema, emptyParam()])
-                }
+            <Form.Section>
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
               >
-                Add Param
-              </Button>
-            </Stack>
+                <Box>
+                  <Form.Header>Config Params</Form.Header>
+                  <Typography variant="caption" color="text.secondary">
+                    {values.type === "code"
+                      ? "Params are passed as keyword arguments to your function (e.g. threshold: float = 0.5)."
+                      : "Params are available as {key} placeholders in your prompt template."}
+                  </Typography>
+                </Box>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() =>
+                    updateField("configSchema", [
+                      ...values.configSchema,
+                      emptyParam(),
+                    ])
+                  }
+                >
+                  Add Param
+                </Button>
+              </Stack>
 
-            {errors.configSchema && (
-              <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
-                {errors.configSchema}
-              </Typography>
-            )}
+              {errors.configSchema && (
+                <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
+                  {errors.configSchema}
+                </Typography>
+              )}
 
-            <Stack spacing={1} sx={{ mt: 1 }}>
-              {values.type === "llm_judge" &&
-                LLM_JUDGE_BASE_CONFIG_SCHEMA.map((param) => (
-                  <Box
-                    key={param.key}
-                    sx={{ border: 1, borderColor: "divider", borderRadius: 1, p: 1 }}
-                  >
-                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
-                      <TextField
-                        placeholder="Key"
-                        size="small"
-                        value={param.key}
-                        disabled
-                        sx={{ flex: 2, minWidth: 120 }}
-                        InputProps={{ sx: { fontFamily: "monospace" } }}
-                      />
-                      <TextField
-                        placeholder="Type"
-                        size="small"
-                        value={param.type}
-                        disabled
-                        sx={{ flex: 1, minWidth: 80 }}
-                      />
-                      <TextField
-                        placeholder="Default"
-                        size="small"
-                        value={param.default !== undefined ? String(param.default) : ""}
-                        disabled
-                        sx={{ flex: 1.5, minWidth: 100 }}
-                      />
-                      <TextField
-                        placeholder="Description"
-                        size="small"
-                        value={param.description}
-                        disabled
-                        sx={{ flex: 3, minWidth: 150 }}
-                      />
-                    </Stack>
-                  </Box>
-                ))}
-
-              {values.configSchema.map((param, idx) => {
-                const updateParam = (patch: Partial<EvaluatorConfigParam>) => {
-                  const next = [...values.configSchema];
-                  next[idx] = { ...next[idx], ...patch };
-                  updateField("configSchema", next);
-                };
-                const removeParam = () => {
-                  updateField(
-                    "configSchema",
-                    values.configSchema.filter((_, i) => i !== idx),
-                  );
-                };
-                return (
-                  <Box
-                    key={idx}
-                    sx={{
-                      border: 1,
-                      borderColor: "divider",
-                      borderRadius: 1,
-                      p: 1,
-                    }}
-                  >
-                    <Stack spacing={1}>
-                      <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Stack spacing={1} sx={{ mt: 1 }}>
+                {values.type === "llm_judge" &&
+                  LLM_JUDGE_BASE_CONFIG_SCHEMA.map((param) => (
+                    <Box
+                      key={param.key}
+                      sx={{
+                        border: 1,
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        p: 1,
+                      }}
+                    >
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        alignItems="center"
+                        flexWrap="wrap"
+                        useFlexGap
+                      >
                         <TextField
                           placeholder="Key"
                           size="small"
                           value={param.key}
-                          onChange={(e) => updateParam({ key: e.target.value })}
+                          disabled
                           sx={{ flex: 2, minWidth: 120 }}
                           InputProps={{ sx: { fontFamily: "monospace" } }}
                         />
                         <TextField
-                          select
                           placeholder="Type"
                           size="small"
                           value={param.type}
-                          onChange={(e) => {
-                            const nextType = e.target.value;
-                            const isNumeric = nextType === "integer" || nextType === "float";
-                            updateParam({
-                              type: nextType,
-                              enumValues: undefined,
-                              ...(isNumeric ? {} : { min: undefined, max: undefined }),
-                            });
-                          }}
+                          disabled
                           sx={{ flex: 1, minWidth: 80 }}
-                        >
-                          {PARAM_TYPES.map((t) => (
-                            <MenuItem key={t} value={t}>
-                              {t}
-                            </MenuItem>
-                          ))}
-                        </TextField>
+                        />
                         <TextField
                           placeholder="Default"
                           size="small"
-                          value={param.default !== undefined ? String(param.default) : ""}
-                          onChange={(e) =>
-                            updateParam({
-                              default: e.target.value === "" ? undefined : e.target.value,
-                            })
+                          value={
+                            param.default !== undefined
+                              ? String(param.default)
+                              : ""
                           }
+                          disabled
                           sx={{ flex: 1.5, minWidth: 100 }}
                         />
                         <TextField
                           placeholder="Description"
                           size="small"
                           value={param.description}
-                          onChange={(e) => updateParam({ description: e.target.value })}
+                          disabled
                           sx={{ flex: 3, minWidth: 150 }}
                         />
-                        <FormControlLabel
-                          control={
-                            <Checkbox
-                              size="small"
-                              checked={!!param.required}
-                              onChange={(e) => updateParam({ required: e.target.checked })}
-                            />
-                          }
-                          label="Required"
-                          sx={{ flexShrink: 0, mr: 0 }}
-                        />
-                        <IconButton size="small" onClick={removeParam}>
-                          <CloseIcon size={16} />
-                        </IconButton>
                       </Stack>
+                    </Box>
+                  ))}
 
-                      {(param.type === "integer" || param.type === "float") && (
-                        <Stack direction="row" spacing={1}>
+                {values.configSchema.map((param, idx) => {
+                  const updateParam = (
+                    patch: Partial<EvaluatorConfigParam>,
+                  ) => {
+                    const next = [...values.configSchema];
+                    next[idx] = { ...next[idx], ...patch };
+                    updateField("configSchema", next);
+                  };
+                  const removeParam = () => {
+                    updateField(
+                      "configSchema",
+                      values.configSchema.filter((_, i) => i !== idx),
+                    );
+                  };
+                  return (
+                    <Box
+                      key={idx}
+                      sx={{
+                        border: 1,
+                        borderColor: "divider",
+                        borderRadius: 1,
+                        p: 1,
+                      }}
+                    >
+                      <Stack spacing={1}>
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          alignItems="center"
+                          flexWrap="wrap"
+                          useFlexGap
+                        >
                           <TextField
-                            placeholder="Min"
+                            placeholder="Key"
                             size="small"
-                            type="number"
-                            value={param.min !== undefined ? param.min : ""}
+                            value={param.key}
                             onChange={(e) =>
-                              updateParam({
-                                min: e.target.value === "" ? undefined : Number(e.target.value),
-                              })
+                              updateParam({ key: e.target.value })
                             }
-                            sx={{ flex: 1 }}
+                            sx={{ flex: 2, minWidth: 120 }}
+                            InputProps={{ sx: { fontFamily: "monospace" } }}
                           />
                           <TextField
-                            placeholder="Max"
+                            select
+                            placeholder="Type"
                             size="small"
-                            type="number"
-                            value={param.max !== undefined ? param.max : ""}
+                            value={param.type}
+                            onChange={(e) => {
+                              const nextType = e.target.value;
+                              const isNumeric =
+                                nextType === "integer" || nextType === "float";
+                              updateParam({
+                                type: nextType,
+                                enumValues: undefined,
+                                ...(isNumeric
+                                  ? {}
+                                  : { min: undefined, max: undefined }),
+                              });
+                            }}
+                            sx={{ flex: 1, minWidth: 80 }}
+                          >
+                            {PARAM_TYPES.map((t) => (
+                              <MenuItem key={t} value={t}>
+                                {t}
+                              </MenuItem>
+                            ))}
+                          </TextField>
+                          <TextField
+                            placeholder="Default"
+                            size="small"
+                            value={
+                              param.default !== undefined
+                                ? String(param.default)
+                                : ""
+                            }
                             onChange={(e) =>
                               updateParam({
-                                max: e.target.value === "" ? undefined : Number(e.target.value),
+                                default:
+                                  e.target.value === ""
+                                    ? undefined
+                                    : e.target.value,
                               })
                             }
-                            sx={{ flex: 1 }}
+                            sx={{ flex: 1.5, minWidth: 100 }}
                           />
+                          <TextField
+                            placeholder="Description"
+                            size="small"
+                            value={param.description}
+                            onChange={(e) =>
+                              updateParam({ description: e.target.value })
+                            }
+                            sx={{ flex: 3, minWidth: 150 }}
+                          />
+                          <FormControlLabel
+                            control={
+                              <Checkbox
+                                size="small"
+                                checked={!!param.required}
+                                onChange={(e) =>
+                                  updateParam({ required: e.target.checked })
+                                }
+                              />
+                            }
+                            label="Required"
+                            sx={{ flexShrink: 0, mr: 0 }}
+                          />
+                          <IconButton size="small" onClick={removeParam}>
+                            <CloseIcon size={16} />
+                          </IconButton>
                         </Stack>
-                      )}
 
-                      {param.type === "enum" && (
-                        <TextField
-                          placeholder="value1, value2, value3"
-                          size="small"
-                          value={(param.enumValues ?? []).join(", ")}
-                          onChange={(e) =>
-                            updateParam({
-                              enumValues: e.target.value
-                                .split(",")
-                                .map((s) => s.trim())
-                                .filter(Boolean),
-                            })
-                          }
-                          fullWidth
-                          helperText="Comma-separated list of allowed values"
-                        />
-                      )}
-                    </Stack>
-                  </Box>
-                );
-              })}
-            </Stack>
-          </Form.Section>
+                        {(param.type === "integer" ||
+                          param.type === "float") && (
+                          <Stack direction="row" spacing={1}>
+                            <TextField
+                              placeholder="Min"
+                              size="small"
+                              type="number"
+                              value={param.min !== undefined ? param.min : ""}
+                              onChange={(e) =>
+                                updateParam({
+                                  min:
+                                    e.target.value === ""
+                                      ? undefined
+                                      : Number(e.target.value),
+                                })
+                              }
+                              sx={{ flex: 1 }}
+                            />
+                            <TextField
+                              placeholder="Max"
+                              size="small"
+                              type="number"
+                              value={param.max !== undefined ? param.max : ""}
+                              onChange={(e) =>
+                                updateParam({
+                                  max:
+                                    e.target.value === ""
+                                      ? undefined
+                                      : Number(e.target.value),
+                                })
+                              }
+                              sx={{ flex: 1 }}
+                            />
+                          </Stack>
+                        )}
+
+                        {param.type === "enum" && (
+                          <TextField
+                            placeholder="value1, value2, value3"
+                            size="small"
+                            value={(param.enumValues ?? []).join(", ")}
+                            onChange={(e) =>
+                              updateParam({
+                                enumValues: e.target.value
+                                  .split(",")
+                                  .map((s) => s.trim())
+                                  .filter(Boolean),
+                              })
+                            }
+                            fullWidth
+                            helperText="Comma-separated list of allowed values"
+                          />
+                        )}
+                      </Stack>
+                    </Box>
+                  );
+                })}
+              </Stack>
+            </Form.Section>
           </SectionErrorBoundary>
 
           <Form.Section>

--- a/console/workspaces/pages/eval/src/subComponents/SelectPresetMonitors.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/SelectPresetMonitors.tsx
@@ -327,18 +327,42 @@ export function SelectPresetMonitors({
               return (
                 <Form.CardButton
                   key={monitor.id}
-                  sx={{ width: "100%", justifyContent: "flex-start" }}
+                  sx={{
+                    width: "100%",
+                    minWidth: 0,
+                    justifyContent: "flex-start",
+                    overflow: "hidden",
+                  }}
                   selected={isSelected}
                   onClick={() => handleOpenDrawer(monitor)}
                 >
                   <CardHeader
+                    sx={{
+                      overflow: "hidden",
+                      minWidth: 0,
+                      width: "100%",
+                      "& .MuiCardHeader-content": {
+                        overflow: "hidden",
+                        minWidth: 0,
+                      },
+                    }}
                     title={
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <Stack direction="column" spacing={2}>
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        alignItems="center"
+                        sx={{ minWidth: 0, overflow: "hidden" }}
+                      >
+                        <Stack
+                          direction="column"
+                          spacing={2}
+                          sx={{ minWidth: 0, overflow: "hidden" }}
+                        >
                           <Stack
                             direction="row"
                             spacing={2}
                             alignItems="center"
+                            sx={{ minWidth: 0, overflow: "hidden" }}
                           >
                             <Avatar
                               sx={{
@@ -350,6 +374,7 @@ export function SelectPresetMonitors({
                                   : "text.secondary",
                                 width: 40,
                                 height: 40,
+                                flexShrink: 0,
                               }}
                             >
                               {isSelected ? (
@@ -363,16 +388,22 @@ export function SelectPresetMonitors({
                               flexGrow={1}
                               spacing={1}
                               alignItems="center"
+                              sx={{ minWidth: 0, overflow: "hidden" }}
                             >
-                              <Typography
-                                variant="h6"
-                                textOverflow="ellipsis"
-                                overflow="hidden"
-                                whiteSpace="nowrap"
-                                maxWidth="90%"
+                              <Tooltip
+                                title={monitor.displayName}
+                                placement="top"
                               >
-                                {monitor.displayName}
-                              </Typography>
+                                <Typography
+                                  variant="h6"
+                                  textOverflow="ellipsis"
+                                  overflow="hidden"
+                                  whiteSpace="nowrap"
+                                  sx={{ flexShrink: 1, minWidth: 0 }}
+                                >
+                                  {monitor.displayName}
+                                </Typography>
+                              </Tooltip>
                               {monitor?.level && (
                                 <Chip
                                   label={
@@ -382,6 +413,7 @@ export function SelectPresetMonitors({
                                   size="small"
                                   variant="outlined"
                                   color="primary"
+                                  sx={{ flexShrink: 0 }}
                                 />
                               )}
                             </Stack>

--- a/libs/amp-evaluation/src/amp_evaluation/codegen/evaluator_schema.py
+++ b/libs/amp-evaluation/src/amp_evaluation/codegen/evaluator_schema.py
@@ -1255,6 +1255,43 @@ def _render_eval_result_markdown() -> str:
     )
 
 
+def _render_supporting_models_markdown() -> str:
+    """Render supporting data models (spans, steps, messages, metrics, etc.) as markdown."""
+    top = set(_TOP_LEVEL_TYPES.values())
+
+    # Group supporting types by category
+    # Spans (exclude top-level LLMSpan which is already documented per-level)
+    span_types = [c for c in sorted(_SPAN_TYPES, key=lambda c: c.__name__) if c not in top]
+    step_types = sorted(_STEP_TYPES, key=lambda c: c.__name__)
+    message_types = sorted(_MESSAGE_TYPES, key=lambda c: c.__name__)
+
+    known = set(_SPAN_TYPES) | set(_STEP_TYPES) | set(_MESSAGE_TYPES) | top
+    remaining = sorted(_EXPANDABLE_CLASSES - known, key=lambda c: c.__name__)
+
+    # Separate metrics from other types
+    metric_types = [c for c in remaining if c.__name__.endswith("Metrics") or c.__name__ == "TokenUsage"]
+    other_types = [c for c in remaining if c not in metric_types]
+
+    sections: List[str] = []
+
+    def _render_group(title: str, types: List[type]) -> None:
+        if not types:
+            return
+        sections.append(f"### {title}\n")
+        for cls in types:
+            var_name = cls.__name__[0].lower() + cls.__name__[1:]
+            sections.append(f"**{cls.__name__}**\n")
+            sections.append(_render_model_fields_markdown(cls, var_name) + "\n")
+
+    _render_group("Span Types", span_types)
+    _render_group("Agent Step Types", step_types)
+    _render_group("Message Types", message_types)
+    _render_group("Metrics", metric_types)
+    _render_group("Other", other_types)
+
+    return "\n".join(sections)
+
+
 def get_ai_copilot_guide() -> str:
     """Generate the full AI copilot reference guide as markdown.
 
@@ -1283,9 +1320,27 @@ def get_ai_copilot_guide() -> str:
     # Header
     sections.append(
         "# Writing Custom Evaluators — AI Copilot Reference\n\n"
-        "> This guide is auto-generated from the AMP evaluation SDK.\n"
-        "> It contains the framework conventions, data models, templates, and rules\n"
-        "> needed to write custom evaluators.\n"
+        "> This is the complete reference for writing AMP custom evaluators.\n"
+        "> It contains all conventions, data models, templates, and rules needed.\n"
+        "> Read the section matching your evaluator type "
+        "(Code or LLM-Judge) and level (trace, agent, or llm).\n"
+    )
+
+    # Table of Contents
+    sections.append(
+        "## Table of Contents\n\n"
+        "- [Code Evaluators](#code-evaluators) — "
+        "[Trace](#code-template--trace-level-trace) · "
+        "[Agent](#code-template--agent-level-agenttrace) · "
+        "[LLM](#code-template--llm-level-llmspan)\n"
+        "- [LLM-Judge Evaluators](#llm-judge-evaluators) — "
+        "[Trace](#llm-judge-template--trace-level-trace) · "
+        "[Agent](#llm-judge-template--agent-level-agenttrace) · "
+        "[LLM](#llm-judge-template--llm-level-llmspan)\n"
+        "- [Supporting Data Models](#supporting-data-models) — "
+        "Span types, agent steps, messages, metrics\n"
+        "- [EvalResult](#evalresult)\n"
+        "- [Common Mistakes](#common-mistakes)\n"
     )
 
     # Overview
@@ -1366,6 +1421,15 @@ def get_ai_copilot_guide() -> str:
         sections.append(f"#### Available {cls_name} Fields\n")
         sections.append(level_models[level] + "\n")
 
+    # Supporting data models
+    sections.append(
+        "## Supporting Data Models\n\n"
+        "These types appear as fields or return values in the main evaluator "
+        "input types above. Refer to them when writing evaluators that inspect "
+        "spans, steps, messages, or metrics.\n"
+    )
+    sections.append(_render_supporting_models_markdown())
+
     # EvalResult
     sections.append(_render_eval_result_markdown() + "\n")
 
@@ -1384,62 +1448,30 @@ def get_ai_copilot_guide() -> str:
         "```\n"
     )
 
-    return "\n".join(sections)
+    # Clean up verbose module paths in type strings
+    result = "\n".join(sections)
+    result = re.sub(r"amp_evaluation(?:\.\w+)*\.models\.", "", result)
+    return result
 
 
-_LEVEL_DISPLAY_NAMES: Dict[str, str] = {
-    "trace": "trace-level",
-    "agent": "agent-level",
-    "llm": "llm-level",
-}
+def get_ai_copilot_prompt_template() -> str:
+    """Return a single AI copilot prompt template with placeholders.
 
-
-def get_ai_copilot_prompts() -> Dict[str, Dict[str, str]]:
-    """Return short, copy-paste AI copilot prompts per type and level.
-
-    Each prompt includes the type, level, a placeholder for the user's
-    description, and a ``{{GUIDE_URL}}`` placeholder that the frontend
-    replaces with the actual documentation URL at runtime.
+    The frontend replaces ``{{TYPE}}``, ``{{LEVEL}}``, ``{{EVALUATOR_NAME}}``,
+    ``{{EVALUATOR_DESCRIPTION}}``, and ``{{GUIDE_URL}}`` at runtime based on
+    the user's selections and form values.
     """
-    prompts: Dict[str, Dict[str, str]] = {"code": {}, "llm_judge": {}}
-
-    for level, cls in _TOP_LEVEL_TYPES.items():
-        display_level = _LEVEL_DISPLAY_NAMES.get(level, level)
-        cls_name = cls.__name__
-
-        prompts["code"][level] = (
-            f"Write a custom code evaluator ({display_level}) for the "
-            f"AMP evaluation framework.\n"
-            f"\n"
-            f"The evaluator is a Python function that receives a `{cls_name}` "
-            f"object and returns an `EvalResult`.\n"
-            f"\n"
-            f"## What it should evaluate\n"
-            f"[Describe your evaluation criteria here]\n"
-            f"\n"
-            f"## Framework reference\n"
-            f"Follow the conventions and data models described in:\n"
-            f"{{{{GUIDE_URL}}}}"
-        )
-
-        var_name = _LEVEL_VAR_NAMES.get(level, level)
-        prompts["llm_judge"][level] = (
-            f"Write a custom LLM-judge evaluator prompt ({display_level}) for the "
-            f"AMP evaluation framework.\n"
-            f"\n"
-            f"The evaluator is a prompt template string (not Python code). "
-            f"Use {{{var_name}.*}} expressions to access {cls_name} fields. "
-            f"Python f-string expressions are supported inside curly braces.\n"
-            f"\n"
-            f"## What it should evaluate\n"
-            f"[Describe your evaluation criteria here]\n"
-            f"\n"
-            f"## Framework reference\n"
-            f"Follow the conventions and data models described in:\n"
-            f"{{{{GUIDE_URL}}}}"
-        )
-
-    return prompts
+    return (
+        "Write a custom {{TYPE}} {{LEVEL}} evaluator. "
+        "It should evaluate:\n"
+        "[Describe scenario]\n"
+        "\n"
+        "## Evaluator details\n"
+        "- **Name**: {{EVALUATOR_NAME}}\n"
+        "- **Description**: {{EVALUATOR_DESCRIPTION}}\n"
+        "\n"
+        "Always refer to this framework reference: {{GUIDE_URL}}"
+    )
 
 
 # ============================================================================
@@ -1550,6 +1582,6 @@ def get_evaluator_editor_schema() -> Dict[str, Any]:
         "code_templates": get_code_templates(),
         "llm_judge_templates": get_llm_judge_templates(),
         "llm_judge_variables": get_llm_judge_variables(),
-        "ai_copilot_prompts": get_ai_copilot_prompts(),
+        "ai_copilot_prompt_template": get_ai_copilot_prompt_template(),
         "ai_copilot_guide": get_ai_copilot_guide(),
     }


### PR DESCRIPTION
## Summary

- Remove secret auto-injection of code/llm-judge tags from backend; pre-fill type tag in evaluator creation form instead so users can see and edit it
- Fix isLlmJudge detection to use evaluator `type` field instead of checking tags
- Fix evaluator name overflow in card layout with proper truncation and tooltip (evaluator list + monitor creation)
- Use consistent orange (primary) color for eval level chips across all views
- Improve AI copilot reference guide with supporting data models, table of contents, and simplified prompt template

## Test plan

- [x] Create a new evaluator: verify "code" tag is pre-filled, switching type swaps to "llm-judge"
- [x] Verify users can remove the pre-filled tag before saving
- [x] Verify existing evaluators show only user-defined tags (no auto-injected ones)
- [x] Create an evaluator with a long name and verify truncation with tooltip in evaluator list and monitor creation
- [x] Verify eval level chips are orange in evaluator list, detail page, and monitor creation
- [x] Verify LLM provider config still shows correctly in the evaluator drawer

Closes wso2/agent-manager#562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Copilot prompt template unified and now injects evaluator name/description for richer prompts.
  * Automatic tag synchronization when switching evaluator types; default tags now include "code".
  * New loading and empty states on the Evaluators page; evaluator items are now clickable for easier navigation.

* **Documentation**
  * Expanded evaluator reference with a new Supporting Data Models section (spans, steps, messages, metrics) and updated guide/TOC.

* **Style**
  * Improved card/layout overflow, truncation, and chip styling; level indicator color updated for clearer emphasis.

* **Bug Fixes**
  * Evaluator tags are now taken directly from evaluator data (removes prior auto-generation/deduplication).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->