### PR TITLE
fix(instrumentation): cap wrapt<2 and release 0.2.1

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -28,7 +28,7 @@
 
   "python-instrumentation-provider": [
     {
-      "instrumentation_version": "0.2.0",
+      "instrumentation_version": "0.2.1",
       "traceloop_version": "0.60.0",
       "python_versions": ["3.10", "3.11", "3.12", "3.13"]
     }

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -113,9 +113,9 @@ func loadEnvs() {
 		SDKVolumeName: r.readOptionalString("OTEL_SDK_VOLUME_NAME", "otel-tracing-sdk-volume"),
 		SDKMountPath:  r.readOptionalString("OTEL_SDK_MOUNT_PATH", "/otel-tracing-sdk"),
 
-		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.2.0"),
+		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.2.1"),
 
-		SupportedInstrumentationVersions: r.readOptionalStringList("OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS", "0.2.0"),
+		SupportedInstrumentationVersions: r.readOptionalStringList("OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS", "0.2.1"),
 
 		// Tracing configuration
 		IsTraceContentEnabled: r.readOptionalBool("OTEL_TRACELOOP_TRACE_CONTENT", true),

--- a/console/workspaces/libs/types/src/api/instrumentation.ts
+++ b/console/workspaces/libs/types/src/api/instrumentation.ts
@@ -19,9 +19,9 @@
 // AMP instrumentation versions the platform supports. Each version maps to a
 // pre-built init-container image (`amp-python-instrumentation-provider:<version>-python<X.Y>`)
 // with a specific pinned `traceloop-sdk`. Server-side source of truth:
-// agent-manager-service `OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS` env (default `["0.2.0"]`).
-export const SUPPORTED_INSTRUMENTATION_VERSIONS = ['0.2.0'] as const;
-export const DEFAULT_INSTRUMENTATION_VERSION: SupportedInstrumentationVersion = '0.2.0';
+// agent-manager-service `OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS` env (default `["0.2.1"]`).
+export const SUPPORTED_INSTRUMENTATION_VERSIONS = ['0.2.1'] as const;
+export const DEFAULT_INSTRUMENTATION_VERSION: SupportedInstrumentationVersion = '0.2.1';
 export type SupportedInstrumentationVersion =
   (typeof SUPPORTED_INSTRUMENTATION_VERSIONS)[number];
 

--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -171,6 +171,6 @@ When AMP raises the platform default, existing agents stay on the version they w
 
 | AMP instrumentation version | Traceloop SDK (`traceloop-sdk`) | Supported Python versions | Init-container image tag |
 |---|---|---|---|
-| 0.2.0 | 0.60.0 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.2.0-python<X.Y>` |
+| 0.2.1 | 0.60.0 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.2.1-python<X.Y>` |
 
 The canonical source for this matrix is [`.github/release-config.json`](https://github.com/wso2/agent-manager/blob/main/.github/release-config.json) under the `python-instrumentation-provider` key. Maintainers cutting a new version: see [`python-instrumentation-provider/RELEASING.md`](https://github.com/wso2/agent-manager/blob/main/python-instrumentation-provider/RELEASING.md) for the release runbook.

--- a/libs/amp-instrumentation/pyproject.toml
+++ b/libs/amp-instrumentation/pyproject.toml
@@ -16,6 +16,9 @@ maintainers = [
 # is a new amp-instrumentation release. See the AMP instrumentation version mapping.
 dependencies = [
     "traceloop-sdk==0.60.0",
+     # Pin wrapt below 2.0: wrapt 2.x removed the `module=` kwarg on
+    # wrap_function_wrapper that opentelemetry-instrumentation-* 0.60.0 still calls.
+    "wrapt<2.0.0",
     "httpx>=0.25.0",
     # Imported directly by amp_instrumentation.otel.init_otel. Left unconstrained
     # on purpose: their version is determined by traceloop-sdk==0.60.0, which

--- a/python-instrumentation-provider/requirements.txt
+++ b/python-instrumentation-provider/requirements.txt
@@ -1,4 +1,7 @@
 # traceloop-sdk (OpenLLMetry) is installed by the Dockerfile from the
 # TRACELOOP_VERSION build arg, so the pinned version is set per AMP
 # instrumentation image. This file holds only the always-needed extras.
+# Pin wrapt below 2.0: wrapt 2.x removed the `module=` kwarg on
+# wrap_function_wrapper that opentelemetry-instrumentation-* 0.60.0 still calls.
+wrapt<2.0.0
 httpx>=0.25.0


### PR DESCRIPTION
## Summary

- Pin `wrapt<2.0.0` in `python-instrumentation-provider/requirements.txt` (init-container image) and `libs/amp-instrumentation/pyproject.toml` (PyPI package). `wrapt 2.x` removed the `module=` kwarg on `wrap_function_wrapper` that `opentelemetry-instrumentation-*` 0.60.0 still calls, crashing the LangChain instrumentor at startup.
- Bump the AMP instrumentation version `0.2.0 → 0.2.1` across `.github/release-config.json`, `agent-manager-service/config/config_loader.go` (`OTEL_DEFAULT_INSTRUMENTATION_VERSION` + `OTEL_SUPPORTED_INSTRUMENTATION_VERSIONS` defaults), and the docs version-mapping table.
- Existing per-agent pins to `0.2.0` still resolve a buildable image (already published to ghcr), but the platform default and the advertised supported version both move to `0.2.1`.

## Root cause

Pip was free to resolve any `wrapt` version into the image / package. When `wrapt 2.x` released, fresh installs pulled it and the OpenLLMetry LangChain instrumentor failed to register:

```
ERROR:root:Error initializing LangChain instrumentor: wrap_function_wrapper() got an unexpected keyword argument 'module'
```

Only the bare `openai.chat` span was emitted afterwards, so traces appeared as a single LLM leaf with empty Input/Output panels in the console.

## Test plan

- [ ] Local: build init-container image with the pin, deploy a Python LangChain agent, send a chat message, verify the trace contains the full `invoke_agent → workflow → execute_task chain → ChatOpenAI.chat` hierarchy (7 spans for the customer-support sample) and no LangChain instrumentor error in the runtime logs.
- [ ] Local: `make dev-rebuild` + `make dev-migrate`, set `OTEL_DEFAULT_INSTRUMENTATION_VERSION` unset, create a new Python agent, verify `agent_configs.instrumentation_version` / Workload init container resolve to `0.2.1`.
- [ ] CI: `make codegenfmt-check` and Go build pass on `agent-manager-service`.

## Release follow-up

Neither artifact is published by merging this PR. After merge, dispatch the publish workflows:

- `.github/workflows/python_instrumentation_image_release.yaml` with `instrumentation_version=0.2.1` → ships `ghcr.io/wso2/amp-python-instrumentation-provider:0.2.1-python{3.10,3.11,3.12,3.13}`.
- `.github/workflows/amp_instrumentation_release.yaml` with `target_version=0.2.1` → ships `amp-instrumentation==0.2.1` to PyPI.