### PR TITLE
Fix monitor llm proxy credential provisioning

### DIFF
--- a/agent-manager-service/db_migrations/015_add_secret_ref_to_monitor_llm_mapping.go
+++ b/agent-manager-service/db_migrations/015_add_secret_ref_to_monitor_llm_mapping.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dbmigrations
+
+import (
+	"gorm.io/gorm"
+)
+
+// Add secret_kv_path and secret_key columns to monitor_llm_mapping so the executor
+// can pass the correct remoteRef fields to the workflow, instead of recomputing
+// the raw OpenBao KV path which cannot be used to mount secrets into pods.
+var migration015 = migration{
+	ID: 15,
+	Migrate: func(db *gorm.DB) error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Exec(`
+				ALTER TABLE monitor_llm_mapping
+				ADD COLUMN IF NOT EXISTS secret_kv_path TEXT NOT NULL DEFAULT '',
+				ADD COLUMN IF NOT EXISTS secret_key    TEXT NOT NULL DEFAULT ''
+			`).Error; err != nil {
+				return err
+			}
+			return nil
+		})
+	},
+}

--- a/agent-manager-service/db_migrations/migration_list.go
+++ b/agent-manager-service/db_migrations/migration_list.go
@@ -16,7 +16,7 @@
 
 package dbmigrations
 
-const latestVersion = 14
+const latestVersion = 15
 
 // migration list sorted by version.  Add new migrations to the end of the list.
 // Previous migrations should not be modified.
@@ -35,4 +35,5 @@ var migrations = []migration{
 	migration012,
 	migration013,
 	migration014,
+	migration015,
 }

