### PR TITLE
Add RFC 9728 OAuth 2.0 Protected Resource Metadata

### DIFF
--- a/agent-manager-service/.env.example
+++ b/agent-manager-service/.env.example
@@ -88,6 +88,10 @@ SERVER_PUBLIC_URL=
 # Example: https://idp.example.com
 OAUTH_AUTHORIZATION_SERVERS=http://thunder.amp.localhost:8080
 
+# When SERVER_PUBLIC_URL is set, the JWT middleware also advertises the
+# /.well-known/oauth-protected-resource URL via WWW-Authenticate: Bearer
+# on every 401, enabling RFC 9728 client discovery.
+
 # -----------------------------------------------------------------------------
 # Deployment Type
 # -----------------------------------------------------------------------------

--- a/agent-manager-service/.env.example
+++ b/agent-manager-service/.env.example
@@ -74,13 +74,19 @@ JWT_SIGNING_DEFAULT_ENVIRONMENT=default
 # KEY_MANAGER_JWKS_URL=
 
 # -----------------------------------------------------------------------------
-# Public URL (Required for /.well-known/oauth-protected-resource)
-# Externally reachable base URL of this service. Used as the `resource`
-# identifier in OAuth 2.0 Protected Resource Metadata (RFC 9728).
-# Must use https:// in production.
-# Example: https://am.example.com
+# OAuth 2.0 Protected Resource Metadata (RFC 9728)
+# Required for /.well-known/oauth-protected-resource to serve.
 # -----------------------------------------------------------------------------
+# Externally reachable base URL of this service. Used as the `resource`
+# identifier. Must use https:// in production.
+# Example: https://am.example.com
 SERVER_PUBLIC_URL=
+
+# Comma-separated list of OAuth 2.0 authorization server URLs that clients
+# (MCP, am CLI, etc.) should use to obtain tokens for this resource. Each
+# entry must be an absolute http/https URL. Validated at startup.
+# Example: https://idp.example.com
+OAUTH_AUTHORIZATION_SERVERS=http://thunder.amp.localhost:8080
 
 # -----------------------------------------------------------------------------
 # Deployment Type

--- a/agent-manager-service/.env.example
+++ b/agent-manager-service/.env.example
@@ -74,6 +74,15 @@ JWT_SIGNING_DEFAULT_ENVIRONMENT=default
 # KEY_MANAGER_JWKS_URL=
 
 # -----------------------------------------------------------------------------
+# Public URL (Required for /.well-known/oauth-protected-resource)
+# Externally reachable base URL of this service. Used as the `resource`
+# identifier in OAuth 2.0 Protected Resource Metadata (RFC 9728).
+# Must use https:// in production.
+# Example: https://am.example.com
+# -----------------------------------------------------------------------------
+SERVER_PUBLIC_URL=
+
+# -----------------------------------------------------------------------------
 # Deployment Type
 # -----------------------------------------------------------------------------
 IS_ON_PREM_DEPLOYMENT=true

--- a/agent-manager-service/api/app.go
+++ b/agent-manager-service/api/app.go
@@ -35,6 +35,9 @@ func MakeHTTPHandler(params *wiring.AppParams) http.Handler {
 	// Register JWKS endpoint at root level (no authentication required)
 	registerJWKSRoute(mux, params.AgentTokenController)
 
+	// Register OAuth 2.0 Protected Resource Metadata (RFC 9728) at root level (no authentication required)
+	registerWellKnownRoutes(mux)
+
 	// Create a sub-mux for API v1 routes (JWT-authenticated)
 	apiMux := http.NewServeMux()
 	registerAgentRoutes(apiMux, params.AgentController)

--- a/agent-manager-service/api/well_known_routes.go
+++ b/agent-manager-service/api/well_known_routes.go
@@ -39,10 +39,15 @@ func registerWellKnownRoutes(mux *http.ServeMux) {
 			http.Error(w, "protected resource metadata not configured", http.StatusServiceUnavailable)
 			return
 		}
+		if len(cfg.OAuthAuthorizationServers) == 0 {
+			logger.GetLogger(r.Context()).Error("OAUTH_AUTHORIZATION_SERVERS is not configured; cannot serve protected resource metadata")
+			http.Error(w, "protected resource metadata not configured", http.StatusServiceUnavailable)
+			return
+		}
 
 		body := protectedResourceMetadata{
 			Resource:               cfg.ServerPublicURL,
-			AuthorizationServers:   cfg.KeyManagerConfigurations.Issuer,
+			AuthorizationServers:   cfg.OAuthAuthorizationServers,
 			BearerMethodsSupported: []string{"header"},
 		}
 

--- a/agent-manager-service/api/well_known_routes.go
+++ b/agent-manager-service/api/well_known_routes.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+)
+
+type protectedResourceMetadata struct {
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers,omitempty"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+}
+
+func registerWellKnownRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+		cfg := config.GetConfig()
+
+		if cfg.ServerPublicURL == "" {
+			logger.GetLogger(r.Context()).Error("SERVER_PUBLIC_URL is not configured; cannot serve protected resource metadata")
+			http.Error(w, "protected resource metadata not configured", http.StatusServiceUnavailable)
+			return
+		}
+
+		body := protectedResourceMetadata{
+			Resource:               cfg.ServerPublicURL,
+			AuthorizationServers:   cfg.KeyManagerConfigurations.Issuer,
+			BearerMethodsSupported: []string{"header"},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			logger.GetLogger(r.Context()).Error("failed to encode protected resource metadata", "error", err)
+		}
+	})
+}

