### PR TITLE
Derive instrumentation doc URLs from config

### DIFF
--- a/console/apps/web-ui/public/config.js
+++ b/console/apps/web-ui/public/config.js
@@ -59,4 +59,8 @@ window.__RUNTIME_CONFIG__ = {
     privacyPolicyUrl: 'https://wso2.com/agent-platform/agent-manager/',
     termsOfUseUrl: 'https://wso2.com/agent-platform/agent-manager/',
   },
+  instrumentationDocLinks: {
+    manualInstrumentation: '/components/amp-instrumentation/#manual-instrumentation',
+    versionMapping: '/components/amp-instrumentation/#amp-instrumentation-version-mapping',
+  },
 };

--- a/console/apps/web-ui/public/config.template.js
+++ b/console/apps/web-ui/public/config.template.js
@@ -53,5 +53,9 @@ window.__RUNTIME_CONFIG__ = {
     privacyPolicyUrl: 'https://wso2.com/agent-platform/agent-manager/',
     termsOfUseUrl: 'https://wso2.com/agent-platform/agent-manager/',
   },
+  instrumentationDocLinks: {
+    manualInstrumentation: '/components/amp-instrumentation/#manual-instrumentation',
+    versionMapping: '/components/amp-instrumentation/#amp-instrumentation-version-mapping',
+  },
 };
 

--- a/console/workspaces/libs/types/src/config/index.ts
+++ b/console/workspaces/libs/types/src/config/index.ts
@@ -44,6 +44,13 @@ export interface AppConfig {
     privacyPolicyUrl?: string;
     termsOfUseUrl?: string;
   };
+  /** Documentation deep-link paths for AMP instrumentation, appended to docsUrl. */
+  instrumentationDocLinks?: {
+    /** Path to the manual instrumentation contract section. */
+    manualInstrumentation?: string;
+    /** Path to the AMP instrumentation version mapping section. */
+    versionMapping?: string;
+  };
 }
 
 export type GuardrailCapabilities = {

--- a/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
+++ b/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
@@ -23,6 +23,7 @@ import { debounce } from "lodash";
 import { useGenerateResourceName } from "@agent-management-platform/api-client";
 import {
   DEFAULT_INSTRUMENTATION_VERSION,
+  globalConfig,
   SUPPORTED_INSTRUMENTATION_VERSIONS,
   SUPPORTED_PYTHON_VERSIONS,
 } from "@agent-management-platform/types";
@@ -54,12 +55,10 @@ const languageOptions = [
   { label: "Docker", value: "docker" },
 ];
 
-const AMP_INSTRUMENTATION_DOCS_URL =
-  "https://wso2.github.io/agent-manager/docs/components/amp-instrumentation/";
 const MANUAL_INSTRUMENTATION_DOCS_URL =
-  `${AMP_INSTRUMENTATION_DOCS_URL}#manual-instrumentation`;
+  `${globalConfig.docsUrl ?? ""}${globalConfig.instrumentationDocLinks?.manualInstrumentation ?? ""}`;
 const VERSION_MAPPING_DOCS_URL =
-  `${AMP_INSTRUMENTATION_DOCS_URL}#amp-instrumentation-version-mapping`;
+  `${globalConfig.docsUrl ?? ""}${globalConfig.instrumentationDocLinks?.versionMapping ?? ""}`;
 
 export const InternalAgentForm = ({
   formData,


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The "Add Internal Agent" form hardcoded the AMP instrumentation
documentation URLs. The hardcoded base lacked the `/next` path segment
that `docsUrl` carries, so both the "manual instrumentation contract"
and "AMP instrumentation version mapping" links returned HTTP 404.

No tracked issue.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

- Make the in-form documentation links resolve correctly.
- Keep the links in step with `docsUrl` across environments instead of
  drifting from a separate hardcoded constant.

## Approach
> Describe how you are implementing the solutions.

- Add an `instrumentationDocLinks` block (`manualInstrumentation` and
  `versionMapping` paths) to the runtime config (`config.js`,
  `config.template.js`) and to the `AppConfig` type.
- In `InternalAgentForm.tsx`, build each URL as
  `docsUrl + instrumentationDocLinks.<path>` from `globalConfig`,
  replacing the hardcoded constants.

UI text is unchanged; only the `href` targets change.

## User stories
> Summary of user stories addressed by this change

As a user creating an internal agent, when I open the instrumentation
docs links in the form, I land on the correct documentation page.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fix broken AMP instrumentation documentation links in the Add Internal
Agent form; doc URLs are now derived from the configured `docsUrl`.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR.

N/A — no product documentation changes. The PR points the console at
existing docs pages under
https://wso2.github.io/agent-manager/docs/next/components/amp-instrumentation/.

## Training
> Link to the PR for changes to the training content, if applicable

N/A

## Certification
> ...

N/A — no impact on certification exams.

## Marketing
> ...

N/A

## Automation tests
 - Unit tests
   > None added. The change is a config-driven string concatenation.
 - Integration tests
   > None added.

Verified manually: computed the resulting URLs from the real
`config.js` and confirmed both return HTTP 200 with the expected
anchor IDs (`#manual-instrumentation`,
`#amp-instrumentation-version-mapping`) present on the page. The
previously hardcoded URLs return HTTP 404.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable to this front-end TypeScript change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> ...

N/A

## Related PRs
> List any other related PRs

N/A

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — `instrumentationDocLinks` is optional in `AppConfig`; existing
runtime configs without it fall back to an empty `href`.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Resolved URLs verified against https://wso2.github.io (macOS, curl).

## Learning
> ...

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable instrumentation documentation links to customize URLs for manual instrumentation and version mapping guides displayed in agent setup instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->