### PR TITLE
Support per-org publisher credentials for multi-tenant monitor scheduling

### DIFF
--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -57,6 +57,9 @@ import (
 //			DetachTraitFunc: func(ctx context.Context, namespaceName string, projectName string, componentName string, traitType client.TraitType) error {
 //				panic("mock out the DetachTrait method")
 //			},
+//			EnsureClusterRoleBindingFunc: func(ctx context.Context, clientID string, roleName string) error {
+//				panic("mock out the EnsureClusterRoleBinding method")
+//			},
 //			ExpireWorkflowRunFunc: func(ctx context.Context, namespaceName string, runName string) error {
 //				panic("mock out the ExpireWorkflowRun method")
 //			},
@@ -208,9 +211,6 @@ type OpenChoreoClientMock struct {
 	// DeleteGitSecretFunc mocks the DeleteGitSecret method.
 	DeleteGitSecretFunc func(ctx context.Context, namespaceName string, secretName string) error
 
-	// EnsureClusterRoleBindingFunc mocks the EnsureClusterRoleBinding method.
-	EnsureClusterRoleBindingFunc func(ctx context.Context, clientID string, roleName string) error
-
 	// DeleteProjectFunc mocks the DeleteProject method.
 	DeleteProjectFunc func(ctx context.Context, namespaceName string, projectName string) error
 
@@ -222,6 +222,9 @@ type OpenChoreoClientMock struct {
 
 	// DetachTraitFunc mocks the DetachTrait method.
 	DetachTraitFunc func(ctx context.Context, namespaceName string, projectName string, componentName string, traitType client.TraitType) error
+
+	// EnsureClusterRoleBindingFunc mocks the EnsureClusterRoleBinding method.
+	EnsureClusterRoleBindingFunc func(ctx context.Context, clientID string, roleName string) error
 
 	// ExpireWorkflowRunFunc mocks the ExpireWorkflowRun method.
 	ExpireWorkflowRunFunc func(ctx context.Context, namespaceName string, runName string) error
@@ -435,15 +438,6 @@ type OpenChoreoClientMock struct {
 			// SecretName is the secretName argument value.
 			SecretName string
 		}
-		// EnsureClusterRoleBinding holds details about calls to the EnsureClusterRoleBinding method.
-		EnsureClusterRoleBinding []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// ClientID is the clientID argument value.
-			ClientID string
-			// RoleName is the roleName argument value.
-			RoleName string
-		}
 		// DeleteProject holds details about calls to the DeleteProject method.
 		DeleteProject []struct {
 			// Ctx is the ctx argument value.
@@ -487,6 +481,15 @@ type OpenChoreoClientMock struct {
 			ComponentName string
 			// TraitType is the traitType argument value.
 			TraitType client.TraitType
+		}
+		// EnsureClusterRoleBinding holds details about calls to the EnsureClusterRoleBinding method.
+		EnsureClusterRoleBinding []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ClientID is the clientID argument value.
+			ClientID string
+			// RoleName is the roleName argument value.
+			RoleName string
 		}
 		// ExpireWorkflowRun holds details about calls to the ExpireWorkflowRun method.
 		ExpireWorkflowRun []struct {
@@ -927,11 +930,11 @@ type OpenChoreoClientMock struct {
 	lockCreateWorkflowRun                   sync.RWMutex
 	lockDeleteComponent                     sync.RWMutex
 	lockDeleteGitSecret                     sync.RWMutex
-	lockEnsureClusterRoleBinding            sync.RWMutex
 	lockDeleteProject                       sync.RWMutex
 	lockDeleteSecretReference               sync.RWMutex
 	lockDeploy                              sync.RWMutex
 	lockDetachTrait                         sync.RWMutex
+	lockEnsureClusterRoleBinding            sync.RWMutex
 	lockExpireWorkflowRun                   sync.RWMutex
 	lockGetBuild                            sync.RWMutex
 	lockGetComponent                        sync.RWMutex
@@ -1357,43 +1360,6 @@ func (mock *OpenChoreoClientMock) DeleteGitSecretCalls() []struct {
 	return calls
 }
 
-// EnsureClusterRoleBinding calls EnsureClusterRoleBindingFunc.
-func (mock *OpenChoreoClientMock) EnsureClusterRoleBinding(ctx context.Context, clientID string, roleName string) error {
-	if mock.EnsureClusterRoleBindingFunc == nil {
-		panic("OpenChoreoClientMock.EnsureClusterRoleBindingFunc: method is nil but OpenChoreoClient.EnsureClusterRoleBinding was just called")
-	}
-	callInfo := struct {
-		Ctx      context.Context
-		ClientID string
-		RoleName string
-	}{
-		Ctx:      ctx,
-		ClientID: clientID,
-		RoleName: roleName,
-	}
-	mock.lockEnsureClusterRoleBinding.Lock()
-	mock.calls.EnsureClusterRoleBinding = append(mock.calls.EnsureClusterRoleBinding, callInfo)
-	mock.lockEnsureClusterRoleBinding.Unlock()
-	return mock.EnsureClusterRoleBindingFunc(ctx, clientID, roleName)
-}
-
-// EnsureClusterRoleBindingCalls gets all the calls that were made to EnsureClusterRoleBinding.
-func (mock *OpenChoreoClientMock) EnsureClusterRoleBindingCalls() []struct {
-	Ctx      context.Context
-	ClientID string
-	RoleName string
-} {
-	var calls []struct {
-		Ctx      context.Context
-		ClientID string
-		RoleName string
-	}
-	mock.lockEnsureClusterRoleBinding.RLock()
-	calls = mock.calls.EnsureClusterRoleBinding
-	mock.lockEnsureClusterRoleBinding.RUnlock()
-	return calls
-}
-
 // DeleteProject calls DeleteProjectFunc.
 func (mock *OpenChoreoClientMock) DeleteProject(ctx context.Context, namespaceName string, projectName string) error {
 	if mock.DeleteProjectFunc == nil {
@@ -1567,6 +1533,46 @@ func (mock *OpenChoreoClientMock) DetachTraitCalls() []struct {
 	mock.lockDetachTrait.RLock()
 	calls = mock.calls.DetachTrait
 	mock.lockDetachTrait.RUnlock()
+	return calls
+}
+
+// EnsureClusterRoleBinding calls EnsureClusterRoleBindingFunc.
+func (mock *OpenChoreoClientMock) EnsureClusterRoleBinding(ctx context.Context, clientID string, roleName string) error {
+	if mock.EnsureClusterRoleBindingFunc == nil {
+		panic("OpenChoreoClientMock.EnsureClusterRoleBindingFunc: method is nil but OpenChoreoClient.EnsureClusterRoleBinding was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		ClientID string
+		RoleName string
+	}{
+		Ctx:      ctx,
+		ClientID: clientID,
+		RoleName: roleName,
+	}
+	mock.lockEnsureClusterRoleBinding.Lock()
+	mock.calls.EnsureClusterRoleBinding = append(mock.calls.EnsureClusterRoleBinding, callInfo)
+	mock.lockEnsureClusterRoleBinding.Unlock()
+	return mock.EnsureClusterRoleBindingFunc(ctx, clientID, roleName)
+}
+
+// EnsureClusterRoleBindingCalls gets all the calls that were made to EnsureClusterRoleBinding.
+// Check the length with:
+//
+//	len(mockedOpenChoreoClient.EnsureClusterRoleBindingCalls())
+func (mock *OpenChoreoClientMock) EnsureClusterRoleBindingCalls() []struct {
+	Ctx      context.Context
+	ClientID string
+	RoleName string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		ClientID string
+		RoleName string
+	}
+	mock.lockEnsureClusterRoleBinding.RLock()
+	calls = mock.calls.EnsureClusterRoleBinding
+	mock.lockEnsureClusterRoleBinding.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -208,6 +208,9 @@ type OpenChoreoClientMock struct {
 	// DeleteGitSecretFunc mocks the DeleteGitSecret method.
 	DeleteGitSecretFunc func(ctx context.Context, namespaceName string, secretName string) error
 
+	// EnsureClusterRoleBindingFunc mocks the EnsureClusterRoleBinding method.
+	EnsureClusterRoleBindingFunc func(ctx context.Context, clientID string, roleName string) error
+
 	// DeleteProjectFunc mocks the DeleteProject method.
 	DeleteProjectFunc func(ctx context.Context, namespaceName string, projectName string) error
 
@@ -431,6 +434,15 @@ type OpenChoreoClientMock struct {
 			NamespaceName string
 			// SecretName is the secretName argument value.
 			SecretName string
+		}
+		// EnsureClusterRoleBinding holds details about calls to the EnsureClusterRoleBinding method.
+		EnsureClusterRoleBinding []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ClientID is the clientID argument value.
+			ClientID string
+			// RoleName is the roleName argument value.
+			RoleName string
 		}
 		// DeleteProject holds details about calls to the DeleteProject method.
 		DeleteProject []struct {
@@ -915,6 +927,7 @@ type OpenChoreoClientMock struct {
 	lockCreateWorkflowRun                   sync.RWMutex
 	lockDeleteComponent                     sync.RWMutex
 	lockDeleteGitSecret                     sync.RWMutex
+	lockEnsureClusterRoleBinding            sync.RWMutex
 	lockDeleteProject                       sync.RWMutex
 	lockDeleteSecretReference               sync.RWMutex
 	lockDeploy                              sync.RWMutex
@@ -1341,6 +1354,43 @@ func (mock *OpenChoreoClientMock) DeleteGitSecretCalls() []struct {
 	mock.lockDeleteGitSecret.RLock()
 	calls = mock.calls.DeleteGitSecret
 	mock.lockDeleteGitSecret.RUnlock()
+	return calls
+}
+
+// EnsureClusterRoleBinding calls EnsureClusterRoleBindingFunc.
+func (mock *OpenChoreoClientMock) EnsureClusterRoleBinding(ctx context.Context, clientID string, roleName string) error {
+	if mock.EnsureClusterRoleBindingFunc == nil {
+		panic("OpenChoreoClientMock.EnsureClusterRoleBindingFunc: method is nil but OpenChoreoClient.EnsureClusterRoleBinding was just called")
+	}
+	callInfo := struct {
+		Ctx      context.Context
+		ClientID string
+		RoleName string
+	}{
+		Ctx:      ctx,
+		ClientID: clientID,
+		RoleName: roleName,
+	}
+	mock.lockEnsureClusterRoleBinding.Lock()
+	mock.calls.EnsureClusterRoleBinding = append(mock.calls.EnsureClusterRoleBinding, callInfo)
+	mock.lockEnsureClusterRoleBinding.Unlock()
+	return mock.EnsureClusterRoleBindingFunc(ctx, clientID, roleName)
+}
+
+// EnsureClusterRoleBindingCalls gets all the calls that were made to EnsureClusterRoleBinding.
+func (mock *OpenChoreoClientMock) EnsureClusterRoleBindingCalls() []struct {
+	Ctx      context.Context
+	ClientID string
+	RoleName string
+} {
+	var calls []struct {
+		Ctx      context.Context
+		ClientID string
+		RoleName string
+	}
+	mock.lockEnsureClusterRoleBinding.RLock()
+	calls = mock.calls.EnsureClusterRoleBinding
+	mock.lockEnsureClusterRoleBinding.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/clients/openchoreosvc/client/authz.go
+++ b/agent-manager-service/clients/openchoreosvc/client/authz.go
@@ -62,7 +62,37 @@ func (c *openChoreoClient) EnsureClusterRoleBinding(ctx context.Context, clientI
 	case http.StatusCreated, http.StatusOK:
 		return nil
 	case http.StatusConflict:
-		// Binding already exists — idempotent success
+		// Binding name already exists — verify it maps the expected clientID → roleName.
+		getResp, err := c.ocClient.GetClusterRoleBindingWithResponse(ctx, bindingName)
+		if err != nil {
+			return fmt.Errorf("failed to get existing ClusterAuthzRoleBinding %s: %w", bindingName, err)
+		}
+		if getResp.StatusCode() == http.StatusOK && getResp.JSON200 != nil {
+			existing := getResp.JSON200
+			if existing.Spec != nil &&
+				existing.Spec.Effect != nil &&
+				*existing.Spec.Effect == effect &&
+				existing.Spec.Entitlement.Claim == "sub" &&
+				existing.Spec.Entitlement.Value == clientID &&
+				len(existing.Spec.RoleMappings) == 1 &&
+				existing.Spec.RoleMappings[0].RoleRef.Kind == roleRefKind &&
+				existing.Spec.RoleMappings[0].RoleRef.Name == roleName {
+				return nil // already correct
+			}
+		}
+		// Spec differs — overwrite with the desired binding.
+		updateResp, err := c.ocClient.UpdateClusterRoleBindingWithResponse(ctx, bindingName, body)
+		if err != nil {
+			return fmt.Errorf("failed to update ClusterAuthzRoleBinding for %s: %w", clientID, err)
+		}
+		if updateResp.StatusCode() != http.StatusOK {
+			return handleErrorResponse(updateResp.StatusCode(), ErrorResponses{
+				JSON400: updateResp.JSON400,
+				JSON401: updateResp.JSON401,
+				JSON403: updateResp.JSON403,
+				JSON500: updateResp.JSON500,
+			})
+		}
 		return nil
 	default:
 		return handleErrorResponse(resp.StatusCode(), ErrorResponses{

--- a/agent-manager-service/clients/openchoreosvc/client/authz.go
+++ b/agent-manager-service/clients/openchoreosvc/client/authz.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+)
+
+// EnsureClusterRoleBinding creates a ClusterAuthzRoleBinding for clientID → roleName.
+// Idempotent: a 409 Conflict means the binding already exists and is treated as success.
+func (c *openChoreoClient) EnsureClusterRoleBinding(ctx context.Context, clientID, roleName string) error {
+	effect := gen.ClusterAuthzRoleBindingSpecEffectAllow
+	roleRefKind := gen.ClusterAuthzRoleMappingRoleRefKindClusterAuthzRole
+	bindingName := "amp-publisher-" + clientID + "-scheduler"
+
+	body := gen.ClusterAuthzRoleBinding{
+		Metadata: gen.ObjectMeta{Name: bindingName},
+		Spec: &gen.ClusterAuthzRoleBindingSpec{
+			Effect: &effect,
+			Entitlement: gen.AuthzEntitlementClaim{
+				Claim: "sub",
+				Value: clientID,
+			},
+			RoleMappings: []gen.ClusterAuthzRoleMapping{
+				{
+					RoleRef: struct {
+						Kind gen.ClusterAuthzRoleMappingRoleRefKind `json:"kind"`
+						Name string                                 `json:"name"`
+					}{
+						Kind: roleRefKind,
+						Name: roleName,
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := c.ocClient.CreateClusterRoleBindingWithResponse(ctx, body)
+	if err != nil {
+		return fmt.Errorf("failed to create ClusterAuthzRoleBinding for %s: %w", clientID, err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusCreated, http.StatusOK:
+		return nil
+	case http.StatusConflict:
+		// Binding already exists — idempotent success
+		return nil
+	default:
+		return handleErrorResponse(resp.StatusCode(), ErrorResponses{
+			JSON400: resp.JSON400,
+			JSON401: resp.JSON401,
+			JSON403: resp.JSON403,
+			JSON500: resp.JSON500,
+		})
+	}
+}

--- a/agent-manager-service/clients/openchoreosvc/client/client.go
+++ b/agent-manager-service/clients/openchoreosvc/client/client.go
@@ -113,6 +113,11 @@ type OpenChoreoClient interface {
 	CreateGitSecret(ctx context.Context, namespaceName string, req CreateGitSecretRequest) (*GitSecretInfo, error)
 	ListGitSecrets(ctx context.Context, namespaceName string) ([]*GitSecretInfo, error)
 	DeleteGitSecret(ctx context.Context, namespaceName, secretName string) error
+
+	// Authz Operations
+	// EnsureClusterRoleBinding creates a ClusterAuthzRoleBinding binding the given clientID (sub claim)
+	// to the named ClusterAuthzRole. Idempotent — succeeds silently if the binding already exists.
+	EnsureClusterRoleBinding(ctx context.Context, clientID, roleName string) error
 }
 
 type openChoreoClient struct {

--- a/agent-manager-service/clients/requests/send_request.go
+++ b/agent-manager-service/clients/requests/send_request.go
@@ -79,7 +79,7 @@ func (r *Result) ScanResponse(body any, successStatus int) error {
 	if r.response == nil {
 		return fmt.Errorf("unexpected nil response")
 	}
-	if body == nil || reflect.ValueOf(body).Kind() != reflect.Ptr {
+	if body == nil || reflect.ValueOf(body).Kind() != reflect.Pointer {
 		return fmt.Errorf("non-nil pointer expected for decoding response body")
 	}
 	if r.response.StatusCode != successStatus {

--- a/agent-manager-service/db_migrations/014_add_encrypted_secret_to_publisher_creds.go
+++ b/agent-manager-service/db_migrations/014_add_encrypted_secret_to_publisher_creds.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -16,23 +16,18 @@
 
 package dbmigrations
 
-const latestVersion = 14
+import (
+	"gorm.io/gorm"
+)
 
-// migration list sorted by version.  Add new migrations to the end of the list.
-// Previous migrations should not be modified.
-var migrations = []migration{
-	migration001,
-	migration002,
-	migration003,
-	migration004,
-	migration005,
-	migration006,
-	migration007,
-	migration008,
-	migration009,
-	migration010,
-	migration011,
-	migration012,
-	migration013,
-	migration014,
+// Add client_secret_encrypted column to org_publisher_credentials so the scheduler
+// can decrypt and use the org's publisher app secret to obtain org-bound OC tokens.
+var migration014 = migration{
+	ID: 14,
+	Migrate: func(db *gorm.DB) error {
+		return db.Exec(`
+			ALTER TABLE org_publisher_credentials
+			ADD COLUMN IF NOT EXISTS client_secret_encrypted BYTEA
+		`).Error
+	},
 }

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -7334,6 +7334,14 @@ components:
           type: integer
           description: Interval in minutes for continuous monitoring (only for 'future' type)
           minimum: 5
+        traceStart:
+          type: string
+          format: date-time
+          description: Start of the trace window (only for 'past' type)
+        traceEnd:
+          type: string
+          format: date-time
+          description: End of the trace window (only for 'past' type)
         samplingRate:
           type: number
           format: float

--- a/agent-manager-service/models/monitor.go
+++ b/agent-manager-service/models/monitor.go
@@ -235,14 +235,15 @@ type MonitorRunsListResponse struct {
 // OrgPublisherCredential stores per-org OAuth2 publisher credentials.
 // Each org gets one set of credentials shared by all monitors in that org.
 type OrgPublisherCredential struct {
-	ID           uuid.UUID `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
-	OrgName      string    `gorm:"column:org_name;not null;uniqueIndex:uq_org_publisher_creds_org"`
-	OrgUUID      string    `gorm:"column:org_uuid;not null;default:''"`
-	ClientID     string    `gorm:"column:client_id;not null"`
-	SecretKVPath string    `gorm:"column:secret_kv_path;not null"`
-	SecretKey    string    `gorm:"column:secret_key;not null;default:'client-secret'"`
-	CreatedAt    time.Time `gorm:"column:created_at;not null;default:NOW()"`
-	UpdatedAt    time.Time `gorm:"column:updated_at;not null;default:NOW()"`
+	ID                    uuid.UUID `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
+	OrgName               string    `gorm:"column:org_name;not null;uniqueIndex:uq_org_publisher_creds_org"`
+	OrgUUID               string    `gorm:"column:org_uuid;not null;default:''"`
+	ClientID              string    `gorm:"column:client_id;not null"`
+	SecretKVPath          string    `gorm:"column:secret_kv_path;not null"`
+	SecretKey             string    `gorm:"column:secret_key;not null;default:'client-secret'"`
+	ClientSecretEncrypted []byte    `gorm:"column:client_secret_encrypted"`
+	CreatedAt             time.Time `gorm:"column:created_at;not null;default:NOW()"`
+	UpdatedAt             time.Time `gorm:"column:updated_at;not null;default:NOW()"`
 }
 
 func (OrgPublisherCredential) TableName() string { return "org_publisher_credentials" }

--- a/agent-manager-service/repositories/org_publisher_credential_repository.go
+++ b/agent-manager-service/repositories/org_publisher_credential_repository.go
@@ -58,6 +58,6 @@ func (r *orgPublisherCredentialRepo) GetByOrgName(orgName string) (*models.OrgPu
 func (r *orgPublisherCredentialRepo) Upsert(cred *models.OrgPublisherCredential) error {
 	return r.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "org_name"}},
-		DoUpdates: clause.AssignmentColumns([]string{"org_uuid", "client_id", "secret_kv_path", "secret_key", "updated_at"}),
+		DoUpdates: clause.AssignmentColumns([]string{"org_uuid", "client_id", "secret_kv_path", "secret_key", "client_secret_encrypted", "updated_at"}),
 	}).Create(cred).Error
 }

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -35,6 +35,23 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
+// ocClientCtxKey is the context key used by the scheduler to inject an org-scoped OC client
+// so that executor calls use the right credentials without needing provisioner awareness.
+type ocClientCtxKey struct{}
+
+// withOCClient stores an OC client in ctx for downstream calls (scheduler use only).
+func withOCClient(ctx context.Context, c client.OpenChoreoClient) context.Context {
+	return context.WithValue(ctx, ocClientCtxKey{}, c)
+}
+
+// ocClientFromContext returns the OC client stored in ctx, or fallback if none was injected.
+func ocClientFromContext(ctx context.Context, fallback client.OpenChoreoClient) client.OpenChoreoClient {
+	if c, ok := ctx.Value(ocClientCtxKey{}).(client.OpenChoreoClient); ok && c != nil {
+		return c
+	}
+	return fallback
+}
+
 // MonitorExecutor handles workflow execution for monitors
 // This is the shared component used by both MonitorManagerService and MonitorSchedulerService
 type MonitorExecutor interface {
@@ -131,8 +148,11 @@ func (e *monitorExecutor) ExecuteMonitorRun(ctx context.Context, params ExecuteM
 		return nil, fmt.Errorf("failed to build WorkflowRun request: %w", err)
 	}
 
-	// Create WorkflowRun via OpenChoreo API
-	workflowRunResp, err := e.ocClient.CreateWorkflowRun(ctx, params.OrgName, *workflowRunReq)
+	// Create WorkflowRun via OpenChoreo API.
+	// The scheduler injects an org-scoped OC client into context before calling here;
+	// user-request paths leave the context as-is and fall back to the system client.
+	ocClient := ocClientFromContext(ctx, e.ocClient)
+	workflowRunResp, err := ocClient.CreateWorkflowRun(ctx, params.OrgName, *workflowRunReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create WorkflowRun: %w", err)
 	}

--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -435,6 +435,21 @@ func (s *monitorManagerService) UpdateMonitor(ctx context.Context, orgName, proj
 			return nil, fmt.Errorf("samplingRate must be between 0 (exclusive) and 1 (inclusive): %w", utils.ErrInvalidInput)
 		}
 	}
+	if monitor.Type == models.MonitorTypePast && (req.TraceStart != nil || req.TraceEnd != nil) {
+		effectiveStart := monitor.TraceStart
+		if req.TraceStart != nil {
+			effectiveStart = req.TraceStart
+		}
+		effectiveEnd := monitor.TraceEnd
+		if req.TraceEnd != nil {
+			effectiveEnd = req.TraceEnd
+		}
+		if effectiveStart != nil && effectiveEnd != nil {
+			if err := validateTraceWindow(effectiveStart, effectiveEnd); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	// Apply partial updates
 	if req.DisplayName != nil {
@@ -960,20 +975,29 @@ func (s *monitorManagerService) deriveMonitorStatus(monitorType string, nextRunT
 	}
 }
 
+// validateTraceWindow checks the three invariants that apply to both create and update:
+// traceEnd > traceStart, traceEnd not in the future, traceStart within 30 days.
+func validateTraceWindow(traceStart, traceEnd *time.Time) error {
+	if !traceEnd.After(*traceStart) {
+		return fmt.Errorf("traceEnd must be after traceStart: %w", utils.ErrInvalidInput)
+	}
+	if traceEnd.After(time.Now()) {
+		return fmt.Errorf("traceEnd must not be in the future: %w", utils.ErrInvalidInput)
+	}
+	if time.Since(*traceStart) > 30*24*time.Hour {
+		return fmt.Errorf("traceStart cannot be more than 30 days ago: %w", utils.ErrInvalidInput)
+	}
+	return nil
+}
+
 // validateCreateRequest validates the create monitor request based on type
 func (s *monitorManagerService) validateCreateRequest(req *models.CreateMonitorRequest) error {
 	if req.Type == models.MonitorTypePast {
 		if req.TraceStart == nil || req.TraceEnd == nil {
 			return fmt.Errorf("traceStart and traceEnd are required for past monitors: %w", utils.ErrInvalidInput)
 		}
-		if !req.TraceEnd.After(*req.TraceStart) {
-			return fmt.Errorf("traceEnd must be after traceStart: %w", utils.ErrInvalidInput)
-		}
-		if req.TraceEnd.After(time.Now().Add(30 * time.Second)) {
-			return fmt.Errorf("traceEnd must not be in the future: %w", utils.ErrInvalidInput)
-		}
-		if time.Since(*req.TraceStart) > 30*24*time.Hour {
-			return fmt.Errorf("traceStart cannot be more than 30 days ago: %w", utils.ErrInvalidInput)
+		if err := validateTraceWindow(req.TraceStart, req.TraceEnd); err != nil {
+			return err
 		}
 	}
 	if req.IntervalMinutes != nil {

--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -969,8 +969,11 @@ func (s *monitorManagerService) validateCreateRequest(req *models.CreateMonitorR
 		if !req.TraceEnd.After(*req.TraceStart) {
 			return fmt.Errorf("traceEnd must be after traceStart: %w", utils.ErrInvalidInput)
 		}
-		if req.TraceEnd.After(time.Now()) {
+		if req.TraceEnd.After(time.Now().Add(30 * time.Second)) {
 			return fmt.Errorf("traceEnd must not be in the future: %w", utils.ErrInvalidInput)
+		}
+		if time.Since(*req.TraceStart) > 30*24*time.Hour {
+			return fmt.Errorf("traceStart cannot be more than 30 days ago: %w", utils.ErrInvalidInput)
 		}
 	}
 	if req.IntervalMinutes != nil {

--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -444,10 +444,11 @@ func (s *monitorManagerService) UpdateMonitor(ctx context.Context, orgName, proj
 		if req.TraceEnd != nil {
 			effectiveEnd = req.TraceEnd
 		}
-		if effectiveStart != nil && effectiveEnd != nil {
-			if err := validateTraceWindow(effectiveStart, effectiveEnd); err != nil {
-				return nil, err
-			}
+		if effectiveStart == nil || effectiveEnd == nil {
+			return nil, fmt.Errorf("traceStart and traceEnd are required for past monitors: %w", utils.ErrInvalidInput)
+		}
+		if err := validateTraceWindow(effectiveStart, effectiveEnd); err != nil {
+			return nil, err
 		}
 	}
 

--- a/agent-manager-service/services/monitor_scheduler.go
+++ b/agent-manager-service/services/monitor_scheduler.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -300,11 +301,11 @@ func (s *monitorSchedulerService) orgOCClient(ctx context.Context, orgName strin
 		return s.ocClient, nil
 	}
 	orgClient, err := s.provisioner.GetOCClientForOrg(ctx, orgName)
+	if errors.Is(err, ErrNotThunderMode) {
+		return s.ocClient, nil
+	}
 	if err != nil {
 		return nil, err
-	}
-	if orgClient == nil {
-		return s.ocClient, nil
 	}
 	return orgClient, nil
 }

--- a/agent-manager-service/services/monitor_scheduler.go
+++ b/agent-manager-service/services/monitor_scheduler.go
@@ -41,7 +41,9 @@ type MonitorSchedulerService interface {
 }
 
 type monitorSchedulerService struct {
+	// ocClient is the system-level OC client used as fallback in non-Thunder mode.
 	ocClient    client.OpenChoreoClient
+	provisioner PublisherCredentialProvisioner
 	logger      *slog.Logger
 	executor    MonitorExecutor
 	monitorRepo repositories.MonitorRepository
@@ -49,15 +51,19 @@ type monitorSchedulerService struct {
 	stopOnce    sync.Once
 }
 
-// NewMonitorSchedulerService creates a new monitor scheduler service
+// NewMonitorSchedulerService creates a new monitor scheduler service.
+// In Thunder mode the provisioner supplies per-org OC clients (org-bound tokens).
+// In non-Thunder mode ocClient is used as the system fallback.
 func NewMonitorSchedulerService(
 	ocClient client.OpenChoreoClient,
+	provisioner PublisherCredentialProvisioner,
 	logger *slog.Logger,
 	executor MonitorExecutor,
 	monitorRepo repositories.MonitorRepository,
 ) MonitorSchedulerService {
 	return &monitorSchedulerService{
 		ocClient:    ocClient,
+		provisioner: provisioner,
 		logger:      logger,
 		executor:    executor,
 		monitorRepo: monitorRepo,
@@ -68,10 +74,7 @@ func NewMonitorSchedulerService(
 // Start begins the scheduler
 func (s *monitorSchedulerService) Start(ctx context.Context) error {
 	s.logger.Info("Initializing monitor scheduler")
-
-	// Run scheduler loop in background
 	go s.runSchedulerLoop(ctx)
-
 	s.logger.Info("Monitor scheduler started")
 	return nil
 }
@@ -85,12 +88,11 @@ func (s *monitorSchedulerService) Stop() error {
 	return nil
 }
 
-// runSchedulerLoop runs the main scheduler loop (only when leader)
+// runSchedulerLoop runs the main scheduler loop
 func (s *monitorSchedulerService) runSchedulerLoop(ctx context.Context) {
 	ticker := time.NewTicker(schedulerTickInterval)
 	defer ticker.Stop()
 
-	// Run immediately on start
 	s.runSchedulerCycle(ctx)
 
 	for {
@@ -109,10 +111,6 @@ func (s *monitorSchedulerService) runSchedulerLoop(ctx context.Context) {
 
 // runSchedulerCycle executes one cycle of the scheduler
 func (s *monitorSchedulerService) runSchedulerCycle(ctx context.Context) {
-	// Use a transaction to pin the advisory lock to a single connection.
-	// pg_try_advisory_xact_lock auto-releases when the transaction ends.
-	// Note: Advisory lock is a DB-level coordination mechanism, kept as direct DB access.
-	// This will be refactored in the future to use an external scheduler
 	tx := db.DB(ctx).Begin()
 	if tx.Error != nil {
 		s.logger.Error("Failed to begin transaction for advisory lock", "error", tx.Error)
@@ -132,17 +130,17 @@ func (s *monitorSchedulerService) runSchedulerCycle(ctx context.Context) {
 
 	s.logger.Debug("Running scheduler cycle")
 
-	// Trigger pending monitors
 	if err := s.triggerPendingMonitors(ctx); err != nil {
 		s.logger.Error("Failed to trigger pending monitors", "error", err)
 	}
 
-	// Sync run status
 	if err := s.syncRunStatus(ctx); err != nil {
 		s.logger.Error("Failed to sync run status", "error", err)
 	}
 
-	tx.Commit()
+	if err := tx.Commit().Error; err != nil {
+		s.logger.Error("Failed to commit scheduler advisory lock transaction", "error", err)
+	}
 }
 
 // triggerPendingMonitors checks for monitors that need to run and creates WorkflowRun CRs
@@ -161,7 +159,6 @@ func (s *monitorSchedulerService) triggerPendingMonitors(ctx context.Context) er
 	for _, monitor := range monitors {
 		if err := s.triggerMonitor(ctx, &monitor); err != nil {
 			s.logger.Error("Failed to trigger monitor", "monitor", monitor.Name, "error", err)
-			// Continue with next monitor
 		}
 	}
 
@@ -177,37 +174,32 @@ func (s *monitorSchedulerService) triggerMonitor(ctx context.Context, monitor *m
 		return fmt.Errorf("next_run_time is nil for monitor %s", monitor.Name)
 	}
 
-	// Calculate safety delta (5% of interval)
 	safetyDelta := time.Duration(float64(*monitor.IntervalMinutes)*models.SafetyDeltaPercent) * time.Minute
 	interval := time.Duration(*monitor.IntervalMinutes) * time.Minute
-
-	// Calculate time window for this run - ensures continuous coverage with no gaps
-	// Look back from next_run_time by one interval to create overlapping windows
 	startTime := monitor.NextRunTime.Add(-interval)
-	// End at current time minus safety delta (to avoid missing late-arriving traces)
 	endTime := time.Now().Add(-safetyDelta)
-
-	// Next run starts interval minutes after this window ends
 	nextRunTime := endTime.Add(interval)
 
-	// Execute the monitor run
-	result, err := s.executor.ExecuteMonitorRun(ctx, ExecuteMonitorRunParams{
+	// Get an org-bound OC client in Thunder mode; nil in non-Thunder mode (executor falls back).
+	orgOCClient, err := s.orgOCClient(ctx, monitor.OrgName)
+	if err != nil {
+		return fmt.Errorf("failed to get OC client for org %s: %w", monitor.OrgName, err)
+	}
+
+	result, err := s.executor.ExecuteMonitorRun(withOCClient(ctx, orgOCClient), ExecuteMonitorRunParams{
 		OrgName:    monitor.OrgName,
 		Monitor:    monitor,
 		StartTime:  startTime,
 		EndTime:    endTime,
-		Evaluators: monitor.Evaluators, // Snapshot at execution time
+		Evaluators: monitor.Evaluators,
 	})
 	if err != nil {
 		s.logger.Error("Failed to execute monitor run", "error", err)
 		return err
 	}
 
-	// Update monitor's next_run_time AFTER successful CR creation
-	// If workflow execution fails later, that's tracked in monitor_runs status
 	if err := s.executor.UpdateNextRunTime(ctx, monitor.ID, nextRunTime); err != nil {
-		s.logger.Error("Failed to update next_run_time", "monitor", monitor.Name, "error", err)
-		// Don't fail - the workflow is already running
+		return fmt.Errorf("failed to update next_run_time for monitor %s: %w", monitor.Name, err)
 	}
 
 	s.logger.Info("Monitor triggered successfully",
@@ -234,7 +226,6 @@ func (s *monitorSchedulerService) syncRunStatus(ctx context.Context) error {
 	for _, run := range runs {
 		if err := s.syncSingleRunStatus(ctx, &run); err != nil {
 			s.logger.Error("Failed to sync run status", "runID", run.ID, "error", err)
-			// Continue with next run
 		}
 	}
 
@@ -243,16 +234,22 @@ func (s *monitorSchedulerService) syncRunStatus(ctx context.Context) error {
 
 // syncSingleRunStatus queries OpenChoreo API for a single run and updates DB
 func (s *monitorSchedulerService) syncSingleRunStatus(ctx context.Context, run *models.MonitorRun) error {
-	// Get monitor to find orgName
 	monitor, err := s.monitorRepo.GetMonitorByID(run.MonitorID)
 	if err != nil {
 		return fmt.Errorf("failed to get monitor: %w", err)
 	}
+	if monitor == nil {
+		s.logger.Warn("Monitor not found for run, skipping status sync", "monitorID", run.MonitorID)
+		return nil
+	}
 
-	// Query OpenChoreo API for WorkflowRun status
-	workflowRun, err := s.ocClient.GetWorkflowRun(ctx, monitor.OrgName, run.Name)
+	ocClient, err := s.orgOCClient(ctx, monitor.OrgName)
 	if err != nil {
-		// If CR not found, it might have been deleted - mark as error
+		return fmt.Errorf("failed to get OC client for org %s: %w", monitor.OrgName, err)
+	}
+
+	workflowRun, err := ocClient.GetWorkflowRun(ctx, monitor.OrgName, run.Name)
+	if err != nil {
 		s.logger.Warn("WorkflowRun not found", "workflowRunName", run.Name)
 		return fmt.Errorf("failed to get workflow run: %w", err)
 	}
@@ -262,7 +259,6 @@ func (s *monitorSchedulerService) syncSingleRunStatus(ctx context.Context, run *
 		"currentDBStatus", run.Status,
 		"workflowStatus", workflowRun.Status)
 
-	// Update DB based on status
 	updates := make(map[string]interface{})
 
 	switch workflowRun.Status {
@@ -281,7 +277,6 @@ func (s *monitorSchedulerService) syncSingleRunStatus(ctx context.Context, run *
 		}
 
 	case "Pending":
-		// Keep as pending
 		return nil
 
 	default:
@@ -297,4 +292,19 @@ func (s *monitorSchedulerService) syncSingleRunStatus(ctx context.Context, run *
 	}
 
 	return nil
+}
+
+// orgOCClient returns a per-org OC client in Thunder mode, or the system client in non-Thunder mode.
+func (s *monitorSchedulerService) orgOCClient(ctx context.Context, orgName string) (client.OpenChoreoClient, error) {
+	if !s.provisioner.IsThunderMode() {
+		return s.ocClient, nil
+	}
+	orgClient, err := s.provisioner.GetOCClientForOrg(ctx, orgName)
+	if err != nil {
+		return nil, err
+	}
+	if orgClient == nil {
+		return s.ocClient, nil
+	}
+	return orgClient, nil
 }

--- a/agent-manager-service/services/monitor_scheduler.go
+++ b/agent-manager-service/services/monitor_scheduler.go
@@ -18,7 +18,6 @@ package services
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -112,7 +111,7 @@ func (s *monitorSchedulerService) runSchedulerLoop(ctx context.Context) {
 
 // runSchedulerCycle executes one cycle of the scheduler
 func (s *monitorSchedulerService) runSchedulerCycle(ctx context.Context) {
-	tx := db.DB(ctx).Begin()
+	tx := db.GetDB().WithContext(ctx).Begin()
 	if tx.Error != nil {
 		s.logger.Error("Failed to begin transaction for advisory lock", "error", tx.Error)
 		return
@@ -300,12 +299,5 @@ func (s *monitorSchedulerService) orgOCClient(ctx context.Context, orgName strin
 	if !s.provisioner.IsThunderMode() {
 		return s.ocClient, nil
 	}
-	orgClient, err := s.provisioner.GetOCClientForOrg(ctx, orgName)
-	if errors.Is(err, ErrNotThunderMode) {
-		return s.ocClient, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return orgClient, nil
+	return s.provisioner.GetOCClientForOrg(ctx, orgName)
 }

--- a/agent-manager-service/services/monitor_scheduler_test.go
+++ b/agent-manager-service/services/monitor_scheduler_test.go
@@ -81,6 +81,7 @@ func newTestScheduler(executor MonitorExecutor) *monitorSchedulerService {
 				return nil, fmt.Errorf("mock: workflow run not found")
 			},
 		},
+		provisioner: NewStaticPublisherCredentialProvisioner(),
 		logger:      slog.Default(),
 		executor:    executor,
 		monitorRepo: repositories.NewMonitorRepo(db.GetDB()),
@@ -210,11 +211,12 @@ func TestTriggerMonitor_UpdateNextRunTimeError(t *testing.T) {
 		Evaluators:      []models.MonitorEvaluator{{Identifier: "eval-1", DisplayName: "eval-1", Config: map[string]interface{}{"level": "trace"}}},
 	}
 
-	// Should NOT return error — update failure is non-fatal
+	// Should return error — update failure is fatal to prevent double-trigger on the next cycle
 	err := s.triggerMonitor(context.Background(), monitor)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to update next_run_time")
 
-	// Executor should still have been called
+	// Executor should still have been called (WorkflowRun was already created)
 	require.Len(t, executor.executeCalls, 1)
 }
 
@@ -258,7 +260,7 @@ func TestTriggerMonitor_TimeWindowCalculation(t *testing.T) {
 
 func TestSchedulerStartStop(t *testing.T) {
 	executor := &mockExecutor{}
-	svc := NewMonitorSchedulerService(nil, slog.Default(), executor, repositories.NewMonitorRepo(db.GetDB()))
+	svc := NewMonitorSchedulerService(nil, NewStaticPublisherCredentialProvisioner(), slog.Default(), executor, repositories.NewMonitorRepo(db.GetDB()))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -272,7 +274,7 @@ func TestSchedulerStartStop(t *testing.T) {
 
 func TestSchedulerStopIdempotent(t *testing.T) {
 	executor := &mockExecutor{}
-	svc := NewMonitorSchedulerService(nil, slog.Default(), executor, repositories.NewMonitorRepo(db.GetDB()))
+	svc := NewMonitorSchedulerService(nil, NewStaticPublisherCredentialProvisioner(), slog.Default(), executor, repositories.NewMonitorRepo(db.GetDB()))
 
 	// Calling Stop multiple times should not panic
 	err := svc.Stop()

--- a/agent-manager-service/services/publisher_credential_provisioner.go
+++ b/agent-manager-service/services/publisher_credential_provisioner.go
@@ -38,6 +38,9 @@ import (
 
 const schedulerRoleName = "amp-monitor-scheduler"
 
+// ErrNotThunderMode is returned by GetOCClientForOrg when the provisioner is not in Thunder mode.
+var ErrNotThunderMode = errors.New("not in Thunder mode")
+
 // PublisherCredentials holds the provisioned OAuth2 credentials for publishing scores.
 type PublisherCredentials struct {
 	ClientID     string // OAuth2 client ID (becomes JWT subject)
@@ -59,7 +62,7 @@ type PublisherCredentialProvisioner interface {
 	// Used by the scheduler which runs without a user request context and therefore has no
 	// user JWT in ctx. Decrypts the stored client secret and exchanges it for an access token
 	// via the IDP token endpoint.
-	// In non-Thunder mode returns nil, nil — callers must fall back to the system OC client.
+	// In non-Thunder mode returns nil, ErrNotThunderMode — callers must fall back to the system OC client.
 	GetOCClientForOrg(ctx context.Context, orgName string) (client.OpenChoreoClient, error)
 }
 
@@ -75,8 +78,8 @@ func (s *staticPublisherCredentialProvisioner) EnsureCredentials(_ context.Conte
 
 func (s *staticPublisherCredentialProvisioner) IsThunderMode() bool { return false }
 
-func (s *staticPublisherCredentialProvisioner) GetOCClientForOrg(_ context.Context, orgName string) (client.OpenChoreoClient, error) {
-	return nil, fmt.Errorf("GetOCClientForOrg called in non-Thunder mode for org %s", orgName)
+func (s *staticPublisherCredentialProvisioner) GetOCClientForOrg(_ context.Context, _ string) (client.OpenChoreoClient, error) {
+	return nil, ErrNotThunderMode
 }
 
 // NewStaticPublisherCredentialProvisioner creates a static provisioner for use in tests.
@@ -192,7 +195,7 @@ func (p *publisherCredentialProvisioner) resolveSecretRef(ctx context.Context, o
 func (p *publisherCredentialProvisioner) EnsureCredentials(ctx context.Context, orgName, orgUUID string) (*PublisherCredentials, error) {
 	p.logger.Debug("EnsureCredentials called", "orgName", orgName, "orgUUID", orgUUID)
 
-	result, err, _ := p.sfg.Do(orgName, func() (any, error) {
+	result, err, _ := p.sfg.Do("provision:"+orgName, func() (any, error) {
 		return p.provisionCredentials(ctx, orgName, orgUUID)
 	})
 	if err != nil {
@@ -336,7 +339,7 @@ func (p *publisherCredentialProvisioner) getOrCreateOrgAuthProvider(ctx context.
 		return authProv, nil
 	}
 
-	result, err, _ := p.sfg.Do("auth-"+orgName, func() (any, error) {
+	result, err, _ := p.sfg.Do("auth:"+orgName, func() (any, error) {
 		// Re-check under write lock — another goroutine may have populated the cache
 		// while we were waiting on singleflight.
 		p.orgAuthMu.Lock()

--- a/agent-manager-service/services/publisher_credential_provisioner.go
+++ b/agent-manager-service/services/publisher_credential_provisioner.go
@@ -21,17 +21,22 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"golang.org/x/sync/singleflight"
 	"gorm.io/gorm"
 
+	ocauth "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/auth"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
+
+const schedulerRoleName = "amp-monitor-scheduler"
 
 // PublisherCredentials holds the provisioned OAuth2 credentials for publishing scores.
 type PublisherCredentials struct {
@@ -44,12 +49,18 @@ type PublisherCredentials struct {
 type PublisherCredentialProvisioner interface {
 	// EnsureCredentials provisions per-org publisher credentials.
 	// orgUUID is the Thunder organization unit UUID (from JWT ouId claim).
-	// If empty, the default OU is used.
 	EnsureCredentials(ctx context.Context, orgName, orgUUID string) (*PublisherCredentials, error)
 
 	// IsThunderMode returns true when Thunder is configured for multi-tenant
 	// credential provisioning, false for static single-tenant mode.
 	IsThunderMode() bool
+
+	// GetOCClientForOrg returns an OC client authenticated with the org's publisher app token.
+	// Used by the scheduler which runs without a user request context and therefore has no
+	// user JWT in ctx. Decrypts the stored client secret and exchanges it for an access token
+	// via the IDP token endpoint.
+	// In non-Thunder mode returns nil, nil — callers must fall back to the system OC client.
+	GetOCClientForOrg(ctx context.Context, orgName string) (client.OpenChoreoClient, error)
 }
 
 // staticPublisherCredentialProvisioner returns hardcoded static credentials
@@ -64,6 +75,21 @@ func (s *staticPublisherCredentialProvisioner) EnsureCredentials(_ context.Conte
 
 func (s *staticPublisherCredentialProvisioner) IsThunderMode() bool { return false }
 
+func (s *staticPublisherCredentialProvisioner) GetOCClientForOrg(_ context.Context, orgName string) (client.OpenChoreoClient, error) {
+	return nil, fmt.Errorf("GetOCClientForOrg called in non-Thunder mode for org %s", orgName)
+}
+
+// NewStaticPublisherCredentialProvisioner creates a static provisioner for use in tests.
+func NewStaticPublisherCredentialProvisioner() PublisherCredentialProvisioner {
+	return &staticPublisherCredentialProvisioner{
+		creds: &PublisherCredentials{
+			ClientID:     "amp-publisher-client",
+			SecretKVPath: "amp-publisher-client-secret",
+			SecretKey:    "value",
+		},
+	}
+}
+
 // publisherCredentialProvisioner provisions per-org credentials via Thunder + SecretManagementClient.
 type publisherCredentialProvisioner struct {
 	thunderClient thundersvc.ThunderClient
@@ -71,8 +97,15 @@ type publisherCredentialProvisioner struct {
 	ocClient      client.OpenChoreoClient
 	credRepo      repositories.OrgPublisherCredentialRepository
 	logger        *slog.Logger
+	encryptionKey []byte
+	idpTokenURL   string
+	ocBaseURL     string
 
 	sfg singleflight.Group // serializes provisioning per orgName
+
+	// per-org auth providers for publisher tokens — created once, cache tokens internally
+	orgAuthMu        sync.RWMutex
+	orgAuthProviders map[string]client.AuthProvider
 }
 
 // NewPublisherCredentialProvisioner creates a provisioner.
@@ -80,6 +113,7 @@ type publisherCredentialProvisioner struct {
 // that always returns the default amp-publisher-client credentials.
 func NewPublisherCredentialProvisioner(
 	cfg config.Config,
+	encryptionKey []byte,
 	logger *slog.Logger,
 	secretClient secretmanagersvc.SecretManagementClient,
 	ocClient client.OpenChoreoClient,
@@ -107,11 +141,15 @@ func NewPublisherCredentialProvisioner(
 	)
 
 	return &publisherCredentialProvisioner{
-		thunderClient: thunderCl,
-		secretClient:  secretClient,
-		ocClient:      ocClient,
-		credRepo:      credRepo,
-		logger:        logger,
+		thunderClient:    thunderCl,
+		secretClient:     secretClient,
+		ocClient:         ocClient,
+		credRepo:         credRepo,
+		logger:           logger,
+		encryptionKey:    encryptionKey,
+		idpTokenURL:      cfg.IDP.TokenURL,
+		ocBaseURL:        cfg.OpenChoreo.BaseURL,
+		orgAuthProviders: make(map[string]client.AuthProvider),
 	}, nil
 }
 
@@ -154,9 +192,6 @@ func (p *publisherCredentialProvisioner) resolveSecretRef(ctx context.Context, o
 func (p *publisherCredentialProvisioner) EnsureCredentials(ctx context.Context, orgName, orgUUID string) (*PublisherCredentials, error) {
 	p.logger.Debug("EnsureCredentials called", "orgName", orgName, "orgUUID", orgUUID)
 
-	// Singleflight ensures only one goroutine provisions per org at a time.
-	// NOTE: uses the first caller's context — if cancelled, other waiters also get the error.
-	// Acceptable because provisioning is rare (once per org) and callers can retry.
 	result, err, _ := p.sfg.Do(orgName, func() (any, error) {
 		return p.provisionCredentials(ctx, orgName, orgUUID)
 	})
@@ -177,6 +212,13 @@ func (p *publisherCredentialProvisioner) provisionCredentials(ctx context.Contex
 		p.logger.Debug("Found existing publisher credentials in DB",
 			"orgName", orgName, "clientID", existing.ClientID)
 
+		// Ensure the binding exists — idempotent, handles orgs provisioned before this was added.
+		// Non-fatal: log and continue if the ClusterAuthzRole isn't installed yet.
+		if bindErr := p.ocClient.EnsureClusterRoleBinding(ctx, existing.ClientID, schedulerRoleName); bindErr != nil {
+			p.logger.Warn("Failed to ensure ClusterAuthzRoleBinding for existing credentials",
+				"orgName", orgName, "clientID", existing.ClientID, "error", bindErr)
+		}
+
 		return &PublisherCredentials{
 			ClientID:     existing.ClientID,
 			SecretKVPath: existing.SecretKVPath,
@@ -194,10 +236,8 @@ func (p *publisherCredentialProvisioner) provisionCredentials(ctx context.Contex
 	p.logger.Info("Thunder EnsurePublisherApp result",
 		"orgName", orgName, "clientID", clientID, "created", created, "hasSecret", clientSecret != "")
 
-	// If app already existed in Thunder but not in DB, clientSecret is empty
-	// (Thunder only returns the secret at creation time). Regenerate the client
-	// secret rather than deleting the whole app — this avoids invalidating any
-	// tokens that may have been issued from the existing app's prior secret.
+	// If app already existed in Thunder but not in DB, clientSecret is empty.
+	// Regenerate rather than deleting the whole app.
 	if !created && clientSecret == "" {
 		p.logger.Warn("Thunder app exists but secret not available — regenerating client secret",
 			"orgName", orgName, "clientID", clientID)
@@ -234,13 +274,28 @@ func (p *publisherCredentialProvisioner) provisionCredentials(ctx context.Contex
 		return nil, fmt.Errorf("failed to resolve SecretReference for org %s: %w", orgName, resolveErr)
 	}
 
+	// Encrypt the client secret so the scheduler can decrypt and use it for token generation.
+	encryptedSecret, err := utils.EncryptBytes([]byte(clientSecret), p.encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt publisher secret for org %s: %w", orgName, err)
+	}
+
+	// Bind the publisher app to the scheduler role in OpenChoreo so it can create/track WorkflowRuns.
+	// Uses the system OC client (not org-bound) — ClusterAuthzRoleBindings are cluster-scoped resources.
+	if bindErr := p.ocClient.EnsureClusterRoleBinding(ctx, clientID, schedulerRoleName); bindErr != nil {
+		return nil, fmt.Errorf("failed to bind publisher app to scheduler role for org %s: %w", orgName, bindErr)
+	}
+	p.logger.Info("ClusterAuthzRoleBinding ensured",
+		"orgName", orgName, "clientID", clientID, "role", schedulerRoleName)
+
 	// Save to DB — treat as fatal since we just provisioned real credentials
 	dbCred := &models.OrgPublisherCredential{
-		OrgName:      orgName,
-		OrgUUID:      orgUUID,
-		ClientID:     clientID,
-		SecretKVPath: resolvedKVPath,
-		SecretKey:    resolvedKey,
+		OrgName:               orgName,
+		OrgUUID:               orgUUID,
+		ClientID:              clientID,
+		SecretKVPath:          resolvedKVPath,
+		SecretKey:             resolvedKey,
+		ClientSecretEncrypted: encryptedSecret,
 	}
 	if dbErr := p.credRepo.Upsert(dbCred); dbErr != nil {
 		return nil, fmt.Errorf("failed to persist publisher credentials for org %s: %w", orgName, dbErr)
@@ -254,4 +309,66 @@ func (p *publisherCredentialProvisioner) provisionCredentials(ctx context.Contex
 		SecretKVPath: resolvedKVPath,
 		SecretKey:    resolvedKey,
 	}, nil
+}
+
+// GetOCClientForOrg returns an OC client authenticated with the publisher app's org-scoped token.
+// Used by the scheduler for CreateWorkflowRun and GetWorkflowRun — operations that run
+// without a live user request context.
+func (p *publisherCredentialProvisioner) GetOCClientForOrg(ctx context.Context, orgName string) (client.OpenChoreoClient, error) {
+	authProv, err := p.getOrCreateOrgAuthProvider(ctx, orgName)
+	if err != nil {
+		return nil, err
+	}
+	return client.NewOpenChoreoClient(&client.Config{
+		BaseURL:      p.ocBaseURL,
+		AuthProvider: authProv,
+	})
+}
+
+// getOrCreateOrgAuthProvider returns (or lazily creates) a cached auth provider for the org.
+// singleflight deduplicates concurrent calls for the same org; the write lock prevents a
+// TOCTOU race between the cache miss check and the map write.
+func (p *publisherCredentialProvisioner) getOrCreateOrgAuthProvider(ctx context.Context, orgName string) (client.AuthProvider, error) {
+	p.orgAuthMu.RLock()
+	authProv, ok := p.orgAuthProviders[orgName]
+	p.orgAuthMu.RUnlock()
+	if ok {
+		return authProv, nil
+	}
+
+	result, err, _ := p.sfg.Do("auth-"+orgName, func() (any, error) {
+		// Re-check under write lock — another goroutine may have populated the cache
+		// while we were waiting on singleflight.
+		p.orgAuthMu.Lock()
+		defer p.orgAuthMu.Unlock()
+		if ap, ok := p.orgAuthProviders[orgName]; ok {
+			return ap, nil
+		}
+
+		cred, err := p.credRepo.GetByOrgName(orgName)
+		if err != nil {
+			return nil, fmt.Errorf("no publisher credentials for org %s: %w", orgName, err)
+		}
+		if len(cred.ClientSecretEncrypted) == 0 {
+			return nil, fmt.Errorf("no encrypted secret stored for org %s — call EnsureCredentials first", orgName)
+		}
+
+		secretBytes, err := utils.DecryptBytes(cred.ClientSecretEncrypted, p.encryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decrypt publisher secret for org %s: %w", orgName, err)
+		}
+
+		ap := ocauth.NewAuthProvider(ocauth.Config{
+			TokenURL:     p.idpTokenURL,
+			ClientID:     cred.ClientID,
+			ClientSecret: string(secretBytes),
+		})
+		p.orgAuthProviders[orgName] = ap
+		p.logger.Debug("Created org auth provider", "orgName", orgName, "clientID", cred.ClientID)
+		return ap, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(client.AuthProvider), nil
 }

--- a/agent-manager-service/services/publisher_credential_provisioner.go
+++ b/agent-manager-service/services/publisher_credential_provisioner.go
@@ -41,6 +41,10 @@ const schedulerRoleName = "amp-monitor-scheduler"
 // ErrNotThunderMode is returned by GetOCClientForOrg when the provisioner is not in Thunder mode.
 var ErrNotThunderMode = errors.New("not in Thunder mode")
 
+// ErrPublisherCredentialNotFound indicates EnsureCredentials has not yet been called for the org.
+// Distinct from real DB errors so callers can decide whether to provision-on-demand vs retry.
+var ErrPublisherCredentialNotFound = errors.New("publisher credentials not found")
+
 // PublisherCredentials holds the provisioned OAuth2 credentials for publishing scores.
 type PublisherCredentials struct {
 	ClientID     string // OAuth2 client ID (becomes JWT subject)
@@ -104,11 +108,13 @@ type publisherCredentialProvisioner struct {
 	idpTokenURL   string
 	ocBaseURL     string
 
-	sfg singleflight.Group // serializes provisioning per orgName
+	sfg singleflight.Group // serializes provisioning and per-org client construction
 
-	// per-org auth providers for publisher tokens — created once, cache tokens internally
-	orgAuthMu        sync.RWMutex
-	orgAuthProviders map[string]client.AuthProvider
+	// orgOCClients caches per-org OpenChoreoClients so that the underlying http.Client
+	// connection pool and the wrapped AuthProvider's token cache are reused across
+	// scheduler cycles. Singleflight serializes builders; the lock guards map access only.
+	orgOCMu      sync.RWMutex
+	orgOCClients map[string]client.OpenChoreoClient
 }
 
 // NewPublisherCredentialProvisioner creates a provisioner.
@@ -144,15 +150,15 @@ func NewPublisherCredentialProvisioner(
 	)
 
 	return &publisherCredentialProvisioner{
-		thunderClient:    thunderCl,
-		secretClient:     secretClient,
-		ocClient:         ocClient,
-		credRepo:         credRepo,
-		logger:           logger,
-		encryptionKey:    encryptionKey,
-		idpTokenURL:      cfg.IDP.TokenURL,
-		ocBaseURL:        cfg.OpenChoreo.BaseURL,
-		orgAuthProviders: make(map[string]client.AuthProvider),
+		thunderClient: thunderCl,
+		secretClient:  secretClient,
+		ocClient:      ocClient,
+		credRepo:      credRepo,
+		logger:        logger,
+		encryptionKey: encryptionKey,
+		idpTokenURL:   cfg.IDP.TokenURL,
+		ocBaseURL:     cfg.OpenChoreo.BaseURL,
+		orgOCClients:  make(map[string]client.OpenChoreoClient),
 	}, nil
 }
 
@@ -208,10 +214,12 @@ func (p *publisherCredentialProvisioner) EnsureCredentials(ctx context.Context, 
 func (p *publisherCredentialProvisioner) provisionCredentials(ctx context.Context, orgName, orgUUID string) (*PublisherCredentials, error) {
 	// Check DB for existing credentials
 	existing, err := p.credRepo.GetByOrgName(orgName)
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, fmt.Errorf("failed to look up publisher credentials for org %s: %w", orgName, err)
-	}
-	if err == nil && existing != nil {
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("failed to look up publisher credentials for org %s: %w", orgName, err)
+		}
+		// ErrRecordNotFound: no credentials yet, fall through to provision.
+	} else {
 		p.logger.Debug("Found existing publisher credentials in DB",
 			"orgName", orgName, "clientID", existing.ClientID)
 
@@ -314,46 +322,41 @@ func (p *publisherCredentialProvisioner) provisionCredentials(ctx context.Contex
 	}, nil
 }
 
-// GetOCClientForOrg returns an OC client authenticated with the publisher app's org-scoped token.
-// Used by the scheduler for CreateWorkflowRun and GetWorkflowRun — operations that run
-// without a live user request context.
-func (p *publisherCredentialProvisioner) GetOCClientForOrg(ctx context.Context, orgName string) (client.OpenChoreoClient, error) {
-	authProv, err := p.getOrCreateOrgAuthProvider(ctx, orgName)
-	if err != nil {
-		return nil, err
-	}
-	return client.NewOpenChoreoClient(&client.Config{
-		BaseURL:      p.ocBaseURL,
-		AuthProvider: authProv,
-	})
-}
-
-// getOrCreateOrgAuthProvider returns (or lazily creates) a cached auth provider for the org.
-// singleflight deduplicates concurrent calls for the same org; the write lock prevents a
-// TOCTOU race between the cache miss check and the map write.
-func (p *publisherCredentialProvisioner) getOrCreateOrgAuthProvider(ctx context.Context, orgName string) (client.AuthProvider, error) {
-	p.orgAuthMu.RLock()
-	authProv, ok := p.orgAuthProviders[orgName]
-	p.orgAuthMu.RUnlock()
+// GetOCClientForOrg returns a cached OC client authenticated with the publisher app's
+// org-scoped token. Used by the scheduler for CreateWorkflowRun and GetWorkflowRun —
+// operations that run without a live user request context.
+//
+// The OpenChoreoClient (and the AuthProvider it wraps, plus the underlying http.Client)
+// is built once per org and cached, so connection-pool keep-alive and token-refresh state
+// are preserved across scheduler cycles.
+func (p *publisherCredentialProvisioner) GetOCClientForOrg(_ context.Context, orgName string) (client.OpenChoreoClient, error) {
+	p.orgOCMu.RLock()
+	c, ok := p.orgOCClients[orgName]
+	p.orgOCMu.RUnlock()
 	if ok {
-		return authProv, nil
+		return c, nil
 	}
 
-	result, err, _ := p.sfg.Do("auth:"+orgName, func() (any, error) {
-		// Re-check under write lock — another goroutine may have populated the cache
-		// while we were waiting on singleflight.
-		p.orgAuthMu.Lock()
-		defer p.orgAuthMu.Unlock()
-		if ap, ok := p.orgAuthProviders[orgName]; ok {
-			return ap, nil
+	result, err, _ := p.sfg.Do("ocClient:"+orgName, func() (any, error) {
+		// Re-check under read lock — singleflight may have just finished a previous build.
+		p.orgOCMu.RLock()
+		if c, ok := p.orgOCClients[orgName]; ok {
+			p.orgOCMu.RUnlock()
+			return c, nil
 		}
+		p.orgOCMu.RUnlock()
 
+		// DB I/O and decrypt run with no lock held; singleflight already serializes
+		// concurrent callers for this orgName.
 		cred, err := p.credRepo.GetByOrgName(orgName)
 		if err != nil {
-			return nil, fmt.Errorf("no publisher credentials for org %s: %w", orgName, err)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, fmt.Errorf("%w: org %s — call EnsureCredentials first", ErrPublisherCredentialNotFound, orgName)
+			}
+			return nil, fmt.Errorf("failed to look up publisher credentials for org %s: %w", orgName, err)
 		}
 		if len(cred.ClientSecretEncrypted) == 0 {
-			return nil, fmt.Errorf("no encrypted secret stored for org %s — call EnsureCredentials first", orgName)
+			return nil, fmt.Errorf("%w: org %s has no encrypted secret stored — call EnsureCredentials first", ErrPublisherCredentialNotFound, orgName)
 		}
 
 		secretBytes, err := utils.DecryptBytes(cred.ClientSecretEncrypted, p.encryptionKey)
@@ -361,17 +364,28 @@ func (p *publisherCredentialProvisioner) getOrCreateOrgAuthProvider(ctx context.
 			return nil, fmt.Errorf("failed to decrypt publisher secret for org %s: %w", orgName, err)
 		}
 
-		ap := ocauth.NewAuthProvider(ocauth.Config{
+		authProv := ocauth.NewAuthProvider(ocauth.Config{
 			TokenURL:     p.idpTokenURL,
 			ClientID:     cred.ClientID,
 			ClientSecret: string(secretBytes),
 		})
-		p.orgAuthProviders[orgName] = ap
-		p.logger.Debug("Created org auth provider", "orgName", orgName, "clientID", cred.ClientID)
-		return ap, nil
+		ocCl, err := client.NewOpenChoreoClient(&client.Config{
+			BaseURL:      p.ocBaseURL,
+			AuthProvider: authProv,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to build OC client for org %s: %w", orgName, err)
+		}
+
+		p.orgOCMu.Lock()
+		p.orgOCClients[orgName] = ocCl
+		p.orgOCMu.Unlock()
+
+		p.logger.Debug("Created org OC client", "orgName", orgName, "clientID", cred.ClientID)
+		return ocCl, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return result.(client.AuthProvider), nil
+	return result.(client.OpenChoreoClient), nil
 }

--- a/agent-manager-service/spec/model_update_monitor_request.go
+++ b/agent-manager-service/spec/model_update_monitor_request.go
@@ -12,6 +12,7 @@ package spec
 
 import (
 	"encoding/json"
+	"time"
 )
 
 // checks if the UpdateMonitorRequest type satisfies the MappedNullable interface at compile time
@@ -26,6 +27,10 @@ type UpdateMonitorRequest struct {
 	LlmProvider NullableUpdateMonitorRequestLlmProvider `json:"llmProvider,omitempty"`
 	// Interval in minutes for continuous monitoring (only for 'future' type)
 	IntervalMinutes *int32 `json:"intervalMinutes,omitempty"`
+	// Start of the trace window (only for 'past' type)
+	TraceStart *time.Time `json:"traceStart,omitempty"`
+	// End of the trace window (only for 'past' type)
+	TraceEnd *time.Time `json:"traceEnd,omitempty"`
 	// Sampling rate for trace collection (0.0 to 1.0)
 	SamplingRate *float32 `json:"samplingRate,omitempty"`
 }
@@ -186,6 +191,70 @@ func (o *UpdateMonitorRequest) SetIntervalMinutes(v int32) {
 	o.IntervalMinutes = &v
 }
 
+// GetTraceStart returns the TraceStart field value if set, zero value otherwise.
+func (o *UpdateMonitorRequest) GetTraceStart() time.Time {
+	if o == nil || IsNil(o.TraceStart) {
+		var ret time.Time
+		return ret
+	}
+	return *o.TraceStart
+}
+
+// GetTraceStartOk returns a tuple with the TraceStart field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateMonitorRequest) GetTraceStartOk() (*time.Time, bool) {
+	if o == nil || IsNil(o.TraceStart) {
+		return nil, false
+	}
+	return o.TraceStart, true
+}
+
+// HasTraceStart returns a boolean if a field has been set.
+func (o *UpdateMonitorRequest) HasTraceStart() bool {
+	if o != nil && !IsNil(o.TraceStart) {
+		return true
+	}
+
+	return false
+}
+
+// SetTraceStart gets a reference to the given time.Time and assigns it to the TraceStart field.
+func (o *UpdateMonitorRequest) SetTraceStart(v time.Time) {
+	o.TraceStart = &v
+}
+
+// GetTraceEnd returns the TraceEnd field value if set, zero value otherwise.
+func (o *UpdateMonitorRequest) GetTraceEnd() time.Time {
+	if o == nil || IsNil(o.TraceEnd) {
+		var ret time.Time
+		return ret
+	}
+	return *o.TraceEnd
+}
+
+// GetTraceEndOk returns a tuple with the TraceEnd field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateMonitorRequest) GetTraceEndOk() (*time.Time, bool) {
+	if o == nil || IsNil(o.TraceEnd) {
+		return nil, false
+	}
+	return o.TraceEnd, true
+}
+
+// HasTraceEnd returns a boolean if a field has been set.
+func (o *UpdateMonitorRequest) HasTraceEnd() bool {
+	if o != nil && !IsNil(o.TraceEnd) {
+		return true
+	}
+
+	return false
+}
+
+// SetTraceEnd gets a reference to the given time.Time and assigns it to the TraceEnd field.
+func (o *UpdateMonitorRequest) SetTraceEnd(v time.Time) {
+	o.TraceEnd = &v
+}
+
 // GetSamplingRate returns the SamplingRate field value if set, zero value otherwise.
 func (o *UpdateMonitorRequest) GetSamplingRate() float32 {
 	if o == nil || IsNil(o.SamplingRate) {
@@ -239,6 +308,12 @@ func (o UpdateMonitorRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.IntervalMinutes) {
 		toSerialize["intervalMinutes"] = o.IntervalMinutes
+	}
+	if !IsNil(o.TraceStart) {
+		toSerialize["traceStart"] = o.TraceStart
+	}
+	if !IsNil(o.TraceEnd) {
+		toSerialize["traceEnd"] = o.TraceEnd
 	}
 	if !IsNil(o.SamplingRate) {
 		toSerialize["samplingRate"] = o.SamplingRate

--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -634,6 +634,8 @@ func ConvertToUpdateMonitorRequest(req *spec.UpdateMonitorRequest) *models.Updat
 		LLMProvider:      llmProvider,
 		ClearLLMProvider: clearLLMProvider,
 		IntervalMinutes:  intervalMinutes,
+		TraceStart:       req.TraceStart,
+		TraceEnd:         req.TraceEnd,
 		SamplingRate:     samplingRate,
 	}
 }

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -165,8 +165,8 @@ func ProvideGitCredentialsService(ocClient occlient.OpenChoreoClient, cfg config
 
 // ProvidePublisherProvisioner creates the publisher credential provisioner
 // for per-org Thunder OAuth app creation and secret storage via SecretManagementClient
-func ProvidePublisherProvisioner(cfg config.Config, logger *slog.Logger, secretClient secretmanagersvc.SecretManagementClient, ocClient occlient.OpenChoreoClient, credRepo repositories.OrgPublisherCredentialRepository) (services.PublisherCredentialProvisioner, error) {
-	return services.NewPublisherCredentialProvisioner(cfg, logger, secretClient, ocClient, credRepo)
+func ProvidePublisherProvisioner(cfg config.Config, encryptionKey []byte, logger *slog.Logger, secretClient secretmanagersvc.SecretManagementClient, ocClient occlient.OpenChoreoClient, credRepo repositories.OrgPublisherCredentialRepository) (services.PublisherCredentialProvisioner, error) {
+	return services.NewPublisherCredentialProvisioner(cfg, encryptionKey, logger, secretClient, ocClient, credRepo)
 }
 
 var loggerProviderSet = wire.NewSet(

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -105,7 +105,7 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	evaluatorManagerService := services.NewEvaluatorManagerService(logger, customEvaluatorRepository, monitorRepository)
 	scoreRepository := ProvideScoreRepository(db)
 	llmProxyProvisioner := services.NewLLMProxyProvisioner(logger, llmProviderRepository, gatewayRepository, llmProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, llmProviderAPIKeyService, secretManagementClient, v)
-	publisherCredentialProvisioner, err := ProvidePublisherProvisioner(configConfig, logger, secretManagementClient, openChoreoClient, orgPublisherCredentialRepository)
+	publisherCredentialProvisioner, err := ProvidePublisherProvisioner(configConfig, v, logger, secretManagementClient, openChoreoClient, orgPublisherCredentialRepository)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	agentConfigurationController := controllers.NewAgentConfigurationController(agentConfigurationService)
 	gitSecretService := services.NewGitSecretService(openChoreoClient)
 	gitSecretController := controllers.NewGitSecretController(gitSecretService)
-	monitorSchedulerService := services.NewMonitorSchedulerService(openChoreoClient, logger, monitorExecutor, monitorRepository)
+	monitorSchedulerService := services.NewMonitorSchedulerService(openChoreoClient, publisherCredentialProvisioner, logger, monitorExecutor, monitorRepository)
 	appParams := &AppParams{
 		AuthMiddleware:                   middleware,
 		Logger:                           logger,
@@ -225,7 +225,7 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	evaluatorManagerService := services.NewEvaluatorManagerService(logger, customEvaluatorRepository, monitorRepository)
 	scoreRepository := ProvideScoreRepository(db)
 	llmProxyProvisioner := services.NewLLMProxyProvisioner(logger, llmProviderRepository, gatewayRepository, llmProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, llmProviderAPIKeyService, secretManagementClient, v)
-	publisherCredentialProvisioner, err := ProvidePublisherProvisioner(configConfig, logger, secretManagementClient, openChoreoClient, orgPublisherCredentialRepository)
+	publisherCredentialProvisioner, err := ProvidePublisherProvisioner(configConfig, v, logger, secretManagementClient, openChoreoClient, orgPublisherCredentialRepository)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	agentConfigurationController := controllers.NewAgentConfigurationController(agentConfigurationService)
 	gitSecretService := services.NewGitSecretService(openChoreoClient)
 	gitSecretController := controllers.NewGitSecretController(gitSecretService)
-	monitorSchedulerService := services.NewMonitorSchedulerService(openChoreoClient, logger, monitorExecutor, monitorRepository)
+	monitorSchedulerService := services.NewMonitorSchedulerService(openChoreoClient, publisherCredentialProvisioner, logger, monitorExecutor, monitorRepository)
 	appParams := &AppParams{
 		AuthMiddleware:                   authMiddleware,
 		Logger:                           logger,
@@ -357,8 +357,8 @@ func ProvideGitCredentialsService(ocClient client.OpenChoreoClient, cfg config.C
 
 // ProvidePublisherProvisioner creates the publisher credential provisioner
 // for per-org Thunder OAuth app creation and secret storage via SecretManagementClient
-func ProvidePublisherProvisioner(cfg config.Config, logger *slog.Logger, secretClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, credRepo repositories.OrgPublisherCredentialRepository) (services.PublisherCredentialProvisioner, error) {
-	return services.NewPublisherCredentialProvisioner(cfg, logger, secretClient, ocClient, credRepo)
+func ProvidePublisherProvisioner(cfg config.Config, encryptionKey []byte, logger *slog.Logger, secretClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, credRepo repositories.OrgPublisherCredentialRepository) (services.PublisherCredentialProvisioner, error) {
+	return services.NewPublisherCredentialProvisioner(cfg, encryptionKey, logger, secretClient, ocClient, credRepo)
 }
 
 var loggerProviderSet = wire.NewSet(

--- a/console/workspaces/libs/types/src/api/monitors.ts
+++ b/console/workspaces/libs/types/src/api/monitors.ts
@@ -113,6 +113,8 @@ export interface UpdateMonitorRequest {
   evaluators?: MonitorEvaluator[];
   llmProvider?: MonitorLLMProviderRef | null;
   intervalMinutes?: number;
+  traceStart?: string;
+  traceEnd?: string;
   samplingRate?: number;
 }
 

--- a/console/workspaces/pages/eval/src/EditMonitor.Component.tsx
+++ b/console/workspaces/pages/eval/src/EditMonitor.Component.tsx
@@ -129,6 +129,8 @@ export const EditMonitorComponent: React.FC = () => {
           ? { llmProvider: values.llmProvider ?? null }
           : {}),
         intervalMinutes: values.intervalMinutes ?? undefined,
+        traceStart: values.traceStart?.toISOString(),
+        traceEnd: values.traceEnd?.toISOString(),
         samplingRate:
           values.samplingRate !== undefined
             ? values.samplingRate / 100

--- a/console/workspaces/pages/eval/src/form/schema.ts
+++ b/console/workspaces/pages/eval/src/form/schema.ts
@@ -102,7 +102,7 @@ export const createMonitorSchema = z
     const now = new Date();
     if (!value.traceStart) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ["traceStart"],
         message: "Start time is required for past traces",
       });
@@ -110,7 +110,7 @@ export const createMonitorSchema = z
 
     if (!value.traceEnd) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ["traceEnd"],
         message: "End time is required for past traces",
       });
@@ -118,9 +118,20 @@ export const createMonitorSchema = z
 
     if (value.traceEnd && value.traceEnd > now) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ["traceEnd"],
         message: "End time cannot be in the future",
+      });
+    }
+
+    if (
+      value.traceStart &&
+      now.getTime() - value.traceStart.getTime() > 30 * 24 * 60 * 60 * 1000
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["traceStart"],
+        message: "Start time cannot be more than 30 days ago",
       });
     }
 
@@ -130,12 +141,12 @@ export const createMonitorSchema = z
       value.traceStart >= value.traceEnd
     ) {
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ["traceStart"],
         message: "Start time must be earlier than the end time",
       });
       ctx.addIssue({
-        code: z.ZodIssueCode.custom,
+        code: "custom",
         path: ["traceEnd"],
         message: "End time must be after the start time",
       });

--- a/console/workspaces/pages/eval/src/subComponents/CreateMonitorForm.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/CreateMonitorForm.tsx
@@ -152,12 +152,16 @@ export function CreateMonitorForm({
                 <DatePickers.DateTimePicker
                   value={formData.traceStart ?? null}
                   onChange={(value) => onFieldChange("traceStart", value)}
+                  minDateTime={new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)}
+                  maxDateTime={formData.traceEnd ?? new Date()}
+                  closeOnSelect={true}
                   slotProps={{
                     textField: {
                       fullWidth: true,
                       error: !!errors.traceStart,
                       helperText: errors.traceStart,
                     },
+                    actionBar: { actions: [] },
                   }}
                 />
               </DatePickers.LocalizationProvider>
@@ -167,12 +171,16 @@ export function CreateMonitorForm({
                 <DatePickers.DateTimePicker
                   value={formData.traceEnd ?? null}
                   onChange={(value) => onFieldChange("traceEnd", value)}
+                  minDateTime={formData.traceStart ?? undefined}
+                  maxDateTime={new Date()}
+                  closeOnSelect={true}
                   slotProps={{
                     textField: {
                       fullWidth: true,
                       error: !!errors.traceEnd,
                       helperText: errors.traceEnd,
                     },
+                    actionBar: { actions: [] },
                   }}
                 />
               </DatePickers.LocalizationProvider>

--- a/console/workspaces/pages/eval/src/subComponents/MonitorFormWizard.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/MonitorFormWizard.tsx
@@ -118,15 +118,15 @@ export function MonitorFormWizard({
         );
         const nextEvaluators = exists
           ? prev.evaluators.filter(
-              (evaluator) => evaluator.identifier !== ev.identifier,
-            )
+            (evaluator) => evaluator.identifier !== ev.identifier,
+          )
           : [
-              ...prev.evaluators,
-              {
-                identifier: ev.identifier,
-                displayName: ev.displayName,
-              },
-            ];
+            ...prev.evaluators,
+            {
+              identifier: ev.identifier,
+              displayName: ev.displayName,
+            },
+          ];
 
         const next = {
           ...prev,
@@ -148,18 +148,18 @@ export function MonitorFormWizard({
         );
         const nextEvaluators = exists
           ? prev.evaluators.map((evaluator) =>
-              evaluator.identifier === ev.identifier
-                ? { ...evaluator, config }
-                : evaluator,
-            )
+            evaluator.identifier === ev.identifier
+              ? { ...evaluator, config }
+              : evaluator,
+          )
           : [
-              ...prev.evaluators,
-              {
-                identifier: ev.identifier,
-                displayName: ev.displayName,
-                config,
-              },
-            ];
+            ...prev.evaluators,
+            {
+              identifier: ev.identifier,
+              displayName: ev.displayName,
+              config,
+            },
+          ];
         const next = {
           ...prev,
           evaluators: nextEvaluators,
@@ -211,12 +211,17 @@ export function MonitorFormWizard({
     onSubmit(formData);
   }, [formData, hasLLMJudge, missingParamsMessage, onSubmit, guardSubmit]);
 
+  // In edit mode (isTypeEditable=false) traceStart/traceEnd errors don't block
+  // navigation — the user may need to reach page 2 to change evaluators even when
+  // the trace window itself has a validation error. guardSubmit catches them at submit.
   const page1Fields: (keyof CreateMonitorFormValues)[] = [
     "displayName",
     "name",
-    "traceStart",
-    "traceEnd",
-    "intervalMinutes",
+    ...(formData.type === "past" && isTypeEditable
+      ? (["traceStart", "traceEnd"] as const)
+      : formData.type === "future"
+        ? (["intervalMinutes"] as const)
+        : []),
   ];
   const page1HasErrors = page1Fields.some((f) => Boolean(errors[f]));
   const canAdvance =

--- a/console/workspaces/pages/eval/src/subComponents/MonitorFormWizard.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/MonitorFormWizard.tsx
@@ -211,8 +211,18 @@ export function MonitorFormWizard({
     onSubmit(formData);
   }, [formData, hasLLMJudge, missingParamsMessage, onSubmit, guardSubmit]);
 
+  const page1Fields: (keyof CreateMonitorFormValues)[] = [
+    "displayName",
+    "name",
+    "traceStart",
+    "traceEnd",
+    "intervalMinutes",
+  ];
+  const page1HasErrors = page1Fields.some((f) => Boolean(errors[f]));
   const canAdvance =
-    formData.displayName.trim().length >= 3 && formData.name.trim().length >= 3;
+    formData.displayName.trim().length >= 3 &&
+    formData.name.trim().length >= 3 &&
+    !page1HasErrors;
   const scheduleReady =
     formData.type === "future" ||
     (!!formData.traceStart && !!formData.traceEnd);

--- a/console/workspaces/pages/eval/src/subComponents/SelectPresetMonitors.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/SelectPresetMonitors.tsx
@@ -300,7 +300,7 @@ export function SelectPresetMonitors({
       return undefined;
     }
     return selectedEvaluators.find(
-      (item) => item.identifier === drawerIdentifier,
+      (item) => getEvaluatorIdentifier(item) === drawerIdentifier,
     )?.config;
   }, [drawerIdentifier, selectedEvaluators]);
 
@@ -578,7 +578,7 @@ export function SelectPresetMonitors({
             {evaluators.map((monitor) => {
               const identifier = getEvaluatorIdentifier(monitor);
               const isSelected = selectedEvaluators.some(
-                (item) => item.identifier === identifier,
+                (item) => getEvaluatorIdentifier(item) === identifier,
               );
               return (
                 <Form.CardButton

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/authz-cluster-role.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/authz-cluster-role.yaml
@@ -1,0 +1,20 @@
+---
+# ClusterAuthzRole for AMP Monitor Scheduler
+# Grants only the actions required to create and monitor WorkflowRuns in OpenChoreo.
+# workflowrun:create → CreateWorkflowRun (org-bound tokens require this explicit action)
+# workflowrun:view   → GetWorkflowRun
+# Note: ExpireWorkflowRun (workflowrun:update) is called by the system client on monitor
+# deletion, not by the org-bound publisher app — so it is intentionally omitted here.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRole
+metadata:
+  name: amp-monitor-scheduler
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  description: "Allows the AMP monitor scheduler to submit and track evaluation WorkflowRuns"
+  actions:
+    - workflowrun:create
+    - workflowrun:view


### PR DESCRIPTION
## Summary

Closes #782

In Thunder (multi-tenant) mode, tokens are org-scoped — a single shared token cannot list or manage monitors across all orgs. This PR makes the monitor scheduler work correctly in that environment by provisioning a per-org OAuth app via Thunder and using org-bound tokens for all OpenChoreo API calls.

- **Per-org credential provisioning** — `PublisherCredentialProvisioner` provisions a Thunder OAuth app for each org on monitor creation, stores the encrypted client secret in the DB, and exposes `GetOCClientForOrg` so the scheduler can obtain org-scoped tokens at runtime without a live user JWT
- **DB migration** — adds `client_secret_encrypted` column to `org_publisher_credentials` (migration 014)
- **Scheduler multi-tenant support** — `orgOCClient()` returns the org-bound OC client in Thunder mode; falls back to the system client otherwise
- **ClusterAuthzRole Helm template** — defines `amp-monitor-scheduler` with `workflowrun:create` + `workflowrun:view`; each org's publisher app is bound to this role via `EnsureClusterRoleBinding`
- **Frontend** — replaces the credential form with an org-level LLM provider picker; updates the monitor API contract (`llmProvider` as a ref instead of an embedded config)

## Bug fixes included

- **Double-trigger prevention** — `UpdateNextRunTime` failure now returns an error so a DB hiccup doesn't leave `next_run_time` stale and cause the next scheduler cycle to fire a duplicate WorkflowRun
- **`tx.Commit()` error now logged** — the advisory lock transaction commit failure was silently swallowed
- **Nil guard in `syncSingleRunStatus`** — defensive check after `GetMonitorByID` to avoid a panic on a deleted monitor
- **Double-checked locking fixed** — `getOrCreateOrgAuthProvider` now uses `singleflight` to prevent redundant auth provider construction under concurrent load
- **Evaluator identifier matching** — `SelectPresetMonitors` now uses `getEvaluatorIdentifier()` on both sides of the config lookup so evaluators resolved via slug fallback still find their saved config

## Test plan

- [ ] Run `make dev-test` in `agent-manager-service/` — all tests pass
- [ ] Create a monitor in Thunder mode and verify the scheduler triggers it using an org-scoped token (not the system token)
- [ ] Stop the DB briefly during a scheduler cycle; confirm no duplicate WorkflowRun is created on recovery
- [ ] Delete a monitor and verify `ExpireWorkflowRun` still succeeds via the system client
- [ ] Verify the `ClusterAuthzRole` CR is created by the Helm chart and that `EnsureClusterRoleBinding` binds the publisher app correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Past monitor evaluations accept traceStart/traceEnd windows (API, UI, and SDK/types).
  * Scheduler supports per-organization provider credentials and org-scoped execution.

* **Improvements**
  * UI datepickers and validation updated (traceStart max 30 days ago; traceEnd must not be in the future).
  * Publisher credentials are now stored encrypted and migration added for the DB.
  * Provisioning enforces required cluster role binding for scheduler; new cluster role grants workflow run create/view.

* **Bug Fixes**
  * Scheduler reliability, error handling, and run-status sync robustness improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->