### PR TITLE
Fix quick-start container PATH so k3d/kubectl/helm are reachable

### DIFF
--- a/deployments/quick-start/.bashrc
+++ b/deployments/quick-start/.bashrc
@@ -1,5 +1,9 @@
 # OpenChoreo Quick-Start Shell Configuration
 
+# BusyBox `su -` resets PATH to /bin:/usr/bin and drops /usr/local/bin, where
+# kubectl, helm, and k3d are installed — prepend it so they're reachable.
+export PATH=/usr/local/bin:$PATH
+
 # Source environment variables passed from Docker (DEV_MODE, OPENCHOREO_VERSION, DEBUG)
 if [ -f "$HOME/.env_from_docker" ]; then
     source "$HOME/.env_from_docker"


### PR DESCRIPTION
## Summary
- Prepend `/usr/local/bin` to PATH in `deployments/quick-start/.bashrc` so `k3d`, `kubectl`, and `helm` (installed there by the Dockerfile) are reachable for the `wso2-amp` user.
- Without this, BusyBox `su -` in `entrypoint.sh` leaves PATH at `/bin:/usr/bin`, so `./install.sh` fails immediately at Step 1/13 with `k3d is not installed` even though the binary is present.

Fixes #795

## Test plan
- [ ] Build the quick-start image and run it; confirm `which k3d`, `which kubectl`, `which helm` all resolve to `/usr/local/bin/...`.
- [ ] Run `./install.sh` inside the container and confirm Step 1/13 (Verifying prerequisites) passes.
- [ ] Confirm the existing `k3d cluster list` call lower in `.bashrc` still works (no regression for repeat shells).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a shell environment issue that caused development and deployment tools to become inaccessible after privilege escalation or when switching user contexts. The shell startup configuration has been updated to ensure these essential utilities remain available in all shell sessions, preventing interruptions during administrative tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->