### PR TITLE
Update documentation related to instrumentation

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -2184,7 +2184,7 @@ func (c *openChoreoClient) buildEnvInjectionTraitParameters(opts ...TraitOption)
 
 // getInstrumentationImage builds the pre-built init-container image reference for
 // the given AMP instrumentation version and the agent's Python runtime version,
-// e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.2.0-python3.11.
+// e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.2.1-python3.11.
 func getInstrumentationImage(languageVersion, instrumentationVersion string) (string, error) {
 	parts := strings.Split(languageVersion, ".")
 	if len(parts) < 2 {

--- a/agent-manager-service/mcp/tools/agents.go
+++ b/agent-manager-service/mcp/tools/agents.go
@@ -204,7 +204,7 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
 			"openapi_path":   stringProperty("Required when interface_type is CUSTOM. OpenAPI specification file path within the repository (must start with /)."),
 
 			"enable_auto_instrumentation": boolProperty("Automatically enables OTEL tracing instrumentation to your agent for observability."),
-			"instrumentation_version":     stringProperty("Optional. AMP instrumentation version to pin for the agent (e.g., '0.2.0'). Selects the matching pre-built init-container image and the bundled traceloop-sdk version. Omit to use the platform default; only versions supported by the deployment are accepted."),
+			"instrumentation_version":     stringProperty("Optional. AMP instrumentation version to pin for the agent (e.g., '0.2.1'). Selects the matching pre-built init-container image and the bundled traceloop-sdk version. Omit to use the platform default; only versions supported by the deployment are accepted."),
 			"env": arrayProperty("Required. Environment variables and other configurations for the agent.(eg: api keys, database URLs, support service URLs). Can be obtained from the .env file in the project repository", map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -1,10 +1,10 @@
-# WSO2 Agent Manager Instrumentation
+# WSO2 Agent Manager Instrumentation Package
 
-Zero-code OpenTelemetry instrumentation for Python agents using the Traceloop SDK, with trace visibility in the WSO2 Agent Manager.
+Zero-code OpenTelemetry instrumentation package for externally-hosted Python agents using the Traceloop SDK, with trace visibility in the WSO2 Agent Manager.
 
 ## Overview
 
-`amp-instrumentation` enables zero-code instrumentation for Python agents, automatically capturing traces for LLM calls, MCP requests, and other operations. It wraps your agent's execution with OpenTelemetry tracing powered by the Traceloop SDK.
+`amp-instrumentation` package enables zero-code instrumentation for Python agents, automatically capturing traces for LLM calls, MCP requests, and other operations. It wraps your agent's execution with OpenTelemetry tracing powered by the Traceloop SDK.
 
 For agents on a custom or non-frontier framework, or anywhere you want full control over the spans you emit, it also ships `init_otel()`, a one-line OpenTelemetry exporter setup so you can instrument the agent yourself against AMP's [manual instrumentation contract](#manual-instrumentation).
 
@@ -29,9 +29,11 @@ Each release of `amp-instrumentation` pins a specific Traceloop SDK version, so 
 
 ### 1. Register Your Agent
 
-First, register your agent at the [WSO2 Agent Manager](https://github.com/wso2/agent-manager) to obtain your agent API key and configuration details.
+First, register your agent as an external agent in the [WSO2 Agent Manager](../getting-started/create-your-first-agent.mdx) to obtain your agent API key and configuration details.
 
-### 2. Set Required Environment Variables
+### 2. Set Required Environment Variables in terminal
+
+Use the OTEL endpoint and agent API key obtained when you registered the agent in the previous step:
 
 ```bash
 export AMP_OTEL_ENDPOINT="https://amp-otel-endpoint.com" # AMP OTEL endpoint

--- a/documentation/docs/getting-started/create-your-first-agent.mdx
+++ b/documentation/docs/getting-started/create-your-first-agent.mdx
@@ -1,0 +1,106 @@
+---
+sidebar_position: 2
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Create Your First Agent
+
+Once Agent Manager is installed, you can create your first agent from the console.
+
+## Choose an Agent Type
+
+1. Navigate to **Agents** in the left sidebar.
+2. Click **Add Agent**.
+3. Choose how you want to get started:
+
+- **Externally-Hosted Agent** — Connect an agent already running outside the platform. WSO2 Agent Manager provides observability and governance without managing the deployment.
+- **Platform-Hosted Agent** — Deploy and manage the full agent lifecycle directly on WSO2 Agent Manager, including build, deployment, scaling, and observability.
+
+---
+
+<Tabs>
+<TabItem value="external" label="Externally-Hosted Agent">
+
+## Register an Externally-Hosted Agent
+
+Fill in the **Agent Details** form:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | A display name for your agent (e.g., `Customer Support`) |
+| **Description** *(optional)* | A short description of what this agent does |
+
+Click **Register** to complete the registration. The agent will appear in your agent list and start receiving observability data once you instrument it using the [AMP instrumentation](../components/amp-instrumentation.mdx) package.
+
+</TabItem>
+<TabItem value="platform" label="Platform-Hosted Agent">
+
+## Create a Platform-Hosted Agent
+
+### Step 1: Choose a Source Type
+
+Select how the agent source will be provided:
+
+- **Source Code** — Point to a GitHub repository containing your agent code. The platform builds and deploys it automatically.
+- **Agent Catalog** — Pick a pre-built agent kind from the Agent Catalog.
+
+### Step 2: Fill in Agent Details
+
+Provide a **Name** (e.g., `Customer Support Agent`) and an optional **Description**.
+
+### Step 3: Repository Details *(Source Code only)*
+
+| Field | Description |
+|-------|-------------|
+| **GitHub Repository** | Full URL of your repository (e.g., `https://github.com/username/repo`) |
+| **Branch** | Branch to build from (default: `main`) |
+| **Project Path** | Path within the repository where the agent code lives (default: `/`) |
+
+### Step 4: Build Details *(Source Code only)*
+
+Choose a build type:
+
+- **Python** — Provide a **Start Command** (default: `python main.py`) and select the **Language Version** (e.g., `3.11`). Dependencies are auto-installed from `requirements.txt`, `pyproject.toml`, or `package.json`.
+- **Docker** — Use a `Dockerfile` in the repository.
+
+**Enable auto instrumentation** *(Python only, checked by default)*
+
+Automatically injects OpenTelemetry tracing into your agent for observability with zero code changes. You can also pin the **AMP Instrumentation Version** used by the init container.
+
+### Step 5: Select an Agent Type
+
+Choose how your agent receives requests:
+
+| Agent Type | Description |
+|------------|-------------|
+| **Chat Agent** | Standard chat interface. Exposes `POST /chat` on port `8000`. Request: `{message: string, session_id: string, context: JSON}` — Response: `{response: string}` |
+| **Custom API Agent** | Custom HTTP API. Specify your own OpenAPI specification and port configuration. |
+
+### Step 6: Configure LLM Providers *(Optional)*
+
+Click **+ Add** to bind one or more LLM providers to this agent. LLM providers are configured separately — see [Register an LLM Service Provider](../tutorials/register-llm-service-provider.mdx).
+
+### Step 7: Set Environment Variables *(Optional)*
+
+Add any environment variables your agent requires at runtime. Mark sensitive values as **Secret** to store them securely.
+
+Click **Deploy** to build and deploy the agent.
+
+</TabItem>
+</Tabs>
+
+---
+
+## What's Next?
+
+| Tutorial | Description |
+|----------|-------------|
+| [Observe Your First Agent](../tutorials/observe-first-agent.mdx) | Set up OpenTelemetry tracing for your agent |
+| [Register an AI Gateway](../tutorials/register-ai-gateway.mdx) | Connect an LLM provider via the AI gateway |
+| [Register an LLM Service Provider](../tutorials/register-llm-service-provider.mdx) | Add and configure LLM providers |
+| [Secure Agent Endpoints with API Keys](../tutorials/secure-agent-endpoints-with-api-keys.mdx) | Protect endpoints with API key authentication |
+| [Evaluation Monitors](../tutorials/evaluation-monitors.mdx) | Automate quality checks for your agents |
+| [Custom Evaluators](../tutorials/custom-evaluators.mdx) | Build and deploy your own evaluators |
+| [Configure Agent LLM Configuration](../tutorials/configure-agent-llm-configuration.mdx) | Bind LLM config to a specific agent |

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -37,6 +37,7 @@ const sidebars: SidebarsConfig = {
             'getting-started/on-your-environment',
           ],
         },
+        "getting-started/create-your-first-agent",
         'getting-started/cli-installation',
       ],
     },

--- a/documentation/versioned_docs/version-cloud/components/amp-instrumentation.mdx
+++ b/documentation/versioned_docs/version-cloud/components/amp-instrumentation.mdx
@@ -1,10 +1,10 @@
-# WSO2 Agent Manager Instrumentation
+# WSO2 Agent Manager Instrumentation Package
 
-Zero-code OpenTelemetry instrumentation for Python agents using the Traceloop SDK, with trace visibility in the WSO2 Agent Manager.
+Zero-code OpenTelemetry instrumentation package for externally-hosted Python agents using the Traceloop SDK, with trace visibility in the WSO2 Agent Manager.
 
 ## Overview
 
-`amp-instrumentation` enables zero-code instrumentation for Python agents, automatically capturing traces for LLM calls, MCP requests, and other operations. It wraps your agent's execution with OpenTelemetry tracing powered by the Traceloop SDK.
+`amp-instrumentation` package enables zero-code instrumentation for Python agents, automatically capturing traces for LLM calls, MCP requests, and other operations. It wraps your agent's execution with OpenTelemetry tracing powered by the Traceloop SDK.
 
 For agents on a custom or non-frontier framework, or anywhere you want full control over the spans you emit, it also ships `init_otel()`, a one-line OpenTelemetry exporter setup so you can instrument the agent yourself against AMP's [manual instrumentation contract](#manual-instrumentation).
 
@@ -29,9 +29,11 @@ Each release of `amp-instrumentation` pins a specific Traceloop SDK version, so 
 
 ### 1. Register Your Agent
 
-First, register your agent at the [WSO2 Agent Manager](https://github.com/wso2/agent-manager) to obtain your agent API key and configuration details.
+First, register your agent as an external agent in the [WSO2 Agent Manager](../getting-started/create-your-first-agent.mdx) to obtain your agent API key and configuration details.
 
-### 2. Set Required Environment Variables
+### 2. Set Required Environment Variables in terminal
+
+Use the OTEL endpoint and agent API key obtained when you registered the agent in the previous step:
 
 ```bash
 export AMP_OTEL_ENDPOINT="https://amp-otel-endpoint.com" # AMP OTEL endpoint

--- a/documentation/versioned_sidebars/version-cloud-sidebars.json
+++ b/documentation/versioned_sidebars/version-cloud-sidebars.json
@@ -28,6 +28,14 @@
     },
     {
       "type": "category",
+      "label": "Components",
+      "collapsed": false,
+      "items": [
+        "components/amp-instrumentation"
+      ]
+    },
+    {
+      "type": "category",
       "label": "Tutorials",
       "collapsed": false,
       "items": [


### PR DESCRIPTION
## Purpose
The platform default AMP instrumentation version moved from `0.2.0` to `0.2.1` (a bugfix release — same pinned `traceloop-sdk 0.60.0`, same supported Python set). The config defaults, the Console constants, `release-config.json`, and the docs mapping table were already updated. Two illustrative `0.2.0` references were left behind; this cleans them up.

N/A for issue linking — trivial follow-up to the `0.2.1` rollout, no dedicated issue.

## Goals
- `getInstrumentationImage` doc comment in `components.go` shows a current example image tag.
- The `create_internal_agent_python` MCP tool's `instrumentation_version` schema description shows `0.2.1` as the example, so an MCP client reading the hint sees the current version.

## Approach
Two one-token edits, both in illustrative text only (a Go doc comment and an MCP JSON-schema `description` string). No behaviour change — version resolution and validation read the config/DB, not these strings.

## User stories
N/A — internal consistency cleanup.

## Release note
N/A — no user-facing behaviour change (example text only).

## Documentation
N/A — the docs mapping table was already updated to `0.2.1` separately.

## Training
N/A — chore.

## Certification
N/A — no behaviour change.

## Marketing
N/A.

## Automation tests
- Unit tests
  > N/A — comment + schema-description text only.
- Integration tests
  > `go build` / `go vet` / `gofumpt -l` clean on the two changed packages (`GOFLAGS=-mod=mod` locally).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Go, no security-relevant change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
- Part of the `0.2.0` → `0.2.1` version bump (config defaults, Console constants, `release-config.json`, docs mapping table landed separately).

## Migrations (if applicable)
N/A — no DB migration. Existing `agent_configs` rows pinned to `0.2.0` (e.g. backfilled by migration 018) are intentionally left as-is; the `0.2.0` init-container images remain pullable, and pre-GA those are dev/test agents that can be re-pinned in the Console if needed.

## Test environment
Verified locally on macOS, Go toolchain with `GOFLAGS=-mod=mod`.

## Learning
N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Create Your First Agent" guide with step-by-step paths for externally‑hosted and platform‑hosted agents.
  * Updated Quick Start and instrumentation docs to instruct registering agents as external and to set environment variables in terminal.
  * Added new sidebar entries and a Components section in the docs navigation.
  * Updated instrumentation provider version references to 0.2.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->