### PR TITLE
Populate trace-list input, output and tokens for OTel 1.40 traces

### DIFF
--- a/console/workspaces/libs/types/src/api/traces.ts
+++ b/console/workspaces/libs/types/src/api/traces.ts
@@ -20,6 +20,12 @@ export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
+  /**
+   * True when the trace had more LLM leaf spans than the trace-list view
+   * aggregates, so the totals are a sum of only the first N leaves. The UI
+   * should render with a "+" / "approximate" marker.
+   */
+  partial?: boolean;
 }
 
 export interface TraceStatus {

--- a/console/workspaces/pages/traces/src/subComponents/TracesTable.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/TracesTable.tsx
@@ -265,7 +265,9 @@ export function TracesTable({
                   <ListingTable.Cell align="right">
                     {(() => {
                       const tu = trace.tokenUsage;
-                      const hasTotal = tu?.totalTokens && tu.totalTokens > 0;
+                      // null-check rather than truthy: a legitimate 0-token
+                      // trace (e.g. error path) should still render "0", not "-".
+                      const hasTotal = tu?.totalTokens != null;
                       // partial=true means the trace had more LLM leaves than
                       // the list view aggregates; render an approximate marker
                       // and an explanatory tooltip.

--- a/console/workspaces/pages/traces/src/subComponents/TracesTable.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/TracesTable.tsx
@@ -203,7 +203,10 @@ export function TracesTable({
                     </Typography>
                   </ListingTable.Cell>
                   <ListingTable.Cell align="left" sx={{ maxWidth: 200 }}>
-                    <Tooltip title={trace.input}>
+                    <Tooltip
+                      title="Preview only. Open the trace for the full input."
+                      disableHoverListener={!trace.input}
+                    >
                       <Typography
                         variant="caption"
                         component="span"
@@ -220,7 +223,10 @@ export function TracesTable({
                     </Tooltip>
                   </ListingTable.Cell>
                   <ListingTable.Cell align="left" sx={{ maxWidth: 200 }}>
-                    <Tooltip title={trace.output}>
+                    <Tooltip
+                      title="Preview only. Open the trace for the full output."
+                      disableHoverListener={!trace.output}
+                    >
                       <Typography
                         variant="caption"
                         component="span"
@@ -257,21 +263,35 @@ export function TracesTable({
                     </Typography>
                   </ListingTable.Cell>
                   <ListingTable.Cell align="right">
-                    <Tooltip
-                      disableHoverListener={
-                        !trace.tokenUsage?.totalTokens ||
-                        trace.tokenUsage.totalTokens === 0
-                      }
-                      title={`${trace.tokenUsage?.inputTokens} input tokens, ${trace.tokenUsage?.outputTokens} output tokens`}
-                    >
-                      <Typography variant="caption" component="span">
-                        {trace.tokenUsage?.totalTokens ? (
-                          <>{trace.tokenUsage.totalTokens}</>
-                        ) : (
-                          "-"
-                        )}
-                      </Typography>
-                    </Tooltip>
+                    {(() => {
+                      const tu = trace.tokenUsage;
+                      const hasTotal = tu?.totalTokens && tu.totalTokens > 0;
+                      // partial=true means the trace had more LLM leaves than
+                      // the list view aggregates; render an approximate marker
+                      // and an explanatory tooltip.
+                      const tooltip = hasTotal
+                        ? tu?.partial
+                          ? "Approximate total. This trace has more LLM spans than the list view aggregates. Open the trace for the exact total."
+                          : `${tu?.inputTokens} input tokens, ${tu?.outputTokens} output tokens`
+                        : "";
+                      return (
+                        <Tooltip
+                          disableHoverListener={!hasTotal}
+                          title={tooltip}
+                        >
+                          <Typography variant="caption" component="span">
+                            {hasTotal ? (
+                              <>
+                                {tu?.totalTokens}
+                                {tu?.partial ? "+" : null}
+                              </>
+                            ) : (
+                              "-"
+                            )}
+                          </Typography>
+                        </Tooltip>
+                      );
+                    })()}
                   </ListingTable.Cell>
                   <ListingTable.Cell align="right">
                     <Typography variant="caption" component="span">

--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -118,14 +118,23 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 		}, nil
 	}
 
-	// Fetch root span details in parallel, bounded by maxConcurrentFetches.
+	// Fetch root spans and run per-trace enrichment in parallel.
+	// outerSem caps how many traces are being enriched at once; innerSem caps
+	// the total observer round-trips across all enrichments in flight (root
+	// fetches plus anything enrichTraceOverview fetches inside).
+	// Two pools avoid the deadlock a single shared pool would hit when every
+	// outer slot is held by a goroutine waiting on a fetch slot.
 	type result struct {
-		idx  int
-		span *opensearch.Span
-		err  error
+		idx        int
+		span       *opensearch.Span
+		input      interface{}
+		output     interface{}
+		tokenUsage *opensearch.TokenUsage
+		err        error
 	}
 	results := make([]result, len(tracesResp.Traces))
-	sem := make(chan struct{}, maxConcurrentFetches)
+	outerSem := make(chan struct{}, maxConcurrentTraces)
+	innerSem := make(chan struct{}, maxConcurrentFetches)
 	var wg sync.WaitGroup
 
 	for i, t := range tracesResp.Traces {
@@ -134,20 +143,22 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 			continue
 		}
 		wg.Add(1)
-		go func(idx int, traceID, rootSpanID string) {
+		go func(idx int, t observer.TraceInfo) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
+			outerSem <- struct{}{}
+			defer func() { <-outerSem }()
 
-			details, err := c.observerClient.GetSpanDetails(ctx, traceID, rootSpanID)
+			innerSem <- struct{}{}
+			details, err := c.observerClient.GetSpanDetails(ctx, t.TraceID, t.RootSpanID)
+			<-innerSem
 			if err != nil {
 				results[idx] = result{idx: idx, err: err}
 				return
 			}
-			span := observer.ConvertSpanDetailsToSpan(traceID, details)
-			enriched := opensearch.ProcessSpan(span)
-			results[idx] = result{idx: idx, span: &enriched}
-		}(i, t.TraceID, t.RootSpanID)
+			enriched := opensearch.ProcessSpan(observer.ConvertSpanDetailsToSpan(t.TraceID, details))
+			input, output, tokens := c.enrichTraceOverview(ctx, params, t, &enriched, innerSem)
+			results[idx] = result{idx: idx, span: &enriched, input: input, output: output, tokenUsage: tokens}
+		}(i, t)
 	}
 	wg.Wait()
 
@@ -163,8 +174,6 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 			continue
 		}
 		rootSpan := res.span
-
-		input, output, tokenUsage := c.enrichTraceOverview(ctx, params, t, rootSpan)
 		traceStatus := opensearch.ExtractTraceStatus([]opensearch.Span{*rootSpan})
 
 		overviews = append(overviews, opensearch.TraceOverview{
@@ -176,10 +185,10 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 			EndTime:         t.EndTime.Format(time.RFC3339Nano),
 			DurationInNanos: t.DurationNs,
 			SpanCount:       t.SpanCount,
-			TokenUsage:      tokenUsage,
+			TokenUsage:      res.tokenUsage,
 			Status:          traceStatus,
-			Input:           input,
-			Output:          output,
+			Input:           res.input,
+			Output:          res.output,
 		})
 	}
 
@@ -210,13 +219,18 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 //
 // Each step only fills in fields the earlier step left nil — so a CrewAI
 // trace that gets all three from step 1 incurs no extra calls.
+//
+// fetchSem bounds the total observer fetches across all concurrent
+// enrichments — callers pass a shared semaphore so a 50-trace page can't
+// fan out into thousands of in-flight requests.
 func (c *TracingController) enrichTraceOverview(
 	ctx context.Context,
 	params TraceQueryParams,
 	traceInfo observer.TraceInfo,
 	rootSpan *opensearch.Span,
+	fetchSem chan struct{},
 ) (input interface{}, output interface{}, tokenUsage *opensearch.TokenUsage) {
-	// Step 1: root span (unchanged behaviour — preserved exactly).
+	// Step 1: root span attributes.
 	if opensearch.IsCrewAISpan(rootSpan.Attributes) {
 		input, output = opensearch.ExtractCrewAIRootSpanInputOutput(rootSpan)
 		tokenUsage = opensearch.ExtractCrewAITraceTokenUsage(rootSpan)
@@ -236,14 +250,14 @@ func (c *TracingController) enrichTraceOverview(
 	}
 
 	// Both steps 2 and 3 need the per-trace span list. Fetch it once.
-	spans, ok := c.fetchTraceSpanSummaries(ctx, params, traceInfo)
+	spans, ok := c.fetchTraceSpanSummaries(ctx, params, traceInfo, fetchSem)
 	if !ok {
 		return input, output, tokenUsage
 	}
 
 	// Step 2: immediate child of the root (Traceloop chain span path).
 	if input == nil || output == nil || tokenUsage == nil {
-		if childInput, childOutput, childTokens, ok := c.tryChildChainSpan(ctx, traceInfo.TraceID, rootSpan.SpanID, spans); ok {
+		if childInput, childOutput, childTokens, ok := c.tryChildChainSpan(ctx, traceInfo.TraceID, rootSpan.SpanID, spans, fetchSem); ok {
 			if input == nil {
 				input = childInput
 			}
@@ -264,7 +278,7 @@ func (c *TracingController) enrichTraceOverview(
 				"spanCount", traceInfo.SpanCount,
 				"threshold", skipLeafAggregationSpanCountThreshold)
 		} else {
-			leafInput, leafOutput, leafTokens := c.aggregateFromLeafLLMSpans(ctx, traceInfo.TraceID, spans)
+			leafInput, leafOutput, leafTokens := c.aggregateFromLeafLLMSpans(ctx, traceInfo.TraceID, spans, fetchSem)
 			if input == nil {
 				input = leafInput
 			}
@@ -282,12 +296,15 @@ func (c *TracingController) enrichTraceOverview(
 
 // fetchTraceSpanSummaries calls QueryTraceSpans for one trace and returns
 // the span-summary list, mirroring the request shape used elsewhere in this
-// controller. Returns ok=false on error (logged as a warning); callers fall
-// back gracefully to whatever they already extracted.
+// controller. Acquires a slot on fetchSem for the duration of the call so
+// the call counts against the shared cross-trace fetch budget. Returns
+// ok=false on error (logged as a warning); callers fall back gracefully to
+// whatever they already extracted.
 func (c *TracingController) fetchTraceSpanSummaries(
 	ctx context.Context,
 	params TraceQueryParams,
 	traceInfo observer.TraceInfo,
+	fetchSem chan struct{},
 ) ([]observer.SpanInfo, bool) {
 	log := logger.GetLogger(ctx)
 
@@ -295,6 +312,7 @@ func (c *TracingController) fetchTraceSpanSummaries(
 	if spanLimit <= 0 || spanLimit > MaxSpansPerRequest {
 		spanLimit = MaxSpansPerRequest
 	}
+	fetchSem <- struct{}{}
 	spansResp, err := c.observerClient.QueryTraceSpans(ctx, traceInfo.TraceID, observer.TracesQueryRequest{
 		StartTime: params.StartTime,
 		EndTime:   params.EndTime,
@@ -306,6 +324,7 @@ func (c *TracingController) fetchTraceSpanSummaries(
 			Environment: params.Environment,
 		},
 	})
+	<-fetchSem
 	if err != nil {
 		log.Warn("enrichTraceOverview: QueryTraceSpans failed, skipping enrichment",
 			"traceId", traceInfo.TraceID, "err", err)
@@ -326,6 +345,7 @@ func (c *TracingController) tryChildChainSpan(
 	traceID string,
 	rootSpanID string,
 	spans []observer.SpanInfo,
+	fetchSem chan struct{},
 ) (input interface{}, output interface{}, tokens *opensearch.TokenUsage, ok bool) {
 	log := logger.GetLogger(ctx)
 
@@ -351,7 +371,9 @@ func (c *TracingController) tryChildChainSpan(
 		return nil, nil, nil, false
 	}
 
+	fetchSem <- struct{}{}
 	details, err := c.observerClient.GetSpanDetails(ctx, traceID, childID)
+	<-fetchSem
 	if err != nil {
 		log.Warn("tryChildChainSpan: GetSpanDetails failed",
 			"traceId", traceID, "childSpanId", childID, "err", err)
@@ -368,10 +390,12 @@ func (c *TracingController) tryChildChainSpan(
 }
 
 // aggregateFromLeafLLMSpans fetches up to maxLLMLeavesPerTrace leaf LLM spans
-// (name matches IsLLMLeafSpan), in parallel bounded by maxConcurrentFetches,
-// and aggregates token usage across them plus first/last message previews.
-// Used when neither the root nor a child chain span carries the data (OpenAI
-// Agents SDK / pure-OTel agents).
+// (name matches IsLLMLeafSpan) and aggregates token usage across them plus
+// first/last message previews. Used when neither the root nor a child chain
+// span carries the data (OpenAI Agents SDK / pure-OTel agents).
+//
+// Fetches share fetchSem with every other enrichment in flight, so leaf fan-
+// out across many concurrent traces doesn't flood the upstream observer.
 //
 // If the trace has more LLM leaves than the cap, the returned TokenUsage has
 // Partial=true so the UI can render an "approximate" marker.
@@ -379,6 +403,7 @@ func (c *TracingController) aggregateFromLeafLLMSpans(
 	ctx context.Context,
 	traceID string,
 	spans []observer.SpanInfo,
+	fetchSem chan struct{},
 ) (input interface{}, output interface{}, tokens *opensearch.TokenUsage) {
 	log := logger.GetLogger(ctx)
 
@@ -403,16 +428,14 @@ func (c *TracingController) aggregateFromLeafLLMSpans(
 			"traceId", traceID, "totalLeaves", totalLeaves, "cap", maxLLMLeavesPerTrace)
 	}
 
-	// Parallel fetch, bounded by the existing controller-wide semaphore.
 	fetched := make([]opensearch.Span, len(leaves))
-	sem := make(chan struct{}, maxConcurrentFetches)
 	var wg sync.WaitGroup
 	for i, leaf := range leaves {
 		wg.Add(1)
 		go func(idx int, spanID string) {
 			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
+			fetchSem <- struct{}{}
+			defer func() { <-fetchSem }()
 
 			details, err := c.observerClient.GetSpanDetails(ctx, traceID, spanID)
 			if err != nil {

--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -36,6 +36,16 @@ const (
 	maxConcurrentFetches = 50
 	// maxConcurrentTraces limits concurrent per-trace goroutines in ExportTraces.
 	maxConcurrentTraces = 10
+	// maxLLMLeavesPerTrace caps the number of leaf LLM spans fetched per trace
+	// when the trace-list view falls back to leaf aggregation for Input/Output
+	// preview and token totals (OpenAI Agents SDK / pure-OTel agents). Realistic
+	// multi-turn agents stay under this; traces beyond the cap get TokenUsage.Partial=true.
+	maxLLMLeavesPerTrace = 50
+	// skipLeafAggregationSpanCountThreshold short-circuits leaf aggregation
+	// entirely when the trace's total span count exceeds this — a rough proxy
+	// for "way more than 50 LLM leaves" that keeps the worst-case list-endpoint
+	// cost bounded.
+	skipLeafAggregationSpanCountThreshold = 100
 )
 
 // TracingController provides tracing functionality via the observer service.
@@ -154,26 +164,7 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 		}
 		rootSpan := res.span
 
-		// Extract input/output — same logic as controller.go lines 315-321.
-		var input, output interface{}
-		if opensearch.IsCrewAISpan(rootSpan.Attributes) {
-			input, output = opensearch.ExtractCrewAIRootSpanInputOutput(rootSpan)
-		} else {
-			input, output = opensearch.ExtractRootSpanInputOutput(rootSpan)
-		}
-
-		// Extract token usage — same fallback chain as controller.go lines 323-335.
-		var tokenUsage *opensearch.TokenUsage
-		if opensearch.IsCrewAISpan(rootSpan.Attributes) {
-			tokenUsage = opensearch.ExtractCrewAITraceTokenUsage(rootSpan)
-		}
-		if tokenUsage == nil {
-			tokenUsage = opensearch.ExtractTokenUsageFromEntityOutput(rootSpan)
-		}
-		if tokenUsage == nil {
-			tokenUsage = opensearch.ExtractTokenUsage([]opensearch.Span{*rootSpan})
-		}
-
+		input, output, tokenUsage := c.enrichTraceOverview(ctx, params, t, rootSpan)
 		traceStatus := opensearch.ExtractTraceStatus([]opensearch.Span{*rootSpan})
 
 		overviews = append(overviews, opensearch.TraceOverview{
@@ -200,6 +191,260 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 		Traces:     overviews,
 		TotalCount: tracesResp.Total,
 	}, nil
+}
+
+// enrichTraceOverview computes Input/Output/Tokens for one row of the trace
+// list, cascading through three sources in order of cost:
+//
+//  1. The root span's own attributes (older Traceloop entity.input/output
+//     and CrewAI roll-up). Free — root span is already fetched.
+//  2. The immediate child of the root, typically a chain span like
+//     LangGraph.workflow that Traceloop's LangChain instrumentation still
+//     decorates with traceloop.entity.input/output. Costs +1 GetSpanDetails.
+//  3. Leaf LLM spans (anything ending in ".chat"). Used for OpenAI Agents
+//     SDK / pure-OTel agents where neither the root nor any chain span
+//     carries the conversation. Bounded: skipped entirely when the trace's
+//     total span count exceeds skipLeafAggregationSpanCountThreshold; up to
+//     maxLLMLeavesPerTrace leaves are fetched in parallel; TokenUsage.Partial
+//     is set true when the cap truncates the aggregation.
+//
+// Each step only fills in fields the earlier step left nil — so a CrewAI
+// trace that gets all three from step 1 incurs no extra calls.
+func (c *TracingController) enrichTraceOverview(
+	ctx context.Context,
+	params TraceQueryParams,
+	traceInfo observer.TraceInfo,
+	rootSpan *opensearch.Span,
+) (input interface{}, output interface{}, tokenUsage *opensearch.TokenUsage) {
+	// Step 1: root span (unchanged behaviour — preserved exactly).
+	if opensearch.IsCrewAISpan(rootSpan.Attributes) {
+		input, output = opensearch.ExtractCrewAIRootSpanInputOutput(rootSpan)
+		tokenUsage = opensearch.ExtractCrewAITraceTokenUsage(rootSpan)
+	} else {
+		input, output = opensearch.ExtractRootSpanInputOutput(rootSpan)
+	}
+	if tokenUsage == nil {
+		tokenUsage = opensearch.ExtractTokenUsageFromEntityOutput(rootSpan)
+	}
+	if tokenUsage == nil {
+		tokenUsage = opensearch.ExtractTokenUsage([]opensearch.Span{*rootSpan})
+	}
+
+	// If the root covered everything, short-circuit — no extra fetches.
+	if input != nil && output != nil && tokenUsage != nil {
+		return input, output, tokenUsage
+	}
+
+	// Both steps 2 and 3 need the per-trace span list. Fetch it once.
+	spans, ok := c.fetchTraceSpanSummaries(ctx, params, traceInfo)
+	if !ok {
+		return input, output, tokenUsage
+	}
+
+	// Step 2: immediate child of the root (Traceloop chain span path).
+	if input == nil || output == nil || tokenUsage == nil {
+		if childInput, childOutput, childTokens, ok := c.tryChildChainSpan(ctx, traceInfo.TraceID, rootSpan.SpanID, spans); ok {
+			if input == nil {
+				input = childInput
+			}
+			if output == nil {
+				output = childOutput
+			}
+			if tokenUsage == nil {
+				tokenUsage = childTokens
+			}
+		}
+	}
+
+	// Step 3: leaf LLM aggregation (OpenAI Agents SDK / pure-OTel path).
+	if input == nil || output == nil || tokenUsage == nil {
+		if traceInfo.SpanCount > skipLeafAggregationSpanCountThreshold {
+			logger.GetLogger(ctx).Debug("skipping leaf-LLM aggregation: trace exceeds spanCount threshold",
+				"traceId", traceInfo.TraceID,
+				"spanCount", traceInfo.SpanCount,
+				"threshold", skipLeafAggregationSpanCountThreshold)
+		} else {
+			leafInput, leafOutput, leafTokens := c.aggregateFromLeafLLMSpans(ctx, traceInfo.TraceID, spans)
+			if input == nil {
+				input = leafInput
+			}
+			if output == nil {
+				output = leafOutput
+			}
+			if tokenUsage == nil {
+				tokenUsage = leafTokens
+			}
+		}
+	}
+
+	return input, output, tokenUsage
+}
+
+// fetchTraceSpanSummaries calls QueryTraceSpans for one trace and returns
+// the span-summary list, mirroring the request shape used elsewhere in this
+// controller. Returns ok=false on error (logged as a warning); callers fall
+// back gracefully to whatever they already extracted.
+func (c *TracingController) fetchTraceSpanSummaries(
+	ctx context.Context,
+	params TraceQueryParams,
+	traceInfo observer.TraceInfo,
+) ([]observer.SpanInfo, bool) {
+	log := logger.GetLogger(ctx)
+
+	spanLimit := traceInfo.SpanCount
+	if spanLimit <= 0 || spanLimit > MaxSpansPerRequest {
+		spanLimit = MaxSpansPerRequest
+	}
+	spansResp, err := c.observerClient.QueryTraceSpans(ctx, traceInfo.TraceID, observer.TracesQueryRequest{
+		StartTime: params.StartTime,
+		EndTime:   params.EndTime,
+		Limit:     &spanLimit,
+		SearchScope: observer.ComponentSearchScope{
+			Namespace:   params.Organization,
+			Project:     params.Project,
+			Component:   params.Agent,
+			Environment: params.Environment,
+		},
+	})
+	if err != nil {
+		log.Warn("enrichTraceOverview: QueryTraceSpans failed, skipping enrichment",
+			"traceId", traceInfo.TraceID, "err", err)
+		return nil, false
+	}
+	return spansResp.Spans, true
+}
+
+// tryChildChainSpan fetches the earliest immediate child of the root span
+// and runs the same entity.input/output / entity.output token extractors
+// against it. Covers LangChain / LangGraph agents where Traceloop emits the
+// conversation summary on a chain span (e.g. LangGraph.workflow) right under
+// an attribute-empty `invoke_agent` root.
+//
+// Returns ok=false when no immediate child is found or the fetch fails.
+func (c *TracingController) tryChildChainSpan(
+	ctx context.Context,
+	traceID string,
+	rootSpanID string,
+	spans []observer.SpanInfo,
+) (input interface{}, output interface{}, tokens *opensearch.TokenUsage, ok bool) {
+	log := logger.GetLogger(ctx)
+
+	// Pick the earliest-started direct child of the root, skipping leaf LLM
+	// spans. We're looking for a chain/agent wrapper (e.g. LangGraph.workflow)
+	// that summarizes the whole conversation, not a single LLM call — those
+	// belong to step 3's full-trace aggregation, not a per-span lookup.
+	var childID string
+	var childStart time.Time
+	for _, s := range spans {
+		if s.ParentSpanID != rootSpanID {
+			continue
+		}
+		if opensearch.IsLLMLeafSpan(s.SpanName) {
+			continue
+		}
+		if childID == "" || s.StartTime.Before(childStart) {
+			childID = s.SpanID
+			childStart = s.StartTime
+		}
+	}
+	if childID == "" {
+		return nil, nil, nil, false
+	}
+
+	details, err := c.observerClient.GetSpanDetails(ctx, traceID, childID)
+	if err != nil {
+		log.Warn("tryChildChainSpan: GetSpanDetails failed",
+			"traceId", traceID, "childSpanId", childID, "err", err)
+		return nil, nil, nil, false
+	}
+	childSpan := opensearch.ProcessSpan(observer.ConvertSpanDetailsToSpan(traceID, details))
+
+	input, output = opensearch.ExtractRootSpanInputOutput(&childSpan)
+	tokens = opensearch.ExtractTokenUsageFromEntityOutput(&childSpan)
+	if tokens == nil {
+		tokens = opensearch.ExtractTokenUsage([]opensearch.Span{childSpan})
+	}
+	return input, output, tokens, true
+}
+
+// aggregateFromLeafLLMSpans fetches up to maxLLMLeavesPerTrace leaf LLM spans
+// (name matches IsLLMLeafSpan), in parallel bounded by maxConcurrentFetches,
+// and aggregates token usage across them plus first/last message previews.
+// Used when neither the root nor a child chain span carries the data (OpenAI
+// Agents SDK / pure-OTel agents).
+//
+// If the trace has more LLM leaves than the cap, the returned TokenUsage has
+// Partial=true so the UI can render an "approximate" marker.
+func (c *TracingController) aggregateFromLeafLLMSpans(
+	ctx context.Context,
+	traceID string,
+	spans []observer.SpanInfo,
+) (input interface{}, output interface{}, tokens *opensearch.TokenUsage) {
+	log := logger.GetLogger(ctx)
+
+	// Filter to leaf LLM spans, ordered by start time.
+	leaves := make([]observer.SpanInfo, 0)
+	for _, s := range spans {
+		if opensearch.IsLLMLeafSpan(s.SpanName) {
+			leaves = append(leaves, s)
+		}
+	}
+	if len(leaves) == 0 {
+		return nil, nil, nil
+	}
+	sort.Slice(leaves, func(i, j int) bool { return leaves[i].StartTime.Before(leaves[j].StartTime) })
+
+	totalLeaves := len(leaves)
+	partial := false
+	if totalLeaves > maxLLMLeavesPerTrace {
+		leaves = leaves[:maxLLMLeavesPerTrace]
+		partial = true
+		log.Debug("aggregateFromLeafLLMSpans: capping leaf fetches",
+			"traceId", traceID, "totalLeaves", totalLeaves, "cap", maxLLMLeavesPerTrace)
+	}
+
+	// Parallel fetch, bounded by the existing controller-wide semaphore.
+	fetched := make([]opensearch.Span, len(leaves))
+	sem := make(chan struct{}, maxConcurrentFetches)
+	var wg sync.WaitGroup
+	for i, leaf := range leaves {
+		wg.Add(1)
+		go func(idx int, spanID string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			details, err := c.observerClient.GetSpanDetails(ctx, traceID, spanID)
+			if err != nil {
+				log.Warn("aggregateFromLeafLLMSpans: GetSpanDetails failed for leaf",
+					"traceId", traceID, "spanId", spanID, "err", err)
+				return
+			}
+			fetched[idx] = opensearch.ProcessSpan(observer.ConvertSpanDetailsToSpan(traceID, details))
+		}(i, leaf.SpanID)
+	}
+	wg.Wait()
+
+	// Trim out any leaves that failed to fetch (zero-value Span).
+	validLeaves := make([]opensearch.Span, 0, len(fetched))
+	for _, s := range fetched {
+		if s.SpanID != "" {
+			validLeaves = append(validLeaves, s)
+		}
+	}
+	if len(validLeaves) == 0 {
+		return nil, nil, nil
+	}
+
+	tokens = opensearch.ExtractTokenUsage(validLeaves)
+	if tokens != nil && partial {
+		tokens.Partial = true
+	}
+
+	// Input preview from the first leaf, output preview from the last.
+	input = opensearch.ExtractInputPreviewFromLeaf(&validLeaves[0])
+	output = opensearch.ExtractOutputPreviewFromLeaf(&validLeaves[len(validLeaves)-1])
+	return input, output, tokens
 }
 
 // GetTraceSpans fetches span summaries for a specific trace (no attributes).

--- a/traces-observer-service/controllers/controller_test.go
+++ b/traces-observer-service/controllers/controller_test.go
@@ -102,6 +102,11 @@ func baseParams() TraceQueryParams {
 	}
 }
 
+// testFetchSem returns a fresh fetch-budget semaphore sized for tests. The
+// cascade's per-trace fetches share this channel in production; tests give
+// each call its own channel for isolation.
+func testFetchSem() chan struct{} { return make(chan struct{}, maxConcurrentFetches) }
+
 // (a) Root span carries entity.input/output and entity.output → root-derived
 // token usage. The cascade must short-circuit at step 1 — no extra fetches.
 func TestEnrichTraceOverview_RootHasEntityShortCircuits(t *testing.T) {
@@ -112,7 +117,7 @@ func TestEnrichTraceOverview_RootHasEntityShortCircuits(t *testing.T) {
 	fake := &fakeObserverClient{rootSpan: &observer.SpanDetailsResponse{SpanID: "root"}}
 	c := NewTracingController(fake)
 
-	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root)
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root, testFetchSem())
 
 	if input == nil || output == nil {
 		t.Errorf("expected input/output from root, got input=%v output=%v", input, output)
@@ -153,7 +158,7 @@ func TestEnrichTraceOverview_FallsBackToChildChainSpan(t *testing.T) {
 	}
 	c := NewTracingController(fake)
 
-	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root)
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root, testFetchSem())
 
 	if input == nil || output == nil {
 		t.Errorf("expected input/output from chain child, got input=%v output=%v", input, output)
@@ -200,7 +205,7 @@ func TestEnrichTraceOverview_AggregatesFromLeafLLMSpans(t *testing.T) {
 	}
 	c := NewTracingController(fake)
 
-	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root)
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root, testFetchSem())
 
 	if input != "first user msg" {
 		t.Errorf("input = %v, want first user msg", input)
@@ -223,7 +228,7 @@ func TestEnrichTraceOverview_AllEmptyReturnsNil(t *testing.T) {
 	fake := &fakeObserverClient{spans: []observer.SpanInfo{}}
 	c := NewTracingController(fake)
 
-	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(1), root)
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(1), root, testFetchSem())
 
 	if input != nil || output != nil || tokens != nil {
 		t.Errorf("expected all nil, got input=%v output=%v tokens=%+v", input, output, tokens)
@@ -258,9 +263,11 @@ func TestEnrichTraceOverview_LeafCapHonoredAndPartialFlagged(t *testing.T) {
 	fake := &fakeObserverClient{spans: spans, spanDetails: details}
 	c := NewTracingController(fake)
 
-	// SpanCount stays under the skip threshold so step 3 runs; the cap
-	// (maxLLMLeavesPerTrace) is what should trigger Partial.
-	_, _, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(skipLeafAggregationSpanCountThreshold), root)
+	// SpanCount stays clearly under the skip threshold so step 3 runs; the
+	// cap (maxLLMLeavesPerTrace) is what should trigger Partial. Using
+	// threshold-1 expresses "below the skip threshold" independently of
+	// whether the guard ever tightens from > to >=.
+	_, _, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(skipLeafAggregationSpanCountThreshold-1), root, testFetchSem())
 
 	if tokens == nil {
 		t.Fatalf("expected tokens, got nil")
@@ -291,7 +298,7 @@ func TestEnrichTraceOverview_SkipsLeafAggregationForHugeTraces(t *testing.T) {
 	c := NewTracingController(fake)
 
 	hugeTrace := baseTraceInfo(skipLeafAggregationSpanCountThreshold + 1)
-	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), hugeTrace, root)
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), hugeTrace, root, testFetchSem())
 
 	if input != nil || output != nil || tokens != nil {
 		t.Errorf("expected nil for huge trace, got input=%v output=%v tokens=%+v", input, output, tokens)

--- a/traces-observer-service/controllers/controller_test.go
+++ b/traces-observer-service/controllers/controller_test.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wso2/ai-agent-management-platform/traces-observer-service/observer"
+	"github.com/wso2/ai-agent-management-platform/traces-observer-service/opensearch"
+)
+
+// fakeObserverClient is a minimal observer.Client implementation that the
+// cascade tests use to script trace-overview enrichment scenarios. Each test
+// installs the spans for a single trace; getSpanDetailsCalls counts how many
+// GetSpanDetails calls the cascade made so we can verify the cost guards.
+type fakeObserverClient struct {
+	// rootSpan is returned by GetSpanDetails when called for the root span.
+	rootSpan *observer.SpanDetailsResponse
+	// spans is the list returned by QueryTraceSpans.
+	spans []observer.SpanInfo
+	// spanDetails maps spanID → detail response for GetSpanDetails lookups
+	// (excluding root, which is rootSpan).
+	spanDetails map[string]*observer.SpanDetailsResponse
+
+	getSpanDetailsCalls  int32
+	queryTraceSpansCalls int32
+}
+
+func (f *fakeObserverClient) QueryTraces(_ context.Context, _ observer.TracesQueryRequest) (*observer.TracesQueryResponse, error) {
+	return nil, fmt.Errorf("not used by enrichTraceOverview tests")
+}
+
+func (f *fakeObserverClient) QueryTraceSpans(_ context.Context, _ string, _ observer.TracesQueryRequest) (*observer.TraceSpansQueryResponse, error) {
+	atomic.AddInt32(&f.queryTraceSpansCalls, 1)
+	return &observer.TraceSpansQueryResponse{Spans: f.spans, Total: len(f.spans)}, nil
+}
+
+func (f *fakeObserverClient) GetSpanDetails(_ context.Context, _, spanID string) (*observer.SpanDetailsResponse, error) {
+	atomic.AddInt32(&f.getSpanDetailsCalls, 1)
+	if f.rootSpan != nil && spanID == f.rootSpan.SpanID {
+		return f.rootSpan, nil
+	}
+	if d, ok := f.spanDetails[spanID]; ok {
+		return d, nil
+	}
+	return nil, fmt.Errorf("fake: span %s not found", spanID)
+}
+
+// makeRootSpan constructs an opensearch.Span suitable for passing to
+// enrichTraceOverview as the rootSpan argument.
+func makeRootSpan(spanID string, attrs map[string]interface{}) *opensearch.Span {
+	return &opensearch.Span{
+		SpanID:     spanID,
+		Name:       "invoke_agent LangGraph",
+		Attributes: attrs,
+	}
+}
+
+// baseTraceInfo returns a TraceInfo with sane defaults; tests override
+// SpanCount where they need to exercise the cost guard.
+func baseTraceInfo(spanCount int) observer.TraceInfo {
+	return observer.TraceInfo{
+		TraceID:    "trace-1",
+		RootSpanID: "root",
+		StartTime:  time.Now().Add(-1 * time.Hour),
+		EndTime:    time.Now(),
+		SpanCount:  spanCount,
+	}
+}
+
+func baseParams() TraceQueryParams {
+	project := "proj"
+	component := "comp"
+	environment := "env"
+	return TraceQueryParams{
+		Organization: "ns",
+		Project:      &project,
+		Agent:        &component,
+		Environment:  &environment,
+		StartTime:    time.Now().Add(-1 * time.Hour),
+		EndTime:      time.Now(),
+		Limit:        50,
+		SortOrder:    "desc",
+	}
+}
+
+// (a) Root span carries entity.input/output and entity.output → root-derived
+// token usage. The cascade must short-circuit at step 1 — no extra fetches.
+func TestEnrichTraceOverview_RootHasEntityShortCircuits(t *testing.T) {
+	root := makeRootSpan("root", map[string]interface{}{
+		"traceloop.entity.input":  `{"inputs":"hello there"}`,
+		"traceloop.entity.output": `{"outputs":{"messages":[{"kwargs":{"content":"hi back","response_metadata":{"token_usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13}}}}]}}`,
+	})
+	fake := &fakeObserverClient{rootSpan: &observer.SpanDetailsResponse{SpanID: "root"}}
+	c := NewTracingController(fake)
+
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root)
+
+	if input == nil || output == nil {
+		t.Errorf("expected input/output from root, got input=%v output=%v", input, output)
+	}
+	if tokens == nil || tokens.TotalTokens != 13 {
+		t.Errorf("expected tokens from root, got %+v", tokens)
+	}
+	if got := atomic.LoadInt32(&fake.getSpanDetailsCalls); got != 0 {
+		t.Errorf("expected no extra GetSpanDetails calls, got %d", got)
+	}
+	if got := atomic.LoadInt32(&fake.queryTraceSpansCalls); got != 0 {
+		t.Errorf("expected no QueryTraceSpans calls, got %d", got)
+	}
+}
+
+// (b) Root span empty, but the immediate child chain span carries
+// traceloop.entity.input/output (LangGraph pattern). Step 2 must fill it in.
+func TestEnrichTraceOverview_FallsBackToChildChainSpan(t *testing.T) {
+	root := makeRootSpan("root", map[string]interface{}{})
+	// Two children of root: a non-chain span starting later, and the chain
+	// span starting first. tryChildChainSpan picks the earliest.
+	startEarly := time.Now().Add(-10 * time.Minute)
+	startLate := time.Now().Add(-5 * time.Minute)
+	fake := &fakeObserverClient{
+		spans: []observer.SpanInfo{
+			{SpanID: "chain-1", SpanName: "LangGraph.workflow", ParentSpanID: "root", StartTime: startEarly},
+			{SpanID: "other", SpanName: "execute_task something", ParentSpanID: "root", StartTime: startLate},
+		},
+		spanDetails: map[string]*observer.SpanDetailsResponse{
+			"chain-1": {
+				SpanID: "chain-1", SpanName: "LangGraph.workflow",
+				Attributes: map[string]interface{}{
+					"traceloop.entity.input":  `{"inputs":"chain in"}`,
+					"traceloop.entity.output": `{"outputs":{"messages":[{"kwargs":{"content":"chain out","response_metadata":{"token_usage":{"prompt_tokens":20,"completion_tokens":5,"total_tokens":25}}}}]}}`,
+				},
+			},
+		},
+	}
+	c := NewTracingController(fake)
+
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root)
+
+	if input == nil || output == nil {
+		t.Errorf("expected input/output from chain child, got input=%v output=%v", input, output)
+	}
+	if tokens == nil || tokens.TotalTokens != 25 {
+		t.Errorf("expected tokens from chain child, got %+v", tokens)
+	}
+	if got := atomic.LoadInt32(&fake.getSpanDetailsCalls); got != 1 {
+		t.Errorf("expected exactly 1 GetSpanDetails (child), got %d", got)
+	}
+}
+
+// (c) Root and child empty, but leaf LLM spans carry gen_ai.input.messages /
+// gen_ai.output.messages / gen_ai.usage.* — the OpenAI Agents SDK case. Step
+// 3 aggregates: token sum across all leaves, first-leaf input, last-leaf output.
+func TestEnrichTraceOverview_AggregatesFromLeafLLMSpans(t *testing.T) {
+	root := makeRootSpan("root", map[string]interface{}{})
+	start := time.Now().Add(-10 * time.Minute)
+	fake := &fakeObserverClient{
+		spans: []observer.SpanInfo{
+			{SpanID: "leaf-1", SpanName: "openai.chat", ParentSpanID: "root", StartTime: start},
+			{SpanID: "leaf-2", SpanName: "openai.chat", ParentSpanID: "root", StartTime: start.Add(1 * time.Minute)},
+		},
+		spanDetails: map[string]*observer.SpanDetailsResponse{
+			"leaf-1": {
+				SpanID: "leaf-1", SpanName: "openai.chat",
+				Attributes: map[string]interface{}{
+					"gen_ai.input.messages":      `[{"role":"user","parts":[{"type":"text","content":"first user msg"}]}]`,
+					"gen_ai.output.messages":     `[{"role":"assistant","parts":[{"type":"text","content":"first assistant"}]}]`,
+					"gen_ai.usage.input_tokens":  float64(100),
+					"gen_ai.usage.output_tokens": float64(20),
+				},
+			},
+			"leaf-2": {
+				SpanID: "leaf-2", SpanName: "openai.chat",
+				Attributes: map[string]interface{}{
+					"gen_ai.input.messages":      `[{"role":"user","parts":[{"type":"text","content":"second user msg"}]}]`,
+					"gen_ai.output.messages":     `[{"role":"assistant","parts":[{"type":"text","content":"final answer"}]}]`,
+					"gen_ai.usage.input_tokens":  float64(50),
+					"gen_ai.usage.output_tokens": float64(10),
+				},
+			},
+		},
+	}
+	c := NewTracingController(fake)
+
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(5), root)
+
+	if input != "first user msg" {
+		t.Errorf("input = %v, want first user msg", input)
+	}
+	if output != "final answer" {
+		t.Errorf("output = %v, want last assistant msg", output)
+	}
+	if tokens == nil || tokens.InputTokens != 150 || tokens.OutputTokens != 30 || tokens.TotalTokens != 180 {
+		t.Errorf("tokens = %+v, want sum across leaves (150/30/180)", tokens)
+	}
+	if tokens.Partial {
+		t.Errorf("expected Partial=false (under cap), got true")
+	}
+}
+
+// (d) Everything empty — degenerate case. No extra fetches beyond QueryTraceSpans.
+// All three return nil; trace overview row simply renders "-" in the UI.
+func TestEnrichTraceOverview_AllEmptyReturnsNil(t *testing.T) {
+	root := makeRootSpan("root", map[string]interface{}{})
+	fake := &fakeObserverClient{spans: []observer.SpanInfo{}}
+	c := NewTracingController(fake)
+
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(1), root)
+
+	if input != nil || output != nil || tokens != nil {
+		t.Errorf("expected all nil, got input=%v output=%v tokens=%+v", input, output, tokens)
+	}
+}
+
+// (e) Leaf cap honoured. With > maxLLMLeavesPerTrace leaves, only the cap is
+// fetched and TokenUsage.Partial is true.
+func TestEnrichTraceOverview_LeafCapHonoredAndPartialFlagged(t *testing.T) {
+	root := makeRootSpan("root", map[string]interface{}{})
+	const totalLeaves = maxLLMLeavesPerTrace + 5
+
+	spans := make([]observer.SpanInfo, 0, totalLeaves)
+	details := make(map[string]*observer.SpanDetailsResponse, totalLeaves)
+	start := time.Now().Add(-1 * time.Hour)
+	for i := 0; i < totalLeaves; i++ {
+		id := fmt.Sprintf("leaf-%02d", i)
+		spans = append(spans, observer.SpanInfo{
+			SpanID: id, SpanName: "openai.chat", ParentSpanID: "root",
+			StartTime: start.Add(time.Duration(i) * time.Second),
+		})
+		details[id] = &observer.SpanDetailsResponse{
+			SpanID: id, SpanName: "openai.chat",
+			Attributes: map[string]interface{}{
+				"gen_ai.input.messages":      `[{"role":"user","content":"u"}]`,
+				"gen_ai.output.messages":     `[{"role":"assistant","content":"a"}]`,
+				"gen_ai.usage.input_tokens":  float64(1),
+				"gen_ai.usage.output_tokens": float64(1),
+			},
+		}
+	}
+	fake := &fakeObserverClient{spans: spans, spanDetails: details}
+	c := NewTracingController(fake)
+
+	// SpanCount stays under the skip threshold so step 3 runs; the cap
+	// (maxLLMLeavesPerTrace) is what should trigger Partial.
+	_, _, tokens := c.enrichTraceOverview(context.Background(), baseParams(), baseTraceInfo(skipLeafAggregationSpanCountThreshold), root)
+
+	if tokens == nil {
+		t.Fatalf("expected tokens, got nil")
+	}
+	if !tokens.Partial {
+		t.Errorf("expected Partial=true when leaves exceed cap")
+	}
+	if tokens.TotalTokens != maxLLMLeavesPerTrace*2 {
+		t.Errorf("expected sum from %d leaves (cap), got TotalTokens=%d", maxLLMLeavesPerTrace, tokens.TotalTokens)
+	}
+	if got := atomic.LoadInt32(&fake.getSpanDetailsCalls); got != int32(maxLLMLeavesPerTrace) {
+		t.Errorf("expected exactly %d GetSpanDetails fetches, got %d", maxLLMLeavesPerTrace, got)
+	}
+}
+
+// Cost guard: when the trace's total span count exceeds the skip threshold,
+// step 3 is bypassed entirely — no leaf fetches happen even if leaves exist.
+func TestEnrichTraceOverview_SkipsLeafAggregationForHugeTraces(t *testing.T) {
+	root := makeRootSpan("root", map[string]interface{}{})
+	fake := &fakeObserverClient{
+		spans: []observer.SpanInfo{
+			{SpanID: "leaf-1", SpanName: "openai.chat", ParentSpanID: "root", StartTime: time.Now()},
+		},
+		spanDetails: map[string]*observer.SpanDetailsResponse{
+			"leaf-1": {SpanID: "leaf-1", Attributes: map[string]interface{}{"gen_ai.usage.input_tokens": float64(1)}},
+		},
+	}
+	c := NewTracingController(fake)
+
+	hugeTrace := baseTraceInfo(skipLeafAggregationSpanCountThreshold + 1)
+	input, output, tokens := c.enrichTraceOverview(context.Background(), baseParams(), hugeTrace, root)
+
+	if input != nil || output != nil || tokens != nil {
+		t.Errorf("expected nil for huge trace, got input=%v output=%v tokens=%+v", input, output, tokens)
+	}
+	if got := atomic.LoadInt32(&fake.getSpanDetailsCalls); got != 0 {
+		t.Errorf("expected no GetSpanDetails calls (skip), got %d", got)
+	}
+}

--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -618,12 +618,15 @@ func IsLLMLeafSpan(spanName string) bool {
 }
 
 // ExtractInputPreviewFromLeaf returns a short preview of the user-facing
-// input on a leaf LLM span — the content of the first message in
-// gen_ai.input.messages. Used by the trace-list view to populate the Input
-// column when neither the root span nor a child chain span carries it
-// (OpenAI Agents SDK / pure-OTel agents).
+// input on a leaf LLM span. It prefers the first message with role "user"
+// (since gen_ai.input.messages on a chat span typically carries the system
+// prompt first followed by the user turn, and the system prompt is not a
+// useful trace-list preview) and falls back to the first non-empty content
+// when no user-role message is present.
 //
-// Returns nil when no input messages are present.
+// Used by the trace-list view to populate the Input column when neither
+// the root span nor a child chain span carries it (OpenAI Agents SDK /
+// pure-OTel agents). Returns nil when no usable content is present.
 func ExtractInputPreviewFromLeaf(leaf *Span) interface{} {
 	if leaf == nil || leaf.Attributes == nil {
 		return nil
@@ -636,14 +639,27 @@ func ExtractInputPreviewFromLeaf(leaf *Span) interface{} {
 	if len(messages) == 0 {
 		return nil
 	}
-	return messages[0].Content
+	for _, m := range messages {
+		if roleEquals(m, "user") && m.Content != "" {
+			return m.Content
+		}
+	}
+	for _, m := range messages {
+		if m.Content != "" {
+			return m.Content
+		}
+	}
+	return nil
 }
 
 // ExtractOutputPreviewFromLeaf returns a short preview of the assistant-
-// facing output on a leaf LLM span — the content of the last message in
-// gen_ai.output.messages.
+// facing output on a leaf LLM span. It prefers the last message with role
+// "assistant" (since gen_ai.output.messages on an agent turn can include
+// trailing tool-response messages, and the trace-list user wants the model's
+// answer, not the tool's output) and falls back to the last non-empty
+// content when no assistant-role message is present.
 //
-// Returns nil when no output messages are present.
+// Returns nil when no usable content is present.
 func ExtractOutputPreviewFromLeaf(leaf *Span) interface{} {
 	if leaf == nil || leaf.Attributes == nil {
 		return nil
@@ -656,7 +672,18 @@ func ExtractOutputPreviewFromLeaf(leaf *Span) interface{} {
 	if len(messages) == 0 {
 		return nil
 	}
-	return messages[len(messages)-1].Content
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if roleEquals(m, "assistant") && m.Content != "" {
+			return m.Content
+		}
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Content != "" {
+			return messages[i].Content
+		}
+	}
+	return nil
 }
 
 // ExtractTokenUsageFromEntityOutput extracts token usage from the traceloop.entity.output
@@ -972,13 +999,18 @@ func ExtractPromptMessages(attrs map[string]interface{}) []PromptMessage {
 	return messages
 }
 
-// hasSystemMessage reports whether any message in the list carries role=system.
-// OTel GenAI / OpenLLMetry / Traceloop all spec lowercase role values, but
+// roleEquals reports whether a PromptMessage's Role matches the given target.
+// OTel GenAI / OpenLLMetry / Traceloop all spec lowercase role values, but we
 // match defensively (case-insensitive, trimmed) so a malformed span carrying
-// "System" or " system " doesn't slip past and produce a duplicate bubble.
+// "User" or " system " doesn't slip past.
+func roleEquals(m PromptMessage, role string) bool {
+	return strings.EqualFold(strings.TrimSpace(m.Role), role)
+}
+
+// hasSystemMessage reports whether any message in the list carries role=system.
 func hasSystemMessage(messages []PromptMessage) bool {
 	for _, m := range messages {
-		if strings.EqualFold(strings.TrimSpace(m.Role), "system") {
+		if roleEquals(m, "system") {
 			return true
 		}
 	}

--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -609,6 +609,56 @@ func ExtractTokenUsage(spans []Span) *TokenUsage {
 	return nil
 }
 
+// IsLLMLeafSpan reports whether a span name looks like a leaf LLM call.
+// Narrow match on the ".chat" suffix covers ChatOpenAI.chat, openai.chat,
+// anthropic.chat, cohere.chat, etc., while avoiding chain / agent / tool
+// spans whose names share the gen_ai surface.
+func IsLLMLeafSpan(spanName string) bool {
+	return strings.HasSuffix(spanName, ".chat")
+}
+
+// ExtractInputPreviewFromLeaf returns a short preview of the user-facing
+// input on a leaf LLM span — the content of the first message in
+// gen_ai.input.messages. Used by the trace-list view to populate the Input
+// column when neither the root span nor a child chain span carries it
+// (OpenAI Agents SDK / pure-OTel agents).
+//
+// Returns nil when no input messages are present.
+func ExtractInputPreviewFromLeaf(leaf *Span) interface{} {
+	if leaf == nil || leaf.Attributes == nil {
+		return nil
+	}
+	messagesJSON, ok := leaf.Attributes["gen_ai.input.messages"].(string)
+	if !ok || messagesJSON == "" {
+		return nil
+	}
+	messages := parseOTELMessages(messagesJSON)
+	if len(messages) == 0 {
+		return nil
+	}
+	return messages[0].Content
+}
+
+// ExtractOutputPreviewFromLeaf returns a short preview of the assistant-
+// facing output on a leaf LLM span — the content of the last message in
+// gen_ai.output.messages.
+//
+// Returns nil when no output messages are present.
+func ExtractOutputPreviewFromLeaf(leaf *Span) interface{} {
+	if leaf == nil || leaf.Attributes == nil {
+		return nil
+	}
+	messagesJSON, ok := leaf.Attributes["gen_ai.output.messages"].(string)
+	if !ok || messagesJSON == "" {
+		return nil
+	}
+	messages := parseOTELMessages(messagesJSON)
+	if len(messages) == 0 {
+		return nil
+	}
+	return messages[len(messages)-1].Content
+}
+
 // ExtractTokenUsageFromEntityOutput extracts token usage from the traceloop.entity.output
 // attribute of a root span. Token info is nested in the last AIMessage:
 // outputs.messages[-1].kwargs.response_metadata.token_usage OR usage_metadata

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -1686,6 +1686,30 @@ func TestExtractInputPreviewFromLeaf(t *testing.T) {
 			t.Errorf("got %v, want 'hi'", got)
 		}
 	})
+
+	// gen_ai.input.messages on a chat span often carries the system prompt
+	// first; we should skip past it to surface the user turn as the preview.
+	t.Run("skips leading system message and returns first user content", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"system","content":"You are a bot."},{"role":"user","content":"order #12347?"},{"role":"assistant","content":"checking..."}]`,
+		}}
+		got := ExtractInputPreviewFromLeaf(s)
+		if got != "order #12347?" {
+			t.Errorf("got %v, want first user content", got)
+		}
+	})
+
+	// When no user role is present (pathological), fall back to the first
+	// non-empty content rather than returning nil.
+	t.Run("falls back to first non-empty content when no user role", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"system","content":"sys prompt"},{"role":"assistant","content":"reply"}]`,
+		}}
+		got := ExtractInputPreviewFromLeaf(s)
+		if got != "sys prompt" {
+			t.Errorf("got %v, want fallback to first content", got)
+		}
+	})
 }
 
 func TestExtractOutputPreviewFromLeaf(t *testing.T) {
@@ -1719,6 +1743,30 @@ func TestExtractOutputPreviewFromLeaf(t *testing.T) {
 		got := ExtractOutputPreviewFromLeaf(s)
 		if got != "final" {
 			t.Errorf("got %v, want 'final'", got)
+		}
+	})
+
+	// In agent flows gen_ai.output.messages can end with a tool response;
+	// the trace-list preview wants the model's answer, not the tool output.
+	t.Run("skips trailing tool message and returns last assistant content", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.output.messages": `[{"role":"assistant","content":"calling search_flights"},{"role":"tool","content":"{flights: [...]}"}]`,
+		}}
+		got := ExtractOutputPreviewFromLeaf(s)
+		if got != "calling search_flights" {
+			t.Errorf("got %v, want last assistant content", got)
+		}
+	})
+
+	// When no assistant role is present (pathological), fall back to the
+	// last non-empty content rather than returning nil.
+	t.Run("falls back to last non-empty content when no assistant role", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.output.messages": `[{"role":"tool","content":"only tool output"}]`,
+		}}
+		got := ExtractOutputPreviewFromLeaf(s)
+		if got != "only tool output" {
+			t.Errorf("got %v, want fallback to last content", got)
 		}
 	})
 }

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -17,6 +17,8 @@
 package opensearch
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -1620,6 +1622,129 @@ func TestProcessSpan_PureOTelGenAISpans(t *testing.T) {
 		amp := ProcessSpan(span).AmpAttributes
 		if amp.Status == nil || !amp.Status.Error {
 			t.Errorf("status = %#v, want error", amp.Status)
+		}
+	})
+}
+
+// ── Trace-list cascade helpers ──────────────────────────────────────────────
+
+func TestIsLLMLeafSpan(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"OpenAI chat leaf", "openai.chat", true},
+		{"LangChain ChatOpenAI", "ChatOpenAI.chat", true},
+		{"Anthropic", "anthropic.chat", true},
+		{"Cohere", "cohere.chat", true},
+		{"LangGraph workflow chain — not a leaf", "LangGraph.workflow", false},
+		{"invoke_agent root", "invoke_agent LangGraph", false},
+		{"execute_task chain", "execute_task call_model", false},
+		{"embedding span", "openai.embeddings", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsLLMLeafSpan(tc.in); got != tc.want {
+				t.Errorf("IsLLMLeafSpan(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractInputPreviewFromLeaf(t *testing.T) {
+	t.Run("nil span returns nil", func(t *testing.T) {
+		if got := ExtractInputPreviewFromLeaf(nil); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("no gen_ai.input.messages attribute returns nil", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{"foo": "bar"}}
+		if got := ExtractInputPreviewFromLeaf(s); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("returns first message content from parts[] shape", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"what flights from ZRH to LHR"}]},{"role":"assistant","parts":[{"type":"text","content":"checking..."}]}]`,
+		}}
+		got := ExtractInputPreviewFromLeaf(s)
+		if got != "what flights from ZRH to LHR" {
+			t.Errorf("got %v, want first user message", got)
+		}
+	})
+
+	t.Run("returns first message content from legacy top-level content shape", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.input.messages": `[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}]`,
+		}}
+		got := ExtractInputPreviewFromLeaf(s)
+		if got != "hi" {
+			t.Errorf("got %v, want 'hi'", got)
+		}
+	})
+}
+
+func TestExtractOutputPreviewFromLeaf(t *testing.T) {
+	t.Run("nil span returns nil", func(t *testing.T) {
+		if got := ExtractOutputPreviewFromLeaf(nil); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("no gen_ai.output.messages attribute returns nil", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{"foo": "bar"}}
+		if got := ExtractOutputPreviewFromLeaf(s); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("returns last message content from parts[] shape", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.output.messages": `[{"role":"assistant","parts":[{"type":"text","content":"Here are the flights..."}]}]`,
+		}}
+		got := ExtractOutputPreviewFromLeaf(s)
+		if got != "Here are the flights..." {
+			t.Errorf("got %v, want assistant response", got)
+		}
+	})
+
+	t.Run("returns last (not first) when multiple output messages", func(t *testing.T) {
+		s := &Span{Attributes: map[string]interface{}{
+			"gen_ai.output.messages": `[{"role":"assistant","content":"draft"},{"role":"assistant","content":"final"}]`,
+		}}
+		got := ExtractOutputPreviewFromLeaf(s)
+		if got != "final" {
+			t.Errorf("got %v, want 'final'", got)
+		}
+	})
+}
+
+func TestTokenUsage_PartialSerialization(t *testing.T) {
+	t.Run("omitted from JSON when false", func(t *testing.T) {
+		tu := TokenUsage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150}
+		buf, err := json.Marshal(tu)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		got := string(buf)
+		if strings.Contains(got, "partial") {
+			t.Errorf("partial should be omitted when false, got %q", got)
+		}
+	})
+
+	t.Run("included when true", func(t *testing.T) {
+		tu := TokenUsage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, Partial: true}
+		buf, err := json.Marshal(tu)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		got := string(buf)
+		if !strings.Contains(got, `"partial":true`) {
+			t.Errorf("partial=true should serialise, got %q", got)
 		}
 	})
 }

--- a/traces-observer-service/opensearch/types.go
+++ b/traces-observer-service/opensearch/types.go
@@ -202,11 +202,15 @@ const (
 	SpanTypeUnknown    SpanType = "unknown"    // Unknown/unclassified spans
 )
 
-// TokenUsage represents aggregated token usage from GenAI spans
+// TokenUsage represents aggregated token usage from GenAI spans.
+// Partial is true when the aggregation was truncated (e.g. trace had more
+// LLM leaf spans than the trace-list view fetches), so consumers know to
+// render the count with a "+" / "approximate" indicator.
 type TokenUsage struct {
-	InputTokens  int `json:"inputTokens"`
-	OutputTokens int `json:"outputTokens"`
-	TotalTokens  int `json:"totalTokens"`
+	InputTokens  int  `json:"inputTokens"`
+	OutputTokens int  `json:"outputTokens"`
+	TotalTokens  int  `json:"totalTokens"`
+	Partial      bool `json:"partial,omitempty"`
 }
 
 // TraceOverviewResponse represents the response for trace overview queries


### PR DESCRIPTION
Related to https://github.com/wso2/agent-manager/discussions/902

## What

The trace list view's `Input`, `Output` and `Tokens` columns rendered `-` for any trace whose root span follows the OTel 1.40 GenAI semantic conventions (LangGraph + recent Traceloop, OpenAI Agents SDK, pure-OTel auto-instrumentation). Older Traceloop / CrewAI / LangChain-with-Traceloop-wrapper kept working because they stuff a convenience payload onto the root. The discussion linked above lays out why this is a real gap and what the trade-offs are.

This PR ships the "incremental" plan agreed on the discussion: cascade the trace-list enrichment through three sources of increasing cost, short-circuiting as soon as the columns are populated. No new infra (no direct-OpenSearch wiring, no upstream openchoreo PR) — just one extra `GetSpanDetails` per affected trace and, in the leaf-aggregation case, a bounded fan-out for the spans we already need.

## Changes

### Observer (`traces-observer-service`)

- `opensearch/types.go` — `TokenUsage` gains an optional `Partial bool` (omitempty), set when leaf aggregation hit the per-trace cap.
- `opensearch/process.go` — three new helpers:
  - `IsLLMLeafSpan(name)` — narrow `.chat` suffix match.
  - `ExtractInputPreviewFromLeaf(span)` / `ExtractOutputPreviewFromLeaf(span)` — first / last message content from `gen_ai.input.messages` / `gen_ai.output.messages`.
- `controllers/controller.go` — `GetTraceOverviews`'s per-trace processing is now factored into `enrichTraceOverview`, which cascades:
  1. **Root span (unchanged).** Older Traceloop entity.input/output and CrewAI roll-up. Free.
  2. **Immediate non-leaf child of the root.** Picks the earliest non-leaf child, fetches its details, reruns the existing entity / token extractors. Covers LangChain / LangGraph `LangGraph.workflow`-style chain spans. +1 `GetSpanDetails` per affected trace.
  3. **Leaf LLM spans (`*.chat`).** Capped at `maxLLMLeavesPerTrace` (50), parallel-bounded via the existing `maxConcurrentFetches` semaphore. Skipped entirely when `traceInfo.SpanCount` exceeds `skipLeafAggregationSpanCountThreshold` (100). When the cap truncates the aggregation, `TokenUsage.Partial` is set true.
- Each step only fills fields the earlier step left nil, so a trace fully served by step 1 incurs no extra fetches.

### Console

- `libs/types/src/api/traces.ts` — `TokenUsage` gains `partial?: boolean` mirroring the server-side flag.
- `pages/traces/src/subComponents/TracesTable.tsx`:
  - **Tokens cell** renders `12,345+` with the tooltip _"Approximate total. This trace has more LLM spans than the list view aggregates. Open the trace for the exact total."_ when `partial` is true.
  - **Input / Output cells** now use _"Preview only. Open the trace for the full input."_ / _"Preview only. Open the trace for the full output."_ tooltips — the columns are populated from a heuristic preview (first user message, final assistant message, or the entity input/output text when present), not the full trace input/output.

## Tests

`go test ./...` green in `traces-observer-service`. 25 new sub-tests:

- **Helper-level** (`opensearch/process_test.go`):
  - `TestIsLLMLeafSpan` — 9 cases: positive (`openai.chat`, `ChatOpenAI.chat`, `anthropic.chat`, `cohere.chat`) and negative (`LangGraph.workflow`, `invoke_agent`, `execute_task`, `openai.embeddings`, empty).
  - `TestExtractInputPreviewFromLeaf` / `TestExtractOutputPreviewFromLeaf` — nil-span, absent-attribute, parts[] shape, legacy top-level content shape, last-not-first ordering.
  - `TestTokenUsage_PartialSerialization` — `partial` omitted when false, serialised when true.
- **Cascade-level** (`controllers/controller_test.go`, new file): a minimal fake `observer.Client` plus six scenario tests:
  - (a) Root has entity attrs — short-circuits at step 1, no extra calls.
  - (b) Root empty, child chain span has entity — step 2 fills in.
  - (c) Root + child empty, leaves have `gen_ai.usage` / messages — step 3 aggregates correctly across multiple leaves (token sum, first-leaf input, last-leaf output).
  - (d) All empty — returns nil/nil/nil.
  - (e) More leaves than cap — cap honored, `Partial: true`, exactly `maxLLMLeavesPerTrace` fetches happen.
  - (f) `spanCount` exceeds the skip threshold — step 3 is bypassed entirely, no leaf fetches.

## Test plan

- [x] Unit tests green (`go test ./...`).
- [x] `gofmt -d` clean, `go vet ./...` silent.
- [x] Local e2e: rebuilt `amp-traces-observer:0.0.0-dev`, hot-swapped into k3d, queried `/api/v1/traces?agent=int-support-agent`. Previously empty `tokenUsage` / `input` / `output` are now populated for every LangGraph trace via the step-2 path. Sample:
  ```
  root=invoke_agent LangGraph  spans= 7   tokens={'inputTokens': 1833, 'outputTokens': 18, 'totalTokens': 1851}
  root=invoke_agent LangGraph  spans=25   tokens={'inputTokens': 2022, 'outputTokens': 54, 'totalTokens': 2076}
  ```
- [x] `cs-agent` trace list also populated; the `create_agent react_agent` single-span trace correctly returns nil/nil/nil — no chain or leaves to fall back to, not a regression.
- [x] Console HMR compiled cleanly on the TracesTable edit.

The step-3 leaf-aggregation path doesn't have a live OpenAI Agents SDK agent deployed locally to exercise end-to-end, so its coverage comes from the cascade unit tests via the fake observer client.

## Release

Same shape as #884 / #895 — purely an observer + console rendering fix. No new infra, no new env vars, no new artefacts. The `amp-traces-observer` image rebuilds on every product release via `release-config.json`, and the console rebuilds via the existing pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token totals now indicate when aggregation is partial/approximate (shown with a `+`).

* **Improvements**
  * Input/Output preview cells now show a consistent "Preview only…" message and disable tooltips when previews are missing.
  * Token display shows `-` when totals are unavailable and provides explanatory tooltips for approximate totals.
  * Token aggregation improved with multi-source fallbacks and capped processing to reduce heavy trace queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->