### PR TITLE
instrumentation: per-version init-container image (build + resolve)

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -28,7 +28,9 @@
 
   "python-instrumentation-provider": [
     {
-      "versions": ["3.10", "3.11", "3.12", "3.13"]
+      "instrumentation_version": "0.2.0",
+      "traceloop_version": "0.60.0",
+      "python_versions": ["3.10", "3.11", "3.12", "3.13"]
     }
   ],
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       images: ${{ steps.set-matrix.outputs.images }}
-      python-versions: ${{ steps.set-matrix.outputs.python-versions }}
+      instrumentation-images: ${{ steps.set-matrix.outputs.instrumentation-images }}
       charts: ${{ steps.set-matrix.outputs.charts }}
     steps:
       - name: Checkout code
@@ -263,16 +263,20 @@ jobs:
             "chart-file": ($base + "/" + . + "/Chart.yaml")
           }]' "$CONFIG_FILE")
 
-          # Extract Python versions from python-instrumentation-provider
-          PYTHON_VERSIONS=$(jq -c '[.["python-instrumentation-provider"][0].versions[]]' "$CONFIG_FILE")
+          # Expand python-instrumentation-provider into one entry per (AMP instrumentation version × Python version)
+          INSTRUMENTATION_IMAGES=$(jq -c '[.["python-instrumentation-provider"][]
+            | .instrumentation_version as $iv
+            | .traceloop_version as $tv
+            | .python_versions[]
+            | {instrumentation_version: $iv, traceloop_version: $tv, python_version: .}]' "$CONFIG_FILE")
 
           echo "images=$IMAGES" >> $GITHUB_OUTPUT
-          echo "python-versions=$PYTHON_VERSIONS" >> $GITHUB_OUTPUT
+          echo "instrumentation-images=$INSTRUMENTATION_IMAGES" >> $GITHUB_OUTPUT
           echo "charts=$CHARTS" >> $GITHUB_OUTPUT
 
           echo "✅ Loaded configuration:"
           echo "  - Images: $(echo "$IMAGES" | jq '. | length')"
-          echo "  - Python Versions: $(echo "$PYTHON_VERSIONS" | jq '. | length')"
+          echo "  - Instrumentation images: $(echo "$INSTRUMENTATION_IMAGES" | jq '. | length')"
           echo "  - Charts: $(echo "$CHARTS" | jq '. | length')"
         shell: bash
 
@@ -316,7 +320,7 @@ jobs:
           context: ${{ matrix.image.context }}
 
   build-python-instrumentation-provider-images:
-    name: Build Instrumentation Provider Python ${{ matrix.python-version }}
+    name: Build Instrumentation Provider ${{ matrix.image.instrumentation_version }} (Python ${{ matrix.image.python_version }})
     needs: load-config
     runs-on:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
