### PR TITLE
Show agent type and subtype in am agent get output

### DIFF
--- a/cli/pkg/cmd/agent/get.go
+++ b/cli/pkg/cmd/agent/get.go
@@ -105,6 +105,11 @@ func runGet(ctx context.Context, o *GetOptions) error {
 	fmt.Fprintf(w, "name:          %s\n", cs.Bold(a.Name))
 	fmt.Fprintf(w, "display name:  %s\n", a.DisplayName)
 	fmt.Fprintf(w, "description:   %s\n", a.Description)
+	typeStr := a.AgentType.Type
+	if a.AgentType.SubType != nil && *a.AgentType.SubType != "" {
+		typeStr = fmt.Sprintf("%s / %s", a.AgentType.Type, *a.AgentType.SubType)
+	}
+	fmt.Fprintf(w, "type:          %s\n", typeStr)
 	status := "-"
 	if a.Status != nil {
 		status = *a.Status


### PR DESCRIPTION
## Purpose
`amctl agent get <name>` currently omits the agent's type information. Users have to fall back to `-o json` to see the agent's type/subtype, which is awkward for routine inspection.

## Goals
Surface `AgentType.Type` (and `AgentType.SubType` when present) in the human-readable output of `am agent get`.

## Approach
Added a `type:` line in `cli/pkg/cmd/agent/get.go` between `description:` and `status:`. Format is `<type> / <subtype>` when subtype is present, or just `<type>` when not. The data already comes from the existing `GetAgent` response — no new API call, no codegen change, no JSON-output change.

## User stories
As a CLI user, I can see an agent's type and subtype directly from `am agent get` without parsing JSON.

## Release note
`am agent get` now displays the agent's type (and subtype when set).

## Documentation
N/A — output is self-describing; existing CLI reference doesn't enumerate every field of `agent get`.

## Training
N/A — no training material covers this CLI output.

## Certification
N/A — no certification impact.

## Marketing
N/A — minor CLI UX improvement.

## Automation tests
 - Unit tests
   > Existing `get_test.go` covers validation-error paths only. No new output-formatting tests added; change is trivial and unconditional.
 - Integration tests
   > N/A — covered by manual CLI run.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — change is a single display-formatting line with no new inputs or data paths
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or API changes.

## Test environment
 - Built with Go 1.25.7 on Linux (6.14.0-37-generic, amd64)
 - `cd cli && go build ./...` clean
 - `cd cli && go test ./pkg/cmd/agent/...` passes

## Learning
N/A — straightforward CLI output enhancement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The agent get command now displays the agent's type and subtype information in the output, formatted as "type / subtype" when a subtype is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/886)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->