### PR TITLE
fix(websocket): evict stale gateway connection on reconnect

### DIFF
--- a/agent-manager-service/websocket/manager.go
+++ b/agent-manager-service/websocket/manager.go
@@ -31,8 +31,13 @@ import (
 // and handles graceful/ungraceful disconnections.
 type Manager struct {
 	// connections maps gatewayID -> []*Connection
-	// Supports multiple connections per gateway ID for clustering scenarios
 	connections sync.Map
+
+	// registryMu serializes all map+count mutation paths (Register, Unregister) so that
+	// LoadAndDelete/Store and the accompanying connectionCount adjustment are one atomic
+	// unit. Without this, parallel reconnects for the same gateway can interleave their
+	// map reads and count decrements, causing count drift or double-decrement.
+	registryMu sync.Mutex
 
 	// mu protects the connectionCount and maxConnections fields
 	mu sync.RWMutex
@@ -90,39 +95,49 @@ func NewManager(config ManagerConfig) *Manager {
 // Register adds a new connection to the registry and starts heartbeat monitoring.
 // Returns an error if the maximum connection limit is reached.
 func (m *Manager) Register(gatewayID string, transport Transport, authToken string) (*Connection, error) {
-	// Evict any existing connections for this gateway before registering the new one.
+	// registryMu ensures the LoadAndDelete → count update → Store sequence is atomic
+	// against concurrent Register/Unregister calls for the same gateway.
+	m.registryMu.Lock()
+
+	// Collect any existing connections to evict. We snapshot them here under the lock
+	// but close them after releasing it so we don't hold registryMu during I/O.
 	// When kgateway reloads config (on each OpenChoreo reconcile), it sends a TCP RST to
 	// the gateway controller which reconnects immediately. Without eviction, kgateway
 	// sometimes hands the reconnect to an old upstream connection whose downstream is
 	// already dead — that upstream receives no heartbeat pings and lingers as stale state.
-	// Closing old connections here sends a WebSocket CLOSE to kgateway, which tears down
+	// Closing old connections sends a WebSocket CLOSE to kgateway, which tears down
 	// the stale upstream immediately and leaves a clean slate for the new connection.
+	var evicted []*Connection
 	if connsInterface, loaded := m.connections.LoadAndDelete(gatewayID); loaded {
-		for _, old := range connsInterface.([]*Connection) {
-			_ = old.Close(1000, "superseded by new connection")
-			m.mu.Lock()
-			m.connectionCount--
-			m.mu.Unlock()
-			log.Printf("[INFO] Evicted superseded connection: gatewayID=%s connectionID=%s",
-				gatewayID, old.ConnectionID)
-		}
+		evicted = connsInterface.([]*Connection)
 	}
 
-	// Check connection limit
+	// Adjust the connection count: subtract evicted, add the new one, then range-check.
 	m.mu.Lock()
-	if m.connectionCount >= m.maxConnections {
+	projected := m.connectionCount - len(evicted)
+	if projected >= m.maxConnections {
 		m.mu.Unlock()
+		m.registryMu.Unlock()
 		return nil, fmt.Errorf("maximum connection limit reached (%d)", m.maxConnections)
 	}
-	m.connectionCount++
+	m.connectionCount = projected + 1
 	m.mu.Unlock()
 
-	// Create connection with unique connection ID
 	connectionID := uuid.New().String()
 	conn := NewConnection(gatewayID, connectionID, transport, authToken)
 
 	// Store as the sole active connection for this gateway (singleton per gateway).
 	m.connections.Store(gatewayID, []*Connection{conn})
+
+	m.registryMu.Unlock()
+
+	// Close evicted connections outside the lock — Close involves I/O and must not
+	// block other Register/Unregister callers.
+	for _, old := range evicted {
+		_ = old.Close(1000, "superseded by new connection")
+		log.Printf("[INFO] Evicted superseded connection: gatewayID=%s connectionID=%s",
+			gatewayID, old.ConnectionID)
+	}
 
 	// Start heartbeat monitoring in background
 	m.wg.Add(1)
@@ -137,8 +152,11 @@ func (m *Manager) Register(gatewayID string, transport Transport, authToken stri
 // Unregister removes a connection from the registry and closes it gracefully.
 // This method is idempotent - calling it multiple times is safe.
 func (m *Manager) Unregister(gatewayID, connectionID string) {
+	m.registryMu.Lock()
+
 	connsInterface, ok := m.connections.Load(gatewayID)
 	if !ok {
+		m.registryMu.Unlock()
 		return // Gateway not found
 	}
 
@@ -156,6 +174,7 @@ func (m *Manager) Unregister(gatewayID, connectionID string) {
 	}
 
 	if removed == nil {
+		m.registryMu.Unlock()
 		return // Connection not found
 	}
 
@@ -166,16 +185,19 @@ func (m *Manager) Unregister(gatewayID, connectionID string) {
 		m.connections.Store(gatewayID, updatedConns)
 	}
 
-	// Close the connection gracefully
-	if err := removed.Close(1000, "normal closure"); err != nil {
-		log.Printf("[DEBUG] Connection close returned error: gatewayID=%s connectionID=%s error=%v",
-			gatewayID, connectionID, err)
-	}
-
 	// Decrement connection count
 	m.mu.Lock()
 	m.connectionCount--
 	m.mu.Unlock()
+
+	m.registryMu.Unlock()
+
+	// Close the connection outside the lock — Close involves I/O and must not
+	// block other Register/Unregister callers.
+	if err := removed.Close(1000, "normal closure"); err != nil {
+		log.Printf("[DEBUG] Connection close returned error: gatewayID=%s connectionID=%s error=%v",
+			gatewayID, connectionID, err)
+	}
 
 	log.Printf("[INFO] Gateway disconnected: gatewayID=%s connectionID=%s totalConnections=%d",
 		gatewayID, connectionID, m.GetConnectionCount())

--- a/agent-manager-service/websocket/manager.go
+++ b/agent-manager-service/websocket/manager.go
@@ -90,6 +90,24 @@ func NewManager(config ManagerConfig) *Manager {
 // Register adds a new connection to the registry and starts heartbeat monitoring.
 // Returns an error if the maximum connection limit is reached.
 func (m *Manager) Register(gatewayID string, transport Transport, authToken string) (*Connection, error) {
+	// Evict any existing connections for this gateway before registering the new one.
+	// When kgateway reloads config (on each OpenChoreo reconcile), it sends a TCP RST to
+	// the gateway controller which reconnects immediately. Without eviction, kgateway
+	// sometimes hands the reconnect to an old upstream connection whose downstream is
+	// already dead — that upstream receives no heartbeat pings and lingers as stale state.
+	// Closing old connections here sends a WebSocket CLOSE to kgateway, which tears down
+	// the stale upstream immediately and leaves a clean slate for the new connection.
+	if connsInterface, loaded := m.connections.LoadAndDelete(gatewayID); loaded {
+		for _, old := range connsInterface.([]*Connection) {
+			_ = old.Close(1000, "superseded by new connection")
+			m.mu.Lock()
+			m.connectionCount--
+			m.mu.Unlock()
+			log.Printf("[INFO] Evicted superseded connection: gatewayID=%s connectionID=%s",
+				gatewayID, old.ConnectionID)
+		}
+	}
+
 	// Check connection limit
 	m.mu.Lock()
 	if m.connectionCount >= m.maxConnections {
@@ -103,11 +121,8 @@ func (m *Manager) Register(gatewayID string, transport Transport, authToken stri
 	connectionID := uuid.New().String()
 	conn := NewConnection(gatewayID, connectionID, transport, authToken)
 
-	// Add connection to registry
-	connsInterface, _ := m.connections.LoadOrStore(gatewayID, []*Connection{})
-	conns := connsInterface.([]*Connection)
-	conns = append(conns, conn)
-	m.connections.Store(gatewayID, conns)
+	// Store as the sole active connection for this gateway (singleton per gateway).
+	m.connections.Store(gatewayID, []*Connection{conn})
 
 	// Start heartbeat monitoring in background
 	m.wg.Add(1)


### PR DESCRIPTION
## Problem                                                                                                                                              
                                                                                                                                                          
  When kgateway reloads its config (triggered by each OpenChoreo reconcile —
  e.g. a workload image bump or ComponentRelease generation), it sends a TCP RST                                                                          
  to connected gateway controllers. The controllers reconnect within milliseconds,                                                                        
  but kgateway doesn't always immediately tear down the old upstream connection to                                                                      
  agent-manager. It can hand the reconnect request to the stale upstream while                                                                            
  opening a new one in parallel.                                                                                                                          
                                                                                                                                                          
  This leaves agent-manager holding two connections for the same `gatewayID`:                                                                             
                                                                                                                                                          
  - **Active connection** — the new one; gateway controller sends heartbeat pings                                                                         
    through it normally.                                                                                                                                
  - **Stale connection** — the old upstream; gateway controller has moved on,                                                                             
    so it receives zero pings. Agent-manager's heartbeat monitor fires a timeout                                                                          
    after 30 s and closes it with a `Heartbeat timeout detected` log.                                                                                     
                                                                                                                                                          
  The stale connection is self-healing (dies in ~40 s), but during that window                                                                            
  the logs are noisy, `totalConnections` is inflated, and on clusters with                                                                                
  frequent reconciles the churn is continuous.                                                                                                            
                                                                                                                                                        
  ## Fix                                                                                                                                                  
                                                                                                                                                        
  Evict all existing connections for a `gatewayID` at the start of `Register`,                                                                            
  before the new connection is stored. `old.Close(1000, "superseded by new connection")` sends a proper WebSocket CLOSE frame, which propagates through                                                                            
  kgateway to close the stale upstream immediately — leaving a clean slate for                                                                            
  the new connection.                                                                                                                                     
                                                                                                                                                          
  **Thread-safety:** `LoadAndDelete` atomically removes the entry so the                                                                                  
  `monitorHeartbeat` goroutine for the old connection finds no registry entry and                                                                       
  exits cleanly on its next tick (via the `IsClosed()` guard), without calling                                                                            
  `Unregister` again. The `connectionCount` decrement is handled in the eviction                                                                          
  loop, not by the goroutine.                                                                                                                             
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                        
  - `agent-manager-service/websocket/manager.go` — `Register`: replace                                                                                    
    `LoadOrStore` + `append` (multi-connection accumulation) with
    `LoadAndDelete` + eviction loop + `Store` (singleton per gateway).                                                                                    
                                                                                                                                                        
  ## Testing                                                                                                                                              
                                                                                                                                                        
  Deploy to dev, then trigger a kgateway config reload (e.g. reconcile any                                                                                
  component release). Expect `Evicted superseded connection` log lines instead
  of `Heartbeat timeout detected` when gateway controllers reconnect.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection management to enforce a single active session per gateway device. Old connections are now automatically terminated when reconnecting from the same gateway, preventing connection resource leaks and enhancing overall stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->