### PR TITLE
fix(traces-observer): synthesize system message from gen_ai.system_instructions

### DIFF
--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -923,9 +923,12 @@ func ExtractPromptMessages(attrs map[string]interface{}) []PromptMessage {
 }
 
 // hasSystemMessage reports whether any message in the list carries role=system.
+// OTel GenAI / OpenLLMetry / Traceloop all spec lowercase role values, but
+// match defensively (case-insensitive, trimmed) so a malformed span carrying
+// "System" or " system " doesn't slip past and produce a duplicate bubble.
 func hasSystemMessage(messages []PromptMessage) bool {
 	for _, m := range messages {
-		if m.Role == "system" {
+		if strings.EqualFold(strings.TrimSpace(m.Role), "system") {
 			return true
 		}
 	}

--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -884,20 +884,52 @@ func ExtractRootSpanInputOutput(rootSpan *Span) (input interface{}, output inter
 // Handles two formats:
 // 1. OTEL format: gen_ai.input.messages (JSON array)
 // 2. Traceloop format: gen_ai.prompt.{index}.{field}
+//
+// The OTel GenAI semantic conventions surface the system prompt in a separate
+// gen_ai.system_instructions attribute rather than as a message in
+// gen_ai.input.messages (this is what LangGraph / OpenAI Agents SDK emit). If
+// no system message is present in the extracted conversation, the system
+// instructions are prepended as a synthetic system message so the Console's
+// Input Messages panel renders it.
 func ExtractPromptMessages(attrs map[string]interface{}) []PromptMessage {
+	var messages []PromptMessage
+
 	// First, try OTEL format (gen_ai.input.messages)
 	if messagesJSON, ok := attrs["gen_ai.input.messages"].(string); ok && messagesJSON != "" {
 		slog.Debug("ExtractPromptMessages: Found OTEL format input messages, parsing")
-		messages := parseOTELMessages(messagesJSON)
-		if len(messages) > 0 {
-			return messages
+		messages = parseOTELMessages(messagesJSON)
+		if len(messages) == 0 {
+			slog.Warn("ExtractPromptMessages: OTEL format parsing returned no messages, falling back to Traceloop format")
 		}
-		slog.Warn("ExtractPromptMessages: OTEL format parsing returned no messages, falling back to Traceloop format")
 	}
 
 	// Fallback to Traceloop format (gen_ai.prompt.*)
-	slog.Debug("ExtractPromptMessages: Using Traceloop format extraction")
-	return extractTraceloopPromptMessages(attrs)
+	if len(messages) == 0 {
+		slog.Debug("ExtractPromptMessages: Using Traceloop format extraction")
+		messages = extractTraceloopPromptMessages(attrs)
+	}
+
+	// Prepend system instructions from the dedicated attribute if the
+	// conversation doesn't already carry a system message. extractAgentSystemPrompt
+	// handles gen_ai.system_instructions (parts[] or string), the Traceloop
+	// gen_ai.prompt.0.role=system path, and a plain system_prompt attribute.
+	if !hasSystemMessage(messages) {
+		if sys := extractAgentSystemPrompt(attrs); sys != "" {
+			messages = append([]PromptMessage{{Role: "system", Content: sys}}, messages...)
+		}
+	}
+
+	return messages
+}
+
+// hasSystemMessage reports whether any message in the list carries role=system.
+func hasSystemMessage(messages []PromptMessage) bool {
+	for _, m := range messages {
+		if m.Role == "system" {
+			return true
+		}
+	}
+	return false
 }
 
 // RecursiveJSONParser recursively parses a potentially deeply stringified JSON string

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -804,6 +804,23 @@ func TestExtractPromptMessages(t *testing.T) {
 			t.Errorf("expected user, got %q", messages[0].Role)
 		}
 	})
+
+	// Defensive: even though the conventions are all lowercase, a malformed
+	// span carrying " System " / "System" must not cause a duplicate system
+	// bubble. hasSystemMessage trims + lowercases before matching.
+	t.Run("Does not duplicate system when input.messages role has odd casing/whitespace", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.system_instructions": `[{"type":"text","content":"Should be ignored"}]`,
+			"gen_ai.input.messages":      `[{"role":" System ","content":"You are a bot."},{"role":"user","content":"hi"}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 2 {
+			t.Fatalf("expected 2 messages (no duplicate), got %d", len(messages))
+		}
+		if messages[0].Content != "You are a bot." {
+			t.Errorf("expected existing system kept, got %+v", messages[0])
+		}
+	})
 }
 
 func TestExtractCompletionMessages(t *testing.T) {

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -721,6 +721,89 @@ func TestExtractPromptMessages(t *testing.T) {
 			t.Errorf("expected tool call 'lookup', got %+v", messages[0].ToolCalls)
 		}
 	})
+
+	// OTel GenAI conventions (used by LangGraph / OpenAI Agents SDK) surface
+	// the system prompt in a separate gen_ai.system_instructions attribute
+	// rather than as the first message in gen_ai.input.messages. The Console
+	// expects to see a system message at the head of the conversation, so the
+	// observer synthesizes one when only system_instructions is present.
+	t.Run("Prepends system from gen_ai.system_instructions parts[] when input.messages has none", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.system_instructions": `[{"type":"text","content":"You are a customer support agent for Acme."}]`,
+			"gen_ai.input.messages":      `[{"role":"user","parts":[{"type":"text","content":"hi"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 2 {
+			t.Fatalf("expected 2 messages (synthesized system + user), got %d", len(messages))
+		}
+		if messages[0].Role != "system" {
+			t.Errorf("expected first message role 'system', got %q", messages[0].Role)
+		}
+		if messages[0].Content != "You are a customer support agent for Acme." {
+			t.Errorf("unexpected system content %q", messages[0].Content)
+		}
+		if messages[1].Role != "user" || messages[1].Content != "hi" {
+			t.Errorf("expected second message user/'hi', got %+v", messages[1])
+		}
+	})
+
+	t.Run("Prepends system from plain-string gen_ai.system_instructions", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.system_instructions": "You are a careful researcher.",
+			"gen_ai.input.messages":      `[{"role":"user","parts":[{"type":"text","content":"hi"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(messages))
+		}
+		if messages[0].Role != "system" || messages[0].Content != "You are a careful researcher." {
+			t.Errorf("unexpected first message %+v", messages[0])
+		}
+	})
+
+	t.Run("Does not duplicate system when input.messages already has one", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.system_instructions": `[{"type":"text","content":"Should be ignored"}]`,
+			"gen_ai.input.messages":      `[{"role":"system","content":"You are a bot."},{"role":"user","content":"hi"}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 2 {
+			t.Fatalf("expected 2 messages (no duplicate), got %d", len(messages))
+		}
+		if messages[0].Role != "system" || messages[0].Content != "You are a bot." {
+			t.Errorf("expected existing system kept, got %+v", messages[0])
+		}
+	})
+
+	t.Run("Does not duplicate system when Traceloop format already has one", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.system_instructions": "Should be ignored",
+			"gen_ai.prompt.0.role":       "system",
+			"gen_ai.prompt.0.content":    "You are a bot.",
+			"gen_ai.prompt.1.role":       "user",
+			"gen_ai.prompt.1.content":    "hi",
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(messages))
+		}
+		if messages[0].Role != "system" || messages[0].Content != "You are a bot." {
+			t.Errorf("expected Traceloop system kept, got %+v", messages[0])
+		}
+	})
+
+	t.Run("Leaves conversation untouched when no system instructions anywhere", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"hi"}]}]`,
+		}
+		messages := ExtractPromptMessages(attrs)
+		if len(messages) != 1 {
+			t.Fatalf("expected 1 message (no synthesized system), got %d", len(messages))
+		}
+		if messages[0].Role != "user" {
+			t.Errorf("expected user, got %q", messages[0].Role)
+		}
+	})
 }
 
 func TestExtractCompletionMessages(t *testing.T) {


### PR DESCRIPTION
Related to #840 — follow-up to #884.

## What

LangGraph and the OpenAI Agents SDK follow the OTel GenAI semantic conventions and surface the system prompt in a **separate** `gen_ai.system_instructions` attribute rather than as a message inside `gen_ai.input.messages`. `ExtractPromptMessages` only consulted `gen_ai.input.messages` and `gen_ai.prompt.*`, so the Console's Input Messages panel rendered those agents' conversations with **no System bubble** — even though the system prompt was clearly present in the span attributes.

\#884 fixed the parts[] body shape so the User / Assistant / Tool turns render with content, but the System bubble was still missing for any agent that uses the OTel system-instructions convention.

There's already an `extractAgentSystemPrompt` helper that handles all three shapes (parts[] JSON, Traceloop `gen_ai.prompt.0.role=system`, plain `system_prompt` attribute), but it was only consulted by `populateAgentAttributes` for agent spans — not by the LLM-span flow that feeds the per-span Input Messages panel.

## Changes

- `traces-observer-service/opensearch/process.go` — `ExtractPromptMessages` now, after building the messages list (from `gen_ai.input.messages` or the Traceloop fallback), prepends `{Role: "system", Content: extractAgentSystemPrompt(attrs)}` **only when no system message is already in the list**. Reuses the existing helper, so all three shapes it already handles work for LLM spans too.
- Conversations that already carry a system message — Traceloop-flat agents (`gen_ai.prompt.0.role=system`), or anyone who put a system message inside `gen_ai.input.messages` directly — are left untouched.
- New helper `hasSystemMessage([]PromptMessage) bool` to keep the gating check readable.

No console changes needed — the existing renderer already treats a `role: "system"` message like any other and shows it with the System chip.

## Tests

`go test ./opensearch/...` green. Added 5 sub-tests to `TestExtractPromptMessages`:

- `Prepends system from gen_ai.system_instructions parts[] when input.messages has none` — LangGraph / OpenAI Agents SDK shape.
- `Prepends system from plain-string gen_ai.system_instructions` — non-parts variant of the same attribute.
- `Does not duplicate system when input.messages already has one` — explicit system in input.messages wins; `gen_ai.system_instructions` is ignored.
- `Does not duplicate system when Traceloop format already has one` — Traceloop-flat conversations untouched.
- `Leaves conversation untouched when no system instructions anywhere` — no-op path.

Existing 8 cases from #884 untouched and still pass.

## Test plan

- [x] Unit: `go test ./opensearch/... -run TestExtractPromptMessages -v` — all 13 sub-tests green.
- [x] Local end-to-end against the `cs-agent` sample (`github.com/nadheesh/2026-AUS-AI-tutorial` `Lab-03/agents/cs-agent`, LangGraph + LangChain): deployed the agent, sent a chat that triggers a tool call, and queried `/api/v1/traces/<id>/spans/<id>` on a `ChatOpenAI.chat` span. Returned conversation now starts with the synthesized system bubble:
  ```
  [0] role=system     "You are a customer support agent for Acme, serving the NA region. ..."   (synthesized from gen_ai.system_instructions)
  [1] role=user       "Hi, where is order #12347?"
  [2] role=assistant  ''                                                  toolCalls=1
          -> get_customer_orders {"customer_id":"C-1001"}
  [3] role=tool       '[{"id": "5050", "customer_id": "C-1001", ...}]'
  ```
- [x] Browser: Trace Details panel for a cs-agent `ChatOpenAI.chat` span now renders System / User / Assistant-tool-call / Tool / Assistant-final all with content; previously-empty System slot is no longer empty.
- [x] Regression: existing top-level-shape spans, Traceloop-flat conversations, and conversations that already include a system message render unchanged.

## Release

No new instrumentation image and no new `amp-instrumentation` PyPI release — purely an observer rendering fix. The `amp-traces-observer` image is in `release-config.json` `images` and rebuilds on every product release, so the fix ships with the next AMP release of the observer chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System instructions are now properly included in prompt messages when not already present, improving consistency across different message format variations.

* **Tests**
  * Added regression tests validating system message synthesis and deduplication across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->