### PR TITLE
fix(traces-observer): render gen_ai parts[] tool calls and tool responses

### DIFF
--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -944,6 +944,78 @@ func parseOTELMessage(rawMsg map[string]interface{}, messageIndex int) (*PromptM
 		msg.Content = content
 	}
 
+	// Newer OTel gen_ai semantic conventions wrap message bodies under
+	// parts:[{type:"text"|"tool_call"|"tool_call_response", ...}] instead of
+	// top-level content / toolCalls fields (emitted by
+	// opentelemetry-instrumentation-openai 0.60.0 and
+	// opentelemetry-instrumentation-openai-agents). Walk parts when present and
+	// extract text into Content and tool_call parts into ToolCalls so the
+	// Console's per-span Input/Output Messages panel renders the full
+	// conversation, including tool calls and tool responses.
+	if partsRaw, ok := rawMsg["parts"].([]interface{}); ok {
+		var textBuilder strings.Builder
+		for partIndex, p := range partsRaw {
+			pm, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			partType, _ := pm["type"].(string)
+			switch partType {
+			case "", "text":
+				if c, ok := pm["content"].(string); ok {
+					textBuilder.WriteString(c)
+				}
+			case "tool_call":
+				tc := ToolCall{}
+				if id, ok := pm["id"].(string); ok {
+					tc.ID = id
+				}
+				if name, ok := pm["name"].(string); ok {
+					tc.Name = name
+				}
+				if args, ok := pm["arguments"]; ok && args != nil {
+					if argsStr, ok := args.(string); ok {
+						tc.Arguments = argsStr
+					} else {
+						argsBytes, err := json.Marshal(args)
+						if err == nil {
+							tc.Arguments = string(argsBytes)
+						} else {
+							slog.Warn("parseOTELMessage: Failed to marshal tool call arguments in parts[]",
+								"messageIndex", messageIndex,
+								"partIndex", partIndex,
+								"toolCallName", tc.Name,
+								"error", err)
+						}
+					}
+				}
+				if tc.Name != "" {
+					msg.ToolCalls = append(msg.ToolCalls, tc)
+				}
+			case "tool_call_response":
+				// Surface tool response text as Content for role="tool" messages.
+				// Field name varies across OpenLLMetry versions: older builds used
+				// "result"; current builds use "response". Accept either.
+				var respText string
+				if r, ok := pm["response"].(string); ok && r != "" {
+					respText = r
+				} else if r, ok := pm["result"].(string); ok && r != "" {
+					respText = r
+				}
+				if respText != "" {
+					if textBuilder.Len() > 0 {
+						textBuilder.WriteString("\n")
+					}
+					textBuilder.WriteString(respText)
+				}
+				// Other types (image, audio, ...) are intentionally skipped.
+			}
+		}
+		if msg.Content == "" && textBuilder.Len() > 0 {
+			msg.Content = textBuilder.String()
+		}
+	}
+
 	// Extract toolCalls (optional, can be null)
 	if toolCallsRaw, ok := rawMsg["toolCalls"].([]interface{}); ok {
 		msg.ToolCalls = make([]ToolCall, 0, len(toolCallsRaw))

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -609,6 +609,118 @@ func TestExtractPromptMessages(t *testing.T) {
 			t.Errorf("expected 'Hi there', got %q", messages[1].Content)
 		}
 	})
