### PR TITLE
Fix secret refernce being removed when manually deploying

### DIFF
--- a/agent-manager-service/repositories/agent_env_config_variable_repository.go
+++ b/agent-manager-service/repositories/agent_env_config_variable_repository.go
@@ -49,6 +49,10 @@ type AgentEnvConfigVariableRepository interface {
 
 	// DeleteByConfigAndEnv deletes variables for config and environment (use within transaction)
 	DeleteByConfigAndEnv(ctx context.Context, tx *gorm.DB, configUUID, envUUID uuid.UUID) error
+
+	// ListSecretReferencesByAgentAndEnv returns distinct non-empty secret_reference values stored
+	// for all LLM config variables belonging to this agent in the given environment.
+	ListSecretReferencesByAgentAndEnv(ctx context.Context, agentID, orgName string, envUUID uuid.UUID) ([]string, error)
 }
 
 type agentEnvConfigVariableRepository struct {
@@ -131,4 +135,25 @@ func (r *agentEnvConfigVariableRepository) DeleteByConfigAndEnv(ctx context.Cont
 	return tx.WithContext(ctx).
 		Where("config_uuid = ? AND environment_uuid = ?", configUUID, envUUID).
 		Delete(&models.AgentEnvConfigVariable{}).Error
+}
+
+func (r *agentEnvConfigVariableRepository) ListSecretReferencesByAgentAndEnv(ctx context.Context, agentID, orgName string, envUUID uuid.UUID) ([]string, error) {
+	var rows []struct {
+		SecretReference string
+	}
+	err := r.db.WithContext(ctx).
+		Table("agent_env_config_variables_mapping AS v").
+		Select("DISTINCT v.secret_reference").
+		Joins("JOIN agent_configurations AS c ON c.uuid = v.config_uuid").
+		Where("c.agent_id = ? AND c.organization_name = ? AND v.environment_uuid = ? AND v.secret_reference != ''",
+			agentID, orgName, envUUID).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list LLM config secret references: %w", err)
+	}
+	refs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		refs = append(refs, row.SecretReference)
+	}
+	return refs, nil
 }

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -48,6 +48,10 @@ type AgentConfigurationService interface {
 	Update(ctx context.Context, configUUID uuid.UUID, orgName, projectName, agentName string,
 		req models.UpdateAgentModelConfigRequest) (*models.AgentModelConfigResponse, error)
 	Delete(ctx context.Context, configUUID uuid.UUID, orgName, projectName, agentName string) error
+	// ListAgentLLMConfigSecretReferences returns the set of SecretReference names persisted in the
+	// DB for all LLM configurations of this agent in the given environment. Used during deploy to
+	// identify which component env var secretRefs are system-managed (LLM config) vs user-provided.
+	ListAgentLLMConfigSecretReferences(ctx context.Context, agentID, orgName, environmentName string) (map[string]struct{}, error)
 }
 
 type EnvConfigTemplate struct {
@@ -2456,4 +2460,24 @@ func (s *agentConfigurationService) processRollBack(ctx context.Context, rollbac
 	s.rollbackProxies(ctx, rollbackResources, orgName)
 	s.compensatingDeleteConfig(ctx, configUUID, orgName)
 	s.logger.Error("Rolled back created proxies and API keys", "count", len(rollbackResources))
+}
+
+func (s *agentConfigurationService) ListAgentLLMConfigSecretReferences(ctx context.Context, agentID, orgName, environmentName string) (map[string]struct{}, error) {
+	env, err := s.ocClient.GetEnvironment(ctx, orgName, environmentName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get environment %q: %w", environmentName, err)
+	}
+	envUUID, err := uuid.Parse(env.UUID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid environment UUID %q: %w", env.UUID, err)
+	}
+	refs, err := s.envVariableRepo.ListSecretReferencesByAgentAndEnv(ctx, agentID, orgName, envUUID)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]struct{}, len(refs))
+	for _, ref := range refs {
+		result[ref] = struct{}{}
+	}
+	return result, nil
 }

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/google/uuid"
 	observabilitysvc "github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
