### PR TITLE
Improve docs SEO: sitemap cleanup, noindex for unreleased pages, and add meta tags

### DIFF
--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -1,3 +1,8 @@
+---
+title: WSO2 Agent Manager Instrumentation | OpenTelemetry for Python Agents
+description: Enable zero-code OpenTelemetry tracing for Python agents using amp-instrumentation in WSO2 Agent Manager. Capture LLM calls, MCP requests, and more.
+---
+
 # WSO2 Agent Manager Instrumentation Package
 
 Zero-code OpenTelemetry instrumentation package for externally-hosted Python agents using the Traceloop SDK, with trace visibility in the WSO2 Agent Manager.

--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -1,5 +1,5 @@
 ---
-title: WSO2 Agent Manager Instrumentation | OpenTelemetry for Python Agents
+title: WSO2 Agent Manager Instrumentation Package
 description: Enable zero-code OpenTelemetry tracing for Python agents using amp-instrumentation in WSO2 Agent Manager. Capture LLM calls, MCP requests, and more.
 ---
 

--- a/documentation/docs/concepts/evaluation.mdx
+++ b/documentation/docs/concepts/evaluation.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: AI Agent Evaluation in WSO2 Agent Manager
+title: Evaluation
 description: Learn how WSO2 Agent Manager evaluates AI agent quality with trace-based scoring, built-in evaluators, and continuous monitoring.
 ---
 

--- a/documentation/docs/concepts/evaluation.mdx
+++ b/documentation/docs/concepts/evaluation.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: AI Agent Evaluation in WSO2 Agent Manager
+description: Learn how WSO2 Agent Manager evaluates AI agent quality with trace-based scoring, built-in evaluators, and continuous monitoring.
 ---
 
 import Tabs from '@theme/Tabs';
@@ -380,4 +382,3 @@ To use LLM-as-Judge evaluators, you need to provide an API key for at least one 
 | **Mistral AI** | `MISTRAL_API_KEY` |
 
 Credentials are stored securely with the monitor and used only when the evaluation job runs. You only need to add each provider once per monitor. All evaluators using that provider share the same credentials.
-

--- a/documentation/docs/concepts/observability.mdx
+++ b/documentation/docs/concepts/observability.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: Observability for AI Agents in WSO2 Agent Manager
+title: Observability 
 description: Understand how WSO2 Agent Manager captures traces, metrics, and logs for deployed and externally hosted AI agents.
 ---
 

--- a/documentation/docs/concepts/observability.mdx
+++ b/documentation/docs/concepts/observability.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+title: Observability for AI Agents in WSO2 Agent Manager
+description: Understand how WSO2 Agent Manager captures traces, metrics, and logs for deployed and externally hosted AI agents.
 ---
 
 # Observability

--- a/documentation/docs/contributing/contributing.mdx
+++ b/documentation/docs/contributing/contributing.mdx
@@ -1,3 +1,8 @@
+---
+title: WSO2 Agent Manager Contributing Guidelines
+description: Guidelines for using GitHub Discussions and Issues to collaborate on WSO2 Agent Manager.
+---
+
 # Contributing Guidelines
 
 This document establishes guidelines for using GitHub Discussions and Issues for technical conversations about the Agent Manager.

--- a/documentation/docs/contributing/contributing.mdx
+++ b/documentation/docs/contributing/contributing.mdx
@@ -1,5 +1,5 @@
 ---
-title: WSO2 Agent Manager Contributing Guidelines
+title: Contributing Guidelines
 description: Guidelines for using GitHub Discussions and Issues to collaborate on WSO2 Agent Manager.
 ---
 

--- a/documentation/docs/getting-started/cli-installation.mdx
+++ b/documentation/docs/getting-started/cli-installation.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+title: CLI Installation
+description: Install and configure amctl CLI to manage WSO2 Agent Manager, log in to an instance, and verify setup from the terminal.
 ---
 
 # CLI Installation

