### PR TITLE
Restart CoreDNS after applying custom rewrite rules

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -672,6 +672,18 @@ else
     exit 1
 fi
 
+# CoreDNS's reload plugin can miss the override files if the configmap is mounted
+# after the pod's initial parse. Restart CoreDNS so the rewrite rules take effect
+# before any client caches a wrong resolution.
+log_info "Restarting CoreDNS to load rewrite rules..."
+if kubectl rollout restart deployment/coredns -n kube-system && \
+   kubectl rollout status deployment/coredns -n kube-system --timeout=60s; then
+    log_success "CoreDNS restarted and ready"
+else
+    log_error "Failed to restart CoreDNS"
+    exit 1
+fi
+
 # ============================================================================
 # Step 4: Generate Machine IDs for observability
 # ============================================================================

--- a/deployments/scripts/setup-k3d.sh
+++ b/deployments/scripts/setup-k3d.sh
@@ -57,6 +57,18 @@ if ! kubectl get configmap coredns-custom -n kube-system --context "${CLUSTER_CO
     echo "❌ CoreDNS custom ConfigMap not found after apply"
     exit 1
 fi
+
+# CoreDNS's reload plugin can miss the override files if the configmap is mounted
+# after the pod's initial parse. Restart CoreDNS so the rewrite rules take effect
+# before any client (e.g. observer) caches a wrong resolution.
+if ! kubectl rollout restart deployment/coredns -n kube-system --context "${CLUSTER_CONTEXT}"; then
+    echo "❌ Failed to restart CoreDNS deployment"
+    exit 1
+fi
+if ! kubectl rollout status deployment/coredns -n kube-system --context "${CLUSTER_CONTEXT}" --timeout=60s; then
+    echo "❌ CoreDNS deployment failed to become ready"
+    exit 1
+fi
 echo "✅ CoreDNS configured to resolve *.openchoreo.localhost and *.amp.localhost"
 
 # Generate Machine IDs for observability


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

On fresh k3d setups (both `setup-k3d.sh` and the `quick-start/install.sh` flow), the CoreDNS rewrite rules for `*.openchoreo.localhost` and `*.amp.localhost` were intermittently not applying. CoreDNS's `reload` plugin can miss the override files when the `coredns-custom` ConfigMap is mounted after the pod has already parsed its initial configuration. When that happens, those hostnames fall through to the upstream forwarder and resolve to `127.0.0.1` per RFC 6761 instead of `host.k3d.internal`. Downstream clients (e.g. the OpenChoreo observer) then cache the wrong address and end up calling themselves, producing misleading authz `404` errors that look like an authorization bug.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Make the rewrite rules deterministically take effect on every install by explicitly restarting the CoreDNS deployment immediately after the `coredns-custom` ConfigMap is applied, before any other component starts resolving these hostnames.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

After the existing `kubectl apply` of `coredns-amp-custom.yaml` in both setup scripts, add a `kubectl rollout restart deployment/coredns -n kube-system` followed by a `kubectl rollout status` with a 60s timeout. The restart is guarded so the script fails fast with a clear error if CoreDNS does not come back ready.

## User stories
> Summary of user stories addressed by this change>

As a developer running the local setup, when I bring up the platform I want `*.openchoreo.localhost` and `*.amp.localhost` to resolve correctly on the first attempt so that observer/traces/logs/metrics pages work without manual intervention.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fix: local setup scripts now restart CoreDNS after applying the custom rewrite ConfigMap so that `*.openchoreo.localhost` and `*.amp.localhost` resolve reliably on first install.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — internal setup script change, no user-facing documentation impact.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type "Sent" when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type "N/A" and explain why.

N/A — no certification impact for a local-setup script fix.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests
   > Code coverage information

   N/A — shell scripts, no unit tests applicable.
 - Integration tests
   > Details about the test cases and coverage

   Verified manually: reproduced the broken state on a live k3d cluster (observer pod resolving `api.openchoreo.localhost` to `127.0.0.1`, repeated authz `404` errors), then ran `kubectl rollout restart deployment/coredns` and confirmed resolution returns `172.19.0.1 host.k3d.internal` and the observer's authz errors stop after its own pod restart.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable to shell scripts.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced installation and setup scripts to ensure CoreDNS custom configurations are properly applied and take effect immediately. The process now automatically restarts the CoreDNS deployment, verifies successful completion within the configured timeout, and includes explicit failure handling to catch any deployment issues during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->