### PR TITLE
Make the instrumentation-matrix heavy tier run green in CI

### DIFF
--- a/.github/actions/amp-dev-stack/action.yaml
+++ b/.github/actions/amp-dev-stack/action.yaml
@@ -56,9 +56,24 @@ runs:
         # from source into k3d.
         make setup-openchoreo
         # Build + start the core platform (agent-manager-service via compose).
-        make setup-platform
+        # COMPOSE_SERVICES restricts the compose bring-up to the service (+ its
+        # postgres dependency), skipping the slow console image the heavy tier
+        # doesn't use.
+        COMPOSE_SERVICES=agent-manager-service make setup-platform
+        # dev-migrate runs `go run -migrate` on the host (not in the compose
+        # container) and loads agent-manager-service/.env via ENV_FILE_PATH.
+        # That file is gitignored, so seed it from the tracked example — its DB
+        # creds match the compose-exposed Postgres on localhost:5432.
+        cp agent-manager-service/.env.example agent-manager-service/.env
         make dev-migrate
-        # Expose AMP API (9000) + traces-observer (9098) on localhost.
-        (cd deployments/scripts && ./port-forward.sh --platform --background)
+        # setup-platform started the service against a fresh, unmigrated DB, so
+        # it crashed on the missing schema and Air won't restart it on its own.
+        # Now that migrations have run, restart it so it boots cleanly. (Locally
+        # this is masked by a pre-populated postgres volume.)
+        docker compose -f deployments/docker-compose.yml restart agent-manager-service
+        # Expose AMP API (9000) + traces-observer (9098). Bind 0.0.0.0 so the
+        # agent-manager container can reach the forwards via the bridge gateway
+        # (a 127.0.0.1-only forward is unreachable from inside the container).
+        (cd deployments/scripts && PORT_FORWARD_ADDRESS=0.0.0.0 ./port-forward.sh --platform --background)
         make setup-gateway
-        (cd deployments/scripts && ./port-forward.sh --background)
+        (cd deployments/scripts && PORT_FORWARD_ADDRESS=0.0.0.0 ./port-forward.sh --background)

--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -168,9 +168,6 @@ jobs:
     # Normal run: gate behind a green emission matrix. heavy_only: run
     # regardless (run-cells is skipped), so always() is needed to evaluate at all.
     if: ${{ always() && (inputs.heavy_only || (inputs.include_heavy_tier && needs.run-cells.result == 'success')) }}
-    # Deploy/poll bodies are implemented but the build-from-source bring-up
-    # is unvalidated in CI — keep continue-on-error until a real run is green.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       # Build AMP component images from this branch + stand up the stack on

--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -31,6 +31,14 @@ on:
         description: 'Re-record cassettes (requires OPENAI/ANTHROPIC keys) and open a refresh PR'
         type: boolean
         default: false
+      heavy_only:
+        description: 'Skip the emission matrix and run only the heavy tier (implies heavy)'
+        type: boolean
+        default: false
+      heavy_cell_id:
+        description: 'Run only this one heavy-subset cell id (cheap iteration); empty = full subset'
+        required: false
+        default: ''
 
 permissions:
   contents: read   # open-record-pr escalates to write at the job level
@@ -42,6 +50,8 @@ concurrency:
 jobs:
   resolve-cells:
     runs-on: ubuntu-latest
+    # Skipped for heavy-only iteration — no emission matrix to expand.
+    if: ${{ !inputs.heavy_only }}
     outputs:
       cell_ids: ${{ steps.expand.outputs.cell_ids }}
       count: ${{ steps.expand.outputs.count }}
@@ -155,7 +165,9 @@ jobs:
   heavy:
     runs-on: ubuntu-latest
     needs: run-cells
-    if: ${{ inputs.include_heavy_tier }}
+    # Normal run: gate behind a green emission matrix. heavy_only: run
+    # regardless (run-cells is skipped), so always() is needed to evaluate at all.
+    if: ${{ always() && (inputs.heavy_only || (inputs.include_heavy_tier && needs.run-cells.result == 'success')) }}
     # Deploy/poll bodies are implemented but the build-from-source bring-up
     # is unvalidated in CI — keep continue-on-error until a real run is green.
     continue-on-error: true
@@ -169,7 +181,8 @@ jobs:
           python-version: '3.11'
       # requests: heavy/driver.py + amp_client/observer use it for the
       # AMP REST + observer calls (the emission tier never makes live calls).
-      - run: pip install nox pyyaml requests
+      # jsonschema: harness.validator validates spans against the contract.
+      - run: pip install nox pyyaml requests jsonschema
       - name: Run heavy tier
         working-directory: test/instrumentation-matrix
         # URLs + IDP creds default to the dev bring-up's values; only the LLM
@@ -177,7 +190,53 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The deployed customer-support-agent's web-search tool needs this.
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          # Optional single-cell run for cheap iteration; empty = full subset.
+          HEAVY_CELL_ID: ${{ inputs.heavy_cell_id }}
         run: nox -s heavy
+      - name: Dump cluster diagnostics on failure
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          echo "=== port-forward liveness (HTTP 000 = no connection / dropped forward) ==="
+          for p in 9000 8195 9243 22893 8090 9098 8200; do
+            code=$(curl -s -m3 -o /dev/null -w "%{http_code}" "http://localhost:$p" 2>/dev/null)
+            echo "  localhost:$p -> ${code:-000}"
+          done
+          echo "=== pods (all namespaces) ==="
+          kubectl get pods -A -o wide
+          echo "=== agent pod logs (incl. Running — the deploy may be healthy yet acked failed) ==="
+          kubectl get pods -A --no-headers 2>/dev/null \
+            | awk '/traceloop-/{print $1" "$2}' \
+            | while read -r ns pod; do
+                echo "----- $ns/$pod -----"
+                kubectl describe pod -n "$ns" "$pod" 2>/dev/null | sed -n '/Events:/,$p' | tail -25
+                kubectl logs -n "$ns" "$pod" --all-containers --tail=80 2>/dev/null
+              done
+          echo "=== OpenChoreo / gateway CRD kinds present ==="
+          mapfile -t KINDS < <(kubectl get crd -o name 2>/dev/null | grep -iE 'openchoreo|api-platform|wso2' | sed 's#.*/##')
+          printf '  %s\n' "${KINDS[@]}"
+          echo "=== agent CR instances + status (deploy/binding/release/component/workload) ==="
+          for k in "${KINDS[@]}"; do
+            while read -r ns name _; do
+              [ "$ns" = "NAMESPACE" ] && continue
+              case "$name" in
+                *traceloop-*)
+                  echo "--- $k $ns/$name ---"
+                  kubectl get "$k" "$name" -n "$ns" -o yaml 2>/dev/null | sed -n '/^status:/,$p' | head -50 ;;
+              esac
+            done < <(kubectl get "$k" -A 2>/dev/null)
+          done
+          echo "=== data-plane cluster-agent logs (sends deploy acks) ==="
+          kubectl logs -n openchoreo-data-plane deploy/cluster-agent-dataplane --tail=100 2>/dev/null
+          echo "=== gateway controller logs ==="
+          kubectl get pods -n openchoreo-data-plane --no-headers 2>/dev/null \
+            | awk '/gateway-controller/{print $1}' \
+            | while read -r p; do echo "----- $p -----"; kubectl logs -n openchoreo-data-plane "$p" --tail=80 2>/dev/null; done
+          echo "=== recent events ==="
+          kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -80
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -49,10 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: full-emission-matrix
     timeout-minutes: 90
