### PR TITLE
agent_configs: per-agent instrumentation version (API + override + backfill)

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -1940,6 +1940,18 @@ func WithLanguageVersion(lv string) TraitOption {
 	}
 }
 
+// WithInstrumentationVersion pins the AMP instrumentation version for the OTEL
+// instrumentation trait — the init-container image resolves to
+// `amp-python-instrumentation-provider:<instrumentation_version>-python<X.Y>`.
+// Nil falls back to the platform default (cfg.OTEL.DefaultInstrumentationVersion).
+func WithInstrumentationVersion(version *string) TraitOption {
+	return func(params map[string]interface{}) {
+		if version != nil && *version != "" {
+			params["instrumentationVersion"] = *version
+		}
+	}
+}
+
 func (c *openChoreoClient) buildTrait(ctx context.Context, namespaceName, projectName, componentName string, req TraitRequest) (gen.ComponentTrait, error) {
 	if req.TraitKind == "" {
 		return gen.ComponentTrait{}, fmt.Errorf("trait kind is required")
@@ -2022,7 +2034,14 @@ func (c *openChoreoClient) buildOTELTraitParameters(ctx context.Context, namespa
 	}
 
 	cfg := config.GetConfig()
-	instrumentationImage, err := getInstrumentationImage(languageVersion, cfg.OTEL.DefaultInstrumentationVersion)
+
+	// Per-agent instrumentation version (from WithInstrumentationVersion) overrides
+	// the platform default; an empty/unset value falls back to the default.
+	instrumentationVersion, _ := params["instrumentationVersion"].(string)
+	if instrumentationVersion == "" {
+		instrumentationVersion = cfg.OTEL.DefaultInstrumentationVersion
+	}
+	instrumentationImage, err := getInstrumentationImage(languageVersion, instrumentationVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build instrumentation image: %w", err)
 	}

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -170,6 +170,11 @@ type OTELConfig struct {
 	// amp-python-instrumentation-provider:<version>-python<X.Y> init-container image.
 	DefaultInstrumentationVersion string
 
+	// SupportedInstrumentationVersions is the set of AMP instrumentation versions an
+	// agent may pin to. The default must be in this set. Requests setting a value
+	// outside the set are rejected.
+	SupportedInstrumentationVersions []string
+
 	// Tracing configuration
 	IsTraceContentEnabled bool
 

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"slices"
 
 	"github.com/joho/godotenv"
 )
@@ -324,15 +325,12 @@ func validateInstrumentationVersionConfig(cfg *Config, r *configReader) {
 		r.errors = append(r.errors, fmt.Errorf("OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS must not be empty"))
 		return
 	}
-	for _, v := range cfg.OTEL.SupportedInstrumentationVersions {
-		if v == cfg.OTEL.DefaultInstrumentationVersion {
-			return
-		}
+	if !slices.Contains(cfg.OTEL.SupportedInstrumentationVersions, cfg.OTEL.DefaultInstrumentationVersion) {
+		r.errors = append(r.errors, fmt.Errorf(
+			"OTEL_DEFAULT_INSTRUMENTATION_VERSION %q must be in OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS %v",
+			cfg.OTEL.DefaultInstrumentationVersion, cfg.OTEL.SupportedInstrumentationVersions,
+		))
 	}
-	r.errors = append(r.errors, fmt.Errorf(
-		"OTEL_DEFAULT_INSTRUMENTATION_VERSION %q must be in OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS %v",
-		cfg.OTEL.DefaultInstrumentationVersion, cfg.OTEL.SupportedInstrumentationVersions,
-	))
 }
 
 func validateInternalServerConfigs(cfg *Config, r *configReader) {

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -114,6 +114,8 @@ func loadEnvs() {
 
 		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.2.0"),
 
+		SupportedInstrumentationVersions: r.readOptionalStringList("OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS", "0.2.0"),
+
 		// Tracing configuration
 		IsTraceContentEnabled: r.readOptionalBool("OTEL_TRACELOOP_TRACE_CONTENT", true),
 

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -240,6 +240,7 @@ func loadEnvs() {
 	validateOAuthAuthorizationServers(config, r)
 	validateServerPublicURL(config, r)
 	validateInstrumentationURL(config, r)
+	validateInstrumentationVersionConfig(config, r)
 
 	r.logAndExitIfErrorsFound()
 
@@ -316,6 +317,22 @@ func validateInstrumentationURL(cfg *Config, r *configReader) {
 	if u.Host == "" {
 		r.errors = append(r.errors, fmt.Errorf("INSTRUMENTATION_URL %q must have a non-empty host", cfg.InstrumentationURL))
 	}
+}
+
+func validateInstrumentationVersionConfig(cfg *Config, r *configReader) {
+	if len(cfg.OTEL.SupportedInstrumentationVersions) == 0 {
+		r.errors = append(r.errors, fmt.Errorf("OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS must not be empty"))
+		return
+	}
+	for _, v := range cfg.OTEL.SupportedInstrumentationVersions {
+		if v == cfg.OTEL.DefaultInstrumentationVersion {
+			return
+		}
+	}
+	r.errors = append(r.errors, fmt.Errorf(
+		"OTEL_DEFAULT_INSTRUMENTATION_VERSION %q must be in OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS %v",
+		cfg.OTEL.DefaultInstrumentationVersion, cfg.OTEL.SupportedInstrumentationVersions,
+	))
 }
 
 func validateInternalServerConfigs(cfg *Config, r *configReader) {

--- a/agent-manager-service/db_migrations/018_backfill_instrumentation_version.go
+++ b/agent-manager-service/db_migrations/018_backfill_instrumentation_version.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dbmigrations
+
+import (
+	"gorm.io/gorm"
+)
+
+// Backfill agent_configs.instrumentation_version for existing rows that were
+// created when the column was nullable and meant "use the platform default".
+// Pinning them to the concrete current default (0.2.0) means a later default
+// bump won't silently move an existing agent to a new AMP instrumentation
+// version. New agents that don't pick a version explicitly still keep
+// instrumentation_version NULL going forward.
+var migration018 = migration{
+	ID: 18,
+	Migrate: func(db *gorm.DB) error {
+		backfill := `UPDATE agent_configs SET instrumentation_version = '0.2.0' WHERE instrumentation_version IS NULL`
+		return runSQL(db, backfill)
+	},
+}

--- a/agent-manager-service/db_migrations/migration_list.go
+++ b/agent-manager-service/db_migrations/migration_list.go
@@ -16,7 +16,7 @@
 
 package dbmigrations
 
-const latestVersion = 17
+const latestVersion = 18
 
 // migration list sorted by version.  Add new migrations to the end of the list.
 // Previous migrations should not be modified.
@@ -38,4 +38,5 @@ var migrations = []migration{
 	migration015,
 	migration016,
 	migration017,
+	migration018,
 }

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -7170,6 +7170,15 @@ components:
           type: boolean
           description: Enable automatic OTEL instrumentation for the agent
           default: true
+        instrumentationVersion:
+          type: string
+          description: |
+            AMP instrumentation version to use for the agent. Selects the
+            pre-built init-container image
+            (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the
+            `traceloop-sdk` it pins. Omit (or send null) to use the platform
+            default. Must be one of the versions supported by the deployment;
+            unknown values are rejected.
     EnvironmentVariable:
       type: object
       required:

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -7172,6 +7172,7 @@ components:
           default: true
         instrumentationVersion:
           type: string
+          nullable: true
           description: |
             AMP instrumentation version to use for the agent. Selects the
             pre-built init-container image

--- a/agent-manager-service/models/agent.go
+++ b/agent-manager-service/models/agent.go
@@ -48,6 +48,7 @@ type AgentResponse struct {
 // Configurations contains runtime configurations for an agent
 type Configurations struct {
 	EnableAutoInstrumentation *bool     `json:"enableAutoInstrumentation,omitempty"`
+	InstrumentationVersion    *string   `json:"instrumentationVersion,omitempty"`
 	Env                       []EnvVars `json:"env,omitempty"`
 }
 

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -302,10 +302,14 @@ func (s *agentManagerService) buildCreateTraitRequests(ctx context.Context, orgN
 
 		if needsOTEL {
 			lv := req.Build.BuildpackBuild.Buildpack.GetLanguageVersion()
+			otelOpts := []client.TraitOption{client.WithAgentApiKey(apiKey), client.WithLanguageVersion(lv)}
+			if req.Configurations != nil && req.Configurations.InstrumentationVersion != nil {
+				otelOpts = append(otelOpts, client.WithInstrumentationVersion(req.Configurations.InstrumentationVersion))
+			}
 			traits = append(traits, client.TraitRequest{
 				TraitKind: client.TraitKindTrait,
 				TraitType: client.TraitOTELInstrumentation,
-				Opts:      []client.TraitOption{client.WithAgentApiKey(apiKey), client.WithLanguageVersion(lv)},
+				Opts:      otelOpts,
 			})
 		} else {
 			traits = append(traits, client.TraitRequest{TraitKind: client.TraitKindTrait, TraitType: client.TraitEnvInjection, Opts: []client.TraitOption{client.WithAgentApiKey(apiKey)}})
@@ -340,14 +344,40 @@ func (s *agentManagerService) attachOTELInstrumentationTrait(ctx context.Context
 		return fmt.Errorf("failed to generate agent API key: %w", err)
 	}
 
+	opts := []client.TraitOption{client.WithAgentApiKey(apiKey)}
+	// Honor the agent's pinned AMP instrumentation version if one is set; otherwise
+	// the trait builder falls back to the platform default.
+	if v := s.lookupAgentInstrumentationVersion(ctx, orgName, projectName, agentName); v != nil {
+		opts = append(opts, client.WithInstrumentationVersion(v))
+	}
+
 	if err := s.ocClient.AttachTraits(ctx, orgName, projectName, agentName, []client.TraitRequest{
-		{TraitKind: client.TraitKindTrait, TraitType: client.TraitOTELInstrumentation, Opts: []client.TraitOption{client.WithAgentApiKey(apiKey)}},
+		{TraitKind: client.TraitKindTrait, TraitType: client.TraitOTELInstrumentation, Opts: opts},
 	}); err != nil {
 		return fmt.Errorf("error attaching OTEL instrumentation trait: %w", err)
 	}
 
 	s.logger.Info("Enabled instrumentation for buildpack agent", "agentName", agentName)
 	return nil
+}
+
+// lookupAgentInstrumentationVersion returns the agent's pinned AMP instrumentation
+// version (from agent_configs.instrumentation_version) or nil when there's no row
+// or no pinned value — the caller should then fall back to the platform default.
+func (s *agentManagerService) lookupAgentInstrumentationVersion(ctx context.Context, orgName, projectName, agentName string) *string {
+	pipeline, err := s.ocClient.GetProjectDeploymentPipeline(ctx, orgName, projectName)
+	if err != nil || len(pipeline.PromotionPaths) == 0 {
+		return nil
+	}
+	lowestEnv := findLowestEnvironment(pipeline.PromotionPaths)
+	if lowestEnv == "" {
+		return nil
+	}
+	cfg, err := s.agentConfigRepo.Get(orgName, projectName, agentName, lowestEnv)
+	if err != nil || cfg == nil {
+		return nil
+	}
+	return cfg.InstrumentationVersion
 }
 
 // detachOTELInstrumentationTrait removes the OTEL instrumentation trait from the agent
@@ -390,8 +420,22 @@ func (s *agentManagerService) detachEnvInjectionTrait(ctx context.Context, orgNa
 	return nil
 }
 
-// persistInstrumentationConfig saves the instrumentation config to the database
-func (s *agentManagerService) persistInstrumentationConfig(ctx context.Context, orgName, projectName, agentName string, enableAutoInstrumentation bool) {
+// validateInstrumentationVersion checks the AMP instrumentation version against
+// the deployment's supported set. Empty / unsupported values return ErrInvalidInput.
+func (s *agentManagerService) validateInstrumentationVersion(version string) error {
+	supported := config.GetConfig().OTEL.SupportedInstrumentationVersions
+	for _, v := range supported {
+		if v == version {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: instrumentationVersion %q is not supported by this deployment; supported: %v", utils.ErrInvalidInput, version, supported)
+}
+
+// persistInstrumentationConfig saves the instrumentation config to the database.
+// instrumentationVersion is nil when the caller did not pin a specific version —
+// the column stays NULL and the resolver falls back to the platform default.
+func (s *agentManagerService) persistInstrumentationConfig(ctx context.Context, orgName, projectName, agentName string, enableAutoInstrumentation bool, instrumentationVersion *string) {
 	// Get the first/lowest environment
 	pipeline, err := s.ocClient.GetProjectDeploymentPipeline(ctx, orgName, projectName)
 	if err != nil {
@@ -417,12 +461,13 @@ func (s *agentManagerService) persistInstrumentationConfig(ctx context.Context, 
 		AgentName:                 agentName,
 		EnvironmentName:           targetEnv.Name,
 		EnableAutoInstrumentation: enableAutoInstrumentation,
+		InstrumentationVersion:    instrumentationVersion,
 	}
 
 	if err := s.agentConfigRepo.Upsert(agentConfig); err != nil {
 		s.logger.Warn("Failed to persist instrumentation config to database", "agentName", agentName, "error", err)
 	} else {
-		s.logger.Debug("Persisted instrumentation config to database", "agentName", agentName, "environment", lowestEnv, "enableAutoInstrumentation", enableAutoInstrumentation)
+		s.logger.Debug("Persisted instrumentation config to database", "agentName", agentName, "environment", lowestEnv, "enableAutoInstrumentation", enableAutoInstrumentation, "instrumentationVersion", instrumentationVersion)
 	}
 }
 
@@ -567,6 +612,7 @@ func (s *agentManagerService) GetAgent(ctx context.Context, orgName string, proj
 			} else {
 				agent.Configurations = &models.Configurations{
 					EnableAutoInstrumentation: &agentConfig.EnableAutoInstrumentation,
+					InstrumentationVersion:    agentConfig.InstrumentationVersion,
 				}
 			}
 
@@ -629,6 +675,12 @@ func (s *agentManagerService) ListAgents(ctx context.Context, orgName string, pr
 }
 
 func (s *agentManagerService) CreateAgent(ctx context.Context, orgName string, projectName string, req *spec.CreateAgentRequest) error {
+	if req.Configurations != nil && req.Configurations.InstrumentationVersion != nil {
+		if err := s.validateInstrumentationVersion(*req.Configurations.InstrumentationVersion); err != nil {
+			return err
+		}
+	}
+
 	imageID := ""
 	if req.Provisioning.AgentKind != nil {
 		kindVersion, err := s.agentKindService.GetKindVersion(ctx, orgName, req.Provisioning.AgentKind.Name, req.Provisioning.AgentKind.Version)
@@ -813,10 +865,14 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, orgName,
 		}
 
 		enableAutoInstrumentation := true
-		if req.Configurations != nil && req.Configurations.EnableAutoInstrumentation != nil {
-			enableAutoInstrumentation = *req.Configurations.EnableAutoInstrumentation
+		var instrumentationVersion *string
+		if req.Configurations != nil {
+			if req.Configurations.EnableAutoInstrumentation != nil {
+				enableAutoInstrumentation = *req.Configurations.EnableAutoInstrumentation
+			}
+			instrumentationVersion = req.Configurations.InstrumentationVersion
 		}
-		s.persistInstrumentationConfig(ctx, orgName, projectName, req.Name, enableAutoInstrumentation)
+		s.persistInstrumentationConfig(ctx, orgName, projectName, req.Name, enableAutoInstrumentation, instrumentationVersion)
 	}
 
 	s.logger.Info("Agent created successfully", "agentName", req.Name, "orgName", orgName, "projectName", projectName, "provisioningType", req.Provisioning.Type)

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 
 	"github.com/google/uuid"
 	observabilitysvc "github.com/wso2/agent-manager/agent-manager-service/clients/observabilitysvc"
@@ -444,10 +445,8 @@ func (s *agentManagerService) detachEnvInjectionTrait(ctx context.Context, orgNa
 // the deployment's supported set. Empty / unsupported values return ErrInvalidInput.
 func (s *agentManagerService) validateInstrumentationVersion(version string) error {
 	supported := config.GetConfig().OTEL.SupportedInstrumentationVersions
-	for _, v := range supported {
-		if v == version {
-			return nil
-		}
+	if slices.Contains(supported, version) {
+		return nil
 	}
 	return fmt.Errorf("%w: instrumentationVersion %q is not supported by this deployment; supported: %v", utils.ErrInvalidInput, version, supported)
 }
@@ -1792,41 +1791,39 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, orgName string, p
 		s.logger.Warn("Failed to get environment details", "environment", lowestEnv, "error", err)
 	}
 
-	// Resolve enableAutoInstrumentation value:
-	// 1. Use request value if provided
-	// 2. Otherwise, read from DB for this environment
-	// 3. If not in DB, default to true (first deployment)
-	//
-	// While we're here, also capture the agent's pinned AMP instrumentation version
-	// from the same DB row so the later Upsert preserves it (Upsert's DoUpdates map
-	// includes instrumentation_version; passing nil would clobber a customer's pin).
+	// Read the existing agent_configs row once (when we have an environment) so we
+	// can both resolve enableAutoInstrumentation (when the request doesn't carry it)
+	// and preserve the pinned instrumentation_version on the later Upsert (Upsert's
+	// DoUpdates map includes that column, so passing nil would clobber a customer's pin).
+	var existingConfig *models.AgentConfig
+	if targetEnv != nil {
+		cfg, configErr := s.agentConfigRepo.Get(orgName, projectName, agentName, targetEnv.Name)
+		switch {
+		case errors.Is(configErr, repositories.ErrAgentConfigNotFound):
+			s.logger.Debug("No instrumentation config in database", "agentName", agentName, "environment", targetEnv.Name)
+		case configErr != nil:
+			s.logger.Warn("Failed to read instrumentation config from database", "agentName", agentName, "environment", targetEnv.Name, "error", configErr)
+		default:
+			existingConfig = cfg
+			s.logger.Debug("Read instrumentation config from database", "agentName", agentName, "environment", targetEnv.Name, "enableAutoInstrumentation", cfg.EnableAutoInstrumentation, "instrumentationVersion", cfg.InstrumentationVersion)
+		}
+	}
+
+	// Resolve enableAutoInstrumentation: request value > DB value > default true.
 	var enableAutoInstrumentation bool
-	var existingInstrumentationVersion *string
-	if req.EnableAutoInstrumentation != nil {
+	switch {
+	case req.EnableAutoInstrumentation != nil:
 		enableAutoInstrumentation = *req.EnableAutoInstrumentation
 		s.logger.Info("Using enableAutoInstrumentation from request", "agentName", agentName, "value", enableAutoInstrumentation)
-		if targetEnv != nil {
-			if existingConfig, configErr := s.agentConfigRepo.Get(orgName, projectName, agentName, targetEnv.Name); configErr == nil && existingConfig != nil {
-				existingInstrumentationVersion = existingConfig.InstrumentationVersion
-			}
-		}
-	} else if targetEnv != nil {
-		// Try to read from database
-		existingConfig, configErr := s.agentConfigRepo.Get(orgName, projectName, agentName, targetEnv.Name)
-		if errors.Is(configErr, repositories.ErrAgentConfigNotFound) {
-			// No config in DB - this is first deployment, default to true
-			enableAutoInstrumentation = true
-			s.logger.Debug("No instrumentation config in database, defaulting to enabled", "agentName", agentName, "environment", targetEnv.Name)
-		} else if configErr != nil {
-			s.logger.Warn("Failed to read instrumentation config from database", "agentName", agentName, "environment", targetEnv.Name, "error", configErr)
-			enableAutoInstrumentation = true // Default to enabled on error
-		} else {
-			enableAutoInstrumentation = existingConfig.EnableAutoInstrumentation
-			existingInstrumentationVersion = existingConfig.InstrumentationVersion
-			s.logger.Debug("Read instrumentation config from database", "agentName", agentName, "environment", targetEnv.Name, "enableAutoInstrumentation", enableAutoInstrumentation, "instrumentationVersion", existingInstrumentationVersion)
-		}
-	} else {
-		enableAutoInstrumentation = true // Default if no environment info available
+	case existingConfig != nil:
+		enableAutoInstrumentation = existingConfig.EnableAutoInstrumentation
+	default:
+		enableAutoInstrumentation = true
+	}
+
+	var existingInstrumentationVersion *string
+	if existingConfig != nil {
+		existingInstrumentationVersion = existingConfig.InstrumentationVersion
 	}
 
 	// Update instrumentation traits before deploy for Python buildpack builds (agent-api only)

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -350,12 +350,14 @@ func (s *agentManagerService) attachOTELInstrumentationTrait(ctx context.Context
 	opts := []client.TraitOption{client.WithAgentApiKey(apiKey)}
 	// Honor the agent's pinned AMP instrumentation version if one is set;
 	// otherwise the trait builder falls back to the platform default. Surface
-	// lookup errors so a transient DB hiccup doesn't silently break the pin.
+	// real lookup errors so a transient DB hiccup doesn't silently break the pin.
 	v, err := s.lookupAgentInstrumentationVersion(ctx, orgName, projectName, agentName)
-	if err != nil {
+	switch {
+	case errors.Is(err, ErrInstrumentationVersionNotPinned):
+		// no pin → fall through to the platform default in the trait builder
+	case err != nil:
 		return fmt.Errorf("looking up pinned instrumentation version: %w", err)
-	}
-	if v != nil {
+	default:
 		opts = append(opts, client.WithInstrumentationVersion(v))
 	}
 
@@ -369,34 +371,39 @@ func (s *agentManagerService) attachOTELInstrumentationTrait(ctx context.Context
 	return nil
 }
 
+// ErrInstrumentationVersionNotPinned indicates an agent has no pinned AMP
+// instrumentation version: no row in agent_configs yet, no project pipeline,
+// or the column is NULL. Callers should treat it as "fall back to the platform
+// default" rather than a real error. It is intentionally distinct from real
+// errors (DB read failures, deployment pipeline lookup failures) so a transient
+// failure can't silently swap a customer's pinned version for the default.
+var ErrInstrumentationVersionNotPinned = errors.New("agent has no pinned instrumentation version")
+
 // lookupAgentInstrumentationVersion returns the agent's pinned AMP instrumentation
-// version (from agent_configs.instrumentation_version). It returns (nil, nil)
-// when there's genuinely no pin to honour — no row for the agent yet, no
-// environment configured on the project, or the column is NULL — so the caller
-// can safely fall back to the platform default. Real errors (deployment pipeline
-// lookup failure, DB read failure other than "not found") propagate so a
-// transient failure doesn't silently swap a customer's pinned version for the default.
+// version (from agent_configs.instrumentation_version). It returns
+// ErrInstrumentationVersionNotPinned when there's genuinely no pin to honour,
+// and a wrapped real error for transient failures.
 func (s *agentManagerService) lookupAgentInstrumentationVersion(ctx context.Context, orgName, projectName, agentName string) (*string, error) {
 	pipeline, err := s.ocClient.GetProjectDeploymentPipeline(ctx, orgName, projectName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deployment pipeline: %w", err)
 	}
 	if len(pipeline.PromotionPaths) == 0 {
-		return nil, nil
+		return nil, ErrInstrumentationVersionNotPinned
 	}
 	lowestEnv := findLowestEnvironment(pipeline.PromotionPaths)
 	if lowestEnv == "" {
-		return nil, nil
+		return nil, ErrInstrumentationVersionNotPinned
 	}
 	cfg, err := s.agentConfigRepo.Get(orgName, projectName, agentName, lowestEnv)
 	if errors.Is(err, repositories.ErrAgentConfigNotFound) {
-		return nil, nil
+		return nil, ErrInstrumentationVersionNotPinned
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read agent config: %w", err)
 	}
-	if cfg == nil {
-		return nil, nil
+	if cfg == nil || cfg.InstrumentationVersion == nil {
+		return nil, ErrInstrumentationVersionNotPinned
 	}
 	return cfg.InstrumentationVersion, nil
 }

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -303,8 +303,10 @@ func (s *agentManagerService) buildCreateTraitRequests(ctx context.Context, orgN
 		if needsOTEL {
 			lv := req.Build.BuildpackBuild.Buildpack.GetLanguageVersion()
 			otelOpts := []client.TraitOption{client.WithAgentApiKey(apiKey), client.WithLanguageVersion(lv)}
-			if req.Configurations != nil && req.Configurations.InstrumentationVersion != nil {
-				otelOpts = append(otelOpts, client.WithInstrumentationVersion(req.Configurations.InstrumentationVersion))
+			if req.Configurations != nil {
+				if v := req.Configurations.InstrumentationVersion.Get(); v != nil {
+					otelOpts = append(otelOpts, client.WithInstrumentationVersion(v))
+				}
 			}
 			traits = append(traits, client.TraitRequest{
 				TraitKind: client.TraitKindTrait,
@@ -345,9 +347,14 @@ func (s *agentManagerService) attachOTELInstrumentationTrait(ctx context.Context
 	}
 
 	opts := []client.TraitOption{client.WithAgentApiKey(apiKey)}
-	// Honor the agent's pinned AMP instrumentation version if one is set; otherwise
-	// the trait builder falls back to the platform default.
-	if v := s.lookupAgentInstrumentationVersion(ctx, orgName, projectName, agentName); v != nil {
+	// Honor the agent's pinned AMP instrumentation version if one is set;
+	// otherwise the trait builder falls back to the platform default. Surface
+	// lookup errors so a transient DB hiccup doesn't silently break the pin.
+	v, err := s.lookupAgentInstrumentationVersion(ctx, orgName, projectName, agentName)
+	if err != nil {
+		return fmt.Errorf("looking up pinned instrumentation version: %w", err)
+	}
+	if v != nil {
 		opts = append(opts, client.WithInstrumentationVersion(v))
 	}
 
@@ -362,22 +369,35 @@ func (s *agentManagerService) attachOTELInstrumentationTrait(ctx context.Context
 }
 
 // lookupAgentInstrumentationVersion returns the agent's pinned AMP instrumentation
-// version (from agent_configs.instrumentation_version) or nil when there's no row
-// or no pinned value — the caller should then fall back to the platform default.
-func (s *agentManagerService) lookupAgentInstrumentationVersion(ctx context.Context, orgName, projectName, agentName string) *string {
+// version (from agent_configs.instrumentation_version). It returns (nil, nil)
+// when there's genuinely no pin to honour — no row for the agent yet, no
+// environment configured on the project, or the column is NULL — so the caller
+// can safely fall back to the platform default. Real errors (deployment pipeline
+// lookup failure, DB read failure other than "not found") propagate so a
+// transient failure doesn't silently swap a customer's pinned version for the default.
+func (s *agentManagerService) lookupAgentInstrumentationVersion(ctx context.Context, orgName, projectName, agentName string) (*string, error) {
 	pipeline, err := s.ocClient.GetProjectDeploymentPipeline(ctx, orgName, projectName)
-	if err != nil || len(pipeline.PromotionPaths) == 0 {
-		return nil
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment pipeline: %w", err)
+	}
+	if len(pipeline.PromotionPaths) == 0 {
+		return nil, nil
 	}
 	lowestEnv := findLowestEnvironment(pipeline.PromotionPaths)
 	if lowestEnv == "" {
-		return nil
+		return nil, nil
 	}
 	cfg, err := s.agentConfigRepo.Get(orgName, projectName, agentName, lowestEnv)
-	if err != nil || cfg == nil {
-		return nil
+	if errors.Is(err, repositories.ErrAgentConfigNotFound) {
+		return nil, nil
 	}
-	return cfg.InstrumentationVersion
+	if err != nil {
+		return nil, fmt.Errorf("failed to read agent config: %w", err)
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+	return cfg.InstrumentationVersion, nil
 }
 
 // detachOTELInstrumentationTrait removes the OTEL instrumentation trait from the agent
@@ -675,9 +695,11 @@ func (s *agentManagerService) ListAgents(ctx context.Context, orgName string, pr
 }
 
 func (s *agentManagerService) CreateAgent(ctx context.Context, orgName string, projectName string, req *spec.CreateAgentRequest) error {
-	if req.Configurations != nil && req.Configurations.InstrumentationVersion != nil {
-		if err := s.validateInstrumentationVersion(*req.Configurations.InstrumentationVersion); err != nil {
-			return err
+	if req.Configurations != nil {
+		if v := req.Configurations.InstrumentationVersion.Get(); v != nil {
+			if err := s.validateInstrumentationVersion(*v); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -870,7 +892,7 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, orgName,
 			if req.Configurations.EnableAutoInstrumentation != nil {
 				enableAutoInstrumentation = *req.Configurations.EnableAutoInstrumentation
 			}
-			instrumentationVersion = req.Configurations.InstrumentationVersion
+			instrumentationVersion = req.Configurations.InstrumentationVersion.Get()
 		}
 		s.persistInstrumentationConfig(ctx, orgName, projectName, req.Name, enableAutoInstrumentation, instrumentationVersion)
 	}
@@ -1774,10 +1796,20 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, orgName string, p
 	// 1. Use request value if provided
 	// 2. Otherwise, read from DB for this environment
 	// 3. If not in DB, default to true (first deployment)
+	//
+	// While we're here, also capture the agent's pinned AMP instrumentation version
+	// from the same DB row so the later Upsert preserves it (Upsert's DoUpdates map
+	// includes instrumentation_version; passing nil would clobber a customer's pin).
 	var enableAutoInstrumentation bool
+	var existingInstrumentationVersion *string
 	if req.EnableAutoInstrumentation != nil {
 		enableAutoInstrumentation = *req.EnableAutoInstrumentation
 		s.logger.Info("Using enableAutoInstrumentation from request", "agentName", agentName, "value", enableAutoInstrumentation)
+		if targetEnv != nil {
+			if existingConfig, configErr := s.agentConfigRepo.Get(orgName, projectName, agentName, targetEnv.Name); configErr == nil && existingConfig != nil {
+				existingInstrumentationVersion = existingConfig.InstrumentationVersion
+			}
+		}
 	} else if targetEnv != nil {
 		// Try to read from database
 		existingConfig, configErr := s.agentConfigRepo.Get(orgName, projectName, agentName, targetEnv.Name)
@@ -1790,7 +1822,8 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, orgName string, p
 			enableAutoInstrumentation = true // Default to enabled on error
 		} else {
 			enableAutoInstrumentation = existingConfig.EnableAutoInstrumentation
-			s.logger.Debug("Read instrumentation config from database", "agentName", agentName, "environment", targetEnv.Name, "enableAutoInstrumentation", enableAutoInstrumentation)
+			existingInstrumentationVersion = existingConfig.InstrumentationVersion
+			s.logger.Debug("Read instrumentation config from database", "agentName", agentName, "environment", targetEnv.Name, "enableAutoInstrumentation", enableAutoInstrumentation, "instrumentationVersion", existingInstrumentationVersion)
 		}
 	} else {
 		enableAutoInstrumentation = true // Default if no environment info available
@@ -1866,7 +1899,10 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, orgName string, p
 		return "", err
 	}
 
-	// Persist instrumentation config to database
+	// Persist instrumentation config to database. Passing the pinned
+	// instrumentation_version (captured above) preserves it across the
+	// Upsert — the repo's DoUpdates map includes that column, so omitting
+	// the value would NULL out a customer's pin on every redeploy.
 	if targetEnv != nil {
 		agentConfig := &models.AgentConfig{
 			OrgName:                   orgName,
@@ -1874,11 +1910,12 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, orgName string, p
 			AgentName:                 agentName,
 			EnvironmentName:           targetEnv.Name,
 			EnableAutoInstrumentation: enableAutoInstrumentation,
+			InstrumentationVersion:    existingInstrumentationVersion,
 		}
 		if configErr := s.agentConfigRepo.Upsert(agentConfig); configErr != nil {
 			s.logger.Error("Failed to persist instrumentation config to database", "agentName", agentName, "environment", lowestEnv, "error", configErr)
 		} else {
-			s.logger.Debug("Persisted instrumentation config to database", "agentName", agentName, "environment", lowestEnv, "enableAutoInstrumentation", enableAutoInstrumentation)
+			s.logger.Debug("Persisted instrumentation config to database", "agentName", agentName, "environment", lowestEnv, "enableAutoInstrumentation", enableAutoInstrumentation, "instrumentationVersion", existingInstrumentationVersion)
 		}
 	}
 

--- a/agent-manager-service/spec/model_configurations.go
+++ b/agent-manager-service/spec/model_configurations.go
@@ -23,6 +23,8 @@ type Configurations struct {
 	Env []EnvironmentVariable `json:"env,omitempty"`
 	// Enable automatic OTEL instrumentation for the agent
 	EnableAutoInstrumentation *bool `json:"enableAutoInstrumentation,omitempty"`
+	// AMP instrumentation version to use for the agent. Selects the pre-built init-container image (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the `traceloop-sdk` it pins. Omit (or send null) to use the platform default. Must be one of the versions supported by the deployment; unknown values are rejected.
+	InstrumentationVersion *string `json:"instrumentationVersion,omitempty"`
 }
 
 // NewConfigurations instantiates a new Configurations object
@@ -110,6 +112,38 @@ func (o *Configurations) SetEnableAutoInstrumentation(v bool) {
 	o.EnableAutoInstrumentation = &v
 }
 
+// GetInstrumentationVersion returns the InstrumentationVersion field value if set, zero value otherwise.
+func (o *Configurations) GetInstrumentationVersion() string {
+	if o == nil || IsNil(o.InstrumentationVersion) {
+		var ret string
+		return ret
+	}
+	return *o.InstrumentationVersion
+}
+
+// GetInstrumentationVersionOk returns a tuple with the InstrumentationVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Configurations) GetInstrumentationVersionOk() (*string, bool) {
+	if o == nil || IsNil(o.InstrumentationVersion) {
+		return nil, false
+	}
+	return o.InstrumentationVersion, true
+}
+
+// HasInstrumentationVersion returns a boolean if a field has been set.
+func (o *Configurations) HasInstrumentationVersion() bool {
+	if o != nil && !IsNil(o.InstrumentationVersion) {
+		return true
+	}
+
+	return false
+}
+
+// SetInstrumentationVersion gets a reference to the given string and assigns it to the InstrumentationVersion field.
+func (o *Configurations) SetInstrumentationVersion(v string) {
+	o.InstrumentationVersion = &v
+}
+
 func (o Configurations) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -125,6 +159,9 @@ func (o Configurations) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.EnableAutoInstrumentation) {
 		toSerialize["enableAutoInstrumentation"] = o.EnableAutoInstrumentation
+	}
+	if !IsNil(o.InstrumentationVersion) {
+		toSerialize["instrumentationVersion"] = o.InstrumentationVersion
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/spec/model_configurations.go
+++ b/agent-manager-service/spec/model_configurations.go
@@ -24,7 +24,7 @@ type Configurations struct {
 	// Enable automatic OTEL instrumentation for the agent
 	EnableAutoInstrumentation *bool `json:"enableAutoInstrumentation,omitempty"`
 	// AMP instrumentation version to use for the agent. Selects the pre-built init-container image (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the `traceloop-sdk` it pins. Omit (or send null) to use the platform default. Must be one of the versions supported by the deployment; unknown values are rejected.
-	InstrumentationVersion *string `json:"instrumentationVersion,omitempty"`
+	InstrumentationVersion NullableString `json:"instrumentationVersion,omitempty"`
 }
 
 // NewConfigurations instantiates a new Configurations object
@@ -112,36 +112,47 @@ func (o *Configurations) SetEnableAutoInstrumentation(v bool) {
 	o.EnableAutoInstrumentation = &v
 }
 
-// GetInstrumentationVersion returns the InstrumentationVersion field value if set, zero value otherwise.
+// GetInstrumentationVersion returns the InstrumentationVersion field value if set, zero value otherwise (both if not set or set to explicit null).
 func (o *Configurations) GetInstrumentationVersion() string {
-	if o == nil || IsNil(o.InstrumentationVersion) {
+	if o == nil || IsNil(o.InstrumentationVersion.Get()) {
 		var ret string
 		return ret
 	}
-	return *o.InstrumentationVersion
+	return *o.InstrumentationVersion.Get()
 }
 
 // GetInstrumentationVersionOk returns a tuple with the InstrumentationVersion field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
 func (o *Configurations) GetInstrumentationVersionOk() (*string, bool) {
-	if o == nil || IsNil(o.InstrumentationVersion) {
+	if o == nil {
 		return nil, false
 	}
-	return o.InstrumentationVersion, true
+	return o.InstrumentationVersion.Get(), o.InstrumentationVersion.IsSet()
 }
 
 // HasInstrumentationVersion returns a boolean if a field has been set.
 func (o *Configurations) HasInstrumentationVersion() bool {
-	if o != nil && !IsNil(o.InstrumentationVersion) {
+	if o != nil && o.InstrumentationVersion.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetInstrumentationVersion gets a reference to the given string and assigns it to the InstrumentationVersion field.
+// SetInstrumentationVersion gets a reference to the given NullableString and assigns it to the InstrumentationVersion field.
 func (o *Configurations) SetInstrumentationVersion(v string) {
-	o.InstrumentationVersion = &v
+	o.InstrumentationVersion.Set(&v)
+}
+
+// SetInstrumentationVersionNil sets the value for InstrumentationVersion to be an explicit nil
+func (o *Configurations) SetInstrumentationVersionNil() {
+	o.InstrumentationVersion.Set(nil)
+}
+
+// UnsetInstrumentationVersion ensures that no value is present for InstrumentationVersion, not even an explicit nil
+func (o *Configurations) UnsetInstrumentationVersion() {
+	o.InstrumentationVersion.Unset()
 }
 
 func (o Configurations) MarshalJSON() ([]byte, error) {
@@ -160,8 +171,8 @@ func (o Configurations) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.EnableAutoInstrumentation) {
 		toSerialize["enableAutoInstrumentation"] = o.EnableAutoInstrumentation
 	}
-	if !IsNil(o.InstrumentationVersion) {
-		toSerialize["instrumentationVersion"] = o.InstrumentationVersion
+	if o.InstrumentationVersion.IsSet() {
+		toSerialize["instrumentationVersion"] = o.InstrumentationVersion.Get()
 	}
 	return toSerialize, nil
 }


### PR DESCRIPTION
Closes #841
Closes #842

## What

Lets an agent pin a specific AMP instrumentation version on create, has `agent-manager-service` resolve a Python agent's init-container image off that pin (falling back to the platform default when unset), and backfills existing `agent_configs` rows to the concrete current default — so a later platform-default bump never silently moves an existing agent to a new instrumentation version.

This completes the per-agent override side of the instrumentation-versioning work — the column + repo plumbing landed in #848, the build & default-resolution landed in #852, and now the read-from-DB + customer-facing API + backfill close the loop.

## What gets released

Nothing additional gets *built* by this PR — it changes how a Python agent's init-container image is *selected*. After merging:
- New agents created with `configurations.instrumentationVersion: "0.2.0"` (or any other supported version) get that version pinned in `agent_configs`.
- New agents created without it stay on `instrumentation_version = NULL` and resolve to whatever `OTEL_DEFAULT_INSTRUMENTATION_VERSION` is set to on the deployment.
- Existing agents (created before this) get backfilled to `"0.2.0"` by migration `018`, so a future default bump never moves them.

## Changes

**API**
- `docs/api_v1_openapi.yaml` — add `instrumentationVersion: string` to `Configurations` (free-form string; the deployment validates server-side against its supported set, see below).
- `spec/model_configurations.go` — regenerated via `make spec` (only this generated file changed).
- `models/agent.go` — `Configurations.InstrumentationVersion *string` in the internal model.

**Validation**
- `config/config.go` + `config/config_loader.go` — new `OTEL.SupportedInstrumentationVersions []string`, sourced from the env var `OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS` (comma-separated; default `["0.2.0"]`).
- `services/agent_manager.go` — `validateInstrumentationVersion(...)` rejects an unknown value with `utils.ErrInvalidInput` (returns 400 via the existing controller error mapping).

**Persistence**
- `services/agent_manager.go` — `persistInstrumentationConfig` now also writes `agent_configs.instrumentation_version` (uses the existing `AgentConfig.InstrumentationVersion *string` field added in #848). The GET path populates the value back into the `Configurations` response.

**Resolver (the per-agent override)**
- `clients/openchoreosvc/client/components.go` — new `WithInstrumentationVersion(*string)` `TraitOption`; `buildOTELTraitParameters` reads it from the trait params (per-agent override) before falling back to `cfg.OTEL.DefaultInstrumentationVersion`.
- `services/agent_manager.go` — `buildCreateTraitRequests` passes the request's `instrumentationVersion` through on create; `attachOTELInstrumentationTrait` (used when re-enabling instrumentation after the agent exists) looks the pinned value up from `agent_configs` via the new `lookupAgentInstrumentationVersion` helper.

**Backfill**
- `db_migrations/018_backfill_instrumentation_version.go` — `UPDATE agent_configs SET instrumentation_version = '0.2.0' WHERE instrumentation_version IS NULL`. The hardcoded `'0.2.0'` is the concrete *current* default at the time we backfilled; the design wants existing agents pinned to that value so a later default bump doesn't move them.

## Not in this PR

- The MCP create path (`mcp/tools/agents.go`, `mcp/tools/deployments.go`) doesn't surface the new field yet — separate small follow-up.
- The Console version selector (B8 / #844) and the `languageVersion` dropdown lock-down (B9) — separate follow-ups; this PR is the API/data side they'll consume.
- The post-GA distribution gap (a deployed install can't surface a *newly-published* AMP-instr version without a product upgrade) is tracked as **B11** in the plan; out of scope for this milestone.

## Tests

`go build ./...`, `go vet`, `gofumpt -l`, `go test ./config/... ./repositories/...` all green. The `services/` package test requires a live DB connection (pre-existing constraint — `DB_HOST`/`DB_USER`/`DB_PASSWORD`/`DB_NAME` env). The `make codegenfmt-check` CI job will re-run `make spec` and verify the regenerated file matches what's committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now specify and pin an instrumentation version for agents; omitted values use the platform default.
  * API and UI schemas expose an optional instrumentationVersion field for agent configurations.
  * Supported instrumentation versions are configurable (default: 0.2.0) and validated at startup.

* **Bug Fixes / Chores**
  * Database migration added to backfill existing agent configurations with the default instrumentation version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/857)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->