### PR TITLE
amp-instrumentation: pin traceloop-sdk; add init_otel() helper

### DIFF
--- a/libs/amp-instrumentation/README.md
+++ b/libs/amp-instrumentation/README.md
@@ -38,6 +38,8 @@ export AMP_OTEL_ENDPOINT="https://amp-otel-endpoint.com" # AMP OTEL endpoint
 export AMP_AGENT_API_KEY="your-agent-api-key" # Agent-specific key generated after registration
 ```
 
+Optional: prompt and completion content is captured by default. To suppress it, set `TRACELOOP_TRACE_CONTENT=false`.
+
 ### 3. Run Your Application
 
 Use the `amp-instrument` command to wrap your application run command:

--- a/libs/amp-instrumentation/README.md
+++ b/libs/amp-instrumentation/README.md
@@ -6,6 +6,8 @@ Zero-code OpenTelemetry instrumentation for Python agents using the Traceloop SD
 
 `amp-instrumentation` enables zero-code instrumentation for Python agents, automatically capturing traces for LLM calls, MCP requests, and other operations. It seamlessly wraps your agent’s execution with OpenTelemetry tracing powered by the Traceloop SDK.
 
+For agents on a custom or non-frontier framework — or anywhere you want full control over the spans you emit — it also ships `init_otel()`, a one-line OpenTelemetry exporter setup so you can instrument the agent yourself against AMP's instrumentation contract. See [Manual instrumentation](#manual-instrumentation).
+
 ## Features
 
 - **Zero Code Changes**: Instrument existing applications without modifying code
@@ -13,12 +15,15 @@ Zero-code OpenTelemetry instrumentation for Python agents using the Traceloop SD
 - **OpenTelemetry Compatible**: Uses industry-standard OpenTelemetry protocol
 - **Flexible Configuration**: Configure via environment variables
 - **Framework Agnostic**: Works with any Python application built using a wide range of agent frameworks supported by the TraceLoop SDK
+- **Manual path**: `init_otel()` for agents that emit their own OpenTelemetry GenAI spans
 
 ## Installation
 
 ```bash
 pip install amp-instrumentation
 ```
+
+Each release of `amp-instrumentation` pins a specific Traceloop SDK version, so a given `amp-instrumentation` version always installs a fully determined SDK. To use a different Traceloop SDK version, install a different `amp-instrumentation` version.
 
 ## Quick Start
 
@@ -50,3 +55,31 @@ amp-instrument uv run python script.py
 ```
 
 That's it! Your application is now instrumented and sending traces to the WSO2 Agent Manager.
+
+## Manual instrumentation
+
+If your agent uses a framework the Traceloop SDK doesn't cover — or you want to emit your own spans — instrument it yourself and send the spans to AMP. `init_otel()` configures the OpenTelemetry exporter (the same `AMP_OTEL_ENDPOINT` / `AMP_AGENT_API_KEY` environment variables as above); it does no instrumentation itself, so you control the spans:
+
+```python
+import json
+from opentelemetry import trace
+from amp_instrumentation import init_otel
+
+init_otel()  # reads AMP_OTEL_ENDPOINT and AMP_AGENT_API_KEY from the environment
+tracer = trace.get_tracer("my-agent")
+
+with tracer.start_as_current_span("chat") as span:
+    span.set_attribute("gen_ai.operation.name", "chat")
+    span.set_attribute("gen_ai.system", "openai")
+    span.set_attribute("gen_ai.request.model", "gpt-4o-mini")
+    span.set_attribute("gen_ai.input.messages", json.dumps(input_messages))
+    response = call_model(...)
+    span.set_attribute("gen_ai.response.model", response.model)
+    span.set_attribute("gen_ai.output.messages", json.dumps(response.messages))
+    span.set_attribute("gen_ai.usage.input_tokens", response.usage.input_tokens)
+    span.set_attribute("gen_ai.usage.output_tokens", response.usage.output_tokens)
+```
+
+Spans that follow AMP's instrumentation contract — the OpenTelemetry GenAI semantic conventions — render with the full trace view in the Agent Manager and run through evaluators; spans that don't still appear, just without the rich view. The contract and the full supported-attribute reference are published in the WSO2 Agent Manager documentation (manual instrumentation guide).
+
+`init_otel()` is idempotent and is roughly ten lines of vanilla OpenTelemetry SDK setup (`TracerProvider` + `BatchSpanProcessor` + an OTLP/HTTP exporter to `<AMP_OTEL_ENDPOINT>/v1/traces` with the `x-amp-api-key` header) — use it so you don't have to write that yourself.