-    # The deploy/poll bodies are implemented but unvalidated against a live
-    # stack, and the build-from-source bring-up itself is first-run-tunable —
-    # so keep continue-on-error until a real run is green, then drop it.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       # Build the AMP component images from this branch and stand up the full
@@ -228,9 +224,8 @@ jobs:
     runs-on: ubuntu-latest
     # All three are listed so the `if:` references below resolve (a
     # needs.<job> reference is only in scope when the job is in `needs`).
-    # `needs.heavy-tier.result == 'failure'` is a no-op today because heavy
-    # is continue-on-error; left in so the condition is correct the moment
-    # that flag flips.
+    # A heavy-tier failure now opens the tracking issue too — it no longer
+    # runs continue-on-error.
     needs: [publish-matrix-summary, full-emission-matrix, heavy-tier]
     permissions:
       contents: read

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -7,7 +7,7 @@ name: Instrumentation matrix — nightly
 
 on:
   schedule:
-    - cron: '30 3 * * *'             # 03:30 UTC / 09:00 IST — matches traceloop-release-watch
+    - cron: '30 20 * * *'            # 20:30 UTC / 02:00 IST
   workflow_dispatch:
 
 permissions:
@@ -64,7 +64,8 @@ jobs:
           python-version: '3.11'
       # requests: heavy/driver.py + amp_client/observer use it for the
       # AMP REST + observer calls (the emission tier never makes live calls).
-      - run: pip install nox pyyaml requests
+      # jsonschema: harness.validator validates spans against the contract.
+      - run: pip install nox pyyaml requests jsonschema
       - name: Run heavy tier
         working-directory: test/instrumentation-matrix
         # Service URLs + IDP creds default to the dev bring-up's values
@@ -73,6 +74,8 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The deployed customer-support-agent's web-search tool needs this.
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
         run: nox -s heavy
       - uses: actions/upload-artifact@v4
         if: always()

--- a/deployments/k8s/coredns-amp-custom.yaml
+++ b/deployments/k8s/coredns-amp-custom.yaml
@@ -17,3 +17,12 @@ data:
       name regex (.+\.)?amp\.localhost host.k3d.internal
       answer auto
     }
+  # The dev gateway chart + setup-gateway.sh reach agent-manager via
+  # host.docker.internal (Docker Desktop / Colima inject it into k3d pods).
+  # A plain Linux k3d runner (CI) has no such injection, so fold it onto
+  # host.k3d.internal, which k3d guarantees on every platform.
+  hostdocker.override: |
+    rewrite stop {
+      name regex host\.docker\.internal host.k3d.internal
+      answer auto
+    }

--- a/deployments/scripts/port-forward.sh
+++ b/deployments/scripts/port-forward.sh
@@ -53,10 +53,20 @@ if ! $BACKGROUND; then
     trap cleanup EXIT INT TERM
 fi
 
+# PORT_FORWARD_ADDRESS optionally binds the forwards to a specific address.
+# Unset = kubectl default (127.0.0.1). CI sets 0.0.0.0 so the agent-manager
+# container (docker-compose) can reach them via the host/bridge gateway —
+# a 127.0.0.1-only forward is unreachable from inside the container on Linux.
+PF_ADDRESS="${PORT_FORWARD_ADDRESS:-}"
+
 start_forward() {
     local desc="$1"; shift
     echo "   $desc"
-    kubectl port-forward "$@" > /dev/null 2>&1 &
+    if [ -n "$PF_ADDRESS" ]; then
+        kubectl port-forward --address "$PF_ADDRESS" "$@" > /dev/null 2>&1 &
+    else
+        kubectl port-forward "$@" > /dev/null 2>&1 &
+    fi
 }
 
 if $PLATFORM; then

--- a/deployments/scripts/setup-platform.sh
+++ b/deployments/scripts/setup-platform.sh
@@ -79,7 +79,14 @@ echo "🚀 Starting Agent Manager platform services..."
 export CONSOLE_HOST_PATH="$(cd "$SCRIPT_DIR/../../console" && pwd)"
 # COMPOSE_SERVICES optionally restricts the bring-up to a subset of services
 # (e.g. CI heavy tier skips the console). Unset = all services (local default).
-docker compose -f "$COMPOSE_FILE" up -d ${COMPOSE_SERVICES:-}
+# Split on whitespace into an array so multiple services work without exposing
+# the value to glob expansion.
+if [ -n "${COMPOSE_SERVICES:-}" ]; then
+    read -r -a compose_services <<< "${COMPOSE_SERVICES}"
+    docker compose -f "$COMPOSE_FILE" up -d "${compose_services[@]}"
+else
+    docker compose -f "$COMPOSE_FILE" up -d
+fi
 
 echo ""
 echo "⏳ Waiting for services to be healthy..."

--- a/deployments/scripts/setup-platform.sh
+++ b/deployments/scripts/setup-platform.sh
@@ -77,7 +77,9 @@ echo "🚀 Starting Agent Manager platform services..."
 # Export console host path so docker-compose can align WORKDIR with the host,
 # preventing Rush temp-file / node_modules path mismatches.
 export CONSOLE_HOST_PATH="$(cd "$SCRIPT_DIR/../../console" && pwd)"
-docker compose -f "$COMPOSE_FILE" up -d
+# COMPOSE_SERVICES optionally restricts the bring-up to a subset of services
+# (e.g. CI heavy tier skips the console). Unset = all services (local default).
+docker compose -f "$COMPOSE_FILE" up -d ${COMPOSE_SERVICES:-}
 
 echo ""
 echo "⏳ Waiting for services to be healthy..."

--- a/test/instrumentation-matrix/DESIGN.md
+++ b/test/instrumentation-matrix/DESIGN.md
@@ -759,9 +759,11 @@ Heavy is a **pipeline test, not a per-framework test**: it deploys one
 representative agent (`samples/customer-support-agent`, a LangChain/LangGraph
 app) and verifies its spans survive the full deployed path. That path is
 framework-agnostic, so the subset (`harness/heavy_subset.py`) is **one cell
