### PR TITLE
Add manual-instrumentation sample agent

### DIFF
--- a/samples/manual-instrumentation-agent/.env.example
+++ b/samples/manual-instrumentation-agent/.env.example
@@ -1,7 +1,7 @@
 # --- AMP telemetry ---------------------------------------------------------
 # Where the agent ships spans, and the key that authenticates them.
 #   Platform-hosted with auto-instrumentation OFF: AMP's env-injection trait
-#     sets both for you — leave these unset.
+#     sets both for you, so leave these unset.
 #   Externally-hosted: set both yourself. Generate the API key in the AMP
 #     Console (register the agent -> Generate API Key).
 AMP_OTEL_ENDPOINT=

--- a/samples/manual-instrumentation-agent/.env.example
+++ b/samples/manual-instrumentation-agent/.env.example
@@ -1,0 +1,17 @@
+# --- AMP telemetry ---------------------------------------------------------
+# Where the agent ships spans, and the key that authenticates them.
+#   Platform-hosted with auto-instrumentation OFF: AMP's env-injection trait
+#     sets both for you — leave these unset.
+#   Externally-hosted: set both yourself. Generate the API key in the AMP
+#     Console (register the agent -> Generate API Key).
+AMP_OTEL_ENDPOINT=
+AMP_AGENT_API_KEY=
+
+# --- OpenAI ----------------------------------------------------------------
+# Required. The sample makes real OpenAI calls for its LLM and embedding spans.
+OPENAI_API_KEY=
+
+# --- Optional --------------------------------------------------------------
+# Set to false to suppress prompt/completion content in the emitted spans
+# (span structure and metadata are still recorded).
+AMP_TRACE_CONTENT=true

--- a/samples/manual-instrumentation-agent/README.md
+++ b/samples/manual-instrumentation-agent/README.md
@@ -30,20 +30,22 @@ no Traceloop SDK and no `amp-instrument` CLI involved.
 
 One `/chat` request produces one trace:
 
-```
+```text
 invoke_agent  (agent, root)
 └── rag-pipeline  (chain)
-    ├── embeddings     (embedding)
-    ├── vector_search  (retriever)
-    ├── rerank         (rerank)
-    ├── execute_tool   (tool)
-    └── chat           (llm)
+    ├── embeddings     (embedding)   real OpenAI call
+    ├── vector_search  (retriever)   simulated
+    ├── rerank         (rerank)      simulated
+    ├── chat           (llm)         simulated: decides to call a tool
+    ├── execute_tool   (tool)        real local call
+    └── chat           (llm)         real OpenAI call: final answer
 ```
 
-The `embeddings` and `chat` spans wrap real OpenAI calls. The `vector_search` and
-`rerank` steps are simulated, so the sample runs with only an OpenAI key. In a
-real agent they'd call your vector DB and rerank provider; the span attributes
-are the same either way.
+The `embeddings` span and the final `chat` span wrap real OpenAI calls. The
+`vector_search`, `rerank`, and the first `chat` span (where the model decides to
+call a tool) are simulated, so the trace is deterministic and the sample runs
+with only an OpenAI key. In a real agent those would call your vector DB, rerank
+provider, and the model; the span attributes are the same either way.
 
 ### Attribute coverage
 

--- a/samples/manual-instrumentation-agent/README.md
+++ b/samples/manual-instrumentation-agent/README.md
@@ -1,54 +1,57 @@
 # Manual Instrumentation Sample Agent
 
-A runnable agent that instruments itself by hand against WSO2 Agent Manager's
-**manual instrumentation contract** — emitting OpenTelemetry GenAI spans directly
-instead of relying on the Traceloop SDK's auto-instrumentation.
+A runnable agent that instruments itself by hand. Instead of relying on the
+Traceloop SDK's auto-instrumentation, it emits OpenTelemetry GenAI spans directly,
+against WSO2 Agent Manager's **manual instrumentation contract**.
 
 ## What this demonstrates
 
-Most AMP agents are auto-instrumented: a platform-injected init container (or the
-`amp-instrument` CLI) loads the Traceloop SDK, which monkey-patches known
-frameworks. That covers LangChain, LlamaIndex, CrewAI, and the rest.
+Most AMP agents are auto-instrumented. A platform-injected init container, or the
+`amp-instrument` CLI, loads the Traceloop SDK, which monkey-patches known
+frameworks like LangChain, LlamaIndex, and CrewAI.
 
-If your agent runs on a framework Traceloop doesn't cover — or you just want full
-control over the spans you emit — you take the **manual path**: turn
+But Traceloop doesn't cover every framework. If yours isn't covered, or you just
+want full control over the spans you emit, you take the **manual path**: turn
 auto-instrumentation off and emit your own spans. This sample is a worked example
 of that path. It's a small retrieval-augmented agent on a hand-written framework
-(plain Python, nothing Traceloop knows about), and it produces spans that render
-in the AMP Console exactly like auto-instrumented ones.
+(plain Python, nothing Traceloop knows about), and its spans render in the AMP
+Console exactly like auto-instrumented ones.
 
-It covers **every span kind and every attribute** in the contract, so it doubles
-as executable reference. The contract itself is documented in the "Manual
-instrumentation" section of the WSO2 Agent Manager Instrumentation docs page.
+It emits a span for every kind in the contract, with every attribute, so it
+doubles as an executable reference. For the full supported schema, see
+[the contract](https://wso2.github.io/agent-manager/docs/latest/components/amp-instrumentation/#the-contract)
+in the WSO2 Agent Manager documentation.
 
 ## How it works
 
-`init_otel()` (from the `amp-instrumentation` package) configures the
-OpenTelemetry exporter to AMP. After that, the agent emits its own spans — there
-is no Traceloop SDK and no `amp-instrument` CLI involved.
+`init_otel()`, from the `amp-instrumentation` package, configures the
+OpenTelemetry exporter to AMP. After that the agent emits its own spans. There's
+no Traceloop SDK and no `amp-instrument` CLI involved.
 
 One `/chat` request produces one trace:
 
 ```
-invoke_agent (agent, root)
-└── rag-pipeline (chain)
-    ├── embeddings    (embedding) — real OpenAI embeddings call
-    ├── vector_search (retriever) — cosine top-k over an in-memory store
-    ├── rerank        (rerank)    — simulated reranking
-    ├── execute_tool  (tool)      — a real local tool
-    └── chat          (llm)       — real OpenAI chat completion
+invoke_agent  (agent, root)
+└── rag-pipeline  (chain)
+    ├── embeddings     (embedding)
+    ├── vector_search  (retriever)
+    ├── rerank         (rerank)
+    ├── execute_tool   (tool)
+    └── chat           (llm)
 ```
 
-The retriever and rerank are simulated so the sample runs with only an OpenAI
-key. In a real agent they'd call your vector DB and rerank provider — the span
-attributes are identical either way.
+The `embeddings` and `chat` spans wrap real OpenAI calls. The `vector_search` and
+`rerank` steps are simulated, so the sample runs with only an OpenAI key. In a
+real agent they'd call your vector DB and rerank provider; the span attributes
+are the same either way.
 
 ### Attribute coverage
 
 Every span-emitting helper lives in [`instrumentation.py`](./instrumentation.py),
-one function per kind. The contract is layered: **Layer 1** is the OpenTelemetry
-GenAI semantic conventions (`gen_ai.*`, plus `db.*` for retriever); **Layer 2** is
-the OpenLLMetry `traceloop.*` extension keys for the gaps OTel hasn't standardized.
+one function per kind. The contract is layered. Layer 1 is the OpenTelemetry
+GenAI semantic conventions (`gen_ai.*`, plus `db.*` for retriever spans). Layer 2
+is the OpenLLMetry `traceloop.*` extension keys, used for the gaps OTel hasn't
+standardized yet.
 
 | Span kind | Helper | Key attributes emitted |
 |---|---|---|
@@ -59,19 +62,22 @@ the OpenLLMetry `traceloop.*` extension keys for the gaps OTel hasn't standardiz
 | `rerank` | `rerank_span` | `traceloop.span.kind=rerank`, `gen_ai.operation.name=rerank`, `rerank.model`, `gen_ai.request.model` |
 | `tool` | `tool_span` | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name/description/call.id`, `traceloop.entity.input/output` |
 | `llm` | `llm_span` | `gen_ai.operation.name=chat`, `gen_ai.system`, `gen_ai.request/response.model`, `gen_ai.request.temperature`, `gen_ai.input/output.messages`, `gen_ai.input.tools`, `gen_ai.usage.*` |
