### PR TITLE
Add amctl agent deploy command

### DIFF
--- a/cli/pkg/clierr/clierr.go
+++ b/cli/pkg/clierr/clierr.go
@@ -54,6 +54,7 @@ const (
 	ServerInvalid        = "SERVER_RESPONSE_INVALID"
 	NotFound             = "NOT_FOUND"
 	Validation           = "VALIDATION"
+	BuildNotDeployable   = "BUILD_NOT_DEPLOYABLE"
 )
 
 // CLIError is both the wire body of an error envelope and a Go error value.

--- a/cli/pkg/cmd/agent/agent.go
+++ b/cli/pkg/cmd/agent/agent.go
@@ -32,6 +32,7 @@ func NewAgentCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewListCmd(f))
 	cmd.AddCommand(NewGetCmd(f))
 	cmd.AddCommand(NewDeleteCmd(f))
+	cmd.AddCommand(NewDeployCmd(f))
 	cmd.AddCommand(build.NewBuildCmd(f))
 	return cmd
 }

--- a/cli/pkg/cmd/agent/delete_test.go
+++ b/cli/pkg/cmd/agent/delete_test.go
@@ -77,6 +77,8 @@ func (p *fakePrompter) ConfirmDeletion(required string) error {
 	return p.confirmDeletionErr
 }
 
+func (p *fakePrompter) Confirm(prompt string) (bool, error) { return false, nil }
+
 func newTestIO(canPrompt bool) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
 	io, _, out, errOut := iostreams.Test()
 	io.SetTerminal(canPrompt, canPrompt, canPrompt)

--- a/cli/pkg/cmd/agent/deploy.go
+++ b/cli/pkg/cmd/agent/deploy.go
@@ -4,13 +4,21 @@
 package agent
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/spf13/cobra"
+
 	"github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/prompter"
+	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
 // envConflict describes a single key where the CLI's --env value differs from
@@ -146,3 +154,222 @@ func renderConflictTable(io *iostreams.IOStreams, conflicts []envConflict) {
 }
 
 func boolPtrLocal(b bool) *bool { return &b }
+
+type DeployOptions struct {
+	IO           *iostreams.IOStreams
+	Prompter     prompter.Prompter
+	Client       func(context.Context) (*gen.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
+
+	Org       string
+	Proj      string
+	Scope     render.Scope
+	AgentName string
+
+	BuildName string   // wired in Task 5
+	EnvFlags  []string // wired in Task 6
+	Yes       bool
+}
+
+type DeployResult struct {
+	Agent             string   `json:"agent"`
+	Build             string   `json:"build"`
+	ImageId           string   `json:"imageId"`
+	TargetEnvironment string   `json:"targetEnvironment"`
+	ConflictsResolved []string `json:"conflictsResolved"`
+}
+
+type deployableBuild struct {
+	Name    string
+	ImageID string
+	Status  string
+}
+
+func NewDeployCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &DeployOptions{
+		IO:           f.IOStreams,
+		Prompter:     f.Prompter,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
+	}
+	cmd := &cobra.Command{
+		Use:   "deploy [agent]",
+		Short: "Deploy a built agent image",
+		Long: "Deploy a built agent image to the lowest environment in the deployment pipeline.\n" +
+			"\n" +
+			"Env vars supplied via --env are merged with the agent's current configuration;\n" +
+			"conflicting values require interactive confirmation or --yes. CLI-supplied values\n" +
+			"are always stored as plain text in v1 — use the platform UI for secrets.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, proj, err := opts.ResolveScope(cmd, true, true)
+			if err != nil {
+				scope := opts.MakeScope(org, proj, "")
+				return render.Error(opts.IO, scope, err)
+			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
+			opts.Org, opts.Proj, opts.Scope = org, proj, scope
+			opts.AgentName = agent
+			return runDeploy(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip the env-conflict confirmation prompt")
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return cmdutil.CompleteBuildableAgents(cmd, f), cobra.ShellCompDirectiveNoFileComp
+	}
+	return cmd
+}
+
+func runDeploy(ctx context.Context, o *DeployOptions) error {
+	if err := cmdutil.ValidatePathParam("agent name", o.AgentName); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	if err := cmdutil.ValidateBuildable(ctx, client, o.Org, o.Proj, o.AgentName); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	build, err := resolveDeployableBuild(ctx, client, o.Org, o.Proj, o.AgentName, o.BuildName)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	pipeResp, err := client.GetDeploymentPipelineWithResponse(ctx, o.Org, o.Proj)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if pipeResp.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(pipeResp.HTTPResponse, cmdutil.FirstNonNil(pipeResp.JSON404, pipeResp.JSON500)))
+	}
+	targetEnv := findLowestEnvironment(pipeResp.JSON200.PromotionPaths)
+	if targetEnv == "" {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Internal,
+			"deployment pipeline has no entry environment for project %q", o.Proj))
+	}
+
+	cfgResp, err := client.GetAgentConfigurationsWithResponse(ctx, o.Org, o.Proj, o.AgentName,
+		&gen.GetAgentConfigurationsParams{Environment: targetEnv})
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if cfgResp.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(cfgResp.HTTPResponse, cmdutil.FirstNonNil(cfgResp.JSON404, cfgResp.JSON500)))
+	}
+	currentEnv := configurationItemsFromResponse(cfgResp.JSON200)
+
+	cliEnv, err := parseEnvFlag(o.EnvFlags)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, cmdutil.FlagErrorf("%v", err))
+	}
+
+	finalEnv, conflicts := mergeEnv(currentEnv, cliEnv)
+
+	if len(conflicts) > 0 && !o.Yes {
+		if o.IO.JSON {
+			return render.Error(o.IO, o.Scope, clierr.New(clierr.ConfirmationRequired,
+				"confirmation required; pass --yes when using --json"))
+		}
+		if !o.IO.CanPrompt() {
+			return render.Error(o.IO, o.Scope, clierr.New(clierr.ConfirmationRequired,
+				"confirmation required; pass --yes when stdin is not a terminal"))
+		}
+		renderConflictTable(o.IO, conflicts)
+		ok, perr := o.Prompter.Confirm("Proceed with deploy?")
+		if perr != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.ConfirmationRequired, "%v", perr))
+		}
+		if !ok {
+			return render.Error(o.IO, o.Scope, clierr.New(clierr.ConfirmationRequired, "deploy cancelled"))
+		}
+	}
+
+	body := gen.DeployAgentJSONRequestBody{
+		ImageId: build.ImageID,
+		Env:     &finalEnv,
+	}
+	depResp, err := client.DeployAgentWithResponse(ctx, o.Org, o.Proj, o.AgentName, body)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if depResp.HTTPResponse == nil || depResp.HTTPResponse.StatusCode != http.StatusAccepted {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(depResp.HTTPResponse,
+			cmdutil.FirstNonNil(depResp.JSON400, depResp.JSON404, depResp.JSON500)))
+	}
+
+	conflictKeys := make([]string, 0, len(conflicts))
+	for _, c := range conflicts {
+		conflictKeys = append(conflictKeys, c.Key)
+	}
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, DeployResult{
+			Agent: o.AgentName, Build: build.Name, ImageId: build.ImageID,
+			TargetEnvironment: targetEnv, ConflictsResolved: conflictKeys,
+		})
+	}
+	cs := o.IO.StderrColorScheme()
+	fmt.Fprintf(o.IO.ErrOut,
+		"%s Deploy requested for agent %q (build: %s, image: %s). Run 'amctl agent get %s' to check status.\n",
+		cs.SuccessIcon(), o.AgentName, build.Name, build.ImageID, o.AgentName)
+	return nil
+}
+
+func resolveDeployableBuild(ctx context.Context, client *gen.ClientWithResponses,
+	org, proj, agent, buildName string,
+) (deployableBuild, error) {
+	if buildName != "" {
+		// --build-name branch lands in Task 5.
+		return deployableBuild{}, clierr.New(clierr.Internal, "--build-name not implemented yet")
+	}
+	limit := 1
+	resp, err := client.GetAgentBuildsWithResponse(ctx, org, proj, agent, &gen.GetAgentBuildsParams{Limit: &limit})
+	if err != nil {
+		return deployableBuild{}, clierr.Newf(clierr.Transport, "%v", err)
+	}
+	if resp.JSON200 == nil {
+		return deployableBuild{}, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON404, resp.JSON500))
+	}
+	builds := buildsFromListResponse(resp.JSON200)
+	if len(builds) == 0 {
+		return deployableBuild{}, clierr.Newf(clierr.BuildNotDeployable,
+			"no builds found for agent %q; run 'amctl agent build create' first", agent)
+	}
+	b := builds[0]
+	status := ""
+	if b.Status != nil {
+		status = string(*b.Status)
+	}
+	if status != "BuildCompleted" || b.ImageId == nil || *b.ImageId == "" {
+		return deployableBuild{}, clierr.Newf(clierr.BuildNotDeployable,
+			"build %q not deployable: status=%s", b.BuildName, status)
+	}
+	return deployableBuild{Name: b.BuildName, ImageID: *b.ImageId, Status: status}, nil
+}
+
+func buildsFromListResponse(r *gen.BuildsListResponse) []gen.BuildResponse {
+	if r == nil {
+		return nil
+	}
+	return r.Builds
+}
+
+func configurationItemsFromResponse(r *gen.ConfigurationResponse) []gen.ConfigurationItem {
+	if r == nil {
+		return nil
+	}
+	return r.Configurations
+}

