### PR TITLE
Add link/unlink commands for directory-bound context

### DIFF
--- a/cli/pkg/clierr/clierr.go
+++ b/cli/pkg/clierr/clierr.go
@@ -45,6 +45,8 @@ const (
 	NoInstance           = "NO_INSTANCE"
 	NoOrg                = "NO_ORG"
 	NoProject            = "NO_PROJECT"
+	NotLinked            = "NOT_LINKED"
+	Internal             = "INTERNAL"
 	ConfirmationRequired = "CONFIRMATION_REQUIRED"
 	InvalidFlag          = "INVALID_FLAG"
 	Unauthorized         = "UNAUTHORIZED"

--- a/cli/pkg/clierr/clierr.go
+++ b/cli/pkg/clierr/clierr.go
@@ -45,6 +45,7 @@ const (
 	NoInstance           = "NO_INSTANCE"
 	NoOrg                = "NO_ORG"
 	NoProject            = "NO_PROJECT"
+	NoAgent              = "NO_AGENT"
 	NotLinked            = "NOT_LINKED"
 	Internal             = "INTERNAL"
 	ConfirmationRequired = "CONFIRMATION_REQUIRED"

--- a/cli/pkg/cmd/agent/build/create.go
+++ b/cli/pkg/cmd/agent/build/create.go
@@ -33,7 +33,8 @@ type CreateOptions struct {
 	IO           *iostreams.IOStreams
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope    func(org, proj string) render.Scope
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
 
 	Org       string
 	Proj      string
@@ -47,20 +48,26 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
-		MakeScope:    f.Scope,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
 	}
 	cmd := &cobra.Command{
-		Use:   "create <agent>",
+		Use:   "create [agent]",
 		Short: "Trigger a build for an agent",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org, proj, err := opts.ResolveScope(cmd, true, true)
-			scope := opts.MakeScope(org, proj)
 			if err != nil {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, err)
 			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
 			opts.Org, opts.Proj, opts.Scope = org, proj, scope
-			opts.AgentName = args[0]
+			opts.AgentName = agent
 			return runCreate(cmd.Context(), opts)
 		},
 	}

--- a/cli/pkg/cmd/agent/build/get.go
+++ b/cli/pkg/cmd/agent/build/get.go
@@ -34,7 +34,8 @@ type GetOptions struct {
 	IO           *iostreams.IOStreams
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope    func(org, proj string) render.Scope
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
 
 	Org       string
 	Proj      string
@@ -48,33 +49,48 @@ func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
-		MakeScope:    f.Scope,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
 	}
 
 	cmd := &cobra.Command{
-		Use:   "get <agent> <build-name>",
+		Use:   "get [agent] <build-name>",
 		Short: "Show details of a build",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org, proj, err := opts.ResolveScope(cmd, true, true)
-			scope := opts.MakeScope(org, proj)
 			if err != nil {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, err)
 			}
+			var agent string
+			var remaining []string
+			var agentErr error
+			if len(args) == 1 {
+				agent, _, agentErr = opts.ResolveAgent(nil)
+				if agentErr == nil {
+					remaining = args
+				} else {
+					agent, remaining, agentErr = opts.ResolveAgent(args)
+				}
+			} else {
+				agent, remaining, agentErr = opts.ResolveAgent(args)
+			}
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
+			if len(remaining) == 0 {
+				return render.Error(opts.IO, scope, clierr.New(clierr.InvalidFlag, "build name is required"))
+			}
 			opts.Org, opts.Proj, opts.Scope = org, proj, scope
-			opts.AgentName = args[0]
-			opts.BuildName = args[1]
+			opts.AgentName = agent
+			opts.BuildName = remaining[0]
 			return runGet(cmd.Context(), opts)
 		},
 	}
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		switch len(args) {
-		case 0:
-			return cmdutil.CompleteBuildableAgents(cmd, f), cobra.ShellCompDirectiveNoFileComp
-		case 1:
-			return cmdutil.CompleteBuilds(cmd, f, args[0]), cobra.ShellCompDirectiveNoFileComp
-		}
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return cmdutil.CompleteBuildWithAgentContext(cmd, f, args)
 	}
 	return cmd
 }

--- a/cli/pkg/cmd/agent/build/list.go
+++ b/cli/pkg/cmd/agent/build/list.go
@@ -33,7 +33,8 @@ type ListOptions struct {
 	IO           *iostreams.IOStreams
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope    func(org, proj string) render.Scope
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
 
 	Org       string
 	Proj      string
@@ -48,31 +49,39 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
-		MakeScope:    f.Scope,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
 	}
 	var limit, offset int
 	var limitSet, offsetSet bool
 
 	cmd := &cobra.Command{
-		Use:   "list <agent>",
+		Use:   "list [agent]",
 		Short: "List builds for an agent",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Limit = nil
 			opts.Offset = nil
 			org, proj, err := opts.ResolveScope(cmd, true, true)
-			scope := opts.MakeScope(org, proj)
 			if err != nil {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, err)
 			}
 			if limitSet && limit < 1 {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--limit must be >= 1"))
 			}
 			if offsetSet && offset < 0 {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--offset must be >= 0"))
 			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
 			opts.Org, opts.Proj, opts.Scope = org, proj, scope
-			opts.AgentName = args[0]
+			opts.AgentName = agent
 			if limitSet {
 				v := limit
 				opts.Limit = &v

--- a/cli/pkg/cmd/agent/build/logs.go
+++ b/cli/pkg/cmd/agent/build/logs.go
@@ -33,13 +33,14 @@ type LogsOptions struct {
 	IO           *iostreams.IOStreams
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope    func(org, proj string) render.Scope
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
 
 	Org       string
 	Proj      string
 	Scope     render.Scope
 	AgentName string
-	BuildName   string
+	BuildName string
 }
 
 func NewLogsCmd(f *cmdutil.Factory) *cobra.Command {
@@ -47,36 +48,50 @@ func NewLogsCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
-		MakeScope:    f.Scope,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
 	}
 
 	cmd := &cobra.Command{
-		Use:   "logs <agent> [build-name]",
+		Use:   "logs [agent] [build-name]",
 		Short: "Show build logs",
 		Long:  "Show logs for a build. If build name is omitted, shows logs for the latest build.",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cobra.RangeArgs(0, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org, proj, err := opts.ResolveScope(cmd, true, true)
-			scope := opts.MakeScope(org, proj)
 			if err != nil {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, err)
 			}
-			opts.Org, opts.Proj, opts.Scope = org, proj, scope
-			opts.AgentName = args[0]
-			if len(args) > 1 {
-				opts.BuildName = args[1]
+			var agent string
+			var remaining []string
+			var agentErr error
+			if len(args) == 1 {
+				agent, _, agentErr = opts.ResolveAgent(nil)
+				if agentErr == nil {
+					remaining = args
+				} else {
+					agent, remaining, agentErr = opts.ResolveAgent(args)
+				}
+			} else {
+				agent, remaining, agentErr = opts.ResolveAgent(args)
 			}
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
+			var buildName string
+			if len(remaining) > 0 {
+				buildName = remaining[0]
+			}
+			opts.Org, opts.Proj, opts.Scope = org, proj, scope
+			opts.AgentName = agent
+			opts.BuildName = buildName
 			return runLogs(cmd.Context(), opts)
 		},
 	}
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		switch len(args) {
-		case 0:
-			return cmdutil.CompleteBuildableAgents(cmd, f), cobra.ShellCompDirectiveNoFileComp
-		case 1:
-			return cmdutil.CompleteBuilds(cmd, f, args[0]), cobra.ShellCompDirectiveNoFileComp
-		}
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return cmdutil.CompleteBuildWithAgentContext(cmd, f, args)
 	}
 	return cmd
 }

