### PR TITLE
Fix test key refetch on window focus

### DIFF
--- a/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
@@ -122,6 +122,6 @@ export function useTestAgentAPIKey(
       && !!(params.orgName && params.projName && params.agentName && params.envId),
     staleTime: 9 * 60 * 1000,
     refetchInterval: 9 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: "always",
   });
 }


### PR DESCRIPTION
## Summary
- always refetch console test API keys when the tab/window regains focus
- prevents focused tabs from reusing cached test keys after another tab rotates the key

## Test
- npm run build in console/workspaces/libs/api-client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Test agent API key now automatically refreshes when you return to the application after switching browser tabs, ensuring the key remains up-to-date.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->