### PR TITLE
Add AI gateway localhost accessibility via HTTPRoute

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -92,6 +92,8 @@ services:
       - "api.openchoreo.localhost:host-gateway"
       # Thunder IDP for OAuth2 token exchange (must match OpenChoreo's security.oidc config)
       - "thunder.amp.localhost:host-gateway"
+      # AI gateway runtime for agent endpoint access via OpenChoreo gateway
+      - "ai-gateway.amp.localhost:host-gateway"
 
   # Agent Manager Console (React Frontend)
   agent-manager-console:

--- a/deployments/helm-charts/wso2-amp-ai-gateway-extension/templates/gateway-httproute.yaml
+++ b/deployments/helm-charts/wso2-amp-ai-gateway-extension/templates/gateway-httproute.yaml
@@ -1,0 +1,50 @@
+---
+# ReferenceGrant to allow HTTPRoute in openchoreo-control-plane to reference Service in openchoreo-data-plane
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: amp-ai-gateway-backend
+  namespace: {{ .Values.apiGateway.namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: ai-gateway
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: openchoreo-control-plane
+  to:
+    - group: ""
+      kind: Service
+---
+# HTTPRoute in openchoreo-control-plane namespace to route traffic to AI Gateway runtime
+# This is required because the gateway-default Gateway only allows HTTPRoutes from the same namespace
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-gateway
+  namespace: openchoreo-control-plane
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: ai-gateway
+spec:
+  hostnames:
+    - {{ .Values.gateway.ocIngress.hostname }}
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-default
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ .Values.gateway.ocIngress.runtimeServiceName }}
+          namespace: {{ .Values.apiGateway.namespace }}
+          port: {{ .Values.gateway.ocIngress.runtimeServicePort }}
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /

--- a/deployments/helm-charts/wso2-amp-ai-gateway-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-ai-gateway-extension/values.yaml
@@ -40,9 +40,18 @@ gateway:
   # Human-readable display name
   displayName: "Default AI Gateway"
   # Virtual host (FQDN or IP) that the gateway is reachable on
-  vhost: "http://default-ai-gateway-gateway-runtime.openchoreo-data-plane.svc.cluster.local:8084"
+  vhost: "http://ai-gateway.amp.localhost:8080"
   # Gateway type: must be "AI"
   type: "AI"
+
+  # OpenChoreo ingress configuration for localhost accessibility
+  ocIngress:
+    # Hostname for the AI gateway HTTPRoute (must resolve to OpenChoreo gateway on port 8080)
+    hostname: "ai-gateway.amp.localhost"
+    # Service name of the AI gateway runtime in the data-plane namespace
+    runtimeServiceName: "default-ai-gateway-gateway-runtime"
+    # Port of the AI gateway runtime service
+    runtimeServicePort: 8084
 
   # The generated registration token is stored in this Kubernetes Secret.
   # It is then referenced by the APIGateway CR spec.controlPlane.tokenSecretRef.

--- a/deployments/scripts/port-forward.sh
+++ b/deployments/scripts/port-forward.sh
@@ -74,6 +74,9 @@ kubectl port-forward -n openbao svc/openbao 8201:8200 &
 echo "Forwarding OpenChoreo Api (8195)..."
 kubectl port-forward svc/openchoreo-api -n openchoreo-control-plane 8195:8080 &
 
+# Port forward AI Gateway Runtime
+echo "🤖 Forwarding AI Gateway Runtime (8084)..."
+kubectl port-forward -n openchoreo-data-plane svc/default-ai-gateway-gateway-runtime 8084:8084 &
 
 echo ""
 echo "✅ Port forwarding active:"
@@ -85,6 +88,7 @@ echo "   Observability Gateway:            http://localhost:22893/otel"
 echo "   Observability Gateway (HTTPS):    https://localhost:22894/otel"
 echo "   OpenBao (Data Plane):             http://localhost:8200"
 echo "   OpenBao (Workflow Plane):         http://localhost:8201"
+echo "   AI Gateway Runtime:               http://localhost:8084"
 
 echo ""
 echo "💡 Keep this terminal open. Press Ctrl+C to stop."


### PR DESCRIPTION
## Summary

- Agent endpoint URLs were returned as internal K8s service DNS names (e.g., `http://default-ai-gateway-gateway-runtime.openchoreo-data-plane.svc.cluster.local:8084/...`), unreachable from the developer's browser
- Adds an HTTPRoute + ReferenceGrant following the existing Thunder IDP pattern, routing traffic from `ai-gateway.amp.localhost:8080` through OpenChoreo's gateway to the AI gateway runtime
- Updates the gateway vhost so endpoint URLs use the reachable hostname

## Changes

| File | Change |
|------|--------|
| `deployments/helm-charts/wso2-amp-ai-gateway-extension/templates/gateway-httproute.yaml` | New HTTPRoute + ReferenceGrant for cross-namespace routing to AI gateway runtime |
| `deployments/helm-charts/wso2-amp-ai-gateway-extension/values.yaml` | Add `gateway.ocIngress` config; update `gateway.vhost` to `http://ai-gateway.amp.localhost:8080` |
| `deployments/docker-compose.yml` | Add `ai-gateway.amp.localhost` extra_hosts entry |
| `deployments/scripts/port-forward.sh` | Add AI gateway runtime port-forward on port 8084 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI Gateway Runtime is now accessible via localhost endpoint (`ai-gateway.amp.localhost:8080`)
  * Added Kubernetes Gateway API cross-namespace routing configuration

* **Chores**
  * Updated Docker Compose configuration for AI Gateway service
  * Updated port-forwarding setup to include AI Gateway Runtime on port 8084

<!-- end of auto-generated comment: release notes by coderabbit.ai -->