### PR TITLE
fix(test-page): per-user test API keys and stale key prevention

### DIFF
--- a/agent-manager-service/controllers/agent_apikey_controller.go
+++ b/agent-manager-service/controllers/agent_apikey_controller.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
@@ -274,7 +275,14 @@ func (c *agentAPIKeyController) IssueTestAPIKey(w http.ResponseWriter, r *http.R
 
 	log.Info("IssueTestAPIKey: starting", "orgName", orgName, "projName", projName, "agentName", agentName, "envID", envID)
 
-	response, err := c.apiKeyService.IssueTestAPIKey(ctx, orgName, projName, agentName, envID)
+	claims := jwtassertion.GetTokenClaims(ctx)
+	if claims == nil || claims.Sub == "" {
+		log.Warn("IssueTestAPIKey: missing token claims")
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "Missing token claims")
+		return
+	}
+
+	response, err := c.apiKeyService.IssueTestAPIKey(ctx, orgName, projName, agentName, envID, claims.Sub)
 	if err != nil {
 		switch {
 		case errors.Is(err, utils.ErrArtifactNotFound):

--- a/agent-manager-service/models/apikey.go
+++ b/agent-manager-service/models/apikey.go
@@ -27,9 +27,10 @@ import (
 const (
 	APIKeyPurposePermanent = 1
 	APIKeyPurposeTest      = 2
-	// APIKeyTestKeyName is the fixed name used for the single test
-	// key per agent. Subsequent IssueTestAPIKey calls rotate this row.
-	APIKeyTestKeyName = "console-test"
+	// APIKeyTestKeyPrefix is the name prefix for per-user console test keys.
+	// Each user gets their own row (prefix + truncated SHA-256 of their JWT sub),
+	// so concurrent sessions across users don't invalidate each other's keys.
+	APIKeyTestKeyPrefix = "console-test-"
 )
 
 // StoredAPIKey represents an API key persisted in the database for gateway bulk-sync

--- a/agent-manager-service/services/agent_apikey_service.go
+++ b/agent-manager-service/services/agent_apikey_service.go
@@ -18,8 +18,11 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
@@ -33,13 +36,21 @@ import (
 // The console refreshes the key at staleTime well before this elapses.
 const testKeyTTL = 10 * time.Minute
 
+// testKeyName returns a stable, per-user key name derived from the JWT subject.
+// Hashing keeps the name within the gateway's alphanumeric-hyphen constraint
+// and avoids storing raw user identifiers as key names.
+func testKeyName(userSub string) string {
+	h := sha256.Sum256([]byte(userSub))
+	return models.APIKeyTestKeyPrefix + hex.EncodeToString(h[:])[:12]
+}
+
 // AgentAPIKeyServiceInterface defines the contract for agent API key operations
 type AgentAPIKeyServiceInterface interface {
 	CreateAPIKey(ctx context.Context, orgName, projectName, agentName, envID string, req *models.CreateAPIKeyRequest) (*models.CreateAPIKeyResponse, error)
 	RevokeAPIKey(ctx context.Context, orgName, projectName, agentName, envID, keyName string) error
 	RotateAPIKey(ctx context.Context, orgName, projectName, agentName, envID, keyName string, req *models.RotateAPIKeyRequest) (*models.CreateAPIKeyResponse, error)
 	ListAPIKeys(ctx context.Context, orgName, projectName, agentName, envID string) ([]models.StoredAPIKey, error)
-	IssueTestAPIKey(ctx context.Context, orgName, projectName, agentName, envID string) (*models.IssueTestAPIKeyResponse, error)
+	IssueTestAPIKey(ctx context.Context, orgName, projectName, agentName, envID, userSub string) (*models.IssueTestAPIKeyResponse, error)
 }
 
 // AgentAPIKeyService handles API key management for agents
@@ -92,8 +103,8 @@ func (s *AgentAPIKeyService) CreateAPIKey(
 	orgName, projectName, agentName, envID string,
 	req *models.CreateAPIKeyRequest,
 ) (*models.CreateAPIKeyResponse, error) {
-	if req != nil && req.Name == models.APIKeyTestKeyName {
-		return nil, fmt.Errorf("%w: %q is reserved for console test keys", utils.ErrBadRequest, models.APIKeyTestKeyName)
+	if req != nil && strings.HasPrefix(req.Name, models.APIKeyTestKeyPrefix) {
+		return nil, fmt.Errorf("%w: names starting with %q are reserved for console test keys", utils.ErrBadRequest, models.APIKeyTestKeyPrefix)
 	}
 	artifact, err := s.resolveAgentAPIArtifact(ctx, orgName, projectName, agentName, envID)
 	if err != nil {
@@ -153,12 +164,13 @@ func (s *AgentAPIKeyService) ListAPIKeys(
 	return result, nil
 }
 
-// IssueTestAPIKey issues (or rotates) the single short-lived test API key
-// associated with an agent. Used by the console Try-It flow. The key is
-// scoped by APIKeyTestKeyName and never appears in the user-facing list.
+// IssueTestAPIKey issues (or rotates) a short-lived test API key scoped to the
+// calling user (userSub). Each user gets their own DB row, so concurrent sessions
+// across different users don't invalidate each other's keys. Used by the console
+// Try-It flow; test keys never appear in the user-facing list.
 func (s *AgentAPIKeyService) IssueTestAPIKey(
 	ctx context.Context,
-	orgName, projectName, agentName, envID string,
+	orgName, projectName, agentName, envID, userSub string,
 ) (*models.IssueTestAPIKeyResponse, error) {
 	artifact, err := s.resolveAgentAPIArtifact(ctx, orgName, projectName, agentName, envID)
 	if err != nil {
@@ -166,9 +178,10 @@ func (s *AgentAPIKeyService) IssueTestAPIKey(
 	}
 	artifactUUID := artifact.UUID.String()
 
+	keyName := testKeyName(userSub)
 	expiresAt := time.Now().UTC().Add(testKeyTTL).Format(time.RFC3339)
 
-	existing, err := s.apiKeyRepo.GetByArtifactAndName(artifactUUID, models.APIKeyTestKeyName)
+	existing, err := s.apiKeyRepo.GetByArtifactAndName(artifactUUID, keyName)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("failed to look up existing test key: %w", err)
 	}
@@ -176,15 +189,15 @@ func (s *AgentAPIKeyService) IssueTestAPIKey(
 	var resp *models.CreateAPIKeyResponse
 	if existing != nil {
 		if existing.Purpose != models.APIKeyPurposeTest {
-			return nil, fmt.Errorf("%w: %q is reserved for console test keys", utils.ErrBadRequest, models.APIKeyTestKeyName)
+			return nil, fmt.Errorf("%w: %q is reserved for console test keys", utils.ErrBadRequest, keyName)
 		}
 		// Same DB row, new hash + expiry; purpose is preserved (Upsert.DoUpdates excludes it).
-		resp, err = s.broadcaster.broadcastRotate(orgName, artifactUUID, artifactUUID, models.APIKeyTestKeyName,
+		resp, err = s.broadcaster.broadcastRotate(orgName, artifactUUID, artifactUUID, keyName,
 			&models.RotateAPIKeyRequest{ExpiresAt: &expiresAt})
 	} else {
 		resp, err = s.broadcaster.broadcastCreate(orgName, artifactUUID, artifactUUID,
 			&models.CreateAPIKeyRequest{
-				Name:        models.APIKeyTestKeyName,
+				Name:        keyName,
 				DisplayName: "Console Try-It",
 				Purpose:     models.APIKeyPurposeTest,
 				ExpiresAt:   &expiresAt,

--- a/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
@@ -122,6 +122,6 @@ export function useTestAgentAPIKey(
       && !!(params.orgName && params.projName && params.agentName && params.envId),
     staleTime: 9 * 60 * 1000,
     refetchInterval: 9 * 60 * 1000,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: "always",
   });
 }

--- a/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
@@ -122,6 +122,6 @@ export function useTestAgentAPIKey(
       && !!(params.orgName && params.projName && params.agentName && params.envId),
     staleTime: 9 * 60 * 1000,
     refetchInterval: 9 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 }

--- a/console/workspaces/pages/test/src/Test.Component.tsx
+++ b/console/workspaces/pages/test/src/Test.Component.tsx
@@ -100,7 +100,7 @@ export const TestComponent: React.FC = () => {
       {isLoading ? (
         <SkeletonTestPageLayout />
       ) : (
-        <>{isChatAgent ? <AgentChat /> : <Swagger />}</>
+        <>{isChatAgent ? <AgentChat key={agentId} /> : <Swagger />}</>
       )}
     </PageLayout>
   );


### PR DESCRIPTION
## Problem

Three intermittent issues were observed in the agent Try-It (test) page:

1. **Multi-user 401s** — The backend stored a single `console-test` key row per agent per environment. When two users (or two browser tabs) opened the same agent's test page, each `IssueTestAPIKey` call rotated that shared row, invalidating the other session's cached key and causing 401s.

2. **Stale key on tab refocus** — When a user switched away, opening two tabs for the same agent try out view and came back, the test key was getting rotated, leaving a window where a rotated key could cause a 401.

3. **Message history bleed on agent switch** — Navigating from Agent A to Agent B in the sidebar reused the same `AgentChat` component instance (React reconciliation), so the previous agent's messages, errors, and endpoint state leaked into the new agent's view.

## Summary by CodeRabbit

* **New Features**
  * Test API keys are now issued and managed individually per user.
  * Test API key data automatically refreshes when your browser window regains focus.

* **Improvements**
  * Enhanced authentication validation for test API key requests.
  * Improved test component rendering stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->