### PR TITLE
ci: standalone workflow to release instrumentation images on demand

### DIFF
--- a/.github/workflows/python_instrumentation_image_release.yaml
+++ b/.github/workflows/python_instrumentation_image_release.yaml
@@ -1,0 +1,144 @@
+name: AMP Python Instrumentation Image Release
+
+# Standalone release workflow for the per-version python-instrumentation-provider
+# init-container images. Builds and pushes
+#   ghcr.io/wso2/amp-python-instrumentation-provider:<instrumentation_version>-python<X.Y>
+# for one (or all) entries in .github/release-config.json's
+# `python-instrumentation-provider` array, independent of the AMP product release
+# in release.yml. Pair it with amp_instrumentation_release.yaml (which publishes
+# the PyPI package): together they let an AMP instrumentation version ship without
+# cutting an AMP product release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Source ref to build from (branch name or commit SHA)"
+        required: false
+        default: main
+        type: string
+      instrumentation_version:
+        description: "AMP instrumentation version to release (must exist in .github/release-config.json), or 'all' to rebuild every listed version"
+        required: true
+        default: all
+        type: string
+
+run-name: AMP Python Instrumentation Image Release ${{ inputs.instrumentation_version }} (from ${{ inputs.branch }})
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_ORG: wso2
+
+jobs:
+  load-config:
+    name: Load instrumentation-image matrix
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    outputs:
+      instrumentation-images: ${{ steps.set-matrix.outputs.instrumentation-images }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Build matrix
+        id: set-matrix
+        env:
+          INSTR_VERSION: ${{ inputs.instrumentation_version }}
+        run: |
+          CONFIG_FILE=".github/release-config.json"
+
+          INSTRUMENTATION_IMAGES=$(jq -c --arg iv "$INSTR_VERSION" '
+            [.["python-instrumentation-provider"][]
+             | select($iv == "all" or .instrumentation_version == $iv)
+             | .instrumentation_version as $v
+             | .traceloop_version as $tv
+             | .python_versions[]
+             | {instrumentation_version: $v, traceloop_version: $tv, python_version: .}]
+          ' "$CONFIG_FILE")
+
+          COUNT=$(echo "$INSTRUMENTATION_IMAGES" | jq '. | length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "❌ No instrumentation images matched '$INSTR_VERSION' in $CONFIG_FILE."
+            echo "Available versions:"
+            jq -r '.["python-instrumentation-provider"][] | "  - " + .instrumentation_version' "$CONFIG_FILE"
+            exit 1
+          fi
+
+          echo "instrumentation-images=$INSTRUMENTATION_IMAGES" >> $GITHUB_OUTPUT
+          echo "✅ Will build $COUNT image(s) for '$INSTR_VERSION':"
+          echo "$INSTRUMENTATION_IMAGES" | jq -r '.[] | "  - " + .instrumentation_version + "-python" + .python_version + " (traceloop-sdk " + .traceloop_version + ")"'
+        shell: bash
+
+  build-images:
+    name: Build ${{ matrix.image.instrumentation_version }}-python${{ matrix.image.python_version }}
+    needs: load-config
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        image: ${{ fromJson(needs.load-config.outputs.instrumentation-images) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.image.instrumentation_version }}-python${{ matrix.image.python_version }}
+        uses: ./.github/actions/build-single-platform-docker-image
+        with:
+          service-dir: python-instrumentation-provider
+          image-name: amp-python-instrumentation-provider
+          registry: ${{ env.REGISTRY }}
+          registry-org: ${{ env.REGISTRY_ORG }}
+          tag: ${{ matrix.image.instrumentation_version }}-python${{ matrix.image.python_version }}
+          platform: linux/amd64
+          build-args: |
+            PYTHON_VERSION=${{ matrix.image.python_version }}
+            TRACELOOP_VERSION=${{ matrix.image.traceloop_version }}
+
+  summary:
+    name: Summary
+    needs: build-images
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    if: always()
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Print published images
+        env:
+          INSTR_VERSION: ${{ inputs.instrumentation_version }}
+        run: |
+          if [ "${{ needs.build-images.result }}" != "success" ]; then
+            echo "❌ One or more image builds failed; nothing was published from this run for the matrix entries that failed."
+            exit 1
+          fi
+          echo "## ✅ AMP Python Instrumentation Image Release ($INSTR_VERSION)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Pushed to \`${REGISTRY}/${REGISTRY_ORG}\`:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          jq -r --arg iv "$INSTR_VERSION" '
+            .["python-instrumentation-provider"][]
+            | select($iv == "all" or .instrumentation_version == $iv)
+            | .instrumentation_version as $v
+            | .traceloop_version as $tv
+            | .python_versions[]
+            | "- `\($v)-python\(.)`  (traceloop-sdk \($tv))"
+          ' .github/release-config.json >> "$GITHUB_STEP_SUMMARY"
+        shell: bash

--- a/python-instrumentation-provider/RELEASING.md
+++ b/python-instrumentation-provider/RELEASING.md
@@ -27,7 +27,8 @@ stay on the version they were pinned to — bumping the default never moves them
 | `traceloop-sdk` pin for the **PyPI package** | `libs/amp-instrumentation/pyproject.toml` → `dependencies` → `"traceloop-sdk==<X>"` |
 | **PyPI package version** | the `target_version` input to `.github/workflows/amp_instrumentation_release.yaml` (it `sed`s `pyproject.toml`'s `version`; the repo value is the placeholder `0.0.0-dev`; `__init__.py.__version__` just reads it back from package metadata — don't hand-edit it) |
 | **Image build matrix** (which `(AMP-instr version × Python)` images to build, and the `traceloop-sdk` baked into each) | `.github/release-config.json` → `python-instrumentation-provider` → array of `{ "instrumentation_version", "traceloop_version", "python_versions" }` |
-| **Image build** | `.github/workflows/release.yml` → `build-python-instrumentation-provider-images` job (it reads `release-config.json`; runs on every AMP product release) |
+| **Image build (primary)** | `.github/workflows/python_instrumentation_image_release.yaml` — standalone `workflow_dispatch` (inputs `branch`, `instrumentation_version`); reads `release-config.json`, filters to the requested version, builds & pushes that matrix. Use this to ship images independently of an AMP product release. |
+| **Image build (also runs on every AMP product release)** | `.github/workflows/release.yml` → `build-python-instrumentation-provider-images` job — same `release-config.json` matrix, but rebuilds **every** listed version on each product release (refreshes base-image layers). |
 | **Image build args / defaults** | `python-instrumentation-provider/Dockerfile` (`ARG TRACELOOP_VERSION`, `ARG PYTHON_VERSION`) and `python-instrumentation-provider/Makefile` — these defaults are only for local `docker build` / `make build`; CI always passes the real values from `release-config.json` |
 | **Platform default AMP-instr version** | `agent-manager-service/config/config_loader.go` → `OTEL_DEFAULT_INSTRUMENTATION_VERSION` (env override) |
 | **Customer-facing version → `traceloop-sdk` → supported-Python mapping table** | `documentation/docs/components/amp-instrumentation.mdx` |
@@ -41,31 +42,36 @@ stay on the version they were pinned to — bumping the default never moves them
 
 ### When do the artifacts actually publish?
 
-**Neither artifact is published by a PR merge.** Both release workflows are
-`workflow_dispatch`-only — they run when someone *manually* dispatches them with a
-target version:
+**Neither artifact is published by a PR merge.** All three release workflows are
+`workflow_dispatch`-only — they run when someone *manually* dispatches them:
 
 - **PyPI package** — `.github/workflows/amp_instrumentation_release.yaml`. Type the
   `target_version` (e.g. `0.3.0`) and the chosen `branch` (usually `main`); the
   workflow `sed`s `pyproject.toml`'s `version`, builds, publishes to PyPI, and tags
   `amp-instrumentation/v<target_version>`. **Run this when** you've merged the
   `traceloop-sdk` pin update and want to publish a new PyPI version.
-- **Init-container images** — `.github/workflows/release.yml` (the *AMP product*
-  release workflow). It reads `release-config.json` and rebuilds the *full*
-  `(instrumentation_version × python_versions)` matrix on every run; pushes
-  `amp-python-instrumentation-provider:<instr_version>-python<X.Y>`. **Run this when**
-  the next AMP product release is being cut.
+- **Init-container images — standalone (primary path)**:
+  `.github/workflows/python_instrumentation_image_release.yaml`. Inputs: `branch`
+  and `instrumentation_version` (a specific version like `0.3.0`, or `all`). It reads
+  `release-config.json`, filters to the requested version, and builds & pushes the
+  matching `(instr × python)` matrix as
+  `amp-python-instrumentation-provider:<instr_version>-python<X.Y>`. **Use this
+  whenever you want to ship instrumentation images independently of an AMP product
+  release** (the common case).
+- **Init-container images — bundled with the AMP product release**:
+  `.github/workflows/release.yml` (the *AMP product* release workflow) also builds
+  the *full* `release-config.json` matrix as part of every product release. So even
+  if you never trigger the standalone workflow, each product release rebuilds every
+  listed instrumentation image with the latest base-image layers.
 
 So when you add a new instrumentation-version entry to `release-config.json` (or a
 new Python to an existing entry) and merge the PR — **the images don't appear
-immediately**. They publish on the next AMP product release run; the entry just
-tells that run what to build.
+immediately**. You publish them by dispatching the standalone workflow (the
+preferred path), or wait for the next AMP product release. The entry in
+`release-config.json` just tells whichever workflow runs *what* to build.
 
-If you genuinely need an image published before the next product release: trigger
-`release.yml` manually with whatever `target_version` makes sense (it'll rebuild
-everything in `release-config.json`, which is idempotent for the `traceloop-sdk`
-pin — only the OS base layer refreshes). Avoid pushing from a local `make build`
-unless absolutely necessary — that bypasses CI.
+Avoid pushing from a local `make build` for customer-pullable images — that bypasses
+CI and leaves no audit trail.
 
 Every subsequent AMP product release re-runs the same image builds (the matrix in
 `release-config.json` doesn't change unless edited), so the same tag gets pushed
@@ -95,10 +101,13 @@ Example: `traceloop-sdk` `0.60.0` → `0.65.0`, cutting AMP-instr version `0.3.0
    ```json
    { "instrumentation_version": "0.3.0", "traceloop_version": "0.65.0", "python_versions": ["3.10", "3.11", "3.12", "3.13"] }
    ```
-   No Dockerfile change needed. The images get built/pushed on the **next AMP product
-   release** (`release.yml`) as `amp-python-instrumentation-provider:0.3.0-python{X.Y}`.
-   - If you need the images sooner than the next product release, build & push manually:
-     `cd python-instrumentation-provider && make build TAG=0.3.0-python3.11 PYTHON_VERSION=3.11 TRACELOOP_VERSION=0.65.0` then `docker push …`. Repeat per Python version. (Prefer letting CI do it.)
+   No Dockerfile change needed. Merge the PR, then publish the images by dispatching the
+   **`AMP Python Instrumentation Image Release`** workflow
+   (`python_instrumentation_image_release.yaml`) with `branch = main`,
+   `instrumentation_version = 0.3.0`. It builds & pushes the `(0.3.0 × supported python)`
+   matrix to `amp-python-instrumentation-provider:0.3.0-python{X.Y}`. (You don't have to
+   wait for an AMP product release — that workflow is independent. The next product
+   release will also rebuild this matrix, refreshing the base layers — that's fine.)
 5. **Make it the platform default** (when you want *new* agents to get `0.3.0`):
    set `OTEL_DEFAULT_INSTRUMENTATION_VERSION=0.3.0` on the `agent-manager-service`
    deployment (or change the default in `config_loader.go`). Existing agents are unaffected.
@@ -140,7 +149,7 @@ Only prune a very old entry after confirming no agent pins it.
 
 ## Quick reference — what changes where
 
-| Change | `libs/amp-instrumentation/pyproject.toml` | `amp_instrumentation_release.yaml` run | `.github/release-config.json` | `agent-manager-service` env | `amp-instrumentation.mdx` | Console `languageVersion` |
-|---|---|---|---|---|---|---|
-| Bump `traceloop-sdk` (new AMP-instr version) | `traceloop-sdk==<new>` | `target_version=<new AMP-instr version>` | add `{instrumentation_version, traceloop_version, python_versions}` entry | bump `OTEL_DEFAULT_INSTRUMENTATION_VERSION` when promoting to default | add a row | add the version (if listed) |
-| Add a supported Python | — | — | add `"3.X"` to `python_versions` | — | update the Python list | add `"3.X"` |
+| Change | `libs/amp-instrumentation/pyproject.toml` | `amp_instrumentation_release.yaml` run | `.github/release-config.json` | `python_instrumentation_image_release.yaml` run | `agent-manager-service` env | `amp-instrumentation.mdx` | Console `languageVersion` |
+|---|---|---|---|---|---|---|---|
+| Bump `traceloop-sdk` (new AMP-instr version) | `traceloop-sdk==<new>` | `target_version=<new AMP-instr version>` | add `{instrumentation_version, traceloop_version, python_versions}` entry | `instrumentation_version=<new>` to publish the images | bump `OTEL_DEFAULT_INSTRUMENTATION_VERSION` when promoting to default | add a row | add the version (if listed) |
+| Add a supported Python | — | — | add `"3.X"` to `python_versions` | re-run (`all` or the affected version) to publish the new-Python images | — | update the Python list | add `"3.X"` |


### PR DESCRIPTION
Related to #847

## What

Add a workflow that builds and pushes the per-version `amp-python-instrumentation-provider` init-container images independent of the AMP product release.

Today (after #852 merged), publishing a new AMP instrumentation version requires either (a) waiting for the next AMP product release to cut, or (b) triggering `release.yml` with an RC `target_version` — which creates an AMP release branch and rebuilds the whole product just to publish a single set of init-container images. That contradicts the design intent that the AMP instrumentation version is decoupled from the AMP product version.

This PR closes that gap. The PyPI side was already decoupled (`amp_instrumentation_release.yaml`). Now the image side is too. Together they let an AMP-instrumentation release ship without touching the AMP product.

## Changes

- **`.github/workflows/python_instrumentation_image_release.yaml`** (new): `workflow_dispatch` with inputs `branch` (default `main`) and `instrumentation_version` (a specific version, e.g. `0.2.0`, or `all` to rebuild every entry in `release-config.json`). It reads `release-config.json`, filters the `(instrumentation_version × python_versions)` matrix, and builds & pushes each entry as `ghcr.io/wso2/amp-python-instrumentation-provider:<v>-python<X.Y>` using the existing `.github/actions/build-single-platform-docker-image` action — same logic the AMP product release uses, just in its own workflow. Emits a markdown step summary listing what was pushed; fails with a clear "available versions" listing if the requested `instrumentation_version` isn't in `release-config.json`.
- **`python-instrumentation-provider/RELEASING.md`**: point at the new workflow as the *primary* image-release path; keep the AMP-product-release path documented as the "also runs on every product release, refreshes base layers" route. Updates the *"When do the artifacts actually publish?"* section and the *Quick reference* matrix to include the new trigger.
- `.github/workflows/release.yml` is **not** modified — the `build-python-instrumentation-provider-images` job stays exactly as it is, so every AMP product release still rebuilds the full matrix (base-layer refresh is a feature, not drift).

## How to trigger

```bash
# Publish just one AMP-instr version (typical case for a new release):
gh workflow run python_instrumentation_image_release.yaml \
  --repo wso2/agent-manager --ref main \
  -f branch=main -f instrumentation_version=0.2.0

# Rebuild every version in release-config.json (e.g. after a base-image security advisory):
gh workflow run python_instrumentation_image_release.yaml \
  --repo wso2/agent-manager --ref main \
  -f branch=main -f instrumentation_version=all
```

## What gets released

Same shape as #852 — depending on the input, the workflow pushes one or more rows of:

| Image | Python | `traceloop-sdk` |
|---|---|---|
| `amp-python-instrumentation-provider:<instr_version>-python3.10` | 3.10 | (per `release-config.json`) |
| `amp-python-instrumentation-provider:<instr_version>-python3.11` | 3.11 | (per `release-config.json`) |
| `amp-python-instrumentation-provider:<instr_version>-python3.12` | 3.12 | (per `release-config.json`) |
| `amp-python-instrumentation-provider:<instr_version>-python3.13` | 3.13 | (per `release-config.json`) |

For the current `release-config.json` that's `0.2.0` pinning `traceloop-sdk 0.60.0` × `[3.10, 3.11, 3.12, 3.13]`.

## Tests

Verified locally:
- YAML parses (`yaml.safe_load`); 3 jobs: `load-config`, `build-images`, `summary`.
- The `jq` matrix-filter expression returns 4 entries for `instrumentation_version=0.2.0`, 4 for `all`, and `[]` for an unknown version (the workflow then exits with a listing of available versions).
- The 4-image build itself was verified end-to-end while preparing #852 (each image built successfully, `traceloop-sdk Version: 0.60.0` baked into `/instrumentations/otel-tracing/`, sizes ~62–65 MB) — the workflow runs that same Dockerfile + ARG matrix via the same shared action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated GitHub Actions workflow for building and publishing Python instrumentation Docker images with version-specific and Python-version-specific tags.

* **Documentation**
  * Updated release runbook to document the new image publishing workflow and manual dispatch procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/856)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->