@@ -326,13 +330,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ${{ fromJson(needs.load-config.outputs.python-versions) }}
+        image: ${{ fromJson(needs.load-config.outputs.instrumentation-images) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: amp/v${{ inputs.target_version }}
-          
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -340,17 +344,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Python ${{ matrix.python-version }} image
+      - name: Build and push instrumentation image ${{ matrix.image.instrumentation_version }}-python${{ matrix.image.python_version }}
         uses: ./.github/actions/build-single-platform-docker-image
         with:
           service-dir: python-instrumentation-provider
           image-name: amp-python-instrumentation-provider
           registry: ${{ env.REGISTRY }}
           registry-org: ${{ env.REGISTRY_ORG }}
-          tag: v${{ inputs.target_version }}-python${{ matrix.python-version }}
+          tag: ${{ matrix.image.instrumentation_version }}-python${{ matrix.image.python_version }}
           platform: linux/amd64
           build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
+            PYTHON_VERSION=${{ matrix.image.python_version }}
+            TRACELOOP_VERSION=${{ matrix.image.traceloop_version }}
 
   package-charts:
     name: Package ${{ matrix.chart.name }}
@@ -445,8 +450,8 @@ jobs:
               echo "- \`${REGISTRY}/${REGISTRY_ORG}/${name}:v${VERSION}\`"
             done
 
-            jq -r '.["python-instrumentation-provider"][0].versions[]' "$CONFIG_FILE" | while read -r pyver; do
-              echo "- \`${REGISTRY}/${REGISTRY_ORG}/amp-python-instrumentation-provider:v${VERSION}-python${pyver}\`"
+            jq -r '.["python-instrumentation-provider"][] | .instrumentation_version as $iv | .python_versions[] | "\($iv) \(.)"' "$CONFIG_FILE" | while read -r iv pyver; do
+              echo "- \`${REGISTRY}/${REGISTRY_ORG}/amp-python-instrumentation-provider:${iv}-python${pyver}\`"
             done
 
             echo ""

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -2022,7 +2022,7 @@ func (c *openChoreoClient) buildOTELTraitParameters(ctx context.Context, namespa
 	}
 
 	cfg := config.GetConfig()
-	instrumentationImage, err := getInstrumentationImage(languageVersion, cfg.PackageVersion)
+	instrumentationImage, err := getInstrumentationImage(languageVersion, cfg.OTEL.DefaultInstrumentationVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build instrumentation image: %w", err)
 	}
@@ -2056,13 +2056,16 @@ func (c *openChoreoClient) buildEnvInjectionTraitParameters(opts ...TraitOption)
 	}, nil
 }
 