--- a/documentation/docs/getting-started/create-your-first-agent.mdx
+++ b/documentation/docs/getting-started/create-your-first-agent.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: Create Your First Agent
+description: Create and deploy your first AI agent in WSO2 Agent Manager using external or platform-hosted options.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/documentation/docs/getting-started/on-k3d.mdx
+++ b/documentation/docs/getting-started/on-k3d.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: Install the Agent Manager on a local Kubernetes cluster 
+description: Install WSO2 Agent Manager on a local single-node k3d Kubernetes cluster for development and exploration.
 ---
 
 import AmpInstallation from './_partials/_amp-installation.mdx';

--- a/documentation/docs/getting-started/on-k3d.mdx
+++ b/documentation/docs/getting-started/on-k3d.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Install the Agent Manager on a local Kubernetes cluster 
+title: On k3d (Locally)
 description: Install WSO2 Agent Manager on a local single-node k3d Kubernetes cluster for development and exploration.
 ---
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Install the Agent Manager on an existing Kubernetes cluster
+title: On Your Environment
 description: Install WSO2 Agent Manager on an existing Kubernetes cluster such as EKS, GKE, AKS, or any distribution with LoadBalancer support.
 ---
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+title: Install the Agent Manager on an existing Kubernetes cluster
+description: Install WSO2 Agent Manager on an existing Kubernetes cluster such as EKS, GKE, AKS, or any distribution with LoadBalancer support.
 ---
 
 import AmpInstallation from './_partials/_amp-installation.mdx';

--- a/documentation/docs/getting-started/quick-start.mdx
+++ b/documentation/docs/getting-started/quick-start.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+title: WSO2 Agent Manager Quick Start Guide
+description: Install WSO2 Agent Manager locally with a single command using the dev container quick start.
 ---
 # Quick Start Guide
 

--- a/documentation/docs/getting-started/quick-start.mdx
+++ b/documentation/docs/getting-started/quick-start.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: WSO2 Agent Manager Quick Start Guide
+title: Quick Start Guide
 description: Install WSO2 Agent Manager locally with a single command using the dev container quick start.
 ---
 # Quick Start Guide

--- a/documentation/docs/overview/what-is-amp.mdx
+++ b/documentation/docs/overview/what-is-amp.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+title: WSO2 Agent Manager
+description: WSO2 Agent Manager is an open control plane for deploying, managing, observing, and evaluating AI agents at scale.
 ---
 # WSO2 Agent Manager
 

--- a/documentation/docs/reference/cli/agent.mdx
+++ b/documentation/docs/reference/cli/agent.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 5
 sidebar_label: Agent
+title: amctl agent
+description: Manage agents in WSO2 Agent Manager using amctl CLI, including create, build, deploy, inspect, logs, metrics, and traces commands.
 ---
 
 # amctl agent

--- a/documentation/docs/reference/cli/context.mdx
+++ b/documentation/docs/reference/cli/context.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 3
 sidebar_label: Context
+title: amctl context
+description: Manage amctl CLI context, including instances, organizations, and per-directory project and agent links in WSO2 Agent Manager.
 ---
 
 # amctl context

--- a/documentation/docs/reference/cli/login.mdx
+++ b/documentation/docs/reference/cli/login.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 2
 sidebar_label: Login
+title: amctl login
+description: Authenticate amctl CLI with a WSO2 Agent Manager instance using browser OAuth or client credentials for CI automation.
 ---
 
 # amctl login

--- a/documentation/docs/reference/cli/overview.mdx
+++ b/documentation/docs/reference/cli/overview.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 1
 sidebar_label: Overview
+title: amctl overview
+description: Overview of the amctl CLI for WSO2 Agent Manager, including command structure, global flags, context resolution, and output formats.
 ---
 
 # Overview

--- a/documentation/docs/reference/cli/project.mdx
+++ b/documentation/docs/reference/cli/project.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 4
 sidebar_label: Project
+title: amctl project
+description: Manage WSO2 Agent Manager projects using amctl CLI, including create, list, get, and delete operations for organizing agents and pipelines.
 ---
 
 # amctl project

