### PR TITLE
Add CI check for amctl client codegen drift

### DIFF
--- a/.github/workflows/cli-codegen-check.yaml
+++ b/.github/workflows/cli-codegen-check.yaml
@@ -1,0 +1,41 @@
+name: CLI Codegen Check
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "agent-manager-service/docs/api_v1_openapi.yaml"
+      - "cli/pkg/clients/amsvc/**"
+      - "Makefile"
+      - ".github/workflows/cli-codegen-check.yaml"
+
+jobs:
+  drift-check:
+    name: Regenerate & Diff
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install oapi-codegen
+        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0
+
+      - name: Regenerate amctl AM client
+        run: make amctl-gen-client
+
+      - name: Verify no drift in generated client
+        run: |
+          if ! git diff --exit-code -- cli/pkg/clients/amsvc/gen; then
+            echo ""
+            echo "::error::Generated amctl AM client is out of sync with agent-manager-service/docs/api_v1_openapi.yaml."
+            echo "::error::Run 'make amctl-gen-client' locally and commit the result."
+            exit 1
+          fi
+
+      - name: Build CLI against regenerated client
+        working-directory: ./cli
+        run: go build ./...

--- a/.github/workflows/cli-codegen-check.yaml
+++ b/.github/workflows/cli-codegen-check.yaml
@@ -19,7 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: ./.github/actions/setup-go
+        uses: actions/setup-go@v6.1.0
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
 
       - name: Install oapi-codegen
         run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.6.0

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -1064,6 +1064,9 @@ type AddAgentKindVersionRequest struct {
 	// ConfigSchema Configuration schema for this version
 	ConfigSchema []AgentKindConfigSchemaItem `json:"configSchema"`
 
+	// Metadata Optional interface metadata (e.g. OpenAPI spec)
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
+
 	// SourceAgentName Name of the agent the build belongs to
 	SourceAgentName string `json:"sourceAgentName"`
 
@@ -1072,12 +1075,6 @@ type AddAgentKindVersionRequest struct {
 
 	// Version Version tag for this release
 	Version string `json:"version"`
-}
-
-// AgentFromKind Identifies the Agent Kind this agent was instantiated from.
-type AgentFromKind struct {
-	KindName string `json:"kindName"`
-	Version  string `json:"version"`
 }
 
 // AgentKindConfigSchemaItem defines model for AgentKindConfigSchemaItem.
@@ -1145,6 +1142,9 @@ type AgentKindVersionResponse struct {
 
 	// ImageId Docker image ID for this version. A kind version is only created once the source build completes successfully with an image.
 	ImageId string `json:"imageId"`
+
+	// Metadata Optional interface metadata for this version (e.g. OpenAPI spec). Only returned on single-version fetch.
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 
 	// SourceAgentName Name of the agent this version was published from
 	SourceAgentName string `json:"sourceAgentName"`
@@ -1257,14 +1257,14 @@ type AgentResponse struct {
 	Description    string          `json:"description"`
 	DisplayName    string          `json:"displayName"`
 
-	// FromKind Identifies the Agent Kind this agent was instantiated from.
-	FromKind *AgentFromKind `json:"fromKind,omitempty"`
-
 	// InputInterface Endpoint configurations
 	InputInterface *InputInterface `json:"inputInterface,omitempty"`
-	Name           string          `json:"name"`
-	ProjectName    string          `json:"projectName"`
-	Provisioning   Provisioning    `json:"provisioning"`
+
+	// KindName Name of the Agent Kind this agent was instantiated from (absent for source-built agents)
+	KindName     *string      `json:"kindName,omitempty"`
+	Name         string       `json:"name"`
+	ProjectName  string       `json:"projectName"`
+	Provisioning Provisioning `json:"provisioning"`
 
 	// Status Current status of the agent
 	Status *string `json:"status,omitempty"`
@@ -3437,6 +3437,9 @@ type PublishAgentKindRequest struct {
 
 	// KindName Target Agent Kind name. Creates a new kind if it does not exist.
 	KindName string `json:"kindName"`
+
+	// Metadata Optional interface metadata (e.g. OpenAPI spec)
+	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 
 	// Version Version tag for this release
 	Version string `json:"version"`


### PR DESCRIPTION
## Purpose
The amctl CLI client at `cli/pkg/clients/amsvc/gen/` is generated from `agent-manager-service/docs/api_v1_openapi.yaml`. There is currently no automated check that the committed client stays in sync with the spec, so silent drift accumulates and only surfaces when someone notices a build break or wrong field name at runtime. This PR adds a PR-time check.

## Goals
- Fail a PR when the committed amctl AM-service client is out of sync with the OpenAPI spec
- Catch up the existing drift in `types.gen.go` so the new check passes on `main`

## Approach
New workflow `.github/workflows/cli-codegen-check.yaml` triggered on PRs that touch:
- `agent-manager-service/docs/api_v1_openapi.yaml`
- `cli/pkg/clients/amsvc/**`
- `Makefile`
- the workflow file itself

Steps:
1. Install `oapi-codegen` pinned to `v2.6.0` (matches the version recorded in the existing generated files).
2. Run `make amctl-gen-client` (the existing target).
3. `git diff --exit-code -- cli/pkg/clients/amsvc/gen` — fail with a clear message telling the developer to run `make amctl-gen-client` and commit the result.
4. `cd cli && go build ./...` so a regen that still type-mismatches consumer code fails the workflow rather than silently passing.

The regenerated `types.gen.go` is included to clear pre-existing drift:
- New `Metadata` field on `AddAgentKindVersionRequest`, `AgentKindVersionResponse`, `PublishAgentKindRequest`
- `AgentFromKind` struct removed, replaced by flat `KindName *string` on `AgentResponse`

`go build ./...` in `cli/` passes against the regenerated types — no consumer code referenced the removed symbols.

## User stories
N/A — internal CI safeguard.

## Release note
N/A — internal CI change, not user-facing.

## Documentation
N/A — no user-facing change.

## Training
N/A.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — internal CI change.

## Automation tests
- Unit tests
  > N/A — workflow change.
- Integration tests
  > The workflow itself is the test. It was validated locally: `make amctl-gen-client` reproduced the drift on the committed file (catch-up included here), and `cd cli && go build ./...` passes against the regenerated client.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Go/Java code changed
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
None.

## Migrations (if applicable)
N/A.

## Test environment
- Linux, Go 1.25.x
- `oapi-codegen` v2.6.0

## Learning
Used the same pattern the agent-manager-service workflow uses for its `codegenfmt-check` job — regenerate in CI and fail on diff. The workflow caught real existing drift on first run, which is the desired behavior.