-func getInstrumentationImage(languageVersion, packageVersion string) (string, error) {
+// getInstrumentationImage builds the pre-built init-container image reference for
+// the given AMP instrumentation version and the agent's Python runtime version,
+// e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.2.0-python3.11.
+func getInstrumentationImage(languageVersion, instrumentationVersion string) (string, error) {
 	parts := strings.Split(languageVersion, ".")
 	if len(parts) < 2 {
 		return "", fmt.Errorf("invalid languageVersion format: expected 'major.minor' but got '%s'", languageVersion)
 	}
 	pythonMajorMinor := parts[0] + "." + parts[1]
-	return fmt.Sprintf("%s/%s:%s-python%s", InstrumentationImageRegistry, InstrumentationImageName, packageVersion, pythonMajorMinor), nil
+	return fmt.Sprintf("%s/%s:%s-python%s", InstrumentationImageRegistry, InstrumentationImageName, instrumentationVersion, pythonMajorMinor), nil
 }
 
 func (c *openChoreoClient) GetComponentEndpoints(ctx context.Context, namespaceName, projectName, componentName, environment string) (map[string]models.EndpointsResponse, error) {

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -165,6 +165,11 @@ type OTELConfig struct {
 	SDKVolumeName string
 	SDKMountPath  string
 
+	// DefaultInstrumentationVersion is the AMP instrumentation version used for an
+	// agent that has not selected one; it resolves to the pre-built
+	// amp-python-instrumentation-provider:<version>-python<X.Y> init-container image.
+	DefaultInstrumentationVersion string
+
 	// Tracing configuration
 	IsTraceContentEnabled bool
 

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -112,6 +112,8 @@ func loadEnvs() {
 		SDKVolumeName: r.readOptionalString("OTEL_SDK_VOLUME_NAME", "otel-tracing-sdk-volume"),
 		SDKMountPath:  r.readOptionalString("OTEL_SDK_MOUNT_PATH", "/otel-tracing-sdk"),
 
+		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.2.0"),
+
 		// Tracing configuration
 		IsTraceContentEnabled: r.readOptionalBool("OTEL_TRACELOOP_TRACE_CONTENT", true),
 

--- a/python-instrumentation-provider/Dockerfile
+++ b/python-instrumentation-provider/Dockerfile
@@ -1,17 +1,22 @@
 ######### OpenLLMetry Instrumentation Image #########
 
-# Build argument to specify Python version (default: 3.11)
+# Python runtime version — must match the agent's Python version (the installed
+# packages, including compiled C extensions, are ABI-tied to it).
 ARG PYTHON_VERSION=3.11
+# traceloop-sdk (OpenLLMetry) version pinned into this image. One pinned version
+# per AMP instrumentation image; bump it by building a new AMP instrumentation version.
+ARG TRACELOOP_VERSION=0.60.0
 
 ############### STAGE 1 — BUILD INSTRUMENTATION PACKAGES ###############
 FROM public.ecr.aws/docker/library/python:${PYTHON_VERSION}-slim AS otel-tracing
+ARG TRACELOOP_VERSION
 
 # Set the working directory where all instrumentation-related build files will be stored.
 WORKDIR /instrumentation
 
 # Copy requirements and install instrumentation-related packages
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt --target packages
+RUN pip install --no-cache-dir -r requirements.txt "traceloop-sdk==${TRACELOOP_VERSION}" --target packages
 
 # #Copy the custom sitecustomize.py into the packages folder.
 COPY sitecustomize.py packages/sitecustomize.py

--- a/python-instrumentation-provider/Makefile
+++ b/python-instrumentation-provider/Makefile
@@ -2,6 +2,8 @@
 
 # Variables
 TAG ?= dev-python3.11
+PYTHON_VERSION ?= 3.11
+TRACELOOP_VERSION ?= 0.60.0
 APP_NAME = ghcr.io/wso2/amp-python-instrumentation-provider
 DOCKER_IMAGE = $(APP_NAME):$(TAG)
 K3D_CLUSTER_NAME = openchoreo-local-setup
@@ -12,7 +14,10 @@ help: ## Show this help message
 
 build: ## Build Docker image
 	@echo "Building $(DOCKER_IMAGE)..."
-	@docker build --platform linux/amd64 -t $(DOCKER_IMAGE) .
+	@docker build --platform linux/amd64 \
+		--build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
+		--build-arg TRACELOOP_VERSION=$(TRACELOOP_VERSION) \
+		-t $(DOCKER_IMAGE) .
 
 docker-load-k3d: build ## Build and load image into k3d cluster
 	@echo "Loading $(DOCKER_IMAGE) into k3d cluster $(K3D_CLUSTER_NAME)..."

--- a/python-instrumentation-provider/RELEASING.md
+++ b/python-instrumentation-provider/RELEASING.md
@@ -1,0 +1,112 @@
+# Releasing a new AMP instrumentation version
+
+This is the maintainer runbook for cutting a new **AMP instrumentation version** —
+the most common reasons being a `traceloop-sdk` (OpenLLMetry) bump or adding/dropping
+a supported Python version. It covers both the init-container image
+(`python-instrumentation-provider/`, this directory) and the PyPI package
+(`libs/amp-instrumentation/`), because they share one version number.
+
+## The model (read this first)
+
+One identifier — the **AMP instrumentation version** (an independent semver, e.g.
+`0.2.0`, *decoupled* from the AMP product release) — drives three artifacts:
+
+| Artifact | What it is | Versioned how |
+|---|---|---|
+| `amp-instrumentation` PyPI package | the externally-hosted auto-instrumentation library + the `init_otel()` helper | the `target_version` you type into the `AMP Instrumentation Release` workflow |
+| `ghcr.io/wso2/amp-python-instrumentation-provider:<version>-python<X.Y>` init-container images | the platform-hosted auto-instrumentation, one image per `(AMP-instr version × Python version)` | the `instrumentation_version` field in `.github/release-config.json` |
+| `agent-manager-service` platform default | the AMP-instr version a Python agent gets when it hasn't selected one | `OTEL_DEFAULT_INSTRUMENTATION_VERSION` env (default in `config_loader.go`) |
+
+Each AMP-instr version pins **exactly one** `traceloop-sdk` version. Existing agents
+stay on the version they were pinned to — bumping the default never moves them.
+
+### Sources of truth — what lives where
+
+| Thing | File / place |
+|---|---|
+| `traceloop-sdk` pin for the **PyPI package** | `libs/amp-instrumentation/pyproject.toml` → `dependencies` → `"traceloop-sdk==<X>"` |
+| **PyPI package version** | the `target_version` input to `.github/workflows/amp_instrumentation_release.yaml` (it `sed`s `pyproject.toml`'s `version`; the repo value is the placeholder `0.0.0-dev`; `__init__.py.__version__` just reads it back from package metadata — don't hand-edit it) |
+| **Image build matrix** (which `(AMP-instr version × Python)` images to build, and the `traceloop-sdk` baked into each) | `.github/release-config.json` → `python-instrumentation-provider` → array of `{ "instrumentation_version", "traceloop_version", "python_versions" }` |
+| **Image build** | `.github/workflows/release.yml` → `build-python-instrumentation-provider-images` job (it reads `release-config.json`; runs on every AMP product release) |
+| **Image build args / defaults** | `python-instrumentation-provider/Dockerfile` (`ARG TRACELOOP_VERSION`, `ARG PYTHON_VERSION`) and `python-instrumentation-provider/Makefile` — these defaults are only for local `docker build` / `make build`; CI always passes the real values from `release-config.json` |
+| **Platform default AMP-instr version** | `agent-manager-service/config/config_loader.go` → `OTEL_DEFAULT_INSTRUMENTATION_VERSION` (env override) |
+| **Customer-facing version → `traceloop-sdk` → supported-Python mapping table** | `documentation/docs/components/amp-instrumentation.mdx` |
+| Console: which Python versions an agent can pick | the `languageVersion` field in `console/workspaces/pages/add-new-agent/` (must stay in sync with the `python_versions` we build images for) |
+
+> The init-container image's Python version **must match the agent's runtime Python** —
+> the image pre-installs `traceloop-sdk` and its compiled-C-extension deps into
+> `packages/`, which the agent's Python loads via `PYTHONPATH`. So we build one image
+> per supported Python version, and the set of `python_versions` in `release-config.json`
+> must cover what the AMP buildpack supports.
+
+---
+
+## Scenario A — bump `traceloop-sdk` (new OpenLLMetry version)
+
+Example: `traceloop-sdk` `0.60.0` → `0.65.0`, cutting AMP-instr version `0.3.0`.
+
+1. **Validate** `traceloop-sdk==0.65.0` against the frontier frameworks (existing
+   validation process — out of scope here). Only cut a version for releases we've validated.
+2. **Pick the new AMP-instr semver.** Minor bump if there's a behaviour change (a new
+   OpenLLMetry usually is); patch for trivial fixes. Say `0.3.0`.
+3. **PyPI package** (`libs/amp-instrumentation/`):
+   - Edit `pyproject.toml` → `dependencies` → `"traceloop-sdk==0.65.0"`. (Leave `version = "0.0.0-dev"` alone.)
+   - PR → review → merge to `main`.
+   - Run the **`AMP Instrumentation Release`** workflow (`amp_instrumentation_release.yaml`,
+     `workflow_dispatch`) with `branch = main`, `target_version = 0.3.0`. It updates
+     `pyproject.toml`'s `version`, builds, publishes `amp-instrumentation==0.3.0` to PyPI,
+     and tags `amp-instrumentation/v0.3.0`.
+4. **Init-container images** (`.github/release-config.json`): **add a new entry** to the
+   `python-instrumentation-provider` array (keep the old ones — see "Retention" below):
+   ```json
+   { "instrumentation_version": "0.3.0", "traceloop_version": "0.65.0", "python_versions": ["3.10", "3.11", "3.12", "3.13"] }
+   ```
+   No Dockerfile change needed. The images get built/pushed on the **next AMP product
+   release** (`release.yml`) as `amp-python-instrumentation-provider:0.3.0-python{X.Y}`.
+   - If you need the images sooner than the next product release, build & push manually:
+     `cd python-instrumentation-provider && make build TAG=0.3.0-python3.11 PYTHON_VERSION=3.11 TRACELOOP_VERSION=0.65.0` then `docker push …`. Repeat per Python version. (Prefer letting CI do it.)
+5. **Make it the platform default** (when you want *new* agents to get `0.3.0`):
+   set `OTEL_DEFAULT_INSTRUMENTATION_VERSION=0.3.0` on the `agent-manager-service`
+   deployment (or change the default in `config_loader.go`). Existing agents are unaffected.
+6. **Docs / mapping table**: add a `0.3.0 → traceloop-sdk 0.65.0 → python 3.10–3.13` row
+   to `documentation/docs/components/amp-instrumentation.mdx`.
+7. **Console** (if a version selector exists): add `0.3.0` to its options.
+
+## Scenario B — add (or drop) a supported Python version
+
+Example: AMP buildpack starts supporting Python `3.14`.
+
+1. **Confirm the buildpack supports it** — an agent can only run on a Python version the
+   buildpack supports; that's what makes the image worth building.
+2. **Init-container images** (`.github/release-config.json`): add `"3.14"` to the
+   `python_versions` array of the AMP-instr version(s) you want it for (typically at least
+   the current one). To *drop* a Python (e.g. EOL `3.10`), remove it — but only once no live
+   agent runs on it; the image stays pullable for whatever versions remain listed in each entry.
+   No Dockerfile change (`ARG PYTHON_VERSION` already parameterizes it).
+3. **Console** (B9): add `"3.14"` to the `languageVersion` dropdown options. Keep this list
+   exactly aligned with the `python_versions` we build images for — if a user picks a Python
+   we have no image for, the init container `ImagePullBackOff`s.
+4. **No PyPI change** — `amp-instrumentation` isn't Python-version-specific (the per-Python
+   pre-install only matters for the init-container image; on the externally-hosted path the
+   user's own environment provides the Python).
+5. **Docs**: update the supported-Python list / mapping table in `amp-instrumentation.mdx`.
+
+## Retention
+
+Keep **every published `instrumentation_version` entry** in `release-config.json` — the
+images are small, and agents pinned to an old version need their image to stay pullable
+(the release workflow simply rebuilds whatever's listed, picking up base-image patches).
+Only prune a very old entry after confirming no agent pins it.
+
+## Verifying a release
+
+- **PyPI:** `pip install amp-instrumentation==0.3.0 && pip show traceloop-sdk` (expect the pinned version) and `python -c "import amp_instrumentation; print(amp_instrumentation.__version__)"` (expect `0.3.0`).
+- **Image:** `docker run --rm ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python3.11 sh -c 'cat /instrumentations/otel-tracing/traceloop_sdk-*.dist-info/METADATA | grep ^Version'` (or just `ls /instrumentations/otel-tracing/`).
+- **agent-manager-service:** deploy a Python agent with auto-instrumentation on; confirm the init container in the pod is `…:<expected version>-python<agent's Python>`.
+
+## Quick reference — what changes where
+
+| Change | `libs/amp-instrumentation/pyproject.toml` | `amp_instrumentation_release.yaml` run | `.github/release-config.json` | `agent-manager-service` env | `amp-instrumentation.mdx` | Console `languageVersion` |
+|---|---|---|---|---|---|---|
+| Bump `traceloop-sdk` (new AMP-instr version) | `traceloop-sdk==<new>` | `target_version=<new AMP-instr version>` | add `{instrumentation_version, traceloop_version, python_versions}` entry | bump `OTEL_DEFAULT_INSTRUMENTATION_VERSION` when promoting to default | add a row | add the version (if listed) |
+| Add a supported Python | — | — | add `"3.X"` to `python_versions` | — | update the Python list | add `"3.X"` |

--- a/python-instrumentation-provider/RELEASING.md
+++ b/python-instrumentation-provider/RELEASING.md
@@ -39,6 +39,40 @@ stay on the version they were pinned to — bumping the default never moves them
 > per supported Python version, and the set of `python_versions` in `release-config.json`
 > must cover what the AMP buildpack supports.
 
+### When do the artifacts actually publish?
+
+**Neither artifact is published by a PR merge.** Both release workflows are
+`workflow_dispatch`-only — they run when someone *manually* dispatches them with a
+target version:
+
+- **PyPI package** — `.github/workflows/amp_instrumentation_release.yaml`. Type the
+  `target_version` (e.g. `0.3.0`) and the chosen `branch` (usually `main`); the
+  workflow `sed`s `pyproject.toml`'s `version`, builds, publishes to PyPI, and tags
+  `amp-instrumentation/v<target_version>`. **Run this when** you've merged the
+  `traceloop-sdk` pin update and want to publish a new PyPI version.
+- **Init-container images** — `.github/workflows/release.yml` (the *AMP product*
+  release workflow). It reads `release-config.json` and rebuilds the *full*
+  `(instrumentation_version × python_versions)` matrix on every run; pushes
+  `amp-python-instrumentation-provider:<instr_version>-python<X.Y>`. **Run this when**
+  the next AMP product release is being cut.
+
+So when you add a new instrumentation-version entry to `release-config.json` (or a
+new Python to an existing entry) and merge the PR — **the images don't appear
+immediately**. They publish on the next AMP product release run; the entry just
+tells that run what to build.
+
+If you genuinely need an image published before the next product release: trigger
+`release.yml` manually with whatever `target_version` makes sense (it'll rebuild
+everything in `release-config.json`, which is idempotent for the `traceloop-sdk`
+pin — only the OS base layer refreshes). Avoid pushing from a local `make build`
+unless absolutely necessary — that bypasses CI.
+
+Every subsequent AMP product release re-runs the same image builds (the matrix in
+`release-config.json` doesn't change unless edited), so the same tag gets pushed
+again with a refreshed base layer (security patches in `python:X.Y-slim`). That's
+expected: the traceloop pin is identical, the tag is logically *"AMP-instr version
+X for Python Y"*, and the OS refresh is a feature, not drift.
+
 ---
 
 ## Scenario A — bump `traceloop-sdk` (new OpenLLMetry version)

--- a/python-instrumentation-provider/requirements.txt
+++ b/python-instrumentation-provider/requirements.txt
@@ -1,4 +1,4 @@
-# Traceloop SDK (OpenLLMetry)
-
-traceloop-sdk>=0.47.0,<=0.60.0
+# traceloop-sdk (OpenLLMetry) is installed by the Dockerfile from the
+# TRACELOOP_VERSION build arg, so the pinned version is set per AMP
+# instrumentation image. This file holds only the always-needed extras.
 httpx>=0.25.0


### PR DESCRIPTION
Closes #843
Related to #842

## What

Build the Python instrumentation init-container image **per AMP instrumentation version** — one pinned `traceloop-sdk` baked into each — and tag it off that version (`amp-python-instrumentation-provider:0.2.0-python3.11`) instead of the AMP product release. `agent-manager-service` now resolves a Python agent's init-container image from the instrumentation version.

This is the platform-hosted side of the instrumentation-versioning work. It's a coherent unit — the image build and the consuming side switch together, so there's no broken intermediate state.

## What gets released

Triggered by the next AMP product release (`.github/workflows/release.yml`, `workflow_dispatch`) after this merges — the workflow reads `release-config.json` and pushes the matrix below to `ghcr.io/wso2`. Merging this PR alone does **not** publish anything.

| Image | Python | `traceloop-sdk` |
|---|---|---|
| `amp-python-instrumentation-provider:0.2.0-python3.10` | 3.10 | 0.60.0 |
| `amp-python-instrumentation-provider:0.2.0-python3.11` | 3.11 | 0.60.0 |
| `amp-python-instrumentation-provider:0.2.0-python3.12` | 3.12 | 0.60.0 |
| `amp-python-instrumentation-provider:0.2.0-python3.13` | 3.13 | 0.60.0 |

`agent-manager-service`'s `OTEL_DEFAULT_INSTRUMENTATION_VERSION` defaults to `0.2.0`, so a Python agent on Python `X.Y` will pick up `amp-python-instrumentation-provider:0.2.0-pythonX.Y` once the deployment is running this build.

The PyPI side (`amp-instrumentation==0.2.0` pinning `traceloop-sdk==0.60.0`) shipped in #849 and is its own `workflow_dispatch` release — not part of this PR.

## Changes

**`python-instrumentation-provider/`**
- `requirements.txt` — drops `traceloop-sdk` (now installed via a build arg); keeps `httpx>=0.25.0`.
- `Dockerfile` — adds `ARG TRACELOOP_VERSION` (default `0.60.0`, re-declared inside the build stage), and installs `traceloop-sdk==${TRACELOOP_VERSION}`. The Python version `ARG` is unchanged; note the image's Python version must match the agent's runtime Python (the installed packages, including compiled C extensions, are ABI-tied to it).
- `Makefile` — passes `PYTHON_VERSION` / `TRACELOOP_VERSION` build args (defaults `3.11` / `0.60.0`).

**Release CI**
- `.github/release-config.json` — `python-instrumentation-provider` now lists `{instrumentation_version, traceloop_version, python_versions}` — `0.2.0` / `0.60.0` / `[3.10, 3.11, 3.12, 3.13]`.
- `.github/workflows/release.yml` — `load-config` emits a flattened `(instrumentation version × python)` matrix; `build-python-instrumentation-provider-images` builds each entry as `amp-python-instrumentation-provider:{version}-python{X.Y}`, passing `PYTHON_VERSION` + `TRACELOOP_VERSION`; the release-notes image listing is updated to the new tag scheme.

**`agent-manager-service/`**
- `config` — new `OTEL.DefaultInstrumentationVersion` (env `OTEL_DEFAULT_INSTRUMENTATION_VERSION`, default `0.2.0`).
- `clients/openchoreosvc/client/components.go` — `getInstrumentationImage` now keys off the AMP instrumentation version (was `cfg.PackageVersion`, the AMP product version), so a Python agent's init container is `amp-python-instrumentation-provider:0.2.0-python{X.Y}`.

## Not in this PR

Reading the *per-agent* `agent_configs.instrumentation_version` (the column already added) as an override of the default — that goes with the agent create/update API change (which also handles "preserve the existing pin when the field is omitted"). Constraining the Console `languageVersion` field to a dropdown of supported Python versions is also a follow-up.

## Notes

- Why `0.2.0`: `amp-instrumentation` is already on PyPI through `0.1.7`; this is the next release (a minor bump given the new `init_otel()` API and the SDK pin landed in #849). The PyPI package, the init-container image tag, and the platform default all use the same `0.2.0`.
- I didn't run a local `docker build` of the per-version image (the `ARG` pattern is standard and mirrors the existing `PYTHON_VERSION` re-declaration); `go build` / `go vet` / `gofumpt`, the `release.yml` YAML and the `release-config.json` JSON all validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple Python instrumentation provider image variants with independent version tracking.
  * Expanded Python version support to include 3.10, 3.11, 3.12, and 3.13.
  * Introduced configurable default instrumentation version for agent deployments via environment variables.

* **Chores**
  * Updated Traceloop SDK version to 0.60.0 and default instrumentation version to 0.2.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/852)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