--- a/cli/pkg/cmd/agent/delete.go
+++ b/cli/pkg/cmd/agent/delete.go
@@ -36,7 +36,8 @@ type DeleteOptions struct {
 	Prompter     prompter.Prompter
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope    func(org, proj string) render.Scope
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
 
 	Org       string
 	Proj      string
@@ -56,20 +57,26 @@ func NewDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		Prompter:     f.Prompter,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
-		MakeScope:    f.Scope,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
 	}
 	cmd := &cobra.Command{
-		Use:   "delete <agent>",
+		Use:   "delete [agent]",
 		Short: "Delete an agent",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org, proj, err := opts.ResolveScope(cmd, true, true)
-			scope := opts.MakeScope(org, proj)
 			if err != nil {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, err)
 			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
 			opts.Org, opts.Proj, opts.Scope = org, proj, scope
-			opts.AgentName = args[0]
+			opts.AgentName = agent
 			return runDelete(cmd.Context(), opts)
 		},
 	}

--- a/cli/pkg/cmd/agent/get.go
+++ b/cli/pkg/cmd/agent/get.go
@@ -33,7 +33,8 @@ type GetOptions struct {
 	IO           *iostreams.IOStreams
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope    func(org, proj string) render.Scope
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
 
 	Org       string
 	Proj      string
@@ -46,20 +47,26 @@ func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
 		IO:           f.IOStreams,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
-		MakeScope:    f.Scope,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
 	}
 	cmd := &cobra.Command{
-		Use:   "get <agent>",
+		Use:   "get [agent]",
 		Short: "Show details of an agent",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org, proj, err := opts.ResolveScope(cmd, true, true)
-			scope := opts.MakeScope(org, proj)
 			if err != nil {
+				scope := opts.MakeScope(org, proj, "")
 				return render.Error(opts.IO, scope, err)
 			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
 			opts.Org, opts.Proj, opts.Scope = org, proj, scope
-			opts.AgentName = args[0]
+			opts.AgentName = agent
 			return runGet(cmd.Context(), opts)
 		},
 	}

--- a/cli/pkg/cmd/context/context.go
+++ b/cli/pkg/cmd/context/context.go
@@ -32,5 +32,7 @@ func NewContextCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewShowCmd(f))
 	cmd.AddCommand(instance.NewInstanceCmd(f))
 	cmd.AddCommand(org.NewOrgCmd(f))
+	cmd.AddCommand(NewLinkCmd(f))
+	cmd.AddCommand(NewUnlinkCmd(f))
 	return cmd
 }

--- a/cli/pkg/cmd/context/instance/use_test.go
+++ b/cli/pkg/cmd/context/instance/use_test.go
@@ -93,3 +93,61 @@ func TestUse_DoesNotTouchCurrentOrg(t *testing.T) {
 		t.Errorf("staging current_org = %q, want staging-org", cfg.Instances["staging"].CurrentOrg)
 	}
 }
