### PR TITLE
Remove threshold param from built-in LLM judge evaluators

### DIFF
--- a/agent-manager-service/catalog/builtin_evaluators.go
+++ b/agent-manager-service/catalog/builtin_evaluators.go
@@ -167,7 +167,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -186,7 +185,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -205,7 +203,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -224,7 +221,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -243,7 +239,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -263,7 +258,6 @@ var entries = []*Entry{
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "on_missing_context", Type: "string", Description: "Behavior when no retrieval spans are found: 'skip' returns EvalResult.skip(), 'zero' returns score=0.0", Required: false, Default: "skip", EnumValues: []string{"skip", "zero"}},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -283,7 +277,6 @@ var entries = []*Entry{
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "on_missing_context", Type: "string", Description: "Behavior when no errors are found in the agent trace: 'skip' returns EvalResult.skip(), 'zero' returns score=0.0", Required: false, Default: "skip", EnumValues: []string{"skip", "zero"}},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -303,7 +296,6 @@ var entries = []*Entry{
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "on_missing_context", Type: "string", Description: "Behavior when no tool or retrieval spans are found: 'skip' returns EvalResult.skip(), 'zero' returns score=0.0", Required: false, Default: "skip", EnumValues: []string{"skip", "zero"}},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -322,7 +314,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -341,7 +332,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -360,7 +350,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -379,7 +368,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -398,7 +386,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -418,7 +405,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.7), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 	{
@@ -438,7 +424,6 @@ var entries = []*Entry{
 			{Key: "max_tokens", Type: "integer", Description: "Max tokens for LLM response", Required: false, Default: float64(1024)},
 			{Key: "model", Type: "string", Description: "LLM model in provider/model format (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)", Required: false, Default: "openai/gpt-4o-mini"},
 			{Key: "temperature", Type: "float", Description: "LLM temperature", Required: false, Default: float64(0.0)},
-			{Key: "threshold", Type: "float", Description: "Pass threshold (0.0-1.0)", Required: false, Default: float64(0.5), Min: floatPtr(0.0), Max: floatPtr(1.0)},
 		},
 	},
 }

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/builtin/llm_judge.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/builtin/llm_judge.py
@@ -78,8 +78,6 @@ class HelpfulnessEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "quality"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
-
     def build_prompt(self, trace: Trace, task: Optional[Task] = None) -> str:
         criteria = f"\n\nAdditional success criteria: {task.success_criteria}" if task and task.success_criteria else ""
 
@@ -112,8 +110,6 @@ class ClarityEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "quality"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
-
     def build_prompt(self, trace: Trace) -> str:
         return f"""You are an expert evaluator. Your sole criterion is CLARITY: is the response clear, well-structured, and easy to understand?
 
@@ -143,8 +139,6 @@ class AccuracyEvaluator(LLMAsJudgeEvaluator):
         "Does not use tool or retrieval evidence."
     )
     tags = ["llm-judge", "correctness"]
-
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
 
     def build_prompt(self, trace: Trace) -> str:
         return f"""You are an expert evaluator. Your sole criterion is ACCURACY: is the factual information in the response correct and reliable?
@@ -177,8 +171,6 @@ class CompletenessEvaluator(LLMAsJudgeEvaluator):
         "Accepts optional success_criteria. 0.0 = nothing addressed, 1.0 = fully covered."
     )
     tags = ["llm-judge", "quality"]
-
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
 
     def build_prompt(self, trace: Trace, task: Optional[Task] = None) -> str:
         coverage = f"\n\nExpected coverage: {task.success_criteria}" if task and task.success_criteria else ""