-per Traceloop/instrumentation version**, on the default framework + python —
-the only axis that changes the deployed init-container. With a single Traceloop
-version today that's one cell; it grows as versions are added.
+per (Traceloop/instrumentation version × python)**, on the default framework.
+Those are the two axes that change the deployed agent: the init-container
+image, and the buildpack python the agent is built and instrumented on. With a
+single Traceloop version and four pythons today that's four cells; it grows as
+Traceloop versions are added.
 
 There is deliberately **no per-framework axis**. Deploying the same agent
 under a `crewai` / `llama-index` label proves nothing about those frameworks,

--- a/test/instrumentation-matrix/DESIGN.md
+++ b/test/instrumentation-matrix/DESIGN.md
@@ -755,9 +755,24 @@ nox -s emission
 
 ### 9.2 Cell subset
 
-Declared in `matrix.yaml.heavyTier`. Currently ~3 Traceloop versions × 1
-default framework + 6 frameworks × 1 default combo ≈ **8–10 cells**. Wall
-time on parallel runners: ~1 h.
+Heavy is a **pipeline test, not a per-framework test**: it deploys one
+representative agent (`samples/customer-support-agent`, a LangChain/LangGraph
+app) and verifies its spans survive the full deployed path. That path is
+framework-agnostic, so the subset (`harness/heavy_subset.py`) is **one cell
+per Traceloop/instrumentation version**, on the default framework + python —
+the only axis that changes the deployed init-container. With a single Traceloop
+version today that's one cell; it grows as versions are added.
+
+There is deliberately **no per-framework axis**. Deploying the same agent
+under a `crewai` / `llama-index` label proves nothing about those frameworks,
+and asserting their span kinds (e.g. `crewaitask`) against a LangGraph agent
+can never pass. So the driver asserts the kinds the *deployed agent* emits
+(`heavy/driver.py:_DEPLOYED_AGENT_SPAN_KINDS` — the `llm` span, plus
+shape-validation of every captured span), **not** each cell's framework kinds.
+Per-framework span *shape* is the emission tier's job (§5). True per-framework
+heavy coverage would require a deployable agent app per framework — the
+`cells/*_sample.py` are in-process scripts, not deployable buildpack apps —
+which is tracked as future work (e.g. a deployable `crewai` sample).
 
 ### 9.3 Infra
 
@@ -790,11 +805,14 @@ k3d on a GHA-hosted runner (default) with a self-hosted-runner escape hatch.
 
 Agents are deployed through `agent-manager-service`'s REST API (the same
 flow `test/e2e/framework/shared_agent.go` uses), not raw Kubernetes
-Workload manifests. The build request carries the cell's
-`instrumentation_version`, `framework_package==framework_version`, and
-`python_version`; `agent-manager-service` picks the right init-container
-image and patches `requirements.txt` before the build. The driver records
-the deployed agent's `(org, project, agent, environment)` on a
+Workload manifests. Creating the agent auto-triggers build + deploy (the
+driver does not POST a separate deployment — a redundant deploy re-renders
+the workload without the secret env and breaks the binding). The request
+pins the cell's `instrumentation_version` (selecting the init-container
+image) and `python_version` (the buildpack language version); the framework
+rides only as an informational `AMP_MATRIX_FRAMEWORK` env var, since the
+deployed sample's own `requirements.txt` defines its framework. The driver
+records the deployed agent's `(org, project, agent, environment)` on a
 `DeployedAgent` record so the subsequent observer poll has the keys
 `GET /api/v1/traces` requires.
 

--- a/test/instrumentation-matrix/FINDINGS.md
+++ b/test/instrumentation-matrix/FINDINGS.md
@@ -196,7 +196,7 @@ reused, so removed numbers just leave a gap.)
 
 - **Status**: mitigated
 - **Combo**: heavy tier, all cells (most visible on `crewai`, `llama-index`)
-- **Discovered**: 2026-05-29 (first green heavy run + design review)
+- **Discovered**: 2026-05-28 (first green heavy run + design review)
 - **Symptom**: the heavy subset is selected "one per framework", but the
   driver deploys a single fixed sample (`samples/customer-support-agent`, a
   LangChain/LangGraph app) for every cell. So a cell labelled `crewai` runs a

--- a/test/instrumentation-matrix/FINDINGS.md
+++ b/test/instrumentation-matrix/FINDINGS.md
@@ -191,3 +191,30 @@ reused, so removed numbers just leave a gap.)
 - **Re-tighten when**: not applicable — these are forward pins to currently-
   compatible versions; if either SDK regresses or Traceloop pins httpx tight
   enough to require an older SDK, the matrix will surface it.
+
+## F-011 — Heavy tier deploys one representative agent, not per-framework
+
+- **Status**: mitigated
+- **Combo**: heavy tier, all cells (most visible on `crewai`, `llama-index`)
+- **Discovered**: 2026-05-29 (first green heavy run + design review)
+- **Symptom**: the heavy subset is selected "one per framework", but the
+  driver deploys a single fixed sample (`samples/customer-support-agent`, a
+  LangChain/LangGraph app) for every cell. So a cell labelled `crewai` runs a
+  LangGraph agent and can never emit `crewaitask`; asserting each cell's
+  framework span kinds against the shared agent fails by construction (and the
+  passes — `openai-direct`, `langchain`, … expecting `llm` — only "pass"
+  because LangGraph happens to emit an `llm` span too).
+- **Cause**: only LangChain/LangGraph deployable sample agents exist under
+  `samples/`. The per-framework artifacts that do exist (`cells/*_sample.py`)
+  are in-process scripts for the emission tier's in-memory exporter — not
+  deployable buildpack apps with an HTTP `/chat` server.
+- **Mitigation**: reframe heavy as a **pipeline test**. The subset is one cell
+  per Traceloop/instrumentation version on the default framework (no
+  per-framework axis), and the driver asserts the kinds the *deployed agent*
+  emits (`heavy/driver.py:_DEPLOYED_AGENT_SPAN_KINDS` = `llm`, plus
+  shape-validation of every captured span) rather than each cell's framework
+  kinds. Per-framework span *shape* remains the emission tier's job.
+- **Re-tighten when**: deployable per-framework sample agents exist (e.g. a
+  `samples/crewai-agent` buildpack app). Then the driver can deploy the sample
+  matching each cell's framework and assert that framework's span kinds —
+  restoring a real per-framework heavy axis.

--- a/test/instrumentation-matrix/RUNBOOK.md
+++ b/test/instrumentation-matrix/RUNBOOK.md
@@ -221,11 +221,28 @@ Pair every `known-broken` entry with an `F-NNN` entry in `FINDINGS.md` so the
 
 ## 7. Heavy tier (deploy contract + ops)
 
