### PR TITLE
Pin oapi-codegen to v2.6.0 in amctl-gen-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,8 +233,14 @@ console-logs:
 	@docker logs -f agent-manager-console
 
 # amctl CLI client codegen (oapi-codegen against local OpenAPI spec)
+# Pinned to the same version used in .github/workflows/cli-codegen-check.yaml
+OAPI_CODEGEN_VERSION := v2.6.0
+
 amctl-gen-client:
-	@command -v oapi-codegen >/dev/null || (echo "Installing oapi-codegen..." && go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest)
+	@if ! command -v oapi-codegen >/dev/null || ! oapi-codegen -version 2>&1 | grep -qx '$(OAPI_CODEGEN_VERSION)'; then \
+		echo "Installing oapi-codegen $(OAPI_CODEGEN_VERSION)..."; \
+		go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@$(OAPI_CODEGEN_VERSION); \
+	fi
 	@oapi-codegen -config cli/pkg/clients/amsvc/gen/oapi-codegen.yaml agent-manager-service/docs/api_v1_openapi.yaml
 	@oapi-codegen -config cli/pkg/clients/amsvc/gen/oapi-codegen-client.yaml agent-manager-service/docs/api_v1_openapi.yaml
 	@echo "amctl client generated successfully"


### PR DESCRIPTION
## Purpose

Align the local `make amctl-gen-client` target with CI so contributors and CI generate the amctl AM client from the same `oapi-codegen` version.

## Goals

- Stop drift between locally-generated and CI-generated clients caused by `oapi-codegen@latest` resolving to whatever has shipped most recently.
- Make `make amctl-gen-client` self-healing when a contributor already has a different `oapi-codegen` version on `$PATH`.

## Approach

- Add an `OAPI_CODEGEN_VERSION := v2.6.0` variable in the root `Makefile`, matching the pin in `.github/workflows/cli-codegen-check.yaml`.
- Replace the existing "install only if missing" check with one that also verifies `oapi-codegen -version` reports the pinned version; reinstall otherwise.

## User stories

N/A — developer-only build target.

## Release note

N/A — internal build tooling change, no user-visible behavior.

## Documentation

N/A — no doc changes required; the target is documented by its CI usage.

## Training

N/A.

## Certification

N/A.

## Marketing

N/A.

## Automation tests

### Unit tests
N/A — `Makefile` target with no code under test.

### Integration tests
Verified locally: `make amctl-gen-client` runs against the pinned version and produces no diff under `cli/pkg/clients/amsvc/gen`. The existing `CLI Codegen Check` workflow continues to gate drift on PRs.

## Security checks

 1. Does the PR add any external client libraries (e.g.: nimbus-jose.jwt) or updates the existing client libraries?: **No**
 2. Does the PR add any new API(s) or affect/change existing APIs?: **No**
 3. Does the PR add/change any configurations (toml, yaml, props)?: **No** — Makefile only.

## Samples

N/A.

## Related PRs

None.

## Migrations (if applicable)

N/A.

## Test environment

Local macOS, `oapi-codegen v2.6.0`, ran `make amctl-gen-client` and confirmed clean `git status` under `cli/pkg/clients/amsvc/gen`.

## Learning

N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling to pin a specific version of the code generation tool for improved consistency and reproducibility in builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->