### PR TITLE
Improve gateway event delivery when agent-manager scaled up

### DIFF
--- a/agent-manager-service/app/app.go
+++ b/agent-manager-service/app/app.go
@@ -163,6 +163,13 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 			slog.Warn("WebSocket manager shutdown timed out")
 		}
 
+		// Close EventHub after WebSocket manager so in-flight events are not dropped
+		if dependencies.EventHub != nil {
+			if err := dependencies.EventHub.Close(); err != nil {
+				slog.Error("error closing EventHub", "error", err)
+			}
+		}
+
 		// Shutdown both servers using the same context
 		if err := mainServer.Shutdown(shutdownCtx); err != nil {
 			slog.Error("Main server forced shutdown after timeout", "error", err)

--- a/agent-manager-service/controllers/websocket_controller.go
+++ b/agent-manager-service/controllers/websocket_controller.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
 	ws "github.com/wso2/agent-manager/agent-manager-service/websocket"
@@ -41,6 +42,7 @@ type WebSocketController interface {
 
 type websocketController struct {
 	manager        *ws.Manager
+	hub            eventhub.EventHub
 	gatewayService *services.PlatformGatewayService
 	ackHandler     *services.DeploymentAckHandler
 	upgrader       websocket.Upgrader
@@ -65,12 +67,14 @@ type ConnectionAckDTO struct {
 // NewWebSocketController creates a new WebSocket controller
 func NewWebSocketController(
 	manager *ws.Manager,
+	hub eventhub.EventHub,
 	gatewayService *services.PlatformGatewayService,
 	ackHandler *services.DeploymentAckHandler,
 	rateLimitCount int,
 ) WebSocketController {
 	ctrl := &websocketController{
 		manager:        manager,
+		hub:            hub,
 		gatewayService: gatewayService,
 		ackHandler:     ackHandler,
 		upgrader: websocket.Upgrader{
@@ -129,6 +133,15 @@ func (c *websocketController) Connect(w http.ResponseWriter, r *http.Request) {
 	gatewayID := gateway.UUID.String()
 	orgName := gateway.OrganizationName
 	gatewayName := gateway.Name
+
+	// Ensure the gateway is registered in the EventHub (idempotent - safe to call on every connect).
+	if c.hub != nil {
+		if err := c.hub.RegisterGateway(gatewayID); err != nil {
+			log.Warn("Failed to register gateway in EventHub",
+				"gatewayID", gatewayID, "gatewayName", gatewayName,
+				"orgName", orgName, "error", err)
+		}
+	}
 
 	// Rate limit by gateway ID so that all gateways behind a shared ingress are
 	// tracked independently instead of sharing a single per-IP bucket.

--- a/agent-manager-service/db_migrations/021_add_eventhub_tables.go
+++ b/agent-manager-service/db_migrations/021_add_eventhub_tables.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dbmigrations
+
+import "gorm.io/gorm"
+
+var migration021 = migration{
+	ID: 21,
+	Migrate: func(db *gorm.DB) error {
+		return db.Exec(`
+			CREATE TABLE IF NOT EXISTS eventhub_gateway_states (
+				gateway_id  TEXT      PRIMARY KEY,
+				version_id  TEXT      NOT NULL DEFAULT '',
+				updated_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			);
+
+			CREATE TABLE IF NOT EXISTS eventhub_events (
+				event_id             TEXT      PRIMARY KEY,
+				gateway_id           TEXT      NOT NULL REFERENCES eventhub_gateway_states(gateway_id) ON DELETE CASCADE,
+				processed_timestamp  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				originated_timestamp TIMESTAMP NOT NULL,
+				entity_type          TEXT      NOT NULL,
+				action               TEXT      NOT NULL CHECK (action IN ('CREATE', 'UPDATE', 'DELETE')),
+				entity_id            TEXT      NOT NULL,
+				event_data           TEXT      NOT NULL
+			);
+
+			CREATE INDEX IF NOT EXISTS idx_eventhub_events_gateway_ts
+				ON eventhub_events(gateway_id, processed_timestamp);
+		`).Error
+	},
+}

--- a/agent-manager-service/db_migrations/021_add_eventhub_tables.go
+++ b/agent-manager-service/db_migrations/021_add_eventhub_tables.go
@@ -34,7 +34,7 @@ var migration021 = migration{
 				processed_timestamp  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 				originated_timestamp TIMESTAMP NOT NULL,
 				entity_type          TEXT      NOT NULL,
-				action               TEXT      NOT NULL CHECK (action IN ('CREATE', 'UPDATE', 'DELETE')),
+				action               TEXT      NOT NULL,
 				entity_id            TEXT      NOT NULL,
 				event_data           TEXT      NOT NULL
 			);

--- a/agent-manager-service/db_migrations/migration_list.go
+++ b/agent-manager-service/db_migrations/migration_list.go
@@ -16,7 +16,7 @@
 
 package dbmigrations
 
-const latestVersion = 20
+const latestVersion = 21
 
 // migration list sorted by version.  Add new migrations to the end of the list.
 // Previous migrations should not be modified.
@@ -41,4 +41,5 @@ var migrations = []migration{
 	migration018,
 	migration019,
 	migration020,
+	migration021,
 }

--- a/agent-manager-service/eventhub/sqlbackend.go
+++ b/agent-manager-service/eventhub/sqlbackend.go
@@ -19,6 +19,7 @@ package eventhub
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -133,7 +134,7 @@ func (b *SQLBackend) closeStatements() {
 		b.cleanupEventsStmt,
 	} {
 		if stmt != nil {
-			stmt.Close()
+			_ = stmt.Close()
 		}
 	}
 }
@@ -237,7 +238,7 @@ func (b *SQLBackend) RegisterGateway(gatewayID string) error {
 		return fmt.Errorf("failed to register gateway: %w", err)
 	}
 
-	if regErr := b.registry.register(gatewayID); regErr != nil && regErr != ErrGatewayAlreadyExists {
+	if regErr := b.registry.register(gatewayID); regErr != nil && !errors.Is(regErr, ErrGatewayAlreadyExists) {
 		return fmt.Errorf("failed to register gateway in registry: %w", regErr)
 	}
 
@@ -264,7 +265,7 @@ func (b *SQLBackend) PublishEvent(gatewayID string, event Event) error {
 	}
 	defer func() {
 		if err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 		}
 	}()
 
@@ -287,7 +288,7 @@ func (b *SQLBackend) PublishEvent(gatewayID string, event Event) error {
 	)
 	if err != nil {
 		insertErr := err
-		if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
 			return fmt.Errorf("failed to rollback after insert failure: %w", rollbackErr)
 		}
 		err = nil
@@ -439,7 +440,7 @@ func (b *SQLBackend) getGatewayStatesPage(cursor string, limit int) ([]GatewaySt
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to query gateway states page: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	states := make([]GatewayState, 0, limit)
 	nextCursor := ""
@@ -488,7 +489,7 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 	if err != nil {
 		return fmt.Errorf("failed to query events: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var events []Event
 	for rows.Next() {

--- a/agent-manager-service/eventhub/sqlbackend.go
+++ b/agent-manager-service/eventhub/sqlbackend.go
@@ -30,7 +30,6 @@ import (
 )
 
 const (
-	initialPollSkewWindow       = 120 * time.Second
 	defaultGatewayStatePageSize = 200
 
 	unixMillisThreshold = int64(100_000_000_000)
@@ -220,9 +219,9 @@ func (b *SQLBackend) Initialize() error {
 	go b.cleanupLoop()
 
 	b.logger.Info("EventHub initialized",
-		slog.Duration("poll_interval", b.config.PollInterval),
-		slog.Duration("cleanup_interval", b.config.CleanupInterval),
-		slog.Duration("retention_period", b.config.RetentionPeriod))
+		slog.String("poll_interval", b.config.PollInterval.String()),
+		slog.String("cleanup_interval", b.config.CleanupInterval.String()),
+		slog.String("retention_period", b.config.RetentionPeriod.String()))
 
 	return nil
 }
@@ -319,11 +318,11 @@ func (b *SQLBackend) PublishEvent(gatewayID string, event Event) error {
 		return fmt.Errorf("failed to commit event publish: %w", err)
 	}
 
-	b.logger.Debug("Event published",
+	b.logger.Info("Event published to EventHub",
 		slog.String("gateway_id", gatewayID),
 		slog.String("event_type", string(event.EventType)),
 		slog.String("action", event.Action),
-		slog.String("entity_id", event.EntityID))
+		slog.String("event_id", eventID))
 
 	return nil
 }
@@ -481,9 +480,10 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 	resumingFromLastPolled := lastPolled > 0
 	if lastPolled > 0 {
 		lastPolledTime = unixTimestampToTime(lastPolled)
-	} else {
-		lastPolledTime = time.Now().Add(-initialPollSkewWindow)
 	}
+	// lastPolled == 0: no event has ever been delivered to this gateway.
+	// Leave lastPolledTime as zero so the query returns all stored events.
+	// The 120s skew window only applies when resuming from a known position.
 
 	rows, err := b.getEventsStmt.Query(gw.id, lastPolledTime)
 	if err != nil {
@@ -516,29 +516,53 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 
 	events = trimSingleBoundaryReplay(events, lastPolledTime, resumingFromLastPolled)
 
-	// Snapshot subscribers under the lock so we don't hold it during channel sends.
-	b.registry.mu.RLock()
-	subscribers := make([]chan Event, len(gw.subscribers))
-	copy(subscribers, gw.subscribers)
-	b.registry.mu.RUnlock()
+	// On catch-up (no prior delivery to this gateway), filter events to current
+	// desired state: skip API key events (gateway bulk-syncs those on reconnect)
+	// and deduplicate the rest by entity_id keeping only the latest per entity.
+	if !resumingFromLastPolled {
+		events = deduplicateLatestPerEntity(events)
+	}
 
+	// Hold the read lock across all channel sends so that Unsubscribe/UnsubscribeAll
+	// (which need the write lock) cannot close a channel while a send is in flight.
+	b.registry.mu.RLock()
+
+	if len(gw.subscribers) == 0 {
+		shouldLog := len(events) > 0 && gw.queuedLoggedAt == 0
+		if shouldLog {
+			gw.queuedLoggedAt = time.Now().UnixNano()
+		}
+		b.registry.mu.RUnlock()
+		if shouldLog {
+			b.logger.Info("Gateway disconnected with pending events, waiting for reconnect",
+				slog.String("gateway_id", gw.id),
+				slog.Int("queued_event_count", len(events)))
+		}
+		return nil
+	}
+	// Subscriber present — clear the queued flag so it fires again after the next disconnect.
+	gw.queuedLoggedAt = 0
+
+	subscriberCount := len(gw.subscribers)
 	var latestDeliveredTimestamp time.Time
 	deliveredCount := 0
 	deliveryBlocked := false
 	for _, evt := range events {
-		if !subscriberChannelsAvailable(subscribers) {
+		if !subscriberChannelsAvailable(gw.subscribers) {
 			deliveryBlocked = true
 			b.logger.Warn("Subscriber channel full, deferring event delivery",
 				slog.String("gateway_id", gw.id),
 				slog.String("entity_id", evt.EntityID))
 			break
 		}
-		for _, ch := range subscribers {
+		for _, ch := range gw.subscribers {
 			ch <- evt
 		}
 		latestDeliveredTimestamp = evt.ProcessedTimestamp
 		deliveredCount++
 	}
+
+	b.registry.mu.RUnlock()
 
 	b.registry.mu.Lock()
 	if deliveryBlocked {
@@ -556,13 +580,51 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 	b.registry.mu.Unlock()
 
 	if deliveredCount > 0 {
-		b.logger.Debug("Delivered events to gateway subscribers",
+		catchUp := knownVersion == ""
+		b.logger.Info("Delivered events to gateway subscribers",
 			slog.String("gateway_id", gw.id),
 			slog.Int("event_count", deliveredCount),
-			slog.Int("subscriber_count", len(subscribers)))
+			slog.Int("subscriber_count", subscriberCount),
+			slog.Bool("catch_up", catchUp))
 	}
 
 	return nil
+}
+
+// apiKeySyncEventTypes lists event types the gateway reconciles via bulk-sync on
+// reconnect. These are skipped during catch-up replay to avoid replaying stale
+// individual key operations that are already reflected in the bulk-sync response.
+var apiKeySyncEventTypes = map[string]bool{
+	"apikey.created": true,
+	"apikey.revoked": true,
+	"apikey.updated": true,
+}
+
+// deduplicateLatestPerEntity filters a catch-up event list to current desired
+// state: skips API key events (covered by bulk-sync) and keeps only the most
+// recent event per entity_id for all other event types. Input must be ordered
+// by processed_timestamp ASC; the last entry per entity_id wins.
+func deduplicateLatestPerEntity(events []Event) []Event {
+	latest := make(map[string]int, len(events))
+	for i, evt := range events {
+		if apiKeySyncEventTypes[string(evt.EventType)] {
+			continue
+		}
+		latest[evt.EntityID] = i
+	}
+	if len(latest) == 0 {
+		return nil
+	}
+	result := make([]Event, 0, len(latest))
+	for i, evt := range events {
+		if apiKeySyncEventTypes[string(evt.EventType)] {
+			continue
+		}
+		if latest[evt.EntityID] == i {
+			result = append(result, evt)
+		}
+	}
+	return result
 }
 
 // trimSingleBoundaryReplay drops the single boundary event that was already

--- a/agent-manager-service/eventhub/sqlbackend.go
+++ b/agent-manager-service/eventhub/sqlbackend.go
@@ -31,10 +31,6 @@ import (
 
 const (
 	defaultGatewayStatePageSize = 200
-
-	unixMillisThreshold = int64(100_000_000_000)
-	unixMicrosThreshold = int64(100_000_000_000_000)
-	unixNanosThreshold  = int64(100_000_000_000_000_000)
 )
 
 // SQLBackendConfig holds configuration for the SQL backend
@@ -69,7 +65,8 @@ type SQLBackend struct {
 	upsertGatewayStmt        *sql.Stmt
 	getGatewayStateStmt      *sql.Stmt
 	getGatewayStatesPageStmt *sql.Stmt
-	getEventsStmt            *sql.Stmt
+	getEventsStmt            *sql.Stmt // cold start: all events for a gateway
+	getEventsAfterCursorStmt *sql.Stmt // resume: (processed_timestamp, event_id) > (?, ?)
 	getEventByIDStmt         *sql.Stmt
 	cleanupEventsStmt        *sql.Stmt
 
@@ -79,19 +76,6 @@ type SQLBackend struct {
 }
 
 var _ EventHub = (*SQLBackend)(nil)
-
-func unixTimestampToTime(ts int64) time.Time {
-	switch {
-	case ts >= unixNanosThreshold:
-		return time.Unix(0, ts)
-	case ts >= unixMicrosThreshold:
-		return time.UnixMicro(ts)
-	case ts >= unixMillisThreshold:
-		return time.UnixMilli(ts)
-	default:
-		return time.Unix(ts, 0)
-	}
-}
 
 // NewSQLBackend creates a new SQL-backed EventHub for PostgreSQL.
 func NewSQLBackend(db *sql.DB, logger *slog.Logger, config SQLBackendConfig) *SQLBackend {
@@ -129,6 +113,7 @@ func (b *SQLBackend) closeStatements() {
 		b.getGatewayStateStmt,
 		b.getGatewayStatesPageStmt,
 		b.getEventsStmt,
+		b.getEventsAfterCursorStmt,
 		b.getEventByIDStmt,
 		b.cleanupEventsStmt,
 	} {
@@ -187,10 +172,19 @@ func (b *SQLBackend) prepareStatements() (err error) {
 	b.getEventsStmt, err = b.db.Prepare(rebind(`
 		SELECT gateway_id, processed_timestamp, originated_timestamp, entity_type, action, entity_id, event_id, event_data
 		FROM eventhub_events
-		WHERE gateway_id = ? AND processed_timestamp >= ?
-		ORDER BY processed_timestamp ASC`))
+		WHERE gateway_id = ?
+		ORDER BY processed_timestamp ASC, event_id ASC`))
 	if err != nil {
 		return fmt.Errorf("prepare get events: %w", err)
+	}
+
+	b.getEventsAfterCursorStmt, err = b.db.Prepare(rebind(`
+		SELECT gateway_id, processed_timestamp, originated_timestamp, entity_type, action, entity_id, event_id, event_data
+		FROM eventhub_events
+		WHERE gateway_id = ? AND (processed_timestamp, event_id) > (?, ?)
+		ORDER BY processed_timestamp ASC, event_id ASC`))
+	if err != nil {
+		return fmt.Errorf("prepare get events after cursor: %w", err)
 	}
 
 	b.getEventByIDStmt, err = b.db.Prepare(rebind(`
@@ -214,6 +208,16 @@ func (b *SQLBackend) Initialize() error {
 		return fmt.Errorf("failed to prepare statements: %w", err)
 	}
 
+	if b.config.PollInterval <= 0 {
+		return fmt.Errorf("invalid config: poll_interval must be > 0, got %s", b.config.PollInterval)
+	}
+	if b.config.CleanupInterval <= 0 {
+		return fmt.Errorf("invalid config: cleanup_interval must be > 0, got %s", b.config.CleanupInterval)
+	}
+	if b.config.RetentionPeriod <= 0 {
+		return fmt.Errorf("invalid config: retention_period must be > 0, got %s", b.config.RetentionPeriod)
+	}
+
 	b.wg.Add(2)
 	go b.pollLoop()
 	go b.cleanupLoop()
@@ -226,11 +230,20 @@ func (b *SQLBackend) Initialize() error {
 	return nil
 }
 
-// RegisterGateway registers a new gateway for event tracking.
-func (b *SQLBackend) RegisterGateway(gatewayID string) error {
+// normalizeGatewayID trims whitespace and returns an error if the result is empty.
+func normalizeGatewayID(gatewayID string) (string, error) {
 	gatewayID = strings.TrimSpace(gatewayID)
 	if gatewayID == "" {
-		return fmt.Errorf("gateway_id cannot be empty")
+		return "", fmt.Errorf("gateway_id cannot be empty")
+	}
+	return gatewayID, nil
+}
+
+// RegisterGateway registers a new gateway for event tracking.
+func (b *SQLBackend) RegisterGateway(gatewayID string) error {
+	var err error
+	if gatewayID, err = normalizeGatewayID(gatewayID); err != nil {
+		return err
 	}
 
 	if _, err := b.upsertGatewayStmt.Exec(gatewayID); err != nil {
@@ -247,6 +260,10 @@ func (b *SQLBackend) RegisterGateway(gatewayID string) error {
 
 // PublishEvent publishes an event atomically (insert event + bump gateway version).
 func (b *SQLBackend) PublishEvent(gatewayID string, event Event) error {
+	var err error
+	if gatewayID, err = normalizeGatewayID(gatewayID); err != nil {
+		return err
+	}
 	newVersion := uuid.New().String()
 	eventData := strings.TrimSpace(event.EventData)
 	if eventData == "" {
@@ -341,6 +358,10 @@ func (b *SQLBackend) eventExists(eventID string) (bool, error) {
 
 // Subscribe subscribes to events for a gateway.
 func (b *SQLBackend) Subscribe(gatewayID string) (<-chan Event, error) {
+	var err error
+	if gatewayID, err = normalizeGatewayID(gatewayID); err != nil {
+		return nil, err
+	}
 	ch := make(chan Event, 100)
 	if err := b.registry.addSubscriber(gatewayID, ch); err != nil {
 		close(ch)
@@ -352,6 +373,10 @@ func (b *SQLBackend) Subscribe(gatewayID string) (<-chan Event, error) {
 
 // Unsubscribe removes a specific subscription for a gateway.
 func (b *SQLBackend) Unsubscribe(gatewayID string, subscriber <-chan Event) error {
+	var err error
+	if gatewayID, err = normalizeGatewayID(gatewayID); err != nil {
+		return err
+	}
 	ch, err := b.registry.removeSubscriber(gatewayID, subscriber)
 	if err != nil {
 		return fmt.Errorf("failed to unsubscribe from gateway %s: %w", gatewayID, err)
@@ -363,6 +388,10 @@ func (b *SQLBackend) Unsubscribe(gatewayID string, subscriber <-chan Event) erro
 
 // UnsubscribeAll removes all subscriptions for a gateway.
 func (b *SQLBackend) UnsubscribeAll(gatewayID string) error {
+	var err error
+	if gatewayID, err = normalizeGatewayID(gatewayID); err != nil {
+		return err
+	}
 	subscribers, err := b.registry.removeAllSubscribers(gatewayID)
 	if err != nil {
 		return fmt.Errorf("failed to unsubscribe all for gateway %s: %w", gatewayID, err)
@@ -389,12 +418,17 @@ func (b *SQLBackend) pollLoop() {
 }
 
 func (b *SQLBackend) pollGateways() {
-	gatewayByID := make(map[string]*gateway)
-	for _, gw := range b.registry.getAll() {
-		gatewayByID[gw.id] = gw
-	}
-	if len(gatewayByID) == 0 {
+	// Snapshot gateway IDs under the lock; do not retain pointers outside it.
+	var gatewayIDs []string
+	b.registry.forEach(func(gw *gateway) {
+		gatewayIDs = append(gatewayIDs, gw.id)
+	})
+	if len(gatewayIDs) == 0 {
 		return
+	}
+	gatewayByID := make(map[string]struct{}, len(gatewayIDs))
+	for _, id := range gatewayIDs {
+		gatewayByID[id] = struct{}{}
 	}
 
 	pageSize := b.config.GatewayStatePageSize
@@ -416,13 +450,18 @@ func (b *SQLBackend) pollGateways() {
 		}
 
 		for _, state := range states {
-			gw, ok := gatewayByID[state.GatewayID]
-			if !ok {
+			if _, ok := gatewayByID[state.GatewayID]; !ok {
+				continue
+			}
+			b.registry.mu.RLock()
+			gw := b.registry.get(state.GatewayID)
+			b.registry.mu.RUnlock()
+			if gw == nil {
 				continue
 			}
 			if err := b.pollGatewayWithState(gw, state); err != nil {
 				b.logger.Warn("Failed to poll gateway",
-					slog.String("gateway_id", gw.id),
+					slog.String("gateway_id", state.GatewayID),
 					slog.Any("error", err))
 			}
 		}
@@ -469,23 +508,26 @@ func subscriberChannelsAvailable(subscribers []chan Event) bool {
 func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error {
 	b.registry.mu.RLock()
 	knownVersion := gw.knownVersion
-	lastPolled := gw.lastPolled
+	lastPolledTime := gw.lastPolledTime
+	lastPolledEventID := gw.lastPolledEventID
 	b.registry.mu.RUnlock()
 
 	if state.VersionID == knownVersion || state.VersionID == "" {
 		return nil
 	}
 
-	var lastPolledTime time.Time
-	resumingFromLastPolled := lastPolled > 0
-	if lastPolled > 0 {
-		lastPolledTime = unixTimestampToTime(lastPolled)
+	// Choose query based on whether a delivery cursor exists.
+	// Cold start (lastPolledTime.IsZero()): fetch all events for the gateway.
+	// Resume: use composite (processed_timestamp, event_id) > (?, ?) so events
+	// sharing a timestamp do not replay — event_id is the stable tie-breaker.
+	var rows *sql.Rows
+	var err error
+	resuming := !lastPolledTime.IsZero()
+	if resuming {
+		rows, err = b.getEventsAfterCursorStmt.Query(gw.id, lastPolledTime, lastPolledEventID)
+	} else {
+		rows, err = b.getEventsStmt.Query(gw.id)
 	}
-	// lastPolled == 0: no event has ever been delivered to this gateway.
-	// Leave lastPolledTime as zero so the query returns all stored events.
-	// The 120s skew window only applies when resuming from a known position.
-
-	rows, err := b.getEventsStmt.Query(gw.id, lastPolledTime)
 	if err != nil {
 		return fmt.Errorf("failed to query events: %w", err)
 	}
@@ -514,12 +556,10 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 		return fmt.Errorf("error iterating event rows: %w", err)
 	}
 
-	events = trimSingleBoundaryReplay(events, lastPolledTime, resumingFromLastPolled)
-
-	// On catch-up (no prior delivery to this gateway), filter events to current
-	// desired state: skip API key events (gateway bulk-syncs those on reconnect)
-	// and deduplicate the rest by entity_id keeping only the latest per entity.
-	if !resumingFromLastPolled {
+	// On cold start, filter to current desired state: skip API key events
+	// (gateway bulk-syncs those on reconnect) and keep only the latest event
+	// per entity_id for all other types.
+	if !resuming {
 		events = deduplicateLatestPerEntity(events)
 	}
 
@@ -544,21 +584,21 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 	gw.queuedLoggedAt = 0
 
 	subscriberCount := len(gw.subscribers)
-	var latestDeliveredTimestamp time.Time
+	var lastDelivered *Event
 	deliveredCount := 0
 	deliveryBlocked := false
-	for _, evt := range events {
+	for i := range events {
 		if !subscriberChannelsAvailable(gw.subscribers) {
 			deliveryBlocked = true
 			b.logger.Warn("Subscriber channel full, deferring event delivery",
 				slog.String("gateway_id", gw.id),
-				slog.String("entity_id", evt.EntityID))
+				slog.String("entity_id", events[i].EntityID))
 			break
 		}
 		for _, ch := range gw.subscribers {
-			ch <- evt
+			ch <- events[i]
 		}
-		latestDeliveredTimestamp = evt.ProcessedTimestamp
+		lastDelivered = &events[i]
 		deliveredCount++
 	}
 
@@ -566,15 +606,17 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 
 	b.registry.mu.Lock()
 	if deliveryBlocked {
-		if !latestDeliveredTimestamp.IsZero() {
-			gw.lastPolled = latestDeliveredTimestamp.UnixNano()
+		if lastDelivered != nil {
+			gw.lastPolledTime = lastDelivered.ProcessedTimestamp
+			gw.lastPolledEventID = lastDelivered.EventID
 		} else {
-			gw.lastPolled = lastPolledTime.UnixNano()
+			// Nothing delivered in this cycle; keep the existing cursor unchanged.
 		}
 	} else {
 		gw.knownVersion = state.VersionID
-		if !latestDeliveredTimestamp.IsZero() {
-			gw.lastPolled = latestDeliveredTimestamp.UnixNano()
+		if lastDelivered != nil {
+			gw.lastPolledTime = lastDelivered.ProcessedTimestamp
+			gw.lastPolledEventID = lastDelivered.EventID
 		}
 	}
 	b.registry.mu.Unlock()
@@ -627,18 +669,6 @@ func deduplicateLatestPerEntity(events []Event) []Event {
 	return result
 }
 
-// trimSingleBoundaryReplay drops the single boundary event that was already
-// delivered on the previous poll (the >= query re-fetches it).
-func trimSingleBoundaryReplay(events []Event, boundary time.Time, enabled bool) []Event {
-	if !enabled || len(events) == 0 || !events[0].ProcessedTimestamp.Equal(boundary) {
-		return events
-	}
-	if len(events) == 1 || !events[1].ProcessedTimestamp.Equal(boundary) {
-		return events[1:]
-	}
-	return events
-}
-
 func (b *SQLBackend) cleanupLoop() {
 	defer b.wg.Done()
 	ticker := time.NewTicker(b.config.CleanupInterval)
@@ -673,14 +703,14 @@ func (b *SQLBackend) Close() error {
 	b.cancel()
 	b.wg.Wait()
 
-	for _, gw := range b.registry.getAll() {
-		b.registry.mu.Lock()
+	b.registry.mu.Lock()
+	for _, gw := range b.registry.gateways {
 		for _, ch := range gw.subscribers {
 			close(ch)
 		}
 		gw.subscribers = nil
-		b.registry.mu.Unlock()
 	}
+	b.registry.mu.Unlock()
 
 	b.stmtMu.Lock()
 	defer b.stmtMu.Unlock()

--- a/agent-manager-service/eventhub/sqlbackend.go
+++ b/agent-manager-service/eventhub/sqlbackend.go
@@ -609,9 +609,8 @@ func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error
 		if lastDelivered != nil {
 			gw.lastPolledTime = lastDelivered.ProcessedTimestamp
 			gw.lastPolledEventID = lastDelivered.EventID
-		} else {
-			// Nothing delivered in this cycle; keep the existing cursor unchanged.
 		}
+		// else: nothing delivered this cycle; cursor unchanged.
 	} else {
 		gw.knownVersion = state.VersionID
 		if lastDelivered != nil {

--- a/agent-manager-service/eventhub/sqlbackend.go
+++ b/agent-manager-service/eventhub/sqlbackend.go
@@ -1,0 +1,628 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eventhub
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	initialPollSkewWindow       = 120 * time.Second
+	defaultGatewayStatePageSize = 200
+
+	unixMillisThreshold = int64(100_000_000_000)
+	unixMicrosThreshold = int64(100_000_000_000_000)
+	unixNanosThreshold  = int64(100_000_000_000_000_000)
+)
+
+// SQLBackendConfig holds configuration for the SQL backend
+type SQLBackendConfig struct {
+	PollInterval         time.Duration
+	CleanupInterval      time.Duration
+	RetentionPeriod      time.Duration
+	GatewayStatePageSize int
+}
+
+// DefaultSQLBackendConfig returns a SQLBackendConfig with sensible defaults
+func DefaultSQLBackendConfig() SQLBackendConfig {
+	return SQLBackendConfig{
+		PollInterval:         2 * time.Second,
+		CleanupInterval:      5 * time.Minute,
+		RetentionPeriod:      1 * time.Hour,
+		GatewayStatePageSize: defaultGatewayStatePageSize,
+	}
+}
+
+// SQLBackend implements EventHub using SQL polling over PostgreSQL.
+type SQLBackend struct {
+	db     *sql.DB
+	logger *slog.Logger
+	config SQLBackendConfig
+
+	registry *gatewayRegistry
+
+	stmtMu                   sync.RWMutex
+	insertEventStmt          *sql.Stmt
+	updateGatewayVersionStmt *sql.Stmt
+	upsertGatewayStmt        *sql.Stmt
+	getGatewayStateStmt      *sql.Stmt
+	getGatewayStatesPageStmt *sql.Stmt
+	getEventsStmt            *sql.Stmt
+	getEventByIDStmt         *sql.Stmt
+	cleanupEventsStmt        *sql.Stmt
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+var _ EventHub = (*SQLBackend)(nil)
+
+func unixTimestampToTime(ts int64) time.Time {
+	switch {
+	case ts >= unixNanosThreshold:
+		return time.Unix(0, ts)
+	case ts >= unixMicrosThreshold:
+		return time.UnixMicro(ts)
+	case ts >= unixMillisThreshold:
+		return time.UnixMilli(ts)
+	default:
+		return time.Unix(ts, 0)
+	}
+}
+
+// NewSQLBackend creates a new SQL-backed EventHub for PostgreSQL.
+func NewSQLBackend(db *sql.DB, logger *slog.Logger, config SQLBackendConfig) *SQLBackend {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &SQLBackend{
+		db:       db,
+		logger:   logger,
+		config:   config,
+		registry: newGatewayRegistry(),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+// rebind replaces ? placeholders with $1, $2, ... for PostgreSQL.
+func rebind(query string) string {
+	var buf strings.Builder
+	n := 1
+	for i := 0; i < len(query); i++ {
+		if query[i] == '?' {
+			fmt.Fprintf(&buf, "$%d", n)
+			n++
+		} else {
+			buf.WriteByte(query[i])
+		}
+	}
+	return buf.String()
+}
+
+func (b *SQLBackend) closeStatements() {
+	for _, stmt := range []*sql.Stmt{
+		b.insertEventStmt,
+		b.updateGatewayVersionStmt,
+		b.upsertGatewayStmt,
+		b.getGatewayStateStmt,
+		b.getGatewayStatesPageStmt,
+		b.getEventsStmt,
+		b.getEventByIDStmt,
+		b.cleanupEventsStmt,
+	} {
+		if stmt != nil {
+			stmt.Close()
+		}
+	}
+}
+
+func (b *SQLBackend) prepareStatements() (err error) {
+	defer func() {
+		if err != nil {
+			b.closeStatements()
+		}
+	}()
+
+	b.insertEventStmt, err = b.db.Prepare(rebind(`
+		INSERT INTO eventhub_events (gateway_id, processed_timestamp, originated_timestamp, entity_type, action, entity_id, event_id, event_data)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`))
+	if err != nil {
+		return fmt.Errorf("prepare insert event: %w", err)
+	}
+
+	b.updateGatewayVersionStmt, err = b.db.Prepare(rebind(`
+		UPDATE eventhub_gateway_states SET version_id = ?, updated_at = CURRENT_TIMESTAMP WHERE gateway_id = ?`))
+	if err != nil {
+		return fmt.Errorf("prepare update gateway version: %w", err)
+	}
+
+	// upsertGatewayStmt ensures the gateway row exists before inserting an event.
+	// ON CONFLICT DO NOTHING is safe: if the row already exists we leave version_id
+	// untouched; the subsequent UPDATE will bump it.
+	b.upsertGatewayStmt, err = b.db.Prepare(rebind(`
+		INSERT INTO eventhub_gateway_states (gateway_id, version_id) VALUES (?, '')
+		ON CONFLICT (gateway_id) DO NOTHING`))
+	if err != nil {
+		return fmt.Errorf("prepare upsert gateway: %w", err)
+	}
+
+	b.getGatewayStateStmt, err = b.db.Prepare(rebind(`
+		SELECT gateway_id, version_id, updated_at FROM eventhub_gateway_states WHERE gateway_id = ?`))
+	if err != nil {
+		return fmt.Errorf("prepare get gateway state: %w", err)
+	}
+
+	b.getGatewayStatesPageStmt, err = b.db.Prepare(rebind(`
+		SELECT gateway_id, version_id, updated_at
+		FROM eventhub_gateway_states
+		WHERE gateway_id > ?
+		ORDER BY gateway_id ASC
+		LIMIT ?`))
+	if err != nil {
+		return fmt.Errorf("prepare get gateway states page: %w", err)
+	}
+
+	b.getEventsStmt, err = b.db.Prepare(rebind(`
+		SELECT gateway_id, processed_timestamp, originated_timestamp, entity_type, action, entity_id, event_id, event_data
+		FROM eventhub_events
+		WHERE gateway_id = ? AND processed_timestamp >= ?
+		ORDER BY processed_timestamp ASC`))
+	if err != nil {
+		return fmt.Errorf("prepare get events: %w", err)
+	}
+
+	b.getEventByIDStmt, err = b.db.Prepare(rebind(`
+		SELECT event_id FROM eventhub_events WHERE event_id = ?`))
+	if err != nil {
+		return fmt.Errorf("prepare get event by ID: %w", err)
+	}
+
+	b.cleanupEventsStmt, err = b.db.Prepare(rebind(`
+		DELETE FROM eventhub_events WHERE processed_timestamp < ?`))
+	if err != nil {
+		return fmt.Errorf("prepare cleanup events: %w", err)
+	}
+
+	return nil
+}
+
+// Initialize prepares statements and starts background goroutines.
+func (b *SQLBackend) Initialize() error {
+	if err := b.prepareStatements(); err != nil {
+		return fmt.Errorf("failed to prepare statements: %w", err)
+	}
+
+	b.wg.Add(2)
+	go b.pollLoop()
+	go b.cleanupLoop()
+
+	b.logger.Info("EventHub initialized",
+		slog.Duration("poll_interval", b.config.PollInterval),
+		slog.Duration("cleanup_interval", b.config.CleanupInterval),
+		slog.Duration("retention_period", b.config.RetentionPeriod))
+
+	return nil
+}
+
+// RegisterGateway registers a new gateway for event tracking.
+func (b *SQLBackend) RegisterGateway(gatewayID string) error {
+	gatewayID = strings.TrimSpace(gatewayID)
+	if gatewayID == "" {
+		return fmt.Errorf("gateway_id cannot be empty")
+	}
+
+	if _, err := b.upsertGatewayStmt.Exec(gatewayID); err != nil {
+		return fmt.Errorf("failed to register gateway: %w", err)
+	}
+
+	if regErr := b.registry.register(gatewayID); regErr != nil && regErr != ErrGatewayAlreadyExists {
+		return fmt.Errorf("failed to register gateway in registry: %w", regErr)
+	}
+
+	b.logger.Info("Gateway registered for event tracking", slog.String("gateway_id", gatewayID))
+	return nil
+}
+
+// PublishEvent publishes an event atomically (insert event + bump gateway version).
+func (b *SQLBackend) PublishEvent(gatewayID string, event Event) error {
+	newVersion := uuid.New().String()
+	eventData := strings.TrimSpace(event.EventData)
+	if eventData == "" {
+		eventData = EmptyEventData
+	}
+	eventID := strings.TrimSpace(event.EventID)
+	if eventID == "" {
+		event.EventID = uuid.New().String()
+		eventID = event.EventID
+	}
+
+	tx, err := b.db.BeginTx(b.ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+		}
+	}()
+
+	// Ensure the gateway row exists. This handles gateways that existed before
+	// the EventHub was introduced and gateways that publish events before their
+	// first WebSocket connection (e.g. API key provisioning at agent creation).
+	if _, err = tx.Stmt(b.upsertGatewayStmt).Exec(gatewayID); err != nil {
+		return fmt.Errorf("failed to ensure gateway registered: %w", err)
+	}
+
+	_, err = tx.Stmt(b.insertEventStmt).Exec(
+		gatewayID,
+		time.Now(),
+		event.OriginatedTimestamp,
+		string(event.EventType),
+		event.Action,
+		event.EntityID,
+		eventID,
+		eventData,
+	)
+	if err != nil {
+		insertErr := err
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+			return fmt.Errorf("failed to rollback after insert failure: %w", rollbackErr)
+		}
+		err = nil
+
+		exists, checkErr := b.eventExists(eventID)
+		if checkErr != nil {
+			return fmt.Errorf("failed to check event existence after insert failure: %w", checkErr)
+		}
+		if exists {
+			b.logger.Info("Duplicate event, skipping publish",
+				slog.String("gateway_id", gatewayID),
+				slog.String("event_id", eventID))
+			return nil
+		}
+		return fmt.Errorf("failed to insert event: %w", insertErr)
+	}
+
+	result, err := tx.Stmt(b.updateGatewayVersionStmt).Exec(newVersion, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to update gateway version: %w", err)
+	}
+	if rows, _ := result.RowsAffected(); rows == 0 {
+		err = fmt.Errorf("gateway %q is not registered", gatewayID)
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit event publish: %w", err)
+	}
+
+	b.logger.Debug("Event published",
+		slog.String("gateway_id", gatewayID),
+		slog.String("event_type", string(event.EventType)),
+		slog.String("action", event.Action),
+		slog.String("entity_id", event.EntityID))
+
+	return nil
+}
+
+func (b *SQLBackend) eventExists(eventID string) (bool, error) {
+	var id string
+	err := b.getEventByIDStmt.QueryRow(eventID).Scan(&id)
+	if err == nil {
+		return true, nil
+	}
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return false, err
+}
+
+// Subscribe subscribes to events for a gateway.
+func (b *SQLBackend) Subscribe(gatewayID string) (<-chan Event, error) {
+	ch := make(chan Event, 100)
+	if err := b.registry.addSubscriber(gatewayID, ch); err != nil {
+		close(ch)
+		return nil, fmt.Errorf("failed to subscribe to gateway %s: %w", gatewayID, err)
+	}
+	b.logger.Info("Subscribed to gateway events", slog.String("gateway_id", gatewayID))
+	return ch, nil
+}
+
+// Unsubscribe removes a specific subscription for a gateway.
+func (b *SQLBackend) Unsubscribe(gatewayID string, subscriber <-chan Event) error {
+	ch, err := b.registry.removeSubscriber(gatewayID, subscriber)
+	if err != nil {
+		return fmt.Errorf("failed to unsubscribe from gateway %s: %w", gatewayID, err)
+	}
+	close(ch)
+	b.logger.Info("Unsubscribed from gateway events", slog.String("gateway_id", gatewayID))
+	return nil
+}
+
+// UnsubscribeAll removes all subscriptions for a gateway.
+func (b *SQLBackend) UnsubscribeAll(gatewayID string) error {
+	subscribers, err := b.registry.removeAllSubscribers(gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to unsubscribe all for gateway %s: %w", gatewayID, err)
+	}
+	for _, ch := range subscribers {
+		close(ch)
+	}
+	b.logger.Info("Unsubscribed all gateway events", slog.String("gateway_id", gatewayID))
+	return nil
+}
+
+func (b *SQLBackend) pollLoop() {
+	defer b.wg.Done()
+	ticker := time.NewTicker(b.config.PollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-ticker.C:
+			b.pollGateways()
+		}
+	}
+}
+
+func (b *SQLBackend) pollGateways() {
+	gatewayByID := make(map[string]*gateway)
+	for _, gw := range b.registry.getAll() {
+		gatewayByID[gw.id] = gw
+	}
+	if len(gatewayByID) == 0 {
+		return
+	}
+
+	pageSize := b.config.GatewayStatePageSize
+	if pageSize <= 0 {
+		pageSize = defaultGatewayStatePageSize
+	}
+
+	cursor := ""
+	for {
+		states, nextCursor, err := b.getGatewayStatesPage(cursor, pageSize)
+		if err != nil {
+			b.logger.Warn("Failed to poll gateway states page",
+				slog.String("cursor", cursor),
+				slog.Any("error", err))
+			return
+		}
+		if len(states) == 0 {
+			return
+		}
+
+		for _, state := range states {
+			gw, ok := gatewayByID[state.GatewayID]
+			if !ok {
+				continue
+			}
+			if err := b.pollGatewayWithState(gw, state); err != nil {
+				b.logger.Warn("Failed to poll gateway",
+					slog.String("gateway_id", gw.id),
+					slog.Any("error", err))
+			}
+		}
+
+		if len(states) < pageSize {
+			return
+		}
+		cursor = nextCursor
+	}
+}
+
+func (b *SQLBackend) getGatewayStatesPage(cursor string, limit int) ([]GatewayState, string, error) {
+	rows, err := b.getGatewayStatesPageStmt.Query(cursor, limit)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to query gateway states page: %w", err)
+	}
+	defer rows.Close()
+
+	states := make([]GatewayState, 0, limit)
+	nextCursor := ""
+	for rows.Next() {
+		var state GatewayState
+		if err := rows.Scan(&state.GatewayID, &state.VersionID, &state.UpdatedAt); err != nil {
+			return nil, "", fmt.Errorf("failed to scan gateway state row: %w", err)
+		}
+		states = append(states, state)
+		nextCursor = state.GatewayID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("error iterating gateway state rows: %w", err)
+	}
+	return states, nextCursor, nil
+}
+
+func subscriberChannelsAvailable(subscribers []chan Event) bool {
+	for _, ch := range subscribers {
+		if len(ch) == cap(ch) {
+			return false
+		}
+	}
+	return true
+}
+
+func (b *SQLBackend) pollGatewayWithState(gw *gateway, state GatewayState) error {
+	b.registry.mu.RLock()
+	knownVersion := gw.knownVersion
+	lastPolled := gw.lastPolled
+	b.registry.mu.RUnlock()
+
+	if state.VersionID == knownVersion || state.VersionID == "" {
+		return nil
+	}
+
+	var lastPolledTime time.Time
+	resumingFromLastPolled := lastPolled > 0
+	if lastPolled > 0 {
+		lastPolledTime = unixTimestampToTime(lastPolled)
+	} else {
+		lastPolledTime = time.Now().Add(-initialPollSkewWindow)
+	}
+
+	rows, err := b.getEventsStmt.Query(gw.id, lastPolledTime)
+	if err != nil {
+		return fmt.Errorf("failed to query events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []Event
+	for rows.Next() {
+		var evt Event
+		var eventType string
+		if err := rows.Scan(
+			&evt.GatewayID,
+			&evt.ProcessedTimestamp,
+			&evt.OriginatedTimestamp,
+			&eventType,
+			&evt.Action,
+			&evt.EntityID,
+			&evt.EventID,
+			&evt.EventData,
+		); err != nil {
+			return fmt.Errorf("failed to scan event row: %w", err)
+		}
+		evt.EventType = EventType(eventType)
+		events = append(events, evt)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating event rows: %w", err)
+	}
+
+	events = trimSingleBoundaryReplay(events, lastPolledTime, resumingFromLastPolled)
+
+	// Snapshot subscribers under the lock so we don't hold it during channel sends.
+	b.registry.mu.RLock()
+	subscribers := make([]chan Event, len(gw.subscribers))
+	copy(subscribers, gw.subscribers)
+	b.registry.mu.RUnlock()
+
+	var latestDeliveredTimestamp time.Time
+	deliveredCount := 0
+	deliveryBlocked := false
+	for _, evt := range events {
+		if !subscriberChannelsAvailable(subscribers) {
+			deliveryBlocked = true
+			b.logger.Warn("Subscriber channel full, deferring event delivery",
+				slog.String("gateway_id", gw.id),
+				slog.String("entity_id", evt.EntityID))
+			break
+		}
+		for _, ch := range subscribers {
+			ch <- evt
+		}
+		latestDeliveredTimestamp = evt.ProcessedTimestamp
+		deliveredCount++
+	}
+
+	b.registry.mu.Lock()
+	if deliveryBlocked {
+		if !latestDeliveredTimestamp.IsZero() {
+			gw.lastPolled = latestDeliveredTimestamp.UnixNano()
+		} else {
+			gw.lastPolled = lastPolledTime.UnixNano()
+		}
+	} else {
+		gw.knownVersion = state.VersionID
+		if !latestDeliveredTimestamp.IsZero() {
+			gw.lastPolled = latestDeliveredTimestamp.UnixNano()
+		}
+	}
+	b.registry.mu.Unlock()
+
+	if deliveredCount > 0 {
+		b.logger.Debug("Delivered events to gateway subscribers",
+			slog.String("gateway_id", gw.id),
+			slog.Int("event_count", deliveredCount),
+			slog.Int("subscriber_count", len(subscribers)))
+	}
+
+	return nil
+}
+
+// trimSingleBoundaryReplay drops the single boundary event that was already
+// delivered on the previous poll (the >= query re-fetches it).
+func trimSingleBoundaryReplay(events []Event, boundary time.Time, enabled bool) []Event {
+	if !enabled || len(events) == 0 || !events[0].ProcessedTimestamp.Equal(boundary) {
+		return events
+	}
+	if len(events) == 1 || !events[1].ProcessedTimestamp.Equal(boundary) {
+		return events[1:]
+	}
+	return events
+}
+
+func (b *SQLBackend) cleanupLoop() {
+	defer b.wg.Done()
+	ticker := time.NewTicker(b.config.CleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := b.CleanUpEvents(); err != nil {
+				b.logger.Warn("Failed to clean up events", slog.Any("error", err))
+			}
+		}
+	}
+}
+
+// CleanUpEvents removes events older than the retention period.
+func (b *SQLBackend) CleanUpEvents() error {
+	cutoff := time.Now().Add(-b.config.RetentionPeriod)
+	result, err := b.cleanupEventsStmt.Exec(cutoff)
+	if err != nil {
+		return fmt.Errorf("failed to clean up events: %w", err)
+	}
+	if affected, _ := result.RowsAffected(); affected > 0 {
+		b.logger.Info("Cleaned up old events", slog.Int64("deleted_count", affected))
+	}
+	return nil
+}
+
+// Close gracefully shuts down the backend.
+func (b *SQLBackend) Close() error {
+	b.cancel()
+	b.wg.Wait()
+
+	for _, gw := range b.registry.getAll() {
+		b.registry.mu.Lock()
+		for _, ch := range gw.subscribers {
+			close(ch)
+		}
+		gw.subscribers = nil
+		b.registry.mu.Unlock()
+	}
+
+	b.stmtMu.Lock()
+	defer b.stmtMu.Unlock()
+	b.closeStatements()
+
+	b.logger.Info("EventHub closed")
+	return nil
+}

--- a/agent-manager-service/eventhub/topic.go
+++ b/agent-manager-service/eventhub/topic.go
@@ -28,10 +28,11 @@ var (
 )
 
 type gateway struct {
-	id           string
-	subscribers  []chan Event
-	knownVersion string
-	lastPolled   int64
+	id             string
+	subscribers    []chan Event
+	knownVersion   string
+	lastPolled     int64
+	queuedLoggedAt int64 // unix nano of last "events queued, no subscribers" log; 0 = not yet logged
 }
 
 type gatewayRegistry struct {

--- a/agent-manager-service/eventhub/topic.go
+++ b/agent-manager-service/eventhub/topic.go
@@ -19,6 +19,7 @@ package eventhub
 import (
 	"errors"
 	"sync"
+	"time"
 )
 
 var (
@@ -28,11 +29,12 @@ var (
 )
 
 type gateway struct {
-	id             string
-	subscribers    []chan Event
-	knownVersion   string
-	lastPolled     int64
-	queuedLoggedAt int64 // unix nano of last "events queued, no subscribers" log; 0 = not yet logged
+	id                  string
+	subscribers         []chan Event
+	knownVersion        string
+	lastPolledTime      time.Time // zero means no event has been delivered yet
+	lastPolledEventID   string    // event_id of the last delivered event; used as tie-breaker
+	queuedLoggedAt      int64     // unix nano of last "events queued, no subscribers" log; 0 = not yet logged
 }
 
 type gatewayRegistry struct {
@@ -97,12 +99,19 @@ func (r *gatewayRegistry) removeAllSubscribers(gatewayID string) ([]chan Event, 
 	return subscribers, nil
 }
 
-func (r *gatewayRegistry) getAll() []*gateway {
+// forEach calls fn for each gateway while holding the read lock.
+// fn must not retain the *gateway pointer after it returns.
+func (r *gatewayRegistry) forEach(fn func(*gateway)) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	gateways := make([]*gateway, 0, len(r.gateways))
 	for _, gw := range r.gateways {
-		gateways = append(gateways, gw)
+		fn(gw)
 	}
-	return gateways
+}
+
+// get returns the gateway pointer for the given ID, or nil if not found.
+// The caller MUST hold r.mu (read or write) before calling and for the
+// duration of any access to fields on the returned pointer.
+func (r *gatewayRegistry) get(gatewayID string) *gateway {
+	return r.gateways[gatewayID]
 }

--- a/agent-manager-service/eventhub/topic.go
+++ b/agent-manager-service/eventhub/topic.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eventhub
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	ErrGatewayNotFound      = errors.New("gateway not found")
+	ErrGatewayAlreadyExists = errors.New("gateway already exists")
+	ErrSubscriberNotFound   = errors.New("subscriber not found")
+)
+
+type gateway struct {
+	id           string
+	subscribers  []chan Event
+	knownVersion string
+	lastPolled   int64
+}
+
+type gatewayRegistry struct {
+	mu       sync.RWMutex
+	gateways map[string]*gateway
+}
+
+func newGatewayRegistry() *gatewayRegistry {
+	return &gatewayRegistry{gateways: make(map[string]*gateway)}
+}
+
+func (r *gatewayRegistry) register(gatewayID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.gateways[gatewayID]; exists {
+		return ErrGatewayAlreadyExists
+	}
+	r.gateways[gatewayID] = &gateway{id: gatewayID, subscribers: make([]chan Event, 0)}
+	return nil
+}
+
+func (r *gatewayRegistry) addSubscriber(gatewayID string, ch chan Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	gw, exists := r.gateways[gatewayID]
+	if !exists {
+		return ErrGatewayNotFound
+	}
+	gw.subscribers = append(gw.subscribers, ch)
+	return nil
+}
+
+func (r *gatewayRegistry) removeSubscriber(gatewayID string, subscriber <-chan Event) (chan Event, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	gw, exists := r.gateways[gatewayID]
+	if !exists {
+		return nil, ErrGatewayNotFound
+	}
+	for i, ch := range gw.subscribers {
+		if (<-chan Event)(ch) != subscriber {
+			continue
+		}
+		last := len(gw.subscribers) - 1
+		gw.subscribers[i] = gw.subscribers[last]
+		gw.subscribers[last] = nil
+		gw.subscribers = gw.subscribers[:last]
+		return ch, nil
+	}
+	return nil, ErrSubscriberNotFound
+}
+
+func (r *gatewayRegistry) removeAllSubscribers(gatewayID string) ([]chan Event, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	gw, exists := r.gateways[gatewayID]
+	if !exists {
+		return nil, ErrGatewayNotFound
+	}
+	subscribers := gw.subscribers
+	gw.subscribers = nil
+	return subscribers, nil
+}
+
+func (r *gatewayRegistry) getAll() []*gateway {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	gateways := make([]*gateway, 0, len(r.gateways))
+	for _, gw := range r.gateways {
+		gateways = append(gateways, gw)
+	}
+	return gateways
+}

--- a/agent-manager-service/eventhub/topic.go
+++ b/agent-manager-service/eventhub/topic.go
@@ -29,12 +29,12 @@ var (
 )
 
 type gateway struct {
-	id                  string
-	subscribers         []chan Event
-	knownVersion        string
-	lastPolledTime      time.Time // zero means no event has been delivered yet
-	lastPolledEventID   string    // event_id of the last delivered event; used as tie-breaker
-	queuedLoggedAt      int64     // unix nano of last "events queued, no subscribers" log; 0 = not yet logged
+	id                string
+	subscribers       []chan Event
+	knownVersion      string
+	lastPolledTime    time.Time // zero means no event has been delivered yet
+	lastPolledEventID string    // event_id of the last delivered event; used as tie-breaker
+	queuedLoggedAt    int64     // unix nano of last "events queued, no subscribers" log; 0 = not yet logged
 }
 
 type gatewayRegistry struct {

--- a/agent-manager-service/eventhub/types.go
+++ b/agent-manager-service/eventhub/types.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eventhub
+
+import "time"
+
+// EventType represents the type of event
+type EventType string
+
+const (
+	EventTypeLLMProvider EventType = "LLM_PROVIDER"
+	EventTypeLLMProxy    EventType = "LLM_PROXY"
+	EventTypeAPIKey      EventType = "API_KEY"
+
+	// EmptyEventData is the canonical JSON payload for events that carry no extra data.
+	EmptyEventData = "{}"
+)
+
+// Event represents a change event in the system
+type Event struct {
+	GatewayID           string    `json:"gateway_id"`
+	ProcessedTimestamp  time.Time `json:"processed_timestamp"`
+	OriginatedTimestamp time.Time `json:"originated_timestamp"`
+	EventType           EventType `json:"event_type"`
+	Action              string    `json:"action"`
+	EntityID            string    `json:"entity_id"`
+	EventID             string    `json:"event_id"`
+	// EventData carries optional event-specific details as a JSON string.
+	EventData string `json:"event_data"`
+}
+
+// GatewayState tracks the version state of a gateway.
+type GatewayState struct {
+	GatewayID string    `json:"gateway_id"`
+	VersionID string    `json:"version_id"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// EventHub defines the interface for event publishing and subscribing
+type EventHub interface {
+	Initialize() error
+	RegisterGateway(gatewayID string) error
+	PublishEvent(gatewayID string, event Event) error
+	Subscribe(gatewayID string) (<-chan Event, error)
+	Unsubscribe(gatewayID string, subscriber <-chan Event) error
+	UnsubscribeAll(gatewayID string) error
+	CleanUpEvents() error
+	Close() error
+}
+
+// Config holds configuration for the EventHub
+type Config struct {
+	PollInterval    time.Duration
+	CleanupInterval time.Duration
+	RetentionPeriod time.Duration
+}
+
+// DefaultConfig returns a Config with sensible defaults
+func DefaultConfig() Config {
+	return Config{
+		PollInterval:    3 * time.Second,
+		CleanupInterval: 10 * time.Minute,
+		RetentionPeriod: 1 * time.Hour,
+	}
+}

--- a/agent-manager-service/services/gateway_events_service.go
+++ b/agent-manager-service/services/gateway_events_service.go
@@ -24,18 +24,20 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
-	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 )
 
 const (
-	// Maximum event payload size (1MB)
+	// MaxEventPayloadSize is the maximum allowed event payload size (1MB)
 	MaxEventPayloadSize = 1024 * 1024
 )
 
-// GatewayEventsService handles broadcasting events to connected gateways
+// GatewayEventsService handles broadcasting events to connected gateways.
+// It publishes events to the EventHub so that any service instance holding
+// the gateway's WebSocket connection will deliver the event.
 type GatewayEventsService struct {
-	manager *websocket.Manager
+	hub eventhub.EventHub
 }
 
 // GatewayEventDTO represents a gateway event
@@ -48,10 +50,8 @@ type GatewayEventDTO struct {
 }
 
 // NewGatewayEventsService creates a new gateway events service
-func NewGatewayEventsService(manager *websocket.Manager) *GatewayEventsService {
-	return &GatewayEventsService{
-		manager: manager,
-	}
+func NewGatewayEventsService(hub eventhub.EventHub) *GatewayEventsService {
+	return &GatewayEventsService{hub: hub}
 }
 
 // DeploymentEvent represents an API deployment event (TODO: move to models package)
@@ -93,38 +93,23 @@ func (s *GatewayEventsService) broadcastEvent(gatewayID string, eventType string
 		return fmt.Errorf("failed to marshal event: %w", err)
 	}
 
-	if s.manager == nil {
-		slog.Warn("WebSocket manager not initialized")
-		return nil
+	evt := eventhub.Event{
+		GatewayID:           gatewayID,
+		OriginatedTimestamp: time.Now(),
+		EventType:           eventhub.EventType(eventType),
+		Action:              "CREATE",
+		EntityID:            correlationID,
+		EventData:           string(eventJSON),
 	}
 
-	connections := s.manager.GetConnections(gatewayID)
-	if len(connections) == 0 {
-		slog.Warn(fmt.Sprintf("broadcast api key event; no active connections for gateway: %s, skipping", gatewayID))
-		return nil
+	if err := s.hub.PublishEvent(gatewayID, evt); err != nil {
+		slog.Error("Failed to publish event to EventHub",
+			"gatewayID", gatewayID, "type", eventType, "correlationID", correlationID, "error", err)
+		return fmt.Errorf("failed to publish %s event: %w", eventType, err)
 	}
 
-	successCount, failureCount := 0, 0
-	var lastError error
-	for _, conn := range connections {
-		if err := conn.Send(eventJSON); err != nil {
-			failureCount++
-			lastError = err
-			slog.Error("Failed to send event", "gatewayID", gatewayID, "connectionID", conn.ConnectionID,
-				"correlationID", correlationID, "type", eventType, "error", err)
-			conn.DeliveryStats.IncrementFailed(fmt.Sprintf("send error: %v", err))
-		} else {
-			successCount++
-			conn.DeliveryStats.IncrementTotalSent()
-		}
-	}
-
-	slog.Info("Broadcast summary", "gatewayID", gatewayID, "correlationID", correlationID,
-		"type", eventType, "total", len(connections), "success", successCount, "failed", failureCount)
-
-	if successCount == 0 {
-		return fmt.Errorf("failed to deliver %s event to any connection: %w", eventType, lastError)
-	}
+	slog.Debug("Event published to EventHub",
+		"gatewayID", gatewayID, "type", eventType, "correlationID", correlationID)
 	return nil
 }
 

--- a/agent-manager-service/services/gateway_events_service.go
+++ b/agent-manager-service/services/gateway_events_service.go
@@ -68,7 +68,7 @@ type APIUndeploymentEvent struct {
 	GatewayID    string `json:"gatewayId"`
 }
 
-func (s *GatewayEventsService) broadcastEvent(gatewayID string, eventType string, payload interface{}) error {
+func (s *GatewayEventsService) broadcastEvent(gatewayID string, eventType string, action string, entityID string, payload interface{}) error {
 	correlationID := uuid.New().String()
 
 	payloadJSON, err := json.Marshal(payload)
@@ -97,8 +97,8 @@ func (s *GatewayEventsService) broadcastEvent(gatewayID string, eventType string
 		GatewayID:           gatewayID,
 		OriginatedTimestamp: time.Now(),
 		EventType:           eventhub.EventType(eventType),
-		Action:              "CREATE",
-		EntityID:            correlationID,
+		Action:              action,
+		EntityID:            entityID,
 		EventData:           string(eventJSON),
 	}
 
@@ -115,37 +115,39 @@ func (s *GatewayEventsService) broadcastEvent(gatewayID string, eventType string
 
 // Public methods become thin one-liners:
 func (s *GatewayEventsService) BroadcastDeploymentEvent(gatewayID string, event *DeploymentEvent) error {
-	return s.broadcastEvent(gatewayID, "api.deployed", event)
+	return s.broadcastEvent(gatewayID, "api.deployed", "CREATE", event.APIID, event)
 }
 
 func (s *GatewayEventsService) BroadcastUndeploymentEvent(gatewayID string, event *APIUndeploymentEvent) error {
-	return s.broadcastEvent(gatewayID, "api.undeployed", event)
+	return s.broadcastEvent(gatewayID, "api.undeployed", "DELETE", event.APIID, event)
 }
 
 func (s *GatewayEventsService) BroadcastLLMProviderDeploymentEvent(gatewayID string, event *models.LLMProviderDeploymentEvent) error {
-	return s.broadcastEvent(gatewayID, "llmprovider.deployed", event)
+	return s.broadcastEvent(gatewayID, "llmprovider.deployed", "CREATE", event.ProviderID, event)
 }
 
 func (s *GatewayEventsService) BroadcastLLMProviderUndeploymentEvent(gatewayID string, event *models.LLMProviderUndeploymentEvent) error {
-	return s.broadcastEvent(gatewayID, "llmprovider.undeployed", event)
+	return s.broadcastEvent(gatewayID, "llmprovider.undeployed", "DELETE", event.ProviderID, event)
 }
 
 func (s *GatewayEventsService) BroadcastLLMProxyDeploymentEvent(gatewayID string, event *models.LLMProxyDeploymentEvent) error {
-	return s.broadcastEvent(gatewayID, "llmproxy.deployed", event)
+	return s.broadcastEvent(gatewayID, "llmproxy.deployed", "CREATE", event.ProxyID, event)
 }
 
 func (s *GatewayEventsService) BroadcastLLMProxyUndeploymentEvent(gatewayID string, event *models.LLMProxyUndeploymentEvent) error {
-	return s.broadcastEvent(gatewayID, "llmproxy.undeployed", event)
+	return s.broadcastEvent(gatewayID, "llmproxy.undeployed", "DELETE", event.ProxyID, event)
 }
 
+// API key events use a unique ID per event — they are not deduplicated on replay
+// because the gateway bulk-syncs API keys on reconnect via the catalog endpoint.
 func (s *GatewayEventsService) BroadcastAPIKeyCreatedEvent(gatewayID string, event *models.APIKeyCreatedEvent) error {
-	return s.broadcastEvent(gatewayID, "apikey.created", event)
+	return s.broadcastEvent(gatewayID, "apikey.created", "PROVISION", event.UUID, event)
 }
 
 func (s *GatewayEventsService) BroadcastAPIKeyRevokedEvent(gatewayID string, event *models.APIKeyRevokedEvent) error {
-	return s.broadcastEvent(gatewayID, "apikey.revoked", event)
+	return s.broadcastEvent(gatewayID, "apikey.revoked", "REVOKE", uuid.New().String(), event)
 }
 
 func (s *GatewayEventsService) BroadcastAPIKeyUpdatedEvent(gatewayID string, event *models.APIKeyUpdatedEvent) error {
-	return s.broadcastEvent(gatewayID, "apikey.updated", event)
+	return s.broadcastEvent(gatewayID, "apikey.updated", "UPDATE", uuid.New().String(), event)
 }

--- a/agent-manager-service/websocket/connection.go
+++ b/agent-manager-service/websocket/connection.go
@@ -19,6 +19,8 @@ package websocket
 import (
 	"sync"
 	"time"
+
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
 )
 
 // Connection represents an active gateway connection with metadata and lifecycle management.
@@ -48,6 +50,12 @@ type Connection struct {
 
 	// DeliveryStats tracks event delivery statistics for this connection
 	DeliveryStats *Stats
+
+	// eventSub is the EventHub subscription channel for this connection.
+	// Set by Manager.Register when an EventHub is configured; nil otherwise.
+	// Stored here so Unregister can call hub.Unsubscribe to clean up the
+	// subscription and stop the forwardEvents goroutine.
+	eventSub <-chan eventhub.Event
 
 	// mu protects concurrent access to mutable fields (LastHeartbeat, closed state)
 	mu sync.RWMutex

--- a/agent-manager-service/websocket/manager.go
+++ b/agent-manager-service/websocket/manager.go
@@ -18,17 +18,25 @@ package websocket
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
 )
 
 // Manager handles the lifecycle of gateway WebSocket connections.
 // It maintains an in-memory registry of active connections, manages heartbeats,
 // and handles graceful/ungraceful disconnections.
+//
+// When an EventHub is configured, Manager subscribes to it on Register and
+// forwards received events to the local WebSocket connection. This allows any
+// service instance to deliver events to gateways connected to a different pod.
 type Manager struct {
 	// connections maps gatewayID -> []*Connection
 	connections sync.Map
@@ -39,26 +47,19 @@ type Manager struct {
 	// map reads and count decrements, causing count drift or double-decrement.
 	registryMu sync.Mutex
 
-	// mu protects the connectionCount and maxConnections fields
+	// mu protects connectionCount
 	mu sync.RWMutex
 
-	// connectionCount tracks the total number of active connections across all gateways
-	connectionCount int
-
-	// maxConnections enforces a limit on concurrent connections (default 1000)
-	maxConnections int
-
-	// heartbeatInterval specifies how often to send ping frames (default 20s)
+	connectionCount   int
+	maxConnections    int
 	heartbeatInterval time.Duration
+	heartbeatTimeout  time.Duration
 
-	// heartbeatTimeout specifies when to consider a connection dead (default 30s)
-	heartbeatTimeout time.Duration
+	hub eventhub.EventHub
 
-	// shutdownCtx is used to signal graceful shutdown to all connection goroutines
 	shutdownCtx context.Context
 	shutdownFn  context.CancelFunc
 
-	// wg tracks active connection handler goroutines for graceful shutdown
 	wg sync.WaitGroup
 }
 
@@ -79,14 +80,13 @@ func DefaultManagerConfig() ManagerConfig {
 }
 
 // NewManager creates a new connection manager with the provided configuration
-func NewManager(config ManagerConfig) *Manager {
+func NewManager(config ManagerConfig, hub eventhub.EventHub) *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Manager{
-		connections:       sync.Map{},
-		connectionCount:   0,
 		maxConnections:    config.MaxConnections,
 		heartbeatInterval: config.HeartbeatInterval,
 		heartbeatTimeout:  config.HeartbeatTimeout,
+		hub:               hub,
 		shutdownCtx:       ctx,
 		shutdownFn:        cancel,
 	}
@@ -94,19 +94,17 @@ func NewManager(config ManagerConfig) *Manager {
 
 // Register adds a new connection to the registry and starts heartbeat monitoring.
 // Returns an error if the maximum connection limit is reached.
+//
+// Any existing connections for the same gateway are evicted first (singleton per
+// gateway). When kgateway reloads config it reconnects immediately; without eviction
+// the stale upstream lingers and receives no heartbeat pings.
 func (m *Manager) Register(gatewayID string, transport Transport, authToken string) (*Connection, error) {
 	// registryMu ensures the LoadAndDelete → count update → Store sequence is atomic
 	// against concurrent Register/Unregister calls for the same gateway.
 	m.registryMu.Lock()
 
-	// Collect any existing connections to evict. We snapshot them here under the lock
-	// but close them after releasing it so we don't hold registryMu during I/O.
-	// When kgateway reloads config (on each OpenChoreo reconcile), it sends a TCP RST to
-	// the gateway controller which reconnects immediately. Without eviction, kgateway
-	// sometimes hands the reconnect to an old upstream connection whose downstream is
-	// already dead — that upstream receives no heartbeat pings and lingers as stale state.
-	// Closing old connections sends a WebSocket CLOSE to kgateway, which tears down
-	// the stale upstream immediately and leaves a clean slate for the new connection.
+	// Snapshot existing connections for eviction. We close them after releasing the
+	// lock so we don't hold registryMu during I/O.
 	var evicted []*Connection
 	if connsInterface, loaded := m.connections.LoadAndDelete(gatewayID); loaded {
 		evicted = connsInterface.([]*Connection)
@@ -131,22 +129,75 @@ func (m *Manager) Register(gatewayID string, transport Transport, authToken stri
 
 	m.registryMu.Unlock()
 
-	// Close evicted connections outside the lock — Close involves I/O and must not
-	// block other Register/Unregister callers.
+	// Unsubscribe and close evicted connections outside the lock.
 	for _, old := range evicted {
+		if m.hub != nil && old.eventSub != nil {
+			if err := m.hub.Unsubscribe(gatewayID, old.eventSub); err != nil {
+				slog.Error("Failed to unsubscribe evicted connection from EventHub",
+					"gatewayID", gatewayID, "connectionID", old.ConnectionID, "error", err)
+			}
+		}
 		_ = old.Close(1000, "superseded by new connection")
 		log.Printf("[INFO] Evicted superseded connection: gatewayID=%s connectionID=%s",
 			gatewayID, old.ConnectionID)
 	}
 
-	// Start heartbeat monitoring in background
 	m.wg.Add(1)
 	go m.monitorHeartbeat(conn)
+
+	// Subscribe to the EventHub and forward events to this connection.
+	if m.hub != nil {
+		ch, err := m.hub.Subscribe(gatewayID)
+		if err != nil {
+			slog.Error("Failed to subscribe to EventHub for gateway",
+				"gatewayID", gatewayID, "connectionID", connectionID, "error", err)
+		} else {
+			conn.eventSub = ch
+			m.wg.Add(1)
+			go m.forwardEvents(conn, ch)
+		}
+	}
 
 	log.Printf("[INFO] Gateway connected: gatewayID=%s connectionID=%s totalConnections=%d",
 		gatewayID, connectionID, m.GetConnectionCount())
 
 	return conn, nil
+}
+
+// forwardEvents reads events from the EventHub subscription channel and sends
+// them to the WebSocket connection. It exits when the channel is closed or
+// the connection is closed.
+func (m *Manager) forwardEvents(conn *Connection, ch <-chan eventhub.Event) {
+	defer m.wg.Done()
+	for {
+		select {
+		case evt, ok := <-ch:
+			if !ok {
+				return
+			}
+			if conn.IsClosed() {
+				return
+			}
+			// EventData already contains the full GatewayEventDTO JSON serialized by
+			// GatewayEventsService.broadcastEvent — send it directly.
+			payload := []byte(evt.EventData)
+			if len(payload) == 0 {
+				payload, _ = json.Marshal(evt)
+			}
+			if err := conn.Send(payload); err != nil {
+				slog.Error("Failed to forward EventHub event to gateway",
+					"gatewayID", conn.GatewayID,
+					"connectionID", conn.ConnectionID,
+					"event_type", string(evt.EventType),
+					"error", err)
+				conn.DeliveryStats.IncrementFailed(fmt.Sprintf("forward error: %v", err))
+			} else {
+				conn.DeliveryStats.IncrementTotalSent()
+			}
+		case <-m.shutdownCtx.Done():
+			return
+		}
+	}
 }
 
 // Unregister removes a connection from the registry and closes it gracefully.
@@ -164,7 +215,6 @@ func (m *Manager) Unregister(gatewayID, connectionID string) {
 	var updatedConns []*Connection
 	var removed *Connection
 
-	// Filter out the connection to remove
 	for _, conn := range conns {
 		if conn.ConnectionID == connectionID {
 			removed = conn
@@ -178,19 +228,26 @@ func (m *Manager) Unregister(gatewayID, connectionID string) {
 		return // Connection not found
 	}
 
-	// Update or delete the gateway entry
 	if len(updatedConns) == 0 {
 		m.connections.Delete(gatewayID)
 	} else {
 		m.connections.Store(gatewayID, updatedConns)
 	}
 
-	// Decrement connection count
 	m.mu.Lock()
 	m.connectionCount--
 	m.mu.Unlock()
 
 	m.registryMu.Unlock()
+
+	// Unsubscribe from the EventHub before closing the connection so the forwardEvents
+	// goroutine exits cleanly (channel close signals it) rather than leaking until shutdown.
+	if m.hub != nil && removed.eventSub != nil {
+		if err := m.hub.Unsubscribe(gatewayID, removed.eventSub); err != nil {
+			slog.Error("Failed to unsubscribe from EventHub",
+				"gatewayID", gatewayID, "connectionID", connectionID, "error", err)
+		}
+	}
 
 	// Close the connection outside the lock — Close involves I/O and must not
 	// block other Register/Unregister callers.
@@ -221,7 +278,7 @@ func (m *Manager) GetAllConnections() map[string][]*Connection {
 		gatewayID := key.(string)
 		conns := value.([]*Connection)
 		result[gatewayID] = conns
-		return true // Continue iteration
+		return true
 	})
 	return result
 }
@@ -241,7 +298,6 @@ func (m *Manager) monitorHeartbeat(conn *Connection) {
 	ticker := time.NewTicker(m.heartbeatInterval)
 	defer ticker.Stop()
 
-	// Configure pong handler to update heartbeat timestamp
 	conn.Transport.EnablePongHandler(func(appData string) error {
 		conn.UpdateHeartbeat()
 		return nil
@@ -250,16 +306,13 @@ func (m *Manager) monitorHeartbeat(conn *Connection) {
 	for {
 		select {
 		case <-m.shutdownCtx.Done():
-			// Graceful shutdown triggered
 			return
 
 		case <-ticker.C:
-			// Check if connection is already closed
 			if conn.IsClosed() {
 				return
 			}
 
-			// Check for heartbeat timeout
 			if time.Since(conn.GetLastHeartbeat()) > m.heartbeatTimeout {
 				log.Printf("[WARN] Heartbeat timeout detected: gatewayID=%s connectionID=%s lastHeartbeat=%v",
 					conn.GatewayID, conn.ConnectionID, conn.GetLastHeartbeat())
@@ -267,7 +320,6 @@ func (m *Manager) monitorHeartbeat(conn *Connection) {
 				return
 			}
 
-			// Send ping frame
 			if err := conn.SendPing(); err != nil {
 				log.Printf("[ERROR] Failed to send ping: gatewayID=%s connectionID=%s error=%v",
 					conn.GatewayID, conn.ConnectionID, err)
@@ -283,10 +335,8 @@ func (m *Manager) monitorHeartbeat(conn *Connection) {
 func (m *Manager) Shutdown() {
 	log.Println("[INFO] Shutting down WebSocket manager...")
 
-	// Signal shutdown to all monitoring goroutines
 	m.shutdownFn()
 
-	// Close all connections
 	m.connections.Range(func(key, value interface{}) bool {
 		gatewayID := key.(string)
 		conns := value.([]*Connection)
@@ -296,10 +346,9 @@ func (m *Manager) Shutdown() {
 					gatewayID, conn.ConnectionID, err)
 			}
 		}
-		return true // Continue iteration
+		return true
 	})
 
-	// Wait for all goroutines to exit
 	m.wg.Wait()
 
 	log.Println("[INFO] WebSocket manager shutdown complete")

--- a/agent-manager-service/websocket/manager.go
+++ b/agent-manager-service/websocket/manager.go
@@ -151,15 +151,21 @@ func (m *Manager) Register(gatewayID string, transport Transport, authToken stri
 		if err != nil {
 			slog.Error("Failed to subscribe to EventHub for gateway",
 				"gatewayID", gatewayID, "connectionID", connectionID, "error", err)
-		} else {
-			conn.eventSub = ch
-			m.wg.Add(1)
-			go m.forwardEvents(conn, ch)
+			m.Unregister(gatewayID, connectionID)
+			return nil, fmt.Errorf("failed to subscribe to EventHub for gateway %s: %w", gatewayID, err)
 		}
+		conn.eventSub = ch
+		m.wg.Add(1)
+		go m.forwardEvents(conn, ch)
 	}
 
-	log.Printf("[INFO] Gateway connected: gatewayID=%s connectionID=%s totalConnections=%d",
-		gatewayID, connectionID, m.GetConnectionCount())
+	if len(evicted) > 0 {
+		log.Printf("[INFO] Gateway reconnected (evicted %d stale connection(s)): gatewayID=%s connectionID=%s totalConnections=%d",
+			len(evicted), gatewayID, connectionID, m.GetConnectionCount())
+	} else {
+		log.Printf("[INFO] Gateway connected: gatewayID=%s connectionID=%s totalConnections=%d",
+			gatewayID, connectionID, m.GetConnectionCount())
+	}
 
 	return conn, nil
 }
@@ -192,6 +198,11 @@ func (m *Manager) forwardEvents(conn *Connection, ch <-chan eventhub.Event) {
 					"error", err)
 				conn.DeliveryStats.IncrementFailed(fmt.Sprintf("forward error: %v", err))
 			} else {
+				slog.Debug("Forwarded event to gateway WebSocket",
+					"gatewayID", conn.GatewayID,
+					"connectionID", conn.ConnectionID,
+					"event_type", string(evt.EventType),
+					"event_id", evt.EventID)
 				conn.DeliveryStats.IncrementTotalSent()
 			}
 		case <-m.shutdownCtx.Done():

--- a/agent-manager-service/wiring/params.go
+++ b/agent-manager-service/wiring/params.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
 	"github.com/wso2/agent-manager/agent-manager-service/websocket"
@@ -79,6 +80,9 @@ type AppParams struct {
 
 	// WebSocket
 	WebSocketManager *websocket.Manager
+
+	// EventHub for cross-instance gateway event delivery
+	EventHub eventhub.EventHub
 
 	// Database
 	DB *gorm.DB

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -32,6 +32,7 @@ import (
 	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
@@ -209,6 +210,7 @@ var repositoryProviderSet = wire.NewSet(
 )
 
 var websocketProviderSet = wire.NewSet(
+	ProvideEventHub,
 	ProvideWebSocketManager,
 	services.NewGatewayEventsService,
 	ProvideDeploymentAckHandler,
@@ -231,25 +233,40 @@ func ProvideTestSecretManagementClient(testClients TestClients) secretmanagersvc
 	return testClients.SecretMgmtClient
 }
 
+// ProvideEventHub creates and initializes the EventHub backed by PostgreSQL.
+func ProvideEventHub(db *gorm.DB, logger *slog.Logger) (eventhub.EventHub, error) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+	cfg := eventhub.DefaultSQLBackendConfig()
+	hub := eventhub.NewSQLBackend(sqlDB, logger, cfg)
+	if err := hub.Initialize(); err != nil {
+		return nil, err
+	}
+	return hub, nil
+}
+
 // ProvideWebSocketManager creates a new WebSocket manager with config
-func ProvideWebSocketManager(cfg config.Config) *websocket.Manager {
+func ProvideWebSocketManager(cfg config.Config, hub eventhub.EventHub) *websocket.Manager {
 	wsConfig := websocket.ManagerConfig{
 		MaxConnections:    cfg.WebSocket.MaxConnections,
 		HeartbeatInterval: 20 * time.Second,
 		HeartbeatTimeout:  time.Duration(cfg.WebSocket.ConnectionTimeout) * time.Second,
 	}
-	return websocket.NewManager(wsConfig)
+	return websocket.NewManager(wsConfig, hub)
 }
 
 // ProvideWebSocketController creates a new WebSocket controller with rate limiting
 func ProvideWebSocketController(
 	manager *websocket.Manager,
+	hub eventhub.EventHub,
 	gatewayService *services.PlatformGatewayService,
 	ackHandler *services.DeploymentAckHandler,
 	cfg config.Config,
 ) controllers.WebSocketController {
 	rateLimitCount := cfg.WebSocket.RateLimitPerMin
-	return controllers.NewWebSocketController(manager, gatewayService, ackHandler, rateLimitCount)
+	return controllers.NewWebSocketController(manager, hub, gatewayService, ackHandler, rateLimitCount)
 }
 
 // ProvideDeploymentAckHandler creates a new deployment ack handler

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -17,6 +17,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/controllers"
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
@@ -66,8 +67,11 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	}
 	llmProxyService := services.NewLLMProxyService(llmProxyRepository, llmProviderRepository, v)
 	deploymentRepository := ProvideDeploymentRepository(db)
-	manager := ProvideWebSocketManager(configConfig)
-	gatewayEventsService := services.NewGatewayEventsService(manager)
+	eventHub, err := ProvideEventHub(db, logger)
+	if err != nil {
+		return nil, err
+	}
+	gatewayEventsService := services.NewGatewayEventsService(eventHub)
 	llmProxyDeploymentService := services.NewLLMProxyDeploymentService(deploymentRepository, llmProxyRepository, llmProviderRepository, gatewayRepository, gatewayEventsService)
 	apiKeyRepository := ProvideAPIKeyRepository(db)
 	llmProxyAPIKeyService := services.NewLLMProxyAPIKeyService(llmProxyRepository, gatewayRepository, gatewayEventsService, apiKeyRepository)
@@ -99,8 +103,9 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	agentAPIKeyService := services.NewAgentAPIKeyService(artifactRepository, openChoreoClient, gatewayRepository, gatewayEventsService, apiKeyRepository)
 	agentAPIKeyController := controllers.NewAgentAPIKeyController(agentAPIKeyService)
 	llmProxyDeploymentController := controllers.NewLLMProxyDeploymentController(llmProxyDeploymentService)
+	manager := ProvideWebSocketManager(configConfig, eventHub)
 	deploymentAckHandler := ProvideDeploymentAckHandler(deploymentRepository)
-	webSocketController := ProvideWebSocketController(manager, platformGatewayService, deploymentAckHandler, configConfig)
+	webSocketController := ProvideWebSocketController(manager, eventHub, platformGatewayService, deploymentAckHandler, configConfig)
 	gatewayInternalAPIService := services.NewGatewayInternalAPIService(llmProviderRepository, llmProxyRepository, deploymentRepository, gatewayRepository, infraResourceManager, v)
 	gatewayInternalController := controllers.NewGatewayInternalController(platformGatewayService, gatewayInternalAPIService, apiKeyRepository)
 	monitorRepository := ProvideMonitorRepository(db)
@@ -165,6 +170,7 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 		OpenChoreoClient:                 openChoreoClient,
 		TraceObserverSvcClient:           traceObserverSvcClient,
 		WebSocketManager:                 manager,
+		EventHub:                         eventHub,
 		DB:                               db,
 	}
 	return appParams, nil
@@ -200,8 +206,11 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	}
 	llmProxyService := services.NewLLMProxyService(llmProxyRepository, llmProviderRepository, v)
 	deploymentRepository := ProvideDeploymentRepository(db)
-	manager := ProvideWebSocketManager(configConfig)
-	gatewayEventsService := services.NewGatewayEventsService(manager)
+	eventHub, err := ProvideEventHub(db, logger)
+	if err != nil {
+		return nil, err
+	}
+	gatewayEventsService := services.NewGatewayEventsService(eventHub)
 	llmProxyDeploymentService := services.NewLLMProxyDeploymentService(deploymentRepository, llmProxyRepository, llmProviderRepository, gatewayRepository, gatewayEventsService)
 	apiKeyRepository := ProvideAPIKeyRepository(db)
 	llmProxyAPIKeyService := services.NewLLMProxyAPIKeyService(llmProxyRepository, gatewayRepository, gatewayEventsService, apiKeyRepository)
@@ -233,8 +242,9 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	agentAPIKeyService := services.NewAgentAPIKeyService(artifactRepository, openChoreoClient, gatewayRepository, gatewayEventsService, apiKeyRepository)
 	agentAPIKeyController := controllers.NewAgentAPIKeyController(agentAPIKeyService)
 	llmProxyDeploymentController := controllers.NewLLMProxyDeploymentController(llmProxyDeploymentService)
+	manager := ProvideWebSocketManager(configConfig, eventHub)
 	deploymentAckHandler := ProvideDeploymentAckHandler(deploymentRepository)
-	webSocketController := ProvideWebSocketController(manager, platformGatewayService, deploymentAckHandler, configConfig)
+	webSocketController := ProvideWebSocketController(manager, eventHub, platformGatewayService, deploymentAckHandler, configConfig)
 	gatewayInternalAPIService := services.NewGatewayInternalAPIService(llmProviderRepository, llmProxyRepository, deploymentRepository, gatewayRepository, infraResourceManager, v)
 	gatewayInternalController := controllers.NewGatewayInternalController(platformGatewayService, gatewayInternalAPIService, apiKeyRepository)
 	monitorRepository := ProvideMonitorRepository(db)
@@ -296,6 +306,7 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 		OpenChoreoClient:                 openChoreoClient,
 		TraceObserverSvcClient:           traceObserverSvcClient,
 		WebSocketManager:                 manager,
+		EventHub:                         eventHub,
 		DB:                               db,
 	}
 	return appParams, nil
@@ -417,6 +428,7 @@ var repositoryProviderSet = wire.NewSet(
 )
 
 var websocketProviderSet = wire.NewSet(
+	ProvideEventHub,
 	ProvideWebSocketManager, services.NewGatewayEventsService, ProvideDeploymentAckHandler,
 )
 
@@ -437,25 +449,40 @@ func ProvideTestSecretManagementClient(testClients TestClients) secretmanagersvc
 	return testClients.SecretMgmtClient
 }
 
+// ProvideEventHub creates and initializes the EventHub backed by PostgreSQL.
+func ProvideEventHub(db *gorm.DB, logger *slog.Logger) (eventhub.EventHub, error) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+	cfg := eventhub.DefaultSQLBackendConfig()
+	hub := eventhub.NewSQLBackend(sqlDB, logger, cfg)
+	if err := hub.Initialize(); err != nil {
+		return nil, err
+	}
+	return hub, nil
+}
+
 // ProvideWebSocketManager creates a new WebSocket manager with config
-func ProvideWebSocketManager(cfg config.Config) *websocket.Manager {
+func ProvideWebSocketManager(cfg config.Config, hub eventhub.EventHub) *websocket.Manager {
 	wsConfig := websocket.ManagerConfig{
 		MaxConnections:    cfg.WebSocket.MaxConnections,
 		HeartbeatInterval: 20 * time.Second,
 		HeartbeatTimeout:  time.Duration(cfg.WebSocket.ConnectionTimeout) * time.Second,
 	}
-	return websocket.NewManager(wsConfig)
+	return websocket.NewManager(wsConfig, hub)
 }
 
 // ProvideWebSocketController creates a new WebSocket controller with rate limiting
 func ProvideWebSocketController(
 	manager *websocket.Manager,
+	hub eventhub.EventHub,
 	gatewayService *services.PlatformGatewayService,
 	ackHandler *services.DeploymentAckHandler,
 	cfg config.Config,
 ) controllers.WebSocketController {
 	rateLimitCount := cfg.WebSocket.RateLimitPerMin
-	return controllers.NewWebSocketController(manager, gatewayService, ackHandler, rateLimitCount)
+	return controllers.NewWebSocketController(manager, hub, gatewayService, ackHandler, rateLimitCount)
 }
 
 // ProvideDeploymentAckHandler creates a new deployment ack handler

--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -153,8 +153,8 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
   );
 
   useEffect(() => {
-    if (gateways.length > 0 && !formData.gatewayIds) {
-      setFormData({ ...formData, gatewayIds: [gateways[0].uuid] });
+    if (gateways.length > 0 && formData.gatewayIds?.length === 0) {
+        setFormData({ ...formData, gatewayIds: [gateways[0].uuid] });
     }
   }, [gateways]);
 

--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -603,7 +603,7 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
           disabled={
             isSubmitting ||
             !formData.gatewayIds ||
-            formData.gatewayIds?.length == 0
+            formData.gatewayIds?.length === 0
           }
         >
           {isSubmitting ? "Creating..." : "Add provider"}


### PR DESCRIPTION
## Purpose

  In a multi-pod deployment, `GatewayEventsService` was delivering events by calling
  `manager.GetConnections(gatewayID)` directly against the local pod's in-memory WebSocket registry. Since each pod
  maintains its own isolated connection state, events were silently dropped whenever the pod handling the API request
  was not the pod holding the gateway's WebSocket connection. This affected all gateway configuration change
  notifications — LLM provider updates, LLM proxy changes, and API key provisioning.

  Closes #948 

  ## Goals

  - Ensure gateway event delivery succeeds regardless of which pod handles the originating API request
  - Remove the coupling between event publishing and the local pod's in-memory WebSocket state
  - Avoid introducing a new infrastructure dependency — reuse the existing PostgreSQL instance

  ## Approach

  Introduce a SQL-backed `EventHub` that acts as a shared event bus between pods:

  - **Publishing**: any pod writes the event to `eventhub_events` and atomically bumps a version ID in
  `eventhub_gateway_states`
  - **Delivery**: each pod runs a poll loop against `eventhub_gateway_states`; when a version change is detected, it
  fetches the new events and fans them out to local subscribers
  - **Forwarding**: on WebSocket connect, the pod subscribes to the EventHub for that gateway and starts a
  `forwardEvents` goroutine that reads from the subscription channel and writes to the WebSocket connection
  - **Cleanup**: on disconnect or eviction, the subscription is removed and the `forwardEvents` goroutine exits
  cleanly

  ```
  API request (any pod)
      └─▶ GatewayEventsService.broadcastEvent
              └─▶ hub.PublishEvent
                      └─▶ INSERT INTO eventhub_events
                          UPDATE eventhub_gateway_states (version bump)

  Poll loop (pod holding the WebSocket connection, every 2s)
      └─▶ SELECT from eventhub_gateway_states WHERE version changed
              └─▶ SELECT from eventhub_events WHERE gateway_id = ? AND processed_timestamp >= ?
                      └─▶ fan out to subscriber channels
                              └─▶ forwardEvents goroutine
                                      └─▶ conn.Send(payload)
  ```


## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent Event Hub with subscription-based delivery and indexed event storage.
  * Configurable automatic retention and periodic cleanup of old events.

* **Improvements**
  * More reliable delivery to connected gateways with subscription forwarding and backpressure handling.
  * Gateway event broadcasting now uses the Event Hub for consistent delivery.

* **Bug Fixes**
  * Improved graceful shutdown to close event delivery cleanly.
  * Form initialization: avoid unwanted auto-population and fix add-button disable logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->