### PR TITLE
observer: build trace view from OpenTelemetry GenAI semantic-convention attributes

### DIFF
--- a/console/workspaces/libs/types/src/api/traces.ts
+++ b/console/workspaces/libs/types/src/api/traces.ts
@@ -106,6 +106,7 @@ export interface EmbeddingData {
 
 export interface RetrieverData {
   vectorDB?: string;
+  collection?: string;
   topK?: number;
 }
 

--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 )
@@ -1845,6 +1846,10 @@ func hasToolAttributes(attrs map[string]interface{}) bool {
 	return false
 }
 
+// vectorDBSystems is the set of db.system / db.system.name values treated as a
+// vector database (and therefore a retriever span).
+var vectorDBSystems = []string{"pinecone", "weaviate", "qdrant", "milvus", "chroma", "chromadb", "pgvector"}
+
 // hasRetrieverAttributes checks if span has retriever/vector DB attributes
 func hasRetrieverAttributes(attrs map[string]interface{}) bool {
 	// Check for Traceloop vector DB query attributes (db.query.*)
@@ -1856,23 +1861,16 @@ func hasRetrieverAttributes(attrs map[string]interface{}) bool {
 
 	// Check for vector database system — accept both the legacy db.system and
 	// the current OTel DB-semconv db.system.name.
-	vectorDBs := []string{"pinecone", "weaviate", "qdrant", "milvus", "chroma", "chromadb", "pgvector"}
 	for _, key := range []string{"db.system.name", "db.system"} {
-		if dbSystem, ok := attrs[key].(string); ok {
-			for _, vdb := range vectorDBs {
-				if dbSystem == vdb {
-					return true
-				}
-			}
+		if dbSystem, ok := attrs[key].(string); ok && slices.Contains(vectorDBSystems, dbSystem) {
+			return true
 		}
 	}
 
 	// Check for retrieval-specific operations (legacy db.operation and current db.operation.name)
 	for _, key := range []string{"db.operation.name", "db.operation"} {
-		if opName, ok := attrs[key].(string); ok {
-			if opName == "query" || opName == "search" || opName == "retrieve" {
-				return true
-			}
+		if opName, ok := attrs[key].(string); ok && (opName == "query" || opName == "search" || opName == "retrieve") {
+			return true
 		}
 	}
 

--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -236,14 +236,24 @@ func populateEmbeddingAttributes(ampAttrs *AmpAttributes, attrs map[string]inter
 func populateRetrieverAttributes(ampAttrs *AmpAttributes, attrs map[string]interface{}) {
 	retrieverData := RetrieverData{}
 
-	// Extract vector DB system
-	if dbSystem, ok := attrs["db.system"].(string); ok {
+	// Extract vector DB system — prefer the current OTel DB-semconv key
+	// (db.system.name), fall back to the legacy db.system.
+	if dbSystem, ok := attrs["db.system.name"].(string); ok && dbSystem != "" {
+		retrieverData.VectorDB = dbSystem
+	} else if dbSystem, ok := attrs["db.system"].(string); ok {
 		retrieverData.VectorDB = dbSystem
 	}
 
-	// Extract top_k parameter
-	if topK, ok := attrs["db.vector.query.top_k"].(float64); ok {
-		retrieverData.TopK = int(topK)
+	// Extract collection / index name (OTel DB semconv)
+	if collection, ok := attrs["db.collection.name"].(string); ok {
+		retrieverData.Collection = collection
+	}
+
+	// Extract top_k parameter — accept int, float64, or string forms.
+	if topKRaw, ok := attrs["db.vector.query.top_k"]; ok {
+		if topK, topKOk := extractIntValue(topKRaw); topKOk {
+			retrieverData.TopK = topK
+		}
 	}
 
 	ampAttrs.Data = retrieverData
@@ -1508,8 +1518,12 @@ func ExtractToolExecutionDetails(attrs map[string]interface{}, spanStatus string
 		input = toolArgs
 	} else if funcArgs, ok := attrs["function.arguments"].(string); ok {
 		input = funcArgs
-	} else if genAIArgs, ok := attrs["gen_ai.tool.arguments"].(string); ok { // OTEL standard
+	} else if genAIArgs, ok := attrs["gen_ai.tool.arguments"].(string); ok { // OTEL-ish
 		input = genAIArgs
+	} else if genAIInputMessages, ok := attrs["gen_ai.input.messages"].(string); ok && genAIInputMessages != "" {
+		// OTel GenAI structured messages — last-resort tool-input fallback
+		// (lower priority than the traceloop.entity.* / tool.* / function.* keys above).
+		input = genAIInputMessages
 	}
 
 	// Extract tool output - prioritize traceloop.entity.output
@@ -1521,8 +1535,11 @@ func ExtractToolExecutionDetails(attrs map[string]interface{}, spanStatus string
 		output = toolResult
 	} else if funcResult, ok := attrs["function.result"].(string); ok {
 		output = funcResult
-	} else if genAIOutput, ok := attrs["gen_ai.tool.output"].(string); ok { // OTEL standard
+	} else if genAIOutput, ok := attrs["gen_ai.tool.output"].(string); ok { // OTEL-ish
 		output = genAIOutput
+	} else if genAIOutputMessages, ok := attrs["gen_ai.output.messages"].(string); ok && genAIOutputMessages != "" {
+		// OTel GenAI structured messages — last-resort tool-output fallback.
+		output = genAIOutputMessages
 	}
 
 	// Determine status
@@ -1795,6 +1812,11 @@ func hasEmbeddingAttributes(attrs map[string]interface{}) bool {
 
 // hasToolAttributes checks if span has tool/function call attributes
 func hasToolAttributes(attrs map[string]interface{}) bool {
+	// OTel GenAI semconv: execute_tool operation
+	if opName, ok := attrs["gen_ai.operation.name"].(string); ok && opName == "execute_tool" {
+		return true
+	}
+
 	// Check for tool call attributes
 	if _, ok := attrs["gen_ai.tool.name"].(string); ok {
 		return true
@@ -1832,20 +1854,25 @@ func hasRetrieverAttributes(attrs map[string]interface{}) bool {
 		}
 	}
 
-	// Check for vector database system
-	if dbSystem, ok := attrs["db.system"].(string); ok {
-		vectorDBs := []string{"pinecone", "weaviate", "qdrant", "milvus", "chroma", "chromadb"}
-		for _, vdb := range vectorDBs {
-			if dbSystem == vdb {
-				return true
+	// Check for vector database system — accept both the legacy db.system and
+	// the current OTel DB-semconv db.system.name.
+	vectorDBs := []string{"pinecone", "weaviate", "qdrant", "milvus", "chroma", "chromadb", "pgvector"}
+	for _, key := range []string{"db.system.name", "db.system"} {
+		if dbSystem, ok := attrs[key].(string); ok {
+			for _, vdb := range vectorDBs {
+				if dbSystem == vdb {
+					return true
+				}
 			}
 		}
 	}
 
-	// Check for retrieval-specific operations
-	if opName, ok := attrs["db.operation"].(string); ok {
-		if opName == "query" || opName == "search" || opName == "retrieve" {
-			return true
+	// Check for retrieval-specific operations (legacy db.operation and current db.operation.name)
+	for _, key := range []string{"db.operation.name", "db.operation"} {
+		if opName, ok := attrs[key].(string); ok {
+			if opName == "query" || opName == "search" || opName == "retrieve" {
+				return true
+			}
 		}
 	}
 
@@ -1879,6 +1906,13 @@ func hasRerankAttributes(attrs map[string]interface{}) bool {
 
 // hasAgentAttributes checks if span has agent orchestration attributes
 func hasAgentAttributes(attrs map[string]interface{}) bool {
+	// OTel GenAI semconv: invoke_agent / create_agent operations
+	if opName, ok := attrs["gen_ai.operation.name"].(string); ok {
+		if opName == "invoke_agent" || opName == "create_agent" {
+			return true
+		}
+	}
+
 	val, ok := attrs["gen_ai.agent.name"]
 	if !ok || val == nil {
 		return false

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -1118,11 +1118,12 @@ func TestExtractEmbeddingDocuments(t *testing.T) {
 	})
 }
 
-// --- Manual-instrumentation contract: pure OTel GenAI semconv spans ---
-// The tests below verify that a span carrying ONLY OpenTelemetry GenAI
-// semantic-convention keys (gen_ai.* / db.*) — no traceloop.* extension keys —
-// still yields a complete AmpAttributes for each of the OTel-covered kinds.
+// The tests below cover the manual-instrumentation contract: AMP trace data
+// reconstructed from OpenTelemetry GenAI semantic-convention keys alone
+// (gen_ai.* / db.*), with no traceloop.* extension keys present.
 
+// TestDetermineSpanType_OTelGenAIOperationNames verifies span-kind detection
+// from the gen_ai.operation.name attribute and the current OTel DB-semconv keys.
 func TestDetermineSpanType_OTelGenAIOperationNames(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1147,6 +1148,8 @@ func TestDetermineSpanType_OTelGenAIOperationNames(t *testing.T) {
 	}
 }
 
+// TestExtractToolExecutionDetails_OTelMessagesFallback verifies that tool spans
+// fall back to gen_ai.input/output.messages, below the traceloop.entity.* keys.
 func TestExtractToolExecutionDetails_OTelMessagesFallback(t *testing.T) {
 	t.Run("falls back to gen_ai.input/output.messages", func(t *testing.T) {
 		attrs := map[string]interface{}{
@@ -1178,6 +1181,8 @@ func TestExtractToolExecutionDetails_OTelMessagesFallback(t *testing.T) {
 	})
 }
 
+// TestPopulateRetrieverAttributes verifies db.system.name precedence over the
+// legacy db.system, db.collection.name extraction, and type-flexible top_k.
 func TestPopulateRetrieverAttributes(t *testing.T) {
 	t.Run("prefers db.system.name over legacy db.system; reads collection and flexible top_k", func(t *testing.T) {
 		amp := &AmpAttributes{}
@@ -1203,6 +1208,9 @@ func TestPopulateRetrieverAttributes(t *testing.T) {
 	})
 }
 
+// TestProcessSpan_PureOTelGenAISpans verifies that a span carrying only OTel
+// GenAI semantic-convention keys (no traceloop.* extensions) yields a complete
+// AmpAttributes for each OTel-covered span kind.
 func TestProcessSpan_PureOTelGenAISpans(t *testing.T) {
 	t.Run("llm chat span", func(t *testing.T) {
 		span := Span{

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -1117,3 +1117,289 @@ func TestExtractEmbeddingDocuments(t *testing.T) {
 		}
 	})
 }
+
+// --- Manual-instrumentation contract: pure OTel GenAI semconv spans ---
+// The tests below verify that a span carrying ONLY OpenTelemetry GenAI
+// semantic-convention keys (gen_ai.* / db.*) — no traceloop.* extension keys —
+// still yields a complete AmpAttributes for each of the OTel-covered kinds.
+
+func TestDetermineSpanType_OTelGenAIOperationNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		attrs    map[string]interface{}
+		expected SpanType
+	}{
+		{"tool via gen_ai.operation.name execute_tool", map[string]interface{}{"gen_ai.operation.name": "execute_tool"}, SpanTypeTool},
+		{"agent via gen_ai.operation.name invoke_agent", map[string]interface{}{"gen_ai.operation.name": "invoke_agent"}, SpanTypeAgent},
+		{"agent via gen_ai.operation.name create_agent", map[string]interface{}{"gen_ai.operation.name": "create_agent"}, SpanTypeAgent},
+		{"llm via gen_ai.operation.name text_completion", map[string]interface{}{"gen_ai.operation.name": "text_completion"}, SpanTypeLLM},
+		{"retriever via db.system.name qdrant", map[string]interface{}{"db.system.name": "qdrant"}, SpanTypeRetriever},
+		{"retriever via db.system.name pgvector", map[string]interface{}{"db.system.name": "pgvector"}, SpanTypeRetriever},
+		{"retriever via legacy db.system pgvector", map[string]interface{}{"db.system": "pgvector"}, SpanTypeRetriever},
+		{"retriever via db.operation.name search", map[string]interface{}{"db.operation.name": "search"}, SpanTypeRetriever},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetermineSpanType(Span{Attributes: tt.attrs}); got != tt.expected {
+				t.Errorf("DetermineSpanType() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractToolExecutionDetails_OTelMessagesFallback(t *testing.T) {
+	t.Run("falls back to gen_ai.input/output.messages", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.tool.name":       "get_weather",
+			"gen_ai.input.messages":  `{"city":"Colombo"}`,
+			"gen_ai.output.messages": `{"temp_c":31}`,
+		}
+		name, input, output, _ := ExtractToolExecutionDetails(attrs, "OK")
+		if name != "get_weather" {
+			t.Errorf("name = %q", name)
+		}
+		if input != `{"city":"Colombo"}` {
+			t.Errorf("input = %q", input)
+		}
+		if output != `{"temp_c":31}` {
+			t.Errorf("output = %q", output)
+		}
+	})
+
+	t.Run("traceloop.entity.* takes priority over gen_ai messages", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.tool.name":        "get_weather",
+			"traceloop.entity.output": "entity result",
+			"gen_ai.output.messages":  `{"temp_c":31}`,
+		}
+		if _, _, output, _ := ExtractToolExecutionDetails(attrs, "OK"); output != "entity result" {
+			t.Errorf("output = %q, want 'entity result'", output)
+		}
+	})
+}
+
+func TestPopulateRetrieverAttributes(t *testing.T) {
+	t.Run("prefers db.system.name over legacy db.system; reads collection and flexible top_k", func(t *testing.T) {
+		amp := &AmpAttributes{}
+		populateRetrieverAttributes(amp, map[string]interface{}{
+			"db.system.name":        "qdrant",
+			"db.system":             "postgresql",
+			"db.collection.name":    "docs",
+			"db.vector.query.top_k": "7",
+		})
+		data, ok := amp.Data.(RetrieverData)
+		if !ok {
+			t.Fatalf("data type = %T, want RetrieverData", amp.Data)
+		}
+		if data.VectorDB != "qdrant" {
+			t.Errorf("vectorDB = %q, want qdrant", data.VectorDB)
+		}
+		if data.Collection != "docs" {
+			t.Errorf("collection = %q, want docs", data.Collection)
+		}
+		if data.TopK != 7 {
+			t.Errorf("topK = %d, want 7", data.TopK)
+		}
+	})
+}
+
+func TestProcessSpan_PureOTelGenAISpans(t *testing.T) {
+	t.Run("llm chat span", func(t *testing.T) {
+		span := Span{
+			Name:   "chat gpt-4o-mini",
+			Status: "OK",
+			Attributes: map[string]interface{}{
+				"gen_ai.operation.name":      "chat",
+				"gen_ai.system":              "openai",
+				"gen_ai.request.model":       "gpt-4o-mini",
+				"gen_ai.response.model":      "gpt-4o-mini-2024-07-18",
+				"gen_ai.request.temperature": float64(0.7),
+				"gen_ai.input.messages":      `[{"role":"user","content":"hello"}]`,
+				"gen_ai.output.messages":     `[{"role":"assistant","content":"hi there"}]`,
+				"gen_ai.usage.input_tokens":  float64(12),
+				"gen_ai.usage.output_tokens": float64(5),
+				"gen_ai.input.tools":         `[{"name":"search","description":"Search the web"}]`,
+			},
+		}
+		amp := ProcessSpan(span).AmpAttributes
+		if amp.Kind != string(SpanTypeLLM) {
+			t.Fatalf("kind = %q, want llm", amp.Kind)
+		}
+		inMsgs, ok := amp.Input.([]PromptMessage)
+		if !ok || len(inMsgs) != 1 || inMsgs[0].Role != "user" || inMsgs[0].Content != "hello" {
+			t.Errorf("input = %#v", amp.Input)
+		}
+		outMsgs, ok := amp.Output.([]PromptMessage)
+		if !ok || len(outMsgs) != 1 || outMsgs[0].Role != "assistant" || outMsgs[0].Content != "hi there" {
+			t.Errorf("output = %#v", amp.Output)
+		}
+		data, ok := amp.Data.(LLMData)
+		if !ok {
+			t.Fatalf("data type = %T, want LLMData", amp.Data)
+		}
+		if data.Model != "gpt-4o-mini-2024-07-18" {
+			t.Errorf("model = %q", data.Model)
+		}
+		if data.Vendor != "openai" {
+			t.Errorf("vendor = %q", data.Vendor)
+		}
+		if data.Temperature == nil || *data.Temperature != 0.7 {
+			t.Errorf("temperature = %v", data.Temperature)
+		}
+		if data.TokenUsage == nil || data.TokenUsage.InputTokens != 12 || data.TokenUsage.OutputTokens != 5 || data.TokenUsage.TotalTokens != 17 {
+			t.Errorf("token usage = %#v", data.TokenUsage)
+		}
+		if len(data.Tools) != 1 || data.Tools[0].Name != "search" {
+			t.Errorf("tools = %#v", data.Tools)
+		}
+		if amp.Status == nil || amp.Status.Error {
+			t.Errorf("status = %#v, want non-error", amp.Status)
+		}
+	})
+
+	t.Run("embedding span", func(t *testing.T) {
+		span := Span{
+			Name: "embeddings text-embedding-3-small",
+			Attributes: map[string]interface{}{
+				"gen_ai.operation.name":     "embeddings",
+				"gen_ai.system":             "openai",
+				"gen_ai.request.model":      "text-embedding-3-small",
+				"gen_ai.usage.input_tokens": float64(8),
+				"gen_ai.prompt.0.content":   "the quick brown fox",
+				"gen_ai.prompt.1.content":   "jumps over the lazy dog",
+			},
+		}
+		amp := ProcessSpan(span).AmpAttributes
+		if amp.Kind != string(SpanTypeEmbedding) {
+			t.Fatalf("kind = %q, want embedding", amp.Kind)
+		}
+		docs, ok := amp.Input.([]string)
+		if !ok || len(docs) != 2 || docs[0] != "the quick brown fox" {
+			t.Errorf("input = %#v", amp.Input)
+		}
+		data, ok := amp.Data.(EmbeddingData)
+		if !ok {
+			t.Fatalf("data type = %T, want EmbeddingData", amp.Data)
+		}
+		if data.Model != "text-embedding-3-small" || data.Vendor != "openai" {
+			t.Errorf("data = %#v", data)
+		}
+		if data.TokenUsage == nil || data.TokenUsage.InputTokens != 8 {
+			t.Errorf("token usage = %#v", data.TokenUsage)
+		}
+	})
+
+	t.Run("tool span detected by operation name with message I/O", func(t *testing.T) {
+		span := Span{
+			Name:   "execute_tool get_weather",
+			Status: "OK",
+			Attributes: map[string]interface{}{
+				"gen_ai.operation.name":  "execute_tool",
+				"gen_ai.system":          "langchain",
+				"gen_ai.tool.name":       "get_weather",
+				"gen_ai.input.messages":  `{"city":"Colombo"}`,
+				"gen_ai.output.messages": `{"temp_c":31}`,
+			},
+		}
+		amp := ProcessSpan(span).AmpAttributes
+		if amp.Kind != string(SpanTypeTool) {
+			t.Fatalf("kind = %q, want tool", amp.Kind)
+		}
+		if amp.Input != `{"city":"Colombo"}` {
+			t.Errorf("input = %#v", amp.Input)
+		}
+		if amp.Output != `{"temp_c":31}` {
+			t.Errorf("output = %#v", amp.Output)
+		}
+		if data, ok := amp.Data.(ToolData); !ok || data.Name != "get_weather" {
+			t.Errorf("data = %#v", amp.Data)
+		}
+	})
+
+	t.Run("agent span detected by operation name", func(t *testing.T) {
+		span := Span{
+			Name: "invoke_agent researcher",
+			Attributes: map[string]interface{}{
+				"gen_ai.operation.name":      "invoke_agent",
+				"gen_ai.system":              "my-framework",
+				"gen_ai.agent.name":          "researcher",
+				"gen_ai.agent.tools":         `["search","summarize"]`,
+				"gen_ai.request.model":       "claude-3-5-sonnet",
+				"gen_ai.system_instructions": "You are a careful researcher.",
+				"gen_ai.conversation.id":     "conv-42",
+				"gen_ai.usage.input_tokens":  float64(100),
+				"gen_ai.usage.output_tokens": float64(40),
+				"gen_ai.input.messages":      `[{"role":"user","content":"research X"}]`,
+				"gen_ai.output.messages":     `[{"role":"assistant","content":"here is X"}]`,
+			},
+		}
+		amp := ProcessSpan(span).AmpAttributes
+		if amp.Kind != string(SpanTypeAgent) {
+			t.Fatalf("kind = %q, want agent", amp.Kind)
+		}
+		if amp.Input != `[{"role":"user","content":"research X"}]` {
+			t.Errorf("input = %#v", amp.Input)
+		}
+		if amp.Output != `[{"role":"assistant","content":"here is X"}]` {
+			t.Errorf("output = %#v", amp.Output)
+		}
+		data, ok := amp.Data.(AgentData)
+		if !ok {
+			t.Fatalf("data type = %T, want AgentData", amp.Data)
+		}
+		if data.Name != "researcher" || data.Model != "claude-3-5-sonnet" || data.Framework != "my-framework" {
+			t.Errorf("data = %#v", data)
+		}
+		if data.SystemPrompt != "You are a careful researcher." {
+			t.Errorf("system prompt = %q", data.SystemPrompt)
+		}
+		if data.ConversationID != "conv-42" {
+			t.Errorf("conversation id = %q", data.ConversationID)
+		}
+		if len(data.Tools) != 2 || data.Tools[0].Name != "search" {
+			t.Errorf("tools = %#v", data.Tools)
+		}
+		if data.TokenUsage == nil || data.TokenUsage.TotalTokens != 140 {
+			t.Errorf("token usage = %#v", data.TokenUsage)
+		}
+	})
+
+	t.Run("retriever span via db.system.name", func(t *testing.T) {
+		span := Span{
+			Name: "qdrant query",
+			Attributes: map[string]interface{}{
+				"db.system.name":        "qdrant",
+				"db.collection.name":    "docs",
+				"db.operation.name":     "query",
+				"db.vector.query.top_k": float64(5),
+			},
+		}
+		amp := ProcessSpan(span).AmpAttributes
+		if amp.Kind != string(SpanTypeRetriever) {
+			t.Fatalf("kind = %q, want retriever", amp.Kind)
+		}
+		data, ok := amp.Data.(RetrieverData)
+		if !ok {
+			t.Fatalf("data type = %T, want RetrieverData", amp.Data)
+		}
+		if data.VectorDB != "qdrant" || data.Collection != "docs" || data.TopK != 5 {
+			t.Errorf("data = %#v", data)
+		}
+	})
+
+	t.Run("error status from span Status code", func(t *testing.T) {
+		span := Span{
+			Name:   "chat gpt-4o",
+			Status: "ERROR",
+			Attributes: map[string]interface{}{
+				"gen_ai.operation.name": "chat",
+				"gen_ai.request.model":  "gpt-4o",
+				"gen_ai.input.messages": `[{"role":"user","content":"hi"}]`,
+			},
+		}
+		amp := ProcessSpan(span).AmpAttributes
+		if amp.Status == nil || !amp.Status.Error {
+			t.Errorf("status = %#v, want error", amp.Status)
+		}
+	})
+}

--- a/traces-observer-service/opensearch/types.go
+++ b/traces-observer-service/opensearch/types.go
@@ -90,8 +90,9 @@ type EmbeddingData struct {
 
 // RetrieverData contains vector database retrieval span information
 type RetrieverData struct {
-	VectorDB string `json:"vectorDB,omitempty"` // Vector database system (e.g., Chroma, Pinecone)
-	TopK     int    `json:"topK,omitempty"`     // Number of top results requested
+	VectorDB   string `json:"vectorDB,omitempty"`   // Vector database system (e.g., chroma, pinecone) — db.system.name or legacy db.system
+	Collection string `json:"collection,omitempty"` // Collection / index name (db.collection.name)
+	TopK       int    `json:"topK,omitempty"`       // Number of top results requested (db.vector.query.top_k)
 }
 
 // AgentData contains agent execution span information


### PR DESCRIPTION
Closes #840

## What

The trace observer (`traces-observer-service/opensearch/process.go`) builds the AMP trace view — span kind, input/output, model, tokens, status, etc. — from span attributes. In several places it relied on OpenLLMetry-specific extension attributes. This change makes it reconstruct that view from the **standard OpenTelemetry GenAI semantic-convention attributes** (`gen_ai.*` / `db.*`), so spans emitted by any conformant instrumentation (not just OpenLLMetry) render with full fidelity and run through evaluators.

The OpenLLMetry/Traceloop extension reads are kept at **higher priority**, so existing auto-instrumented agents are unaffected; the CrewAI handling (`crewai_process.go`) is untouched; the publish pipeline (gateway, collector, OpenSearch indexing) is unchanged.

## Changes

- **Span-kind detection**: recognize `gen_ai.operation.name` — `execute_tool` → tool span, `invoke_agent` / `create_agent` → agent span — in addition to the existing signals. (Previously only `chat` / `completion` / `text_completion` / `embeddings` were recognized via operation name, so a standards-only tool/agent span without `gen_ai.tool.name` / `gen_ai.agent.name` fell through to `unknown`.)
- **Retriever spans**: read the current OpenTelemetry database semantic-convention keys `db.system.name` and `db.operation.name` (preferred over the legacy `db.system` / `db.operation`); add `pgvector` to the recognized vector databases; accept `db.vector.query.top_k` as int / float / string; surface the collection name (`db.collection.name`) on the retriever card (`RetrieverData.collection`, mirrored to the Console types).
- **Tool spans**: fall back to `gen_ai.input.messages` / `gen_ai.output.messages` for tool-call input/output when the existing keys are absent (lowest priority).
- `llm` / `embedding` / `agent` core fields were already derived from `gen_ai.*`; no change there. `gen_ai.tool.description` / `gen_ai.tool.call.id` / `gen_ai.agent.description` are not surfaced yet (no UI fields for them) — consistent with how rerank data and retrieved documents are handled today.

## Tests

`go test ./opensearch/...` is green; `gofmt` / `go vet` clean. Added:
- `TestProcessSpan_PureOTelGenAISpans` — one "standards-only, no OpenLLMetry extensions" case per span kind (`llm`, `embedding`, `tool`, `agent`, `retriever`), plus an error-status case.
- `TestDetermineSpanType_OTelGenAIOperationNames`, `TestExtractToolExecutionDetails_OTelMessagesFallback`, `TestPopulateRetrieverAttributes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collection field to retriever data
  * Extended support for additional database systems, including pgvector

* **Improvements**
  * Enhanced message extraction and span classification with improved fallback mechanisms
  * Refined attribute detection for better trace processing

* **Documentation**
  * Updated attribute documentation

* **Tests**
  * Added comprehensive test coverage for new functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/839)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