-| any span | `mark_error` | OTel span `Status=Error` + `error.type` → error badge |
-| any span | `evaluation_baggage` | W3C baggage `task_id` / `trial_id` → evaluation-trial correlation |
+| any span | `mark_error` | OTel span `Status=Error` plus `error.type`, which the Console shows as an error badge |
+| any span | `evaluation_baggage` | W3C baggage `task_id` / `trial_id`, which correlates the trace to an evaluation trial |
+
+This table is a quick map. The authoritative reference, with every attribute and
+whether it's required, is [the contract](https://wso2.github.io/agent-manager/docs/latest/components/amp-instrumentation/#the-contract).
 
 ## Prerequisites
 
-- Python 3.10–3.13.
-- An OpenAI API key — the LLM and embedding spans make real OpenAI calls.
-- An agent registered in the AMP Console, to get an `AMP_AGENT_API_KEY` and the
-  OTLP endpoint.
+- Python 3.10 to 3.13.
+- An OpenAI API key. The LLM and embedding spans make real OpenAI calls.
+- An agent registered in the AMP Console, which gives you an `AMP_AGENT_API_KEY`
+  and the OTLP endpoint.
 
-## Run it — externally-hosted
+## Run it externally-hosted
 
-First register the agent in the AMP Console and generate its API key — follow
+First register the agent in the AMP Console and generate its API key. Follow
 [Register an externally-hosted agent](https://wso2.github.io/agent-manager/docs/latest/getting-started/create-your-first-agent/#register-an-externally-hosted-agent).
 That gives you the OTLP endpoint and the `AMP_AGENT_API_KEY`.
 
@@ -89,15 +95,17 @@ export OPENAI_API_KEY="<your-openai-key>"
 python main.py
 ```
 
-Note there is no `amp-instrument` wrapper — that's the auto path. On the manual
-path you run the app directly; `init_otel()` inside `app.py` wires up the exporter.
+There's no `amp-instrument` wrapper here; that's the auto path. On the manual
+path you run the app directly, and `init_otel()` inside `app.py` wires up the
+exporter.
 
-## Run it — platform-hosted
+## Run it platform-hosted
 
-Deploy it through AMP like any other agent, with **one difference: turn
-auto-instrumentation off**. That makes AMP attach the env-injection trait — which
-still supplies `AMP_OTEL_ENDPOINT` and `AMP_AGENT_API_KEY` — instead of the
-auto-instrumentation init container. The agent then does its own instrumentation.
+Deploy it through AMP like any other agent, with one difference: **turn
+auto-instrumentation off**. With it off, AMP attaches the env-injection trait
+instead of the auto-instrumentation init container. The trait still supplies
+`AMP_OTEL_ENDPOINT` and `AMP_AGENT_API_KEY`, so the agent has what it needs to
+export. It just does the instrumentation itself.
 
 Follow [Create a platform-hosted agent](https://wso2.github.io/agent-manager/docs/latest/getting-started/create-your-first-agent/#create-a-platform-hosted-agent)
 for the full walkthrough. Use these values in the create-agent form:
@@ -114,7 +122,7 @@ for the full walkthrough. Use these values in the create-agent form:
 | Port | `8000` |
 | **Enable auto instrumentation** | **Off** |
 
-Add one environment variable — `OPENAI_API_KEY`. Leave `AMP_OTEL_ENDPOINT` and
+Add one environment variable, `OPENAI_API_KEY`. Leave `AMP_OTEL_ENDPOINT` and
 `AMP_AGENT_API_KEY` unset; the env-injection trait provides them.
 
 ## Testing
@@ -127,22 +135,22 @@ curl -X POST http://localhost:8000/chat \
 
 The response is the agent's answer. Behind it, one full trace was emitted.
 
-To see an **error badge**, point the agent at a model that doesn't exist (edit
-`CHAT_MODEL` in `agent.py`): the LLM call fails, `mark_error` flags the agent
+To see an error badge, point the agent at a model that doesn't exist (edit
+`CHAT_MODEL` in `agent.py`). The LLM call fails, `mark_error` flags the agent
 span, and the trace shows an error.
 
 ## Observe the traces
 
-In the AMP Console, open the agent → **OBSERVABILITY → Traces**. A `/chat` call
-produces one trace whose spans carry the per-kind icons, model and token chips,
-input/output, and — on a failed run — an error badge. Because the spans follow
-the contract, evaluators run against them too.
+In the AMP Console, open the agent and go to **OBSERVABILITY → Traces**. A
+`/chat` call produces one trace. Its spans carry the per-kind icons, the model
+and token chips, the input and output, and an error badge on a failed run.
+Because the spans follow the contract, evaluators run against them too.
 
 ## File guide
 
 | File | Role |
 |---|---|
-| `instrumentation.py` | The manual-instrumentation helpers — one per span kind. The contract, in code. |
+| `instrumentation.py` | The manual-instrumentation helpers, one per span kind. The contract, in code. |
 | `agent.py` | The hand-written RAG agent that calls those helpers around real OpenAI calls. |
 | `app.py` | FastAPI entrypoint; calls `init_otel()`. |
 | `main.py` | Local runner (`python main.py`). |

--- a/samples/manual-instrumentation-agent/README.md
+++ b/samples/manual-instrumentation-agent/README.md
@@ -71,7 +71,11 @@ the OpenLLMetry `traceloop.*` extension keys for the gaps OTel hasn't standardiz
 
 ## Run it — externally-hosted
 
-You set the two AMP environment variables yourself.
+First register the agent in the AMP Console and generate its API key — follow
+[Register an externally-hosted agent](https://wso2.github.io/agent-manager/docs/latest/getting-started/create-your-first-agent/#register-an-externally-hosted-agent).
+That gives you the OTLP endpoint and the `AMP_AGENT_API_KEY`.
+
+Then set the two AMP environment variables yourself and run the agent:
 
 ```bash
 cd samples/manual-instrumentation-agent
@@ -95,7 +99,8 @@ auto-instrumentation off**. That makes AMP attach the env-injection trait — wh
 still supplies `AMP_OTEL_ENDPOINT` and `AMP_AGENT_API_KEY` — instead of the
 auto-instrumentation init container. The agent then does its own instrumentation.
 
-In the AMP Console, **Add Agent → Platform-Hosted Agent**:
+Follow [Create a platform-hosted agent](https://wso2.github.io/agent-manager/docs/latest/getting-started/create-your-first-agent/#create-a-platform-hosted-agent)
+for the full walkthrough. Use these values in the create-agent form:
 
 | Field | Value |
 |---|---|

--- a/samples/manual-instrumentation-agent/README.md
+++ b/samples/manual-instrumentation-agent/README.md
@@ -143,6 +143,18 @@ instead.
 Either way, the response is the agent's answer, and behind it one full trace was
 emitted.
 
+The bundled knowledge base is a handful of facts about WSO2 Agent Manager, so ask
+it questions it can actually answer:
+
+- `What is WSO2 Agent Manager?`
+- `How does AMP handle observability?`
+- `How are platform-hosted Python agents instrumented?`
+- `When should I use manual instrumentation instead of auto-instrumentation?`
+- `What do LLM-as-judge evaluators need from a trace?`
+
+Ask something the knowledge base doesn't cover and the agent says so. That's a
+valid trace too, and a good one to inspect.
+
 To see an error badge, point the agent at a model that doesn't exist (edit
 `CHAT_MODEL` in `agent.py`). The LLM call fails, `mark_error` flags the agent
 span, and the trace shows an error.

--- a/samples/manual-instrumentation-agent/README.md
+++ b/samples/manual-instrumentation-agent/README.md
@@ -1,0 +1,144 @@
+# Manual Instrumentation Sample Agent
+
+A runnable agent that instruments itself by hand against WSO2 Agent Manager's
+**manual instrumentation contract** — emitting OpenTelemetry GenAI spans directly
+instead of relying on the Traceloop SDK's auto-instrumentation.
+
+## What this demonstrates
+
+Most AMP agents are auto-instrumented: a platform-injected init container (or the
+`amp-instrument` CLI) loads the Traceloop SDK, which monkey-patches known
+frameworks. That covers LangChain, LlamaIndex, CrewAI, and the rest.
+
+If your agent runs on a framework Traceloop doesn't cover — or you just want full
+control over the spans you emit — you take the **manual path**: turn
+auto-instrumentation off and emit your own spans. This sample is a worked example
+of that path. It's a small retrieval-augmented agent on a hand-written framework
+(plain Python, nothing Traceloop knows about), and it produces spans that render
+in the AMP Console exactly like auto-instrumented ones.
+
+It covers **every span kind and every attribute** in the contract, so it doubles
+as executable reference. The contract itself is documented in the "Manual
+instrumentation" section of the WSO2 Agent Manager Instrumentation docs page.
+
+## How it works
+
+`init_otel()` (from the `amp-instrumentation` package) configures the
+OpenTelemetry exporter to AMP. After that, the agent emits its own spans — there
+is no Traceloop SDK and no `amp-instrument` CLI involved.
+
+One `/chat` request produces one trace:
+
+```
+invoke_agent (agent, root)
+└── rag-pipeline (chain)
+    ├── embeddings    (embedding) — real OpenAI embeddings call
+    ├── vector_search (retriever) — cosine top-k over an in-memory store
+    ├── rerank        (rerank)    — simulated reranking
+    ├── execute_tool  (tool)      — a real local tool
+    └── chat          (llm)       — real OpenAI chat completion
+```
+
+The retriever and rerank are simulated so the sample runs with only an OpenAI
+key. In a real agent they'd call your vector DB and rerank provider — the span
+attributes are identical either way.
+
+### Attribute coverage
+
+Every span-emitting helper lives in [`instrumentation.py`](./instrumentation.py),
+one function per kind. The contract is layered: **Layer 1** is the OpenTelemetry
+GenAI semantic conventions (`gen_ai.*`, plus `db.*` for retriever); **Layer 2** is
+the OpenLLMetry `traceloop.*` extension keys for the gaps OTel hasn't standardized.
+
+| Span kind | Helper | Key attributes emitted |
+|---|---|---|
+| `agent` | `agent_span` | `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name/description/tools`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.system_instructions`, `gen_ai.conversation.id`, `gen_ai.input/output.messages`, `gen_ai.usage.*` |
+| `chain` | `chain_span` | `traceloop.span.kind=workflow`, `traceloop.entity.input/output` |
+| `embedding` | `embedding_span` | `gen_ai.operation.name=embeddings`, `gen_ai.system`, `gen_ai.request/response.model`, `gen_ai.prompt.{i}.content`, `gen_ai.usage.input_tokens` |
+| `retriever` | `retriever_span` | `db.system.name`, `db.collection.name`, `db.vector.query.top_k` |
+| `rerank` | `rerank_span` | `traceloop.span.kind=rerank`, `gen_ai.operation.name=rerank`, `rerank.model`, `gen_ai.request.model` |
+| `tool` | `tool_span` | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name/description/call.id`, `traceloop.entity.input/output` |
+| `llm` | `llm_span` | `gen_ai.operation.name=chat`, `gen_ai.system`, `gen_ai.request/response.model`, `gen_ai.request.temperature`, `gen_ai.input/output.messages`, `gen_ai.input.tools`, `gen_ai.usage.*` |
+| any span | `mark_error` | OTel span `Status=Error` + `error.type` → error badge |
+| any span | `evaluation_baggage` | W3C baggage `task_id` / `trial_id` → evaluation-trial correlation |
+
+## Prerequisites
+
+- Python 3.10–3.13.
+- An OpenAI API key — the LLM and embedding spans make real OpenAI calls.
+- An agent registered in the AMP Console, to get an `AMP_AGENT_API_KEY` and the
+  OTLP endpoint.
+
+## Run it — externally-hosted
+
+You set the two AMP environment variables yourself.
+
+```bash
+cd samples/manual-instrumentation-agent
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+
+export AMP_OTEL_ENDPOINT="<your-amp-otel-endpoint>"
+export AMP_AGENT_API_KEY="<key-from-the-amp-console>"
+export OPENAI_API_KEY="<your-openai-key>"
+
+python main.py
+```
+
+Note there is no `amp-instrument` wrapper — that's the auto path. On the manual
+path you run the app directly; `init_otel()` inside `app.py` wires up the exporter.
+
+## Run it — platform-hosted
+
+Deploy it through AMP like any other agent, with **one difference: turn
+auto-instrumentation off**. That makes AMP attach the env-injection trait — which
+still supplies `AMP_OTEL_ENDPOINT` and `AMP_AGENT_API_KEY` — instead of the
+auto-instrumentation init container. The agent then does its own instrumentation.
+
+In the AMP Console, **Add Agent → Platform-Hosted Agent**:
+
+| Field | Value |
+|---|---|
+| Display Name | `Manual Instrumentation Agent` |
+| GitHub Repository | `https://github.com/wso2/agent-manager` |
+| Branch | `main` |
+| App Path | `samples/manual-instrumentation-agent` |
+| Language | `Python` |
+| Language Version | `3.11` |
+| Start Command | `python main.py` |
+| Port | `8000` |
+| **Enable auto instrumentation** | **Off** |
+
+Add one environment variable — `OPENAI_API_KEY`. Leave `AMP_OTEL_ENDPOINT` and
+`AMP_AGENT_API_KEY` unset; the env-injection trait provides them.
+
+## Testing
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"session_id": "demo-1", "message": "How does AMP handle observability?"}'
+```
+
+The response is the agent's answer. Behind it, one full trace was emitted.
+
+To see an **error badge**, point the agent at a model that doesn't exist (edit
+`CHAT_MODEL` in `agent.py`): the LLM call fails, `mark_error` flags the agent
+span, and the trace shows an error.
+
+## Observe the traces
+
+In the AMP Console, open the agent → **OBSERVABILITY → Traces**. A `/chat` call
+produces one trace whose spans carry the per-kind icons, model and token chips,
+input/output, and — on a failed run — an error badge. Because the spans follow
+the contract, evaluators run against them too.
+
+## File guide
+
+| File | Role |
+|---|---|
+| `instrumentation.py` | The manual-instrumentation helpers — one per span kind. The contract, in code. |
+| `agent.py` | The hand-written RAG agent that calls those helpers around real OpenAI calls. |
+| `app.py` | FastAPI entrypoint; calls `init_otel()`. |
+| `main.py` | Local runner (`python main.py`). |
+| `.env.example` | Environment variable template. |

--- a/samples/manual-instrumentation-agent/README.md
+++ b/samples/manual-instrumentation-agent/README.md
@@ -127,13 +127,21 @@ Add one environment variable, `OPENAI_API_KEY`. Leave `AMP_OTEL_ENDPOINT` and
 
 ## Testing
 
+If you ran it externally-hosted, the agent is listening on `localhost:8000`, so
+`curl` it directly:
+
 ```bash
 curl -X POST http://localhost:8000/chat \
   -H 'Content-Type: application/json' \
   -d '{"session_id": "demo-1", "message": "How does AMP handle observability?"}'
 ```
 
-The response is the agent's answer. Behind it, one full trace was emitted.
+If you deployed it platform-hosted, the agent runs inside the AMP cluster, not on
+your machine. Test it from the agent's **Chat** interface in the AMP Console
+instead.
+
+Either way, the response is the agent's answer, and behind it one full trace was
+emitted.
 
 To see an error badge, point the agent at a model that doesn't exist (edit
 `CHAT_MODEL` in `agent.py`). The LLM call fails, `mark_error` flags the agent

--- a/samples/manual-instrumentation-agent/agent.py
+++ b/samples/manual-instrumentation-agent/agent.py
@@ -1,6 +1,6 @@
 """A small RAG agent on a hand-written framework.
 
-This agent is deliberately *not* built on LangChain / LlamaIndex / CrewAI — it's
+This agent is deliberately *not* built on LangChain, LlamaIndex, or CrewAI. It's
 plain Python. The Traceloop SDK can't auto-instrument it, which is exactly when
 you reach for the manual instrumentation path: you emit your own OpenTelemetry
 GenAI spans against AMP's contract. All the span emission lives in
@@ -10,15 +10,16 @@ One ``run_agent`` call produces one trace covering every span kind AMP supports:
 
     invoke_agent (agent, root)
     └── rag-pipeline (chain)
-        ├── embeddings   (embedding) — real OpenAI embeddings call
-        ├── vector_search (retriever) — cosine top-k over an in-memory store
-        ├── rerank       (rerank)    — simulated reranking
-        ├── execute_tool (tool)      — a real local tool
-        └── chat         (llm)       — real OpenAI chat completion
+        ├── embeddings    (embedding)
+        ├── vector_search (retriever)
+        ├── rerank        (rerank)
+        ├── execute_tool  (tool)
+        └── chat          (llm)
 
-The retriever and rerank are simulated (no external vector DB / rerank service)
-so the sample runs with only an OpenAI key. In a real agent they'd call your
-vector DB and rerank provider — the span attributes stay the same.
+The embeddings and chat spans wrap real OpenAI calls. The retriever and rerank
+steps are simulated (no external vector DB or rerank service), so the sample
+runs with only an OpenAI key. In a real agent they'd call your vector DB and
+rerank provider, and the span attributes stay the same.
 """
 
 from __future__ import annotations
@@ -48,8 +49,8 @@ KNOWLEDGE_BASE = [
      "text": "WSO2 Agent Manager is a platform to run, govern, observe, and "
              "evaluate AI agents at scale."},
     {"id": "kb-2", "title": "Observability",
-     "text": "AMP captures every agent interaction — LLM calls, tool calls, "
-             "retrievals — as OpenTelemetry traces stored for analysis."},
+     "text": "AMP captures every agent interaction (LLM calls, tool calls, "
+             "retrievals) as OpenTelemetry traces stored for analysis."},
     {"id": "kb-3", "title": "Auto-instrumentation",
      "text": "Platform-hosted Python agents are auto-instrumented by an injected "
              "init container; externally-hosted agents use the amp-instrument CLI."},
@@ -95,7 +96,7 @@ def _cosine(a: list[float], b: list[float]) -> float:
 
 
 def _word_count(text: str) -> int:
-    """A trivial local tool — the kind of function a custom agent calls."""
+    """A trivial local tool: the kind of function a custom agent calls."""
     return len(text.split())
 
 
@@ -141,7 +142,7 @@ def run_agent(
 
 def _rag_pipeline(client, doc_vectors, question, tool_defs):
     with ix.chain_span(name="rag-pipeline", workflow_input=question) as (chain, chain_result):
-        # 1. Embedding — embed the user's question (real OpenAI call).
+        # 1. Embedding: embed the user's question (real OpenAI call).
         with ix.embedding_span(
             system="openai", request_model=EMBED_MODEL, texts=[question],
         ) as (_embed_span, embed_result):
@@ -150,7 +151,7 @@ def _rag_pipeline(client, doc_vectors, question, tool_defs):
             embed_result.response_model = resp.model
             embed_result.input_tokens = resp.usage.prompt_tokens
 
-        # 2. Retriever — cosine top-k over the in-memory store.
+        # 2. Retriever: cosine top-k over the in-memory store.
         with ix.retriever_span(
             vector_db="chroma", collection="amp-knowledge-base", top_k=TOP_K,
         ):
@@ -161,7 +162,7 @@ def _rag_pipeline(client, doc_vectors, question, tool_defs):
             )
             hits = [doc for doc, _score in ranked[:TOP_K]]
 
-        # 3. Rerank — reorder the hits (simulated rerank service).
+        # 3. Rerank: reorder the hits (simulated rerank service).
         with ix.rerank_span(
             model=RERANK_MODEL, query=question, candidate_count=len(hits),
         ):
@@ -174,7 +175,7 @@ def _rag_pipeline(client, doc_vectors, question, tool_defs):
 
         context_text = "\n".join(f"- {d['title']}: {d['text']}" for d in hits)
 
-        # 4. Tool — a real local tool call.
+        # 4. Tool: a real local tool call.
         with ix.tool_span(
             name="word_count",
             description="Counts the words in a piece of text.",
@@ -183,7 +184,7 @@ def _rag_pipeline(client, doc_vectors, question, tool_defs):
         ) as (_tool_span, tool_result):
             tool_result["output"] = {"word_count": _word_count(context_text)}
 
-        # 5. LLM — generate the answer with the retrieved context (real call).
+        # 5. LLM: generate the answer with the retrieved context (real call).
         input_messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user",

--- a/samples/manual-instrumentation-agent/agent.py
+++ b/samples/manual-instrumentation-agent/agent.py
@@ -1,0 +1,209 @@
+"""A small RAG agent on a hand-written framework.
+
+This agent is deliberately *not* built on LangChain / LlamaIndex / CrewAI — it's
+plain Python. The Traceloop SDK can't auto-instrument it, which is exactly when
+you reach for the manual instrumentation path: you emit your own OpenTelemetry
+GenAI spans against AMP's contract. All the span emission lives in
+``instrumentation.py``; this file is the agent logic that calls those helpers.
+
+One ``run_agent`` call produces one trace covering every span kind AMP supports:
+
+    invoke_agent (agent, root)
+    └── rag-pipeline (chain)
+        ├── embeddings   (embedding) — real OpenAI embeddings call
+        ├── vector_search (retriever) — cosine top-k over an in-memory store
+        ├── rerank       (rerank)    — simulated reranking
+        ├── execute_tool (tool)      — a real local tool
+        └── chat         (llm)       — real OpenAI chat completion
+
+The retriever and rerank are simulated (no external vector DB / rerank service)
+so the sample runs with only an OpenAI key. In a real agent they'd call your
+vector DB and rerank provider — the span attributes stay the same.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import uuid
+
+from openai import OpenAI
+
+import instrumentation as ix
+
+EMBED_MODEL = "text-embedding-3-small"
+CHAT_MODEL = "gpt-4o-mini"
+RERANK_MODEL = "rerank-english-v3.0"
+TOP_K = 3
+
+SYSTEM_PROMPT = (
+    "You are a concise assistant that answers questions about the WSO2 Agent "
+    "Manager using only the provided context. If the context does not cover the "
+    "question, say so."
+)
+
+# A tiny in-memory knowledge base. In a real agent this is your vector DB.
+KNOWLEDGE_BASE = [
+    {"id": "kb-1", "title": "What AMP is",
+     "text": "WSO2 Agent Manager is a platform to run, govern, observe, and "
+             "evaluate AI agents at scale."},
+    {"id": "kb-2", "title": "Observability",
+     "text": "AMP captures every agent interaction — LLM calls, tool calls, "
+             "retrievals — as OpenTelemetry traces stored for analysis."},
+    {"id": "kb-3", "title": "Auto-instrumentation",
+     "text": "Platform-hosted Python agents are auto-instrumented by an injected "
+             "init container; externally-hosted agents use the amp-instrument CLI."},
+    {"id": "kb-4", "title": "Manual instrumentation",
+     "text": "Agents on a framework the Traceloop SDK does not cover emit their "
+             "own OpenTelemetry GenAI spans against AMP's published contract."},
+    {"id": "kb-5", "title": "Evaluation",
+     "text": "AMP runs evaluators over agent traces; LLM-as-judge evaluators need "
+             "the span input and output to be populated."},
+]
+
+_client: OpenAI | None = None
+_doc_vectors: list[list[float]] | None = None
+
+
+def _openai() -> OpenAI:
+    global _client
+    if _client is None:
+        if not os.getenv("OPENAI_API_KEY"):
+            raise RuntimeError("OPENAI_API_KEY is required to run this sample.")
+        _client = OpenAI()
+    return _client
+
+
+def _ensure_index() -> list[list[float]]:
+    """Embed the knowledge base once (real OpenAI call) and cache the vectors.
+    This is index-building, not request handling, so it isn't traced.
+    """
+    global _doc_vectors
+    if _doc_vectors is None:
+        resp = _openai().embeddings.create(
+            model=EMBED_MODEL, input=[d["text"] for d in KNOWLEDGE_BASE]
+        )
+        _doc_vectors = [item.embedding for item in resp.data]
+    return _doc_vectors
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def _word_count(text: str) -> int:
+    """A trivial local tool — the kind of function a custom agent calls."""
+    return len(text.split())
+
+
+def run_agent(
+    question: str,
+    conversation_id: str | None = None,
+    task_id: str | None = None,
+    trial_id: str | None = None,
+) -> str:
+    """Run one agent turn and emit one fully-instrumented trace."""
+    conversation_id = conversation_id or str(uuid.uuid4())
+    client = _openai()
+    doc_vectors = _ensure_index()
+
+    tool_defs = [{
+        "name": "word_count",
+        "description": "Counts the words in a piece of text.",
+    }]
+
+    # W3C baggage joins this trace to an evaluation trial, when one drove it.
+    with ix.evaluation_baggage(task_id, trial_id):
+        with ix.agent_span(
+            name="amp-knowledge-agent",
+            description="Answers questions about WSO2 Agent Manager from a knowledge base.",
+            framework="custom-rag-framework",
+            model=CHAT_MODEL,
+            system_instructions=SYSTEM_PROMPT,
+            conversation_id=conversation_id,
+            input_messages=[{"role": "user", "content": question}],
+            tools=tool_defs,
+        ) as (agent, agent_result):
+            try:
+                answer, usage = _rag_pipeline(client, doc_vectors, question, tool_defs)
+            except Exception as exc:  # noqa: BLE001 - surface any failure as an error span
+                ix.mark_error(agent, f"agent run failed: {exc}")
+                raise
+
+            agent_result.output_messages = [{"role": "assistant", "content": answer}]
+            agent_result.input_tokens = usage[0]
+            agent_result.output_tokens = usage[1]
+            return answer
+
+
+def _rag_pipeline(client, doc_vectors, question, tool_defs):
+    with ix.chain_span(name="rag-pipeline", workflow_input=question) as (chain, chain_result):
+        # 1. Embedding — embed the user's question (real OpenAI call).
+        with ix.embedding_span(
+            system="openai", request_model=EMBED_MODEL, texts=[question],
+        ) as (_embed_span, embed_result):
+            resp = client.embeddings.create(model=EMBED_MODEL, input=[question])
+            query_vector = resp.data[0].embedding
+            embed_result.response_model = resp.model
+            embed_result.input_tokens = resp.usage.prompt_tokens
+
+        # 2. Retriever — cosine top-k over the in-memory store.
+        with ix.retriever_span(
+            vector_db="chroma", collection="amp-knowledge-base", top_k=TOP_K,
+        ):
+            ranked = sorted(
+                zip(KNOWLEDGE_BASE, (_cosine(query_vector, v) for v in doc_vectors)),
+                key=lambda pair: pair[1],
+                reverse=True,
+            )
+            hits = [doc for doc, _score in ranked[:TOP_K]]
+
+        # 3. Rerank — reorder the hits (simulated rerank service).
+        with ix.rerank_span(
+            model=RERANK_MODEL, query=question, candidate_count=len(hits),
+        ):
+            q_words = {w.lower() for w in question.split()}
+            hits = sorted(
+                hits,
+                key=lambda d: len(q_words & {w.lower() for w in d["text"].split()}),
+                reverse=True,
+            )
+
+        context_text = "\n".join(f"- {d['title']}: {d['text']}" for d in hits)
+
+        # 4. Tool — a real local tool call.
+        with ix.tool_span(
+            name="word_count",
+            description="Counts the words in a piece of text.",
+            call_id=str(uuid.uuid4()),
+            arguments={"text": context_text},
+        ) as (_tool_span, tool_result):
+            tool_result["output"] = {"word_count": _word_count(context_text)}
+
+        # 5. LLM — generate the answer with the retrieved context (real call).
+        input_messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user",
+             "content": f"Context:\n{context_text}\n\nQuestion: {question}"},
+        ]
+        with ix.llm_span(
+            system="openai",
+            request_model=CHAT_MODEL,
+            input_messages=input_messages,
+            temperature=0.3,
+            tools=tool_defs,
+        ) as (_llm_span, llm_result):
+            resp = client.chat.completions.create(
+                model=CHAT_MODEL, messages=input_messages, temperature=0.3,
+            )
+            answer = resp.choices[0].message.content or ""
+            llm_result.response_model = resp.model
+            llm_result.output_messages = [{"role": "assistant", "content": answer}]
+            llm_result.input_tokens = resp.usage.prompt_tokens
+            llm_result.output_tokens = resp.usage.completion_tokens
+
+        chain_result["output"] = answer
+        return answer, (llm_result.input_tokens, llm_result.output_tokens)

--- a/samples/manual-instrumentation-agent/agent.py
+++ b/samples/manual-instrumentation-agent/agent.py
@@ -10,20 +10,24 @@ One ``run_agent`` call produces one trace covering every span kind AMP supports:
 
     invoke_agent (agent, root)
     └── rag-pipeline (chain)
-        ├── embeddings    (embedding)
-        ├── vector_search (retriever)
-        ├── rerank        (rerank)
-        ├── execute_tool  (tool)
-        └── chat          (llm)
+        ├── embeddings    (embedding)  - real OpenAI call
+        ├── vector_search (retriever)  - simulated
+        ├── rerank        (rerank)     - simulated
+        ├── chat          (llm)        - simulated: decides to call a tool
+        ├── execute_tool  (tool)       - real local call
+        └── chat          (llm)        - real OpenAI call: final answer
 
-The embeddings and chat spans wrap real OpenAI calls. The retriever and rerank
-steps are simulated (no external vector DB or rerank service), so the sample
-runs with only an OpenAI key. In a real agent they'd call your vector DB and
-rerank provider, and the span attributes stay the same.
+The embeddings span and the final chat span wrap real OpenAI calls. The
+retriever, rerank, and the tool-deciding chat call are simulated (no external
+vector DB, rerank service, or model round-trip), so the trace is deterministic
+and the sample runs with only an OpenAI key. In a real agent those would call
+your vector DB, rerank provider, and the model, and the span attributes stay
+the same.
 """
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import uuid
@@ -174,31 +178,62 @@ def _rag_pipeline(client, doc_vectors, question, tool_defs):
             )
 
         context_text = "\n".join(f"- {d['title']}: {d['text']}" for d in hits)
-
-        # 4. Tool: a real local tool call.
-        with ix.tool_span(
-            name="word_count",
-            description="Counts the words in a piece of text.",
-            call_id=str(uuid.uuid4()),
-            arguments={"text": context_text},
-        ) as (_tool_span, tool_result):
-            tool_result["output"] = {"word_count": _word_count(context_text)}
-
-        # 5. LLM: generate the answer with the retrieved context (real call).
-        input_messages = [
+        base_messages = [
             {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user",
              "content": f"Context:\n{context_text}\n\nQuestion: {question}"},
         ]
+
+        # 4. LLM call 1: given the tools, the model asks to run one. A real
+        #    model returns this tool call; the sample hard-codes it to keep the
+        #    trace deterministic, the same reason the rerank step is simulated.
+        call_id = f"call_{uuid.uuid4().hex[:8]}"
+        tool_call = {
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": "word_count",
+                "arguments": json.dumps({"text": context_text}),
+            },
+        }
         with ix.llm_span(
             system="openai",
             request_model=CHAT_MODEL,
-            input_messages=input_messages,
+            input_messages=base_messages,
             temperature=0.3,
             tools=tool_defs,
+        ) as (_decide_span, decide_result):
+            # Simulated: no OpenAI call. A real call fills these from the
+            # response; here the tool call is hard-coded and usage stays zero.
+            decide_result.response_model = CHAT_MODEL
+            decide_result.output_messages = [
+                {"role": "assistant", "content": None, "tool_calls": [tool_call]},
+            ]
+
+        # 5. Tool: run the tool the model asked for (real local call). The span
+        #    call_id matches the tool call above, linking it to the decision.
+        with ix.tool_span(
+            name="word_count",
+            description="Counts the words in a piece of text.",
+            call_id=call_id,
+            arguments={"text": context_text},
+        ) as (_tool_span, tool_result):
+            tool_result["output"] = {"word_count": _word_count(context_text)}
+
+        # 6. LLM call 2: feed the tool result back, get the answer (real call).
+        answer_messages = base_messages + [
+            {"role": "assistant", "content": None, "tool_calls": [tool_call]},
+            {"role": "tool", "tool_call_id": call_id,
+             "content": json.dumps(tool_result["output"])},
+        ]
+        with ix.llm_span(
+            system="openai",
+            request_model=CHAT_MODEL,
+            input_messages=answer_messages,
+            temperature=0.3,
         ) as (_llm_span, llm_result):
             resp = client.chat.completions.create(
-                model=CHAT_MODEL, messages=input_messages, temperature=0.3,
+                model=CHAT_MODEL, messages=answer_messages, temperature=0.3,
             )
             answer = resp.choices[0].message.content or ""
             llm_result.response_model = resp.model

--- a/samples/manual-instrumentation-agent/app.py
+++ b/samples/manual-instrumentation-agent/app.py
@@ -4,7 +4,7 @@ Implements the AM chat-agent contract: ``POST /chat`` on port 8000 accepting
 ``{session_id, message}`` and returning ``{response, session_id}``.
 ``GET /health`` is provided for local checks.
 
-``init_otel()`` is the only AMP-specific setup on the manual path — there is no
+``init_otel()`` is the only AMP-specific setup on the manual path. There is no
 Traceloop SDK and no ``amp-instrument`` CLI here. It configures the OpenTelemetry
 OTLP exporter to AMP; the agent emits its own spans (see ``instrumentation.py``).
 """
@@ -24,8 +24,8 @@ log = logging.getLogger("manual-instrumentation-agent")
 
 # Configure the OTLP exporter to AMP. Reads AMP_OTEL_ENDPOINT and
 # AMP_AGENT_API_KEY from the environment:
-#   * platform-hosted (auto-instrumentation OFF) — AMP's env-injection trait sets both
-#   * externally-hosted — you set both yourself
+#   * platform-hosted (auto-instrumentation OFF): AMP's env-injection trait sets both
+#   * externally-hosted: you set both yourself
 # init_otel() raises ValueError if either is missing, and is idempotent.
 init_otel()
 
@@ -35,7 +35,7 @@ app = FastAPI(title="Manual Instrumentation Sample Agent")
 class ChatRequest(BaseModel):
     session_id: str
     message: str
-    # Optional W3C-baggage correlation — only set when an evaluation run drives the agent.
+    # Optional W3C-baggage correlation; set only when an evaluation run drives the agent.
     task_id: str | None = None
     trial_id: str | None = None
 

--- a/samples/manual-instrumentation-agent/app.py
+++ b/samples/manual-instrumentation-agent/app.py
@@ -1,0 +1,67 @@
+"""FastAPI entrypoint for the manual-instrumentation sample agent.
+
+Implements the AM chat-agent contract: ``POST /chat`` on port 8000 accepting
+``{session_id, message}`` and returning ``{response, session_id}``.
+``GET /health`` is provided for local checks.
+
+``init_otel()`` is the only AMP-specific setup on the manual path — there is no
+Traceloop SDK and no ``amp-instrument`` CLI here. It configures the OpenTelemetry
+OTLP exporter to AMP; the agent emits its own spans (see ``instrumentation.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from amp_instrumentation import init_otel
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from agent import run_agent
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("manual-instrumentation-agent")
+
+# Configure the OTLP exporter to AMP. Reads AMP_OTEL_ENDPOINT and
+# AMP_AGENT_API_KEY from the environment:
+#   * platform-hosted (auto-instrumentation OFF) — AMP's env-injection trait sets both
+#   * externally-hosted — you set both yourself
+# init_otel() raises ValueError if either is missing, and is idempotent.
+init_otel()
+
+app = FastAPI(title="Manual Instrumentation Sample Agent")
+
+
+class ChatRequest(BaseModel):
+    session_id: str
+    message: str
+    # Optional W3C-baggage correlation — only set when an evaluation run drives the agent.
+    task_id: str | None = None
+    trial_id: str | None = None
+
+
+class ChatResponse(BaseModel):
+    response: str
+    session_id: str
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/chat", response_model=ChatResponse)
+def chat(req: ChatRequest) -> ChatResponse:
+    if not req.message.strip():
+        raise HTTPException(status_code=400, detail="message must not be empty")
+    try:
+        answer = run_agent(
+            req.message,
+            conversation_id=req.session_id,
+            task_id=req.task_id,
+            trial_id=req.trial_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - surface agent failures as HTTP 500
+        log.exception("agent run failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return ChatResponse(response=answer, session_id=req.session_id)

--- a/samples/manual-instrumentation-agent/instrumentation.py
+++ b/samples/manual-instrumentation-agent/instrumentation.py
@@ -1,4 +1,4 @@
-"""Manual instrumentation helpers — AMP's instrumentation contract, in code.
+"""Manual instrumentation helpers: AMP's instrumentation contract, in code.
 
 This module is the point of the sample. Each helper opens one OpenTelemetry span
 and sets exactly the attributes AMP's observer reads for that span kind, so the
@@ -7,9 +7,9 @@ through evaluators.
 
 The contract is layered:
 
-  * Layer 1 — OpenTelemetry GenAI semantic conventions (``gen_ai.*``, plus
+  * Layer 1: OpenTelemetry GenAI semantic conventions (``gen_ai.*``, plus
     ``db.*`` for retriever spans). The primary set.
-  * Layer 2 — OpenLLMetry / Traceloop extension keys (``traceloop.*``) for the
+  * Layer 2: OpenLLMetry / Traceloop extension keys (``traceloop.*``) for the
     few decisions OTel has not standardized yet: the ``chain`` span kind,
     ``rerank``, and tool-call arguments / result.
 
@@ -43,7 +43,7 @@ def _tracer() -> trace.Tracer:
 
 # --- Trace content toggle --------------------------------------------------
 # On the auto path the Traceloop SDK reads TRACELOOP_TRACE_CONTENT. On the
-# manual path you control span content yourself — this sample honours
+# manual path you control span content yourself, so this sample honours
 # AMP_TRACE_CONTENT (the variable the platform env-injection trait sets) so
 # prompt/completion text can be suppressed without dropping the spans.
 
@@ -66,7 +66,7 @@ def _messages(msgs: list[dict[str, str]]) -> str:
 @contextmanager
 def evaluation_baggage(task_id: str | None, trial_id: str | None) -> Iterator[None]:
     """Attach W3C baggage so a trace can be joined to the evaluation trial that
-    produced it. Optional — only relevant when the agent is driven by an
+    produced it. Optional; only relevant when the agent is driven by an
     evaluation run. Baggage propagates to every span started inside the block.
     """
     ctx = context.get_current()
@@ -213,7 +213,7 @@ def retriever_span(
 
 @contextmanager
 def rerank_span(*, model: str, query: str, candidate_count: int) -> Iterator[Span]:
-    """A reranking step. Recognized as a *kind* only — a rerank span gets the
+    """A reranking step. Recognized as a *kind* only. A rerank span gets the
     rerank icon, no data card (no RerankData payload in v1). The observer reads
     the Layer-2 `traceloop.span.kind`; the other keys are de-facto signals.
     """

--- a/samples/manual-instrumentation-agent/instrumentation.py
+++ b/samples/manual-instrumentation-agent/instrumentation.py
@@ -55,10 +55,42 @@ def _content(text: str) -> str:
     return text if _trace_content_enabled() else "[redacted]"
 
 
-def _messages(msgs: list[dict[str, str]]) -> str:
+def _messages(msgs: list[dict[str, Any]]) -> str:
     if _trace_content_enabled():
         return json.dumps(msgs)
-    return json.dumps([{"role": m["role"], "content": "[redacted]"} for m in msgs])
+    return json.dumps([_redact_message(m) for m in msgs])
+
+
+def _redact_message(msg: dict[str, Any]) -> dict[str, Any]:
+    """Redact the free text of one chat message, keeping role and tool-call
+    structure. A tool call's ``arguments`` string is content too.
+    """
+    redacted = dict(msg)
+    if redacted.get("content") is not None:
+        redacted["content"] = "[redacted]"
+    if redacted.get("tool_calls"):
+        redacted["tool_calls"] = [
+            {**tc, "function": {**tc["function"], "arguments": "[redacted]"}}
+            for tc in redacted["tool_calls"]
+        ]
+    return redacted
+
+
+def _redact_value(value: Any) -> Any:
+    """Redact string content anywhere inside an arbitrary value when content
+    tracing is off, preserving structure (dict keys, list shape) so the trace
+    view stays readable. Used for the Layer-2 ``traceloop.entity.*`` payloads,
+    which carry free-form input/output rather than typed messages.
+    """
+    if _trace_content_enabled():
+        return value
+    if isinstance(value, str):
+        return "[redacted]"
+    if isinstance(value, list):
+        return [_redact_value(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _redact_value(v) for k, v in value.items()}
+    return value
 
 
 # --- Evaluation correlation -------------------------------------------------
@@ -158,13 +190,17 @@ def chain_span(*, name: str, workflow_input: Any) -> Iterator[tuple[Span, dict]]
     """
     with _tracer().start_as_current_span(name, kind=SpanKind.INTERNAL) as span:
         span.set_attribute("traceloop.span.kind", "workflow")     # -> kind = chain
-        span.set_attribute("traceloop.entity.input", json.dumps({"input": workflow_input}))
+        span.set_attribute(
+            "traceloop.entity.input",
+            json.dumps({"input": _redact_value(workflow_input)}),
+        )
         result: dict[str, Any] = {"output": None}
         try:
             yield span, result
         finally:
             span.set_attribute(
-                "traceloop.entity.output", json.dumps({"output": result["output"]})
+                "traceloop.entity.output",
+                json.dumps({"output": _redact_value(result["output"])}),
             )
 
 
@@ -247,13 +283,14 @@ def tool_span(
         span.set_attribute("gen_ai.tool.name", name)              # required
         span.set_attribute("gen_ai.tool.description", description)
         span.set_attribute("gen_ai.tool.call.id", call_id)
-        span.set_attribute("traceloop.entity.input", json.dumps(arguments))
+        span.set_attribute("traceloop.entity.input", json.dumps(_redact_value(arguments)))
         result: dict[str, Any] = {"output": None}
         try:
             yield span, result
         finally:
             span.set_attribute(
-                "traceloop.entity.output", json.dumps({"result": result["output"]})
+                "traceloop.entity.output",
+                json.dumps({"result": _redact_value(result["output"])}),
             )
 
 

--- a/samples/manual-instrumentation-agent/instrumentation.py
+++ b/samples/manual-instrumentation-agent/instrumentation.py
@@ -1,0 +1,292 @@
+"""Manual instrumentation helpers — AMP's instrumentation contract, in code.
+
+This module is the point of the sample. Each helper opens one OpenTelemetry span
+and sets exactly the attributes AMP's observer reads for that span kind, so the
+span renders with the full trace view in the WSO2 Agent Manager Console and runs
+through evaluators.
+
+The contract is layered:
+
+  * Layer 1 — OpenTelemetry GenAI semantic conventions (``gen_ai.*``, plus
+    ``db.*`` for retriever spans). The primary set.
+  * Layer 2 — OpenLLMetry / Traceloop extension keys (``traceloop.*``) for the
+    few decisions OTel has not standardized yet: the ``chain`` span kind,
+    ``rerank``, and tool-call arguments / result.
+
+Full reference: the "Manual instrumentation" section of the WSO2 Agent Manager
+Instrumentation docs page.
+
+Every helper is a context manager. Helpers whose response data is only known
+after a call (LLM, embedding, agent) yield a small result object for the caller
+to fill; the helper writes the response attributes when the block exits.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Iterator
+
+from opentelemetry import baggage, context, trace
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+_TRACER_NAME = "manual-instrumentation-agent"
+
+
+def _tracer() -> trace.Tracer:
+    # Fetched per call so it always binds to the provider init_otel() installed,
+    # regardless of import order.
+    return trace.get_tracer(_TRACER_NAME)
+
+
+# --- Trace content toggle --------------------------------------------------
+# On the auto path the Traceloop SDK reads TRACELOOP_TRACE_CONTENT. On the
+# manual path you control span content yourself — this sample honours
+# AMP_TRACE_CONTENT (the variable the platform env-injection trait sets) so
+# prompt/completion text can be suppressed without dropping the spans.
+
+def _trace_content_enabled() -> bool:
+    return os.getenv("AMP_TRACE_CONTENT", "true").lower() != "false"
+
+
+def _content(text: str) -> str:
+    return text if _trace_content_enabled() else "[redacted]"
+
+
+def _messages(msgs: list[dict[str, str]]) -> str:
+    if _trace_content_enabled():
+        return json.dumps(msgs)
+    return json.dumps([{"role": m["role"], "content": "[redacted]"} for m in msgs])
+
+
+# --- Evaluation correlation -------------------------------------------------
+
+@contextmanager
+def evaluation_baggage(task_id: str | None, trial_id: str | None) -> Iterator[None]:
+    """Attach W3C baggage so a trace can be joined to the evaluation trial that
+    produced it. Optional — only relevant when the agent is driven by an
+    evaluation run. Baggage propagates to every span started inside the block.
+    """
+    ctx = context.get_current()
+    if task_id:
+        ctx = baggage.set_baggage("task_id", task_id, context=ctx)
+    if trial_id:
+        ctx = baggage.set_baggage("trial_id", trial_id, context=ctx)
+    token = context.attach(ctx)
+    try:
+        yield
+    finally:
+        context.detach(token)
+
+
+def mark_error(span: Span, message: str) -> None:
+    """Flag a span as failed. The observer turns this into an error badge on the
+    span and bumps the trace's error count. Works on any span kind.
+    """
+    span.set_status(Status(StatusCode.ERROR, message))
+    span.set_attribute("error.type", "AgentError")
+
+
+# --- Result objects (filled by the caller, written out on block exit) ------
+
+@dataclass
+class LLMResult:
+    response_model: str = ""
+    output_messages: list[dict[str, str]] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@dataclass
+class EmbeddingResult:
+    response_model: str = ""
+    input_tokens: int = 0
+
+
+@dataclass
+class AgentResult:
+    output_messages: list[dict[str, str]] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+# --- agent -----------------------------------------------------------------
+
+@contextmanager
+def agent_span(
+    *,
+    name: str,
+    description: str,
+    framework: str,
+    model: str,
+    system_instructions: str,
+    conversation_id: str,
+    input_messages: list[dict[str, str]],
+    tools: list[dict[str, Any]] | None = None,
+) -> Iterator[tuple[Span, AgentResult]]:
+    """Root span for one agent invocation. `gen_ai.operation.name = invoke_agent`."""
+    with _tracer().start_as_current_span("invoke_agent", kind=SpanKind.INTERNAL) as span:
+        span.set_attribute("gen_ai.operation.name", "invoke_agent")
+        span.set_attribute("gen_ai.system", framework)            # framework chip
+        span.set_attribute("gen_ai.agent.name", name)             # required
+        span.set_attribute("gen_ai.agent.description", description)
+        span.set_attribute("gen_ai.request.model", model)
+        span.set_attribute("gen_ai.system_instructions", _content(system_instructions))
+        span.set_attribute("gen_ai.conversation.id", conversation_id)
+        span.set_attribute("gen_ai.input.messages", _messages(input_messages))
+        if tools:
+            span.set_attribute("gen_ai.agent.tools", json.dumps(tools))
+        result = AgentResult()
+        try:
+            yield span, result
+        finally:
+            if result.output_messages:
+                span.set_attribute("gen_ai.output.messages", _messages(result.output_messages))
+            span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens)
+            span.set_attribute("gen_ai.usage.output_tokens", result.output_tokens)
+
+
+# --- chain / workflow ------------------------------------------------------
+
+@contextmanager
+def chain_span(*, name: str, workflow_input: Any) -> Iterator[tuple[Span, dict]]:
+    """A workflow / pipeline step. OTel has no key for this kind, so the
+    observer reads the Layer-2 `traceloop.span.kind`. Put the chain's output in
+    `result["output"]` before the block exits.
+    """
+    with _tracer().start_as_current_span(name, kind=SpanKind.INTERNAL) as span:
+        span.set_attribute("traceloop.span.kind", "workflow")     # -> kind = chain
+        span.set_attribute("traceloop.entity.input", json.dumps({"input": workflow_input}))
+        result: dict[str, Any] = {"output": None}
+        try:
+            yield span, result
+        finally:
+            span.set_attribute(
+                "traceloop.entity.output", json.dumps({"output": result["output"]})
+            )
+
+
+# --- embedding -------------------------------------------------------------
+
+@contextmanager
+def embedding_span(
+    *, system: str, request_model: str, texts: list[str]
+) -> Iterator[tuple[Span, EmbeddingResult]]:
+    """An embedding call. `gen_ai.operation.name = embeddings`."""
+    with _tracer().start_as_current_span("embeddings", kind=SpanKind.CLIENT) as span:
+        span.set_attribute("gen_ai.operation.name", "embeddings")
+        span.set_attribute("gen_ai.system", system)
+        span.set_attribute("gen_ai.request.model", request_model)
+        for i, text in enumerate(texts):
+            # Indexed embedded text. The OTel key here is not fully settled;
+            # this is the de-facto form the observer reads.
+            span.set_attribute(f"gen_ai.prompt.{i}.content", _content(text))
+        result = EmbeddingResult()
+        try:
+            yield span, result
+        finally:
+            if result.response_model:
+                span.set_attribute("gen_ai.response.model", result.response_model)
+            span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens)
+
+
+# --- retriever -------------------------------------------------------------
+
+@contextmanager
+def retriever_span(
+    *, vector_db: str, collection: str, top_k: int
+) -> Iterator[Span]:
+    """A vector-DB retrieval. Uses the OTel database semantic conventions; the
+    observer keys `kind = retriever` off `db.system.name`. Retrieved documents
+    are not extracted in v1, so they aren't set here.
+    """
+    with _tracer().start_as_current_span("vector_search", kind=SpanKind.CLIENT) as span:
+        span.set_attribute("db.system.name", vector_db)           # required
+        span.set_attribute("db.collection.name", collection)
+        span.set_attribute("db.vector.query.top_k", top_k)
+        yield span
+
+
+# --- rerank ----------------------------------------------------------------
+
+@contextmanager
+def rerank_span(*, model: str, query: str, candidate_count: int) -> Iterator[Span]:
+    """A reranking step. Recognized as a *kind* only — a rerank span gets the
+    rerank icon, no data card (no RerankData payload in v1). The observer reads
+    the Layer-2 `traceloop.span.kind`; the other keys are de-facto signals.
+    """
+    with _tracer().start_as_current_span("rerank", kind=SpanKind.CLIENT) as span:
+        span.set_attribute("traceloop.span.kind", "rerank")       # -> kind = rerank
+        span.set_attribute("gen_ai.operation.name", "rerank")     # de-facto, not standard OTel
+        span.set_attribute("rerank.model", model)
+        span.set_attribute("gen_ai.request.model", model)
+        span.set_attribute("traceloop.entity.input", json.dumps({
+            "query": _content(query), "candidate_count": candidate_count,
+        }))
+        yield span
+
+
+# --- tool ------------------------------------------------------------------
+
+@contextmanager
+def tool_span(
+    *,
+    name: str,
+    description: str,
+    call_id: str,
+    arguments: dict[str, Any],
+) -> Iterator[tuple[Span, dict]]:
+    """A tool / function call. `gen_ai.operation.name = execute_tool`. OTel has
+    no stable key for tool I/O, so arguments/result go in the Layer-2
+    `traceloop.entity.*` keys. Put the tool's result in `result["output"]`.
+    """
+    with _tracer().start_as_current_span("execute_tool", kind=SpanKind.INTERNAL) as span:
+        span.set_attribute("gen_ai.operation.name", "execute_tool")
+        span.set_attribute("gen_ai.tool.name", name)              # required
+        span.set_attribute("gen_ai.tool.description", description)
+        span.set_attribute("gen_ai.tool.call.id", call_id)
+        span.set_attribute("traceloop.entity.input", json.dumps(arguments))
+        result: dict[str, Any] = {"output": None}
+        try:
+            yield span, result
+        finally:
+            span.set_attribute(
+                "traceloop.entity.output", json.dumps({"result": result["output"]})
+            )
+
+
+# --- llm -------------------------------------------------------------------
+
+@contextmanager
+def llm_span(
+    *,
+    system: str,
+    request_model: str,
+    input_messages: list[dict[str, str]],
+    temperature: float | None = None,
+    tools: list[dict[str, Any]] | None = None,
+) -> Iterator[tuple[Span, LLMResult]]:
+    """An LLM chat call. `gen_ai.operation.name = chat`. LLM evaluators need the
+    input and output messages, so those are required for a useful span.
+    """
+    with _tracer().start_as_current_span("chat", kind=SpanKind.CLIENT) as span:
+        span.set_attribute("gen_ai.operation.name", "chat")
+        span.set_attribute("gen_ai.system", system)
+        span.set_attribute("gen_ai.request.model", request_model)
+        if temperature is not None:
+            span.set_attribute("gen_ai.request.temperature", temperature)
+        span.set_attribute("gen_ai.input.messages", _messages(input_messages))
+        if tools:
+            span.set_attribute("gen_ai.input.tools", json.dumps(tools))
+        result = LLMResult()
+        try:
+            yield span, result
+        finally:
+            if result.response_model:
+                span.set_attribute("gen_ai.response.model", result.response_model)
+            if result.output_messages:
+                span.set_attribute("gen_ai.output.messages", _messages(result.output_messages))
+            span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens)
+            span.set_attribute("gen_ai.usage.output_tokens", result.output_tokens)

--- a/samples/manual-instrumentation-agent/main.py
+++ b/samples/manual-instrumentation-agent/main.py
@@ -1,0 +1,8 @@
+"""Local runner: ``python main.py`` serves the agent on port 8000."""
+
+import uvicorn
+
+from app import app
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/samples/manual-instrumentation-agent/requirements.txt
+++ b/samples/manual-instrumentation-agent/requirements.txt
@@ -1,0 +1,5 @@
+amp-instrumentation
+openai
+fastapi
+uvicorn
+opentelemetry-api


### PR DESCRIPTION
## Purpose
The instrumentation-versioning work added a **manual instrumentation path*,* an agent on a framework the Traceloop SDK doesn't auto-instrument emits its own OpenTelemetry GenAI spans against AMP's published contract. The contract is documented, but there was no runnable example of it. This adds one under `samples/`.

Resolves https://github.com/wso2/agent-manager/issues/939

## Goals
- Give customers (and the team) an executable reference for the manual instrumentation path.
- Cover every span kind and every attribute in the contract, in one place.
- Show the path working for both hosting models — externally-hosted and platform-hosted.

## Approach
`samples/manual-instrumentation-agent/` is a small retrieval-augmented agent built on a deliberately hand-written framework (plain Python — nothing the Traceloop SDK knows about, which is the whole reason to instrument manually).

- `instrumentation.py` is the teaching core: one context-manager helper per span kind (`agent`, `chain`, `embedding`, `retriever`, `rerank`, `tool`, `llm`), each setting exactly the contract attributes the observer reads, heavily commented and split into the Layer 1 (OTel GenAI semconv) / Layer 2 (`traceloop.*`) structure. Plus `mark_error` (error badge) and `evaluation_baggage` (W3C `task_id`/`trial_id` correlation).
- `agent.py` is the agent logic — a RAG flow that calls those helpers around real OpenAI embedding and chat calls. One `/chat` request emits one trace covering all seven kinds.
- `app.py` is a FastAPI app following the AM chat-agent contract (`POST /chat`, `GET /health`); it calls `init_otel()` — the only AMP-specific setup on the manual path.
- The README documents both hosting modes. The platform-hosted instructions call out the key step: **deploy with auto-instrumentation off**, so AMP attaches the env-injection trait (which still supplies `AMP_OTEL_ENDPOINT` / `AMP_AGENT_API_KEY`) instead of the auto-instrumentation init container.

The retriever and rerank steps are simulated (no external vector DB / rerank service) so the sample runs with only an OpenAI key; the span attributes are identical to a real one. The LLM and embedding spans wrap real OpenAI calls.

## User stories
- *Agent developer, custom framework.* I need to see, in code, exactly which attributes my spans must carry. → `instrumentation.py`, one helper per kind.
- *Agent developer.* I want to run the manual path end to end before adapting it to my agent. → clone, set env vars, `python main.py`.

## Release note
Added `samples/manual-instrumentation-agent` — a runnable example of AMP's manual instrumentation path. It emits OpenTelemetry GenAI spans for every span kind in the contract and runs both externally-hosted and platform-hosted (auto-instrumentation off).

## Documentation
The sample's README is self-contained and cross-references the "Manual instrumentation" section of the WSO2 Agent Manager Instrumentation docs page.

## Training
N/A — sample code.

## Certification
N/A — sample code, no behaviour change to the product.

## Marketing
N/A.

## Automation tests
- Unit tests
  > N/A — sample. Verified separately (see below).
- Integration tests
  > Verified locally: `pip install -r requirements.txt` resolves; all modules compile and import; the seven span helpers + the error-status path were run against an in-memory OpenTelemetry exporter and asserted to carry every contract attribute. The full real-OpenAI end-to-end (`/chat`) needs an `OPENAI_API_KEY` and was not run in CI.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Python sample
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — `.env.example` ships empty placeholders only

## Samples
This PR *is* a sample: `samples/manual-instrumentation-agent/`.

## Related PRs
- #871 (docs) — published the manual instrumentation contract this sample implements.
- #849 (`amp-instrumentation` pin + `init_otel()`) — the helper this sample uses.

## Migrations (if applicable)
N/A.

## Test environment
Verified locally on macOS, Python 3.13.2, in a clean venv.

## Learning
N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runnable sample agent with a chat API, health endpoint, and local runner demonstrating manual OpenTelemetry span instrumentation

* **Configuration**
  * Added environment example with telemetry settings, OpenAI key, and trace-content toggle

* **Documentation**
  * Complete README with setup, two run modes, testing instructions, error-observation guidance, and where to view traces

* **Chores**
  * Added sample requirements for local development and testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->