--- a/cli/pkg/cmd/agent/deploy.go
+++ b/cli/pkg/cmd/agent/deploy.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+// Licensed under the Apache License, Version 2.0.
+
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+// envConflict describes a single key where the CLI's --env value differs from
+// what's currently configured on the agent.
+type envConflict struct {
+	Key              string
+	CurrentValue     string
+	NewValue         string
+	CurrentSensitive bool
+}
+
+func parseEnvFlag(inputs []string) (map[string]string, error) {
+	out := make(map[string]string, len(inputs))
+	for _, raw := range inputs {
+		idx := strings.IndexByte(raw, '=')
+		if idx < 0 {
+			return nil, fmt.Errorf("invalid --env %q: expected KEY=VALUE", raw)
+		}
+		key := raw[:idx]
+		if key == "" {
+			return nil, fmt.Errorf("invalid --env %q: empty key", raw)
+		}
+		out[key] = raw[idx+1:]
+	}
+	return out, nil
+}
+
+// findLowestEnvironment returns the entry environment of the deployment
+// pipeline — the SourceEnvironmentRef that does not appear anywhere as a
+// target. Mirrors the server-side selection rule; replicated client-side so we
+// can fetch GetAgentConfigurations for that env before the deploy call.
+func findLowestEnvironment(paths []gen.PromotionPath) string {
+	targets := make(map[string]struct{})
+	for _, p := range paths {
+		for _, t := range p.TargetEnvironmentRefs {
+			targets[t.Name] = struct{}{}
+		}
+	}
+	for _, p := range paths {
+		if _, isTarget := targets[p.SourceEnvironmentRef]; !isTarget {
+			return p.SourceEnvironmentRef
+		}
+	}
+	return ""
+}
+
+func mergeEnv(current []gen.ConfigurationItem, cli map[string]string) ([]gen.EnvironmentVariable, []envConflict) {
+	final := make([]gen.EnvironmentVariable, 0, len(current)+len(cli))
+	conflicts := make([]envConflict, 0, len(current)+len(cli))
+	seen := make(map[string]struct{}, len(current))
+
+	for _, c := range current {
+		seen[c.Key] = struct{}{}
+		isSensitive := c.IsSensitive != nil && *c.IsSensitive
+		newVal, hasNew := cli[c.Key]
+		switch {
+		case !hasNew:
+			val := c.Value
+			ev := gen.EnvironmentVariable{Key: c.Key, Value: &val}
+			if isSensitive {
+				ev.IsSensitive = boolPtrLocal(true)
+				if c.SecretRef != nil {
+					ev.SecretRef = c.SecretRef
+				}
+				ev.Value = nil
+			}
+			final = append(final, ev)
+		case isSensitive:
+			v := newVal
+			final = append(final, gen.EnvironmentVariable{Key: c.Key, Value: &v})
+			conflicts = append(conflicts, envConflict{
+				Key: c.Key, CurrentValue: "", NewValue: newVal, CurrentSensitive: true,
+			})
+		case newVal == c.Value:
+			v := newVal
+			final = append(final, gen.EnvironmentVariable{Key: c.Key, Value: &v})
+		default:
+			v := newVal
+			final = append(final, gen.EnvironmentVariable{Key: c.Key, Value: &v})
+			conflicts = append(conflicts, envConflict{
+				Key: c.Key, CurrentValue: c.Value, NewValue: newVal, CurrentSensitive: false,
+			})
+		}
+	}
+
+	addedKeys := make([]string, 0, len(cli))
+	for k := range cli {
+		if _, ok := seen[k]; !ok {
+			addedKeys = append(addedKeys, k)
+		}
+	}
+	sort.Strings(addedKeys)
+	for _, k := range addedKeys {
+		v := cli[k]
+		final = append(final, gen.EnvironmentVariable{Key: k, Value: &v})
+	}
+
+	return final, conflicts
+}
+
+func renderConflictTable(io *iostreams.IOStreams, conflicts []envConflict) {
+	w := io.ErrOut
+
+	sensitiveKeys := make([]string, 0)
+	for _, c := range conflicts {
+		if c.CurrentSensitive {
+			sensitiveKeys = append(sensitiveKeys, c.Key)
+		}
+	}
+	if len(sensitiveKeys) > 0 {
+		fmt.Fprintf(w,
+			"Warning: %s is currently stored as a secret. Replacing it via --env will "+
+				"store the new value as plain text. Use the platform UI to keep it as a secret.\n\n",
+			strings.Join(sensitiveKeys, ", "))
+	}
+
+	fmt.Fprintln(w, "The following env vars will be replaced:")
+	fmt.Fprintln(w)
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  KEY\tCURRENT\tNEW")
+	for _, c := range conflicts {
+		cur := c.CurrentValue
+		newV := c.NewValue
+		if c.CurrentSensitive {
+			cur = "(secret)"
+			newV = "***"
+		}
+		fmt.Fprintf(tw, "  %s\t%s\t%s\n", c.Key, cur, newV)
+	}
+	_ = tw.Flush()
+	fmt.Fprintln(w)
+}
+
+func boolPtrLocal(b bool) *bool { return &b }