--- a/libs/amp-instrumentation/pyproject.toml
+++ b/libs/amp-instrumentation/pyproject.toml
@@ -11,9 +11,16 @@ authors = [
 maintainers = [
     { name = "WSO2", email = "hansi@wso2.org" }
 ]
+# traceloop-sdk is pinned to a specific version (not a range): an installed
+# amp-instrumentation version maps to exactly one OpenLLMetry version. Bumping it
+# is a new amp-instrumentation release. See the AMP instrumentation version mapping.
 dependencies = [
-    "traceloop-sdk>=0.47.0,<=0.60.0",
+    "traceloop-sdk==0.60.0",
     "httpx>=0.25.0",
+    # Used directly by amp_instrumentation.otel.init_otel (also pulled in transitively
+    # by traceloop-sdk); range kept consistent with traceloop-sdk 0.60.0's own pins.
+    "opentelemetry-sdk>=1.38.0,<2",
+    "opentelemetry-exporter-otlp-proto-http>=1.38.0,<2",
 ]
 
 [project.urls]

--- a/libs/amp-instrumentation/pyproject.toml
+++ b/libs/amp-instrumentation/pyproject.toml
@@ -17,10 +17,11 @@ maintainers = [
 dependencies = [
     "traceloop-sdk==0.60.0",
     "httpx>=0.25.0",
-    # Used directly by amp_instrumentation.otel.init_otel (also pulled in transitively
-    # by traceloop-sdk); range kept consistent with traceloop-sdk 0.60.0's own pins.
-    "opentelemetry-sdk>=1.38.0,<2",
-    "opentelemetry-exporter-otlp-proto-http>=1.38.0,<2",
+    # Imported directly by amp_instrumentation.otel.init_otel. Left unconstrained
+    # on purpose: their version is determined by traceloop-sdk==0.60.0, which
+    # already requires both (kept here only to declare the direct import).
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
 ]
 
 [project.urls]

--- a/libs/amp-instrumentation/src/amp_instrumentation/__init__.py
+++ b/libs/amp-instrumentation/src/amp_instrumentation/__init__.py
@@ -18,8 +18,12 @@
 WSO2 Agent Management Platform - Automatic Instrumentation Package
 
 This package provides automatic tracing instrumentation for Python applications
-using the Traceloop SDK and OpenTelemetry.
+using the Traceloop SDK and OpenTelemetry. For agents that instrument themselves
+against the AMP manual-instrumentation contract, :func:`init_otel` configures the
+OTLP exporter without doing any instrumentation.
 """
 
+from .otel import init_otel
+
 __version__ = "0.1.0"
-__all__ = []
+__all__ = ["init_otel"]

--- a/libs/amp-instrumentation/src/amp_instrumentation/__init__.py
+++ b/libs/amp-instrumentation/src/amp_instrumentation/__init__.py
@@ -23,7 +23,15 @@ against the AMP manual-instrumentation contract, :func:`init_otel` configures th
 OTLP exporter without doing any instrumentation.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .otel import init_otel
 
-__version__ = "0.2.0"
+try:
+    # Single source of truth: the version baked into the installed distribution
+    # (set from pyproject.toml's `version`, which the release pipeline updates).
+    __version__ = version("amp-instrumentation")
+except PackageNotFoundError:  # running from a source checkout, not installed
+    __version__ = "0.0.0"
+
 __all__ = ["init_otel"]

--- a/libs/amp-instrumentation/src/amp_instrumentation/__init__.py
+++ b/libs/amp-instrumentation/src/amp_instrumentation/__init__.py
@@ -25,5 +25,5 @@ OTLP exporter without doing any instrumentation.
 
 from .otel import init_otel
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["init_otel"]

--- a/libs/amp-instrumentation/src/amp_instrumentation/otel.py
+++ b/libs/amp-instrumentation/src/amp_instrumentation/otel.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Manual-instrumentation helper.
+
+``init_otel()`` configures the global OpenTelemetry tracer provider to export
+spans over OTLP/HTTP to the AMP gateway, using the ``AMP_OTEL_ENDPOINT`` and
+``AMP_AGENT_API_KEY`` environment variables (the same ones AMP injects into
+platform-hosted agents). It does *no* instrumentation itself — it only wires up
+the exporter so a customer emitting their own OpenTelemetry GenAI spans does not
+have to hand-write the exporter boilerplate. See the manual-instrumentation
+guide for the span-attribute contract those spans should follow.
+"""
+
+import logging
+import os
+import threading
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from ._bootstrap import constants as env_vars
+
+logger = logging.getLogger(__name__)
+
+# OTLP/HTTP traces signal path appended to AMP_OTEL_ENDPOINT.
+_TRACES_PATH = "/v1/traces"
+
+_init_lock = threading.Lock()
+_initialized = False
+
+
+def _traces_endpoint(base: str) -> str:
+    """Return the OTLP/HTTP traces endpoint for the given base AMP endpoint."""
+    base = base.rstrip("/")
+    if base.endswith(_TRACES_PATH):
+        return base
+    return base + _TRACES_PATH
+
+
+def _require_env(name: str) -> str:
+    value = (os.getenv(name) or "").strip()
+    if not value:
+        raise ValueError(f"Environment variable '{name}' is required but not set.")
+    return value
+
+
+def init_otel() -> None:
+    """
+    Configure the global OpenTelemetry tracer provider to export spans to AMP.
+
+    Reads ``AMP_OTEL_ENDPOINT`` and ``AMP_AGENT_API_KEY`` from the environment,
+    sets up a :class:`~opentelemetry.sdk.trace.TracerProvider` with a
+    :class:`~opentelemetry.sdk.trace.export.BatchSpanProcessor` feeding an
+    OTLP/HTTP exporter (``<AMP_OTEL_ENDPOINT>/v1/traces`` with the
+    ``x-amp-api-key`` header), and installs it via
+    :func:`opentelemetry.trace.set_tracer_provider`.
+
+    Idempotent: a second call is a no-op. Instruments no library — the caller is
+    responsible for emitting spans (see the manual-instrumentation guide).
+
+    Raises:
+        ValueError: if ``AMP_OTEL_ENDPOINT`` or ``AMP_AGENT_API_KEY`` is unset.
+    """
+    global _initialized
+
+    with _init_lock:
+        if _initialized:
+            logger.debug("init_otel: already initialized, skipping")
+            return
+
+        endpoint = _require_env(env_vars.AMP_OTEL_ENDPOINT)
+        api_key = _require_env(env_vars.AMP_AGENT_API_KEY)
+
+        provider = TracerProvider()
+        provider.add_span_processor(
+            BatchSpanProcessor(
+                OTLPSpanExporter(
+                    endpoint=_traces_endpoint(endpoint),
+                    headers={"x-amp-api-key": api_key},
+                )
+            )
+        )
+        trace.set_tracer_provider(provider)
+
+        _initialized = True
+        logger.info("init_otel: OpenTelemetry exporter configured for AMP")

--- a/libs/amp-instrumentation/tests/test_otel.py
+++ b/libs/amp-instrumentation/tests/test_otel.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the init_otel manual-instrumentation helper."""
+
+import os
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from amp_instrumentation import otel
+from amp_instrumentation._bootstrap import constants as env_vars
+
+
+class TestTracesEndpoint:
+    """Test the _traces_endpoint helper."""
+
+    @pytest.mark.parametrize(
+        ("base", "expected"),
+        [
+            ("https://otel.example.com", "https://otel.example.com/v1/traces"),
+            ("https://otel.example.com/", "https://otel.example.com/v1/traces"),
+            (
+                "https://otel.example.com/v1/traces",
+                "https://otel.example.com/v1/traces",
+            ),
+            (
+                "https://otel.example.com/v1/traces/",
+                "https://otel.example.com/v1/traces",
+            ),
+        ],
+    )
+    def test_appends_traces_path_once(self, base, expected):
+        assert otel._traces_endpoint(base) == expected
+
+
+class TestInitOtel:
+    """Test the init_otel function."""
+
+    def test_missing_endpoint_raises(self, clean_environment):
+        otel._initialized = False
+        os.environ[env_vars.AMP_AGENT_API_KEY] = "test-key"
+        with pytest.raises(ValueError) as exc_info:
+            otel.init_otel()
+        assert env_vars.AMP_OTEL_ENDPOINT in str(exc_info.value)
+
+    def test_missing_api_key_raises(self, clean_environment):
+        otel._initialized = False
+        os.environ[env_vars.AMP_OTEL_ENDPOINT] = "https://otel.example.com"
+        with pytest.raises(ValueError) as exc_info:
+            otel.init_otel()
+        assert env_vars.AMP_AGENT_API_KEY in str(exc_info.value)
+
+    def test_configures_provider_and_is_idempotent(self, configure_environment):
+        otel._initialized = False
+        otel.init_otel()
+        assert otel._initialized is True
+        assert isinstance(trace.get_tracer_provider(), TracerProvider)
+
+        # A second call must not raise and must not change state.
+        otel.init_otel()
+        assert otel._initialized is True


### PR DESCRIPTION
Closes #845

## What

Two changes to the `amp-instrumentation` package:

1. **Pin `traceloop-sdk` to a specific version** instead of a range. `pyproject.toml` had `traceloop-sdk>=0.47.0,<=0.60.0`; now it's `traceloop-sdk==0.60.0`. Installing a given `amp-instrumentation` version now resolves to exactly one OpenLLMetry version — a bump is a deliberate new release, not whatever pip happens to pick.
2. **Add an `init_otel()` helper** (`amp_instrumentation.otel.init_otel`, re-exported as `from amp_instrumentation import init_otel`) for agents that emit their own OpenTelemetry spans. It configures the global tracer provider — `TracerProvider` + `BatchSpanProcessor` + an OTLP/HTTP exporter pointed at `AMP_OTEL_ENDPOINT` + `/v1/traces` with the `x-amp-api-key` header sourced from `AMP_AGENT_API_KEY` (the same env vars AMP injects). It does **no** instrumentation itself — it just removes the OpenTelemetry exporter boilerplate; the caller emits spans. Idempotent. Raises `ValueError` if either env var is missing.

`opentelemetry-sdk` / `opentelemetry-exporter-otlp-proto-http` are now declared as direct dependencies (the helper imports them; they were already pulled in transitively by `traceloop-sdk`) with ranges that match `traceloop-sdk 0.60.0`'s own pins (`>=1.38.0,<2`).

## Tests

`ruff check .`, `ruff format --check .`, `mypy src`, `pytest` (21 tests, 7 new in `tests/test_otel.py`) all pass; wheel builds and includes `otel.py`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public manual-instrumentation entrypoint to configure OpenTelemetry for AMP and made it idempotent.

* **Documentation**
  * Expanded README with a “manual path” guide, Python examples, note that prompt/completion content is captured by default (can be suppressed), and installation notes about deterministic SDK pinning.

* **Chores**
  * Pinned the Traceloop SDK to a single version for reproducible installs.

* **Tests**
  * Added tests covering the manual-instrumentation flow and endpoint handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/849)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->