### PR TITLE
Remove helm hooks from evaluation extension workflow templates

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
@@ -2,9 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: ClusterWorkflowTemplate
 metadata:
   name: amp-monitor-evaluation
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "15"
   labels:
 {{- include "amp-evaluation-extension.labels" . | nindent 4 }}
 spec:

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/workflow-monitor-evaluation.yaml
@@ -4,9 +4,6 @@ metadata:
   name: monitor-evaluation-workflow
   namespace: {{ .Values.ampEvaluation.workflowNamespace | default .Release.Namespace }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation
     openchoreo.dev/description: "Periodic evaluation monitor for AI agents - runs evaluators against agent traces"
   labels:
 {{- include "amp-evaluation-extension.labels" . | nindent 4 }}

--- a/deployments/quick-start/uninstall.sh
+++ b/deployments/quick-start/uninstall.sh
@@ -27,6 +27,7 @@ AMP_NS="${AMP_NS:-wso2-amp}"
 BUILD_CI_NS="${BUILD_CI_NS:-openchoreo-build-plane}"
 OBSERVABILITY_NS="${OBSERVABILITY_NS:-openchoreo-observability-plane}"
 DEFAULT_NS="${DEFAULT_NS:-default}"
+EVALUATION_NS="${EVALUATION_NS:-openchoreo-build-plane}"
 
 # Colors for output (8-bit mode for maximum compatibility)
 RED='\033[1;31m'
@@ -161,6 +162,18 @@ if helm status "build-workflow-extensions" -n "${BUILD_CI_NS}" &>/dev/null 2>&1;
     fi
 else
     log_info "Build Extension not found, skipping..."
+fi
+
+# Uninstall Evaluation Extension
+if helm status "amp-evaluation-extension" -n "${EVALUATION_NS}" &>/dev/null 2>&1; then
+    log_info "Uninstalling Evaluation Extension..."
+    if helm uninstall "amp-evaluation-extension" -n "${EVALUATION_NS}" &>/dev/null; then
+        log_success "Evaluation Extension uninstalled"
+    else
+        log_warning "Failed to uninstall Evaluation Extension (non-fatal)"
+    fi
+else
+    log_info "Evaluation Extension not found, skipping..."
 fi
 
 # Uninstall Observability Extension


### PR DESCRIPTION
## Summary

- Remove `helm.sh/hook` annotations from `ClusterWorkflowTemplate` and `Workflow` CR in the evaluation extension chart so they are created as regular Helm resources
- Add `amp-evaluation-extension` to `uninstall.sh` cleanup and add `EVALUATION_NS` variable

Fixes #569

## Why

Commits 6cab0e81/8a893cb1 converted these resources to Helm hooks (`post-install,post-upgrade`). In dev mode (`VERSION=0.0.0-dev`), the chart doesn't exist in the OCI registry so `helm install` fails silently — neither the `Workflow` CR nor `ClusterWorkflowTemplate` get created, causing all monitor creation to fail with `Workflow not found`.

These hooks were unnecessary — the evaluation extension always installs after the OpenChoreo build plane which already registers the Argo Workflows CRDs.

## Test plan

- [ ] Run `./install.sh` inside `amp-quick-start` container
- [ ] Verify `kubectl get workflows.openchoreo.dev -A` shows `monitor-evaluation-workflow`
- [ ] Verify `kubectl get clusterworkflowtemplate` shows `amp-monitor-evaluation`
- [ ] Create a monitor from the UI and confirm it succeeds without `Workflow not found` error
- [ ] Run `./uninstall.sh` and confirm `amp-evaluation-extension` is uninstalled cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Helm hook annotations from workflow templates; resources now deploy as standard manifests
  * Added uninstall support for the Evaluation Extension during package removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->