### PR TITLE
Refactor project name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WSO2 Agent Manager
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/wso2/ai-agent-management-platform/agent-manager-service)](https://goreportcard.com/report/github.com/wso2/ai-agent-management-platform/agent-manager-service)
+[![Go Report Card](https://goreportcard.com/badge/github.com/wso2/agent-manager/agent-manager-service)](https://goreportcard.com/report/github.com/wso2/agent-manager/agent-manager-service)
 [![Platform Release](https://img.shields.io/github/v/release/wso2/ai-agent-management-platform?filter=amp/*&label=platform&color=orange)](https://github.com/wso2/agent-manager/releases?q=amp)
 [![Python Instrumentation](https://img.shields.io/github/v/release/wso2/ai-agent-management-platform?filter=amp-instrumentation/*&label=python-instrumentation&color=blue)](https://github.com/wso2/agent-manager/releases?q=amp-instrumentation)
 

--- a/agent-manager-service/Dockerfile
+++ b/agent-manager-service/Dockerfile
@@ -21,7 +21,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -a \
     -installsuffix cgo \
-    -ldflags="-w -s -X github.com/wso2/ai-agent-management-platform/agent-manager-service/config.Version=${VERSION}" \
+    -ldflags="-w -s -X github.com/wso2/agent-manager/agent-manager-service/config.Version=${VERSION}" \
     -o /go/bin/agent-manager-service \
     -buildvcs=false
 

--- a/agent-manager-service/api/agent_config_routes.go
+++ b/agent-manager-service/api/agent_config_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // RegisterAgentConfigRoutes registers all agent configuration routes

--- a/agent-manager-service/api/agent_routes.go
+++ b/agent-manager-service/api/agent_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func registerAgentRoutes(mux *http.ServeMux, ctrl controllers.AgentController) {

--- a/agent-manager-service/api/agent_token_routes.go
+++ b/agent-manager-service/api/agent_token_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // registerAgentTokenRoutes registers the agent token API routes

--- a/agent-manager-service/api/app.go
+++ b/agent-manager-service/api/app.go
@@ -19,10 +19,10 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 // MakeHTTPHandler creates a new HTTP handler with middleware and routes

--- a/agent-manager-service/api/catalog_routes.go
+++ b/agent-manager-service/api/catalog_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func registerCatalogRoutes(mux *http.ServeMux, ctrl controllers.CatalogController) {

--- a/agent-manager-service/api/environment_routes.go
+++ b/agent-manager-service/api/environment_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func registerEnvironmentRoutes(mux *http.ServeMux, ctrl controllers.EnvironmentController) {

--- a/agent-manager-service/api/evaluator_routes.go
+++ b/agent-manager-service/api/evaluator_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func registerEvaluatorRoutes(mux *http.ServeMux, controller controllers.EvaluatorController) {

--- a/agent-manager-service/api/gateway_internal_routes.go
+++ b/agent-manager-service/api/gateway_internal_routes.go
@@ -19,7 +19,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
 )
 
 // RegisterGatewayInternalRoutes registers all gateway internal API routes

--- a/agent-manager-service/api/gateway_routes.go
+++ b/agent-manager-service/api/gateway_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func RegisterGatewayRoutes(mux *http.ServeMux, ctrl controllers.GatewayController) {

--- a/agent-manager-service/api/health_check_routes.go
+++ b/agent-manager-service/api/health_check_routes.go
@@ -21,9 +21,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func registerHealthCheck(mux *http.ServeMux) {

--- a/agent-manager-service/api/infra_resource_routes.go
+++ b/agent-manager-service/api/infra_resource_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func registerInfraRoutes(mux *http.ServeMux, ctrl controllers.InfraResourceController) {

--- a/agent-manager-service/api/llm_deployment_routes.go
+++ b/agent-manager-service/api/llm_deployment_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // RegisterLLMDeploymentRoutes registers all LLM deployment-related routes

--- a/agent-manager-service/api/llm_provider_apikey_routes.go
+++ b/agent-manager-service/api/llm_provider_apikey_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // RegisterLLMProviderAPIKeyRoutes registers API key routes for LLM providers

--- a/agent-manager-service/api/llm_proxy_apikey_routes.go
+++ b/agent-manager-service/api/llm_proxy_apikey_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // RegisterLLMProxyAPIKeyRoutes registers API key routes for LLM proxies

--- a/agent-manager-service/api/llm_proxy_deployment_routes.go
+++ b/agent-manager-service/api/llm_proxy_deployment_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // RegisterLLMProxyDeploymentRoutes registers all LLM proxy deployment-related routes

--- a/agent-manager-service/api/llm_routes.go
+++ b/agent-manager-service/api/llm_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // RegisterLLMRoutes registers all LLM-related routes

--- a/agent-manager-service/api/monitor_publisher_routes.go
+++ b/agent-manager-service/api/monitor_publisher_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 // RegisterMonitorPublisherRoutes registers monitor score publishing routes

--- a/agent-manager-service/api/monitor_routes.go
+++ b/agent-manager-service/api/monitor_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func route(method, path string) string {

--- a/agent-manager-service/api/observability_routes.go
+++ b/agent-manager-service/api/observability_routes.go
@@ -19,8 +19,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 )
 
 func registerObservabilityRoutes(mux *http.ServeMux, ctrl controllers.ObservabilityController) {

--- a/agent-manager-service/api/repository_routes.go
+++ b/agent-manager-service/api/repository_routes.go
@@ -19,7 +19,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
 )
 
 func registerRepositoryRoutes(mux *http.ServeMux, ctrl controllers.RepositoryController) {

--- a/agent-manager-service/api/websocket_routes.go
+++ b/agent-manager-service/api/websocket_routes.go
@@ -19,7 +19,7 @@ package api
 import (
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
 )
 
 // RegisterWebSocketRoutes registers all WebSocket routes

--- a/agent-manager-service/catalog/builtin_evaluators.go
+++ b/agent-manager-service/catalog/builtin_evaluators.go
@@ -2,7 +2,7 @@
 
 package catalog
 
-import "github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+import "github.com/wso2/agent-manager/agent-manager-service/models"
 
 var entries = []*Entry{
 	{

--- a/agent-manager-service/catalog/catalog.go
+++ b/agent-manager-service/catalog/catalog.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // catalogNamespace is a fixed namespace UUID used to derive deterministic evaluator IDs from identifiers.

--- a/agent-manager-service/clients/clientmocks/observability_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/observability_client_fake.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
 // ObservabilitySvcClientMock is a mock implementation of observabilitysvc.ObservabilitySvcClient.

--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	ocapi "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	ocapi "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // OpenChoreoClientMock is a mock implementation of client.OpenChoreoClient.

--- a/agent-manager-service/clients/clientmocks/secret_mgmt_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/secret_mgmt_client_fake.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
 )
 
 // Ensure, that SecretManagementClientMock does implement secretmanagersvc.SecretManagementClient.

--- a/agent-manager-service/clients/clientmocks/trace_observer_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/trace_observer_client_fake.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"sync"
 
-	traceobserversvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
+	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
 )
 
 // Ensure TraceObserverClientMock implements TraceObserverClient interface

--- a/agent-manager-service/clients/gitprovider/github.go
+++ b/agent-manager-service/clients/gitprovider/github.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/requests"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/requests"
 )
 
 const (

--- a/agent-manager-service/clients/observabilitysvc/client.go
+++ b/agent-manager-service/clients/observabilitysvc/client.go
@@ -26,12 +26,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/requests"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/requests"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // Build log constants

--- a/agent-manager-service/clients/openchoreosvc/auth/auth.go
+++ b/agent-manager-service/clients/openchoreosvc/auth/auth.go
@@ -28,8 +28,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/requests"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/requests"
 )
 
 // Compile-time check that AuthProvider implements client.AuthProvider

--- a/agent-manager-service/clients/openchoreosvc/client/builds.go
+++ b/agent-manager-service/clients/openchoreosvc/client/builds.go
@@ -25,10 +25,10 @@ import (
 	"sort"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func (c *openChoreoClient) TriggerBuild(ctx context.Context, orgName, projectName, componentName, commitID string) (*models.BuildResponse, error) {

--- a/agent-manager-service/clients/openchoreosvc/client/client.go
+++ b/agent-manager-service/clients/openchoreosvc/client/client.go
@@ -26,9 +26,9 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/requests"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/requests"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // Config contains configuration for the OpenChoreo client

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -28,10 +28,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func (c *openChoreoClient) CreateComponent(ctx context.Context, namespaceName, projectName string, req CreateComponentRequest) error {

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -24,10 +24,10 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func (c *openChoreoClient) Deploy(ctx context.Context, orgName, projectName, componentName string, req DeployRequest) error {

--- a/agent-manager-service/clients/openchoreosvc/client/errors.go
+++ b/agent-manager-service/clients/openchoreosvc/client/errors.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // ErrorResponses holds typed error responses from API calls.

--- a/agent-manager-service/clients/openchoreosvc/client/generic-workflows.go
+++ b/agent-manager-service/clients/openchoreosvc/client/generic-workflows.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // CreateWorkflowRunRequest contains parameters for creating a workflow run

--- a/agent-manager-service/clients/openchoreosvc/client/infrastructure.go
+++ b/agent-manager-service/clients/openchoreosvc/client/infrastructure.go
@@ -22,9 +22,9 @@ import (
 	"net/http"
 	"time"
 
-	ocapi "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	ocapi "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // -----------------------------------------------------------------------------

--- a/agent-manager-service/clients/openchoreosvc/client/projects.go
+++ b/agent-manager-service/clients/openchoreosvc/client/projects.go
@@ -22,9 +22,9 @@ import (
 	"net/http"
 	"time"
 
-	ocapi "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	ocapi "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func (c *openChoreoClient) CreateProject(ctx context.Context, namespaceName string, req CreateProjectRequest) error {

--- a/agent-manager-service/clients/openchoreosvc/client/secret_references.go
+++ b/agent-manager-service/clients/openchoreosvc/client/secret_references.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // -----------------------------------------------------------------------------

--- a/agent-manager-service/clients/requests/send_request.go
+++ b/agent-manager-service/clients/requests/send_request.go
@@ -25,7 +25,7 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 )
 
 // HttpClient interface for making HTTP requests.

--- a/agent-manager-service/clients/secretmanagersvc/providers/openbao/client.go
+++ b/agent-manager-service/clients/secretmanagersvc/providers/openbao/client.go
@@ -26,7 +26,7 @@ import (
 
 	vault "github.com/hashicorp/vault/api"
 
-	secretmanagersvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
+	secretmanagersvc "github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
 )
 
 // Client implements the secretmanagersvc.SecretsClient interface for OpenBao/Vault.

--- a/agent-manager-service/clients/secretmanagersvc/providers/openbao/provider.go
+++ b/agent-manager-service/clients/secretmanagersvc/providers/openbao/provider.go
@@ -21,7 +21,7 @@ import (
 
 	vault "github.com/hashicorp/vault/api"
 
-	secretmanagersvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
+	secretmanagersvc "github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
 )
 
 const (

--- a/agent-manager-service/clients/traceobserversvc/client.go
+++ b/agent-manager-service/clients/traceobserversvc/client.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 )
 
 // TraceObserverClient is the interface for interacting with the trace observer service

--- a/agent-manager-service/controllers/agent_configuration_controller.go
+++ b/agent-manager-service/controllers/agent_configuration_controller.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // Note: uuid import retained for configUUID parsing in path parameters

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -24,10 +24,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 type AgentController interface {

--- a/agent-manager-service/controllers/agent_token_controller.go
+++ b/agent-manager-service/controllers/agent_token_controller.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // AgentTokenController defines the interface for agent token operations

--- a/agent-manager-service/controllers/catalog_controller.go
+++ b/agent-manager-service/controllers/catalog_controller.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // CatalogController defines the interface for catalog HTTP handlers

--- a/agent-manager-service/controllers/environment_controller.go
+++ b/agent-manager-service/controllers/environment_controller.go
@@ -22,11 +22,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // EnvironmentController defines the interface for environment HTTP handlers

--- a/agent-manager-service/controllers/evaluator_controller.go
+++ b/agent-manager-service/controllers/evaluator_controller.go
@@ -24,12 +24,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/catalog"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/catalog"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 type EvaluatorController interface {

--- a/agent-manager-service/controllers/gateway_controller.go
+++ b/agent-manager-service/controllers/gateway_controller.go
@@ -27,12 +27,12 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	occlient "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/controllers/gateway_internal_controller.go
+++ b/agent-manager-service/controllers/gateway_internal_controller.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // GatewayInternalController defines interface for gateway internal API HTTP handlers

--- a/agent-manager-service/controllers/infra_resource_controller.go
+++ b/agent-manager-service/controllers/infra_resource_controller.go
@@ -23,10 +23,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 type InfraResourceController interface {

--- a/agent-manager-service/controllers/llm_controller.go
+++ b/agent-manager-service/controllers/llm_controller.go
@@ -23,13 +23,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMController defines interface for LLM provider HTTP handlers

--- a/agent-manager-service/controllers/llm_deployment_controller.go
+++ b/agent-manager-service/controllers/llm_deployment_controller.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMDeploymentController defines interface for LLM deployment HTTP handlers

--- a/agent-manager-service/controllers/llm_provider_apikey_controller.go
+++ b/agent-manager-service/controllers/llm_provider_apikey_controller.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProviderAPIKeyController handles API key operations for LLM providers

--- a/agent-manager-service/controllers/llm_proxy_apikey_controller.go
+++ b/agent-manager-service/controllers/llm_proxy_apikey_controller.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProxyAPIKeyController handles API key operations for LLM proxies

--- a/agent-manager-service/controllers/llm_proxy_deployment_controller.go
+++ b/agent-manager-service/controllers/llm_proxy_deployment_controller.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProxyDeploymentController defines interface for LLM proxy deployment HTTP handlers

--- a/agent-manager-service/controllers/monitor_controller.go
+++ b/agent-manager-service/controllers/monitor_controller.go
@@ -23,11 +23,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // MonitorController defines the interface for monitor HTTP handlers

--- a/agent-manager-service/controllers/monitor_scores_controller.go
+++ b/agent-manager-service/controllers/monitor_scores_controller.go
@@ -27,10 +27,10 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/controllers/monitor_scores_publisher_controller.go
+++ b/agent-manager-service/controllers/monitor_scores_publisher_controller.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // MonitorScoresPublisherController defines the interface for monitor scores publishing HTTP handlers

--- a/agent-manager-service/controllers/observability_controller.go
+++ b/agent-manager-service/controllers/observability_controller.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/controllers/repository_controller.go
+++ b/agent-manager-service/controllers/repository_controller.go
@@ -22,11 +22,11 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/gitprovider"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/gitprovider"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/controllers/websocket_controller.go
+++ b/agent-manager-service/controllers/websocket_controller.go
@@ -27,9 +27,9 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	ws "github.com/wso2/ai-agent-management-platform/agent-manager-service/websocket"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	ws "github.com/wso2/agent-manager/agent-manager-service/websocket"
 )
 
 // WebSocketController defines interface for WebSocket HTTP handlers

--- a/agent-manager-service/db/db.go
+++ b/agent-manager-service/db/db.go
@@ -29,8 +29,8 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db/connpool"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/db/connpool"
 )
 
 var db *gorm.DB

--- a/agent-manager-service/db/tx_utils.go
+++ b/agent-manager-service/db/tx_utils.go
@@ -23,7 +23,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 )
 
 type ctxTX struct{}

--- a/agent-manager-service/db_migrations/migrations.go
+++ b/agent-manager-service/db_migrations/migrations.go
@@ -24,7 +24,7 @@ import (
 	"github.com/go-gormigrate/gormigrate/v2"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
 )
 
 var migrateOptions = &gormigrate.Options{

--- a/agent-manager-service/go.mod
+++ b/agent-manager-service/go.mod
@@ -1,4 +1,4 @@
-module github.com/wso2/ai-agent-management-platform/agent-manager-service
+module github.com/wso2/agent-manager/agent-manager-service
 
 go 1.25.0
 

--- a/agent-manager-service/main.go
+++ b/agent-manager-service/main.go
@@ -27,21 +27,21 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/api"
-	ocauth "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/auth"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/resources"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/server"
+	"github.com/wso2/agent-manager/agent-manager-service/api"
+	ocauth "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/auth"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/resources"
+	"github.com/wso2/agent-manager/agent-manager-service/server"
 
 	// Register secret management providers
-	_ "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc/providers/openbao"
+	_ "github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc/providers/openbao"
 
 	"go.uber.org/automaxprocs/maxprocs"
 
-	dbmigrations "github.com/wso2/ai-agent-management-platform/agent-manager-service/db_migrations"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/signals"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	dbmigrations "github.com/wso2/agent-manager/agent-manager-service/db_migrations"
+	"github.com/wso2/agent-manager/agent-manager-service/signals"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 func setupLogger(cfg *config.Config) {

--- a/agent-manager-service/middleware/correlation_id.go
+++ b/agent-manager-service/middleware/correlation_id.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/middleware/jwtassertion/auth.go
+++ b/agent-manager-service/middleware/jwtassertion/auth.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 type TokenClaims struct {

--- a/agent-manager-service/middleware/logger/request_logger.go
+++ b/agent-manager-service/middleware/logger/request_logger.go
@@ -21,7 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 type loggerKey struct{}

--- a/agent-manager-service/middleware/panic_recover.go
+++ b/agent-manager-service/middleware/panic_recover.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func RecovererOnPanic() func(http.Handler) http.Handler {

--- a/agent-manager-service/middleware/path_params.go
+++ b/agent-manager-service/middleware/path_params.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const DefaultOrgName = "default"

--- a/agent-manager-service/models/traces.go
+++ b/agent-manager-service/models/traces.go
@@ -19,7 +19,7 @@ package models
 import (
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
 )
 
 // TraceOverview represents a summary of a trace

--- a/agent-manager-service/repositories/agent_config_repository.go
+++ b/agent-manager-service/repositories/agent_config_repository.go
@@ -22,7 +22,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // ErrAgentConfigNotFound is returned when no agent config exists for the given agent and environment.

--- a/agent-manager-service/repositories/agent_configuration_repository.go
+++ b/agent-manager-service/repositories/agent_configuration_repository.go
@@ -24,8 +24,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // AgentConfigurationRepository defines data access for agent configurations

--- a/agent-manager-service/repositories/agent_env_config_variable_repository.go
+++ b/agent-manager-service/repositories/agent_env_config_variable_repository.go
@@ -24,7 +24,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // AgentEnvConfigVariableRepository defines data access for environment variables

--- a/agent-manager-service/repositories/artifact_repository.go
+++ b/agent-manager-service/repositories/artifact_repository.go
@@ -22,8 +22,8 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // ArtifactRepository defines the interface for artifact data access

--- a/agent-manager-service/repositories/catalog_repository.go
+++ b/agent-manager-service/repositories/catalog_repository.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // CatalogRepository defines the interface for catalog data access

--- a/agent-manager-service/repositories/custom_evaluator_repository.go
+++ b/agent-manager-service/repositories/custom_evaluator_repository.go
@@ -23,7 +23,7 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // CustomEvaluatorFilters holds filter/pagination options for listing custom evaluators

--- a/agent-manager-service/repositories/deployment_repository.go
+++ b/agent-manager-service/repositories/deployment_repository.go
@@ -25,8 +25,8 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // DeploymentRepository defines the interface for deployment data operations

--- a/agent-manager-service/repositories/env_agent_model_mapping_repository.go
+++ b/agent-manager-service/repositories/env_agent_model_mapping_repository.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // EnvAgentModelMappingRepository defines data access for environment mappings

--- a/agent-manager-service/repositories/evaluation_score_repository.go
+++ b/agent-manager-service/repositories/evaluation_score_repository.go
@@ -24,7 +24,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // ScoreRepository defines the interface for score data access

--- a/agent-manager-service/repositories/gateway_repository.go
+++ b/agent-manager-service/repositories/gateway_repository.go
@@ -22,8 +22,8 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // GatewayFilterOptions defines filtering options for gateway queries

--- a/agent-manager-service/repositories/llm_provider_repository.go
+++ b/agent-manager-service/repositories/llm_provider_repository.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // LLMProviderRepository defines the interface for LLM provider persistence

--- a/agent-manager-service/repositories/llm_provider_template_repository.go
+++ b/agent-manager-service/repositories/llm_provider_template_repository.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 type llmProviderTemplateConfig struct {

--- a/agent-manager-service/repositories/llm_proxy_repository.go
+++ b/agent-manager-service/repositories/llm_proxy_repository.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // LLMProxyRepository defines the interface for LLM proxy persistence

--- a/agent-manager-service/repositories/monitor_repository.go
+++ b/agent-manager-service/repositories/monitor_repository.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // MonitorRepository defines the interface for monitor and monitor run data access

--- a/agent-manager-service/resources/builtin_llm_templates.go
+++ b/agent-manager-service/resources/builtin_llm_templates.go
@@ -16,7 +16,7 @@
 
 package resources
 
-import "github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+import "github.com/wso2/agent-manager/agent-manager-service/models"
 
 // BuiltInLLMProviderTemplates contains all built-in LLM provider templates
 // These templates are immutable and available globally across all organizations

--- a/agent-manager-service/scripts/fmt.sh
+++ b/agent-manager-service/scripts/fmt.sh
@@ -1,5 +1,5 @@
 gofumpt -l -w .
 # golines -m 100 -w .
 gofmt -s -w . # already covered by gofumpt, but keeping it for now
-goimports -w -local github.com/wso2/ai-agent-management-platform/agent-manager-service .
+goimports -w -local github.com/wso2/agent-manager/agent-manager-service .
 bash scripts/newline.sh

--- a/agent-manager-service/scripts/generate-builtin-evaluators.sh
+++ b/agent-manager-service/scripts/generate-builtin-evaluators.sh
@@ -314,7 +314,7 @@ lines = [
     "",
     "package catalog",
     "",
-    'import "github.com/wso2/ai-agent-management-platform/agent-manager-service/models"',
+    'import "github.com/wso2/agent-manager/agent-manager-service/models"',
     "",
     "var entries = []*Entry{",
 ]

--- a/agent-manager-service/server/internal_server.go
+++ b/agent-manager-service/server/internal_server.go
@@ -33,7 +33,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 )
 
 // InternalServer represents the internal HTTPS server for WebSocket and gateway internal APIs

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -28,12 +28,12 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	appConfig "github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	appConfig "github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // AgentConfigurationService interface defines agent configuration business logic

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -23,15 +23,15 @@ import (
 	"log/slog"
 	"strings"
 
-	observabilitysvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/gen"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	observabilitysvc "github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 type AgentManagerService interface {

--- a/agent-manager-service/services/agent_token_manager.go
+++ b/agent-manager-service/services/agent_token_manager.go
@@ -34,10 +34,10 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // AgentTokenManagerService defines the interface for agent token operations

--- a/agent-manager-service/services/apikey_broadcaster.go
+++ b/agent-manager-service/services/apikey_broadcaster.go
@@ -20,9 +20,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // apiKeyBroadcaster encapsulates the shared create/revoke/rotate broadcast pattern

--- a/agent-manager-service/services/catalog_service.go
+++ b/agent-manager-service/services/catalog_service.go
@@ -23,9 +23,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
 // Environment mapping cache with TTL to reduce external API calls

--- a/agent-manager-service/services/deployment_service.go
+++ b/agent-manager-service/services/deployment_service.go
@@ -17,7 +17,7 @@
 package services
 
 import (
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
 // DeploymentService handles deployment business logic for artifacts to gateways

--- a/agent-manager-service/services/environment_service.go
+++ b/agent-manager-service/services/environment_service.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/google/uuid"
 
-	occlient "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // EnvironmentService defines the interface for environment operations

--- a/agent-manager-service/services/evaluator_manager.go
+++ b/agent-manager-service/services/evaluator_manager.go
@@ -26,10 +26,10 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/catalog"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/catalog"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // EvaluatorManagerService defines the interface for evaluator catalog and custom evaluator operations

--- a/agent-manager-service/services/gateway_events_service.go
+++ b/agent-manager-service/services/gateway_events_service.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/websocket"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 )
 
 const (

--- a/agent-manager-service/services/gateway_internal_service.go
+++ b/agent-manager-service/services/gateway_internal_service.go
@@ -24,9 +24,9 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // GatewayInternalAPIService handles internal gateway API operations

--- a/agent-manager-service/services/infra_resource_manager.go
+++ b/agent-manager-service/services/infra_resource_manager.go
@@ -23,10 +23,10 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 type InfraResourceManager interface {

--- a/agent-manager-service/services/llm_deployment_service.go
+++ b/agent-manager-service/services/llm_deployment_service.go
@@ -27,9 +27,9 @@ import (
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/services/llm_deployment_service_test.go
+++ b/agent-manager-service/services/llm_deployment_service_test.go
@@ -21,7 +21,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // Test helper functions

--- a/agent-manager-service/services/llm_provider_apikey_service.go
+++ b/agent-manager-service/services/llm_provider_apikey_service.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProviderAPIKeyService handles API key management for LLM providers

--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -27,10 +27,10 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/services/llm_provider_template_service.go
+++ b/agent-manager-service/services/llm_provider_template_service.go
@@ -23,9 +23,9 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProviderTemplateService handles LLM provider template business logic

--- a/agent-manager-service/services/llm_proxy_apikey_service.go
+++ b/agent-manager-service/services/llm_proxy_apikey_service.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProxyAPIKeyService handles API key management for LLM proxies

--- a/agent-manager-service/services/llm_proxy_deployment_service.go
+++ b/agent-manager-service/services/llm_proxy_deployment_service.go
@@ -25,9 +25,9 @@ import (
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/services/llm_proxy_deployment_service_test.go
+++ b/agent-manager-service/services/llm_proxy_deployment_service_test.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // Mock repository for LLM Provider

--- a/agent-manager-service/services/llm_proxy_service.go
+++ b/agent-manager-service/services/llm_proxy_service.go
@@ -24,9 +24,9 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProxyService handles LLM proxy business logic

--- a/agent-manager-service/services/llm_template_seeder.go
+++ b/agent-manager-service/services/llm_template_seeder.go
@@ -19,8 +19,8 @@ package services
 import (
 	"fmt"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
 // LLMTemplateSeeder handles seeding of LLM provider templates

--- a/agent-manager-service/services/llm_template_store.go
+++ b/agent-manager-service/services/llm_template_store.go
@@ -19,7 +19,7 @@ package services
 import (
 	"sync"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // LLMTemplateStore provides thread-safe in-memory storage for built-in LLM provider templates

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/catalog"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/catalog"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // MonitorExecutor handles workflow execution for monitors

--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -27,11 +27,11 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 const (

--- a/agent-manager-service/services/monitor_scheduler.go
+++ b/agent-manager-service/services/monitor_scheduler.go
@@ -23,10 +23,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
 const (

--- a/agent-manager-service/services/monitor_scheduler_test.go
+++ b/agent-manager-service/services/monitor_scheduler_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
 // mockExecutor is a test mock for the MonitorExecutor interface

--- a/agent-manager-service/services/monitor_scores_service.go
+++ b/agent-manager-service/services/monitor_scores_service.go
@@ -25,9 +25,9 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // MonitorScoresService handles evaluation score business logic

--- a/agent-manager-service/services/observability_manager.go
+++ b/agent-manager-service/services/observability_manager.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	traceobserversvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // ErrTraceNotFound is returned when a trace is not found

--- a/agent-manager-service/services/platform_gateway_service.go
+++ b/agent-manager-service/services/platform_gateway_service.go
@@ -32,9 +32,9 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // PlatformGatewayService handles gateway business logic for API Platform integration

--- a/agent-manager-service/services/repository_service.go
+++ b/agent-manager-service/services/repository_service.go
@@ -19,9 +19,9 @@ package services
 import (
 	"context"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/gitprovider"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/gitprovider"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
 // RepositoryService defines the interface for repository operations

--- a/agent-manager-service/services/token_cache.go
+++ b/agent-manager-service/services/token_cache.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 // TokenCacheEntry represents a cached token with its gateway and verification data

--- a/agent-manager-service/tests/agent_token_test.go
+++ b/agent-manager-service/tests/agent_token_test.go
@@ -31,13 +31,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 func createMockOpenChoreoClientForToken(agentName string, componentUid string, envUid string, orgUid string, projUid string) *clientmocks.OpenChoreoClientMock {

--- a/agent-manager-service/tests/apitestutils/mock_clients.go
+++ b/agent-manager-service/tests/apitestutils/mock_clients.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // CreateMockOpenChoreoClient creates a mock OpenChoreo client with default behavior for testing

--- a/agent-manager-service/tests/apitestutils/test_utils.go
+++ b/agent-manager-service/tests/apitestutils/test_utils.go
@@ -21,11 +21,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/api"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/api"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 // MakeAppClientWithDeps creates an HTTP handler with the provided dependencies for testing

--- a/agent-manager-service/tests/application_logs_test.go
+++ b/agent-manager-service/tests/application_logs_test.go
@@ -30,14 +30,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/build_agent_test.go
+++ b/agent-manager-service/tests/build_agent_test.go
@@ -28,12 +28,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/build_logs_test.go
+++ b/agent-manager-service/tests/build_logs_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/create_agent_test.go
+++ b/agent-manager-service/tests/create_agent_test.go
@@ -30,14 +30,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/create_external_agent_test.go
+++ b/agent-manager-service/tests/create_external_agent_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/create_project_test.go
+++ b/agent-manager-service/tests/create_project_test.go
@@ -28,14 +28,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/delete_agent_test.go
+++ b/agent-manager-service/tests/delete_agent_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/delete_project_test.go
+++ b/agent-manager-service/tests/delete_project_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/deploy_agent_test.go
+++ b/agent-manager-service/tests/deploy_agent_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 var (

--- a/agent-manager-service/tests/evaluator_test.go
+++ b/agent-manager-service/tests/evaluator_test.go
@@ -30,15 +30,15 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/catalog"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/catalog"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 // --- Mock and helpers for unit tests ---

--- a/agent-manager-service/tests/get_trace_test.go
+++ b/agent-manager-service/tests/get_trace_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	traceobserversvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 func createMockTraceObserverClientWithDetails() *clientmocks.TraceObserverClientMock {

--- a/agent-manager-service/tests/list_traces_test.go
+++ b/agent-manager-service/tests/list_traces_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	traceobserversvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 func createMockTraceObserverClient() *clientmocks.TraceObserverClientMock {

--- a/agent-manager-service/tests/monitor_executor_test.go
+++ b/agent-manager-service/tests/monitor_executor_test.go
@@ -28,13 +28,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // testEncryptionKey returns a 32-byte AES-256 key for tests.

--- a/agent-manager-service/tests/monitor_scores_test.go
+++ b/agent-manager-service/tests/monitor_scores_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // stubScoreRepo is a minimal ScoreRepository that returns "not found" for monitor lookups.

--- a/agent-manager-service/tests/monitor_test.go
+++ b/agent-manager-service/tests/monitor_test.go
@@ -30,14 +30,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/clientmocks"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/tests/apitestutils"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/wiring"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 )
 
 // uniqueMonitorName generates a unique monitor name for testing

--- a/agent-manager-service/tests/score_repository_test.go
+++ b/agent-manager-service/tests/score_repository_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/db"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
 // ─── helpers ──────────────────────────────────────────────────────────────────

--- a/agent-manager-service/utils/crypto.go
+++ b/agent-manager-service/utils/crypto.go
@@ -29,7 +29,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 var (

--- a/agent-manager-service/utils/llm_template_loader.go
+++ b/agent-manager-service/utils/llm_template_loader.go
@@ -24,7 +24,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
 type extractionIdentifierYAML struct {

--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -17,8 +17,8 @@
 package utils
 
 import (
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
 // Helper functions to convert between spec and models MonitorEvaluator types

--- a/agent-manager-service/utils/spec_converter.go
+++ b/agent-manager-service/utils/spec_converter.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/models"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
 // Helper function to convert *string to string

--- a/agent-manager-service/utils/utils.go
+++ b/agent-manager-service/utils/utils.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
 // MaxReplicasLimit is the maximum number of replicas allowed for agents

--- a/agent-manager-service/wiring/params.go
+++ b/agent-manager-service/wiring/params.go
@@ -23,15 +23,15 @@ import (
 
 	"gorm.io/gorm"
 
-	observabilitysvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	occlient "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	traceobserversvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/websocket"
+	observabilitysvc "github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 )
 
 // AppParams contains all wired application dependencies

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -27,16 +27,16 @@ import (
 	"github.com/google/wire"
 	"gorm.io/gorm"
 
-	observabilitysvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	occlient "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	traceobserversvc "github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/websocket"
+	observabilitysvc "github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 )
 
 // Provider sets

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -14,16 +14,16 @@ import (
 	"github.com/google/wire"
 	"gorm.io/gorm"
 
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/observabilitysvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/openchoreosvc/client"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/secretmanagersvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/clients/traceobserversvc"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/config"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/repositories"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/services"
-	"github.com/wso2/ai-agent-management-platform/agent-manager-service/websocket"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 )
 
 // Injectors from wire.go:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/Chart.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 0.0.0-dev
 appVersion: "0.0.0-dev"
 
-home: https://github.com/wso2/ai-agent-management-platform
+home: https://github.com/wso2/agent-manager
 sources:
-  - https://github.com/wso2/ai-agent-management-platform
+  - https://github.com/wso2/agent-manager
 maintainers:
   - name: WSO2
     url: https://wso2.com

--- a/deployments/helm-charts/wso2-amp-secrets-extension/Chart.yaml
+++ b/deployments/helm-charts/wso2-amp-secrets-extension/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 version: 0.0.0-dev
 appVersion: "0.0.0-dev"
 
-home: https://github.com/wso2/ai-agent-management-platform
+home: https://github.com/wso2/agent-manager
 sources:
-  - https://github.com/wso2/ai-agent-management-platform
+  - https://github.com/wso2/agent-manager
 maintainers:
   - name: WSO2
     url: https://wso2.com

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -247,5 +247,5 @@ Before submitting a PR, please ensure:
 
 ## Links
 
-- [AI Agent Management Platform Repository](https://github.com/wso2/ai-agent-management-platform)
+- [AI Agent Management Platform Repository](https://github.com/wso2/agent-manager)
 - [Documentation](https://wso2.github.io/ai-agent-management-platform/)

--- a/documentation/versioned_docs/version-v0.3.0/components/amp-instrumentation.md
+++ b/documentation/versioned_docs/version-v0.3.0/components/amp-instrumentation.md
@@ -24,7 +24,7 @@ pip install amp-instrumentation
 
 ### 1. Register Your Agent
 
-First, register your agent at the [WSO2 AI Agent Management Platform](https://github.com/wso2/ai-agent-management-platform) to obtain your agent API key and configuration details.
+First, register your agent at the [WSO2 AI Agent Management Platform](https://github.com/wso2/agent-manager) to obtain your agent API key and configuration details.
 
 ### 2. Set Required Environment Variables
 

--- a/documentation/versioned_docs/version-v0.3.0/getting-started/single-cluster-installation.md
+++ b/documentation/versioned_docs/version-v0.3.0/getting-started/single-cluster-installation.md
@@ -159,4 +159,4 @@ Verify PostgreSQL is running:
 kubectl get pods -n amp-system -l app=postgresql
 ```
 
-For more help, visit our [GitHub Discussions](https://github.com/wso2/ai-agent-management-platform/discussions).
+For more help, visit our [GitHub Discussions](https://github.com/wso2/agent-manager/discussions).

--- a/documentation/versioned_docs/version-v0.3.0/overview/what-is-amp.md
+++ b/documentation/versioned_docs/version-v0.3.0/overview/what-is-amp.md
@@ -42,7 +42,7 @@ Deploy WSO2 AI Agent Management Platform on Kubernetes using our Helm charts:
 
 ## Getting Started
 
-For installation instructions and a step-by-step guide, see the [Quick Start Guide](https://github.com/wso2/ai-agent-management-platform/blob/amp/v0/docs/quick-start.md).
+For installation instructions and a step-by-step guide, see the [Quick Start Guide](https://github.com/wso2/agent-manager/blob/amp/v0/docs/quick-start.md).
 
 ## Contributing
 
@@ -56,9 +56,9 @@ Please ensure your contributions adhere to our coding standards and include appr
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/wso2/ai-agent-management-platform/blob/main/LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/wso2/agent-manager/blob/main/LICENSE) file for details.
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/wso2/ai-agent-management-platform/issues)
+- **Issues**: [GitHub Issues](https://github.com/wso2/agent-manager/issues)
 - **Community**: [WSO2 Community](https://wso2.com/community/)

--- a/documentation/versioned_docs/version-v0.4.0/components/amp-instrumentation.md
+++ b/documentation/versioned_docs/version-v0.4.0/components/amp-instrumentation.md
@@ -24,7 +24,7 @@ pip install amp-instrumentation
 
 ### 1. Register Your Agent
 
-First, register your agent at the [WSO2 Agent Manager](https://github.com/wso2/ai-agent-management-platform) to obtain your agent API key and configuration details.
+First, register your agent at the [WSO2 Agent Manager](https://github.com/wso2/agent-manager) to obtain your agent API key and configuration details.
 
 ### 2. Set Required Environment Variables
 

--- a/documentation/versioned_docs/version-v0.4.0/overview/what-is-amp.md
+++ b/documentation/versioned_docs/version-v0.4.0/overview/what-is-amp.md
@@ -43,7 +43,7 @@ Deploy WSO2 Agent Manager on Kubernetes using our Helm charts:
 
 ## Getting Started
 
-For installation instructions and a step-by-step guide, see the [Quick Start Guide](https://github.com/wso2/ai-agent-management-platform/blob/amp/v0/docs/quick-start.md).
+For installation instructions and a step-by-step guide, see the [Quick Start Guide](https://github.com/wso2/agent-manager/blob/amp/v0/docs/quick-start.md).
 
 ## Contributing
 
@@ -57,9 +57,9 @@ Please ensure your contributions adhere to our coding standards and include appr
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/wso2/ai-agent-management-platform/blob/main/LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/wso2/agent-manager/blob/main/LICENSE) file for details.
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/wso2/ai-agent-management-platform/issues)
+- **Issues**: [GitHub Issues](https://github.com/wso2/agent-manager/issues)
 - **Community**: [WSO2 Community](https://wso2.com/community/)

--- a/evaluation-job/Dockerfile
+++ b/evaluation-job/Dockerfile
@@ -20,7 +20,7 @@
 
 FROM public.ecr.aws/docker/library/python:3.11-alpine
 
-LABEL org.opencontainers.image.source="https://github.com/wso2/ai-agent-management-platform"
+LABEL org.opencontainers.image.source="https://github.com/wso2/agent-manager"
 LABEL org.opencontainers.image.description="AMP Evaluation Monitor - AI Agent evaluation job for monitoring workflows"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 

--- a/evaluation-job/Dockerfile.dev
+++ b/evaluation-job/Dockerfile.dev
@@ -20,7 +20,7 @@
 
 FROM public.ecr.aws/docker/library/python:3.11-alpine
 
-LABEL org.opencontainers.image.source="https://github.com/wso2/ai-agent-management-platform"
+LABEL org.opencontainers.image.source="https://github.com/wso2/agent-manager"
 LABEL org.opencontainers.image.description="AMP Evaluation Monitor - AI Agent evaluation job (development build)"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 

--- a/libs/amp-evaluation/pyproject.toml
+++ b/libs/amp-evaluation/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
 ]
 
 [project.urls]
-Repository = "https://github.com/wso2/ai-agent-management-platform"
+Repository = "https://github.com/wso2/agent-manager"
 
 [build-system]
 build-backend = "hatchling.build"

--- a/samples/customer-support-agent/README.md
+++ b/samples/customer-support-agent/README.md
@@ -41,7 +41,7 @@ Fill in the agent creation form with these exact values:
 | --------------------- | ------------------------------------------------------- |
 | **Display Name**      | `Support Agent`                                         |
 | **Description**       | `AI-powered customer support agent for travel services` |
-| **GitHub Repository** | `https://github.com/wso2/ai-agent-management-platform`  |
+| **GitHub Repository** | `https://github.com/wso2/agent-manager`  |
 | **Branch**            | `main`                                                  |
 | **App Path**          | `samples/customer-support-agent`                        |
 | **Language**          | `Python`                                                |

--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -23,8 +23,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/opensearch"
+	"github.com/wso2/agent-manager/traces-observer-service/middleware/logger"
+	"github.com/wso2/agent-manager/traces-observer-service/opensearch"
 )
 
 // ErrTraceNotFound is returned when a trace is not found

--- a/traces-observer-service/go.mod
+++ b/traces-observer-service/go.mod
@@ -1,4 +1,4 @@
-module github.com/wso2/ai-agent-management-platform/traces-observer-service
+module github.com/wso2/agent-manager/traces-observer-service
 
 go 1.25.0
 

--- a/traces-observer-service/handlers/handlers.go
+++ b/traces-observer-service/handlers/handlers.go
@@ -25,9 +25,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/opensearch"
+	"github.com/wso2/agent-manager/traces-observer-service/controllers"
+	"github.com/wso2/agent-manager/traces-observer-service/middleware/logger"
+	"github.com/wso2/agent-manager/traces-observer-service/opensearch"
 )
 
 // Handler handles HTTP requests for tracing

--- a/traces-observer-service/main.go
+++ b/traces-observer-service/main.go
@@ -26,12 +26,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/config"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/controllers"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/handlers"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/middleware"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/middleware/logger"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/opensearch"
+	"github.com/wso2/agent-manager/traces-observer-service/config"
+	"github.com/wso2/agent-manager/traces-observer-service/controllers"
+	"github.com/wso2/agent-manager/traces-observer-service/handlers"
+	"github.com/wso2/agent-manager/traces-observer-service/middleware"
+	"github.com/wso2/agent-manager/traces-observer-service/middleware/logger"
+	"github.com/wso2/agent-manager/traces-observer-service/opensearch"
 )
 
 func setupLogger(cfg *config.Config) {

--- a/traces-observer-service/opensearch/client.go
+++ b/traces-observer-service/opensearch/client.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/opensearch-project/opensearch-go"
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/config"
-	"github.com/wso2/ai-agent-management-platform/traces-observer-service/middleware/logger"
+	"github.com/wso2/agent-manager/traces-observer-service/config"
+	"github.com/wso2/agent-manager/traces-observer-service/middleware/logger"
 )
 
 // Client wraps the OpenSearch client


### PR DESCRIPTION
## Purpose
Change project refences to the new project name to eliminate the redirect requirement on github from readmes.

## Goals
Search and replace old name to new name

## Approach
Used:
`grep -rlI --exclude-dir=.git "github.com/wso2/ai-agent-management-platform" . \
  | xargs sed -i '' 's|github\.com/wso2/ai-agent-management-platform|github.com/wso2/agent-manager|g' 
`

## User stories
N/A

## Release note
Changed from old project name of `ai-agent-management-platform` to new name `agent-manager`.

## Documentation
N/A but README.md files were updated along with the code files.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
N/A
 - Integration tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A