-The heavy tier (`nox -s heavy`, `heavy/driver.py`) deploys a representative
-cell subset (`harness/heavy_subset.py`: one per Traceloop version + one per
-framework, on the default python) against a real AMP stack on k3d, invokes
-each agent, polls `traces-observer-service`, and validates the spans that
-survive the full pipeline against the same `traceloop/v1` contract.
+The heavy tier (`nox -s heavy`, `heavy/driver.py`) is a **pipeline test**: it
+deploys one representative agent (`samples/customer-support-agent`, a
+LangChain/LangGraph app) against a real AMP stack on k3d, invokes it, polls
+`traces-observer-service`, and checks that the spans survive the full path
+(auto-instrumentation → gateway → collector → OpenSearch → observer) and
+validate against the `traceloop/v1` contract.
+
+Because that path is framework-agnostic, one agent proves it — so the subset
+(`harness/heavy_subset.py`) is **one cell per Traceloop/instrumentation
+version** on the default framework + python (the only axis that changes the
+deployed init-container). There is deliberately **no per-framework axis**:
+deploying the same LangGraph agent under a `crewai`/`llama-index` label proves
+nothing about those frameworks, and asserting their span kinds (e.g.
+`crewaitask`) against it can never pass. The driver therefore validates the
+kinds the *deployed agent* emits (`heavy/driver.py:_DEPLOYED_AGENT_SPAN_KINDS`
+— the `llm` span, plus shape-validation of every captured span), **not** each
+cell's framework kinds. Per-framework span *shape* is the emission tier's job.
+
+True per-framework heavy coverage would need a deployable agent app per
+framework (the `cells/*_sample.py` are in-process scripts, not deployable
+buildpack apps). That's tracked as future work — e.g. adding a deployable
+`crewai` sample and deploying it for crewai cells (see FINDINGS).
 
 ### Bring-up: build-from-source
 

--- a/test/instrumentation-matrix/RUNBOOK.md
+++ b/test/instrumentation-matrix/RUNBOOK.md
@@ -229,9 +229,11 @@ LangChain/LangGraph app) against a real AMP stack on k3d, invokes it, polls
 validate against the `traceloop/v1` contract.
 
 Because that path is framework-agnostic, one agent proves it — so the subset
-(`harness/heavy_subset.py`) is **one cell per Traceloop/instrumentation
-version** on the default framework + python (the only axis that changes the
-deployed init-container). There is deliberately **no per-framework axis**:
+(`harness/heavy_subset.py`) is **one cell per (Traceloop/instrumentation
+version × python)** on the default framework. Those are the two axes that
+change the deployed agent: the init-container image, and the buildpack python
+the agent is built and instrumented on. There is deliberately **no
+per-framework axis**:
 deploying the same LangGraph agent under a `crewai`/`llama-index` label proves
 nothing about those frameworks, and asserting their span kinds (e.g.
 `crewaitask`) against it can never pass. The driver therefore validates the

--- a/test/instrumentation-matrix/harness/heavy_subset.py
+++ b/test/instrumentation-matrix/harness/heavy_subset.py
@@ -2,17 +2,23 @@
 
 The heavy tier is expensive — every cell deploys a real agent against a k3d
 snapshot, hits the API, polls the observer. So we run a sample, not the full
-matrix. The sample is chosen along two axes:
+matrix.
 
-1. **Per-traceloop axis** — one cell per traceloop version, pinning the
-   framework + python to the manifest's `defaultCell`. Surfaces regressions
-   that ride along with a Traceloop bump.
-2. **Per-framework axis** — one cell per framework, pinning traceloop +
-   python to the default. Surfaces regressions in framework-specific
-   instrumentation wrappers.
+**Heavy is a pipeline test, not a per-framework test.** It deploys one
+representative agent (`samples/customer-support-agent`, a LangChain/LangGraph
+app) and asks: *do its spans survive the full deployed path —
+auto-instrumentation → gateway → collector → OpenSearch → traces-observer —
+and arrive well-formed?* That path is framework-agnostic, so a single agent
+proves it. Per-framework span *shape* is the emission tier's job (it runs each
+`cells/<framework>_sample.py` in-process), so heavy does NOT vary the framework
+or assert framework-specific span kinds — doing so would only be meaningful
+with a deployable agent per framework, which we don't have yet (see
+FINDINGS / RUNBOOK §7).
 
-Cells that satisfy both axes (default-traceloop × default-framework) appear
-once, not twice.
+The one axis that *does* change what gets deployed is the
+**instrumentation/Traceloop version** (it pins the init-container). So the
+subset is one cell per Traceloop version, on the default framework + python —
+i.e. the representative agent re-validated against each init-container version.
 """
 from __future__ import annotations
 
@@ -22,39 +28,21 @@ from harness.manifest import Cell, Manifest
 def select_heavy_subset(cells: list[Cell], manifest: Manifest) -> list[Cell]:
     default = manifest.default_cell
 
-    # Per-traceloop axis: each version of the default provider, pinned to the
-    # default framework + framework_version + python so it's exactly one cell
-    # per provider version (not one per framework_version too).
-    per_tl = [
-        c
-        for c in cells
-        if c.provider_name == default.provider
-        and c.framework_name == default.framework
-        and c.framework_version == default.framework_version
-        and c.python == default.python
-    ]
-
-    # Per-framework axis: each framework once, on the default provider
-    # version + python.
-    per_fw_seen: set[str] = set()
-    per_fw: list[Cell] = []
+    # One cell per Traceloop/provider version, pinned to the default framework
+    # + framework_version + python. Each maps to a distinct init-container
+    # (instrumentation) version — the only axis that changes the deployed
+    # agent. The framework is fixed to the default (which matches the deployed
+    # sample), so the cell's label reflects what actually runs.
+    per_version: list[Cell] = []
+    seen: set[str] = set()
     for c in cells:
         if (
-            c.provider_name != default.provider
-            or c.provider_version != default.provider_version
-            or c.python != default.python
+            c.provider_name == default.provider
+            and c.framework_name == default.framework
+            and c.framework_version == default.framework_version
+            and c.python == default.python
+            and c.id not in seen
         ):
-            continue
-        if c.framework_name in per_fw_seen:
-            continue
-        per_fw_seen.add(c.framework_name)
-        per_fw.append(c)
-
-    seen: set[str] = set()
-    out: list[Cell] = []
-    for c in [*per_tl, *per_fw]:
-        if c.id in seen:
-            continue
-        seen.add(c.id)
-        out.append(c)
-    return out
+            seen.add(c.id)
+            per_version.append(c)
+    return per_version

--- a/test/instrumentation-matrix/harness/heavy_subset.py
+++ b/test/instrumentation-matrix/harness/heavy_subset.py
@@ -15,10 +15,17 @@ or assert framework-specific span kinds — doing so would only be meaningful
 with a deployable agent per framework, which we don't have yet (see
 FINDINGS / RUNBOOK §7).
 
-The one axis that *does* change what gets deployed is the
-**instrumentation/Traceloop version** (it pins the init-container). So the
-subset is one cell per Traceloop version, on the default framework + python —
-i.e. the representative agent re-validated against each init-container version.
+Two axes *do* change what gets deployed, so the subset crosses both:
+
+1. **instrumentation/Traceloop version** — pins the init-container image.
+2. **python version** — the buildpack builds (and the instrumentation runs)
+   the agent on that interpreter, so a py-version-specific break surfaces
+   through the deployed pipeline.
+
+So the subset is one cell per (Traceloop version × python), on the default
+framework + framework_version — the representative agent re-validated against
+each init-container version and each python. (Unlike the framework axis,
+varying python deploys a genuinely different agent build.)
 """
 from __future__ import annotations
 
