### PR TITLE
Add external provisioning support to amctl agent create

### DIFF
--- a/cli/pkg/clients/traceobssvc/client.go
+++ b/cli/pkg/clients/traceobssvc/client.go
@@ -64,6 +64,8 @@ func NewClient(baseURL string, opts ...Option) (*Client, error) {
 	return c, nil
 }
 
+func (c *Client) URL() string { return c.baseURL }
+
 func (c *Client) do(ctx context.Context, method, path string, q url.Values, out any) error {
 	u := c.baseURL + path
 	if len(q) > 0 {

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clients/traceobssvc"
 	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
@@ -30,11 +31,11 @@ import (
 )
 
 type CreateOptions struct {
-	IO               *iostreams.IOStreams
-	Client           func(context.Context) (*amsvc.ClientWithResponses, error)
-	TraceObserverURL func(context.Context) (string, error)
-	ResolveScope     func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope        func(string, string) render.Scope
+	IO            *iostreams.IOStreams
+	Client        func(context.Context) (*amsvc.ClientWithResponses, error)
+	TraceObserver func(context.Context) (*traceobssvc.Client, error)
+	ResolveScope  func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope     func(string, string) render.Scope
 
 	Org   string
 	Proj  string
@@ -75,11 +76,11 @@ type CreateOptions struct {
 
 func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &CreateOptions{
-		IO:               f.IOStreams,
-		Client:           f.AgentManager,
-		TraceObserverURL: f.TraceObserverURL,
-		ResolveScope:     f.ResolveOrgProject,
-		MakeScope:        f.Scope,
+		IO:            f.IOStreams,
+		Client:        f.AgentManager,
+		TraceObserver: f.TraceObserver,
+		ResolveScope:  f.ResolveOrgProject,
+		MakeScope:     f.Scope,
 	}
 
 	cmd := &cobra.Command{

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -30,10 +30,11 @@ import (
 )
 
 type CreateOptions struct {
-	IO           *iostreams.IOStreams
-	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
-	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
-	MakeScope    func(string, string) render.Scope
+	IO               *iostreams.IOStreams
+	Client           func(context.Context) (*amsvc.ClientWithResponses, error)
+	TraceObserverURL func(context.Context) (string, error)
+	ResolveScope     func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope        func(string, string) render.Scope
 
 	Org   string
 	Proj  string
@@ -74,10 +75,11 @@ type CreateOptions struct {
 
 func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &CreateOptions{
-		IO:           f.IOStreams,
-		Client:       f.AgentManager,
-		ResolveScope: f.ResolveOrgProject,
-		MakeScope:    f.Scope,
+		IO:               f.IOStreams,
+		Client:           f.AgentManager,
+		TraceObserverURL: f.TraceObserverURL,
+		ResolveScope:     f.ResolveOrgProject,
+		MakeScope:        f.Scope,
 	}
 
 	cmd := &cobra.Command{
@@ -171,18 +173,33 @@ func runCreate(ctx context.Context, opts *CreateOptions) error {
 		return render.Error(opts.IO, opts.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON409, resp.JSON500)))
 	}
 
-	if opts.IO.JSON {
-		return render.JSONSuccess(opts.IO, opts.Scope, resp.JSON202)
+	isExternal := opts.Provisioning == provisioningExternal
+
+	if !opts.IO.JSON {
+		cs := opts.IO.StderrColorScheme()
+		fmt.Fprintf(opts.IO.ErrOut, "%s Created agent %s\n\n", cs.SuccessIcon(), resp.JSON202.Name)
+		fmt.Fprintf(opts.IO.ErrOut, "  Name:         %s\n", resp.JSON202.Name)
+		fmt.Fprintf(opts.IO.ErrOut, "  Display Name: %s\n", resp.JSON202.DisplayName)
+		fmt.Fprintf(opts.IO.ErrOut, "  Type:         %s\n", resp.JSON202.AgentType.Type)
+		if resp.JSON202.AgentType.SubType != nil {
+			fmt.Fprintf(opts.IO.ErrOut, "  Sub-Type:     %s\n", *resp.JSON202.AgentType.SubType)
+		}
+		fmt.Fprintf(opts.IO.ErrOut, "  Provisioning: %s\n", resp.JSON202.Provisioning.Type)
 	}
 
-	cs := opts.IO.StderrColorScheme()
-	fmt.Fprintf(opts.IO.ErrOut, "%s Created agent %s\n\n", cs.SuccessIcon(), resp.JSON202.Name)
-	fmt.Fprintf(opts.IO.ErrOut, "  Name:         %s\n", resp.JSON202.Name)
-	fmt.Fprintf(opts.IO.ErrOut, "  Display Name: %s\n", resp.JSON202.DisplayName)
-	fmt.Fprintf(opts.IO.ErrOut, "  Type:         %s\n", resp.JSON202.AgentType.Type)
-	if resp.JSON202.AgentType.SubType != nil {
-		fmt.Fprintf(opts.IO.ErrOut, "  Sub-Type:     %s\n", *resp.JSON202.AgentType.SubType)
+	if !isExternal {
+		if opts.IO.JSON {
+			return render.JSONSuccess(opts.IO, opts.Scope, resp.JSON202)
+		}
+		return nil
 	}
-	fmt.Fprintf(opts.IO.ErrOut, "  Provisioning: %s\n", resp.JSON202.Provisioning.Type)
+
+	traceObsURL, err := opts.TraceObserverURL(ctx)
+	if err != nil {
+		return render.Error(opts.IO, opts.Scope, err)
+	}
+	if err := runExternalPostCreate(ctx, opts, resp.JSON202.Name, client, traceObsURL); err != nil {
+		return render.Error(opts.IO, opts.Scope, err)
+	}
 	return nil
 }

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -188,9 +188,9 @@ func runCreate(ctx context.Context, opts *CreateOptions) error {
 	// mint, trace-observer discovery) is a warning, not an error — otherwise the
 	// user retries and hits 409.
 	if err := runExternalPostCreate(ctx, opts, resp.JSON202, client); err != nil {
-		fmt.Fprintf(opts.IO.ErrOut, "warning: agent created but post-create setup failed: %v\n", err)
+		fmt.Fprintf(opts.IO.ErrOut, "warning: agent created but failed to generate token: %v\n", err)
 		if opts.IO.JSON {
-			return render.JSONSuccess(opts.IO, opts.Scope, resp.JSON202)
+			return render.JSONSuccess(opts.IO, opts.Scope, map[string]any{"agent": resp.JSON202})
 		}
 	}
 	return nil

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -184,8 +184,14 @@ func runCreate(ctx context.Context, opts *CreateOptions) error {
 		return nil
 	}
 
+	// The agent is already created server-side, so a post-create failure (token
+	// mint, trace-observer discovery) is a warning, not an error — otherwise the
+	// user retries and hits 409.
 	if err := runExternalPostCreate(ctx, opts, resp.JSON202, client); err != nil {
-		return render.Error(opts.IO, opts.Scope, err)
+		fmt.Fprintf(opts.IO.ErrOut, "warning: agent created but post-create setup failed: %v\n", err)
+		if opts.IO.JSON {
+			return render.JSONSuccess(opts.IO, opts.Scope, resp.JSON202)
+		}
 	}
 	return nil
 }

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -173,33 +173,31 @@ func runCreate(ctx context.Context, opts *CreateOptions) error {
 		return render.Error(opts.IO, opts.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON409, resp.JSON500)))
 	}
 
-	isExternal := opts.Provisioning == provisioningExternal
-
 	if !opts.IO.JSON {
-		cs := opts.IO.StderrColorScheme()
-		fmt.Fprintf(opts.IO.ErrOut, "%s Created agent %s\n\n", cs.SuccessIcon(), resp.JSON202.Name)
-		fmt.Fprintf(opts.IO.ErrOut, "  Name:         %s\n", resp.JSON202.Name)
-		fmt.Fprintf(opts.IO.ErrOut, "  Display Name: %s\n", resp.JSON202.DisplayName)
-		fmt.Fprintf(opts.IO.ErrOut, "  Type:         %s\n", resp.JSON202.AgentType.Type)
-		if resp.JSON202.AgentType.SubType != nil {
-			fmt.Fprintf(opts.IO.ErrOut, "  Sub-Type:     %s\n", *resp.JSON202.AgentType.SubType)
-		}
-		fmt.Fprintf(opts.IO.ErrOut, "  Provisioning: %s\n", resp.JSON202.Provisioning.Type)
+		printAgentSummary(opts.IO, resp.JSON202)
 	}
 
-	if !isExternal {
+	if opts.Provisioning != provisioningExternal {
 		if opts.IO.JSON {
 			return render.JSONSuccess(opts.IO, opts.Scope, resp.JSON202)
 		}
 		return nil
 	}
 
-	traceObsURL, err := opts.TraceObserverURL(ctx)
-	if err != nil {
-		return render.Error(opts.IO, opts.Scope, err)
-	}
-	if err := runExternalPostCreate(ctx, opts, resp.JSON202.Name, client, traceObsURL); err != nil {
+	if err := runExternalPostCreate(ctx, opts, resp.JSON202, client); err != nil {
 		return render.Error(opts.IO, opts.Scope, err)
 	}
 	return nil
+}
+
+func printAgentSummary(io *iostreams.IOStreams, a *amsvc.AgentResponse) {
+	cs := io.StderrColorScheme()
+	fmt.Fprintf(io.ErrOut, "%s Created agent %s\n\n", cs.SuccessIcon(), a.Name)
+	fmt.Fprintf(io.ErrOut, "  Name:         %s\n", a.Name)
+	fmt.Fprintf(io.ErrOut, "  Display Name: %s\n", a.DisplayName)
+	fmt.Fprintf(io.ErrOut, "  Type:         %s\n", a.AgentType.Type)
+	if a.AgentType.SubType != nil {
+		fmt.Fprintf(io.ErrOut, "  Sub-Type:     %s\n", *a.AgentType.SubType)
+	}
+	fmt.Fprintf(io.ErrOut, "  Provisioning: %s\n", a.Provisioning.Type)
 }

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cobra"
 
 	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clients/traceobssvc"
 	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 	"github.com/wso2/agent-manager/cli/pkg/config"
@@ -122,8 +123,11 @@ func testCreateCmd(t *testing.T, ios *iostreams.IOStreams, clientFn func(context
 	f := &cmdutil.Factory{
 		IOStreams:    ios,
 		AgentManager: clientFn,
-		TraceObserverURL: func(context.Context) (string, error) {
-			return traceObsURL, nil
+		TraceObserver: func(context.Context) (*traceobssvc.Client, error) {
+			if traceObsURL == "" {
+				return nil, nil
+			}
+			return traceobssvc.NewClient(traceObsURL)
 		},
 		Config: func() (*config.Config, error) {
 			return &config.Config{

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -694,12 +694,61 @@ func TestCreate_External_TokenFailure_WarnsAndSucceeds(t *testing.T) {
 	env := decodeEnvelope(t, out.String())
 	data, ok := env["data"].(map[string]any)
 	if !ok {
-		t.Fatalf("missing data envelope (should fall back to bare agent): %v", env)
+		t.Fatalf("missing data envelope: %v", env)
 	}
-	if data["name"] != "testing" {
-		t.Errorf("data.name = %v, want testing", data["name"])
+	agent, ok := data["agent"].(map[string]any)
+	if !ok {
+		t.Fatalf("data.agent missing or wrong shape (success and failure envelopes must share the .data.agent selector): %v", data)
+	}
+	if agent["name"] != "testing" {
+		t.Errorf("data.agent.name = %v, want testing", agent["name"])
 	}
 	if _, hasToken := data["token"]; hasToken {
 		t.Errorf("data.token should be absent on failure fallback: %v", data["token"])
+	}
+}
+
+func TestCreate_External_TokenFailure_TextMode(t *testing.T) {
+	ios, _, errOut := newTestIO(false)
+	routes := map[string]routeResponse{
+		"/orgs/acme/projects/triage/agents/testing/token": {
+			Status: 500,
+			Body:   amsvc.ErrorResponse{Code: "INTERNAL", Message: "boom"},
+		},
+		"/orgs/acme/projects/triage/agents": {
+			Status: 202,
+			Body: amsvc.AgentResponse{
+				Name:         "testing",
+				DisplayName:  "Testing",
+				AgentType:    amsvc.AgentType{Type: "external-agent-api"},
+				Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
+				ProjectName:  "triage",
+				Uuid:         "u",
+			},
+		},
+	}
+	clientFn, _, cleanup := newTestRouter(t, routes)
+	defer cleanup()
+
+	cmd := testCreateCmd(t, ios, clientFn, "https://otel.example")
+	cmd.SetArgs([]string{
+		"agent", "create", "testing",
+		"--project", "triage",
+		"--display-name", "Testing",
+		"--provisioning", "external",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected nil error (post-create failure is a warning), got %v", err)
+	}
+
+	stderr := errOut.String()
+	if !strings.Contains(stderr, "Created agent testing") {
+		t.Errorf("stderr missing success line: %q", stderr)
+	}
+	if !strings.Contains(stderr, "warning:") {
+		t.Errorf("stderr missing warning prefix: %q", stderr)
+	}
+	if strings.Contains(stderr, "amp-instrument") {
+		t.Errorf("stderr should not contain instrumentation block when token mint failed: %q", stderr)
 	}
 }

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -65,17 +66,65 @@ func newTestClient(t *testing.T, status int, respBody any) (func(context.Context
 	return func(context.Context) (*amsvc.ClientWithResponses, error) { return client, nil }, captured, server.Close
 }
 
+type routeResponse struct {
+	Status int
+	Body   any
+}
+
+// newTestRouter mounts multiple routes on one httptest server. Each captured
+// request is keyed by route pattern. Patterns are matched with strings.HasPrefix
+// against r.URL.Path, longest-first, so a more specific route (e.g.
+// /agents/foo/token) wins over its prefix (/agents).
+func newTestRouter(t *testing.T, routes map[string]routeResponse) (func(context.Context) (*amsvc.ClientWithResponses, error), map[string]*capturedRequest, func()) {
+	t.Helper()
+	keys := make([]string, 0, len(routes))
+	for k := range routes {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return len(keys[i]) > len(keys[j]) })
+
+	captured := map[string]*capturedRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, pattern := range keys {
+			if !strings.HasPrefix(r.URL.Path, pattern) {
+				continue
+			}
+			route := routes[pattern]
+			cap := &capturedRequest{method: r.Method, path: r.URL.Path}
+			cap.body, _ = io.ReadAll(r.Body)
+			captured[pattern] = cap
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(route.Status)
+			if route.Body != nil {
+				_ = json.NewEncoder(w).Encode(route.Body)
+			}
+			return
+		}
+		t.Errorf("unrouted request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	client, err := amsvc.NewClientWithResponses(server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("new client: %v", err)
+	}
+	return func(context.Context) (*amsvc.ClientWithResponses, error) { return client, nil }, captured, server.Close
+}
+
 func newTestIO(jsonMode bool) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
 	ios, _, out, errOut := iostreams.Test()
 	ios.JSON = jsonMode
 	return ios, out, errOut
 }
 
-func testCreateCmd(t *testing.T, ios *iostreams.IOStreams, clientFn func(context.Context) (*amsvc.ClientWithResponses, error)) *cobra.Command {
+func testCreateCmd(t *testing.T, ios *iostreams.IOStreams, clientFn func(context.Context) (*amsvc.ClientWithResponses, error), traceObsURL string) *cobra.Command {
 	t.Helper()
 	f := &cmdutil.Factory{
-		IOStreams:     ios,
+		IOStreams:    ios,
 		AgentManager: clientFn,
+		TraceObserverURL: func(context.Context) (string, error) {
+			return traceObsURL, nil
+		},
 		Config: func() (*config.Config, error) {
 			return &config.Config{
 				CurrentInstance: "default",
@@ -159,7 +208,7 @@ func TestCreate_Buildpack_JSON(t *testing.T) {
 	clientFn, captured, cleanup := newTestClient(t, 202, agentResponse())
 	defer cleanup()
 
-	cmd := testCreateCmd(t, ios, clientFn)
+	cmd := testCreateCmd(t, ios, clientFn, "")
 	cmd.SetArgs(buildpackArgs())
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -201,7 +250,7 @@ func TestCreate_Docker_JSON(t *testing.T) {
 	clientFn, captured, cleanup := newTestClient(t, 202, agentResponse())
 	defer cleanup()
 
-	cmd := testCreateCmd(t, ios, clientFn)
+	cmd := testCreateCmd(t, ios, clientFn, "")
 	cmd.SetArgs(dockerArgs())
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -230,7 +279,7 @@ func TestCreate_TextMode(t *testing.T) {
 	clientFn, _, cleanup := newTestClient(t, 202, agentResponse())
 	defer cleanup()
 
-	cmd := testCreateCmd(t, ios, clientFn)
+	cmd := testCreateCmd(t, ios, clientFn, "")
 	cmd.SetArgs(buildpackArgs())
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -250,7 +299,7 @@ func TestCreate_ChatAPI_RequestBody(t *testing.T) {
 	clientFn, captured, cleanup := newTestClient(t, 202, agentResponse())
 	defer cleanup()
 
-	cmd := testCreateCmd(t, ios, clientFn)
+	cmd := testCreateCmd(t, ios, clientFn, "")
 	cmd.SetArgs([]string{
 		"agent", "create", "chat-bot",
 		"--project", "triage",
@@ -305,7 +354,7 @@ func TestCreate_400Error(t *testing.T) {
 	clientFn, _, cleanup := newTestClient(t, 400, errBody)
 	defer cleanup()
 
-	cmd := testCreateCmd(t, ios, clientFn)
+	cmd := testCreateCmd(t, ios, clientFn, "")
 	cmd.SetArgs(buildpackArgs())
 	err := cmd.Execute()
 	if err == nil {
@@ -328,7 +377,7 @@ func TestCreate_409Conflict(t *testing.T) {
 	clientFn, _, cleanup := newTestClient(t, 409, errBody)
 	defer cleanup()
 
-	cmd := testCreateCmd(t, ios, clientFn)
+	cmd := testCreateCmd(t, ios, clientFn, "")
 	cmd.SetArgs(buildpackArgs())
 	err := cmd.Execute()
 	if err == nil {
@@ -351,7 +400,7 @@ func TestCreate_500Error(t *testing.T) {
 	clientFn, _, cleanup := newTestClient(t, 500, errBody)
 	defer cleanup()
 
-	cmd := testCreateCmd(t, ios, clientFn)
+	cmd := testCreateCmd(t, ios, clientFn, "")
 	cmd.SetArgs(buildpackArgs())
 	err := cmd.Execute()
 	if err == nil {
@@ -367,7 +416,7 @@ func TestCreate_500Error(t *testing.T) {
 
 func TestCreate_ValidationError_JSON(t *testing.T) {
 	ios, out, _ := newTestIO(true)
-	cmd := testCreateCmd(t, ios, nil)
+	cmd := testCreateCmd(t, ios, nil, "")
 	cmd.SetArgs([]string{"agent", "create", "--project", "triage"})
 	err := cmd.Execute()
 	if err == nil {
@@ -391,7 +440,7 @@ func TestCreate_ValidationError_JSON(t *testing.T) {
 
 func TestCreate_ValidationError_Text(t *testing.T) {
 	ios, _, errOut := newTestIO(false)
-	cmd := testCreateCmd(t, ios, nil)
+	cmd := testCreateCmd(t, ios, nil, "")
 	cmd.SetArgs([]string{"agent", "create", "--project", "triage"})
 	err := cmd.Execute()
 	if err == nil {
@@ -409,7 +458,7 @@ func TestCreate_ValidationError_Text(t *testing.T) {
 
 func TestCreate_UnknownProvisioning(t *testing.T) {
 	ios, out, _ := newTestIO(true)
-	cmd := testCreateCmd(t, ios, nil)
+	cmd := testCreateCmd(t, ios, nil, "")
 	cmd.SetArgs([]string{
 		"agent", "create", "foo",
 		"--project", "triage",
@@ -438,7 +487,7 @@ func TestCreate_UnknownProvisioning(t *testing.T) {
 
 func TestCreate_MissingName_BatchedError(t *testing.T) {
 	ios, out, _ := newTestIO(true)
-	cmd := testCreateCmd(t, ios, nil)
+	cmd := testCreateCmd(t, ios, nil, "")
 	cmd.SetArgs([]string{"agent", "create", "--project", "triage"})
 	err := cmd.Execute()
 	if err == nil {
@@ -471,5 +520,138 @@ func TestCreate_MissingName_BatchedError(t *testing.T) {
 	}
 	if !foundDisplayName {
 		t.Errorf("expected '--display-name is required' in details, got %v", details)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestCreate_External_Text(t *testing.T) {
+	ios, _, errOut := newTestIO(false)
+	routes := map[string]routeResponse{
+		"/orgs/acme/projects/triage/agents/testing/token": {
+			Status: 200,
+			Body: amsvc.TokenResponse{
+				Token:     "tok-abc",
+				ExpiresAt: 1700000000,
+				IssuedAt:  1690000000,
+				TokenType: "Bearer",
+			},
+		},
+		"/orgs/acme/projects/triage/agents": {
+			Status: 202,
+			Body: amsvc.AgentResponse{
+				Name:         "testing",
+				DisplayName:  "Testing",
+				Description:  "dssdf",
+				AgentType:    amsvc.AgentType{Type: "external-agent-api", SubType: ptr("custom-api")},
+				Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
+				ProjectName:  "triage",
+				Uuid:         "uuid-ext",
+				CreatedAt:    time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	clientFn, captured, cleanup := newTestRouter(t, routes)
+	defer cleanup()
+
+	cmd := testCreateCmd(t, ios, clientFn, "https://otel.example")
+	cmd.SetArgs([]string{
+		"agent", "create", "testing",
+		"--project", "triage",
+		"--display-name", "Testing",
+		"--description", "dssdf",
+		"--provisioning", "external",
+		"--subtype", "custom-api",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	createReq, ok := captured["/orgs/acme/projects/triage/agents"]
+	if !ok {
+		t.Fatal("no create request captured")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(createReq.body, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	prov := body["provisioning"].(map[string]any)
+	if prov["type"] != "external" {
+		t.Errorf("provisioning.type = %v, want external", prov["type"])
+	}
+	if _, ok := prov["repository"]; ok {
+		t.Errorf("provisioning.repository should be absent, got %v", prov["repository"])
+	}
+	for _, k := range []string{"build", "inputInterface", "configurations"} {
+		if _, ok := body[k]; ok {
+			t.Errorf("body.%s should be absent for external, got %v", k, body[k])
+		}
+	}
+
+	if _, ok := captured["/orgs/acme/projects/triage/agents/testing/token"]; !ok {
+		t.Error("no token request captured")
+	}
+
+	out := errOut.String()
+	for _, sub := range []string{
+		"Created agent testing",
+		"Provisioning: external",
+		`export AMP_OTEL_ENDPOINT="https://otel.example/v1/traces"`,
+		`export AMP_AGENT_API_KEY="tok-abc"`,
+		"amp-instrument <your_existing_start_command>",
+	} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("output missing %q\n---\n%s", sub, out)
+		}
+	}
+}
+
+func TestCreate_External_JSON(t *testing.T) {
+	ios, out, _ := newTestIO(true)
+	routes := map[string]routeResponse{
+		"/orgs/acme/projects/triage/agents/testing/token": {
+			Status: 200,
+			Body:   amsvc.TokenResponse{Token: "tok-abc", ExpiresAt: 1700000000, IssuedAt: 1690000000, TokenType: "Bearer"},
+		},
+		"/orgs/acme/projects/triage/agents": {
+			Status: 202,
+			Body: amsvc.AgentResponse{
+				Name:         "testing",
+				DisplayName:  "Testing",
+				AgentType:    amsvc.AgentType{Type: "external-agent-api", SubType: ptr("custom-api")},
+				Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
+				ProjectName:  "triage",
+				Uuid:         "u",
+			},
+		},
+	}
+	clientFn, _, cleanup := newTestRouter(t, routes)
+	defer cleanup()
+
+	cmd := testCreateCmd(t, ios, clientFn, "https://otel.example")
+	cmd.SetArgs([]string{
+		"agent", "create", "testing",
+		"--project", "triage",
+		"--display-name", "Testing",
+		"--provisioning", "external",
+		"--subtype", "custom-api",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, out.String())
+	data, ok := env["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing data: %v", env)
+	}
+	if data["token"] != "tok-abc" {
+		t.Errorf("data.token = %v, want tok-abc", data["token"])
+	}
+	if data["otelEndpoint"] != "https://otel.example/v1/traces" {
+		t.Errorf("data.otelEndpoint = %v", data["otelEndpoint"])
+	}
+	if _, ok := data["instrumentationInstructions"].(string); !ok {
+		t.Errorf("data.instrumentationInstructions missing or not a string: %v", data["instrumentationInstructions"])
 	}
 }

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -523,8 +523,6 @@ func TestCreate_MissingName_BatchedError(t *testing.T) {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func TestCreate_External_Text(t *testing.T) {
 	ios, _, errOut := newTestIO(false)
 	routes := map[string]routeResponse{
@@ -543,7 +541,7 @@ func TestCreate_External_Text(t *testing.T) {
 				Name:         "testing",
 				DisplayName:  "Testing",
 				Description:  "dssdf",
-				AgentType:    amsvc.AgentType{Type: "external-agent-api", SubType: ptr("custom-api")},
+				AgentType:    amsvc.AgentType{Type: "external-agent-api"},
 				Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
 				ProjectName:  "triage",
 				Uuid:         "uuid-ext",
@@ -561,7 +559,6 @@ func TestCreate_External_Text(t *testing.T) {
 		"--display-name", "Testing",
 		"--description", "dssdf",
 		"--provisioning", "external",
-		"--subtype", "custom-api",
 	})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -618,7 +615,7 @@ func TestCreate_External_JSON(t *testing.T) {
 			Body: amsvc.AgentResponse{
 				Name:         "testing",
 				DisplayName:  "Testing",
-				AgentType:    amsvc.AgentType{Type: "external-agent-api", SubType: ptr("custom-api")},
+				AgentType:    amsvc.AgentType{Type: "external-agent-api"},
 				Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
 				ProjectName:  "triage",
 				Uuid:         "u",
@@ -634,7 +631,6 @@ func TestCreate_External_JSON(t *testing.T) {
 		"--project", "triage",
 		"--display-name", "Testing",
 		"--provisioning", "external",
-		"--subtype", "custom-api",
 	})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -651,3 +651,55 @@ func TestCreate_External_JSON(t *testing.T) {
 		t.Errorf("data.instrumentationInstructions missing or not a string: %v", data["instrumentationInstructions"])
 	}
 }
+
+// Agent creation succeeds server-side; the token mint fails. The CLI must
+// exit 0 with a warning so the user does not retry into a 409.
+func TestCreate_External_TokenFailure_WarnsAndSucceeds(t *testing.T) {
+	ios, out, errOut := newTestIO(true)
+	routes := map[string]routeResponse{
+		"/orgs/acme/projects/triage/agents/testing/token": {
+			Status: 500,
+			Body:   amsvc.ErrorResponse{Code: "INTERNAL", Message: "boom"},
+		},
+		"/orgs/acme/projects/triage/agents": {
+			Status: 202,
+			Body: amsvc.AgentResponse{
+				Name:         "testing",
+				DisplayName:  "Testing",
+				AgentType:    amsvc.AgentType{Type: "external-agent-api"},
+				Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
+				ProjectName:  "triage",
+				Uuid:         "u",
+			},
+		},
+	}
+	clientFn, _, cleanup := newTestRouter(t, routes)
+	defer cleanup()
+
+	cmd := testCreateCmd(t, ios, clientFn, "https://otel.example")
+	cmd.SetArgs([]string{
+		"agent", "create", "testing",
+		"--project", "triage",
+		"--display-name", "Testing",
+		"--provisioning", "external",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected nil error (post-create failure is a warning), got %v", err)
+	}
+
+	if !strings.Contains(errOut.String(), "warning:") {
+		t.Errorf("stderr missing warning prefix: %q", errOut.String())
+	}
+
+	env := decodeEnvelope(t, out.String())
+	data, ok := env["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing data envelope (should fall back to bare agent): %v", env)
+	}
+	if data["name"] != "testing" {
+		t.Errorf("data.name = %v, want testing", data["name"])
+	}
+	if _, hasToken := data["token"]; hasToken {
+		t.Errorf("data.token should be absent on failure fallback: %v", data["token"])
+	}
+}

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -407,31 +407,6 @@ func TestCreate_ValidationError_Text(t *testing.T) {
 	}
 }
 
-func TestCreate_ExternalProvisioning(t *testing.T) {
-	ios, out, _ := newTestIO(true)
-	cmd := testCreateCmd(t, ios, nil)
-	cmd.SetArgs([]string{
-		"agent", "create", "foo",
-		"--project", "triage",
-		"--display-name", "Foo",
-		"--provisioning", "external",
-	})
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("expected error")
-	}
-
-	env := decodeEnvelope(t, out.String())
-	errMap := env["error"].(map[string]any)
-	if errMap["code"] != clierr.InvalidFlag {
-		t.Errorf("code = %v", errMap["code"])
-	}
-	msg := errMap["message"].(string)
-	if !strings.Contains(msg, "not yet supported") {
-		t.Errorf("message = %q, want 'not yet supported'", msg)
-	}
-}
-
 func TestCreate_UnknownProvisioning(t *testing.T) {
 	ios, out, _ := newTestIO(true)
 	cmd := testCreateCmd(t, ios, nil)

--- a/cli/pkg/cmd/agent/create/external.go
+++ b/cli/pkg/cmd/agent/create/external.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+const externalTokenExpiresIn = "8760h"
+
+// runExternalPostCreate is invoked after a successful external CreateAgent call.
+// It mints a long-lived agent token and prints (or returns, for JSON mode) the
+// Python instrumentation instructions.
+func runExternalPostCreate(ctx context.Context, opts *CreateOptions, agentName string, client *amsvc.ClientWithResponses, traceObsURL string) error {
+	expires := externalTokenExpiresIn
+	body := amsvc.TokenRequest{ExpiresIn: &expires}
+
+	tokenResp, err := client.GenerateAgentTokenWithResponse(ctx, opts.Org, opts.Proj, agentName, nil, body)
+	if err != nil {
+		return clierr.Newf(clierr.Transport, "generate agent token: %v", err)
+	}
+	if tokenResp.JSON200 == nil {
+		return cmdutil.ErrorFromServer(tokenResp.HTTPResponse, cmdutil.FirstNonNil(tokenResp.JSON400, tokenResp.JSON401, tokenResp.JSON404))
+	}
+
+	endpoint := otelIngestEndpoint(traceObsURL)
+	instructions := buildPythonInstructions(endpoint, tokenResp.JSON200.Token)
+
+	if opts.IO.JSON {
+		return render.JSONSuccess(opts.IO, opts.Scope, map[string]any{
+			"agent":                       agentName,
+			"token":                       tokenResp.JSON200.Token,
+			"tokenExpiresAt":              tokenResp.JSON200.ExpiresAt,
+			"otelEndpoint":                endpoint,
+			"instrumentationInstructions": instructions,
+		})
+	}
+
+	fmt.Fprintln(opts.IO.ErrOut)
+	fmt.Fprintln(opts.IO.ErrOut, instructions)
+	return nil
+}
+
+func otelIngestEndpoint(base string) string {
+	return strings.TrimRight(base, "/") + "/v1/traces"
+}
+
+// buildPythonInstructions renders the Python instrumentation block shown after
+// an external agent is created. The MCP server has its own copy of this
+// renderer (agent-manager-service/mcp/tools/agents.go); the duplication is
+// intentional and avoids a cli -> agent-manager-service Go dependency.
+func buildPythonInstructions(otelEndpoint, token string) string {
+	return fmt.Sprintf(`Follow these steps to enable instrumentation:
+
+  1. Install the AMP instrumentation package:
+     pip install amp-instrumentation
+
+  2. Export the following environment variables in the agent's runtime environment:
+     export AMP_OTEL_ENDPOINT=%q
+     export AMP_AGENT_API_KEY=%q
+
+  3. Run the agent with instrumentation enabled:
+     amp-instrument <your_existing_start_command>`, otelEndpoint, token)
+}

--- a/cli/pkg/cmd/agent/create/external.go
+++ b/cli/pkg/cmd/agent/create/external.go
@@ -31,10 +31,11 @@ import (
 const externalTokenExpiresIn = "8760h"
 
 func runExternalPostCreate(ctx context.Context, opts *CreateOptions, agent *amsvc.AgentResponse, client *amsvc.ClientWithResponses) error {
-	traceObsURL, err := opts.TraceObserverURL(ctx)
+	tc, err := opts.TraceObserver(ctx)
 	if err != nil {
 		return err
 	}
+	traceObsURL := tc.URL()
 
 	expires := externalTokenExpiresIn
 	body := amsvc.TokenRequest{ExpiresIn: &expires}

--- a/cli/pkg/cmd/agent/create/external.go
+++ b/cli/pkg/cmd/agent/create/external.go
@@ -27,16 +27,19 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
+// 1 year — matches the MCP create_agent flow.
 const externalTokenExpiresIn = "8760h"
 
-// runExternalPostCreate is invoked after a successful external CreateAgent call.
-// It mints a long-lived agent token and prints (or returns, for JSON mode) the
-// Python instrumentation instructions.
-func runExternalPostCreate(ctx context.Context, opts *CreateOptions, agentName string, client *amsvc.ClientWithResponses, traceObsURL string) error {
+func runExternalPostCreate(ctx context.Context, opts *CreateOptions, agent *amsvc.AgentResponse, client *amsvc.ClientWithResponses) error {
+	traceObsURL, err := opts.TraceObserverURL(ctx)
+	if err != nil {
+		return err
+	}
+
 	expires := externalTokenExpiresIn
 	body := amsvc.TokenRequest{ExpiresIn: &expires}
 
-	tokenResp, err := client.GenerateAgentTokenWithResponse(ctx, opts.Org, opts.Proj, agentName, nil, body)
+	tokenResp, err := client.GenerateAgentTokenWithResponse(ctx, opts.Org, opts.Proj, agent.Name, nil, body)
 	if err != nil {
 		return clierr.Newf(clierr.Transport, "generate agent token: %v", err)
 	}
@@ -49,7 +52,7 @@ func runExternalPostCreate(ctx context.Context, opts *CreateOptions, agentName s
 
 	if opts.IO.JSON {
 		return render.JSONSuccess(opts.IO, opts.Scope, map[string]any{
-			"agent":                       agentName,
+			"agent":                       agent,
 			"token":                       tokenResp.JSON200.Token,
 			"tokenExpiresAt":              tokenResp.JSON200.ExpiresAt,
 			"otelEndpoint":                endpoint,
@@ -66,10 +69,8 @@ func otelIngestEndpoint(base string) string {
 	return strings.TrimRight(base, "/") + "/v1/traces"
 }
 
-// buildPythonInstructions renders the Python instrumentation block shown after
-// an external agent is created. The MCP server has its own copy of this
-// renderer (agent-manager-service/mcp/tools/agents.go); the duplication is
-// intentional and avoids a cli -> agent-manager-service Go dependency.
+// The MCP server keeps its own copy at agent-manager-service/mcp/tools/agents.go;
+// the duplication is intentional and avoids a cli -> agent-manager-service Go dependency.
 func buildPythonInstructions(otelEndpoint, token string) string {
 	return fmt.Sprintf(`Follow these steps to enable instrumentation:
 

--- a/cli/pkg/cmd/agent/create/external_test.go
+++ b/cli/pkg/cmd/agent/create/external_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPythonInstructions_ContainsExportLines(t *testing.T) {
+	got := buildPythonInstructions("https://otel.example/v1/traces", "tok-123")
+	for _, sub := range []string{
+		"pip install amp-instrumentation",
+		`export AMP_OTEL_ENDPOINT="https://otel.example/v1/traces"`,
+		`export AMP_AGENT_API_KEY="tok-123"`,
+		"amp-instrument <your_existing_start_command>",
+	} {
+		if !strings.Contains(got, sub) {
+			t.Errorf("instructions missing %q\n---\n%s", sub, got)
+		}
+	}
+}
+
+func TestOtelIngestEndpoint(t *testing.T) {
+	cases := map[string]string{
+		"https://opentelemetry.obs.dp.cloud.wso2.com":  "https://opentelemetry.obs.dp.cloud.wso2.com/v1/traces",
+		"https://opentelemetry.obs.dp.cloud.wso2.com/": "https://opentelemetry.obs.dp.cloud.wso2.com/v1/traces",
+		"http://localhost:22893":                       "http://localhost:22893/v1/traces",
+	}
+	for in, want := range cases {
+		if got := otelIngestEndpoint(in); got != want {
+			t.Errorf("otelIngestEndpoint(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/pkg/cmd/agent/create/request.go
+++ b/cli/pkg/cmd/agent/create/request.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	provisioningInternal = string(amsvc.ProvisioningTypeInternal)
-	provisioningExternal = "external" // CLI-only: API spec has no ProvisioningTypeExternal yet.
+	provisioningExternal = string(amsvc.ProvisioningTypeExternal)
 
 	buildTypeBuildpack = string(amsvc.Buildpack)
 	buildTypeDocker    = string(amsvc.Docker)

--- a/cli/pkg/cmd/agent/create/request.go
+++ b/cli/pkg/cmd/agent/create/request.go
@@ -70,6 +70,10 @@ func Build(opts *CreateOptions) (amsvc.CreateAgentRequest, error) {
 		req.AgentType.SubType = &opts.SubType
 	}
 
+	if opts.Provisioning == provisioningExternal {
+		return req, nil
+	}
+
 	b, err := buildBuild(opts)
 	if err != nil {
 		return amsvc.CreateAgentRequest{}, err
@@ -90,6 +94,9 @@ func ensureLeadingSlash(s string) string {
 }
 
 func buildProvisioning(opts *CreateOptions) amsvc.Provisioning {
+	if opts.Provisioning == provisioningExternal {
+		return amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal}
+	}
 	repo := &amsvc.RepositoryConfig{
 		Url:     opts.RepoURL,
 		Branch:  opts.RepoBranch,

--- a/cli/pkg/cmd/agent/create/request_test.go
+++ b/cli/pkg/cmd/agent/create/request_test.go
@@ -473,6 +473,58 @@ func TestBuild_NoConfigWhenUnset(t *testing.T) {
 	}
 }
 
+func TestBuildProvisioning_External(t *testing.T) {
+	opts := &CreateOptions{Provisioning: "external"}
+	p := buildProvisioning(opts)
+	if p.Type != amsvc.ProvisioningTypeExternal {
+		t.Errorf("Type = %q, want %q", p.Type, amsvc.ProvisioningTypeExternal)
+	}
+	if p.Repository != nil {
+		t.Errorf("Repository = %v, want nil", p.Repository)
+	}
+}
+
+func TestBuild_External(t *testing.T) {
+	opts := &CreateOptions{
+		Name:         "testing",
+		DisplayName:  "Testing",
+		Description:  "dssdf",
+		Provisioning: "external",
+		SubType:      "custom-api",
+	}
+	req, err := Build(opts)
+	if err != nil {
+		t.Fatalf("Build returned error: %v", err)
+	}
+	if req.Name != "testing" || req.DisplayName != "Testing" {
+		t.Errorf("name/displayName mismatch: %+v", req)
+	}
+	if req.Description == nil || *req.Description != "dssdf" {
+		t.Errorf("Description = %v, want \"dssdf\"", req.Description)
+	}
+	if req.AgentType == nil || req.AgentType.Type != "external-agent-api" {
+		t.Errorf("AgentType.Type = %v, want external-agent-api", req.AgentType)
+	}
+	if req.AgentType.SubType == nil || *req.AgentType.SubType != "custom-api" {
+		t.Errorf("AgentType.SubType = %v, want custom-api", req.AgentType.SubType)
+	}
+	if req.Provisioning.Type != amsvc.ProvisioningTypeExternal {
+		t.Errorf("Provisioning.Type = %q, want external", req.Provisioning.Type)
+	}
+	if req.Provisioning.Repository != nil {
+		t.Errorf("Repository should be nil for external, got %+v", req.Provisioning.Repository)
+	}
+	if req.Build != nil {
+		t.Errorf("Build should be nil for external, got %+v", req.Build)
+	}
+	if req.InputInterface != nil {
+		t.Errorf("InputInterface should be nil for external, got %+v", req.InputInterface)
+	}
+	if req.Configurations != nil {
+		t.Errorf("Configurations should be nil for external, got %+v", req.Configurations)
+	}
+}
+
 // --- helpers ---
 
 func strPtr(s string) *string { return &s }

--- a/cli/pkg/cmd/agent/create/request_test.go
+++ b/cli/pkg/cmd/agent/create/request_test.go
@@ -490,7 +490,6 @@ func TestBuild_External(t *testing.T) {
 		DisplayName:  "Testing",
 		Description:  "dssdf",
 		Provisioning: "external",
-		SubType:      "custom-api",
 	}
 	req, err := Build(opts)
 	if err != nil {
@@ -505,8 +504,8 @@ func TestBuild_External(t *testing.T) {
 	if req.AgentType == nil || req.AgentType.Type != "external-agent-api" {
 		t.Errorf("AgentType.Type = %v, want external-agent-api", req.AgentType)
 	}
-	if req.AgentType.SubType == nil || *req.AgentType.SubType != "custom-api" {
-		t.Errorf("AgentType.SubType = %v, want custom-api", req.AgentType.SubType)
+	if req.AgentType.SubType != nil {
+		t.Errorf("AgentType.SubType should be nil for external, got %v", *req.AgentType.SubType)
 	}
 	if req.Provisioning.Type != amsvc.ProvisioningTypeExternal {
 		t.Errorf("Provisioning.Type = %q, want external", req.Provisioning.Type)

--- a/cli/pkg/cmd/agent/create/validation.go
+++ b/cli/pkg/cmd/agent/create/validation.go
@@ -40,7 +40,7 @@ func validate(opts *CreateOptions) error {
 
 	switch opts.Provisioning {
 	case provisioningExternal:
-		return cmdutil.FlagErrorf("external provisioning is not yet supported by amctl agent create")
+		v = append(v, validateExternal(opts)...)
 	case provisioningInternal:
 		v = append(v, validateInternal(opts)...)
 	default:
@@ -171,4 +171,49 @@ func parseEnvKey(entry string) (string, error) {
 		return "", fmt.Errorf("invalid key %q (must match [A-Za-z_][A-Za-z0-9_]*)", key)
 	}
 	return key, nil
+}
+
+func validateExternal(opts *CreateOptions) []string {
+	var v []string
+
+	switch opts.SubType {
+	case subTypeCustomAPI:
+		// ok
+	case "":
+		v = append(v, "--subtype is required for external provisioning (custom-api)")
+	default:
+		v = append(v, fmt.Sprintf("--subtype must be %q for external provisioning, got %q", subTypeCustomAPI, opts.SubType))
+	}
+
+	// Internal-only flags must be unset. PortSet (not Port != 0) because the
+	// --port flag default is 8000; we only want to flag when the user
+	// explicitly passed --port.
+	for _, c := range []struct {
+		cond bool
+		msg  string
+	}{
+		{opts.RepoURL != "", "--repo-url is not allowed for external provisioning"},
+		{opts.RepoBranch != "", "--repo-branch is not allowed for external provisioning"},
+		{opts.RepoPath != "", "--repo-path is not allowed for external provisioning"},
+		{opts.RepoSecret != "", "--repo-secret is not allowed for external provisioning"},
+		{opts.BuildType != "", "--build-type is not allowed for external provisioning"},
+		{opts.Language != "", "--language is not allowed for external provisioning"},
+		{opts.LanguageVersion != "", "--language-version is not allowed for external provisioning"},
+		{opts.RunCommand != "", "--run-command is not allowed for external provisioning"},
+		{opts.Dockerfile != "", "--dockerfile is not allowed for external provisioning"},
+		{opts.PortSet, "--port is not allowed for external provisioning"},
+		{opts.BasePath != "", "--base-path is not allowed for external provisioning"},
+		{opts.OpenAPISpec != "", "--openapi-spec is not allowed for external provisioning"},
+		{len(opts.Env) > 0, "--env is not allowed for external provisioning"},
+		{len(opts.EnvSecret) > 0, "--env-secret is not allowed for external provisioning"},
+		{len(opts.EnvFromSecret) > 0, "--env-from-secret is not allowed for external provisioning"},
+		{opts.DisableAutoInstrumentation, "--no-auto-instrumentation is not allowed for external provisioning"},
+		{opts.ModelConfigFile != "", "--model-config-file is not allowed for external provisioning"},
+	} {
+		if c.cond {
+			v = append(v, c.msg)
+		}
+	}
+
+	return v
 }

--- a/cli/pkg/cmd/agent/create/validation.go
+++ b/cli/pkg/cmd/agent/create/validation.go
@@ -176,15 +176,6 @@ func parseEnvKey(entry string) (string, error) {
 func validateExternal(opts *CreateOptions) []string {
 	var v []string
 
-	switch opts.SubType {
-	case subTypeCustomAPI:
-		// ok
-	case "":
-		v = append(v, "--subtype is required for external provisioning (custom-api)")
-	default:
-		v = append(v, fmt.Sprintf("--subtype must be %q for external provisioning, got %q", subTypeCustomAPI, opts.SubType))
-	}
-
 	// Internal-only flags must be unset. PortSet (not Port != 0) because the
 	// --port flag default is 8000; we only want to flag when the user
 	// explicitly passed --port.
@@ -192,6 +183,7 @@ func validateExternal(opts *CreateOptions) []string {
 		cond bool
 		msg  string
 	}{
+		{opts.SubType != "", "--subtype is not allowed for external provisioning"},
 		{opts.RepoURL != "", "--repo-url is not allowed for external provisioning"},
 		{opts.RepoBranch != "", "--repo-branch is not allowed for external provisioning"},
 		{opts.RepoPath != "", "--repo-path is not allowed for external provisioning"},

--- a/cli/pkg/cmd/agent/create/validation.go
+++ b/cli/pkg/cmd/agent/create/validation.go
@@ -175,37 +175,31 @@ func parseEnvKey(entry string) (string, error) {
 
 func validateExternal(opts *CreateOptions) []string {
 	var v []string
-
-	// Internal-only flags must be unset. PortSet (not Port != 0) because the
-	// --port flag default is 8000; we only want to flag when the user
-	// explicitly passed --port.
-	for _, c := range []struct {
-		cond bool
-		msg  string
-	}{
-		{opts.SubType != "", "--subtype is not allowed for external provisioning"},
-		{opts.RepoURL != "", "--repo-url is not allowed for external provisioning"},
-		{opts.RepoBranch != "", "--repo-branch is not allowed for external provisioning"},
-		{opts.RepoPath != "", "--repo-path is not allowed for external provisioning"},
-		{opts.RepoSecret != "", "--repo-secret is not allowed for external provisioning"},
-		{opts.BuildType != "", "--build-type is not allowed for external provisioning"},
-		{opts.Language != "", "--language is not allowed for external provisioning"},
-		{opts.LanguageVersion != "", "--language-version is not allowed for external provisioning"},
-		{opts.RunCommand != "", "--run-command is not allowed for external provisioning"},
-		{opts.Dockerfile != "", "--dockerfile is not allowed for external provisioning"},
-		{opts.PortSet, "--port is not allowed for external provisioning"},
-		{opts.BasePath != "", "--base-path is not allowed for external provisioning"},
-		{opts.OpenAPISpec != "", "--openapi-spec is not allowed for external provisioning"},
-		{len(opts.Env) > 0, "--env is not allowed for external provisioning"},
-		{len(opts.EnvSecret) > 0, "--env-secret is not allowed for external provisioning"},
-		{len(opts.EnvFromSecret) > 0, "--env-from-secret is not allowed for external provisioning"},
-		{opts.DisableAutoInstrumentation, "--no-auto-instrumentation is not allowed for external provisioning"},
-		{opts.ModelConfigFile != "", "--model-config-file is not allowed for external provisioning"},
-	} {
-		if c.cond {
-			v = append(v, c.msg)
+	disallow := func(flag string, set bool) {
+		if set {
+			v = append(v, flag+" is not allowed for external provisioning")
 		}
 	}
+
+	disallow("--subtype", opts.SubType != "")
+	disallow("--repo-url", opts.RepoURL != "")
+	disallow("--repo-branch", opts.RepoBranch != "")
+	disallow("--repo-path", opts.RepoPath != "")
+	disallow("--repo-secret", opts.RepoSecret != "")
+	disallow("--build-type", opts.BuildType != "")
+	disallow("--language", opts.Language != "")
+	disallow("--language-version", opts.LanguageVersion != "")
+	disallow("--run-command", opts.RunCommand != "")
+	disallow("--dockerfile", opts.Dockerfile != "")
+	// PortSet (not Port != 0) — the --port flag defaults to 8000.
+	disallow("--port", opts.PortSet)
+	disallow("--base-path", opts.BasePath != "")
+	disallow("--openapi-spec", opts.OpenAPISpec != "")
+	disallow("--env", len(opts.Env) > 0)
+	disallow("--env-secret", len(opts.EnvSecret) > 0)
+	disallow("--env-from-secret", len(opts.EnvFromSecret) > 0)
+	disallow("--no-auto-instrumentation", opts.DisableAutoInstrumentation)
+	disallow("--model-config-file", opts.ModelConfigFile != "")
 
 	return v
 }

--- a/cli/pkg/cmd/agent/create/validation_test.go
+++ b/cli/pkg/cmd/agent/create/validation_test.go
@@ -95,7 +95,6 @@ func validExternalOpts() *CreateOptions {
 		Name:         "my-agent",
 		DisplayName:  "My Agent",
 		Provisioning: "external",
-		SubType:      "custom-api",
 	}
 }
 
@@ -105,24 +104,9 @@ func TestValidate_ValidExternal(t *testing.T) {
 	}
 }
 
-func TestValidate_ExternalRequiresSubtype(t *testing.T) {
-	opts := validExternalOpts()
-	opts.SubType = ""
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--subtype is required for external provisioning (custom-api)")
-}
-
-func TestValidate_ExternalSubtypeMustBeCustomAPI(t *testing.T) {
-	opts := validExternalOpts()
-	opts.SubType = "chat-api"
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, `--subtype must be "custom-api" for external provisioning, got "chat-api"`)
-}
-
 func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
 	opts := validExternalOpts()
+	opts.SubType = "custom-api"
 	opts.RepoURL = "https://x"
 	opts.RepoBranch = "main"
 	opts.RepoPath = "/"
@@ -145,6 +129,7 @@ func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
 	err := validate(opts)
 	details := mustFlagDetails(t, err)
 	for _, msg := range []string{
+		"--subtype is not allowed for external provisioning",
 		"--repo-url is not allowed for external provisioning",
 		"--repo-branch is not allowed for external provisioning",
 		"--repo-path is not allowed for external provisioning",

--- a/cli/pkg/cmd/agent/create/validation_test.go
+++ b/cli/pkg/cmd/agent/create/validation_test.go
@@ -89,22 +89,81 @@ func TestValidate_MissingRequiredFlags(t *testing.T) {
 	assertContains(t, details, "--subtype is required")
 }
 
-func TestValidate_ExternalProvisioning(t *testing.T) {
-	opts := validBuildpackOpts()
-	opts.Provisioning = "external"
+// validExternalOpts returns a CreateOptions for external that passes validation.
+func validExternalOpts() *CreateOptions {
+	return &CreateOptions{
+		Name:         "my-agent",
+		DisplayName:  "My Agent",
+		Provisioning: "external",
+		SubType:      "custom-api",
+	}
+}
+
+func TestValidate_ValidExternal(t *testing.T) {
+	if err := validate(validExternalOpts()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_ExternalRequiresSubtype(t *testing.T) {
+	opts := validExternalOpts()
+	opts.SubType = ""
 	err := validate(opts)
-	if err == nil {
-		t.Fatal("expected error for external provisioning")
-	}
-	var ce clierr.CLIError
-	if !errors.As(err, &ce) {
-		t.Fatalf("expected CLIError, got %T", err)
-	}
-	if ce.Message != "external provisioning is not yet supported by amctl agent create" {
-		t.Errorf("message = %q", ce.Message)
-	}
-	if _, ok := ce.AdditionalData["details"]; ok {
-		t.Error("external error should not have aggregate details")
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "--subtype is required for external provisioning (custom-api)")
+}
+
+func TestValidate_ExternalSubtypeMustBeCustomAPI(t *testing.T) {
+	opts := validExternalOpts()
+	opts.SubType = "chat-api"
+	err := validate(opts)
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, `--subtype must be "custom-api" for external provisioning, got "chat-api"`)
+}
+
+func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
+	opts := validExternalOpts()
+	opts.RepoURL = "https://x"
+	opts.RepoBranch = "main"
+	opts.RepoPath = "/"
+	opts.RepoSecret = "gh-token"
+	opts.BuildType = "buildpack"
+	opts.Language = "python"
+	opts.LanguageVersion = "3.11"
+	opts.RunCommand = "python main.py"
+	opts.Dockerfile = "Dockerfile"
+	opts.PortSet = true
+	opts.Port = 9000
+	opts.BasePath = "/api"
+	opts.OpenAPISpec = "/openapi.yaml"
+	opts.Env = []string{"FOO=bar"}
+	opts.EnvSecret = []string{"BAZ=quux"}
+	opts.EnvFromSecret = []string{"QUUX=secret-name"}
+	opts.DisableAutoInstrumentation = true
+	opts.ModelConfigFile = "models.yaml"
+
+	err := validate(opts)
+	details := mustFlagDetails(t, err)
+	for _, msg := range []string{
+		"--repo-url is not allowed for external provisioning",
+		"--repo-branch is not allowed for external provisioning",
+		"--repo-path is not allowed for external provisioning",
+		"--repo-secret is not allowed for external provisioning",
+		"--build-type is not allowed for external provisioning",
+		"--language is not allowed for external provisioning",
+		"--language-version is not allowed for external provisioning",
+		"--run-command is not allowed for external provisioning",
+		"--dockerfile is not allowed for external provisioning",
+		"--port is not allowed for external provisioning",
+		"--base-path is not allowed for external provisioning",
+		"--openapi-spec is not allowed for external provisioning",
+		"--env is not allowed for external provisioning",
+		"--env-secret is not allowed for external provisioning",
+		"--env-from-secret is not allowed for external provisioning",
+		"--no-auto-instrumentation is not allowed for external provisioning",
+		"--model-config-file is not allowed for external provisioning",
+	} {
+		assertContains(t, details, msg)
 	}
 }
 

--- a/cli/pkg/cmdutil/factory.go
+++ b/cli/pkg/cmdutil/factory.go
@@ -39,14 +39,13 @@ import (
 const refreshBuffer = 5 * time.Minute
 
 type Factory struct {
-	Config           func() (*config.Config, error)
-	IOStreams        *iostreams.IOStreams
-	Prompter         prompter.Prompter
-	HTTPClient       func() *http.Client
-	AgentManager     func(ctx context.Context) (*amsvc.ClientWithResponses, error)
-	TraceObserver    func(ctx context.Context) (*traceobssvc.Client, error)
-	TraceObserverURL func(ctx context.Context) (string, error)
-	Token            func(ctx context.Context) (string, error)
+	Config        func() (*config.Config, error)
+	IOStreams     *iostreams.IOStreams
+	Prompter      prompter.Prompter
+	HTTPClient    func() *http.Client
+	AgentManager  func(ctx context.Context) (*amsvc.ClientWithResponses, error)
+	TraceObserver func(ctx context.Context) (*traceobssvc.Client, error)
+	Token         func(ctx context.Context) (string, error)
 
 	traceObsOnce sync.Once
 	traceObsURL  string
@@ -69,9 +68,6 @@ func NewFactory(cfg *config.Config, io *iostreams.IOStreams) *Factory {
 	}
 	f.TraceObserver = func(ctx context.Context) (*traceobssvc.Client, error) {
 		return f.traceObserver(ctx)
-	}
-	f.TraceObserverURL = func(ctx context.Context) (string, error) {
-		return f.discoverTraceObserverURL(ctx)
 	}
 	return f
 }

--- a/cli/pkg/cmdutil/factory.go
+++ b/cli/pkg/cmdutil/factory.go
@@ -43,9 +43,10 @@ type Factory struct {
 	IOStreams     *iostreams.IOStreams
 	Prompter      prompter.Prompter
 	HTTPClient    func() *http.Client
-	AgentManager  func(ctx context.Context) (*amsvc.ClientWithResponses, error)
-	TraceObserver func(ctx context.Context) (*traceobssvc.Client, error)
-	Token         func(ctx context.Context) (string, error)
+	AgentManager     func(ctx context.Context) (*amsvc.ClientWithResponses, error)
+	TraceObserver    func(ctx context.Context) (*traceobssvc.Client, error)
+	TraceObserverURL func(ctx context.Context) (string, error)
+	Token            func(ctx context.Context) (string, error)
 
 	traceObsOnce sync.Once
 	traceObsURL  string
@@ -68,6 +69,9 @@ func NewFactory(cfg *config.Config, io *iostreams.IOStreams) *Factory {
 	}
 	f.TraceObserver = func(ctx context.Context) (*traceobssvc.Client, error) {
 		return f.traceObserver(ctx)
+	}
+	f.TraceObserverURL = func(ctx context.Context) (string, error) {
+		return f.discoverTraceObserverURL(ctx)
 	}
 	return f
 }

--- a/cli/pkg/cmdutil/factory.go
+++ b/cli/pkg/cmdutil/factory.go
@@ -39,10 +39,10 @@ import (
 const refreshBuffer = 5 * time.Minute
 
 type Factory struct {
-	Config        func() (*config.Config, error)
-	IOStreams     *iostreams.IOStreams
-	Prompter      prompter.Prompter
-	HTTPClient    func() *http.Client
+	Config           func() (*config.Config, error)
+	IOStreams        *iostreams.IOStreams
+	Prompter         prompter.Prompter
+	HTTPClient       func() *http.Client
 	AgentManager     func(ctx context.Context) (*amsvc.ClientWithResponses, error)
 	TraceObserver    func(ctx context.Context) (*traceobssvc.Client, error)
 	TraceObserverURL func(ctx context.Context) (string, error)


### PR DESCRIPTION
## Purpose
`amctl agent create` previously rejected `--provisioning=external` with a "not yet supported" error. Operators creating agents whose code runs outside the platform had to fall through to the API or console and then mint a token manually before they could wire up Python instrumentation.

<img width="790" height="314" alt="Screenshot 2026-05-19 at 16 41 54" src="https://github.com/user-attachments/assets/9e0bf3b1-0544-4486-abdc-4ffbde13b66c" />


## Goals
- Accept `--provisioning=external` in `amctl agent create`.
- Validate that internal-only flags (`--repo-*`, `--build-type`, `--language`, `--port`, `--env*`, `--model-config-file`, `--no-auto-instrumentation`, etc.) are not combined with external provisioning.
- After a successful external create, auto-generate a long-lived agent token and print copy-paste Python instrumentation instructions (OTEL endpoint + `amp-instrument` start command).
- Preserve JSON-mode output: external creates emit a single JSON envelope containing the agent, token, expiry, OTEL endpoint, and rendered instructions.

## Approach
- `cli/pkg/cmd/agent/create/request.go`: route `provisioningExternal` through `amsvc.ProvisioningTypeExternal` (the API spec now exposes it) and skip build/repo payload assembly for external agents.
- `cli/pkg/cmd/agent/create/validation.go`: replace the hard rejection with `validateExternal`, which surfaces a per-flag error message for every internal-only flag the user mistakenly passed. `--port` uses the new `PortSet` signal so the default value doesn't trigger a false positive.
- `cli/pkg/cmd/agent/create/external.go` (new): post-create hook calls `GenerateAgentToken` with an 8760h expiry, derives the OTEL ingest URL from the factory-discovered trace-observer base, and renders the Python instructions. JSON callers get a structured envelope; text callers get the rendered block on stderr.
- `cli/pkg/cmdutil/factory.go`: expose `TraceObserverURL` so the create command can fetch the discovered observer base URL without re-running discovery.
- Unit tests cover the validation matrix, the request builder's external branch, the JSON/text post-create output, and the end-to-end create + token flow against a httptest server.

The renderer for the Python instructions intentionally duplicates the one in `agent-manager-service/mcp/tools/agents.go` — pulling it into a shared package would create a cli → service Go dependency that the repo otherwise avoids.

## User stories
As an operator deploying an externally-hosted agent, I want a single `amctl agent create --provisioning=external` invocation to register the agent and hand me everything needed to wire up instrumentation, so I don't have to interleave API/console steps.

## Release note
`amctl agent create --provisioning=external` is now supported and prints ready-to-run Python instrumentation instructions (OTEL endpoint + auto-minted agent token).

## Documentation
N/A — `amctl agent create --help` already enumerates flags; the external flow is discoverable via the same flag.

## Training
N/A — no training content impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — small CLI ergonomics improvement.

## Automation tests
 - Unit tests
   > New/updated coverage in `cli/pkg/cmd/agent/create`:
   > - `validation_test.go`: external provisioning matrix (each internal-only flag rejected; valid external request accepted).
   > - `request_test.go`: builder skips repo/build sections and emits `ProvisioningTypeExternal`.
   > - `external_test.go`: token request payload, OTEL endpoint derivation, JSON vs text rendering.
   > - `create_test.go`: end-to-end create-then-token flow against `httptest.Server`, covering both JSON and text output and the failure path when the token endpoint returns 4xx.
 - Integration tests
   > N/A — CLI-only change; exercised against a stub server in the unit suite.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no (Go CLI; not part of the FindSecurityBugs scope)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
- Upstream API spec change that introduced `ProvisioningTypeExternal` (already merged into `main`).

## Migrations (if applicable)
N/A — no schema or state changes.

## Test environment
- macOS 15 (Darwin 25.3.0), Go 1.22.x via the repo toolchain.
- `go test ./pkg/cmd/agent/create/... ./pkg/cmdutil/...` from `cli/`.
- Manual smoke against a local agent-manager: `amctl agent create --provisioning=external <name>` prints instructions; JSON mode emits the structured envelope; passing `--repo-url` is rejected with a clear message.

## Learning
The post-create hook reuses the factory's existing trace-observer discovery rather than re-resolving the URL, which keeps the create command from duplicating the gateway/observer lookup logic. The 8760h token lifetime mirrors what the MCP `create_agent` tool mints for the same flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added full support for creating externally provisioned agents
  * External agent creation now automatically provides minted tokens, OTEL ingest endpoints, and Python instrumentation instructions

* **Improvements**
  * Enhanced validation to enforce proper configuration options for external provisioning

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->