+
+func TestUse_ClearsLinkedProjects(t *testing.T) {
+	io, out := newTestIO()
+	cfgFn := writeConfig(t, &config.Config{
+		CurrentInstance: "staging",
+		Instances: map[string]config.Instance{
+			"prod":    {URL: "https://prod.example.com"},
+			"staging": {URL: "https://staging.example.com"},
+		},
+		LinkedProjects: map[string]config.LinkedProject{
+			"/path/a": {Org: "o1", Project: "p1"},
+			"/path/b": {Org: "o2", Project: "p2"},
+		},
+	})
+
+	err := runUse(&UseOptions{IO: io, Config: cfgFn, Name: "prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, _ := cfgFn()
+	if len(cfg.LinkedProjects) != 0 {
+		t.Errorf("LinkedProjects len after switch = %d, want 0", len(cfg.LinkedProjects))
+	}
+
+	env := decodeEnvelope(t, out.String())
+	data := env["data"].(map[string]any)
+	cleared, ok := data["cleared_links"]
+	if !ok {
+		t.Fatal("expected cleared_links field in JSON response")
+	}
+	if cleared.(float64) != 2 {
+		t.Errorf("cleared_links = %v, want 2", cleared)
+	}
+}
+
+func TestUse_SameInstanceKeepsLinks(t *testing.T) {
+	io, _ := newTestIO()
+	cfgFn := writeConfig(t, &config.Config{
+		CurrentInstance: "prod",
+		Instances: map[string]config.Instance{
+			"prod": {URL: "https://prod.example.com"},
+		},
+		LinkedProjects: map[string]config.LinkedProject{
+			"/path/a": {Org: "o1", Project: "p1"},
+		},
+	})
+
+	err := runUse(&UseOptions{IO: io, Config: cfgFn, Name: "prod"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg, _ := cfgFn()
+	if len(cfg.LinkedProjects) != 1 {
+		t.Errorf("LinkedProjects len = %d, want 1 (no-op switch should preserve)", len(cfg.LinkedProjects))
+	}
+}

--- a/cli/pkg/cmd/context/link.go
+++ b/cli/pkg/cmd/context/link.go
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmd
+package context
 
 import (
 	"context"

--- a/cli/pkg/cmd/context/show.go
+++ b/cli/pkg/cmd/context/show.go
@@ -18,6 +18,7 @@ package context
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -34,8 +35,9 @@ type ShowOptions struct {
 }
 
 type ShowResult struct {
-	URL string `json:"url"`
-	Org string `json:"org,omitempty"`
+	URL    string                `json:"url"`
+	Org    string                `json:"org,omitempty"`
+	Linked *config.LinkedProject `json:"linked,omitempty"`
 }
 
 func NewShowCmd(f *cmdutil.Factory) *cobra.Command {
@@ -73,16 +75,32 @@ func runShow(o *ShowOptions) error {
 	scope.Instance = cfg.CurrentInstance
 	scope.Org = inst.CurrentOrg
 
+	var linked *config.LinkedProject
+	if wd, wdErr := os.Getwd(); wdErr == nil {
+		_, linked = cfg.GetLinkedProject(wd)
+	}
+
 	if o.IO.JSON {
-		return render.JSONSuccess(o.IO, scope, ShowResult{URL: inst.URL, Org: inst.CurrentOrg})
+		return render.JSONSuccess(o.IO, scope, ShowResult{URL: inst.URL, Org: inst.CurrentOrg, Linked: linked})
 	}
 
 	w := o.IO.Out
 	cs := o.IO.ColorScheme()
-	fmt.Fprintf(w, "instance:  %s\n", cs.Bold(cfg.CurrentInstance))
-	fmt.Fprintf(w, "url:       %s\n", inst.URL)
+	fmt.Fprintf(w, "instance:     %s\n", cs.Bold(cfg.CurrentInstance))
+	fmt.Fprintf(w, "url:          %s\n", inst.URL)
 	if inst.CurrentOrg != "" {
-		fmt.Fprintf(w, "org:       %s\n", cs.Cyan(inst.CurrentOrg))
+		fmt.Fprintf(w, "org:          %s\n", cs.Cyan(inst.CurrentOrg))
+	}
+	if linked != nil {
+		fmt.Fprintf(w, "\nlinked project:\n")
+		fmt.Fprintf(w, "  org:          %s\n", cs.Cyan(linked.Org))
+		fmt.Fprintf(w, "  project:      %s\n", cs.Bold(linked.Project))
+		if linked.Environment != "" {
+			fmt.Fprintf(w, "  environment:  %s\n", cs.Green(linked.Environment))
+		}
+		if linked.Agent != "" {
+			fmt.Fprintf(w, "  agent:        %s\n", cs.Yellow(linked.Agent))
+		}
 	}
 	return nil
 }

--- a/cli/pkg/cmd/context/unlink.go
+++ b/cli/pkg/cmd/context/unlink.go
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package cmd
+package context
 
 import (
 	"fmt"

--- a/cli/pkg/cmd/link.go
+++ b/cli/pkg/cmd/link.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/config"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+const defaultEnvironment = "default"
+
+type LinkOptions struct {
+	IO           *iostreams.IOStreams
+	Config       func() (*config.Config, error)
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(string, string) render.Scope
+
+	Agent string
+}
+
+type LinkResult struct {
+	Dir         string `json:"dir"`
+	Org         string `json:"org"`
+	Project     string `json:"project"`
+	Environment string `json:"environment"`
+	Agent       string `json:"agent,omitempty"`
+}
+
+func NewLinkCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &LinkOptions{
+		IO:           f.IOStreams,
+		Config:       f.Config,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.Scope,
+	}
+	cmd := &cobra.Command{
+		Use:   "link",
+		Short: "Link the current directory to an org, project, and optional agent",
+		Long: `Link associates the current working directory with a specific org, project,
+and optionally an agent. Linked directories always use the "default"
+environment. Once linked, commands run from this directory (or any
+subdirectory) use this context automatically.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, project, err := opts.ResolveScope(cmd, true, true)
+			scope := opts.MakeScope(org, project)
+			if err != nil {
+				return render.Error(opts.IO, scope, err)
+			}
+			return runLink(cmd.Context(), opts, org, project, scope)
+		},
+	}
+	cmdutil.EnableProjectOverride(cmd, f)
+	cmd.Flags().StringVar(&opts.Agent, "agent", "", "Agent name (optional)")
+
+	_ = cmd.RegisterFlagCompletionFunc("agent", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return cmdutil.CompleteAgents(cmd, f), cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+func runLink(ctx context.Context, o *LinkOptions, org, project string, scope render.Scope) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return render.Error(o.IO, scope, clierr.Newf(clierr.Internal, "get working directory: %v", err))
+	}
+
+	cfg, err := o.Config()
+	if err != nil {
+		return render.Error(o.IO, scope, clierr.Newf(clierr.ConfigNotLoaded, "%v", err))
+	}
+
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, scope, err)
+	}
+
+	if err := cmdutil.ValidatePathParam("project", project); err != nil {
+		return render.Error(o.IO, scope, err)
+	}
+	projResp, err := client.GetProjectWithResponse(ctx, org, project)
+	if err != nil {
+		return render.Error(o.IO, scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if projResp.JSON200 == nil {
+		return render.Error(o.IO, scope, cmdutil.ErrorFromServer(projResp.HTTPResponse, cmdutil.FirstNonNil(projResp.JSON404, projResp.JSON500)))
+	}
+
+	envResp, err := client.GetEnvironmentWithResponse(ctx, org, defaultEnvironment)
+	if err != nil {
+		return render.Error(o.IO, scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if envResp.JSON200 == nil {
+		return render.Error(o.IO, scope, cmdutil.ErrorFromServer(envResp.HTTPResponse, cmdutil.FirstNonNil(envResp.JSON404, envResp.JSON400, envResp.JSON500)))
+	}
+	scope.Environment = defaultEnvironment
+
+	if o.Agent != "" {
+		if err := cmdutil.ValidatePathParam("agent", o.Agent); err != nil {
+			return render.Error(o.IO, scope, err)
+		}
+		agentResp, err := client.GetAgentWithResponse(ctx, org, project, o.Agent)
+		if err != nil {
+			return render.Error(o.IO, scope, clierr.Newf(clierr.Transport, "%v", err))
+		}
+		if agentResp.JSON200 == nil {
+			return render.Error(o.IO, scope, cmdutil.ErrorFromServer(agentResp.HTTPResponse, cmdutil.FirstNonNil(agentResp.JSON404, agentResp.JSON500)))
+		}
+		scope.Agent = o.Agent
+	}
+
+	cfg.LinkProject(wd, config.LinkedProject{
+		Org:         org,
+		Project:     project,
+		Environment: defaultEnvironment,
+		Agent:       o.Agent,
+	})
+	if err := cfg.Save(); err != nil {
+		return render.Error(o.IO, scope, clierr.Newf(clierr.ConfigSaveFailed, "save config: %v", err))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, scope, LinkResult{
+			Dir:         wd,
+			Org:         org,
+			Project:     project,
+			Environment: defaultEnvironment,
+			Agent:       o.Agent,
+		})
+	}
+
+	cs := o.IO.StderrColorScheme()
+	fmt.Fprintf(o.IO.ErrOut, "%s Linked %s to %s/%s (env: %s)", cs.SuccessIcon(), cs.Bold(wd), cs.Cyan(org), cs.Bold(project), cs.Green(defaultEnvironment))
+	if o.Agent != "" {
+		fmt.Fprintf(o.IO.ErrOut, " (agent: %s)", cs.Yellow(o.Agent))
+	}
+	fmt.Fprintln(o.IO.ErrOut)
+	return nil
+}

--- a/cli/pkg/cmd/login.go
+++ b/cli/pkg/cmd/login.go
@@ -110,6 +110,7 @@ func runLogin(ctx context.Context, opts *LoginOptions) error {
 	if err != nil {
 		return render.Error(opts.IO, scope, clierr.Newf(clierr.ConfigNotLoaded, "%v", err))
 	}
+	cleared := cfg.ClearLinksIfSwitching(opts.Name)
 	cfg.AddInstance(opts.Name, *inst)
 	if err := cfg.Save(); err != nil {
 		return render.Error(opts.IO, scope, clierr.Newf(clierr.ConfigSaveFailed, "save config: %v", err))
@@ -151,6 +152,9 @@ func runLogin(ctx context.Context, opts *LoginOptions) error {
 	fmt.Fprintf(opts.IO.ErrOut, "%s Logged in to %s as %s\n", cs.SuccessIcon(), inst.URL, cs.Bold(opts.Name))
 	if scope.Org != "" {
 		fmt.Fprintf(opts.IO.ErrOut, "%s Organization set to %s\n", cs.SuccessIcon(), cs.Bold(scope.Org))
+	}
+	if cleared > 0 {
+		fmt.Fprintf(opts.IO.ErrOut, "%s Cleared %d linked project(s). Run 'amctl link' to re-link.\n", cs.SuccessIcon(), cleared)
 	}
 	return nil
 }

--- a/cli/pkg/cmd/login.go
+++ b/cli/pkg/cmd/login.go
@@ -41,6 +41,7 @@ type loginData struct {
 	URL           string                       `json:"url"`
 	ExpiresAt     time.Time                    `json:"expires_at"`
 	OrgsAvailable []amsvc.OrganizationListItem `json:"orgs_available"`
+	ClearedLinks  int                          `json:"cleared_links,omitempty"`
 }
 
 type LoginOptions struct {
@@ -111,6 +112,11 @@ func runLogin(ctx context.Context, opts *LoginOptions) error {
 		return render.Error(opts.IO, scope, clierr.Newf(clierr.ConfigNotLoaded, "%v", err))
 	}
 	cleared := cfg.ClearLinksIfSwitching(opts.Name)
+	if cleared == 0 {
+		if prev, ok := cfg.Instances[opts.Name]; ok && prev.URL != inst.URL {
+			cleared = cfg.ClearLinkedProjects()
+		}
+	}
 	cfg.AddInstance(opts.Name, *inst)
 	if err := cfg.Save(); err != nil {
 		return render.Error(opts.IO, scope, clierr.Newf(clierr.ConfigSaveFailed, "save config: %v", err))
@@ -145,6 +151,7 @@ func runLogin(ctx context.Context, opts *LoginOptions) error {
 			URL:           inst.URL,
 			ExpiresAt:     inst.Auth.ExpiresAt,
 			OrgsAvailable: orgs,
+			ClearedLinks:  cleared,
 		})
 	}
 

--- a/cli/pkg/cmd/root.go
+++ b/cli/pkg/cmd/root.go
@@ -41,6 +41,8 @@ func NewRootCmd(f *cmdutil.Factory) (*cobra.Command, error) {
 	cmd.PersistentFlags().BoolVar(&f.IOStreams.JSON, "json", false, "Output as JSON envelopes")
 
 	cmd.AddCommand(NewLoginCmd(f))
+	cmd.AddCommand(NewLinkCmd(f))
+	cmd.AddCommand(NewUnlinkCmd(f))
 	cmd.AddCommand(agent.NewAgentCmd(f))
 	cmd.AddCommand(amcontext.NewContextCmd(f))
 	cmd.AddCommand(project.NewProjectCmd(f))

--- a/cli/pkg/cmd/root.go
+++ b/cli/pkg/cmd/root.go
@@ -41,12 +41,17 @@ func NewRootCmd(f *cmdutil.Factory) (*cobra.Command, error) {
 	cmd.PersistentFlags().BoolVar(&f.IOStreams.JSON, "json", false, "Output as JSON envelopes")
 
 	cmd.AddCommand(NewLoginCmd(f))
-	cmd.AddCommand(NewLinkCmd(f))
-	cmd.AddCommand(NewUnlinkCmd(f))
 	cmd.AddCommand(agent.NewAgentCmd(f))
 	cmd.AddCommand(amcontext.NewContextCmd(f))
 	cmd.AddCommand(project.NewProjectCmd(f))
 	cmd.AddCommand(NewVersionCmd())
+
+	linkAlias := amcontext.NewLinkCmd(f)
+	linkAlias.Hidden = true
+	unlinkAlias := amcontext.NewUnlinkCmd(f)
+	unlinkAlias.Hidden = true
+	cmd.AddCommand(linkAlias)
+	cmd.AddCommand(unlinkAlias)
 
 	return cmd, nil
 }

--- a/cli/pkg/cmd/unlink.go
+++ b/cli/pkg/cmd/unlink.go
@@ -14,10 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package instance
+package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -28,69 +29,59 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
-type UseOptions struct {
+type UnlinkOptions struct {
 	IO     *iostreams.IOStreams
 	Config func() (*config.Config, error)
-
-	Name string
 }
 
-type UseResult struct {
-	Instance     string `json:"instance"`
-	ClearedLinks int    `json:"cleared_links,omitempty"`
+type UnlinkResult struct {
+	Dir string `json:"dir"`
 }
 
-func NewUseCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &UseOptions{
+func NewUnlinkCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &UnlinkOptions{
 		IO:     f.IOStreams,
 		Config: f.Config,
 	}
-	cmd := &cobra.Command{
-		Use:   "use <name>",
-		Short: "Switch the active instance",
-		Args:  cobra.ExactArgs(1),
+	return &cobra.Command{
+		Use:   "unlink",
+		Short: "Remove the project link for the current directory",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Name = args[0]
-			return runUse(opts)
+			return runUnlink(opts)
 		},
 	}
-	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) > 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-		return cmdutil.CompleteInstances(f), cobra.ShellCompDirectiveNoFileComp
-	}
-	return cmd
 }
 
-func runUse(o *UseOptions) error {
+func runUnlink(o *UnlinkOptions) error {
 	scope := render.Scope{}
 
 	cfg, err := o.Config()
 	if err != nil {
 		return render.Error(o.IO, scope, clierr.Newf(clierr.ConfigNotLoaded, "%v", err))
 	}
+	scope.Instance = cfg.CurrentInstance
 
-	if _, ok := cfg.Instances[o.Name]; !ok {
-		return render.Error(o.IO, scope, clierr.Newf(clierr.NoInstance, "instance %q not found in config", o.Name))
+	wd, err := os.Getwd()
+	if err != nil {
+		return render.Error(o.IO, scope, clierr.Newf(clierr.Internal, "get working directory: %v", err))
 	}
 
-	cleared := cfg.ClearLinksIfSwitching(o.Name)
-	cfg.CurrentInstance = o.Name
+	linkedDir, lp := cfg.GetLinkedProject(wd)
+	if lp == nil {
+		return render.Error(o.IO, scope, clierr.Newf(clierr.NotLinked, "no linked project in %s", wd))
+	}
+
+	cfg.UnlinkProject(linkedDir)
 	if err := cfg.Save(); err != nil {
 		return render.Error(o.IO, scope, clierr.Newf(clierr.ConfigSaveFailed, "save config: %v", err))
 	}
 
-	scope.Instance = o.Name
-
 	if o.IO.JSON {
-		return render.JSONSuccess(o.IO, scope, UseResult{Instance: o.Name, ClearedLinks: cleared})
+		return render.JSONSuccess(o.IO, scope, UnlinkResult{Dir: linkedDir})
 	}
 
 	cs := o.IO.StderrColorScheme()
-	fmt.Fprintf(o.IO.ErrOut, "%s Switched to instance %s\n", cs.SuccessIcon(), o.Name)
-	if cleared > 0 {
-		fmt.Fprintf(o.IO.ErrOut, "%s Cleared %d linked project(s). Run 'amctl link' to re-link.\n", cs.SuccessIcon(), cleared)
-	}
+	fmt.Fprintf(o.IO.ErrOut, "%s Unlinked %s\n", cs.SuccessIcon(), cs.Bold(linkedDir))
 	return nil
 }

--- a/cli/pkg/cmdutil/completion.go
+++ b/cli/pkg/cmdutil/completion.go
@@ -243,6 +243,27 @@ func CompleteBuilds(cmd *cobra.Command, f *Factory, agentName string) []string {
 	return out
 }
 
+// CompleteBuildWithAgentContext provides tab-completions for commands that take
+// an optional [agent] followed by a <build-name>. When a linked-context agent
+// exists, positional args shift: arg0 becomes the build name instead of the
+// agent.
+func CompleteBuildWithAgentContext(cmd *cobra.Command, f *Factory, args []string) ([]string, cobra.ShellCompDirective) {
+	switch len(args) {
+	case 0:
+		agent, _, err := f.ResolveAgent(nil)
+		if err == nil {
+			return CompleteBuilds(cmd, f, agent), cobra.ShellCompDirectiveNoFileComp
+		}
+		return CompleteBuildableAgents(cmd, f), cobra.ShellCompDirectiveNoFileComp
+	case 1:
+		if _, _, err := f.ResolveAgent(nil); err == nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return CompleteBuilds(cmd, f, args[0]), cobra.ShellCompDirectiveNoFileComp
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}
+
 // CompleteOrgs returns sorted organization names. Returns nil on any error
 // (no instance, network, server). Times out at 2s.
 func CompleteOrgs(cmd *cobra.Command, f *Factory) []string {

--- a/cli/pkg/cmdutil/scope.go
+++ b/cli/pkg/cmdutil/scope.go
@@ -17,31 +17,48 @@
 package cmdutil
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
-// ResolveOrgProject extracts --org / --project from cobra flags and falls back to
-// the active instance's current_org. requireOrg/requireProject decide whether
-// missing values should produce a clierr.CLIError.
+// ResolveOrgProject returns (org, project) using this fallback chain:
+//  1. --org / --project flags
+//  2. linked project for the current working directory (or its ancestor)
+//  3. current instance's current_org (org only)
+//
+// requireOrg/requireProject promote a missing value to a clierr.CLIError.
 func (f *Factory) ResolveOrgProject(cmd *cobra.Command, requireOrg, requireProject bool) (org, project string, err error) {
 	org, _ = cmd.Flags().GetString("org")
 	project, _ = cmd.Flags().GetString("project")
 
-	if org == "" {
-		if cfg, cerr := f.Config(); cerr == nil {
-			if inst, ierr := cfg.Current(); ierr == nil {
-				org = inst.CurrentOrg
+	cfg, _ := f.Config()
+	if cfg != nil && (org == "" || project == "") {
+		if wd, wdErr := os.Getwd(); wdErr == nil {
+			if _, lp := cfg.GetLinkedProject(wd); lp != nil {
+				if org == "" {
+					org = lp.Org
+				}
+				if project == "" {
+					project = lp.Project
+				}
 			}
 		}
 	}
+
+	if cfg != nil && org == "" {
+		if inst, ierr := cfg.Current(); ierr == nil {
+			org = inst.CurrentOrg
+		}
+	}
 	if requireOrg && org == "" {
-		return "", "", clierr.New(clierr.NoOrg, "no organization (set --org or run `amctl login` to capture current_org)")
+		return "", "", clierr.New(clierr.NoOrg, "no organization (set --org, run `amctl link`, or run `amctl login`)")
 	}
 	if requireProject && project == "" {
-		return "", "", clierr.New(clierr.NoProject, "--project is required")
+		return "", "", clierr.New(clierr.NoProject, "no project (set --project or run `amctl link`)")
 	}
 	return org, project, nil
 }

--- a/cli/pkg/cmdutil/scope.go
+++ b/cli/pkg/cmdutil/scope.go
@@ -76,3 +76,31 @@ func (f *Factory) Scope(org, project string) render.Scope {
 		Project:  project,
 	}
 }
+
+// ResolveAgent returns the agent name using this fallback chain:
+//  1. args[0] if present and non-empty
+//  2. linked project's Agent for the current working directory (or ancestor)
+//
+// remaining holds the args that were not consumed as the agent name.
+func (f *Factory) ResolveAgent(args []string) (agent string, remaining []string, err error) {
+	if len(args) > 0 && args[0] != "" {
+		return args[0], args[1:], nil
+	}
+
+	cfg, _ := f.Config()
+	if cfg != nil {
+		if wd, wdErr := os.Getwd(); wdErr == nil {
+			if _, lp := cfg.GetLinkedProject(wd); lp != nil && lp.Agent != "" {
+				return lp.Agent, args, nil
+			}
+		}
+	}
+	return "", nil, clierr.New(clierr.NoAgent, "agent is required")
+}
+
+// AgentScope builds a render envelope scope that includes the resolved agent.
+func (f *Factory) AgentScope(org, project, agent string) render.Scope {
+	s := f.Scope(org, project)
+	s.Agent = agent
+	return s
+}

--- a/cli/pkg/cmdutil/scope_test.go
+++ b/cli/pkg/cmdutil/scope_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdutil
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/config"
+)
+
+func TestResolveAgent_FromArgs(t *testing.T) {
+	f := &Factory{
+		Config: func() (*config.Config, error) {
+			return &config.Config{
+				LinkedProjects: map[string]config.LinkedProject{
+					"/some/dir": {Org: "o", Project: "p", Agent: "linked-agent"},
+				},
+			}, nil
+		},
+	}
+	agent, remaining, err := f.ResolveAgent([]string{"explicit-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "explicit-agent" {
+		t.Errorf("agent = %q, want %q", agent, "explicit-agent")
+	}
+	if len(remaining) != 0 {
+		t.Errorf("remaining = %v, want empty", remaining)
+	}
+}
+
+func TestResolveAgent_FromLinkedContext(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	f := &Factory{
+		Config: func() (*config.Config, error) {
+			return &config.Config{
+				LinkedProjects: map[string]config.LinkedProject{
+					wd: {Org: "o", Project: "p", Agent: "linked-agent"},
+				},
+			}, nil
+		},
+	}
+	agent, remaining, err := f.ResolveAgent(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "linked-agent" {
+		t.Errorf("agent = %q, want %q", agent, "linked-agent")
+	}
+	if remaining != nil {
+		t.Errorf("remaining = %v, want nil", remaining)
+	}
+}
+
+func TestResolveAgent_NoAgentAvailable(t *testing.T) {
+	f := &Factory{
+		Config: func() (*config.Config, error) {
+			return &config.Config{}, nil
+		},
+	}
+	_, _, err := f.ResolveAgent(nil)
+	if err == nil {
+		t.Fatal("expected error when no agent available")
+	}
+	var cliErr clierr.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatalf("error type = %T, want clierr.CLIError", err)
+	}
+	if cliErr.Code != clierr.NoAgent {
+		t.Errorf("code = %q, want %q", cliErr.Code, clierr.NoAgent)
+	}
+}
+
+func TestResolveAgent_RemainingArgs(t *testing.T) {
+	f := &Factory{
+		Config: func() (*config.Config, error) {
+			return &config.Config{}, nil
+		},
+	}
+	agent, remaining, err := f.ResolveAgent([]string{"my-agent", "build-001"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "my-agent" {
+		t.Errorf("agent = %q, want %q", agent, "my-agent")
+	}
+	if len(remaining) != 1 || remaining[0] != "build-001" {
+		t.Errorf("remaining = %v, want [\"build-001\"]", remaining)
+	}
+}
+
+func TestResolveAgent_EmptyStringArgFallsThrough(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	f := &Factory{
+		Config: func() (*config.Config, error) {
+			return &config.Config{
+				LinkedProjects: map[string]config.LinkedProject{
+					wd: {Org: "o", Project: "p", Agent: "linked-agent"},
+				},
+			}, nil
+		},
+	}
+	agent, remaining, err := f.ResolveAgent([]string{""})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "linked-agent" {
+		t.Errorf("agent = %q, want %q", agent, "linked-agent")
+	}
+	if len(remaining) != 1 || remaining[0] != "" {
+		t.Errorf("remaining = %v, want [\"\"]", remaining)
+	}
+}

--- a/cli/pkg/config/config.go
+++ b/cli/pkg/config/config.go
@@ -27,10 +27,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// LinkedProject is keyed in Config.LinkedProjects by absolute directory path.
+type LinkedProject struct {
+	Org         string `yaml:"org" json:"org"`
+	Project     string `yaml:"project,omitempty" json:"project,omitempty"`
+	Environment string `yaml:"environment,omitempty" json:"environment,omitempty"`
+	Agent       string `yaml:"agent,omitempty" json:"agent,omitempty"`
+}
+
 type Config struct {
-	Path            string              `yaml:"-"`
-	CurrentInstance string              `yaml:"current_instance"`
-	Instances       map[string]Instance `yaml:"instances"`
+	Path            string                   `yaml:"-"`
+	CurrentInstance string                   `yaml:"current_instance"`
+	Instances       map[string]Instance      `yaml:"instances"`
+	LinkedProjects  map[string]LinkedProject `yaml:"linked_projects,omitempty"`
 }
 
 type Instance struct {
@@ -60,6 +69,51 @@ func (c *Config) Current() (*Instance, error) {
 		return nil, fmt.Errorf("current instance %q not found in config", c.CurrentInstance)
 	}
 	return &instance, nil
+}
+
+func (c *Config) LinkProject(dir string, lp LinkedProject) {
+	if c.LinkedProjects == nil {
+		c.LinkedProjects = map[string]LinkedProject{}
+	}
+	c.LinkedProjects[dir] = lp
+}
+
+func (c *Config) UnlinkProject(dir string) {
+	delete(c.LinkedProjects, dir)
+}
+
+func (c *Config) ClearLinkedProjects() int {
+	n := len(c.LinkedProjects)
+	c.LinkedProjects = nil
+	return n
+}
+
+// ClearLinksIfSwitching clears all linked projects when newInstance differs
+// from CurrentInstance. Returns the number cleared.
+func (c *Config) ClearLinksIfSwitching(newInstance string) int {
+	if c.CurrentInstance == newInstance {
+		return 0
+	}
+	return c.ClearLinkedProjects()
+}
+
+// GetLinkedProject walks startDir's ancestors for the closest linked entry and
+// returns its directory key plus the entry. Both are zero when no match.
+func (c *Config) GetLinkedProject(startDir string) (string, *LinkedProject) {
+	if len(c.LinkedProjects) == 0 {
+		return "", nil
+	}
+	dir := startDir
+	for {
+		if lp, ok := c.LinkedProjects[dir]; ok {
+			return dir, &lp
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
 }
 
 func (c *Config) AddInstance(name string, inst Instance) {

--- a/cli/pkg/config/config_test.go
+++ b/cli/pkg/config/config_test.go
@@ -140,6 +140,163 @@ func TestSaveConcurrentDoesNotCollide(t *testing.T) {
 	}
 }
 
+func TestLinkedProjectRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+
+	cfg := Config{
+		CurrentInstance: "dev",
+		Instances:       map[string]Instance{"dev": {URL: "https://am.example.com"}},
+	}
+	cfg.LinkProject("/home/user/my-app", LinkedProject{
+		Org:         "acme",
+		Project:     "chatbot",
+		Environment: "dev-env",
+		Agent:       "assistant",
+	})
+	cfg.LinkProject("/home/user/other", LinkedProject{
+		Org:     "acme",
+		Project: "other-proj",
+	})
+
+	if err := Save(path, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	lp, ok := loaded.LinkedProjects["/home/user/my-app"]
+	if !ok {
+		t.Fatal("expected linked project for /home/user/my-app")
+	}
+	if lp.Org != "acme" || lp.Project != "chatbot" || lp.Environment != "dev-env" || lp.Agent != "assistant" {
+		t.Errorf("linked project mismatch: %+v", lp)
+	}
+	if _, ok := loaded.LinkedProjects["/home/user/other"]; !ok {
+		t.Fatal("expected linked project for /home/user/other")
+	}
+}
+
+func TestGetLinkedProjectAncestorWalk(t *testing.T) {
+	cfg := Config{
+		LinkedProjects: map[string]LinkedProject{
+			"/home/user/projects/repo": {
+				Org:     "acme",
+				Project: "myproj",
+			},
+		},
+	}
+
+	tests := []struct {
+		startDir string
+		wantOrg  string
+		wantNil  bool
+	}{
+		{"/home/user/projects/repo", "acme", false},
+		{"/home/user/projects/repo/src/cmd", "acme", false},
+		{"/home/user/projects/repo/deep/nested/dir", "acme", false},
+		{"/home/user/projects/other", "", true},
+		{"/home/user", "", true},
+		{"/", "", true},
+	}
+
+	for _, tt := range tests {
+		gotDir, got := cfg.GetLinkedProject(tt.startDir)
+		if tt.wantNil {
+			if got != nil {
+				t.Errorf("GetLinkedProject(%q) = (%q, %+v), want nil", tt.startDir, gotDir, got)
+			}
+			continue
+		}
+		if got == nil {
+			t.Errorf("GetLinkedProject(%q) = nil, want org=%q", tt.startDir, tt.wantOrg)
+			continue
+		}
+		if got.Org != tt.wantOrg {
+			t.Errorf("GetLinkedProject(%q).Org = %q, want %q", tt.startDir, got.Org, tt.wantOrg)
+		}
+	}
+}
+
+func TestGetLinkedProjectReturnsDir(t *testing.T) {
+	cfg := Config{
+		LinkedProjects: map[string]LinkedProject{
+			"/home/user/app": {Org: "acme", Project: "app"},
+		},
+	}
+
+	if dir, _ := cfg.GetLinkedProject("/home/user/app/src"); dir != "/home/user/app" {
+		t.Errorf("dir from subdir = %q, want /home/user/app", dir)
+	}
+	if dir, _ := cfg.GetLinkedProject("/home/user/other"); dir != "" {
+		t.Errorf("dir for unlinked = %q, want empty", dir)
+	}
+}
+
+func TestUnlinkProject(t *testing.T) {
+	cfg := Config{
+		LinkedProjects: map[string]LinkedProject{
+			"/home/user/app": {Org: "acme", Project: "app"},
+		},
+	}
+
+	cfg.UnlinkProject("/home/user/app")
+	if len(cfg.LinkedProjects) != 0 {
+		t.Errorf("expected empty linked projects after unlink, got %d", len(cfg.LinkedProjects))
+	}
+
+	if _, lp := cfg.GetLinkedProject("/home/user/app"); lp != nil {
+		t.Errorf("expected nil after unlink, got %+v", lp)
+	}
+}
+
+func TestGetLinkedProjectClosestMatch(t *testing.T) {
+	cfg := Config{
+		LinkedProjects: map[string]LinkedProject{
+			"/home/user/projects":      {Org: "parent-org", Project: "parent"},
+			"/home/user/projects/repo": {Org: "child-org", Project: "child"},
+		},
+	}
+
+	_, got := cfg.GetLinkedProject("/home/user/projects/repo/src")
+	if got == nil {
+		t.Fatal("expected linked project, got nil")
+	}
+	if got.Org != "child-org" {
+		t.Errorf("expected closest match child-org, got %q", got.Org)
+	}
+
+	_, got = cfg.GetLinkedProject("/home/user/projects/other")
+	if got == nil {
+		t.Fatal("expected linked project, got nil")
+	}
+	if got.Org != "parent-org" {
+		t.Errorf("expected parent-org fallback, got %q", got.Org)
+	}
+}
+
+func TestClearLinksIfSwitching(t *testing.T) {
+	cfg := &Config{
+		CurrentInstance: "prod",
+		LinkedProjects:  map[string]LinkedProject{"/a": {Org: "o", Project: "p"}},
+	}
+	if n := cfg.ClearLinksIfSwitching("prod"); n != 0 {
+		t.Errorf("same instance: cleared = %d, want 0", n)
+	}
+	if len(cfg.LinkedProjects) != 1 {
+		t.Errorf("same instance: links len = %d, want 1", len(cfg.LinkedProjects))
+	}
+	if n := cfg.ClearLinksIfSwitching("staging"); n != 1 {
+		t.Errorf("different instance: cleared = %d, want 1", n)
+	}
+	if len(cfg.LinkedProjects) != 0 {
+		t.Errorf("different instance: links len = %d, want 0", len(cfg.LinkedProjects))
+	}
+}
+
 func TestLoadMissingFileReturnsEmpty(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "does-not-exist")
 
@@ -155,5 +312,30 @@ func TestLoadMissingFileReturnsEmpty(t *testing.T) {
 	}
 	if len(cfg.Instances) != 0 {
 		t.Errorf("expected no instances, got %d", len(cfg.Instances))
+	}
+}
+
+func TestClearLinkedProjects(t *testing.T) {
+	cfg := &Config{
+		LinkedProjects: map[string]LinkedProject{
+			"/a": {Org: "o1", Project: "p1"},
+			"/b": {Org: "o2", Project: "p2"},
+		},
+	}
+
+	n := cfg.ClearLinkedProjects()
+	if n != 2 {
+		t.Errorf("returned count = %d, want 2", n)
+	}
+	if len(cfg.LinkedProjects) != 0 {
+		t.Errorf("LinkedProjects len = %d, want 0", len(cfg.LinkedProjects))
+	}
+}
+
+func TestClearLinkedProjectsEmpty(t *testing.T) {
+	cfg := &Config{}
+	n := cfg.ClearLinkedProjects()
+	if n != 0 {
+		t.Errorf("returned count = %d, want 0", n)
 	}
 }

--- a/cli/pkg/iostreams/color.go
+++ b/cli/pkg/iostreams/color.go
@@ -21,6 +21,7 @@ const (
 	ansiBold     = "\033[1m"
 	ansiFgRed    = "\033[31m"
 	ansiFgGreen  = "\033[32m"
+	ansiFgYellow = "\033[33m"
 	ansiFgCyan   = "\033[36m"
 	ansiFgGray   = "\033[90m"
 )
@@ -36,11 +37,12 @@ func (cs *ColorScheme) apply(code, t string) string {
 	return code + t + ansiReset
 }
 
-func (cs *ColorScheme) Bold(t string) string  { return cs.apply(ansiBold, t) }
-func (cs *ColorScheme) Red(t string) string   { return cs.apply(ansiFgRed, t) }
-func (cs *ColorScheme) Green(t string) string { return cs.apply(ansiFgGreen, t) }
-func (cs *ColorScheme) Cyan(t string) string  { return cs.apply(ansiFgCyan, t) }
-func (cs *ColorScheme) Gray(t string) string  { return cs.apply(ansiFgGray, t) }
+func (cs *ColorScheme) Bold(t string) string   { return cs.apply(ansiBold, t) }
+func (cs *ColorScheme) Red(t string) string    { return cs.apply(ansiFgRed, t) }
+func (cs *ColorScheme) Green(t string) string  { return cs.apply(ansiFgGreen, t) }
+func (cs *ColorScheme) Yellow(t string) string { return cs.apply(ansiFgYellow, t) }
+func (cs *ColorScheme) Cyan(t string) string   { return cs.apply(ansiFgCyan, t) }
+func (cs *ColorScheme) Gray(t string) string   { return cs.apply(ansiFgGray, t) }
 
 func (cs *ColorScheme) SuccessIcon() string { return cs.Green("✓") }
 func (cs *ColorScheme) FailureIcon() string { return cs.Red("X") }

--- a/cli/pkg/render/render.go
+++ b/cli/pkg/render/render.go
@@ -40,11 +40,13 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
 )
 
-// Scope is the {instance, org, project} triple included on every JSON envelope.
+// Scope is the context included on every JSON envelope.
 type Scope struct {
-	Instance string `json:"instance"`
-	Org      string `json:"org,omitempty"`
-	Project  string `json:"project,omitempty"`
+	Instance    string `json:"instance"`
+	Org         string `json:"org,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	Agent       string `json:"agent,omitempty"`
 }
 
 type successEnvelope struct {


### PR DESCRIPTION
## Purpose
Commands like `amctl agent deploy`, `amctl agent build`, and others require `--org` and `--project` flags on every invocation. When working within a single project directory, repeating these flags is tedious and error-prone.


https://github.com/user-attachments/assets/0b5165f6-a298-475c-a648-3e3164cc5705


## Goals
Allow users to bind a directory to an org/project/environment/agent so that commands run from that directory (or any subdirectory) automatically inherit the context without explicit flags.

## Approach
- Add `amctl link` command that validates the org, project, and optional agent against the server, then persists the mapping in the CLI config under `linked_projects` keyed by absolute directory path.
- Add `amctl unlink` command that removes the mapping for the current directory.
- Extend `ResolveOrgProject` to check linked projects as a fallback between explicit flags and `current_org`: flags → linked project → current_org.
- `GetLinkedProject` walks the directory ancestry to find the closest linked entry, supporting subdirectory resolution.
- Linked projects are automatically cleared when switching instances (via `amctl login` or `amctl context instance use`) since links are instance-specific.
- `amctl context show` now displays linked project info when present.
- `Scope` (JSON envelope) extended with `environment` and `agent` fields.

## User stories
- As a developer working in a project directory, I want to run `amctl link --project myproj` once and then use `amctl agent deploy` without repeating `--org` and `--project`.
- As a developer switching instances, I expect stale project links to be cleared automatically.

## Release note
Added `amctl link` and `amctl unlink` commands that bind the current directory to a project context, eliminating the need for `--org` and `--project` flags on subsequent commands.

## Documentation
N/A — CLI `--help` text is self-documenting. Product docs can be added as a follow-up.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact.

## Marketing
N/A

## Automation tests
- Unit tests
  - `cli/pkg/config/config_test.go`: Tests for `LinkProject`, `UnlinkProject`, `GetLinkedProject` (ancestor walk, closest match, empty map), `ClearLinkedProjects`, `ClearLinksIfSwitching`, and round-trip persistence.
  - `cli/pkg/cmd/context/instance/use_test.go`: Tests that switching instances clears links and same-instance switch preserves them.

- Integration tests
  N/A — `link` command requires a running server for validation; integration tests can be added when the test harness supports it.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Go project, not Java
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
No migrations. The `linked_projects` field is added to the CLI config YAML with `omitempty`, so existing configs are unaffected.

## Test environment
- Go 1.25.7, macOS (Darwin 25.3.0)

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `amctl link` and `amctl unlink` commands to associate projects with directories for quick context switching
  * Agent arguments are now optional in agent build and delete commands; agents resolve from linked project context when available
  * `context show` now displays linked project information
  * Linked projects automatically clear when switching instances or logging in
  * JSON output now includes environment and agent scope information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/826)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->