### PR TITLE
Console: AMP instrumentation version selector + Python version dropdown

### DIFF
--- a/console/workspaces/libs/shared-component/src/components/DeploymentConfig.tsx
+++ b/console/workspaces/libs/shared-component/src/components/DeploymentConfig.tsx
@@ -272,6 +272,18 @@ export function DeploymentConfig({
                   Automatically adds OTEL tracing instrumentation to your agent
                   for observability.
                 </Typography>
+                {enableAutoInstrumentation &&
+                  agent?.configurations?.instrumentationVersion && (
+                    <Typography variant="body2" color="text.secondary">
+                      AMP instrumentation version:{" "}
+                      <Typography component="code"
+                        sx={{ bgcolor: "action.hover", px: 0.5, borderRadius: 0.5 }}
+                      >
+                        {agent.configurations.instrumentationVersion}
+                      </Typography>{" "}
+                      (set at agent creation time)
+                    </Typography>
+                  )}
               </Form.Stack>
             </Form.Section>
           )}

--- a/console/workspaces/libs/types/src/api/common.ts
+++ b/console/workspaces/libs/types/src/api/common.ts
@@ -81,6 +81,7 @@ export type Build = BuildpackBuild | DockerBuild;
 export interface Configurations {
   env?: EnvironmentVariable[];
   enableAutoInstrumentation?: boolean;
+  instrumentationVersion?: string;
 }
 
 export interface EndpointSchema {

--- a/console/workspaces/libs/types/src/api/deployments.ts
+++ b/console/workspaces/libs/types/src/api/deployments.ts
@@ -23,6 +23,7 @@ export interface DeployAgentRequest {
   imageId: string;
   env?: EnvironmentVariable[];
   enableAutoInstrumentation?: boolean;
+  instrumentationVersion?: string;
 }
 
 // Responses

--- a/console/workspaces/libs/types/src/api/index.ts
+++ b/console/workspaces/libs/types/src/api/index.ts
@@ -17,6 +17,7 @@
  */
 
 export * from './common';
+export * from './instrumentation';
 export * from './agent-model-configs';
 export * from './catalog';
 export * from './agents';

--- a/console/workspaces/libs/types/src/api/instrumentation.ts
+++ b/console/workspaces/libs/types/src/api/instrumentation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/console/workspaces/libs/types/src/api/instrumentation.ts
+++ b/console/workspaces/libs/types/src/api/instrumentation.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// AMP instrumentation versions the platform supports. Each version maps to a
+// pre-built init-container image (`amp-python-instrumentation-provider:<version>-python<X.Y>`)
+// with a specific pinned `traceloop-sdk`. Server-side source of truth:
+// agent-manager-service `OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS` env (default `["0.2.0"]`).
+export const SUPPORTED_INSTRUMENTATION_VERSIONS = ['0.2.0'] as const;
+export const DEFAULT_INSTRUMENTATION_VERSION: SupportedInstrumentationVersion = '0.2.0';
+export type SupportedInstrumentationVersion =
+  (typeof SUPPORTED_INSTRUMENTATION_VERSIONS)[number];
+
+// Python versions supported by the platform's buildpack. The instrumentation
+// init-container image is ABI-locked to the agent's Python runtime, so this
+// set must match the `python_versions` entries in
+// `.github/release-config.json` for the `python-instrumentation-provider`.
+export const SUPPORTED_PYTHON_VERSIONS = ['3.10', '3.11', '3.12', '3.13'] as const;
+export const DEFAULT_PYTHON_VERSION: SupportedPythonVersion = '3.11';
+export type SupportedPythonVersion = (typeof SUPPORTED_PYTHON_VERSIONS)[number];

--- a/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
@@ -20,12 +20,13 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Alert, Form } from "@wso2/oxygen-ui";
 import { PageLayout, useFormValidation } from "@agent-management-platform/views";
 import { generatePath, useNavigate, useParams } from "react-router-dom";
-import { absoluteRouteMap, OrgProjPathParams } from "@agent-management-platform/types";
-import { useCreateAgent } from "@agent-management-platform/api-client";
 import {
+  absoluteRouteMap,
   DEFAULT_INSTRUMENTATION_VERSION,
   DEFAULT_PYTHON_VERSION,
+  OrgProjPathParams,
 } from "@agent-management-platform/types";