@@ -216,7 +208,6 @@ class GroundednessEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "correctness", "safety"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
     on_missing_context: str = Param(
         default="skip",
         enum=["skip", "zero"],
@@ -276,7 +267,6 @@ class ContextRelevanceEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "relevance"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
     on_missing_context: str = Param(
         default="skip",
         enum=["skip", "zero"],
@@ -330,8 +320,6 @@ class RelevanceEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "relevance"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
-
     def build_prompt(self, trace: Trace) -> str:
         return f"""You are an expert evaluator. Your sole criterion is RELEVANCE: does the response address the same topic and intent as the user's query?
 
@@ -367,7 +355,6 @@ class SemanticSimilarityEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "correctness"]
 
-    threshold: float = Param(default=0.7, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
     on_missing_context: str = Param(
         default="skip",
         enum=["skip", "zero"],
@@ -426,8 +413,6 @@ class CoherenceEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "quality"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
-
     def build_prompt(self, llm_span: LLMSpan) -> str:
         return f"""You are an expert evaluator. Your sole criterion is COHERENCE: does this LLM response maintain logical flow and internal consistency throughout?
 
@@ -457,8 +442,6 @@ class ConcisenessEvaluator(LLMAsJudgeEvaluator):
         "Does not penalize thoroughness, only padding. Runs per LLM span."
     )
     tags = ["llm-judge", "quality", "efficiency"]
-
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
 
     def build_prompt(self, llm_span: LLMSpan) -> str:
         return f"""You are an expert evaluator. Your sole criterion is CONCISENESS: does this response communicate its content without unnecessary padding or repetition?
@@ -496,7 +479,6 @@ class SafetyEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "safety"]
 
-    threshold: float = Param(default=0.7, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
     context: str = Param(
         default="",
         description=(
@@ -546,7 +528,6 @@ class ToneEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "quality"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
     context: str = Param(
         default="",
         description=(
@@ -594,8 +575,6 @@ class ReasoningQualityEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "reasoning"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
-
     def build_prompt(self, agent_trace: AgentTrace, task: Optional[Task] = None) -> str:
         task_section = f"\nTask: {task.description}" if task and task.description else ""
 
@@ -634,8 +613,6 @@ class PathEfficiencyEvaluator(LLMAsJudgeEvaluator):
         "Detects redundant steps, loops, and wasted work. Runs per agent."
     )
     tags = ["llm-judge", "efficiency"]
-
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
 
     def build_prompt(self, agent_trace: AgentTrace, task: Optional[Task] = None) -> str:
         task_section = f"\nTask: {task.description}" if task and task.description else ""
@@ -677,7 +654,6 @@ class ErrorRecoveryEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "reasoning"]
 
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
     on_missing_context: str = Param(
         default="skip",
         enum=["skip", "zero"],
@@ -741,8 +717,6 @@ class InstructionFollowingEvaluator(LLMAsJudgeEvaluator):
         "Runs per agent. Always evaluates since user input is always available."
     )
     tags = ["llm-judge", "compliance"]
-
-    threshold: float = Param(default=0.5, min=0.0, max=1.0, description="Pass threshold (0.0-1.0)")
 
     def build_prompt(self, agent_trace: AgentTrace, task: Optional[Task] = None) -> str:
         return f"""You are an expert evaluator. Your sole criterion is INSTRUCTION FOLLOWING: does the agent comply with all instructions — both from its system prompt and the user's request?


### PR DESCRIPTION
## Summary

- Removes the unused `threshold` Param from all 16 built-in LLM judge evaluator classes in `llm_judge.py`
- The `threshold` field had no effect on the score — `passed` is determined by `score >= 0.5` hardcoded in `LLMAsJudgeEvaluator._parse_and_validate()`, not by the per-evaluator `threshold` Param
- Exposing it as a configurable parameter was misleading to platform users who might expect changing it to alter evaluation outcomes
- Regenerates `catalog/builtin_evaluators.go` to reflect the removal

## Test plan

- [ ] Run `make dev-test` in `agent-manager-service/` to verify no regressions
- [ ] Re-run `./scripts/generate-builtin-evaluators.sh --dev` and confirm `threshold` no longer appears in any LLM judge `ConfigSchema` entries in `builtin_evaluators.go`
- [ ] Verify LLM judge evaluators still produce correct `score` and `passed` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the customizable pass threshold parameter from 15 built-in evaluators. The threshold configuration (previously supporting values from 0.0 to 1.0 with a default of 0.5) is no longer available for accuracy, clarity, coherence, completeness, conciseness, context relevance, error recovery, groundedness, helpfulness, instruction following, path efficiency, reasoning quality, relevance, safety, and tone evaluators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->