### PR TITLE
agent_configs: add instrumentation_version column

### DIFF
--- a/agent-manager-service/db_migrations/017_add_instrumentation_version_to_agent_configs.go
+++ b/agent-manager-service/db_migrations/017_add_instrumentation_version_to_agent_configs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -16,26 +16,18 @@
 
 package dbmigrations
 
-const latestVersion = 17
+import (
+	"gorm.io/gorm"
+)
 
-// migration list sorted by version.  Add new migrations to the end of the list.
-// Previous migrations should not be modified.
-var migrations = []migration{
-	migration001,
-	migration002,
-	migration003,
-	migration004,
-	migration005,
-	migration006,
-	migration007,
-	migration008,
-	migration009,
-	migration010,
-	migration011,
-	migration012,
-	migration013,
-	migration014,
-	migration015,
-	migration016,
-	migration017,
+// Add a nullable instrumentation_version column to agent_configs.
+// It holds the AMP instrumentation version the customer selected for the agent;
+// NULL means "use the platform default".
+var migration017 = migration{
+	ID: 17,
+	Migrate: func(db *gorm.DB) error {
+		return runSQL(db,
+			`ALTER TABLE agent_configs ADD COLUMN IF NOT EXISTS instrumentation_version VARCHAR(64)`,
+		)
+	},
 }

--- a/agent-manager-service/db_migrations/017_add_instrumentation_version_to_agent_configs.go
+++ b/agent-manager-service/db_migrations/017_add_instrumentation_version_to_agent_configs.go
@@ -26,8 +26,7 @@ import (
 var migration017 = migration{
 	ID: 17,
 	Migrate: func(db *gorm.DB) error {
-		return runSQL(db,
-			`ALTER TABLE agent_configs ADD COLUMN IF NOT EXISTS instrumentation_version VARCHAR(64)`,
-		)
+		addColumn := `ALTER TABLE agent_configs ADD COLUMN IF NOT EXISTS instrumentation_version VARCHAR(64)`
+		return runSQL(db, addColumn)
 	},
 }

--- a/agent-manager-service/models/agent_config.go
+++ b/agent-manager-service/models/agent_config.go
@@ -31,8 +31,11 @@ type AgentConfig struct {
 	AgentName                 string    `gorm:"column:agent_name;not null"`
 	EnvironmentName           string    `gorm:"column:environment_name;not null"`
 	EnableAutoInstrumentation bool      `gorm:"column:enable_auto_instrumentation;not null"`
-	CreatedAt                 time.Time `gorm:"column:created_at;not null;default:NOW()"`
-	UpdatedAt                 time.Time `gorm:"column:updated_at;not null;default:NOW()"`
+	// InstrumentationVersion is the AMP instrumentation version selected for the
+	// agent. Nil means "use the platform default".
+	InstrumentationVersion *string   `gorm:"column:instrumentation_version"`
+	CreatedAt              time.Time `gorm:"column:created_at;not null;default:NOW()"`
+	UpdatedAt              time.Time `gorm:"column:updated_at;not null;default:NOW()"`
 }
 
 func (AgentConfig) TableName() string { return "agent_configs" }

--- a/agent-manager-service/repositories/agent_config_repository.go
+++ b/agent-manager-service/repositories/agent_config_repository.go
@@ -58,6 +58,7 @@ func (r *AgentConfigRepo) Upsert(config *models.AgentConfig) error {
 		Columns: []clause.Column{{Name: "org_name"}, {Name: "project_name"}, {Name: "agent_name"}, {Name: "environment_name"}},
 		DoUpdates: clause.Assignments(map[string]interface{}{
 			"enable_auto_instrumentation": config.EnableAutoInstrumentation,
+			"instrumentation_version":     config.InstrumentationVersion,
 			"updated_at":                  clause.Expr{SQL: "NOW()"},
 		}),
 	}).Create(config).Error


### PR DESCRIPTION
Related to #841.

## What

Adds a nullable `instrumentation_version` column to the `agent_configs` table — the AMP instrumentation version a customer selects for an agent — and wires it through the GORM model and the repository upsert. `NULL` means "use the platform default".

This is the data-layer groundwork; there's no public API for it yet (that lands with the agent create/update endpoints) and nothing reads it yet, so this change is behaviourally inert on its own.

## Changes

- DB migration `017` — `ALTER TABLE agent_configs ADD COLUMN IF NOT EXISTS instrumentation_version VARCHAR(64)`.
- `models.AgentConfig.InstrumentationVersion *string`.
- `AgentConfigRepo.Upsert` persists the column on the conflict-update path (it's already covered on insert via `Select("*")`).

## Tests

`go build ./...`, `go vet`, `go test ./db_migrations/... ./models/... ./repositories/...` all pass; `gofmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent configurations now support instrumentation version selection, allowing users to specify which instrumentation version each agent uses. When not specified, the platform default is applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/848)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->