@@ -28,21 +35,20 @@ from harness.manifest import Cell, Manifest
 def select_heavy_subset(cells: list[Cell], manifest: Manifest) -> list[Cell]:
     default = manifest.default_cell
 
-    # One cell per Traceloop/provider version, pinned to the default framework
-    # + framework_version + python. Each maps to a distinct init-container
-    # (instrumentation) version — the only axis that changes the deployed
-    # agent. The framework is fixed to the default (which matches the deployed
-    # sample), so the cell's label reflects what actually runs.
-    per_version: list[Cell] = []
+    # One cell per (Traceloop/provider version × python), pinned to the default
+    # framework + framework_version. The framework is fixed to the default
+    # (which matches the deployed sample), so the cell's label reflects what
+    # actually runs; the provider version and python are the two axes that
+    # change the deployed agent (init-container image, buildpack interpreter).
+    out: list[Cell] = []
     seen: set[str] = set()
     for c in cells:
         if (
             c.provider_name == default.provider
             and c.framework_name == default.framework
             and c.framework_version == default.framework_version
-            and c.python == default.python
             and c.id not in seen
         ):
             seen.add(c.id)
-            per_version.append(c)
-    return per_version
+            out.append(c)
+    return out

--- a/test/instrumentation-matrix/heavy/amp_client.py
+++ b/test/instrumentation-matrix/heavy/amp_client.py
@@ -22,6 +22,7 @@ validates this end to end.
 """
 from __future__ import annotations
 
+import hashlib
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -31,19 +32,35 @@ import requests
 # Timeout budget (see RUNBOOK.md §7).
 _BUILD_TIMEOUT_S = 600
 _BUILD_POLL_S = 10
-_DEPLOY_TIMEOUT_S = 300
+_DEPLOY_TIMEOUT_S = 600
 _DEPLOY_POLL_S = 10
+# Consecutive "failed" polls before giving up (tolerates a transient failed
+# during reconciliation while still bailing fast on a genuinely stuck deploy).
+_DEPLOY_FAILED_STREAK = 3
 _HTTP_TIMEOUT_S = 30
 _TOKEN_REFRESH_SKEW_S = 30
 
+# AMP caps resource names at 25 chars (utils.MaxResourceNameLength); when a
+# cell id exceeds it, _safe_name keeps a prefix plus this many hash chars.
+_MAX_NAME_LEN = 25
+_HASH_LEN = 6
+
 
 def _safe_name(cell_id: str) -> str:
-    """Coerce a cell id into an AMP project/agent name: lowercase, and only
-    `[a-z0-9-]` (cell ids carry dots in versions, which AMP names reject)."""
-    out = []
-    for ch in cell_id.lower():
-        out.append(ch if (ch.isalnum() or ch == "-") else "-")
-    return "".join(out).strip("-")
+    """Coerce a cell id into an AMP project/agent name.
+
+    AMP enforces RFC 1035 DNS labels (agent-manager-service
+    utils.ValidateResourceName): at most 25 chars, only `[a-z0-9-]`, starts
+    with a letter, ends alphanumeric. Cell ids carry dotted versions and run
+    ~47 chars, so fold non-alnum to `-` and, when too long, keep a readable
+    prefix plus a short stable hash — deterministic so teardown reuses the
+    same name, and collision-resistant when prefixes coincide."""
+    slug = "".join(ch if (ch.isalnum() or ch == "-") else "-" for ch in cell_id.lower()).strip("-")
+    if len(slug) <= _MAX_NAME_LEN:
+        return slug
+    digest = hashlib.sha1(cell_id.encode()).hexdigest()[:_HASH_LEN]
+    prefix = slug[: _MAX_NAME_LEN - _HASH_LEN - 1].strip("-")
+    return f"{prefix}-{digest}"
 
 
 def _utc_rfc3339(*, hours_from_now: int) -> str:
@@ -223,7 +240,10 @@ class AmpClient:
         )
 
         image_id = self._wait_for_build(org, name)
-        self._deploy(org, name, image_id)
+        # No explicit deploy: creating an internal agent auto-triggers build and
+        # deploy (mirroring test/e2e's shared-agent setup, which only waits).
+        # A redundant POST /deployments re-renders the workload without the
+        # sensitive env, dropping the SecretReference and failing the binding.
         endpoint = self._wait_for_active_endpoint(org, name)
         api_key = self._mint_api_key(org, name)
 
@@ -264,13 +284,6 @@ class AmpClient:
             time.sleep(_BUILD_POLL_S)
         raise TimeoutError(f"build {build_name} did not complete within {_BUILD_TIMEOUT_S}s")
 
-    def _deploy(self, org: str, name: str, image_id: str) -> None:
-        self._request(
-            "POST", f"/api/v1/orgs/{org}/projects/{name}/agents/{name}/deployments",
-            json={"imageId": image_id, "enableAutoInstrumentation": True},
-            expect=(202,),
-        )
-
     def _wait_for_active_endpoint(self, org: str, name: str) -> str:
         # FIRST-RUN-TUNABLE: reads the endpoint URL from the deployments
         # response (`endpoints[].url`). The e2e suite instead reads it from
@@ -278,17 +291,35 @@ class AmpClient:
         # turns out not to carry the URL, switch to that endpoint here.
         path = f"/api/v1/orgs/{org}/projects/{name}/agents/{name}/deployments"
         deadline = time.monotonic() + _DEPLOY_TIMEOUT_S
+        last_seen = "<no deployments response>"
+        failed_streak = 0
         while time.monotonic() < deadline:
             deployments = self._request("GET", path, expect=(200,)).json()
             dep = deployments.get(self.environment)
-            if dep and dep.get("status") == "active":
-                endpoints = dep.get("endpoints") or []
-                if endpoints:
-                    return endpoints[0]["url"]
-                raise AmpError(f"{name} active but exposes no endpoint")
+            if dep is None:
+                last_seen = f"env {self.environment!r} absent; present={list(deployments)}"
+                failed_streak = 0
+            else:
+                status = dep.get("status")
+                last_seen = f"status={status!r}"
+                if status == "active":
+                    endpoints = dep.get("endpoints") or []
+                    if endpoints:
+                        return endpoints[0]["url"]
+                    raise AmpError(f"{name} active but exposes no endpoint")
+                # Tolerate a transient failed during reconciliation (the e2e
+                # suite polls through non-active states); bail only once it
+                # persists, so a genuinely stuck deploy fails fast.
+                if status == "failed":
+                    failed_streak += 1
+                    if failed_streak >= _DEPLOY_FAILED_STREAK:
+                        raise AmpError(f"{name} deployment failed in {self.environment}")
+                else:
+                    failed_streak = 0
             time.sleep(_DEPLOY_POLL_S)
         raise TimeoutError(
-            f"{name} not active in {self.environment} within {_DEPLOY_TIMEOUT_S}s"
+            f"{name} not active in {self.environment} within {_DEPLOY_TIMEOUT_S}s "
+            f"(last: {last_seen})"
         )
 
     def _mint_api_key(self, org: str, name: str) -> str:

--- a/test/instrumentation-matrix/heavy/driver.py
+++ b/test/instrumentation-matrix/heavy/driver.py
@@ -75,6 +75,23 @@ def _env(name: str) -> str:
     return os.environ.get(name, _DEFAULTS[name])
 
 
+def _log(msg: str) -> None:
+    # flush=True so progress streams live to the CI log — stdout is block-
+    # buffered off a TTY, which would otherwise dump everything at the end.
+    print(msg, flush=True)
+
+
+def _outcome(r: CellResult) -> str:
+    if r.result == "pass":
+        return f"✅ pass ({','.join(r.coverage.get('actual', []))})"
+    if r.result == "skipped":
+        return f"⊘ skipped — {r.skip_reason}"
+    detail = ""
+    if r.violations:
+        detail = ": " + (r.violations[0].get("message") or "").strip()
+    return f"❌ fail ({r.category}){detail}"
+
+
 def main() -> int:
     m = load_manifest(HERE / "matrix.yaml")
     cells = select_heavy_subset(expand_matrix(m), m)
@@ -103,8 +120,11 @@ def main() -> int:
     agent_env = {k: os.environ[k] for k in _AGENT_SECRET_ENV_KEYS if os.environ.get(k)}
 
     reports_dir = HERE / "reports" / "heavy"
-    overall_fail = False
-    for cell in cells:
+    total = len(cells)
+    _log(f"heavy tier: running {total} cell(s)")
+    passed = failed = skipped = 0
+    for idx, cell in enumerate(cells, 1):
+        _log(f"[{idx}/{total}] {cell.id}")
         try:
             result = _run_cell(cell, client, observer_base_url, agent_env)
         except Exception as e:  # noqa: BLE001 - one cell's failure must not abort the rest
@@ -123,9 +143,15 @@ def main() -> int:
                 captured_spans=[],
             )
         write_cell_report(result, reports_dir=reports_dir)
+        _log("      " + _outcome(result))
         if result.result == "fail":
-            overall_fail = True
-    return 1 if overall_fail else 0
+            failed += 1
+        elif result.result == "skipped":
+            skipped += 1
+        else:
+            passed += 1
+    _log(f"heavy summary: {passed} passed, {failed} failed, {skipped} skipped")
+    return 1 if failed else 0
 
 
 def _run_cell(
@@ -145,6 +171,7 @@ def _run_cell(
             captured_spans=[],
         )
 
+    _log(f"      deploying (instr {cell.instrumentation_version}, py{cell.python})…")
     k3d.reset_opensearch_indices()
     deployed = client.deploy_agent(
         cell_id=cell.id,
@@ -154,11 +181,14 @@ def _run_cell(
         python_version=cell.python,
         agent_env=agent_env,
     )
+    _log(f"      deployed {deployed.agent_name}; invoking /chat…")
     try:
         _invoke_agent(deployed)
+        _log("      invoked; polling observer for spans…")
         spans = poll_traces(client, deployed, observer_base_url)
     finally:
         client.teardown_agent(deployed)
+    _log(f"      captured {len(spans)} span(s)")
 
     if not spans:
         return CellResult(

--- a/test/instrumentation-matrix/heavy/driver.py
+++ b/test/instrumentation-matrix/heavy/driver.py
@@ -22,6 +22,7 @@ tune on first run.
 from __future__ import annotations
 
 import os
+import sys
 import time
 from pathlib import Path
 
@@ -54,11 +55,20 @@ _DEFAULTS = {
     "IDP_CLIENT_SECRET": "amp-api-client-secret",
 }
 
-# LLM keys the deployed agent needs to make real calls. Forwarded as
-# sensitive env vars into each agent at create time; absent keys are simply
-# not forwarded (a cell whose framework needs one will then fail its call,
-# which the matrix surfaces).
-_LLM_ENV_KEYS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY")
+# Secrets the deployed sample agent needs to start and make real calls:
+# the LLM provider keys plus TAVILY_API_KEY (the customer-support-agent's
+# web-search tool fails construction without it). Forwarded as sensitive env
+# vars at create time; absent keys are simply not forwarded.
+_AGENT_SECRET_ENV_KEYS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "TAVILY_API_KEY")
+
+# Heavy deploys ONE representative agent (samples/customer-support-agent, a
+# LangChain/LangGraph app) for every cell, so it asserts the kinds THAT agent
+# emits — not each cell's framework kinds (which would need a deployable agent
+# per framework; see RUNBOOK §7). We require the llm span (every chat turn
+# makes a model call); the richer kinds it also emits (agent/chain/embedding)
+# are shape-validated when present via validate_all and surfaced in the
+# coverage "actual" list. Per-framework span shape is the emission tier's job.
+_DEPLOYED_AGENT_SPAN_KINDS = ["llm"]
 
 
 def _env(name: str) -> str:
@@ -69,6 +79,18 @@ def main() -> int:
     m = load_manifest(HERE / "matrix.yaml")
     cells = select_heavy_subset(expand_matrix(m), m)
 
+    # Optional single-cell filter for cheap iteration: set HEAVY_CELL_ID to a
+    # cell id from the heavy subset to run just that one. Empty/unset runs all.
+    only = os.environ.get("HEAVY_CELL_ID", "").strip()
+    if only:
+        cells = [c for c in cells if c.id == only]
+        if not cells:
+            print(
+                f"HEAVY_CELL_ID={only!r} matched no cell in the heavy subset",
+                file=sys.stderr,
+            )
+            return 1
+
     client = AmpClient(
         base_url=_env("AMP_API_BASE_URL"),
         idp=IdpCredentials(
@@ -78,7 +100,7 @@ def main() -> int:
         ),
     )
     observer_base_url = _env("TRACES_OBSERVER_BASE_URL")
-    agent_env = {k: os.environ[k] for k in _LLM_ENV_KEYS if os.environ.get(k)}
+    agent_env = {k: os.environ[k] for k in _AGENT_SECRET_ENV_KEYS if os.environ.get(k)}
 
     reports_dir = HERE / "reports" / "heavy"
     overall_fail = False
@@ -95,7 +117,7 @@ def main() -> int:
                 category="pipeline-error",
                 skip_reason=None,
                 durations={},
-                coverage={"expected": cell.span_kinds, "actual": [], "missing": cell.span_kinds},
+                coverage={"expected": _DEPLOYED_AGENT_SPAN_KINDS, "actual": [], "missing": _DEPLOYED_AGENT_SPAN_KINDS},
                 violations=[{"spanName": "", "kind": "", "rule": "driver",
                              "path": "", "message": f"{type(e).__name__}: {e}"}],
                 captured_spans=[],
@@ -118,7 +140,7 @@ def _run_cell(
             category=None,
             skip_reason="no instrumentation_version (manual provider)",
             durations={},
-            coverage={"expected": cell.span_kinds, "actual": [], "missing": []},
+            coverage={"expected": _DEPLOYED_AGENT_SPAN_KINDS, "actual": [], "missing": []},
             violations=[],
             captured_spans=[],
         )
@@ -146,9 +168,9 @@ def _run_cell(
             skip_reason=None,
             durations={},
             coverage={
-                "expected": cell.span_kinds,
+                "expected": _DEPLOYED_AGENT_SPAN_KINDS,
                 "actual": [],
-                "missing": cell.span_kinds,
+                "missing": _DEPLOYED_AGENT_SPAN_KINDS,
             },
             violations=[],
             captured_spans=[],
@@ -156,7 +178,7 @@ def _run_cell(
 
     provider = PROVIDERS[cell.provider_name]
     validator = ContractValidator.load(provider.contract_schema_id())
-    coverage = validator.assert_coverage(spans, expected_kinds=cell.span_kinds)
+    coverage = validator.assert_coverage(spans, expected_kinds=_DEPLOYED_AGENT_SPAN_KINDS)
     shape_results = validator.validate_all(spans)
     violations = [
         {
@@ -171,7 +193,7 @@ def _run_cell(
     ]
 
     base_coverage = {
-        "expected": cell.span_kinds,
+        "expected": _DEPLOYED_AGENT_SPAN_KINDS,
         "actual": sorted(coverage.actual),
         "missing": sorted(coverage.missing),
     }

--- a/test/instrumentation-matrix/heavy/observer.py
+++ b/test/instrumentation-matrix/heavy/observer.py
@@ -32,6 +32,11 @@ from heavy.amp_client import AmpClient, DeployedAgent
 
 _HTTP_TIMEOUT_S = 30
 _POLL_S = 10
+# Spans index incrementally: a chat turn's chain/embedding spans land before
+# the llm completion span. Don't return on the first non-empty fetch — wait
+# until the span count holds steady across this many consecutive polls so
+# late-arriving spans aren't missed.
+_SETTLE_POLLS = 2
 
 
 def _rfc3339(dt: datetime) -> str:
@@ -59,39 +64,56 @@ def poll_traces(
     session = requests.Session()
 
     deadline = time.monotonic() + timeout_s
-    trace_ids: list[str] = []
     got_clean_response = False
     last_error: str | None = None
-    while time.monotonic() < deadline:
+    best_spans: list[dict] = []
+    last_count = -1
+    stable_polls = 0
+    while True:
         trace_ids, err = _list_trace_ids(session, client, base, deployed, start_time, end_time)
         if err is None:
             got_clean_response = True
         else:
             last_error = err
-        if trace_ids:
+
+        spans: list[dict] = []
+        for trace_id in trace_ids:
+            for span_id in _list_span_ids(
+                session, client, base, deployed, trace_id, start_time, end_time
+            ):
+                detail = _get_span_detail(session, client, base, trace_id, span_id)
+                if detail is not None:
+                    spans.append(_to_validator_span(detail))
+
+        if spans:
+            best_spans = spans
+            # Settled once the count holds steady across consecutive polls —
+            # this lets the late llm span join the early chain/embedding ones.
+            if len(spans) == last_count:
+                stable_polls += 1
+                if stable_polls >= _SETTLE_POLLS:
+                    return spans
+            else:
+                stable_polls = 0
+            last_count = len(spans)
+
+        # Stop before a sleep would overrun the deadline.
+        if time.monotonic() + _POLL_S >= deadline:
             break
         time.sleep(_POLL_S)
-    if not trace_ids:
-        # Distinguish "observer answered 200 but no traces" (genuinely empty →
-        # the driver maps [] to no-spans-captured) from "every list call
-        # errored" (transport/HTTP problem → raise so the driver records a
-        # pipeline-error, not a misleading no-spans-captured).
-        if not got_clean_response:
-            raise RuntimeError(
-                f"trace listing never succeeded within {timeout_s}s "
-                f"(last error: {last_error})"
-            )
-        return []
 
-    spans: list[dict] = []
-    for trace_id in trace_ids:
-        for span_id in _list_span_ids(
-            session, client, base, deployed, trace_id, start_time, end_time
-        ):
-            detail = _get_span_detail(session, client, base, trace_id, span_id)
-            if detail is not None:
-                spans.append(_to_validator_span(detail))
-    return spans
+    if best_spans:
+        return best_spans
+    # Distinguish "observer answered 200 but no traces" (genuinely empty → the
+    # driver maps [] to no-spans-captured) from "every list call errored"
+    # (transport/HTTP problem → raise so the driver records a pipeline-error,
+    # not a misleading no-spans-captured).
+    if not got_clean_response:
+        raise RuntimeError(
+            f"trace listing never succeeded within {timeout_s}s "
+            f"(last error: {last_error})"
+        )
+    return []
 
 
 def _auth_get(session, client: AmpClient, url: str, params: dict | None = None):

--- a/test/instrumentation-matrix/tests/test_heavy_client.py
+++ b/test/instrumentation-matrix/tests/test_heavy_client.py
@@ -10,8 +10,14 @@ import pytest
 
 responses = pytest.importorskip("responses")
 
-from heavy.amp_client import AmpClient, AmpError, IdpCredentials  # noqa: E402
+import re  # noqa: E402
+
+from heavy.amp_client import AmpClient, AmpError, IdpCredentials, _safe_name  # noqa: E402
 from heavy.observer import poll_traces  # noqa: E402
+
+# AMP resource-name rule (agent-manager-service utils.ValidateResourceName):
+# <=25 chars, [a-z0-9-], starts with a letter, ends alphanumeric.
+_AMP_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,23}[a-z0-9]$")
 
 BASE = "http://amp.test"
 OBS = "http://obs.test"
@@ -59,7 +65,8 @@ def _mock_happy_deploy(org="default", name="traceloop-0-60-0-langchain-0-3-27-py
     # build: appears, then completes with an imageId
     responses.add(responses.GET, f"{BASE}{a}/builds", json={"builds": [{"buildName": "b1"}]}, status=200)
     responses.add(responses.GET, f"{BASE}{a}/builds/b1", json={"buildName": "b1", "status": "Completed", "imageId": "img-9"}, status=200)
-    responses.add(responses.POST, f"{BASE}{a}/deployments", json={}, status=202)
+    # No POST /deployments: the agent auto-deploys on create; the driver only
+    # polls GET /deployments for the active endpoint.
     responses.add(
         responses.GET, f"{BASE}{a}/deployments",
         # endpoint is the agent's base URL; the driver appends /chat at invoke.
@@ -73,9 +80,10 @@ def _mock_happy_deploy(org="default", name="traceloop-0-60-0-langchain-0-3-27-py
 @responses.activate
 def test_deploy_agent_happy_path():
     _mock_token()
-    name = _mock_happy_deploy()
+    cell_id = "traceloop-0.60.0-langchain-0.3.27-py3.11"
+    name = _mock_happy_deploy(name=_safe_name(cell_id))
     d = _client().deploy_agent(
-        cell_id="traceloop-0.60.0-langchain-0.3.27-py3.11",
+        cell_id=cell_id,
         instrumentation_version="0.2.1",
         framework_package="langchain",
         framework_version="0.3.27",
@@ -169,3 +177,27 @@ def test_poll_traces_empty_when_no_traces():
     )
     responses.add(responses.GET, f"{OBS}/api/v1/traces", json={"traces": []}, status=200)
     assert poll_traces(_client(), d, OBS, timeout_s=1) == []
+
+
+# A representative heavy-subset cell id — its dotted versions make the naive
+# slug 47 chars, well over AMP's 25-char cap.
+_LONG_CELL = "traceloop-0.60.0-anthropic-direct-0.45.0-py3.11"
+
+
+def test_safe_name_obeys_amp_resource_rule():
+    name = _safe_name(_LONG_CELL)
+    assert len(name) <= 25
+    assert _AMP_NAME_RE.match(name), name
+
+
+def test_safe_name_short_id_passes_through():
+    assert _safe_name("traceloop-langchain") == "traceloop-langchain"
+
+
+def test_safe_name_is_stable_and_unique():
+    # deterministic: same input -> same name (teardown reuses it)
+    assert _safe_name(_LONG_CELL) == _safe_name(_LONG_CELL)
+    # distinct long cells that share a 25-char prefix must not collide
+    a = _safe_name("traceloop-0.60.0-anthropic-direct-0.45.0-py3.11")
+    b = _safe_name("traceloop-0.60.0-anthropic-direct-0.45.0-py3.12")
+    assert a != b

--- a/test/instrumentation-matrix/tests/test_heavy_subset.py
+++ b/test/instrumentation-matrix/tests/test_heavy_subset.py
@@ -56,16 +56,19 @@ def _multi_manifest() -> Manifest:
     )
 
 
-def test_subset_covers_each_traceloop_version_once_and_each_framework_once():
+def test_subset_covers_each_traceloop_version_on_the_default_framework():
     m = _multi_manifest()
     cells = expand_matrix(m)
     sub = select_heavy_subset(cells, m)
     versions = {(c.provider_version, c.framework_name) for c in sub}
-    # per-traceloop axis: each version paired with the default framework.
+    # One cell per Traceloop version, all on the default framework — that's the
+    # only axis that changes the deployed init-container.
     assert ("0.60.0", "langchain") in versions
     assert ("0.61.0", "langchain") in versions
-    # per-framework axis: each framework paired with the default traceloop.
-    assert ("0.60.0", "crewai") in versions
+    # Heavy deploys one representative agent, so there is NO per-framework
+    # axis: non-default frameworks (crewai) are not in the subset.
+    assert all(c.framework_name == "langchain" for c in sub)
+    assert ("0.60.0", "crewai") not in versions
 
 
 def test_subset_deduplicates_overlapping_axes():

--- a/test/instrumentation-matrix/tests/test_heavy_subset.py
+++ b/test/instrumentation-matrix/tests/test_heavy_subset.py
@@ -80,12 +80,17 @@ def test_subset_deduplicates_overlapping_axes():
     assert len(ids) == len(set(ids))
 
 
-def test_subset_uses_default_python_only():
+def test_subset_covers_each_python_version():
     m = _multi_manifest()
     m.python_versions = ["3.10", "3.11", "3.12"]
     cells = expand_matrix(m)
     sub = select_heavy_subset(cells, m)
-    assert all(c.python == "3.11" for c in sub)
+    # Python is a heavy axis: each python appears (the agent is rebuilt on it).
+    assert {c.python for c in sub} == {"3.10", "3.11", "3.12"}
+    # Still default framework only — no per-framework axis.
+    assert all(c.framework_name == "langchain" for c in sub)
+    # 2 provider versions × 3 pythons.
+    assert len(sub) == 6
 
 
 def test_per_tl_axis_pins_default_framework_version():


### PR DESCRIPTION
## Summary

Follow-up to the instrumentation compatibility-matrix suite (merged advisory in #970): this gets the **heavy tier** running green end-to-end in CI and makes it gate. The heavy tier brings up AMP from the working tree on k3d (build-from-source, not the released quick-start images), deploys a real agent, invokes it, and validates that its spans survive the full pipeline (auto-instrumentation → gateway → collector → OpenSearch → traces-observer) against the `traceloop/v1` contract.

Related to #975.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Port-forwarding can bind to specific addresses (improves reachability) and CI can run only the heavy tier via a new option.
* **Bug Fixes**
  * DNS rewrite for host.docker.internal improves host resolution in containerized CI.
  * More robust local platform bring-up and deployment polling (tolerates transient failures; waits for spans to settle).
* **Documentation**
  * Clarified heavy-tier scope and added findings about representative-agent validation.
* **Tests**
  * Improved heavy-tier logging, progress, diagnostics, and name/ deployment test coverage.
* **Chores**
  * Nightly schedule and heavy-tier failure behavior updated in CI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->