### PR TITLE
setup-console-local: use rush install to keep pnpm-lock stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ setup-gateway:
 		echo "⚠️  Rush not found. Installing Rush globally..."; \
 		npm install -g @microsoft/rush@5.157.0; \
 	fi
-	@echo "📥 Running rush update..."
-	@cd console && rush update --full
+	@echo "📥 Running rush install..."
+	@cd console && rush install
 	@touch .make/console-deps-installed
 
 .make/console-built: .make/console-deps-installed


### PR DESCRIPTION
Switch `setup-console-local` from `rush update --full` to `rush install` so running `make setup` no longer re-resolves every transitive dep against the live registry and rewrites `console/common/config/rush/pnpm-lock.yaml`.

`rush install` honors the committed lockfile and errors if `package.json` drifts from it — the explicit `setup-console-local-force` path is still available for intentional updates.