--- a/documentation/docs/reference/cli/skills.mdx
+++ b/documentation/docs/reference/cli/skills.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 6
 sidebar_label: Skills
+title: amctl skills
+description: Install, list, and manage AI assistant skills for amctl CLI, enabling Agent Manager integration in tools like Claude Code, Cursor, and Windsurf.
 ---
 
 # amctl skills

--- a/documentation/docs/reference/cli/version.mdx
+++ b/documentation/docs/reference/cli/version.mdx
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 7
 sidebar_label: Version
+title: amctl version
+description: Print the installed amctl CLI version, build metadata, and commit hash for WSO2 Agent Manager.
 ---
 
 # amctl version

--- a/documentation/docs/tutorials/configure-agent-llm-configuration.mdx
+++ b/documentation/docs/tutorials/configure-agent-llm-configuration.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 8
+title: Configure LLM Providers for an Agent in WSO2 Agent Manager
+description: Attach organization-level LLM providers to platform-hosted or external agents and use the generated connection details in code.
 ---
 
 # Configure LLM Providers for an Agent

--- a/documentation/docs/tutorials/configure-agent-llm-configuration.mdx
+++ b/documentation/docs/tutorials/configure-agent-llm-configuration.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 8
-title: Configure LLM Providers for an Agent in WSO2 Agent Manager
+title: Configure LLM Providers for an Agent 
 description: Attach organization-level LLM providers to platform-hosted or external agents and use the generated connection details in code.
 ---
 

--- a/documentation/docs/tutorials/custom-evaluators.mdx
+++ b/documentation/docs/tutorials/custom-evaluators.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: Custom Evaluators in WSO2 Agent Manager 
+title: Custom Evaluators
 description: Create custom code-based and LLM-judge evaluators in the AMP Console for domain-specific quality checks.
 ---
 

--- a/documentation/docs/tutorials/custom-evaluators.mdx
+++ b/documentation/docs/tutorials/custom-evaluators.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+title: Custom Evaluators in WSO2 Agent Manager 
+description: Create custom code-based and LLM-judge evaluators in the AMP Console for domain-specific quality checks.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/documentation/docs/tutorials/evaluation-monitors.mdx
+++ b/documentation/docs/tutorials/evaluation-monitors.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: Evaluation Monitors in WSO2 Agent Manager
+description: Create, configure, and manage evaluation monitors in the AMP Console to score agent traces over time.
 ---
 
 # Evaluation Monitors

--- a/documentation/docs/tutorials/evaluation-monitors.mdx
+++ b/documentation/docs/tutorials/evaluation-monitors.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Evaluation Monitors in WSO2 Agent Manager
+title: Evaluation Monitors
 description: Create, configure, and manage evaluation monitors in the AMP Console to score agent traces over time.
 ---
 

--- a/documentation/docs/tutorials/observe-first-agent.mdx
+++ b/documentation/docs/tutorials/observe-first-agent.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 1
+title: Observe Your First Agent in WSO2 Agent Manager
+description: Register an externally hosted agent, enable zero-code instrumentation, and view traces in the AMP Console.
 ---
 
 import Tabs from '@theme/Tabs';

--- a/documentation/docs/tutorials/register-ai-gateway.mdx
+++ b/documentation/docs/tutorials/register-ai-gateway.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Register an AI Gateway in WSO2 Agent Manager
+title: Register an AI Gateway
 description: Register and configure a WSO2 AI Gateway in WSO2 Agent Manager to route LLM traffic through a controlled proxy.
 ---
 

--- a/documentation/docs/tutorials/register-ai-gateway.mdx
+++ b/documentation/docs/tutorials/register-ai-gateway.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 4
+title: Register an AI Gateway in WSO2 Agent Manager
+description: Register and configure a WSO2 AI Gateway in WSO2 Agent Manager to route LLM traffic through a controlled proxy.
 ---
 
 # Register an AI Gateway

