### PR TITLE
Fix customer-support-agent sample docs to match actual code

### DIFF
--- a/samples/customer-support-agent/README.md
+++ b/samples/customer-support-agent/README.md
@@ -41,12 +41,13 @@ Fill in the agent creation form with these exact values:
 | --------------------- | ------------------------------------------------------- |
 | **Display Name**      | `Support Agent`                                         |
 | **Description**       | `AI-powered customer support agent for travel services` |
-| **GitHub Repository** | `https://github.com/wso2/ai-agent-management-platform`  |
+| **GitHub Repository** | `https://github.com/wso2/agent-manager`                 |
 | **Branch**            | `main`                                                  |
 | **App Path**          | `samples/customer-support-agent`                        |
 | **Language**          | `Python`                                                |
 | **Language Version**  | `3.11`                                                  |
 | **Start Command**     | `python main.py`                                        |
+| **Port**              | `8000`                                                  |
 
 ### Step 3: Select Agent Interface
 

--- a/samples/customer-support-agent/openapi.yaml
+++ b/samples/customer-support-agent/openapi.yaml
@@ -8,96 +8,54 @@ info:
   contact:
     name: API Support
 servers:
-  - url: http://localhost:8080
+  - url: http://localhost:8000
     description: Local development server
-  - url: http://127.0.0.1:8080
-    description: Local development server (alternative)
 paths:
   /chat:
     post:
       summary: Chat with the customer support agent
       description: |
-        Sends a question to the customer support agent and receives a response.
-        The agent uses the passenger_id to fetch relevant flight and booking information
-        and maintains conversation state using the thread_id.
+        Sends a message to the customer support agent and receives a response.
+        The agent maintains conversation state using the session_id.
       operationId: chat
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - thread_id
-                - passenger_id
-                - question
-              properties:
-                thread_id:
-                  type: integer
-                  description: |
-                    Unique identifier for the conversation thread.
-                    Used to maintain conversation state across multiple requests.
-                  example: 123
-                passenger_id:
-                  type: string
-                  description: |
-                    Passenger identifier used to fetch user's flight and booking information.
-                  example: "3442 587242"
-                question:
-                  type: string
-                  description: |
-                    The customer's question or query about their travel arrangements.
-                  example: "What is my flight status?"
+              $ref: "#/components/schemas/ChatRequest"
             examples:
               flightStatus:
                 summary: Check flight status
                 value:
-                  thread_id: 123
-                  passenger_id: "3442 587242"
-                  question: "What is my flight status?"
+                  session_id: "session_123"
+                  message: "What is my flight status?"
               bookingQuery:
                 summary: Check booking details
                 value:
-                  thread_id: 124
-                  passenger_id: "3442 587242"
-                  question: "Can you show me my hotel reservation?"
+                  session_id: "session_124"
+                  message: "Can you show me my hotel reservation?"
               generalInquiry:
                 summary: General travel inquiry
                 value:
-                  thread_id: 125
-                  passenger_id: "3442 587242"
-                  question: "What rental cars are available at my destination?"
+                  session_id: "session_125"
+                  message: "What rental cars are available at my destination?"
       responses:
         '200':
           description: Successful response from the agent
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  results:
-                    type: string
-                    description: The agent's response to the customer's question
-                    example: "Your flight UA1234 is scheduled to depart at 3:30 PM and is currently on time."
+                $ref: "#/components/schemas/ChatResponse"
               examples:
                 flightStatusResponse:
                   summary: Flight status response
                   value:
-                    results: "Your flight UA1234 is scheduled to depart at 3:30 PM and is currently on time."
+                    response: "Your flight UA1234 is scheduled to depart at 3:30 PM and is currently on time."
                 bookingResponse:
                   summary: Booking details response
                   value:
-                    results: "I found your hotel reservation at Grand Plaza Hotel for 3 nights starting December 20th."
-        '400':
-          description: Bad request - missing required fields
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  detail:
-                    type: string
-                    example: "Missing required field: thread_id"
+                    response: "I found your hotel reservation at Grand Plaza Hotel for 3 nights starting December 20th."
         '500':
           description: Internal server error
           content:
@@ -113,22 +71,20 @@ components:
     ChatRequest:
       type: object
       required:
-        - thread_id
-        - passenger_id
-        - question
+        - session_id
+        - message
       properties:
-        thread_id:
-          type: integer
-          description: Unique identifier for the conversation thread
-        passenger_id:
+        session_id:
           type: string
-          description: Passenger identifier for fetching travel information
-        question:
+          description: Unique identifier for the conversation session
+        message:
           type: string
-          description: Customer's question or query
+          description: Customer's message or query
     ChatResponse:
       type: object
+      required:
+        - response
       properties:
-        results:
+        response:
           type: string
-          description: Agent's response to the customer's question
+          description: Agent's response to the customer's message


### PR DESCRIPTION
## Summary
- Fix GitHub repo URL in README (`ai-agent-management-platform` → `agent-manager`)
- Add missing port (`8000`) to README deployment table
- Fix openapi.yaml to match actual `app.py` implementation: correct field names (`session_id`/`message`/`response` instead of `thread_id`/`question`/`results`), correct port (`8000` instead of `8080`), remove `passenger_id` from request schema

## Test plan
- [ ] Verify openapi.yaml fields match `app.py` POST `/chat` handler
- [ ] Confirm README repo URL resolves to the correct repository