--- a/agent-manager-service/api/well_known_routes_test.go
+++ b/agent-manager-service/api/well_known_routes_test.go
@@ -31,17 +31,21 @@ func setupWellKnownMux() *http.ServeMux {
 	return mux
 }
 
-func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
+func withWellKnownConfig(t *testing.T, publicURL string, authServers []string) {
+	t.Helper()
 	cfg := config.GetConfig()
 	origURL := cfg.ServerPublicURL
-	origIssuers := cfg.KeyManagerConfigurations.Issuer
-	defer func() {
+	origServers := cfg.OAuthAuthorizationServers
+	t.Cleanup(func() {
 		cfg.ServerPublicURL = origURL
-		cfg.KeyManagerConfigurations.Issuer = origIssuers
-	}()
+		cfg.OAuthAuthorizationServers = origServers
+	})
+	cfg.ServerPublicURL = publicURL
+	cfg.OAuthAuthorizationServers = authServers
+}
 
-	cfg.ServerPublicURL = "https://am.example.com"
-	cfg.KeyManagerConfigurations.Issuer = []string{"https://idp.example.com"}
+func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
+	withWellKnownConfig(t, "https://am.example.com", []string{"https://idp.example.com"})
 
 	mux := setupWellKnownMux()
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
@@ -73,17 +77,8 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	}
 }
 