+
+	// Regression: opentelemetry-instrumentation-openai (0.60.0) and
+	// opentelemetry-instrumentation-openai-agents emit content nested under
+	// parts:[{type:"text", content:"..."}] instead of a top-level content field.
+	// parseOTELMessage must fall back to parts[].content so the Console's
+	// per-span Input Messages panel doesn't render empty bubbles.
+	t.Run("OTEL format with gen_ai parts[]", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"system","parts":[{"type":"text","content":"You are helpful"}]},{"role":"user","parts":[{"type":"text","content":"Hello"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(messages))
+		}
+		if messages[0].Content != "You are helpful" {
+			t.Errorf("expected content 'You are helpful' from parts[], got %q", messages[0].Content)
+		}
+		if messages[1].Content != "Hello" {
+			t.Errorf("expected content 'Hello' from parts[], got %q", messages[1].Content)
+		}
+	})
+
+	t.Run("OTEL format with gen_ai parts[] - skips non-text parts", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"caption: "},{"type":"image","content":"<binary>"},{"type":"text","content":"a cat"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(messages))
+		}
+		if messages[0].Content != "caption: a cat" {
+			t.Errorf("expected concatenated text parts 'caption: a cat', got %q", messages[0].Content)
+		}
+	})
+
+	// Regression for the parts[] tool_call path that #181 inadvertently dropped:
+	// an assistant turn that carries only a tool_call part must surface as a
+	// PromptMessage with empty Content but populated ToolCalls so the console
+	// renders the tool name + arguments instead of an empty bubble.
+	t.Run("OTEL format with parts[] tool_call", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"assistant","parts":[{"type":"tool_call","id":"call_1","name":"search_flights","arguments":{"departure_airport":"ZRH","arrival_airport":"LHR"}}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(messages))
+		}
+		if messages[0].Role != "assistant" {
+			t.Errorf("expected role 'assistant', got %q", messages[0].Role)
+		}
+		if messages[0].Content != "" {
+			t.Errorf("expected empty Content (tool_call only), got %q", messages[0].Content)
+		}
+		if len(messages[0].ToolCalls) != 1 {
+			t.Fatalf("expected 1 tool call, got %d", len(messages[0].ToolCalls))
+		}
+		tc := messages[0].ToolCalls[0]
+		if tc.ID != "call_1" {
+			t.Errorf("expected tool call ID 'call_1', got %q", tc.ID)
+		}
+		if tc.Name != "search_flights" {
+			t.Errorf("expected tool name 'search_flights', got %q", tc.Name)
+		}
+		if tc.Arguments != `{"arrival_airport":"LHR","departure_airport":"ZRH"}` {
+			t.Errorf("expected JSON-marshalled arguments, got %q", tc.Arguments)
+		}
+	})
+
+	t.Run("OTEL format with parts[] tool_call_response - 'response' field", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"tool","parts":[{"type":"tool_call_response","id":"call_1","response":"Error: ValueError('boom')"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(messages))
+		}
+		if messages[0].Role != "tool" {
+			t.Errorf("expected role 'tool', got %q", messages[0].Role)
+		}
+		if messages[0].Content != "Error: ValueError('boom')" {
+			t.Errorf("expected response surfaced into Content, got %q", messages[0].Content)
+		}
+	})
+
+	t.Run("OTEL format with parts[] tool_call_response - legacy 'result' field", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"tool","parts":[{"type":"tool_call_response","id":"call_1","result":"ok"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(messages))
+		}
+		if messages[0].Content != "ok" {
+			t.Errorf("expected legacy 'result' surfaced into Content, got %q", messages[0].Content)
+		}
+	})
+
+	t.Run("OTEL format with parts[] mixed text + tool_call", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"assistant","parts":[{"type":"text","content":"Let me search."},{"type":"tool_call","id":"call_1","name":"lookup","arguments":"{}"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(messages))
+		}
+		if messages[0].Content != "Let me search." {
+			t.Errorf("expected text part in Content, got %q", messages[0].Content)
+		}
+		if len(messages[0].ToolCalls) != 1 || messages[0].ToolCalls[0].Name != "lookup" {
+			t.Errorf("expected tool call 'lookup', got %+v", messages[0].ToolCalls)
+		}
+	})
 }
 
 func TestExtractCompletionMessages(t *testing.T) {


### PR DESCRIPTION
Related to #840

## What

Per-span **Input Messages** / **Output Messages** bubbles in the Console rendered empty (role chip only, no body) for any LLM/agent span emitted by `opentelemetry-instrumentation-openai` 0.60.0 or `opentelemetry-instrumentation-openai-agents` — i.e. anything using the OpenAI Agents SDK, or pure-OTel OpenAI auto-instrumentation. The data was present on the span (`gen_ai.input.messages` / `gen_ai.output.messages` were populated), so this looked like a UI bug, but the data was being dropped server-side in `parseOTELMessage`.

Concretely, those instrumentors emit each message with bodies nested under `parts: [{type, …}]` instead of a top-level `content`/`toolCalls` field:

```json
[
  {"role": "user",      "parts": [{"type": "text", "content": "search flights ZRH → LHR"}]},
  {"role": "assistant", "parts": [{"type": "tool_call", "id": "...", "name": "search_flights", "arguments": {...}}]},
  {"role": "tool",      "parts": [{"type": "tool_call_response", "id": "...", "response": "Error: ..."}]}
]
```

`parseOTELMessage` only read `rawMsg["content"]` / `rawMsg["toolCalls"]` at the top level, so role was captured but everything else was lost. Result: each turn became `{role: "user|assistant|tool", content: ""}`, which rendered as the empty bubbles people kept reporting.

### Why this regressed

The pre-#181 implementation (introduced in #109) had a `parts` walker that handled `text` / `tool_call` / `tool_call_response`. #181 ("Add ballerina trace parsing") refactored `parseOTELMessage` to add recursive JSON parsing and stricter input handling — and in doing so **inadvertently dropped the entire parts walker**. The PR body never called out removing tool_call support, and no follow-up issue/PR re-introduced it. So this is a regression-restore, not new scope.

The user-visible breakage only surfaced recently because (a) LangChain-instrumented spans were emitting Traceloop-flat attributes (`gen_ai.prompt.N.*`) which `extractTraceloopPromptMessages` still handles, and (b) the bare `openai.chat` leaf span was the only one emitting the new `parts[]` shape, so a healthy LangChain trace tree masked the problem. Once wrapt 2.x broke the LangChain instrumentor (#881), the bare `openai.chat` became the only span emitted, and the empty-bubble bug became impossible to miss.

## Changes

- `traces-observer-service/opensearch/process.go` — `parseOTELMessage` now walks `rawMsg["parts"]` when present and switches on `type`:
  - `"" | "text"` → append `content` to a `strings.Builder`; written to `msg.Content` as a fallback when no top-level `content` was set.
  - `"tool_call"` → build a `ToolCall{ID, Name, Arguments}` and append to `msg.ToolCalls`. `arguments` is accepted as either a string or an object (object → `json.Marshal`).
  - `"tool_call_response"` → surface the response text into `msg.Content` for `role="tool"` messages. Accepts **both** the current OpenLLMetry field name `response` and the older `result`, since the field was renamed between versions and we want this to remain robust across the matrix.
  - Other types (`image`, `audio`, ...) are intentionally skipped.
- Top-level `content` / `toolCalls` reads are unchanged and still run at higher priority, so old-shape spans (and the existing top-level test cases) render exactly the same.
- No console changes needed — `console/workspaces/pages/traces/src/subComponents/spanDetails/Overview.tsx` already renders `message.toolCalls[]` as a card with `name` + monospaced `arguments` and `message.content` via `MarkdownView` when `role` is set.

## Tests

`go test ./...` green in `traces-observer-service`. Added under `TestExtractPromptMessages`:

- `OTEL format with gen_ai parts[]` — basic text-only parts.
- `OTEL format with gen_ai parts[] - skips non-text parts` — `type:"image"` is correctly skipped instead of having its binary payload concatenated into text.
- `OTEL format with parts[] tool_call` — assistant turn with only a `tool_call` part → empty `Content`, one `ToolCalls` entry with the right id/name/arguments (object form JSON-marshalled deterministically).
- `OTEL format with parts[] tool_call_response - 'response' field` — current OpenLLMetry field name surfaces into `Content`.
- `OTEL format with parts[] tool_call_response - legacy 'result' field` — older field name still works.
- `OTEL format with parts[] mixed text + tool_call` — both `Content` and `ToolCalls` populated together.

Existing baseline cases (`OTEL format gen_ai.input.messages`, `Traceloop format gen_ai.prompt.*`) untouched and still pass.

## Test plan

- [x] Unit: `go test ./opensearch/... -run TestExtractPromptMessages -v` — all 8 sub-tests green.
- [x] Local end-to-end: rebuilt `amp-traces-observer:0.0.0-dev`, loaded into k3d, rolled the deployment, sent a multi-tool-call chat to a Python LangGraph agent, and queried `/api/v1/traces/<id>/spans/<id>` directly. Returned conversation includes populated `content` for user/assistant-text/tool turns and populated `toolCalls` for assistant turns that invoked tools (raw observer response, abbreviated):
  ```
  [0] role=user       content='search flights from Zurich to London tomorrow'   toolCalls=0
  [1] role=assistant  content=''                                                  toolCalls=1
          -> search_flights {"arrival_airport":"London","departure_airport":"Zurich",...}
  [2] role=tool       content="Error: ValueError('Either DATABASE_URL ...')"      toolCalls=0
  [3] role=assistant  content='I encountered an error ...'                        toolCalls=1
          -> tavily_search_results_json {"query":"Swiss Airlines flights ..."}
  [4] role=tool       content="HTTPError('401 Client Error: Unauthorized ...')"  toolCalls=0
  ```
- [x] Browser: refreshed the Trace Details panel — assistant tool-call turns now render a card with the tool name + JSON arguments, tool response turns render the response text, and previously-broken Input/Output bubbles are no longer empty.
- [x] Regression: existing top-level-shape spans still render via the unchanged code path.

## Release

No new instrumentation image release and no new `amp-instrumentation` PyPI release are needed — agents emit the data correctly, this is purely an observer rendering fix. The `amp-traces-observer` image is in `release-config.json` `images` and rebuilds on every product release, so the fix ships with the next AMP release of the observer chart.