--- a/agent-manager-service/models/monitor_llm_mapping.go
+++ b/agent-manager-service/models/monitor_llm_mapping.go
@@ -29,7 +29,12 @@ type MonitorLLMMapping struct {
 	MonitorID           uuid.UUID   `gorm:"column:monitor_id;type:uuid;not null" json:"monitorId"`
 	LLMProxyUUID        uuid.UUID   `gorm:"column:llm_proxy_uuid;type:uuid;not null" json:"llmProxyUuid"`
 	PolicyConfiguration LLMPolicies `gorm:"column:policy_configuration;type:jsonb;default:[]" json:"policyConfiguration,omitempty"`
-	CreatedAt           time.Time   `gorm:"column:created_at;type:timestamp;default:CURRENT_TIMESTAMP" json:"createdAt"`
+	// SecretKVPath and SecretKey are the remoteRef.key / remoteRef.property values
+	// resolved from the OpenChoreo SecretReference after secret creation. These are
+	// what the workflow runtime needs to mount the LLM_API_KEY into the evaluation pod.
+	SecretKVPath string    `gorm:"column:secret_kv_path" json:"-"`
+	SecretKey    string    `gorm:"column:secret_key" json:"-"`
+	CreatedAt    time.Time `gorm:"column:created_at;type:timestamp;default:CURRENT_TIMESTAMP" json:"createdAt"`
 
 	// Relations (for preloading — used during cleanup to derive proxy handle)
 	LLMProxy *LLMProxy `gorm:"foreignKey:LLMProxyUUID" json:"llmProxy,omitempty"`

--- a/agent-manager-service/repositories/monitor_llm_mapping_repository.go
+++ b/agent-manager-service/repositories/monitor_llm_mapping_repository.go
@@ -30,6 +30,9 @@ type MonitorLLMMappingRepository interface {
 	// Create creates a new monitor LLM mapping (use within transaction)
 	Create(ctx context.Context, tx *gorm.DB, mapping *models.MonitorLLMMapping) error
 
+	// Update persists changes to an existing mapping row (use within transaction)
+	Update(ctx context.Context, tx *gorm.DB, mapping *models.MonitorLLMMapping) error
+
 	// ListByMonitorID retrieves all mappings for a monitor (with LLMProxy preloaded)
 	ListByMonitorID(ctx context.Context, monitorID uuid.UUID) ([]models.MonitorLLMMapping, error)
 
@@ -51,6 +54,10 @@ func NewMonitorLLMMappingRepository(db *gorm.DB) MonitorLLMMappingRepository {
 
 func (r *monitorLLMMappingRepository) Create(ctx context.Context, tx *gorm.DB, mapping *models.MonitorLLMMapping) error {
 	return tx.WithContext(ctx).Create(mapping).Error
+}
+
+func (r *monitorLLMMappingRepository) Update(ctx context.Context, tx *gorm.DB, mapping *models.MonitorLLMMapping) error {
+	return tx.WithContext(ctx).Save(mapping).Error
 }
 
 func (r *monitorLLMMappingRepository) ListByMonitorID(ctx context.Context, monitorID uuid.UUID) ([]models.MonitorLLMMapping, error) {

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -199,11 +199,12 @@ func (e *monitorExecutor) UpdateNextRunTime(ctx context.Context, monitorID uuid.
 	return nil
 }
 
-// resolveLLMProxyConfig returns the OpenBao KV path of the composite LLM proxy credentials
-// secret, the gateway proxy URL, and the LiteLLM provider template handle.
+// resolveLLMProxyConfig returns the secret KV path, gateway proxy URL, and LiteLLM
+// provider template handle for the monitor's LLM proxy mapping.
 // Returns empty strings if no proxy mapping exists.
-// The proxy URL is derived at runtime (not stored) by joining LLMProxy.Configuration.Context
-// with the gateway vhost — mirroring the env_agent_model_mapping pattern used by agents.
+// The KV path and secret key are read from the persisted mapping (set during provisioning
+// from the OpenChoreo SecretReference remoteRef fields) rather than recomputed from the
+// raw OpenBao path, which the workflow runtime cannot use to mount env vars into pods.
 func (e *monitorExecutor) resolveLLMProxyConfig(ctx context.Context, monitor *models.Monitor) (secretPath, proxyURL, templateHandle string, err error) {
 	mappings, err := e.monitorLLMMappingRepo.ListByMonitorID(ctx, monitor.ID)
 	if err != nil {
@@ -214,24 +215,23 @@ func (e *monitorExecutor) resolveLLMProxyConfig(ctx context.Context, monitor *mo
 		return "", "", "", nil
 	}
 
-	loc := monitorCompositeSecretLocation(monitor.OrgName, monitor.ID)
-	kvPath, err := loc.KVPath()
-	if err != nil {
-		return "", "", "", fmt.Errorf("failed to compute composite secret path: %w", err)
+	mapping := mappings[0]
+	if mapping.SecretKVPath == "" {
+		return "", "", "", fmt.Errorf("monitor LLM mapping for monitor %s has no secret KV path — was it provisioned correctly?", monitor.ID)
 	}
 
-	resolvedURL, err := e.resolveProxyURL(ctx, monitor.OrgName, monitor.EnvironmentID, mappings[0].LLMProxy)
+	resolvedURL, err := e.resolveProxyURL(ctx, monitor.OrgName, monitor.EnvironmentID, mapping.LLMProxy)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to resolve proxy URL: %w", err)
 	}
 
-	if mappings[0].LLMProxy != nil {
-		if provider, provErr := e.llmProviderRepo.GetByUUID(mappings[0].LLMProxy.ProviderUUID.String(), monitor.OrgName); provErr == nil {
+	if mapping.LLMProxy != nil {
+		if provider, provErr := e.llmProviderRepo.GetByUUID(mapping.LLMProxy.ProviderUUID.String(), monitor.OrgName); provErr == nil {
 			templateHandle = provider.TemplateHandle
 		}
 	}
 
-	return kvPath, resolvedURL, templateHandle, nil
+	return mapping.SecretKVPath, resolvedURL, templateHandle, nil
 }
 
 // resolveProxyURL derives the proxy base URL from the preloaded LLMProxy and the gateway

--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -253,8 +253,9 @@ func (s *monitorManagerService) CreateMonitor(ctx context.Context, orgName strin
 		// Write composite secret only after the DB row is committed so that a persist
 		// failure above does not corrupt the existing proxy's credentials.
 		compositeLoc := monitorCompositeSecretLocation(orgName, monitor.ID)
-		if _, err := s.llmProvisioner.SecretClient().CreateSecret(ctx, compositeLoc,
-			map[string]string{"LLM_API_KEY": proxyAPIKey}); err != nil {
+		secretRefName, err := s.llmProvisioner.SecretClient().CreateSecret(ctx, compositeLoc,
+			map[string]string{"LLM_API_KEY": proxyAPIKey})
+		if err != nil {
 			s.llmProvisioner.RollbackProxy(ctx, rollbackState, orgName)
 			if delErr := s.monitorLLMMappingRepo.DeleteByMonitorIDAndProxyUUID(ctx, s.db, monitor.ID, mapping.LLMProxyUUID); delErr != nil {
 				s.logger.Error("Failed to rollback monitor LLM mapping on secret write failure", "error", delErr)
@@ -263,6 +264,33 @@ func (s *monitorManagerService) CreateMonitor(ctx context.Context, orgName strin
 				s.logger.Error("Failed to rollback monitor on error", "error", delErr)
 			}
 			return nil, fmt.Errorf("failed to write composite LLM proxy secret: %w", err)
+		}
+
+		// Resolve the SecretReference to get the remoteRef key/property that the
+		// workflow runtime uses to mount LLM_API_KEY into the evaluation job pod.
+		resolvedKVPath, resolvedSecretKey, err := s.resolveMonitorSecretRef(ctx, orgName, secretRefName)
+		if err != nil {
+			s.llmProvisioner.RollbackProxy(ctx, rollbackState, orgName)
+			if delErr := s.monitorLLMMappingRepo.DeleteByMonitorIDAndProxyUUID(ctx, s.db, monitor.ID, mapping.LLMProxyUUID); delErr != nil {
+				s.logger.Error("Failed to rollback monitor LLM mapping on secret ref resolve failure", "error", delErr)
+			}
+			if delErr := s.monitorRepo.DeleteMonitor(monitor); delErr != nil {
+				s.logger.Error("Failed to rollback monitor on error", "error", delErr)
+			}
+			return nil, fmt.Errorf("failed to resolve LLM proxy SecretReference: %w", err)
+		}
+
+		mapping.SecretKVPath = resolvedKVPath
+		mapping.SecretKey = resolvedSecretKey
+		if err := s.monitorLLMMappingRepo.Update(ctx, s.db, mapping); err != nil {
+			s.llmProvisioner.RollbackProxy(ctx, rollbackState, orgName)
+			if delErr := s.monitorLLMMappingRepo.DeleteByMonitorIDAndProxyUUID(ctx, s.db, monitor.ID, mapping.LLMProxyUUID); delErr != nil {
+				s.logger.Error("Failed to rollback monitor LLM mapping on secret ref persist failure", "error", delErr)
+			}
+			if delErr := s.monitorRepo.DeleteMonitor(monitor); delErr != nil {
+				s.logger.Error("Failed to rollback monitor on error", "error", delErr)
+			}
+			return nil, fmt.Errorf("failed to persist LLM proxy secret reference: %w", err)
 		}
 	}
 
@@ -532,8 +560,9 @@ func (s *monitorManagerService) UpdateMonitor(ctx context.Context, orgName, proj
 
 			// Write composite secret only after the new DB row is committed.
 			compositeLoc := monitorCompositeSecretLocation(orgName, monitor.ID)
-			if _, err := s.llmProvisioner.SecretClient().CreateSecret(ctx, compositeLoc,
-				map[string]string{"LLM_API_KEY": proxyAPIKey}); err != nil {
+			secretRefName, err := s.llmProvisioner.SecretClient().CreateSecret(ctx, compositeLoc,
+				map[string]string{"LLM_API_KEY": proxyAPIKey})
+			if err != nil {
 				s.llmProvisioner.RollbackProxy(ctx, rollbackState, orgName)
 				// Remove the newly-committed mapping row so the monitor is not left pointing
 				// at a proxy with no valid secret.
@@ -550,6 +579,42 @@ func (s *monitorManagerService) UpdateMonitor(ctx context.Context, orgName, proj
 					}
 				}
 				return nil, fmt.Errorf("failed to write composite LLM proxy secret: %w", err)
+			}
+
+			// Resolve the SecretReference to get the remoteRef key/property.
+			resolvedKVPath, resolvedSecretKey, err := s.resolveMonitorSecretRef(ctx, orgName, secretRefName)
+			if err != nil {
+				s.llmProvisioner.RollbackProxy(ctx, rollbackState, orgName)
+				if delErr := s.monitorLLMMappingRepo.DeleteByMonitorIDAndProxyUUID(ctx, s.db, monitor.ID, mapping.LLMProxyUUID); delErr != nil {
+					s.logger.Error("Failed to rollback monitor LLM mapping on secret ref resolve failure", "error", delErr)
+				}
+				for _, old := range oldMappings {
+					if reErr := s.monitorLLMMappingRepo.Create(ctx, s.db, &models.MonitorLLMMapping{
+						MonitorID:    old.MonitorID,
+						LLMProxyUUID: old.LLMProxyUUID,
+					}); reErr != nil {
+						s.logger.Error("Failed to restore old LLM mapping after secret ref resolve failure", "error", reErr)
+					}
+				}
+				return nil, fmt.Errorf("failed to resolve LLM proxy SecretReference: %w", err)
+			}
+
+			mapping.SecretKVPath = resolvedKVPath
+			mapping.SecretKey = resolvedSecretKey
+			if err := s.monitorLLMMappingRepo.Update(ctx, s.db, mapping); err != nil {
+				s.llmProvisioner.RollbackProxy(ctx, rollbackState, orgName)
+				if delErr := s.monitorLLMMappingRepo.DeleteByMonitorIDAndProxyUUID(ctx, s.db, monitor.ID, mapping.LLMProxyUUID); delErr != nil {
+					s.logger.Error("Failed to rollback monitor LLM mapping on secret ref persist failure", "error", delErr)
+				}
+				for _, old := range oldMappings {
+					if reErr := s.monitorLLMMappingRepo.Create(ctx, s.db, &models.MonitorLLMMapping{
+						MonitorID:    old.MonitorID,
+						LLMProxyUUID: old.LLMProxyUUID,
+					}); reErr != nil {
+						s.logger.Error("Failed to restore old LLM mapping after secret ref persist failure", "error", reErr)
+					}
+				}
+				return nil, fmt.Errorf("failed to persist LLM proxy secret reference: %w", err)
 			}
 
 			// Clean up old proxy infrastructure now that the new mapping is committed.
@@ -1218,15 +1283,32 @@ func checkMinMax(prefix string, param models.EvaluatorConfigParam, num float64) 
 
 // ── LLM Proxy Lifecycle ───────────────────────────────────────────────────────
 
-// monitorCompositeSecretLocation returns the OpenBao SecretLocation for the per-monitor
-// composite LLM proxy credentials secret.  The path is deterministic from monitorID so
-// the executor can compute it without any extra DB lookup.
+// monitorCompositeSecretLocation returns the SecretLocation for the per-monitor
+// composite LLM proxy credentials secret.
 func monitorCompositeSecretLocation(orgName string, monitorID uuid.UUID) secretmanagersvc.SecretLocation {
 	return secretmanagersvc.SecretLocation{
 		OrgName:    orgName,
 		EntityName: "monitor-" + monitorID.String(),
 		SecretKey:  "llm-proxy-configs",
 	}
+}
+
+// resolveMonitorSecretRef resolves the remoteRef.key and remoteRef.property from the
+// OpenChoreo SecretReference created for the monitor's LLM API key. These values are
+// what the workflow runtime uses to mount LLM_API_KEY into the evaluation job pod.
+func (s *monitorManagerService) resolveMonitorSecretRef(ctx context.Context, orgName, secretRefName string) (kvPath, secretKey string, err error) {
+	ref, err := s.ocClient.GetSecretReference(ctx, orgName, secretRefName)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get SecretReference %s: %w", secretRefName, err)
+	}
+
+	for _, ds := range ref.Data {
+		if ds.SecretKey == "LLM_API_KEY" {
+			return ds.RemoteRef.Key, ds.RemoteRef.Property, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("SecretReference %s has no \"LLM_API_KEY\" data source (found %d sources)", secretRefName, len(ref.Data))
 }
 
 func (s *monitorManagerService) provisionLLMProxy(

--- a/agent-manager-service/tests/monitor_executor_test.go
+++ b/agent-manager-service/tests/monitor_executor_test.go
@@ -333,10 +333,15 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 	}))
 	proxy := &models.LLMProxy{UUID: proxyUUID}
 
-	// Seed the MonitorLLMMapping linking monitor to proxy.
+	// Seed the MonitorLLMMapping with the resolved SecretReference remoteRef fields,
+	// as they would be written by monitor_manager after CreateSecret + GetSecretReference.
+	expectedSecretPath := "secret/data/" + monitor.OrgName + "/monitor-" + monitor.ID.String()
+	expectedSecretKey := "LLM_API_KEY"
 	mapping := &models.MonitorLLMMapping{
 		MonitorID:    monitor.ID,
 		LLMProxyUUID: proxyUUID,
+		SecretKVPath: expectedSecretPath,
+		SecretKey:    expectedSecretKey,
 	}
 	require.NoError(t, gdb.Create(mapping).Error)
 
@@ -388,9 +393,8 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 
 	evalParams := capturedReq.Parameters["evaluation"].(map[string]interface{})
 
-	// Secret path is deterministic: <orgName>/monitor-<monitorID>/llm-proxy-configs
-	expectedSecretPath := monitor.OrgName + "/monitor-" + monitor.ID.String() + "/llm-proxy-configs"
-	assert.Equal(t, expectedSecretPath, evalParams["llmProxySecretPath"], "llmProxySecretPath should match composite secret location")
+	// Secret path comes from the persisted SecretReference remoteRef (not a computed KV path).
+	assert.Equal(t, expectedSecretPath, evalParams["llmProxySecretPath"], "llmProxySecretPath should be the SecretReference remoteRef key")
 
 	// Proxy URL is gateway vhost + context path.
 	expectedProxyURL := "https://gw.example.com" + contextPath

--- a/deployments/scripts/port-forward.sh
+++ b/deployments/scripts/port-forward.sh
@@ -64,8 +64,10 @@ echo "🌐 Forwarding Observability Gateway HTTPS (22894)..."
 kubectl port-forward -n openchoreo-data-plane svc/obs-gateway-gateway-gateway-runtime 22894:22894 &
 
 # Port forward OpenBao (system & user secrets)
+# amp-secrets-openbao is the instance used by the amp-openbao-store ClusterSecretStore,
+# which the workflow ExternalSecrets read from. Agent-manager must write here too.
 echo "🔐 Forwarding OpenBao (8200)..."
-kubectl port-forward -n openbao svc/openbao 8200:8200 &
+kubectl port-forward -n amp-secrets svc/amp-secrets-openbao 8200:8200 &
 
 echo "Forwarding OpenChoreo Api (8195)..."
 kubectl port-forward svc/openchoreo-api -n openchoreo-control-plane 8195:8080 &


### PR DESCRIPTION
## Purpose

  Evaluation job pods for monitors with LLM judge evaluators fail to start (`CreateContainerConfigError`), preventing
  any evaluation runs from completing. `LLM_API_KEY` and `IDP_CLIENT_SECRET` are never injected into the pod because
  the ExternalSecret operator cannot sync the secrets it needs.

  Fixes https://github.com/wso2/agent-manager/issues/811

  ## Goals

  - Ensure secrets written by the agent-manager during monitor provisioning are readable by the ExternalSecret operator
   that syncs them into workflow pods.
  - Ensure the `llmProxySecretPath` passed to the workflow is the `remoteRef.key` from the OpenChoreo `SecretReference`
   CR, not a raw OpenBao vault path, so the workflow runtime can mount `LLM_API_KEY` into the evaluation job pod.

  ## Approach

  Two bugs compound to produce this failure:

  **1. Wrong OpenBao instance targeted by the local dev port-forward**

  There are two OpenBao instances in the cluster:

  | Instance | Namespace | Backing ClusterSecretStore |
  |---|---|---|
  | `openbao-0` | `openbao` | `default` (OpenChoreo system) |
  | `amp-secrets-openbao-0` | `amp-secrets` | `amp-openbao-store` (AMP) |

  The workflow ExternalSecrets (`*-llm-proxy-credentials`, `*-amp-publisher-credentials`) use `amp-openbao-store`.
  `port-forward.sh` was forwarding `openbao/openbao` to `localhost:8200`, so the agent-manager was writing secrets into
   the wrong instance. Fixed by forwarding `amp-secrets/amp-secrets-openbao` instead.

  **2. Raw OpenBao KV path passed to workflow instead of SecretReference `remoteRef.key`**

  `monitor_executor.go` was computing `loc.KVPath()` (e.g. `default/monitor-<id>/llm-proxy-configs`) and passing it as
  `llmProxySecretPath` to the workflow. The workflow runtime uses this as a `secretKeyRef` to mount `LLM_API_KEY` — a
  raw vault path cannot be used for that. The correct value is `remoteRef.Key` from the OpenChoreo `SecretReference`
  CR, which is what the ExternalSecret operator resolves. This is exactly how `OrgPublisherCredential.SecretKVPath`
  works for the publisher credentials flow; the monitor LLM proxy path was not following the same pattern.

  Fixed by:
  - Capturing the `secretRefName` returned by `CreateSecret` (previously discarded with `_`) in both `CreateMonitor`
  and `UpdateMonitor`.
  - Resolving the `SecretReference` via `ocClient.GetSecretReference` to extract `remoteRef.Key` and
  `remoteRef.Property` for the `LLM_API_KEY` data source — mirroring
  `publisher_credential_provisioner.resolveSecretRef`.
  - Persisting the resolved values as `SecretKVPath` / `SecretKey` on the `MonitorLLMMapping` row (new columns,
  migration 015).
  - Reading `mapping.SecretKVPath` in the executor instead of recomputing the KV path.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enhanced LLM proxy secret management to use per-monitor secret references stored in the database, replacing the previous inline secret write approach.
  * Improved secret handling lifecycle with robust error recovery and rollback capabilities for monitor creation and updates.
  * Updated OpenBao integration to use dedicated secrets namespace.

* **Database Schema**
  * Added support for storing secret reference paths and keys in monitor-LLM mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->