-func TestWellKnownOAuthProtectedResource_MultipleIssuers(t *testing.T) {
-	cfg := config.GetConfig()
-	origURL := cfg.ServerPublicURL
-	origIssuers := cfg.KeyManagerConfigurations.Issuer
-	defer func() {
-		cfg.ServerPublicURL = origURL
-		cfg.KeyManagerConfigurations.Issuer = origIssuers
-	}()
-
-	cfg.ServerPublicURL = "https://am.example.com"
-	cfg.KeyManagerConfigurations.Issuer = []string{"https://idp1.example.com", "https://idp2.example.com"}
+func TestWellKnownOAuthProtectedResource_MultipleAuthorizationServers(t *testing.T) {
+	withWellKnownConfig(t, "https://am.example.com", []string{"https://idp1.example.com", "https://idp2.example.com"})
 
 	mux := setupWellKnownMux()
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
@@ -106,12 +101,32 @@ func TestWellKnownOAuthProtectedResource_MultipleIssuers(t *testing.T) {
 	}
 }
 
-func TestWellKnownOAuthProtectedResource_Unconfigured(t *testing.T) {
-	cfg := config.GetConfig()
-	origURL := cfg.ServerPublicURL
-	defer func() { cfg.ServerPublicURL = origURL }()
+func TestWellKnownOAuthProtectedResource_TrailingSlashPreserved(t *testing.T) {
+	withWellKnownConfig(t, "https://am.example.com/", []string{"https://idp.example.com/"})
 
-	cfg.ServerPublicURL = ""
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body protectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.Resource != "https://am.example.com/" {
+		t.Errorf("expected resource to preserve trailing slash, got %q", body.Resource)
+	}
+	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://idp.example.com/" {
+		t.Errorf("expected authorization_servers to preserve trailing slash, got %v", body.AuthorizationServers)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_MissingPublicURL(t *testing.T) {
+	withWellKnownConfig(t, "", []string{"https://idp.example.com"})
 
 	mux := setupWellKnownMux()
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
@@ -123,12 +138,21 @@ func TestWellKnownOAuthProtectedResource_Unconfigured(t *testing.T) {
 	}
 }
 
-func TestWellKnownOAuthProtectedResource_MethodNotAllowed(t *testing.T) {
-	cfg := config.GetConfig()
-	origURL := cfg.ServerPublicURL
-	defer func() { cfg.ServerPublicURL = origURL }()
+func TestWellKnownOAuthProtectedResource_MissingAuthorizationServers(t *testing.T) {
+	withWellKnownConfig(t, "https://am.example.com", nil)
 
-	cfg.ServerPublicURL = "https://am.example.com"
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when OAUTH_AUTHORIZATION_SERVERS is empty, got %d", rec.Code)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_MethodNotAllowed(t *testing.T) {
+	withWellKnownConfig(t, "https://am.example.com", []string{"https://idp.example.com"})
 
 	mux := setupWellKnownMux()
 	req := httptest.NewRequest(http.MethodPost, "/.well-known/oauth-protected-resource", nil)
@@ -141,20 +165,10 @@ func TestWellKnownOAuthProtectedResource_MethodNotAllowed(t *testing.T) {
 }
 
 func TestWellKnownOAuthProtectedResource_NoAuthRequired(t *testing.T) {
-	cfg := config.GetConfig()
-	origURL := cfg.ServerPublicURL
-	origIssuers := cfg.KeyManagerConfigurations.Issuer
-	defer func() {
-		cfg.ServerPublicURL = origURL
-		cfg.KeyManagerConfigurations.Issuer = origIssuers
-	}()
-
-	cfg.ServerPublicURL = "https://am.example.com"
-	cfg.KeyManagerConfigurations.Issuer = []string{"https://idp.example.com"}
+	withWellKnownConfig(t, "https://am.example.com", []string{"https://idp.example.com"})
 
 	mux := setupWellKnownMux()
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
-	// Explicitly no Authorization header
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 

--- a/agent-manager-service/api/well_known_routes_test.go
+++ b/agent-manager-service/api/well_known_routes_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+)
+
+func setupWellKnownMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	registerWellKnownRoutes(mux)
+	return mux
+}
+
+func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
+	cfg := config.GetConfig()
+	origURL := cfg.ServerPublicURL
+	origIssuers := cfg.KeyManagerConfigurations.Issuer
+	defer func() {
+		cfg.ServerPublicURL = origURL
+		cfg.KeyManagerConfigurations.Issuer = origIssuers
+	}()
+
+	cfg.ServerPublicURL = "https://am.example.com"
+	cfg.KeyManagerConfigurations.Issuer = []string{"https://idp.example.com"}
+
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "public, max-age=3600" {
+		t.Errorf("expected Cache-Control public, max-age=3600, got %q", cc)
+	}
+
+	var body protectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.Resource != "https://am.example.com" {
+		t.Errorf("expected resource %q, got %q", "https://am.example.com", body.Resource)
+	}
+	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://idp.example.com" {
+		t.Errorf("expected authorization_servers [https://idp.example.com], got %v", body.AuthorizationServers)
+	}
+	if len(body.BearerMethodsSupported) != 1 || body.BearerMethodsSupported[0] != "header" {
+		t.Errorf("expected bearer_methods_supported [header], got %v", body.BearerMethodsSupported)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_MultipleIssuers(t *testing.T) {
+	cfg := config.GetConfig()
+	origURL := cfg.ServerPublicURL
+	origIssuers := cfg.KeyManagerConfigurations.Issuer
+	defer func() {
+		cfg.ServerPublicURL = origURL
+		cfg.KeyManagerConfigurations.Issuer = origIssuers
+	}()
+
+	cfg.ServerPublicURL = "https://am.example.com"
+	cfg.KeyManagerConfigurations.Issuer = []string{"https://idp1.example.com", "https://idp2.example.com"}
+
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body protectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(body.AuthorizationServers) != 2 {
+		t.Fatalf("expected 2 authorization_servers, got %d", len(body.AuthorizationServers))
+	}
+	if body.AuthorizationServers[0] != "https://idp1.example.com" || body.AuthorizationServers[1] != "https://idp2.example.com" {
+		t.Errorf("expected [https://idp1.example.com, https://idp2.example.com], got %v", body.AuthorizationServers)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_Unconfigured(t *testing.T) {
+	cfg := config.GetConfig()
+	origURL := cfg.ServerPublicURL
+	defer func() { cfg.ServerPublicURL = origURL }()
+
+	cfg.ServerPublicURL = ""
+
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when SERVER_PUBLIC_URL is empty, got %d", rec.Code)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_MethodNotAllowed(t *testing.T) {
+	cfg := config.GetConfig()
+	origURL := cfg.ServerPublicURL
+	defer func() { cfg.ServerPublicURL = origURL }()
+
+	cfg.ServerPublicURL = "https://am.example.com"
+
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodPost, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for POST, got %d", rec.Code)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_NoAuthRequired(t *testing.T) {
+	cfg := config.GetConfig()
+	origURL := cfg.ServerPublicURL
+	origIssuers := cfg.KeyManagerConfigurations.Issuer
+	defer func() {
+		cfg.ServerPublicURL = origURL
+		cfg.KeyManagerConfigurations.Issuer = origIssuers
+	}()
+
+	cfg.ServerPublicURL = "https://am.example.com"
+	cfg.KeyManagerConfigurations.Issuer = []string{"https://idp.example.com"}
+
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	// Explicitly no Authorization header
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200 without Authorization header, got %d", rec.Code)
+	}
+}

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -56,6 +56,12 @@ type Config struct {
 	IsOnPremDeployment       bool
 	ServerPublicURL          string
 
+	// OAuthAuthorizationServers is the list of OAuth 2.0 authorization server URLs
+	// advertised in the RFC 9728 protected resource metadata document. Each entry
+	// MUST be an absolute http/https URL (validated at config load). Required for
+	// the /.well-known/oauth-protected-resource endpoint to serve.
+	OAuthAuthorizationServers []string
+
 	// IDP OAuth2 client credentials for service-to-service auth
 	IDP IDPConfig
 

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 
 	KeyManagerConfigurations KeyManagerConfigurations
 	IsOnPremDeployment       bool
+	ServerPublicURL          string
 
 	// IDP OAuth2 client credentials for service-to-service auth
 	IDP IDPConfig

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -133,6 +134,7 @@ func loadEnvs() {
 	}
 	config.IsOnPremDeployment = r.readOptionalBool("IS_ON_PREM_DEPLOYMENT", true)
 	config.ServerPublicURL = r.readOptionalString("SERVER_PUBLIC_URL", "")
+	config.OAuthAuthorizationServers = r.readOptionalStringList("OAUTH_AUTHORIZATION_SERVERS", "")
 
 	// IDP OAuth2 client credentials for service-to-service auth
 	config.IDP = IDPConfig{
@@ -224,6 +226,8 @@ func loadEnvs() {
 	// Validate Internal server configurations
 	validateInternalServerConfigs(config, r)
 
+	validateOAuthAuthorizationServers(config, r)
+
 	r.logAndExitIfErrorsFound()
 
 	slog.Info("configReader: configs loaded")
@@ -248,6 +252,22 @@ func validateHTTPServerConfigs(cfg *Config, r *configReader) {
 	}
 	if cfg.MaxHeaderBytes < 1024 || cfg.MaxHeaderBytes > 1048576 { // 1KB to 1MB
 		r.errors = append(r.errors, fmt.Errorf("HTTP_MAX_HEADER_BYTES must be between 1024 and 1048576, got %d", cfg.MaxHeaderBytes))
+	}
+}
+
+func validateOAuthAuthorizationServers(cfg *Config, r *configReader) {
+	for _, raw := range cfg.OAuthAuthorizationServers {
+		u, err := url.Parse(raw)
+		if err != nil {
+			r.errors = append(r.errors, fmt.Errorf("OAUTH_AUTHORIZATION_SERVERS entry %q is not a valid URL: %w", raw, err))
+			continue
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			r.errors = append(r.errors, fmt.Errorf("OAUTH_AUTHORIZATION_SERVERS entry %q must use http or https scheme", raw))
+		}
+		if u.Host == "" {
+			r.errors = append(r.errors, fmt.Errorf("OAUTH_AUTHORIZATION_SERVERS entry %q must have a non-empty host", raw))
+		}
 	}
 }
 

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -132,6 +132,7 @@ func loadEnvs() {
 		JWKSUrl:  r.readOptionalString("KEY_MANAGER_JWKS_URL", ""),
 	}
 	config.IsOnPremDeployment = r.readOptionalBool("IS_ON_PREM_DEPLOYMENT", true)
+	config.ServerPublicURL = r.readOptionalString("SERVER_PUBLIC_URL", "")
 
 	// IDP OAuth2 client credentials for service-to-service auth
 	config.IDP = IDPConfig{

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -227,6 +227,7 @@ func loadEnvs() {
 	validateInternalServerConfigs(config, r)
 
 	validateOAuthAuthorizationServers(config, r)
+	validateServerPublicURL(config, r)
 
 	r.logAndExitIfErrorsFound()
 
@@ -268,6 +269,23 @@ func validateOAuthAuthorizationServers(cfg *Config, r *configReader) {
 		if u.Host == "" {
 			r.errors = append(r.errors, fmt.Errorf("OAUTH_AUTHORIZATION_SERVERS entry %q must have a non-empty host", raw))
 		}
+	}
+}
+
+func validateServerPublicURL(cfg *Config, r *configReader) {
+	if cfg.ServerPublicURL == "" {
+		return
+	}
+	u, err := url.Parse(cfg.ServerPublicURL)
+	if err != nil {
+		r.errors = append(r.errors, fmt.Errorf("SERVER_PUBLIC_URL %q is not a valid URL: %w", cfg.ServerPublicURL, err))
+		return
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		r.errors = append(r.errors, fmt.Errorf("SERVER_PUBLIC_URL %q must use http or https scheme", cfg.ServerPublicURL))
+	}
+	if u.Host == "" {
+		r.errors = append(r.errors, fmt.Errorf("SERVER_PUBLIC_URL %q must have a non-empty host", cfg.ServerPublicURL))
 	}
 }
 

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -98,3 +98,75 @@ func TestValidateOAuthAuthorizationServers(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateServerPublicURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		wantErrors  int
+		errContains string
+	}{
+		{
+			name:       "empty is allowed",
+			url:        "",
+			wantErrors: 0,
+		},
+		{
+			name:       "valid https URL",
+			url:        "https://api.example.com",
+			wantErrors: 0,
+		},
+		{
+			name:       "valid http URL with port",
+			url:        "http://localhost:8080",
+			wantErrors: 0,
+		},
+		{
+			name:       "valid https URL with path",
+			url:        "https://api.example.com/v1",
+			wantErrors: 0,
+		},
+		{
+			name:        "non-http(s) scheme rejected",
+			url:         "ftp://api.example.com",
+			wantErrors:  1,
+			errContains: "must use http or https",
+		},
+		{
+			name:        "missing host rejected",
+			url:         "https://",
+			wantErrors:  1,
+			errContains: "must have a non-empty host",
+		},
+		{
+			name:        "bare string rejected",
+			url:         "not-a-url",
+			wantErrors:  2,
+			errContains: "SERVER_PUBLIC_URL",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{ServerPublicURL: tc.url}
+			r := &configReader{}
+			validateServerPublicURL(cfg, r)
+
+			if len(r.errors) != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tc.wantErrors, len(r.errors), r.errors)
+			}
+			if tc.errContains != "" {
+				found := false
+				for _, e := range r.errors {
+					if strings.Contains(e.Error(), tc.errContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected an error containing %q, got %v", tc.errContains, r.errors)
+				}
+			}
+		})
+	}
+}

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateOAuthAuthorizationServers(t *testing.T) {
+	tests := []struct {
+		name        string
+		servers     []string
+		wantErrors  int
+		errContains string
+	}{
+		{
+			name:       "empty list is allowed at config-load time",
+			servers:    nil,
+			wantErrors: 0,
+		},
+		{
+			name:       "valid https URL",
+			servers:    []string{"https://idp.example.com"},
+			wantErrors: 0,
+		},
+		{
+			name:       "valid http URL (dev)",
+			servers:    []string{"http://thunder.amp.localhost:8080"},
+			wantErrors: 0,
+		},
+		{
+			name:       "multiple valid URLs",
+			servers:    []string{"https://idp1.example.com", "https://idp2.example.com/path"},
+			wantErrors: 0,
+		},
+		{
+			name:        "non-http(s) scheme rejected",
+			servers:     []string{"ftp://idp.example.com"},
+			wantErrors:  1,
+			errContains: "must use http or https",
+		},
+		{
+			name:        "missing host rejected",
+			servers:     []string{"https://"},
+			wantErrors:  1,
+			errContains: "must have a non-empty host",
+		},
+		{
+			name:        "non-URL string rejected",
+			servers:     []string{"Agent Management Platform Local"},
+			wantErrors:  2, // missing scheme + missing host
+			errContains: "OAUTH_AUTHORIZATION_SERVERS",
+		},
+		{
+			name:        "one good one bad accumulates only the bad",
+			servers:     []string{"https://idp.example.com", "ftp://nope.example.com"},
+			wantErrors:  1,
+			errContains: "ftp://nope.example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{OAuthAuthorizationServers: tc.servers}
+			r := &configReader{}
+			validateOAuthAuthorizationServers(cfg, r)
+
+			if len(r.errors) != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tc.wantErrors, len(r.errors), r.errors)
+			}
+			if tc.errContains != "" {
+				found := false
+				for _, e := range r.errors {
+					if strings.Contains(e.Error(), tc.errContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected an error containing %q, got %v", tc.errContains, r.errors)
+				}
+			}
+		})
+	}
+}

--- a/agent-manager-service/middleware/jwtassertion/auth.go
+++ b/agent-manager-service/middleware/jwtassertion/auth.go
@@ -136,11 +136,23 @@ func isValidPublisherClient(sub string) bool {
 	return validPublisherSubPattern.MatchString(sub)
 }
 
-func JWTAuthMiddleware(header string) func(http.Handler) http.Handler {
+func buildBearerChallenge(resourceMetadataURL, errorCode string) string {
+	parts := []string{`realm="agent-manager"`}
+	if errorCode != "" {
+		parts = append(parts, `error="`+errorCode+`"`)
+	}
+	if resourceMetadataURL != "" {
+		parts = append(parts, `resource_metadata="`+resourceMetadataURL+`"`)
+	}
+	return "Bearer " + strings.Join(parts, ", ")
+}
+
+func JWTAuthMiddleware(header, resourceMetadataURL string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tokenString := r.Header.Get(header)
 			if tokenString == "" {
+				w.Header().Set("WWW-Authenticate", buildBearerChallenge(resourceMetadataURL, ""))
 				utils.WriteErrorResponse(w, http.StatusUnauthorized, fmt.Sprintf("missing header: %s", header))
 				return
 			}
@@ -151,6 +163,7 @@ func JWTAuthMiddleware(header string) func(http.Handler) http.Handler {
 			claims, err := validateJWTWithJWKS(tokenString)
 			if err != nil {
 				slog.Error("JWT validation failed", "error", err)
+				w.Header().Set("WWW-Authenticate", buildBearerChallenge(resourceMetadataURL, "invalid_token"))
 				utils.WriteErrorResponse(w, http.StatusUnauthorized, "invalid jwt")
 				return
 			}

--- a/agent-manager-service/middleware/jwtassertion/auth_test.go
+++ b/agent-manager-service/middleware/jwtassertion/auth_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package jwtassertion
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildBearerChallenge(t *testing.T) {
+	tests := []struct {
+		name                string
+		resourceMetadataURL string
+		errorCode           string
+		want                string
+	}{
+		{
+			name:                "realm only",
+			resourceMetadataURL: "",
+			errorCode:           "",
+			want:                `Bearer realm="agent-manager"`,
+		},
+		{
+			name:                "with error code",
+			resourceMetadataURL: "",
+			errorCode:           "invalid_token",
+			want:                `Bearer realm="agent-manager", error="invalid_token"`,
+		},
+		{
+			name:                "with resource metadata URL",
+			resourceMetadataURL: "https://am.example.com/.well-known/oauth-protected-resource",
+			errorCode:           "",
+			want:                `Bearer realm="agent-manager", resource_metadata="https://am.example.com/.well-known/oauth-protected-resource"`,
+		},
+		{
+			name:                "with error and resource metadata URL",
+			resourceMetadataURL: "https://am.example.com/.well-known/oauth-protected-resource",
+			errorCode:           "invalid_token",
+			want:                `Bearer realm="agent-manager", error="invalid_token", resource_metadata="https://am.example.com/.well-known/oauth-protected-resource"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildBearerChallenge(tt.resourceMetadataURL, tt.errorCode)
+			if got != tt.want {
+				t.Errorf("buildBearerChallenge() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJWTAuthMiddleware_MissingHeader_WithURL(t *testing.T) {
+	metadataURL := "https://am.example.com/.well-known/oauth-protected-resource"
+	handler := JWTAuthMiddleware("Authorization", metadataURL)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called when Authorization header is missing")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	want := `Bearer realm="agent-manager", resource_metadata="https://am.example.com/.well-known/oauth-protected-resource"`
+	if got := rec.Header().Get("WWW-Authenticate"); got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+}
+
+func TestJWTAuthMiddleware_MissingHeader_NoURL(t *testing.T) {
+	handler := JWTAuthMiddleware("Authorization", "")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called when Authorization header is missing")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	want := `Bearer realm="agent-manager"`
+	if got := rec.Header().Get("WWW-Authenticate"); got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+}
+
+func TestJWTAuthMiddleware_InvalidJWT_WithURL(t *testing.T) {
+	metadataURL := "https://am.example.com/.well-known/oauth-protected-resource"
+	handler := JWTAuthMiddleware("Authorization", metadataURL)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called for invalid JWT")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents", nil)
+	req.Header.Set("Authorization", "Bearer invalid.jwt.token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	want := `Bearer realm="agent-manager", error="invalid_token", resource_metadata="https://am.example.com/.well-known/oauth-protected-resource"`
+	if got := rec.Header().Get("WWW-Authenticate"); got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+}
+
+func TestJWTAuthMiddleware_InvalidJWT_NoURL(t *testing.T) {
+	handler := JWTAuthMiddleware("Authorization", "")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called for invalid JWT")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents", nil)
+	req.Header.Set("Authorization", "Bearer invalid.jwt.token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	want := `Bearer realm="agent-manager", error="invalid_token"`
+	if got := rec.Header().Get("WWW-Authenticate"); got != want {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, want)
+	}
+}

--- a/agent-manager-service/wiring/params.go
+++ b/agent-manager-service/wiring/params.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"gorm.io/gorm"
 
@@ -87,7 +88,12 @@ func ProvideConfigFromPtr(config *config.Config) config.Config {
 }
 
 func ProvideAuthMiddleware(config config.Config) jwtassertion.Middleware {
-	return jwtassertion.JWTAuthMiddleware(config.AuthHeader)
+	var resourceMetadataURL string
+	if config.ServerPublicURL != "" {
+		resourceMetadataURL = strings.TrimRight(config.ServerPublicURL, "/") +
+			"/.well-known/oauth-protected-resource"
+	}
+	return jwtassertion.JWTAuthMiddleware(config.AuthHeader, resourceMetadataURL)
 }
 
 func ProvideJWTSigningConfig(config config.Config) config.JWTSigningConfig {

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - DB_NAME=agentmanager
       # Server Configuration
       - SERVER_PORT=8080
+      - SERVER_PUBLIC_URL=http://localhost:9000
+      - OAUTH_AUTHORIZATION_SERVERS=http://thunder.amp.localhost:8080
       # Kubernetes Configuration
       - KUBECONFIG=/app/.kube/config
       - IS_LOCAL_DEV_ENV=true

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -26,6 +26,7 @@ data:
   KEY_MANAGER_AUDIENCE: {{ .Values.agentManagerService.config.keyManager.audience | quote }}                                   
   KEY_MANAGER_JWKS_URL: {{ .Values.agentManagerService.config.keyManager.jwksUrl | quote }}                                         
   SERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.serverPublicURL | default "" | quote }}
+  OAUTH_AUTHORIZATION_SERVERS: {{ .Values.agentManagerService.config.oauthAuthorizationServers | default "" | quote }}
   IS_ON_PREM_DEPLOYMENT: {{ .Values.agentManagerService.config.isOnPremDeployment | quote }}
   IDP_TOKEN_URL: {{ .Values.agentManagerService.config.oidc.tokenUrl | quote }}
   IDP_CLIENT_ID: {{ .Values.agentManagerService.config.oidc.clientId | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -25,6 +25,7 @@ data:
   KEY_MANAGER_ISSUER: {{ .Values.agentManagerService.config.keyManager.issuer | quote }}                                         
   KEY_MANAGER_AUDIENCE: {{ .Values.agentManagerService.config.keyManager.audience | quote }}                                   
   KEY_MANAGER_JWKS_URL: {{ .Values.agentManagerService.config.keyManager.jwksUrl | quote }}                                         
+  SERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.serverPublicURL | default "" | quote }}
   IS_ON_PREM_DEPLOYMENT: {{ .Values.agentManagerService.config.isOnPremDeployment | quote }}
   IDP_TOKEN_URL: {{ .Values.agentManagerService.config.oidc.tokenUrl | quote }}
   IDP_CLIENT_ID: {{ .Values.agentManagerService.config.oidc.clientId | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -134,13 +134,13 @@ agentManagerService:
 
     # Externally reachable base URL of this service.
     # Used as the `resource` identifier in RFC 9728 protected resource metadata.
-    serverPublicURL: ""
+    serverPublicURL: "http://localhost:9000"
 
     # Comma-separated list of OAuth 2.0 authorization server URLs advertised
     # in RFC 9728 protected resource metadata. Each entry must be an absolute
     # http/https URL. Validated at startup. Required for the well-known
     # endpoint to serve.
-    oauthAuthorizationServers: ""
+    oauthAuthorizationServers: "http://thunder.amp.localhost:8080"
 
     # On-premise deployment flag
     isOnPremDeployment: "true"

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -136,6 +136,12 @@ agentManagerService:
     # Used as the `resource` identifier in RFC 9728 protected resource metadata.
     serverPublicURL: ""
 
+    # Comma-separated list of OAuth 2.0 authorization server URLs advertised
+    # in RFC 9728 protected resource metadata. Each entry must be an absolute
+    # http/https URL. Validated at startup. Required for the well-known
+    # endpoint to serve.
+    oauthAuthorizationServers: ""
+
     # On-premise deployment flag
     isOnPremDeployment: "true"
 

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -132,6 +132,10 @@ agentManagerService:
       audience: "amp-console-client,amp-api-client,amp-publisher-*"
       jwksUrl: "http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/jwks"
 
+    # Externally reachable base URL of this service.
+    # Used as the `resource` identifier in RFC 9728 protected resource metadata.
+    serverPublicURL: ""
+
     # On-premise deployment flag
     isOnPremDeployment: "true"
 


### PR DESCRIPTION

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Summary
                                                                                                                                                                                                 
  - Expose GET /.well-known/oauth-protected-resource so OAuth clients (MCP, am CLI) can discover authorization servers for this resource, per RFC 9728                                           
  - Return WWW-Authenticate: Bearer challenge with resource_metadata pointer on all JWT middleware 401 responses (RFC 6750 §3), completing the standard discovery handshake
  - Add SERVER_PUBLIC_URL and OAUTH_AUTHORIZATION_SERVERS config with startup validation                                                                                                         
                                                                                                                                                                                                 
  Test plan                                                                                                                                                                                      
                                                                                                                                                                                                 
  - Unit tests for well-known endpoint (happy path, multiple auth servers, missing config → 503, method not allowed, no auth required)                                                           
  - Unit tests for buildBearerChallenge helper (all parameter combinations)
  - Unit tests for middleware 401 paths: missing header and invalid JWT, with and without SERVER_PUBLIC_URL configured                                                                           
  - Manual smoke test: curl -i <base>/api/v1/agents (no auth) returns 401 with WWW-Authenticate header pointing at the well-known URL                                                            
                                                                                                                                        

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/.well-known/oauth-protected-resource` endpoint that serves metadata about the service and authorized authorization servers, with a 1-hour cache policy.

* **Chores**
  * Introduced `SERVER_PUBLIC_URL` and `OAUTH_AUTHORIZATION_SERVERS` configuration variables.
  * Updated Helm charts to support new configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->