+import { useCreateAgent } from "@agent-management-platform/api-client";
 import { createAgentSchema, type CreateAgentFormValues, type LLMProviderFormEntry } from "../form/schema";
 import { InternalAgentForm } from "../forms/InternalAgentForm";
 import { CreateButtons } from "./CreateButtons";

--- a/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
@@ -22,6 +22,10 @@ import { PageLayout, useFormValidation } from "@agent-management-platform/views"
 import { generatePath, useNavigate, useParams } from "react-router-dom";
 import { absoluteRouteMap, OrgProjPathParams } from "@agent-management-platform/types";
 import { useCreateAgent } from "@agent-management-platform/api-client";
+import {
+  DEFAULT_INSTRUMENTATION_VERSION,
+  DEFAULT_PYTHON_VERSION,
+} from "@agent-management-platform/types";
 import { createAgentSchema, type CreateAgentFormValues, type LLMProviderFormEntry } from "../form/schema";
 import { InternalAgentForm } from "../forms/InternalAgentForm";
 import { CreateButtons } from "./CreateButtons";
@@ -37,6 +41,7 @@ export const InternalAgentFlow: React.FC = () => {
   const [formData, setFormData] = useState<CreateAgentFormValues>({
     deploymentType: "new" as const,
     enableAutoInstrumentation: true,
+    instrumentationVersion: DEFAULT_INSTRUMENTATION_VERSION,
     name: "",
     displayName: "",
     description: "",
@@ -45,7 +50,7 @@ export const InternalAgentFlow: React.FC = () => {
     appPath: "/",
     runCommand: "python main.py",
     language: "python",
-    languageVersion: "3.11",
+    languageVersion: DEFAULT_PYTHON_VERSION,
     dockerfilePath: "/Dockerfile",
     interfaceType: "DEFAULT" as const,
     port: "" as unknown as number,

--- a/console/workspaces/pages/add-new-agent/src/form/schema.ts
+++ b/console/workspaces/pages/add-new-agent/src/form/schema.ts
@@ -17,7 +17,11 @@
  */
 
 import { z } from 'zod';
-import type { InputInterfaceType } from '@agent-management-platform/types';
+import {
+  SUPPORTED_INSTRUMENTATION_VERSIONS,
+  SUPPORTED_PYTHON_VERSIONS,
+  type InputInterfaceType,
+} from '@agent-management-platform/types';
 
 export type InterfaceType = InputInterfaceType;
 
@@ -58,6 +62,9 @@ export const createAgentSchema = z.object({
   ...baseAgentFields,
   deploymentType: z.literal('new').optional(),
   enableAutoInstrumentation: z.boolean().default(true),
+  instrumentationVersion: z
+    .enum(SUPPORTED_INSTRUMENTATION_VERSIONS)
+    .optional(),
   repositoryUrl: z
     .string()
     .trim()
@@ -169,6 +176,26 @@ export const createAgentSchema = z.object({
     return true;
   },
   { message: 'Python version is required for Python agents', path: ['languageVersion'] }
+).refine(
+  (data) => {
+    // Python languageVersion must be one of the supported versions
+    // (the AMP instrumentation init-container image is ABI-locked to the
+    // agent's Python runtime, so only versions with a matching image work).
+    if (
+      data.language === 'python' &&
+      data.languageVersion?.trim() &&
+      !SUPPORTED_PYTHON_VERSIONS.includes(
+        data.languageVersion.trim() as (typeof SUPPORTED_PYTHON_VERSIONS)[number]
+      )
+    ) {
+      return false;
+    }
+    return true;
+  },
+  {
+    message: `Python version must be one of: ${SUPPORTED_PYTHON_VERSIONS.join(', ')}`,
+    path: ['languageVersion'],
+  }
 ).refine(
   (data) => {
     // Validate Docker-specific fields: dockerfilePath is required for Docker

--- a/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
+++ b/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
@@ -16,11 +16,15 @@
  * under the License.
  */
 
-import { Alert, Checkbox, Collapse, Form, FormControlLabel, Stack, TextField, Typography, CircularProgress } from "@wso2/oxygen-ui";
+import { Alert, Checkbox, Collapse, Form, FormControl, FormControlLabel, FormHelperText, MenuItem, Select, Stack, TextField, Typography, CircularProgress } from "@wso2/oxygen-ui";
 import { useEffect, useMemo, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import { debounce } from "lodash";
 import { useGenerateResourceName } from "@agent-management-platform/api-client";
+import {
+  SUPPORTED_INSTRUMENTATION_VERSIONS,
+  SUPPORTED_PYTHON_VERSIONS,
+} from "@agent-management-platform/types";
 import { InputInterface } from "../components/InputInterface";
 import { EnvironmentVariable } from "../components/EnvironmentVariable";
 import { GitSecretSelector } from "../components/GitSecretSelector";
@@ -269,18 +273,22 @@ export const InternalAgentForm = ({
                 />
               </Form.ElementWrapper>
               <Form.ElementWrapper label="Language Version" name="languageVersion">
-                <TextField
-                  id="languageVersion"
-                  placeholder="3.11"
-                  value={formData.languageVersion || ''}
-                  onChange={(e) => handleFieldChange('languageVersion', e.target.value)}
-                  error={!!errors.languageVersion}
-                  helperText={
-                    errors.languageVersion ||
-                    "e.g., 3.11, 20, 1.21"
-                  }
-                  fullWidth
-                />
+                <FormControl fullWidth error={!!errors.languageVersion}>
+                  <Select
+                    id="languageVersion"
+                    value={formData.languageVersion || ''}
+                    onChange={(e) => handleFieldChange('languageVersion', e.target.value)}
+                  >
+                    {SUPPORTED_PYTHON_VERSIONS.map((v) => (
+                      <MenuItem key={v} value={v}>
+                        {v}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <FormHelperText>
+                    {errors.languageVersion || 'Python runtime version'}
+                  </FormHelperText>
+                </FormControl>
               </Form.ElementWrapper>
             </Form.Stack>
             <FormControlLabel
@@ -293,9 +301,38 @@ export const InternalAgentForm = ({
               label="Enable auto instrumentation"
             />
             <Collapse in={formData.enableAutoInstrumentation !== false}>
-              <Typography variant="body2" color="text.secondary">
-                Automatically adds OTEL tracing instrumentation to your agent for observability.
-              </Typography>
+              <Stack spacing={1}>
+                <Typography variant="body2" color="text.secondary">
+                  Automatically adds OTEL tracing instrumentation to your agent for observability.
+                </Typography>
+                <Form.ElementWrapper
+                  label="AMP Instrumentation Version"
+                  name="instrumentationVersion"
+                >
+                  <FormControl
+                    sx={{ minWidth: 200 }}
+                    error={!!errors.instrumentationVersion}
+                  >
+                    <Select
+                      id="instrumentationVersion"
+                      value={formData.instrumentationVersion || ''}
+                      onChange={(e) =>
+                        handleFieldChange('instrumentationVersion', e.target.value)
+                      }
+                    >
+                      {SUPPORTED_INSTRUMENTATION_VERSIONS.map((v) => (
+                        <MenuItem key={v} value={v}>
+                          {v}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                    <FormHelperText>
+                      {errors.instrumentationVersion ||
+                        'Pins the init-container image and the bundled OpenLLMetry SDK version.'}
+                    </FormHelperText>
+                  </FormControl>
+                </Form.ElementWrapper>
+              </Stack>
             </Collapse>
             <Collapse in={formData.enableAutoInstrumentation === false}>
               <Alert severity="info" sx={{ mt: 1 }}>

--- a/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
@@ -116,6 +116,11 @@ export const buildAgentCreationPayload = (
               isSensitive: envVar.isSensitive || false,
             })),
           enableAutoInstrumentation: data.enableAutoInstrumentation,
+          ...(data.language === "python" &&
+          data.enableAutoInstrumentation !== false &&
+          data.instrumentationVersion
+            ? { instrumentationVersion: data.instrumentationVersion }
+            : {}),
         },
         inputInterface: {
           type: "HTTP",


### PR DESCRIPTION
## Purpose

The previous PRs in this workstream made the instrumentation version a real, customer-selectable knob end-to-end (DB column → API → image resolution → init-container). But there was still nothing in the Console to actually *set* it on a new agent — and the existing `Language Version` field was free-text, so a user could happily type `3.9` and get an `ImagePullBackOff` because we don't ship a `…-python3.9` init-container image.

Resolves #844.

### Old View
<img width="1728" height="994" alt="old" src="https://github.com/user-attachments/assets/14d84047-12a4-4b88-945d-2d43dd0e16b4" />

### New View
<img width="1726" height="953" alt="new" src="https://github.com/user-attachments/assets/888795b3-b93c-4269-acb5-45a60175cb68" />

## Goals

- Let a user pick an AMP instrumentation version when creating an agent, with the platform default pre-filled.
- Stop accepting unsupported Python versions on the create form, so `agent-manager-service`'s image resolver only ever sees an `X.Y` that has a matching image.
- Surface the pinned version on the deploy drawer so the user can see what their agent is using (read-only for now — see below).

## Approach

Two small UI changes on the create-agent flow plus one informational addition on the deploy drawer:

- Added a shared `libs/types/src/api/instrumentation.ts` module that exports `SUPPORTED_INSTRUMENTATION_VERSIONS` (`['0.2.0']`), `SUPPORTED_PYTHON_VERSIONS` (`['3.10', '3.11', '3.12', '3.13']`), and the matching `DEFAULT_*` constants. The Python list mirrors `.github/release-config.json`'s `python_versions`; the instrumentation-version list mirrors the server's `OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS` env (default `["0.2.0"]`).
- In `pages/add-new-agent`:
  - The free-text `languageVersion` `TextField` is now a `Select` of the supported Pythons. The Zod schema also has a new `refine` that rejects an out-of-set value defensively (in case anything sets it programmatically).
  - A new "AMP Instrumentation Version" `Select` shows up inside the auto-instrumentation `Collapse` (so only when Python + auto-instrumentation is on). `buildAgentPayload` only sends `configurations.instrumentationVersion` under those same conditions.
- In `libs/shared-component/DeploymentConfig.tsx`: the pinned `instrumentationVersion` is now shown read-only next to the auto-instrumentation switch when the agent has one set. It's not editable here because `DeployAgentRequest` doesn't accept `instrumentationVersion` server-side yet — wiring a deploy-time re-pin is a separate change (noted in the plan as a follow-up).

The "newer version available" hint from the design (E4) is deliberately skipped — there's only one supported version at GA, so nothing useful to hint at. It can land alongside whatever PR introduces the second version.

## User stories

- As an agent author, I can choose which AMP instrumentation version my new Python agent should pin, without leaving the Console.
- As an agent author, I can't accidentally request a Python version the platform has no matching instrumentation image for.

## Release note

Console: when creating a Python agent, you can now select an AMP instrumentation version from a dropdown next to the auto-instrumentation toggle, and `Language Version` is now a fixed list of supported Python versions instead of free text.

## Documentation

N/A in this PR. The customer-facing documentation update (the `(amp-instr version → traceloop-sdk → image-tag)` mapping table, observability two-paths description, manual-instrumentation guide) is tracked separately under #846.

## Training

N/A.

## Certification

N/A.

## Marketing

N/A.

## Automation tests

- Unit tests
  - None added. The `add-new-agent` page doesn't have form-level unit tests today; the change is straightforward UI plumbing (free-text → enum-backed `Select`) and the Zod schema's refine is the contract.
- Integration tests
  - Manually exercised: create-agent → pick `3.11` + version `0.2.0`, agent gets created with `configurations.instrumentationVersion = "0.2.0"`; toggle auto-instrumentation off → version field disappears and isn't sent on the payload; switch language to Docker → version field disappears.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** (TypeScript / React changes only)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

N/A.

## Related PRs

This is the Console-side surface that makes the prior server-side and image-build work reachable from the UI:

- #839 — observer: pure OTel-GenAI extraction
- #848 — `agent_configs.instrumentation_version` column
- #849 — `amp-instrumentation` package: pin `traceloop-sdk`, add `init_otel()`
- #852 — per-version init-container image build + image resolver default
- #856 — standalone image-release workflow
- #857 — per-agent API + override + backfill

## Migrations (if applicable)

N/A — no schema or data migration.

## Test environment

- Browser: Chrome (latest) on macOS.
- Node 20.x for local Console build; pnpm via Rush.

## Learning

N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AMP instrumentation version selection for Python agents with auto-instrumentation enabled.
  * Changed Python language version input to a dropdown menu with supported versions (3.10, 3.11, 3.12, 3.13).
  
* **Improvements**
  * Display instrumentation version in agent configuration details when auto-instrumentation is active.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/864)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->