@@ -1761,9 +1760,10 @@ func findLowestEnvironment(promotionPaths []models.PromotionPath) string {
 // getSystemManagedEnvVars fetches existing env vars from the Component CR / ReleaseBinding and
 // identifies system-managed secret env vars (e.g., LLM provider config API keys).
 //
-// System-managed env vars are identified by having a secretRef that differs from the agent's
-// default secretRef (<agent-name>-secrets). For example, LLM config env vars have a secretRef
-// like "test-agent-llm-config-default-test-agent-llm-config-default-pro".
+// System-managed env vars are identified by looking up the secretRef in the DB: if it is
+// recorded in agent_env_config_variables_mapping for this agent's LLM configurations, it is
+// system-managed. This is provider-agnostic — it works for both OpenBao and the Secret Manager
+// API without relying on secret reference name patterns.
 //
 // These must be handled separately from processEnvVars because processEnvVars would use the
 // env var name (e.g., "CUSTOM_API_KEY") as the SecretKeyRef.Key, but the actual key in the
@@ -1785,48 +1785,45 @@ func (s *agentManagerService) getSystemManagedEnvVars(
 		return nil, nil, nil
 	}
 
-	// User-managed secrets use the agent's default secretRef: <agent-name>-secrets
-	defaultSecretRefName := secretmanagersvc.SecretLocation{
-		OrgName:         orgName,
-		ProjectName:     projectName,
-		EnvironmentName: environmentName,
-		EntityName:      componentName,
-	}.SecretRefName()
+	// Fetch the set of SecretReference names that belong to LLM configurations for this agent
+	// and environment from the DB. These are the source of truth — provider-agnostic.
+	llmSecretRefs, err := s.agentConfigurationService.ListAgentLLMConfigSecretReferences(ctx, componentName, orgName, environmentName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch LLM config secret references: %w", err)
+	}
 
 	s.logger.Debug("Identifying system-managed env vars",
 		"agentName", componentName, "existingCount", len(existingConfigs),
-		"defaultSecretRef", defaultSecretRefName)
+		"llmSecretRefCount", len(llmSecretRefs))
 
 	var result []client.EnvVar
 	keySet := make(map[string]bool)
 
 	for _, existing := range existingConfigs {
-		// System-managed: sensitive env var with a secretRef that is NOT the agent's default.
-		// e.g., LLM config API key with secretRef "test-agent-llm-config-default-..."
-		// vs user-managed secrets with secretRef "test-agent-secrets"
-		if existing.IsSensitive && existing.SecretRef != "" && !strings.EqualFold(existing.SecretRef, defaultSecretRefName) {
-			// Use the original SecretKey from the existing config (e.g., "api-key"),
-			// NOT the env var name, to correctly reference the key within the K8s Secret.
-			secretKey := existing.SecretKey
-			if secretKey == "" {
-				secretKey = existing.Key
-				s.logger.Warn("System-managed secret env var missing SecretKey, falling back to env var name",
-					"key", existing.Key, "secretRef", existing.SecretRef)
-			}
-			result = append(result, client.EnvVar{
-				Key: existing.Key,
-				ValueFrom: &client.EnvVarValueFrom{
-					SecretKeyRef: &client.SecretKeyRef{
-						Name: existing.SecretRef,
-						Key:  secretKey,
-					},
-				},
-			})
-			keySet[existing.Key] = true
-			s.logger.Info("Identified system-managed secret env var",
-				"key", existing.Key, "secretRef", existing.SecretRef,
-				"secretKey", secretKey, "defaultSecretRef", defaultSecretRefName)
+		if !existing.IsSensitive || existing.SecretRef == "" {
+			continue
 		}
+		if _, isLLMRef := llmSecretRefs[existing.SecretRef]; !isLLMRef {
+			continue
+		}
+		secretKey := existing.SecretKey
+		if secretKey == "" {
+			secretKey = existing.Key
+			s.logger.Warn("System-managed secret env var missing SecretKey, falling back to env var name",
+				"key", existing.Key, "secretRef", existing.SecretRef)
+		}
+		result = append(result, client.EnvVar{
+			Key: existing.Key,
+			ValueFrom: &client.EnvVarValueFrom{
+				SecretKeyRef: &client.SecretKeyRef{
+					Name: existing.SecretRef,
+					Key:  secretKey,
+				},
+			},
+		})
+		keySet[existing.Key] = true
+		s.logger.Info("Identified system-managed secret env var",
+			"key", existing.Key, "secretRef", existing.SecretRef, "secretKey", secretKey)
 	}
 
 	return result, keySet, nil


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Fixes https://github.com/wso2/agent-manager/issues/806


 Fix

  Replace the name-pattern comparison with a DB lookup. The agent_env_config_variables_mapping table stores the
  secret_reference value at LLM config creation time — this is the authoritative, provider-agnostic record of which
  SecretReferences are LLM-owned.

  A new repository method ListSecretReferencesByAgentAndEnv queries this table (joined with agent_configurations) to
  return the set of LLM-owned secret reference names for a given agent and environment. getSystemManagedEnvVars uses
  this set as the sole discriminator: an env var is system-managed if and only if its secretRef appears in the DB set.

Files Changed

  - **repositories/agent_env_config_variable_repository.go** — Added ListSecretReferencesByAgentAndEnv: DB query returning
  distinct LLM config secret reference names for an agent+environment
  - **services/agent_configuration_service.go** — Added ListAgentLLMConfigSecretReferences to interface and implementation:
   resolves env name → UUID, delegates to repo
  - **services/agent_manager.go** — Rewrote getSystemManagedEnvVars to use DB lookup as sole discriminator; removed all
  name-pattern matching



## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.