### PR TITLE
MCP: surface instrumentation_version on create_internal_agent_python

### DIFF
--- a/agent-manager-service/mcp/tools/agents.go
+++ b/agent-manager-service/mcp/tools/agents.go
@@ -78,6 +78,7 @@ type createInternalAgentPythonInput struct {
 	OpenAPIPath   string `json:"openapi_path"`
 
 	EnableAutoInstrumentation *bool         `json:"enable_auto_instrumentation"`
+	InstrumentationVersion    *string       `json:"instrumentation_version,omitempty"`
 	Env                       []envVarInput `json:"env"`
 }
 type internalAgentInput struct {
@@ -96,6 +97,7 @@ type internalAgentInput struct {
 	OpenAPIPath   string
 
 	EnableAutoInstrumentation *bool
+	InstrumentationVersion    *string
 	Env                       []envVarInput
 }
 
@@ -202,6 +204,7 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
 			"openapi_path":   stringProperty("Required when interface_type is CUSTOM. OpenAPI specification file path within the repository (must start with /)."),
 
 			"enable_auto_instrumentation": boolProperty("Automatically enables OTEL tracing instrumentation to your agent for observability."),
+			"instrumentation_version":     stringProperty("Optional. AMP instrumentation version to pin for the agent (e.g., '0.2.0'). Selects the matching pre-built init-container image and the bundled traceloop-sdk version. Omit to use the platform default; only versions supported by the deployment are accepted."),
 			"env": arrayProperty("Required. Environment variables and other configurations for the agent.(eg: api keys, database URLs, support service URLs). Can be obtained from the .env file in the project repository", map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -462,6 +465,7 @@ func createInternalAgentPython(handler AgentToolsetHandler) func(context.Context
 			BasePath:                  input.BasePath,
 			OpenAPIPath:               input.OpenAPIPath,
 			EnableAutoInstrumentation: input.EnableAutoInstrumentation,
+			InstrumentationVersion:    input.InstrumentationVersion,
 			Env:                       input.Env,
 		})
 		if err != nil {
@@ -669,12 +673,15 @@ func buildCreateAgentBuild(input internalAgentInput) (*spec.Build, error) {
 
 func buildConfigurations(input internalAgentInput) *spec.Configurations {
 	envVars := sanitizeEnvVars(input.Env)
-	if len(envVars) == 0 && input.EnableAutoInstrumentation == nil {
+	if len(envVars) == 0 && input.EnableAutoInstrumentation == nil && input.InstrumentationVersion == nil {
 		return nil
 	}
 	config := &spec.Configurations{Env: envVars}
 	if input.EnableAutoInstrumentation != nil {
 		config.EnableAutoInstrumentation = input.EnableAutoInstrumentation
+	}
+	if input.InstrumentationVersion != nil {
+		config.SetInstrumentationVersion(*input.InstrumentationVersion)
 	}
 	return config
 }

--- a/agent-manager-service/mcp/tools/agents_specs_test.go
+++ b/agent-manager-service/mcp/tools/agents_specs_test.go
@@ -112,7 +112,7 @@ func agentToolSpecs() []toolTestSpec {
 			optionalParams: []string{
 				"org_name", "description", "language_version",
 				"run_command", "port", "base_path", "openapi_path",
-				"enable_auto_instrumentation",
+				"enable_auto_instrumentation", "instrumentation_version",
 			},
 			// Skipping invocation for this tool: the schema requires `env`
 			// (an array of {key,value} objects) and the production handler


### PR DESCRIPTION
## Purpose

The REST `POST /agents` endpoint and the Console create-agent form both let a user pin a specific AMP instrumentation version on a new agent (PR #857 and PR #864). The MCP `create_internal_agent_python` tool was the only create surface still missing the knob — so an MCP-driven agent creation always landed on the platform default with no way to change it. This PR closes that small gap.

Related to #847.

## Goals

- Let an MCP client pass `instrumentation_version` when creating an internal Python agent, with the same semantics as the REST and Console paths.
- Keep validation in one place: the controller's existing `validateInstrumentationVersion` (added by #857) still rejects unknown values, so MCP doesn't need to duplicate the check.

## Approach

`agent-manager-service/mcp/tools/agents.go`:
- Added `InstrumentationVersion *string` (json tag `instrumentation_version,omitempty`) to `createInternalAgentPythonInput` and the internal `internalAgentInput` carrier struct, sitting right next to `EnableAutoInstrumentation`.
- Added an `instrumentation_version` entry to the tool's JSON schema with a short description that names the resolved init-container image and notes that only supported versions are accepted.
- Threaded the value through `buildInternalAgentRequest` into `buildConfigurations`, which now calls `config.SetInstrumentationVersion(*input.InstrumentationVersion)` when supplied (and includes it in the early-return short-circuit, alongside `EnableAutoInstrumentation`).
- Updated the `create_internal_agent_python` spec test's `optionalParams` to include `instrumentation_version` so the schema-vs-spec consistency check stays accurate.

Not touched: `mcp/tools/deployments.go`. `spec.DeployAgentRequest` doesn't accept `instrumentationVersion` server-side yet (only `enableAutoInstrumentation`), so the MCP deploy tool can't pass through what the REST endpoint doesn't model. Wiring deploy-time re-pinning is a separate change across the REST endpoint, the MCP deploy tool, and the Console deploy drawer.

## User stories

- As an MCP client (e.g. an LLM agent invoking AMP tools), I can pin a specific AMP instrumentation version when I create a Python agent, mirroring what a human can do via the Console or REST.
- As an integrator, if I pass an unsupported `instrumentation_version`, the create call fails fast with the same error the REST endpoint returns.

## Release note

The `create_internal_agent_python` MCP tool now accepts an optional `instrumentation_version` parameter that pins a specific AMP instrumentation version on the created agent.

## Documentation

N/A in this PR. The AMP-instr documentation update (mapping table, manual-instrumentation guide, observability two-paths description) is tracked separately under #846.

## Training

N/A.

## Certification

N/A.

## Marketing

N/A.

## Automation tests

- Unit tests
  - `mcp/tools/agents_specs_test.go` updated to include `instrumentation_version` in the `create_internal_agent_python` optional-params spec; the existing schema-vs-spec validator now exercises the new property.
- Integration tests
  - `go test ./mcp/tools/...` passes locally with the package's usual env-var setup (`DB_HOST` / `DB_USER` / `DB_PASSWORD` / `DB_NAME` / `OPEN_CHOREO_BASE_URL`).
  - Manually exercised: invoking the tool with `instrumentation_version: "0.2.0"` persists `agent_configs.instrumentation_version = "0.2.0"`; omitting it leaves the column NULL and the agent picks up the platform default at deploy time; an unsupported value is rejected by the existing controller-side `validateInstrumentationVersion`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** (Go change; we run golangci-lint, which passes — `0 issues` against `.github/linters/.golangci.yaml`).
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

N/A.

## Related PRs

- #857 — per-agent `instrumentationVersion` on the REST create path + override + backfill (the foundation this PR extends to MCP).
- #864 — Console create-agent UI for the same field.

## Migrations (if applicable)

N/A — no schema or data migration. The DB column and backfill landed in #857.

## Test environment

- macOS / Go 1.x (project's `go.mod` toolchain).
- Verified with `go build ./...`, `go vet ./...`, `gofumpt -l ./...` (no diffs), and `golangci-lint run -c .github/linters/.golangci.yaml ./mcp/...` (0 issues).

## Learning

N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional instrumentation version configuration for Python agent creation, providing enhanced control over agent instrumentation settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/867)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->