### PR TITLE
console: pin amp-instrumentation in the Docker tracing banner; link the manual contract

### DIFF
--- a/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
+++ b/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
@@ -22,6 +22,7 @@ import { useParams } from "react-router-dom";
 import { debounce } from "lodash";
 import { useGenerateResourceName } from "@agent-management-platform/api-client";
 import {
+  DEFAULT_INSTRUMENTATION_VERSION,
   SUPPORTED_INSTRUMENTATION_VERSIONS,
   SUPPORTED_PYTHON_VERSIONS,
 } from "@agent-management-platform/types";
@@ -52,6 +53,13 @@ const languageOptions = [
   { label: "Python", value: "python" },
   { label: "Docker", value: "docker" },
 ];
+
+const AMP_INSTRUMENTATION_DOCS_URL =
+  "https://wso2.github.io/agent-manager/docs/components/amp-instrumentation/";
+const MANUAL_INSTRUMENTATION_DOCS_URL =
+  `${AMP_INSTRUMENTATION_DOCS_URL}#manual-instrumentation`;
+const VERSION_MAPPING_DOCS_URL =
+  `${AMP_INSTRUMENTATION_DOCS_URL}#amp-instrumentation-version-mapping`;
 
 export const InternalAgentForm = ({
   formData,
@@ -348,7 +356,25 @@ export const InternalAgentForm = ({
                 </Typography>
                 <Typography variant="body2" sx={{ mt: 1 }}>
                   With auto-instrumentation disabled, you can still manually instrument your Python agent using{' '}
-                  your desired instrumentation library.
+                  your desired instrumentation library. Emit your own spans against the{' '}
+                  <Typography
+                    component="a"
+                    href={MANUAL_INSTRUMENTATION_DOCS_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{ color: 'primary.main' }}
+                  >
+                    manual instrumentation contract
+                  </Typography>
+                  {' '}—{' '}
+                  <Typography component="code" sx={{ bgcolor: 'action.hover', px: 0.5, borderRadius: 0.5 }}>
+                    amp-instrumentation
+                  </Typography>
+                  {' '}ships an{' '}
+                  <Typography component="code" sx={{ bgcolor: 'action.hover', px: 0.5, borderRadius: 0.5 }}>
+                    init_otel()
+                  </Typography>
+                  {' '}helper that configures the OTLP exporter for you.
                 </Typography>
                 <Typography variant="body2" sx={{ mt: 1 }}>
                   Environment variables provided:{' '}
@@ -407,13 +433,34 @@ export const InternalAgentForm = ({
                   Docker-based agents require OTEL instrumentation to export traces.
                   For Python, use{' '}
                   <Typography component="code" sx={{ bgcolor: 'action.hover', px: 0.5, borderRadius: 0.5 }}>
-                    pip install amp-instrumentation
+                    {`pip install amp-instrumentation==${DEFAULT_INSTRUMENTATION_VERSION}`}
                   </Typography>
                   {' '}and run with{' '}
                   <Typography component="code" sx={{ bgcolor: 'action.hover', px: 0.5, borderRadius: 0.5 }}>
                     amp-instrument python your_script.py
                   </Typography>
-                  {' '}for zero-code tracing.
+                  {' '}for zero-code tracing. To pick a different version, see the{' '}
+                  <Typography
+                    component="a"
+                    href={VERSION_MAPPING_DOCS_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{ color: 'primary.main' }}
+                  >
+                    AMP instrumentation version mapping
+                  </Typography>
+                  . For agents on a framework the Traceloop SDK doesn&apos;t cover,
+                  emit your own spans against the{' '}
+                  <Typography
+                    component="a"
+                    href={MANUAL_INSTRUMENTATION_DOCS_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{ color: 'primary.main' }}
+                  >
+                    manual instrumentation contract
+                  </Typography>
+                  .
                 </Typography>
                 <Typography variant="body2" gutterBottom>
                   Environment variables provided:{' '}


### PR DESCRIPTION
## Purpose
The two info banners on the create-agent form left customers without enough information to act on. The Docker-tracing banner suggested a generic \`pip install amp-instrumentation\` with no version pin, and the auto-instrumentation-disabled Python banner pointed at \"your desired instrumentation library\" without telling them AMP publishes a contract or that the same package ships an exporter helper. Both now reflect the version model that #864 wired into the form and link the documentation the docs PR (#871) publishes.

Related to #846.

<img width="1726" height="953" alt="Screenshot 2026-05-14 at 21 28 29" src="https://github.com/user-attachments/assets/adc552d6-deee-4b1d-beb5-a81a0582f78c" />


## Goals
- Show a version-pinned \`pip install\` command on the Docker tracing banner so customers know exactly which Traceloop SDK they get.
- Give Docker users a path forward when their framework isn't Traceloop-covered: link the manual instrumentation contract and the version mapping table on the \`amp-instrumentation\` docs page.
- Give Python users who turned auto-instrumentation off the same manual-contract pointer plus a mention of \`init_otel()\` (the exporter helper PR #849 added).

## Approach
- Import the existing \`DEFAULT_INSTRUMENTATION_VERSION\` constant from \`@agent-management-platform/types\` (same module that backs the version selector and the deploy panel) so the pinned version in the banner stays aligned with the platform default — no second source of truth.
- Add two URL constants near the top of \`InternalAgentForm.tsx\` (\`AMP_INSTRUMENTATION_DOCS_URL\` + two anchored variants) so the docs hyperlinks have one home.
- Docker banner: interpolate the pinned version into the \`pip install\` snippet via a template literal, and append a sentence linking the **AMP instrumentation version mapping** and the **manual instrumentation contract** on the docs site.
- Python auto-off banner: append a sentence linking the same manual-contract page and mention \`init_otel()\` for the exporter setup.

Both links open in a new tab with \`rel=\"noopener noreferrer\"\`, matching the existing external-link pattern in \`MonitorLLMProviderDrawer.tsx\` and \`InternalAgentOverview.tsx\`. No new dependencies. Verified \`rushx lint\` clean and \`rush build --to @agent-management-platform/add-new-agent\` green.

## User stories
- *Docker-agent developer.* I'm reading the tracing banner before I write my Dockerfile; I want to know exactly which \`amp-instrumentation\` to pin and where to look up what it gives me. → version-pinned snippet + version-mapping link.
- *Python developer turning auto-instrumentation off.* The banner says I can manually instrument; tell me what contract my spans need to satisfy. → manual-contract link.

## Release note
The create-agent form's Docker tracing banner now pins the recommended \`amp-instrumentation\` version (\`0.2.0\`) in the \`pip install\` snippet and links the AMP instrumentation version mapping plus the manual instrumentation contract on the docs site. The auto-instrumentation-disabled Python banner now also links the manual contract and mentions the \`init_otel()\` exporter helper.

## Documentation
The links go to the manual-instrumentation reference and version-mapping table that land in PR #871 on the \`components/amp-instrumentation\` page.

## Training
N/A — small Console copy / linking update.

## Certification
N/A — no behaviour change worth certifying.

## Marketing
N/A — internal create-agent flow polish.

## Automation tests
- Unit tests
  > N/A — copy/links only, no logic.
- Integration tests
  > \`rushx lint\` and \`rush build --to @agent-management-platform/add-new-agent\` pass.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — TypeScript console change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
- #864 (Console version selector + Python dropdown) — added \`DEFAULT_INSTRUMENTATION_VERSION\` to the shared types module that this PR imports.
- #849 (\`amp-instrumentation\` pin + \`init_otel()\`) — the helper this banner now mentions.
- #871 (docs) — publishes the manual-instrumentation reference and the version mapping anchor this banner links to.

## Migrations (if applicable)
N/A.

## Test environment
Verified locally on macOS 25.3.0, Node 20.20.2, Rush 5.160.1; \`rushx lint\` and \`rush build --to @agent-management-platform/add-new-agent\` both green. UI was not started in a browser for this change — the modification is copy + two anchor hrefs; no logic changed.

## Learning
The Console package uses \`Typography component=\"a\"\` for inline external links (per \`InternalAgentOverview.tsx\`), so no \`Link\` import from \`@wso2/oxygen-ui\` is needed. eslint's \`react/no-unescaped-entities\` rule rejects literal apostrophes in JSX text — use \`&apos;\`.