### PR TITLE
Align ComponentSearchScope field names with observer service terminology

### DIFF
--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -88,10 +88,10 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 		Limit:     &params.Limit,
 		SortOrder: &sortOrder,
 		SearchScope: observer.ComponentSearchScope{
-			Organization: params.Organization,
-			Project:      params.Project,
-			Agent:        params.Agent,
-			Environment:  params.Environment,
+			Namespace:   params.Organization,
+			Project:     params.Project,
+			Component:   params.Agent,
+			Environment: params.Environment,
 		},
 	}
 
@@ -212,10 +212,10 @@ func (c *TracingController) GetTraceSpans(ctx context.Context, traceID string, p
 		Limit:     &params.Limit,
 		SortOrder: &sortOrder,
 		SearchScope: observer.ComponentSearchScope{
-			Organization: params.Organization,
-			Project:      params.Project,
-			Agent:        params.Agent,
-			Environment:  params.Environment,
+			Namespace:   params.Organization,
+			Project:     params.Project,
+			Component:   params.Agent,
+			Environment: params.Environment,
 		},
 	}
 
@@ -273,10 +273,10 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 		Limit:     &params.Limit,
 		SortOrder: &sortOrder,
 		SearchScope: observer.ComponentSearchScope{
-			Organization: params.Organization,
-			Project:      params.Project,
-			Agent:        params.Agent,
-			Environment:  params.Environment,
+			Namespace:   params.Organization,
+			Project:     params.Project,
+			Component:   params.Agent,
+			Environment: params.Environment,
 		},
 	}
 
@@ -332,10 +332,10 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 				EndTime:   params.EndTime,
 				Limit:     &spanLimit,
 				SearchScope: observer.ComponentSearchScope{
-					Organization: params.Organization,
-					Project:      params.Project,
-					Agent:        params.Agent,
-					Environment:  params.Environment,
+					Namespace:   params.Organization,
+					Project:     params.Project,
+					Component:   params.Agent,
+					Environment: params.Environment,
 				},
 			})
 			if err != nil {

--- a/traces-observer-service/observer/types.go
+++ b/traces-observer-service/observer/types.go
@@ -19,12 +19,12 @@ package observer
 import "time"
 
 // ComponentSearchScope identifies a component in the observer service.
-// Organization is required; Project, Agent, and Environment are optional filters.
+// Namespace is required; Project, Component, and Environment are optional filters.
 type ComponentSearchScope struct {
-	Organization string  `json:"namespace"`
-	Project      *string `json:"project,omitempty"`
-	Agent        *string `json:"component,omitempty"`
-	Environment  *string `json:"environment,omitempty"`
+	Namespace   string  `json:"namespace"`
+	Project     *string `json:"project,omitempty"`
+	Component   *string `json:"component,omitempty"`
+	Environment *string `json:"environment,omitempty"`
 }
 
 // TracesQueryRequest is the POST body for both


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

`ComponentSearchScope` in the observer package had Go field names (`Organization`, `Agent`) that did not match their JSON tags (`namespace`, `component`) or the observer service's own vocabulary. This created a silent mismatch where reading the struct gave a misleading picture of what was actually sent on the wire.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Rename `Organization` → `Namespace` and `Agent` → `Component` in `ComponentSearchScope` so the Go field names align with the JSON tags and the observer service's terminology. The domain-to-observer mapping (org/agent → namespace/component) remains explicit at the controller boundary in `TraceQueryParams`. The wire format is unchanged.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal Go identifier rename, no user-facing or API change.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type "Sent" when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type "N/A" and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Go service)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.