--- a/documentation/docs/tutorials/register-llm-service-provider.mdx
+++ b/documentation/docs/tutorials/register-llm-service-provider.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: Register an LLM Service Provider in WSO2 Agent Manager
+title: Register an LLM Service Provider
 description: Register upstream LLM providers such as OpenAI, Anthropic, and Bedrock and expose them through an AI Gateway.
 ---
 

--- a/documentation/docs/tutorials/register-llm-service-provider.mdx
+++ b/documentation/docs/tutorials/register-llm-service-provider.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 5
+title: Register an LLM Service Provider in WSO2 Agent Manager
+description: Register upstream LLM providers such as OpenAI, Anthropic, and Bedrock and expose them through an AI Gateway.
 ---
 
 # Register an LLM Service Provider

--- a/documentation/docs/tutorials/secure-agent-endpoints-with-api-keys.mdx
+++ b/documentation/docs/tutorials/secure-agent-endpoints-with-api-keys.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 6
+title: Secure Agent Endpoints with API Keys
+description: Protect API agents in WSO2 Agent Manager using API key authentication via the X-API-Key header for deployment, access, and credential management.
 ---
 
 # Secure Agent Endpoints with API Keys

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -88,6 +88,7 @@ const config: Config = {
             current: {
               label: 'Next',
               banner: 'unreleased',
+              noIndex: true,
             },
             cloud: {
               label: 'Cloud',

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -105,11 +105,25 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/wso2/agent-manager/edit/main/documentation/',
+              'https://github.com/wso2/agent-manager/edit/main/documentation/',
+        },
+        sitemap: {
+            lastmod: 'date',
+            changefreq: 'weekly',
+            priority: 0.5,
+            ignorePatterns: [
+                ...versions
+                .filter((version) => version !== latestVersion)
+                .map((version) => `/agent-manager/docs/${version}/**`),
+                    '/agent-manager/docs/next/**',
+                '/agent-manager/docs/',
+                '/agent-manager/search/',
+                '/agent-manager/docs/getting-started/quick-start/',
+            ],
         },
         blog: false, // Disable blog until we have content
         theme: {
-          customCss: './src/css/custom.css',
+            customCss: './src/css/custom.css',
         },
       } satisfies Preset.Options,
     ],
@@ -117,12 +131,12 @@ const config: Config = {
 
   themeConfig: {
 
-    // Replace with your project's social card
-    // image: 'img/amp-social-card.png',
-    announcementBar: {
-      id: `release_${quickStartDockerTag.replace(/\./g, '_')}`,
-      content:
-        `🎉 WSO2 Agent Manager <a target="_blank" rel="noopener noreferrer" href="https://github.com/wso2/agent-manager/releases/tag/amp%2F${quickStartDockerTag}">${quickStartDockerTag}</a> has been released! Explore what's new. 🎉`,
+      // Replace with your project's social card
+      // image: 'img/amp-social-card.png',
+      announcementBar: {
+          id: `release_${quickStartDockerTag.replace(/\./g, '_')}`,
+          content:
+              `🎉 WSO2 Agent Manager <a target="_blank" rel="noopener noreferrer" href="https://github.com/wso2/agent-manager/releases/tag/amp%2F${quickStartDockerTag}">${quickStartDockerTag}</a> has been released! Explore what's new. 🎉`,
       isCloseable: true,
     },
 


### PR DESCRIPTION
## Purpose
> This PR improves the SEO configuration of the documentation site by ensuring only canonical, production-ready content is indexed.

## Changes
- Configure sitemap to include only the latest docs version  
- Exclude non-canonical and preview routes from sitemap  
- Add `noindex` to unreleased (`current`) docs version  
- Add meta `title` and `description` tags to docs pages  

## Why
- Prevents search engines from indexing outdated or duplicate content  
- Ensures only the latest, canonical docs appear in search results  
- Improves search result quality with proper meta tags  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized documentation front matter with improved titles and descriptions across multiple guides, including getting started, tutorials, concepts, and contribution pages for better content organization and discoverability.

* **Chores**
  * Updated site configuration with SEO enhancements including sitemap generation settings, refined documentation version handling, and improved routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->