--- a/cli/pkg/cmd/agent/deploy.go
+++ b/cli/pkg/cmd/agent/deploy.go
@@ -223,6 +223,7 @@ func NewDeployCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip the env-conflict confirmation prompt")
 	cmd.Flags().StringVar(&opts.BuildName, "build-name", "", "Specific build to deploy (default: latest by startedAt)")
+	cmd.Flags().StringArrayVar(&opts.EnvFlags, "env", nil, "Set env var as KEY=VALUE (repeatable; merges with current config)")
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cli/pkg/cmd/agent/deploy.go
+++ b/cli/pkg/cmd/agent/deploy.go
@@ -346,7 +346,7 @@ func resolveDeployableBuild(ctx context.Context, client *gen.ClientWithResponses
 		if b.Status != nil {
 			status = string(*b.Status)
 		}
-		if status != "BuildCompleted" || b.ImageId == nil || *b.ImageId == "" {
+		if !isBuildDeployable(status) || b.ImageId == nil || *b.ImageId == "" {
 			return deployableBuild{}, clierr.Newf(clierr.BuildNotDeployable,
 				"build %q not deployable: status=%s", b.BuildName, status)
 		}
@@ -370,11 +370,22 @@ func resolveDeployableBuild(ctx context.Context, client *gen.ClientWithResponses
 	if b.Status != nil {
 		status = string(*b.Status)
 	}
-	if status != "BuildCompleted" || b.ImageId == nil || *b.ImageId == "" {
+	if !isBuildDeployable(status) || b.ImageId == nil || *b.ImageId == "" {
 		return deployableBuild{}, clierr.Newf(clierr.BuildNotDeployable,
 			"build %q not deployable: status=%s", b.BuildName, status)
 	}
 	return deployableBuild{Name: b.BuildName, ImageID: *b.ImageId, Status: status}, nil
+}
+
+// isBuildDeployable returns true for build status strings the server actually
+// emits when an image is available. The OpenAPI spec advertises a
+// BuildCompleted/BuildInProgress/BuildTriggered enum, but the server emits the
+// upstream WorkflowRun phase verbatim (see agent-manager-service/clients/
+// openchoreosvc/client/builds.go:677-693). "Succeeded" means image pushed but
+// workload CR not yet updated; "Completed" means both done. imageId is
+// populated in both states.
+func isBuildDeployable(status string) bool {
+	return status == "Completed" || status == "Succeeded"
 }
 
 func buildsFromListResponse(r *gen.BuildsListResponse) []gen.BuildResponse {

--- a/cli/pkg/cmd/agent/deploy.go
+++ b/cli/pkg/cmd/agent/deploy.go
@@ -222,6 +222,7 @@ func NewDeployCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip the env-conflict confirmation prompt")
+	cmd.Flags().StringVar(&opts.BuildName, "build-name", "", "Specific build to deploy (default: latest by startedAt)")
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) > 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -332,8 +333,23 @@ func resolveDeployableBuild(ctx context.Context, client *gen.ClientWithResponses
 	org, proj, agent, buildName string,
 ) (deployableBuild, error) {
 	if buildName != "" {
-		// --build-name branch lands in Task 5.
-		return deployableBuild{}, clierr.New(clierr.Internal, "--build-name not implemented yet")
+		resp, err := client.GetBuildWithResponse(ctx, org, proj, agent, buildName)
+		if err != nil {
+			return deployableBuild{}, clierr.Newf(clierr.Transport, "%v", err)
+		}
+		if resp.JSON200 == nil {
+			return deployableBuild{}, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON404, resp.JSON500))
+		}
+		b := resp.JSON200
+		status := ""
+		if b.Status != nil {
+			status = string(*b.Status)
+		}
+		if status != "BuildCompleted" || b.ImageId == nil || *b.ImageId == "" {
+			return deployableBuild{}, clierr.Newf(clierr.BuildNotDeployable,
+				"build %q not deployable: status=%s", b.BuildName, status)
+		}
+		return deployableBuild{Name: b.BuildName, ImageID: *b.ImageId, Status: status}, nil
 	}
 	limit := 1
 	resp, err := client.GetAgentBuildsWithResponse(ctx, org, proj, agent, &gen.GetAgentBuildsParams{Limit: &limit})

--- a/cli/pkg/cmd/agent/deploy.go
+++ b/cli/pkg/cmd/agent/deploy.go
@@ -1,5 +1,18 @@
 // Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
-// Licensed under the Apache License, Version 2.0.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package agent
 

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -4,12 +4,19 @@
 package agent
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
 func boolPtr(b bool) *bool { return &b }
@@ -232,3 +239,295 @@ func TestRenderConflictTable_SensitiveBanner(t *testing.T) {
 		t.Errorf("table must NOT echo incoming CLI value for sensitive key, got: %q", out)
 	}
 }
+
+// fakeDeployPrompter records Confirm calls and returns a canned answer.
+type fakeDeployPrompter struct {
+	confirmCalls  int
+	confirmAnswer bool
+	confirmErr    error
+	confirmPrompt string
+}
+
+func (p *fakeDeployPrompter) ConfirmDeletion(required string) error { return nil }
+func (p *fakeDeployPrompter) Confirm(prompt string) (bool, error) {
+	p.confirmCalls++
+	p.confirmPrompt = prompt
+	return p.confirmAnswer, p.confirmErr
+}
+
+// recordedRequest captures a single inbound request body for assertions.
+type recordedRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+type stubResponse struct {
+	status int
+	body   any
+}
+
+func newStubServer(t *testing.T, routes map[string]stubResponse, recorder *[]recordedRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := readAllBody(r)
+		*recorder = append(*recorder, recordedRequest{method: r.Method, path: r.URL.Path, body: body})
+		key := r.Method + " " + r.URL.Path
+		resp, ok := routes[key]
+		if !ok {
+			w.WriteHeader(500)
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": "NOT_STUBBED", "message": key})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.status)
+		if resp.body != nil {
+			_ = json.NewEncoder(w).Encode(resp.body)
+		}
+	}))
+}
+
+func readAllBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	defer r.Body.Close()
+	buf := &bytes.Buffer{}
+	if _, err := buf.ReadFrom(r.Body); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func newTestDeployIO(canPrompt, jsonMode bool) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	io, _, out, errOut := iostreams.Test()
+	io.SetTerminal(canPrompt, canPrompt, canPrompt)
+	io.JSON = jsonMode
+	return io, out, errOut
+}
+
+func stubBuildableAgent() map[string]any {
+	return map[string]any{
+		"name":        "order-bot",
+		"displayName": "Order Bot",
+		"description": "",
+		"projectName": "triage",
+		"createdAt":   "2026-05-13T10:00:00Z",
+		"provisioning": map[string]any{"type": "internal"},
+		"agentType":   map[string]any{"type": "chat"},
+		"uuid":        "00000000-0000-0000-0000-000000000001",
+	}
+}
+
+func stubBuildsListLatest(name, imageID, status string) map[string]any {
+	return map[string]any{
+		"builds": []any{
+			map[string]any{
+				"agentName":       "order-bot",
+				"projectName":     "triage",
+				"buildName":       name,
+				"imageId":         imageID,
+				"startedAt":       "2026-05-13T11:00:00Z",
+				"status":          status,
+				"buildParameters": map[string]any{},
+			},
+		},
+	}
+}
+
+func stubPipelineDevToProd() map[string]any {
+	return map[string]any{
+		"name":        "default-pipeline",
+		"displayName": "Default",
+		"description": "",
+		"orgName":     "acme",
+		"createdAt":   "2026-05-13T09:00:00Z",
+		"promotionPaths": []any{
+			map[string]any{
+				"sourceEnvironmentRef":  "dev",
+				"targetEnvironmentRefs": []any{map[string]any{"name": "prod"}},
+			},
+		},
+	}
+}
+
+func stubConfigurations(items []map[string]any) map[string]any {
+	if items == nil {
+		items = []map[string]any{}
+	}
+	return map[string]any{
+		"agentName":      "order-bot",
+		"projectName":    "triage",
+		"environment":    "dev",
+		"configurations": items,
+	}
+}
+
+func stubDeployAccepted(imageID string) map[string]any {
+	return map[string]any{
+		"agentName":   "order-bot",
+		"projectName": "triage",
+		"imageId":     imageID,
+		"environment": "dev",
+	}
+}
+
+func TestDeploy_LatestBuild_HappyPath(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	prompter := &fakeDeployPrompter{}
+	requests := []recordedRequest{}
+
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "image-sha-123", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("image-sha-123")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	opts := &DeployOptions{
+		IO:        io,
+		Prompter:  prompter,
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme",
+		Proj:      "triage",
+		AgentName: "order-bot",
+	}
+	if err := runDeploy(context.Background(), opts); err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+
+	var deployBody []byte
+	for _, r := range requests {
+		if r.method == "POST" && strings.HasSuffix(r.path, "/deployments") {
+			deployBody = r.body
+		}
+	}
+	if deployBody == nil {
+		t.Fatalf("POST /deployments not called; requests: %v", requests)
+	}
+	var sent map[string]any
+	if err := json.Unmarshal(deployBody, &sent); err != nil {
+		t.Fatalf("decode POST body: %v", err)
+	}
+	if sent["imageId"] != "image-sha-123" {
+		t.Errorf("imageId = %v, want image-sha-123", sent["imageId"])
+	}
+	if envField, ok := sent["env"]; ok && envField != nil {
+		if arr, isArr := envField.([]any); !isArr || len(arr) != 0 {
+			t.Errorf("env = %v, want absent or empty", envField)
+		}
+	}
+	if _, hasInstr := sent["enableAutoInstrumentation"]; hasInstr {
+		t.Errorf("enableAutoInstrumentation must not be sent; server reads from DB")
+	}
+	if prompter.confirmCalls != 0 {
+		t.Errorf("confirm should not be called for no-conflict deploy; got %d", prompter.confirmCalls)
+	}
+}
+
+func TestDeploy_NoBuilds_ReturnsBuildNotDeployable(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	prompter := &fakeDeployPrompter{}
+	requests := []recordedRequest{}
+
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, map[string]any{"builds": []any{}}},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: prompter,
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.BuildNotDeployable {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.BuildNotDeployable)
+	}
+	if !strings.Contains(errBody["message"].(string), "no builds found") {
+		t.Errorf("message = %v, want 'no builds found' substring", errBody["message"])
+	}
+}
+
+func TestDeploy_NotBuildable_PassthroughError(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+
+	externalAgent := stubBuildableAgent()
+	externalAgent["provisioning"] = map[string]any{"type": "external"}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot": {200, externalAgent},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.Validation {
+		t.Errorf("code = %v, want %s (ValidateBuildable returns Validation)", errBody["code"], clierr.Validation)
+	}
+}
+
+func TestDeploy_EmptyPipeline_ReturnsInternal(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+
+	emptyPipeline := stubPipelineDevToProd()
+	emptyPipeline["promotionPaths"] = []any{}
+
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "image-sha-123", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":     {200, emptyPipeline},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.Internal {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.Internal)
+	}
+	if !strings.Contains(errBody["message"].(string), "no entry environment") {
+		t.Errorf("message = %v, want 'no entry environment' substring", errBody["message"])
+	}
+}
+
+// ensure render import is used (test helpers rely on render.Scope indirectly via baseScope)
+var _ render.Scope

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+// Licensed under the Apache License, Version 2.0.
+
+package agent
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestParseEnvFlag(t *testing.T) {
+	cases := []struct {
+		name    string
+		inputs  []string
+		want    map[string]string
+		wantErr string
+	}{
+		{"single pair", []string{"A=1"}, map[string]string{"A": "1"}, ""},
+		{"value with equals", []string{"URL=k=v"}, map[string]string{"URL": "k=v"}, ""},
+		{"empty value", []string{"A="}, map[string]string{"A": ""}, ""},
+		{"multiple", []string{"A=1", "B=2"}, map[string]string{"A": "1", "B": "2"}, ""},
+		{"duplicate last-wins", []string{"A=1", "A=2"}, map[string]string{"A": "2"}, ""},
+		{"empty key", []string{"=foo"}, nil, `invalid --env "=foo": empty key`},
+		{"no equals", []string{"FOO"}, nil, `invalid --env "FOO": expected KEY=VALUE`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseEnvFlag(tc.inputs)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got %v)", len(got), len(tc.want), got)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("got[%q] = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestFindLowestEnvironment(t *testing.T) {
+	cases := []struct {
+		name  string
+		paths []gen.PromotionPath
+		want  string
+	}{
+		{
+			name: "linear dev->staging->prod, dev is entry",
+			paths: []gen.PromotionPath{
+				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []gen.TargetEnvironmentRef{{Name: "staging"}}},
+				{SourceEnvironmentRef: "staging", TargetEnvironmentRefs: []gen.TargetEnvironmentRef{{Name: "prod"}}},
+			},
+			want: "dev",
+		},
+		{
+			name:  "empty pipeline",
+			paths: nil,
+			want:  "",
+		},
+		{
+			name: "single path dev->prod",
+			paths: []gen.PromotionPath{
+				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []gen.TargetEnvironmentRef{{Name: "prod"}}},
+			},
+			want: "dev",
+		},
+		{
+			name: "every source is also a target (cycle) -> empty",
+			paths: []gen.PromotionPath{
+				{SourceEnvironmentRef: "a", TargetEnvironmentRefs: []gen.TargetEnvironmentRef{{Name: "b"}}},
+				{SourceEnvironmentRef: "b", TargetEnvironmentRefs: []gen.TargetEnvironmentRef{{Name: "a"}}},
+			},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findLowestEnvironment(tc.paths)
+			if got != tc.want {
+				t.Errorf("findLowestEnvironment = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeEnv(t *testing.T) {
+	type result struct {
+		final     map[string]string
+		conflicts []string
+	}
+	cases := []struct {
+		name    string
+		current []gen.ConfigurationItem
+		cli     map[string]string
+		want    result
+	}{
+		{
+			name:    "no current, no cli",
+			current: nil, cli: nil,
+			want: result{final: map[string]string{}, conflicts: nil},
+		},
+		{
+			name: "preserve current when cli absent",
+			current: []gen.ConfigurationItem{
+				{Key: "A", Value: "1"},
+				{Key: "B", Value: "2"},
+			},
+			cli:  nil,
+			want: result{final: map[string]string{"A": "1", "B": "2"}, conflicts: nil},
+		},
+		{
+			name:    "add new cli key",
+			current: []gen.ConfigurationItem{{Key: "A", Value: "1"}},
+			cli:     map[string]string{"B": "2"},
+			want:    result{final: map[string]string{"A": "1", "B": "2"}, conflicts: nil},
+		},
+		{
+			name:    "same value is not a conflict",
+			current: []gen.ConfigurationItem{{Key: "A", Value: "1"}},
+			cli:     map[string]string{"A": "1"},
+			want:    result{final: map[string]string{"A": "1"}, conflicts: nil},
+		},
+		{
+			name:    "different value is a conflict",
+			current: []gen.ConfigurationItem{{Key: "A", Value: "1"}},
+			cli:     map[string]string{"A": "2"},
+			want:    result{final: map[string]string{"A": "2"}, conflicts: []string{"A"}},
+		},
+		{
+			name: "sensitive current key always conflicts when cli sets it",
+			current: []gen.ConfigurationItem{
+				{Key: "SECRET", Value: "", IsSensitive: boolPtr(true)},
+			},
+			cli:  map[string]string{"SECRET": "new"},
+			want: result{final: map[string]string{"SECRET": "new"}, conflicts: []string{"SECRET"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			final, conflicts := mergeEnv(tc.current, tc.cli)
+
+			gotFinal := map[string]string{}
+			for _, ev := range final {
+				if ev.Value == nil {
+					gotFinal[ev.Key] = ""
+				} else {
+					gotFinal[ev.Key] = *ev.Value
+				}
+			}
+			if len(gotFinal) != len(tc.want.final) {
+				t.Errorf("final size = %d, want %d (%v vs %v)", len(gotFinal), len(tc.want.final), gotFinal, tc.want.final)
+			}
+			for k, v := range tc.want.final {
+				if gotFinal[k] != v {
+					t.Errorf("final[%q] = %q, want %q", k, gotFinal[k], v)
+				}
+			}
+
+			gotConflicts := make([]string, 0, len(conflicts))
+			for _, c := range conflicts {
+				gotConflicts = append(gotConflicts, c.Key)
+			}
+			sort.Strings(gotConflicts)
+			wantConflicts := append([]string{}, tc.want.conflicts...)
+			sort.Strings(wantConflicts)
+			if len(gotConflicts) != len(wantConflicts) {
+				t.Fatalf("conflicts = %v, want %v", gotConflicts, wantConflicts)
+			}
+			for i := range gotConflicts {
+				if gotConflicts[i] != wantConflicts[i] {
+					t.Errorf("conflicts[%d] = %q, want %q", i, gotConflicts[i], wantConflicts[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRenderConflictTable_PlainOnly(t *testing.T) {
+	io, _, _, errOut := iostreams.Test()
+	io.SetTerminal(true, true, true)
+	conflicts := []envConflict{
+		{Key: "OPENAI_MODEL", CurrentValue: "gpt-4o-mini", NewValue: "gpt-4o", CurrentSensitive: false},
+	}
+	renderConflictTable(io, conflicts)
+	out := errOut.String()
+	if strings.Contains(out, "secret") {
+		t.Errorf("plain-only render should not mention secrets, got: %q", out)
+	}
+	for _, want := range []string{"OPENAI_MODEL", "gpt-4o-mini", "gpt-4o"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestRenderConflictTable_SensitiveBanner(t *testing.T) {
+	io, _, _, errOut := iostreams.Test()
+	io.SetTerminal(true, true, true)
+	conflicts := []envConflict{
+		{Key: "PINECONE_API_KEY", CurrentValue: "", NewValue: "new-secret-value", CurrentSensitive: true},
+	}
+	renderConflictTable(io, conflicts)
+	out := errOut.String()
+	if !strings.Contains(out, "PINECONE_API_KEY") {
+		t.Errorf("banner should name affected key, got: %q", out)
+	}
+	if !strings.Contains(out, "secret") {
+		t.Errorf("banner should mention secret demotion, got: %q", out)
+	}
+	if !strings.Contains(out, "(secret)") {
+		t.Errorf("table should render current sensitive value as (secret), got: %q", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("table should render incoming sensitive value as ***, got: %q", out)
+	}
+	if strings.Contains(out, "new-secret-value") {
+		t.Errorf("table must NOT echo incoming CLI value for sensitive key, got: %q", out)
+	}
+}

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -379,7 +379,7 @@ func TestDeploy_LatestBuild_HappyPath(t *testing.T) {
 
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "image-sha-123", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "image-sha-123", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
 		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("image-sha-123")},
@@ -502,7 +502,7 @@ func TestDeploy_EmptyPipeline_ReturnsInternal(t *testing.T) {
 
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "image-sha-123", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "image-sha-123", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":     {200, emptyPipeline},
 	}
 	srv := newStubServer(t, routes, &requests)
@@ -562,7 +562,7 @@ func TestDeploy_BuildNameSuccess_PreservesExistingEnv(t *testing.T) {
 
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                   {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds/specific-b": {200, stubBuildDetails("specific-b", "image-X", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds/specific-b": {200, stubBuildDetails("specific-b", "image-X", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":                {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations":    {200, stubConfigsWithKVs([2]string{"FOO", "1"}, [2]string{"BAR", "2"})},
 		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":      {202, stubDeployAccepted("image-X")},
@@ -654,7 +654,7 @@ func TestDeploy_BuildCompletedButNoImageID_Errors(t *testing.T) {
 				"agentName":       "order-bot",
 				"projectName":     "triage",
 				"buildName":       "b1",
-				"status":          "BuildCompleted",
+				"status":          "Completed",
 				"startedAt":       "2026-05-13T11:00:00Z",
 				"buildParameters": map[string]any{},
 				// imageId omitted
@@ -719,7 +719,7 @@ func TestDeploy_EnvNewKey_NoConflict(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"EXISTING", "1"})},
 		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
@@ -753,7 +753,7 @@ func TestDeploy_EnvConflict_YesFlagBypassesPrompt(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
 		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
@@ -788,7 +788,7 @@ func TestDeploy_EnvConflict_PromptAccepted(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
 		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
@@ -821,7 +821,7 @@ func TestDeploy_EnvConflict_PromptDeclined(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
 	}
@@ -857,7 +857,7 @@ func TestDeploy_EnvConflict_JSONModeWithoutYes_Errors(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
 	}
@@ -890,7 +890,7 @@ func TestDeploy_EnvConflict_NonTTYWithoutYes_Errors(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
 	}
@@ -935,7 +935,7 @@ func TestDeploy_EnvSensitiveConflict_WithYes_JSONReportsKeyOnly(t *testing.T) {
 	sk, sv := sensitiveConfigsRoute()
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":              {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":       {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":       {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":           {200, stubPipelineDevToProd()},
 		sk: sv,
 		"POST /orgs/acme/projects/triage/agents/order-bot/deployments": {202, stubDeployAccepted("img1")},
@@ -976,7 +976,7 @@ func TestDeploy_EnvSensitiveConflict_JSONWithoutYes_ErrorsKeyOnly(t *testing.T) 
 	sk, sv := sensitiveConfigsRoute()
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":     {200, stubPipelineDevToProd()},
 		sk: sv,
 	}
@@ -1012,7 +1012,7 @@ func TestDeploy_EnvFlag_MalformedEmptyKey(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
 	}
@@ -1042,7 +1042,7 @@ func TestDeploy_EnvFlag_MalformedNoEquals(t *testing.T) {
 	requests := []recordedRequest{}
 	routes := map[string]stubResponse{
 		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
 		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
 		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
 	}
@@ -1065,4 +1065,75 @@ func TestDeploy_EnvFlag_MalformedNoEquals(t *testing.T) {
 	if errBody["code"] != clierr.InvalidFlag {
 		t.Errorf("code = %v, want %s", errBody["code"], clierr.InvalidFlag)
 	}
+}
+
+// The server emits raw WorkflowRun phase strings ("Completed", "Succeeded",
+// "Running", "Failed", "Pending") in BuildResponse.Status, not the spec's
+// advertised BuildCompleted/BuildInProgress/BuildTriggered enum. See
+// agent-manager-service/clients/openchoreosvc/client/builds.go:677-693.
+// Both "Completed" (workload CR updated) and "Succeeded" (image pushed,
+// workload CR not yet updated) have an imageId populated and are deployable.
+
+func TestDeploy_StatusCompleted_IsDeployable(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Completed")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+	})
+	if err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+	if captureDeployPost(requests) == nil {
+		t.Fatal("expected POST /deployments to be issued for status=Completed")
+	}
+}
+
+func TestDeploy_StatusSucceeded_IsDeployable(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "Succeeded")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+	})
+	if err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+	if captureDeployPost(requests) == nil {
+		t.Fatal("expected POST /deployments to be issued for status=Succeeded")
+	}
+}
+
+func TestDeploy_StatusRunning_Errors(t *testing.T) {
+	deployStatusErrorTest(t, "Running", "status=Running")
+}
+
+func TestDeploy_StatusFailed_Errors(t *testing.T) {
+	deployStatusErrorTest(t, "Failed", "status=Failed")
 }

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
 	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
-	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
 func boolPtr(b bool) *bool { return &b }
@@ -529,5 +528,3 @@ func TestDeploy_EmptyPipeline_ReturnsInternal(t *testing.T) {
 	}
 }
 
-// ensure render import is used (test helpers rely on render.Scope indirectly via baseScope)
-var _ render.Scope

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -528,3 +528,159 @@ func TestDeploy_EmptyPipeline_ReturnsInternal(t *testing.T) {
 	}
 }
 
+// stubBuildDetails is the response shape for GetBuild (single build).
+func stubBuildDetails(name, imageID, status string) map[string]any {
+	out := map[string]any{
+		"agentName":       "order-bot",
+		"projectName":     "triage",
+		"buildName":       name,
+		"startedAt":       "2026-05-13T11:00:00Z",
+		"buildParameters": map[string]any{},
+	}
+	if imageID != "" {
+		out["imageId"] = imageID
+	}
+	if status != "" {
+		out["status"] = status
+	}
+	return out
+}
+
+// stubConfigsWithKVs builds a configurations response from (key, value) pairs.
+func stubConfigsWithKVs(kvs ...[2]string) map[string]any {
+	items := make([]map[string]any, 0, len(kvs))
+	for _, kv := range kvs {
+		items = append(items, map[string]any{"key": kv[0], "value": kv[1]})
+	}
+	return stubConfigurations(items)
+}
+
+func TestDeploy_BuildNameSuccess_PreservesExistingEnv(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	requests := []recordedRequest{}
+
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                   {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds/specific-b": {200, stubBuildDetails("specific-b", "image-X", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":                {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations":    {200, stubConfigsWithKVs([2]string{"FOO", "1"}, [2]string{"BAR", "2"})},
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":      {202, stubDeployAccepted("image-X")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		BuildName: "specific-b",
+	})
+	if err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+
+	var post []byte
+	for _, r := range requests {
+		if r.method == "POST" && strings.HasSuffix(r.path, "/deployments") {
+			post = r.body
+		}
+	}
+	var sent map[string]any
+	_ = json.Unmarshal(post, &sent)
+	if sent["imageId"] != "image-X" {
+		t.Errorf("imageId = %v, want image-X", sent["imageId"])
+	}
+	envArr, _ := sent["env"].([]any)
+	gotKeys := map[string]string{}
+	for _, e := range envArr {
+		m := e.(map[string]any)
+		if v, ok := m["value"].(string); ok {
+			gotKeys[m["key"].(string)] = v
+		}
+	}
+	if gotKeys["FOO"] != "1" || gotKeys["BAR"] != "2" {
+		t.Errorf("env should preserve FOO=1, BAR=2; got %v", gotKeys)
+	}
+}
+
+func deployStatusErrorTest(t *testing.T, status, wantSubstr string) {
+	t.Helper()
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "image-X", status)},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.BuildNotDeployable {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.BuildNotDeployable)
+	}
+	if !strings.Contains(errBody["message"].(string), wantSubstr) {
+		t.Errorf("message = %v, want %q substring", errBody["message"], wantSubstr)
+	}
+}
+
+func TestDeploy_BuildInProgress_Errors(t *testing.T) {
+	deployStatusErrorTest(t, "BuildInProgress", "status=BuildInProgress")
+}
+
+func TestDeploy_BuildTriggered_Errors(t *testing.T) {
+	deployStatusErrorTest(t, "BuildTriggered", "status=BuildTriggered")
+}
+
+func TestDeploy_BuildCompletedButNoImageID_Errors(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+	noImg := map[string]any{
+		"builds": []any{
+			map[string]any{
+				"agentName":       "order-bot",
+				"projectName":     "triage",
+				"buildName":       "b1",
+				"status":          "BuildCompleted",
+				"startedAt":       "2026-05-13T11:00:00Z",
+				"buildParameters": map[string]any{},
+				// imageId omitted
+			},
+		},
+	}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, noImg},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.BuildNotDeployable {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.BuildNotDeployable)
+	}
+}
+

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -684,3 +685,384 @@ func TestDeploy_BuildCompletedButNoImageID_Errors(t *testing.T) {
 	}
 }
 
+// envFromPost decodes the env field of a captured deploy POST body into key->value.
+func envFromPost(t *testing.T, body []byte) map[string]string {
+	t.Helper()
+	var sent map[string]any
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatalf("decode POST: %v", err)
+	}
+	out := map[string]string{}
+	arr, _ := sent["env"].([]any)
+	for _, e := range arr {
+		m := e.(map[string]any)
+		v := ""
+		if val, ok := m["value"].(string); ok {
+			v = val
+		}
+		out[m["key"].(string)] = v
+	}
+	return out
+}
+
+func captureDeployPost(requests []recordedRequest) []byte {
+	for _, r := range requests {
+		if r.method == "POST" && strings.HasSuffix(r.path, "/deployments") {
+			return r.body
+		}
+	}
+	return nil
+}
+
+func TestDeploy_EnvNewKey_NoConflict(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"EXISTING", "1"})},
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	prompter := &fakeDeployPrompter{}
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: prompter,
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"NEW_KEY=hello"},
+	})
+	if err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+	got := envFromPost(t, captureDeployPost(requests))
+	if got["EXISTING"] != "1" || got["NEW_KEY"] != "hello" {
+		t.Errorf("env = %v, want EXISTING=1, NEW_KEY=hello", got)
+	}
+	if prompter.confirmCalls != 0 {
+		t.Errorf("no prompt expected when no conflict")
+	}
+}
+
+func TestDeploy_EnvConflict_YesFlagBypassesPrompt(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	prompter := &fakeDeployPrompter{}
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: prompter,
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"A=2"},
+		Yes:       true,
+	})
+	if err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+	got := envFromPost(t, captureDeployPost(requests))
+	if got["A"] != "2" {
+		t.Errorf("env[A] = %q, want 2", got["A"])
+	}
+	if prompter.confirmCalls != 0 {
+		t.Errorf("--yes should bypass prompt; got %d calls", prompter.confirmCalls)
+	}
+}
+
+func TestDeploy_EnvConflict_PromptAccepted(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments":   {202, stubDeployAccepted("img1")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	prompter := &fakeDeployPrompter{confirmAnswer: true}
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: prompter,
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"A=2"},
+	})
+	if err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+	if prompter.confirmCalls != 1 {
+		t.Errorf("expected 1 confirm call, got %d", prompter.confirmCalls)
+	}
+	if captureDeployPost(requests) == nil {
+		t.Fatal("expected POST to be sent after accepted prompt")
+	}
+}
+
+func TestDeploy_EnvConflict_PromptDeclined(t *testing.T) {
+	io, _, _ := newTestDeployIO(true, false)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	prompter := &fakeDeployPrompter{confirmAnswer: false}
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: prompter,
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"A=2"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if captureDeployPost(requests) != nil {
+		t.Errorf("POST should not be sent when prompt is declined")
+	}
+	var cliErr clierr.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Code != clierr.ConfirmationRequired {
+		t.Errorf("err = %v, want ConfirmationRequired", err)
+	}
+	if !strings.Contains(cliErr.Message, "deploy cancelled") {
+		t.Errorf("message = %q, want 'deploy cancelled'", cliErr.Message)
+	}
+}
+
+func TestDeploy_EnvConflict_JSONModeWithoutYes_Errors(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"A=2"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
+	}
+	if !strings.Contains(errBody["message"].(string), "--json") {
+		t.Errorf("message should mention --json: %v", errBody["message"])
+	}
+}
+
+func TestDeploy_EnvConflict_NonTTYWithoutYes_Errors(t *testing.T) {
+	io, _, _ := newTestDeployIO(false, false)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigsWithKVs([2]string{"A", "1"})},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"A=2"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var cliErr clierr.CLIError
+	if !errors.As(err, &cliErr) || cliErr.Code != clierr.ConfirmationRequired {
+		t.Errorf("code = %v, want ConfirmationRequired", err)
+	}
+	if !strings.Contains(cliErr.Message, "stdin is not a terminal") {
+		t.Errorf("message should mention stdin: %q", cliErr.Message)
+	}
+}
+
+func sensitiveConfigsRoute() (string, stubResponse) {
+	return "GET /orgs/acme/projects/triage/agents/order-bot/configurations",
+		stubResponse{200, map[string]any{
+			"agentName":   "order-bot",
+			"projectName": "triage",
+			"environment": "dev",
+			"configurations": []any{
+				map[string]any{"key": "PINECONE_API_KEY", "value": "", "isSensitive": true},
+			},
+		}}
+}
+
+func TestDeploy_EnvSensitiveConflict_WithYes_JSONReportsKeyOnly(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+	sk, sv := sensitiveConfigsRoute()
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":              {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":       {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":           {200, stubPipelineDevToProd()},
+		sk: sv,
+		"POST /orgs/acme/projects/triage/agents/order-bot/deployments": {202, stubDeployAccepted("img1")},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"PINECONE_API_KEY=newval"},
+		Yes:       true,
+	})
+	if err != nil {
+		t.Fatalf("runDeploy: %v", err)
+	}
+	env := decodeEnvelope(t, out.String())
+	data := env["data"].(map[string]any)
+	resolved, ok := data["conflictsResolved"].([]any)
+	if !ok || len(resolved) != 1 || resolved[0] != "PINECONE_API_KEY" {
+		t.Errorf("conflictsResolved = %v, want [PINECONE_API_KEY]", resolved)
+	}
+	body := captureDeployPost(requests)
+	if !strings.Contains(string(body), "newval") {
+		t.Errorf("POST should still send the new value")
+	}
+	if strings.Contains(out.String(), "newval") {
+		t.Errorf("envelope must NOT contain the new sensitive value: %s", out.String())
+	}
+}
+
+func TestDeploy_EnvSensitiveConflict_JSONWithoutYes_ErrorsKeyOnly(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+	sk, sv := sensitiveConfigsRoute()
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":     {200, stubPipelineDevToProd()},
+		sk: sv,
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"PINECONE_API_KEY=newval"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if captureDeployPost(requests) != nil {
+		t.Errorf("no POST should be issued before confirmation")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
+	}
+	if strings.Contains(out.String(), "newval") {
+		t.Errorf("error envelope must NOT contain the new sensitive value: %s", out.String())
+	}
+}
+
+func TestDeploy_EnvFlag_MalformedEmptyKey(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"=foo"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.InvalidFlag {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.InvalidFlag)
+	}
+}
+
+func TestDeploy_EnvFlag_MalformedNoEquals(t *testing.T) {
+	io, out, _ := newTestDeployIO(true, true)
+	requests := []recordedRequest{}
+	routes := map[string]stubResponse{
+		"GET /orgs/acme/projects/triage/agents/order-bot":                {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds":         {200, stubBuildsListLatest("b1", "img1", "BuildCompleted")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":             {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/configurations": {200, stubConfigurations(nil)},
+	}
+	srv := newStubServer(t, routes, &requests)
+	defer srv.Close()
+	client, _ := gen.NewClientWithResponses(srv.URL)
+
+	err := runDeploy(context.Background(), &DeployOptions{
+		IO: io, Prompter: &fakeDeployPrompter{},
+		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:     baseScope(),
+		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags:  []string{"FOO"},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.InvalidFlag {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.InvalidFlag)
+	}
+}

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -1,5 +1,18 @@
 // Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
-// Licensed under the Apache License, Version 2.0.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package agent
 

--- a/cli/pkg/cmd/context/instance/remove_test.go
+++ b/cli/pkg/cmd/context/instance/remove_test.go
@@ -37,6 +37,8 @@ func (p *fakePrompter) ConfirmDeletion(required string) error {
 	return p.confirmDeletionErr
 }
 
+func (p *fakePrompter) Confirm(prompt string) (bool, error) { return false, nil }
+
 func TestRemove_Success(t *testing.T) {
 	io, out := newTestIO()
 	io.SetTerminal(true, true, true)

--- a/cli/pkg/cmd/project/helpers_test.go
+++ b/cli/pkg/cmd/project/helpers_test.go
@@ -87,6 +87,8 @@ func (p *fakePrompter) ConfirmDeletion(required string) error {
 	return p.confirmDeletionErr
 }
 
+func (p *fakePrompter) Confirm(prompt string) (bool, error) { return false, nil }
+
 func newTestIO(canPrompt bool) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
 	io, _, out, errOut := iostreams.Test()
 	io.SetTerminal(canPrompt, canPrompt, canPrompt)

--- a/cli/pkg/prompter/prompter.go
+++ b/cli/pkg/prompter/prompter.go
@@ -25,6 +25,7 @@ import (
 
 type Prompter interface {
 	ConfirmDeletion(required string) error
+	Confirm(prompt string) (bool, error)
 }
 
 type linePrompter struct {
@@ -48,6 +49,22 @@ func (p *linePrompter) ConfirmDeletion(required string) error {
 		return fmt.Errorf("confirmation %q did not match %q", strings.TrimSpace(line), required)
 	}
 	return nil
+}
+
+func (p *linePrompter) Confirm(prompt string) (bool, error) {
+	if _, err := fmt.Fprintf(p.out, "%s [y/N]: ", prompt); err != nil {
+		return false, err
+	}
+	line, err := p.readLine()
+	if err != nil {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 func (p *linePrompter) readLine() (string, error) {

--- a/cli/pkg/prompter/prompter_test.go
+++ b/cli/pkg/prompter/prompter_test.go
@@ -1,5 +1,18 @@
 // Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
-// Licensed under the Apache License, Version 2.0.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package prompter
 

--- a/cli/pkg/prompter/prompter_test.go
+++ b/cli/pkg/prompter/prompter_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+// Licensed under the Apache License, Version 2.0.
+
+package prompter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestLinePrompter_Confirm(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"yes lowercase", "y\n", true},
+		{"yes word", "yes\n", true},
+		{"YES uppercase", "YES\n", true},
+		{"yes with whitespace", "  y  \n", true},
+		{"no lowercase", "n\n", false},
+		{"no word", "no\n", false},
+		{"empty defaults to no", "\n", false},
+		{"junk defaults to no", "maybe\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			p := New(strings.NewReader(tc.input), out)
+			got, err := p.Confirm("Proceed?")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Confirm() = %v, want %v", got, tc.want)
+			}
+			if !strings.Contains(out.String(), "Proceed?") {
+				t.Errorf("prompt not written to out: %q", out.String())
+			}
+		})
+	}
+}
+
+func TestLinePrompter_ConfirmDeletion_StillWorks(t *testing.T) {
+	out := &bytes.Buffer{}
+	p := New(strings.NewReader("foo\n"), out)
+	if err := p.ConfirmDeletion("foo"); err != nil {
+		t.Fatalf("ConfirmDeletion: %v", err)
+	}
+}


### PR DESCRIPTION
## Purpose
CLI users can build agents (`amctl agent build create`) but must switch to the platform UI to deploy. This breaks scriptability and forces context-switching for routine work.

## Goals
Add `amctl agent deploy [agent]` — a fire-and-forget command that POSTs `DeployAgent` with a resolved image and a merged env-var set. By default it picks the latest deployable build; `--build-name` overrides. Env vars supplied via `--env KEY=VALUE` are merged with the agent's current configuration; conflicts require interactive confirmation or `--yes`.

## Approach
- Extended the `Prompter` interface with `Confirm(prompt) (bool, error)` for y/N prompts
- Added `clierr.BuildNotDeployable` wire-stable error code
- Implemented four pure helpers (`parseEnvFlag`, `findLowestEnvironment`, `mergeEnv`, `renderConflictTable`) with table-driven unit tests
- Wired `DeployOptions` / `NewDeployCmd` / `runDeploy` following the canonical Options/RunE/runX pattern from `agent/delete.go`
- Added `--build-name` flag with `GetBuildWithResponse` resolution and build-status error paths
- Added `--env` flag (`StringArrayVar` to avoid comma-splitting) with conflict detection, sensitive-key handling, and three confirmation gates (JSON mode, non-TTY, interactive prompt)
- Fixed build status gate to accept real server wire values (`Completed`, `Succeeded`) rather than the OpenAPI spec's unemitted enum (`BuildCompleted`)

## User stories
- As a CLI user, I can deploy a built agent image without leaving the terminal
- As a CI pipeline, I can deploy with `--yes` to skip interactive confirmation
- As a user overriding env vars, I see a clear diff table of conflicts before confirming

## Release note
New `amctl agent deploy [agent]` command: deploys a built agent image to the lowest pipeline environment with merged env vars, conflict confirmation, and `--build-name` / `--env` / `--yes` flags.

## Documentation
N/A — CLI `--help` text is self-documenting; no external doc site for amctl yet.

## Training
N/A — internal CLI tooling, not a platform feature requiring training content.

## Certification
N/A — CLI tooling, no certification exam impact.

## Marketing
N/A — internal developer tooling.

## Automation tests
- Unit tests
  - 22 `TestDeploy_*` test cases covering: latest-build happy path, `--build-name` resolution, build status error paths (`Running`, `Failed`, `BuildInProgress`, `BuildTriggered`, nil imageId, no builds), env merge (new key, conflict + `--yes`, conflict + prompt accept/decline, JSON mode, non-TTY, sensitive key redaction, malformed `--env`), pipeline errors, non-buildable agent passthrough
  - 8 `TestLinePrompter_Confirm` cases + 1 `ConfirmDeletion` regression test
  - 6 `TestParseEnvFlag` + 4 `TestFindLowestEnvironment` + 6 `TestMergeEnv` + 2 `TestRenderConflictTable` pure helper tests
  - All tests use `httptest.NewServer` stub servers matching real API routes — no mocks
- Integration tests
  - Manually verified end-to-end against local agent-manager stack (k3d + OpenBao + agent-manager-service)

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Go codebase, not Java; `go vet` clean
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — CLI command, no samples needed. Usage examples in `--help` text.

## Related PRs
None.

## Migrations (if applicable)
N/A — no database or configuration migrations.

## Test environment
- macOS Darwin 25.3.0 (arm64)
- Go (version from go.mod)
- k3d local cluster with agent-manager-service, OpenBao

## Learning
- Investigated server-side build status mismatch: the OpenAPI spec advertises `BuildCompleted`/`BuildInProgress`/`BuildTriggered` but the server emits upstream WorkflowRun phases (`Completed`, `Succeeded`, `Running`, `Failed`, `Pending`). The CLI gate was updated to accept the real wire values. A separate server-side fix to align the spec is recommended as follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `agent deploy` command to deploy built agent images to the lowest pipeline environment, with env var overrides, conflict detection, and `--build-name` option.
  * Interactive confirmation for env conflicts via a new generic confirm prompt (use `--yes` to bypass).
  * Introduced a stable CLI error code for non-deployable builds.

* **Tests**
  * Added comprehensive tests covering deploy flows, env parsing/merging, conflict handling, prompter behavior, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/858)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->