### PR TITLE
Fix LLM proxy name collision across agents/projects

### DIFF
--- a/agent-manager-service/clients/requests/send_request.go
+++ b/agent-manager-service/clients/requests/send_request.go
@@ -79,7 +79,7 @@ func (r *Result) ScanResponse(body any, successStatus int) error {
 	if r.response == nil {
 		return fmt.Errorf("unexpected nil response")
 	}
-	if body == nil || reflect.ValueOf(body).Kind() != reflect.Ptr {
+	if body == nil || reflect.ValueOf(body).Kind() != reflect.Pointer {
 		return fmt.Errorf("non-nil pointer expected for decoding response body")
 	}
 	if r.response.StatusCode != successStatus {

--- a/agent-manager-service/controllers/agent_configuration_controller.go
+++ b/agent-manager-service/controllers/agent_configuration_controller.go
@@ -115,6 +115,9 @@ func (c *agentConfigurationController) CreateAgentModelConfig(w http.ResponseWri
 		case errors.Is(err, utils.ErrForbidden):
 			utils.WriteErrorResponse(w, http.StatusForbidden, "Forbidden")
 			return
+		case errors.Is(err, utils.ErrLLMProxyExists):
+			utils.WriteErrorResponse(w, http.StatusConflict, "LLM proxy name collision: another agent in this org already uses the same model-config name")
+			return
 		default:
 			log.Error("CreateAgentModelConfig: failed to create configuration", "error", err)
 			utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to create agent model configuration")

--- a/agent-manager-service/controllers/agent_configuration_controller.go
+++ b/agent-manager-service/controllers/agent_configuration_controller.go
@@ -250,6 +250,9 @@ func (c *agentConfigurationController) UpdateAgentModelConfig(w http.ResponseWri
 		case errors.Is(err, utils.ErrInvalidInput):
 			utils.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
 			return
+		case errors.Is(err, utils.ErrLLMProxyExists):
+			utils.WriteErrorResponse(w, http.StatusConflict, "LLM proxy name collision: another agent in this org already uses the same model-config name")
+			return
 		default:
 			log.Error("UpdateAgentModelConfig: failed to update configuration", "error", err)
 			utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to update configuration")

--- a/agent-manager-service/controllers/gateway_controller.go
+++ b/agent-manager-service/controllers/gateway_controller.go
@@ -106,6 +106,8 @@ func handleGatewayErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 		utils.WriteErrorResponse(w, http.StatusNotFound, "Gateway not found")
 	case errors.Is(err, utils.ErrGatewayAlreadyExists):
 		utils.WriteErrorResponse(w, http.StatusConflict, "Gateway already exists")
+	case errors.Is(err, utils.ErrGatewayHasDeployments):
+		utils.WriteErrorResponse(w, http.StatusConflict, err.Error())
 	case errors.Is(err, utils.ErrEnvironmentNotFound):
 		utils.WriteErrorResponse(w, http.StatusNotFound, "Environment not found")
 	case errors.Is(err, utils.ErrInvalidInput):
@@ -342,13 +344,6 @@ func (c *gatewayController) DeleteGateway(w http.ResponseWriter, r *http.Request
 	orgName := r.PathValue(utils.PathParamOrgName)
 	gatewayID := strings.TrimSpace(r.PathValue("gatewayID"))
 
-	// Delete environment mappings first
-	if err := c.gatewayService.DeleteGatewayEnvironmentMappings(gatewayID); err != nil {
-		log.Warn("DeleteGateway: failed to delete gateway-environment mappings", "error", err)
-		// Continue with gateway deletion even if mapping deletion fails
-	}
-
-	// Delete using local service
 	if err := c.gatewayService.DeleteGateway(gatewayID, orgName); err != nil {
 		log.Error("DeleteGateway: failed to delete gateway", "error", err)
 		handleGatewayErrors(w, err, "Failed to delete gateway")

--- a/agent-manager-service/controllers/llm_controller.go
+++ b/agent-manager-service/controllers/llm_controller.go
@@ -678,6 +678,10 @@ func (c *llmController) DeleteLLMProvider(w http.ResponseWriter, r *http.Request
 			log.Error("DeleteLLMProvider: invalid provider id", "orgName", orgName, "providerID", providerID, "error", err)
 			utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid provider id")
 			return
+		case errors.Is(err, utils.ErrLLMProviderHasProxies):
+			log.Warn("DeleteLLMProvider: provider has associated proxies", "orgName", orgName, "providerID", providerID)
+			utils.WriteErrorResponse(w, http.StatusConflict, utils.ErrLLMProviderHasProxies.Error())
+			return
 		default:
 			log.Error("DeleteLLMProvider: failed to delete provider", "orgName", orgName, "providerID", providerID, "error", err)
 			utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to delete LLM provider")

--- a/agent-manager-service/controllers/websocket_controller.go
+++ b/agent-manager-service/controllers/websocket_controller.go
@@ -173,7 +173,7 @@ func (c *websocketController) Connect(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if err := conn.Close(); err != nil {
-			log.Error("Failed to close connection",
+			log.Debug("Connection close returned error",
 				"gatewayID", gatewayID, "gatewayName", gatewayName,
 				"orgName", orgName, "error", err)
 		}

--- a/agent-manager-service/repositories/catalog_repository.go
+++ b/agent-manager-service/repositories/catalog_repository.go
@@ -141,24 +141,21 @@ func (r *CatalogRepo) ListLLMProviders(filters *models.CatalogListFilters) ([]mo
 
 	// Apply environment filter if provided (join with deployment_status)
 	if filters.HasEnvironmentFilter() {
-		// Join with deployment_status and gateway_environment_mappings
 		baseQuery = baseQuery.
 			Joins("JOIN deployment_status ds ON llm_providers.uuid = ds.artifact_uuid AND ds.organization_name = a.organization_name").
+			Joins("JOIN gateways g ON ds.gateway_uuid = g.uuid AND g.deleted_at IS NULL").
 			Joins("JOIN gateway_environment_mappings gem ON ds.gateway_uuid = gem.gateway_uuid").
 			Where("gem.environment_uuid = ? AND ds.status = ?",
-					filters.EnvironmentUUID, models.DeploymentStatusDeployed).
-			Distinct() // Ensure unique providers (one provider can have multiple deployments)
+				filters.EnvironmentUUID, models.DeploymentStatusDeployed).
+			Distinct()
 	}
 
-	// Apply name filter if provided (partial match, case-insensitive)
 	if filters.HasNameFilter() {
-		// Escape LIKE wildcards to prevent SQL injection
 		escapedName := escapeLikeWildcards(filters.Name)
 		baseQuery = baseQuery.Where("LOWER(a.name) LIKE LOWER(?) ESCAPE '\\'", "%"+escapedName+"%")
 	}
 
-	// Count total matching records
-	countQuery := baseQuery.Session(&gorm.Session{}) // Clone to avoid mutation
+	countQuery := baseQuery.Session(&gorm.Session{})
 	if err := countQuery.Count(&total).Error; err != nil {
 		return nil, 0, fmt.Errorf("failed to count catalog entries: %w", err)
 	}
@@ -177,14 +174,14 @@ func (r *CatalogRepo) ListLLMProviders(filters *models.CatalogListFilters) ([]mo
 		Where("a.organization_name = ? AND a.kind = ? AND a.in_catalog = ?",
 			filters.OrganizationName, models.KindLLMProvider, true)
 
-	// Apply same filters to data query
 	if filters.HasEnvironmentFilter() {
 		query = query.
 			Joins("JOIN deployment_status ds ON llm_providers.uuid = ds.artifact_uuid AND ds.organization_name = a.organization_name").
+			Joins("JOIN gateways g ON ds.gateway_uuid = g.uuid AND g.deleted_at IS NULL").
 			Joins("JOIN gateway_environment_mappings gem ON ds.gateway_uuid = gem.gateway_uuid").
 			Where("gem.environment_uuid = ? AND ds.status = ?",
-					filters.EnvironmentUUID, models.DeploymentStatusDeployed).
-			Distinct() // Ensure unique providers (one provider can have multiple deployments)
+				filters.EnvironmentUUID, models.DeploymentStatusDeployed).
+			Distinct()
 	}
 
 	if filters.HasNameFilter() {
@@ -355,7 +352,7 @@ func (r *CatalogRepo) populateDeploymentsInBatch(entries []models.CatalogLLMProv
 			ds.status as deployment_status,
 			ds.updated_at as deployment_updated_at
 		`).
-		Joins("JOIN gateways g ON ds.gateway_uuid = g.uuid").
+		Joins("JOIN gateways g ON ds.gateway_uuid = g.uuid AND g.deleted_at IS NULL").
 		Joins("LEFT JOIN gateway_environment_mappings gem ON ds.gateway_uuid = gem.gateway_uuid").
 		Where("ds.artifact_uuid IN ? AND ds.organization_name = ? AND ds.status = ?",
 			providerUUIDs, orgUUID, models.DeploymentStatusDeployed)

--- a/agent-manager-service/repositories/gateway_repository.go
+++ b/agent-manager-service/repositories/gateway_repository.go
@@ -191,24 +191,23 @@ func (r *GatewayRepo) buildFilterQuery(filters GatewayFilterOptions) *gorm.DB {
 	return query
 }
 
-// Delete removes a gateway with organization isolation and cleans up all associations
+// Delete hard-deletes a gateway with organization isolation.
+// Uses Unscoped() to bypass GORM soft delete so FK ON DELETE CASCADE
+// fires and cleans up child tables (tokens, deployments, mappings).
+// API associations have no FK to gateways and must be cleaned up explicitly.
 func (r *GatewayRepo) Delete(gatewayID, orgName string) error {
 	return r.db.Transaction(func(tx *gorm.DB) error {
-		// Delete API associations for this gateway
 		if err := tx.Where("resource_uuid = ? AND association_type = ? AND organization_name = ?",
 			gatewayID, "gateway", orgName).
 			Delete(&models.APIAssociation{}).Error; err != nil {
 			return err
 		}
 
-		// Delete gateway with organization isolation (gateway_tokens and deployments will be cascade deleted via FK)
-		result := tx.Where("uuid = ? AND organization_name = ?", gatewayID, orgName).
+		result := tx.Unscoped().Where("uuid = ? AND organization_name = ?", gatewayID, orgName).
 			Delete(&models.Gateway{})
 		if result.Error != nil {
 			return result.Error
 		}
-
-		// Check if gateway was actually deleted
 		if result.RowsAffected == 0 {
 			return utils.ErrGatewayNotFound
 		}

--- a/agent-manager-service/repositories/gateway_repository.go
+++ b/agent-manager-service/repositories/gateway_repository.go
@@ -329,8 +329,8 @@ func (r *GatewayRepo) CountActiveTokens(gatewayId string) (int, error) {
 func (r *GatewayRepo) HasGatewayDeployments(gatewayID, orgName string) (bool, error) {
 	var count int64
 	err := r.db.Model(&models.DeploymentStatusRecord{}).
-		Where("gateway_uuid = ? AND organization_name = ? AND status = ?",
-			gatewayID, orgName, string(models.DeploymentStatusDeployed)).
+		Where("gateway_uuid = ? AND organization_name = ?",
+			gatewayID, orgName).
 		Count(&count).Error
 	if err != nil {
 		return false, err

--- a/agent-manager-service/repositories/llm_provider_repository.go
+++ b/agent-manager-service/repositories/llm_provider_repository.go
@@ -23,9 +23,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // LLMProviderRepository defines the interface for LLM provider persistence
@@ -251,9 +253,13 @@ func (r *LLMProviderRepo) Delete(providerID, orgUUID string) error {
 
 		slog.Info("LLMProviderRepo.Delete: provider verified", "providerID", providerID, "uuid", providerUUID)
 
-		// Delete from llm_providers first
 		slog.Info("LLMProviderRepo.Delete: deleting from llm_providers table", "providerID", providerID, "uuid", providerUUID)
 		if err := tx.Where("uuid = ?", providerUUID).Delete(&models.LLMProvider{}).Error; err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+				slog.Warn("LLMProviderRepo.Delete: provider has associated proxies", "providerID", providerID, "uuid", providerUUID, "constraint", pgErr.ConstraintName)
+				return utils.ErrLLMProviderHasProxies
+			}
 			slog.Error("LLMProviderRepo.Delete: failed to delete provider", "providerID", providerID, "uuid", providerUUID, "error", err)
 			return err
 		}

--- a/agent-manager-service/services/agent_configuration_naming_test.go
+++ b/agent-manager-service/services/agent_configuration_naming_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScopedProxyIdentifier(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+		agentName   string
+		configName  string
+		envName     string
+	}{
+		{
+			name:        "short names",
+			projectName: "default",
+			agentName:   "agent-1",
+			configName:  "openai",
+			envName:     "default",
+		},
+		{
+			name:        "long config name truncated to 10 chars",
+			projectName: "default-project",
+			agentName:   "my-lonnnnnnnnnngname-ugly-anaaaaaame-agent",
+			configName:  "my-looooooooonbgngekshn-fdhhjkddf",
+			envName:     "development",
+		},
+		{
+			name:        "config name exactly 10 chars",
+			projectName: "proj",
+			agentName:   "agent",
+			configName:  "1234567890",
+			envName:     "dev",
+		},
+		{
+			name:        "config name with special characters",
+			projectName: "proj",
+			agentName:   "agent",
+			configName:  "My_Config Name!",
+			envName:     "staging",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := scopedProxyIdentifier(tt.projectName, tt.agentName, tt.configName, tt.envName)
+
+			// Must contain a hyphen separating prefix from hash.
+			if !strings.Contains(id, "-") {
+				t.Errorf("expected identifier to contain hyphen, got %q", id)
+			}
+
+			// Hash suffix is 8 hex chars, prefix is at most 10, separator is 1 → max 19 chars.
+			if len(id) > proxyNamePrefixMaxLen+1+8 {
+				t.Errorf("identifier too long: %q (len=%d, max=%d)", id, len(id), proxyNamePrefixMaxLen+1+8)
+			}
+
+			// Must be a valid K8s name segment (lowercase, alphanumeric + hyphens, no leading/trailing hyphen).
+			if id != strings.ToLower(id) {
+				t.Errorf("identifier not lowercase: %q", id)
+			}
+			if strings.HasPrefix(id, "-") || strings.HasSuffix(id, "-") {
+				t.Errorf("identifier has leading/trailing hyphen: %q", id)
+			}
+			if strings.Contains(id, "--") {
+				t.Errorf("identifier has consecutive hyphens: %q", id)
+			}
+		})
+	}
+}
+
+func TestScopedProxyIdentifierUniqueness(t *testing.T) {
+	// Same config name in different agents must produce different identifiers.
+	id1 := scopedProxyIdentifier("projectA", "agent-1", "openai", "default")
+	id2 := scopedProxyIdentifier("projectA", "agent-2", "openai", "default")
+	if id1 == id2 {
+		t.Errorf("expected different identifiers for different agents, both got %q", id1)
+	}
+
+	// Same config name in different projects must produce different identifiers.
+	id3 := scopedProxyIdentifier("projectA", "agent-1", "openai", "default")
+	id4 := scopedProxyIdentifier("projectB", "agent-1", "openai", "default")
+	if id3 == id4 {
+		t.Errorf("expected different identifiers for different projects, both got %q", id3)
+	}
+}
+
+func TestScopedProxyIdentifierDeterministic(t *testing.T) {
+	id1 := scopedProxyIdentifier("proj", "agent", "openai", "dev")
+	id2 := scopedProxyIdentifier("proj", "agent", "openai", "dev")
+	if id1 != id2 {
+		t.Errorf("expected deterministic output, got %q and %q", id1, id2)
+	}
+}

--- a/agent-manager-service/services/agent_configuration_naming_test.go
+++ b/agent-manager-service/services/agent_configuration_naming_test.go
@@ -68,9 +68,9 @@ func TestScopedProxyIdentifier(t *testing.T) {
 				t.Errorf("expected identifier to contain hyphen, got %q", id)
 			}
 
-			// Hash suffix is 8 hex chars, prefix is at most 10, separator is 1 → max 19 chars.
-			if len(id) > proxyNamePrefixMaxLen+1+8 {
-				t.Errorf("identifier too long: %q (len=%d, max=%d)", id, len(id), proxyNamePrefixMaxLen+1+8)
+			// Hash suffix is 16 hex chars, prefix is at most 10, separator is 1 → max 27 chars.
+			if len(id) > proxyNamePrefixMaxLen+1+16 {
+				t.Errorf("identifier too long: %q (len=%d, max=%d)", id, len(id), proxyNamePrefixMaxLen+1+16)
 			}
 
 			// Must be a valid K8s name segment (lowercase, alphanumeric + hyphens, no leading/trailing hyphen).

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -18,7 +18,9 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -108,6 +110,24 @@ func sanitizeForK8sName(s string) string {
 		s = strings.TrimRight(s[:63], "-")
 	}
 	return s
+}
+
+const proxyNamePrefixMaxLen = 10
+
+// scopedProxyIdentifier builds a deterministic, collision-resistant identifier
+// from the config name and a hash of all scoping segments (project, agent, config, env).
+// Format: "<configPrefix>-<8-hex-chars>" where configPrefix is the first 10 chars
+// of the sanitized config name.
+func scopedProxyIdentifier(projectName, agentName, configName, envName string) string {
+	raw := fmt.Sprintf("%s/%s/%s/%s", projectName, agentName, configName, envName)
+	hash := sha256.Sum256([]byte(raw))
+	hashSuffix := hex.EncodeToString(hash[:4])
+
+	prefix := sanitizeForK8sName(configName)
+	if len(prefix) > proxyNamePrefixMaxLen {
+		prefix = strings.TrimRight(prefix[:proxyNamePrefixMaxLen], "-")
+	}
+	return fmt.Sprintf("%s-%s", prefix, hashSuffix)
 }
 
 // buildProxyURL constructs the proxy base URL from a gateway vhost and an optional context path.
@@ -366,8 +386,9 @@ func (s *agentConfigurationService) Create(ctx context.Context, orgName, project
 		// Update the rollback entry with the proxy handle now that it was created.
 		rollbackResources[rbIdx].proxyHandle = proxy.Handle
 
+		scopedID := scopedProxyIdentifier(config.ProjectName, config.AgentID, config.Name, env.Name)
 		deployment, err := s.llmProxyDeploymentService.DeployLLMProxy(proxy.Handle, &models.DeployAPIRequest{
-			Name:      fmt.Sprintf("%s-%s-deployment", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)),
+			Name:      fmt.Sprintf("%s-deployment", scopedID),
 			Base:      "current",
 			GatewayID: gateway.UUID.String(),
 		}, orgName)
@@ -378,14 +399,14 @@ func (s *agentConfigurationService) Create(ctx context.Context, orgName, project
 		rollbackResources[rbIdx].deploymentID = deployment.DeploymentID
 
 		proxyAPIKey, err := s.llmProxyAPIKeyService.CreateAPIKey(ctx, orgName, proxy.Handle, &models.CreateAPIKeyRequest{
-			Name: fmt.Sprintf("%s-%s-key", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)),
+			Name: fmt.Sprintf("%s-key", scopedID),
 		})
 		if err != nil {
 			s.rollbackProxies(ctx, rollbackResources, orgName)
 			s.compensatingDeleteConfig(ctx, config.UUID, orgName)
 			return nil, fmt.Errorf("failed to generate API key for environment %s: %w", envName, err)
 		}
-		s.logger.Info("Created proxy API key", "proxyHandle", proxy.Handle, "proxyKeyName", proxyAPIKey.KeyID, "name", fmt.Sprintf("%s-%s-key", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)))
+		s.logger.Info("Created proxy API key", "proxyHandle", proxy.Handle, "proxyKeyName", proxyAPIKey.KeyID, "name", fmt.Sprintf("%s-key", scopedID))
 		rollbackResources[rbIdx].proxyAPIKeyID = proxyAPIKey.KeyID
 
 		// Store proxy API key in OpenBao KV and create SecretReference
@@ -650,8 +671,9 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	}
 	rbRes.proxyHandle = proxy.Handle
 
+	scopedID := scopedProxyIdentifier(config.ProjectName, config.AgentID, config.Name, env.Name)
 	deployment, err := s.llmProxyDeploymentService.DeployLLMProxy(proxy.Handle, &models.DeployAPIRequest{
-		Name:      fmt.Sprintf("%s-%s-deployment", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)),
+		Name:      fmt.Sprintf("%s-deployment", scopedID),
 		Base:      "current",
 		GatewayID: gateway.UUID.String(),
 	}, orgName)
@@ -661,7 +683,7 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	rbRes.deploymentID = deployment.DeploymentID
 
 	proxyAPIKey, err := s.llmProxyAPIKeyService.CreateAPIKey(ctx, orgName, proxy.Handle, &models.CreateAPIKeyRequest{
-		Name: fmt.Sprintf("%s-%s-key", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)),
+		Name: fmt.Sprintf("%s-key", scopedID),
 	})
 	if err != nil {
 		return "", rbRes, fmt.Errorf("failed to generate API key for environment %s: %w", envName, err)
@@ -806,8 +828,9 @@ func (s *agentConfigurationService) processEnvProxyUpdate(
 	}
 
 	deployBase := "current"
+	scopedID := scopedProxyIdentifier(config.ProjectName, config.AgentID, config.Name, env.Name)
 	newDeployment, err := s.llmProxyDeploymentService.DeployLLMProxy(updatedProxy.Handle, &models.DeployAPIRequest{
-		Name:      fmt.Sprintf("%s-%s-deployment", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)),
+		Name:      fmt.Sprintf("%s-deployment", scopedID),
 		Base:      deployBase,
 		GatewayID: gateway.UUID.String(),
 	}, orgName)
@@ -884,8 +907,9 @@ func (s *agentConfigurationService) processNewEnv(
 	}
 	rbRes.proxyHandle = proxy.Handle
 
+	scopedID := scopedProxyIdentifier(config.ProjectName, config.AgentID, config.Name, env.Name)
 	deployment, err := s.llmProxyDeploymentService.DeployLLMProxy(proxy.Handle, &models.DeployAPIRequest{
-		Name:      fmt.Sprintf("%s-%s-deployment", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)),
+		Name:      fmt.Sprintf("%s-deployment", scopedID),
 		Base:      "current",
 		GatewayID: gateway.UUID.String(),
 	}, orgName)
@@ -895,7 +919,7 @@ func (s *agentConfigurationService) processNewEnv(
 	rbRes.deploymentID = deployment.DeploymentID
 
 	proxyAPIKey, err := s.llmProxyAPIKeyService.CreateAPIKey(ctx, orgName, proxy.Handle, &models.CreateAPIKeyRequest{
-		Name: fmt.Sprintf("%s-%s-key", sanitizeForK8sName(config.Name), sanitizeForK8sName(env.Name)),
+		Name: fmt.Sprintf("%s-key", scopedID),
 	})
 	if err != nil {
 		return rbRes, fmt.Errorf("failed to generate API key for environment %s: %w", envName, err)
@@ -1548,9 +1572,9 @@ func (s *agentConfigurationService) Delete(ctx context.Context, configUUID uuid.
 	// the proxy config when it processes the revocation event.
 	//
 	// Key names mirror the naming convention used during Create/buildLLMProxyConfig:
-	//   proxyHandle       = "{sanitizedConfigName}-{sanitizedEnvName}-proxy"  (= Configuration.Name)
-	//   proxy API key     = "{sanitizedConfigName}-{sanitizedEnvName}-key"
-	//   provider API key  = "{sanitizedConfigName}-{sanitizedEnvName}-proxy"  (= proxyHandle)
+	//   proxyHandle       = "{configPrefix}-{hash}-proxy"  (= Configuration.Name)
+	//   proxy API key     = "{configPrefix}-{hash}-key"
+	//   provider API key  = "{configPrefix}-{hash}-proxy"  (= proxyHandle)
 	for _, mapping := range mappings {
 		if mapping.LLMProxy == nil {
 			continue
@@ -1561,7 +1585,7 @@ func (s *agentConfigurationService) Delete(ctx context.Context, configUUID uuid.
 			continue
 		}
 
-		// Configuration.Name = proxyHandle = "{sanitizedConfigName}-{sanitizedEnvName}-proxy".
+		// Configuration.Name = proxyHandle = "{configPrefix}-{hash}-proxy".
 		// Use it directly as the proxy handle (Handle field is gorm:"-" and not populated by Preload).
 		proxyHandle := mapping.LLMProxy.Configuration.Name
 
@@ -1861,11 +1885,9 @@ func (s *agentConfigurationService) buildLLMProxyConfig(
 	envName string,
 	envMapping models.EnvModelConfigRequest,
 ) (*models.LLMProxy, string, string, *secretmanagersvc.SecretLocation, error) {
-	sanitizedConfigName := sanitizeForK8sName(config.Name)
-	sanitizedEnvName := sanitizeForK8sName(envName)
-	proxyName := fmt.Sprintf("%s-%s-proxy", sanitizedConfigName, sanitizedEnvName)
-	contextUuid := uuid.New()
-	contextPath := fmt.Sprintf("/%s", contextUuid)
+	scopedID := scopedProxyIdentifier(config.ProjectName, config.AgentID, config.Name, envName)
+	proxyName := fmt.Sprintf("%s-proxy", scopedID)
+	contextPath := fmt.Sprintf("/%s", scopedID)
 
 	project, err := s.ocClient.GetProject(ctx, config.OrganizationName, config.ProjectName)
 	if err != nil {

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -116,12 +116,12 @@ const proxyNamePrefixMaxLen = 10
 
 // scopedProxyIdentifier builds a deterministic, collision-resistant identifier
 // from the config name and a hash of all scoping segments (project, agent, config, env).
-// Format: "<configPrefix>-<8-hex-chars>" where configPrefix is the first 10 chars
+// Format: "<configPrefix>-<16-hex-chars>" where configPrefix is the first 10 chars
 // of the sanitized config name.
 func scopedProxyIdentifier(projectName, agentName, configName, envName string) string {
 	raw := fmt.Sprintf("%s/%s/%s/%s", projectName, agentName, configName, envName)
 	hash := sha256.Sum256([]byte(raw))
-	hashSuffix := hex.EncodeToString(hash[:4])
+	hashSuffix := hex.EncodeToString(hash[:8])
 
 	prefix := sanitizeForK8sName(configName)
 	if len(prefix) > proxyNamePrefixMaxLen {

--- a/agent-manager-service/services/platform_gateway_service.go
+++ b/agent-manager-service/services/platform_gateway_service.go
@@ -374,7 +374,7 @@ func (s *PlatformGatewayService) UpdateGateway(
 	return updatedGateway, nil
 }
 
-// DeleteGateway deletes a gateway and all associated tokens (CASCADE)
+// DeleteGateway deletes a gateway after verifying no active deployments exist
 func (s *PlatformGatewayService) DeleteGateway(gatewayID, orgName string) error {
 	// Validate UUID format
 	if _, err := uuid.Parse(gatewayID); err != nil {
@@ -393,7 +393,15 @@ func (s *PlatformGatewayService) DeleteGateway(gatewayID, orgName string) error 
 		return utils.ErrGatewayNotFound
 	}
 
-	// Delete gateway (FK CASCADE will automatically remove tokens and deployments)
+	// Reject deletion if the gateway has active deployments (LLM providers/proxies)
+	hasDeployments, err := s.gatewayRepo.HasGatewayDeployments(gatewayID, orgName)
+	if err != nil {
+		return fmt.Errorf("failed to check gateway deployments: %w", err)
+	}
+	if hasDeployments {
+		return utils.ErrGatewayHasDeployments
+	}
+
 	err = s.gatewayRepo.Delete(gatewayID, orgName)
 	if err != nil {
 		return err

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -135,6 +135,7 @@ var (
 	ErrLLMProviderTemplateExists   = errors.New("LLM provider template already exists")
 	ErrLLMProviderNotFound         = errors.New("LLM provider not found")
 	ErrLLMProviderExists           = errors.New("LLM provider already exists")
+	ErrLLMProviderHasProxies       = errors.New("cannot delete LLM provider: it has associated LLM proxies. Please delete all proxies before deleting the provider")
 	ErrLLMProxyNotFound            = errors.New("LLM proxy not found")
 	ErrLLMProxyExists              = errors.New("LLM proxy already exists")
 	ErrBaseDeploymentNotFound      = errors.New("base deployment not found")

--- a/agent-manager-service/websocket/connection.go
+++ b/agent-manager-service/websocket/connection.go
@@ -98,6 +98,18 @@ func (c *Connection) Close(code int, reason string) error {
 	return c.Transport.Close(code, reason)
 }
 
+// SendPing sends a ping frame through the underlying transport.
+func (c *Connection) SendPing() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.closed {
+		return ErrConnectionClosed
+	}
+
+	return c.Transport.SendPing()
+}
+
 // IsClosed returns true if the connection has been explicitly closed.
 // Thread-safe for concurrent access.
 func (c *Connection) IsClosed() bool {

--- a/agent-manager-service/websocket/manager.go
+++ b/agent-manager-service/websocket/manager.go
@@ -231,7 +231,7 @@ func (m *Manager) monitorHeartbeat(conn *Connection) {
 			}
 
 			// Send ping frame
-			if err := conn.Transport.SendPing(); err != nil {
+			if err := conn.SendPing(); err != nil {
 				log.Printf("[ERROR] Failed to send ping: gatewayID=%s connectionID=%s error=%v",
 					conn.GatewayID, conn.ConnectionID, err)
 				m.Unregister(conn.GatewayID, conn.ConnectionID)

--- a/agent-manager-service/websocket/manager.go
+++ b/agent-manager-service/websocket/manager.go
@@ -153,7 +153,7 @@ func (m *Manager) Unregister(gatewayID, connectionID string) {
 
 	// Close the connection gracefully
 	if err := removed.Close(1000, "normal closure"); err != nil {
-		log.Printf("[ERROR] Failed to close connection: gatewayID=%s connectionID=%s error=%v",
+		log.Printf("[DEBUG] Connection close returned error: gatewayID=%s connectionID=%s error=%v",
 			gatewayID, connectionID, err)
 	}
 
@@ -255,7 +255,7 @@ func (m *Manager) Shutdown() {
 		conns := value.([]*Connection)
 		for _, conn := range conns {
 			if err := conn.Close(1000, "server shutdown"); err != nil {
-				log.Printf("[ERROR] Failed to close connection during shutdown: gatewayID=%s connectionID=%s error=%v",
+				log.Printf("[DEBUG] Connection close returned error during shutdown: gatewayID=%s connectionID=%s error=%v",
 					gatewayID, conn.ConnectionID, err)
 			}
 		}

--- a/agent-manager-service/websocket/websocket_transport.go
+++ b/agent-manager-service/websocket/websocket_transport.go
@@ -44,11 +44,14 @@ func (t *WebSocketTransport) Send(message []byte) error {
 // Close terminates the WebSocket connection with a close frame
 func (t *WebSocketTransport) Close(code int, reason string) error {
 	closeMessage := websocket.FormatCloseMessage(code, reason)
-	err := t.conn.WriteMessage(websocket.CloseMessage, closeMessage)
-	if err != nil {
-		return err
+	if err := t.conn.WriteMessage(websocket.CloseMessage, closeMessage); err != nil {
+		// "close sent" means a close frame was already written — the connection
+		// is already shutting down, so we just need to close the underlying conn.
+		if !websocket.IsCloseError(err) && err.Error() != "websocket: close sent" {
+			_ = t.conn.Close()
+			return err
+		}
 	}
-	// Close the underlying connection
 	return t.conn.Close()
 }
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Fixes https://github.com/wso2/agent-manager/issues/784

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

 - **Scoped proxy naming**: Replace org-scoped `{configName}-{envName}-proxy` with `{configPrefix}-{hash}-proxy` using a SHA256 hash of
  `project/agent/config/env`, preventing collisions when different agents use the same model-config name
  - **Deterministic context path**: Replace random UUID context path with the same scoped identifier (`/{configPrefix}-{hash}`), making proxy routes debuggable
  and reproducible
  - **Proper error mapping**: Surface `ErrLLMProxyExists` as **409 Conflict** instead of **500 Internal Error** in the `CreateAgentModelConfig` controller

  ## What Changed

  | File | Change |
  |---|---|
  | `services/agent_configuration_service.go` | New `scopedProxyIdentifier()` function; updated proxy name, context path, deployment name, and API key name
  derivation across all 4 code paths (Create, provider change, proxy update, new env) |
  | `controllers/agent_configuration_controller.go` | Added `ErrLLMProxyExists` → 409 Conflict case |
  | `services/agent_configuration_naming_test.go` | Unit tests for identifier length, K8s validity, cross-agent/project uniqueness, and determinism |

  ## Naming Examples

  | Input | Proxy Name | Context Path |
  |---|---|---|
  | config=`openai`, env=`default` | `openai-7e2f1a09-proxy` | `/openai-7e2f1a09` |
  | config=`my-loooong-config-name`, env=`dev` | `my-loooooo-a3f8b2c1-proxy` | `/my-loooooo-a3f8b2c1` |

  Same config name `openai` in two different agents produces different hashes — no collision.





## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic, hash-based proxy and deployment naming for stable identifiers.
  * Added ping/send capability for websocket connections.

* **Bug Fixes**
  * Deletion requests now return HTTP 409 Conflict when blocked by existing deployments or proxy associations, with clearer messages.
  * Listings exclude deployments tied to soft-deleted gateways; gateway deletion is now explicit (hard-delete).

* **Tests**
  * Unit tests added for proxy identifier determinism, uniqueness, and naming rules.

* **Reliability / Logging**
  * Reduced noisy logs for connection-close operations and improved websocket close handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->