### PR TITLE
Pin Node-20 GitHub Actions to their Node-24 versions

### DIFF
--- a/.github/actions/setup-helm-chart/action.yml
+++ b/.github/actions/setup-helm-chart/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Cache Helm chart dependencies
       id: helm-cache
       if: hashFiles(format('{0}/Chart.lock', inputs.chart-path)) != ''
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ inputs.chart-path }}/charts
         key: helm-charts-${{ hashFiles(format('{0}/Chart.lock', inputs.chart-path)) }}

--- a/.github/workflows/agent-manager-service-pr-checks.yaml
+++ b/.github/workflows/agent-manager-service-pr-checks.yaml
@@ -14,7 +14,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs
           path: agent-manager-service/localdata/test_output.log
@@ -100,7 +100,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -121,7 +121,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/amctl_release.yaml
+++ b/.github/workflows/amctl_release.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -42,7 +42,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
           fetch-depth: 0

--- a/.github/workflows/amp-console-package-pr-checks.yaml
+++ b/.github/workflows/amp-console-package-pr-checks.yaml
@@ -17,10 +17,10 @@ jobs:
         working-directory: console
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.19.0"
 
@@ -39,10 +39,10 @@ jobs:
         working-directory: console
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.19.0"
 

--- a/.github/workflows/amp-evaluation-package-pr-checks.yaml
+++ b/.github/workflows/amp-evaluation-package-pr-checks.yaml
@@ -17,10 +17,10 @@ jobs:
         working-directory: libs/amp-evaluation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -47,10 +47,10 @@ jobs:
         working-directory: libs/amp-evaluation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: amp-evaluation-coverage-py${{ matrix.python-version }}
           path: libs/amp-evaluation/htmlcov
@@ -81,10 +81,10 @@ jobs:
         working-directory: libs/amp-evaluation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -106,10 +106,10 @@ jobs:
         working-directory: libs/amp-evaluation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -122,7 +122,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: amp-evaluation-dist
           path: libs/amp-evaluation/dist

--- a/.github/workflows/amp-instrumentation-package-pr-checks.yaml
+++ b/.github/workflows/amp-instrumentation-package-pr-checks.yaml
@@ -17,10 +17,10 @@ jobs:
         working-directory: libs/amp-instrumentation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -47,10 +47,10 @@ jobs:
         working-directory: libs/amp-instrumentation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: amp-instrumentation-coverage-py${{ matrix.python-version }}
           path: libs/amp-instrumentation/htmlcov
@@ -81,10 +81,10 @@ jobs:
         working-directory: libs/amp-instrumentation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -106,10 +106,10 @@ jobs:
         working-directory: libs/amp-instrumentation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -122,7 +122,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: amp-instrumentation-dist
           path: libs/amp-instrumentation/dist

--- a/.github/workflows/amp_evaluation_release.yaml
+++ b/.github/workflows/amp_evaluation_release.yaml
@@ -25,12 +25,12 @@ jobs:
         working-directory: libs/amp-evaluation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -45,7 +45,7 @@ jobs:
           pytest --cov=src --cov-report=html --cov-report=term
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: amp-evaluation-coverage
           path: libs/amp-evaluation/htmlcov
@@ -62,7 +62,7 @@ jobs:
         working-directory: libs/amp-evaluation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
           fetch-tags: true
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/amp_instrumentation_release.yaml
+++ b/.github/workflows/amp_instrumentation_release.yaml
@@ -25,12 +25,12 @@ jobs:
         working-directory: libs/amp-instrumentation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -45,7 +45,7 @@ jobs:
           pytest --cov=src --cov-report=html --cov-report=term
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: amp-instrumentation-coverage
           path: htmlcov
@@ -62,7 +62,7 @@ jobs:
         working-directory: libs/amp-instrumentation
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -72,7 +72,7 @@ jobs:
           echo "VERSION=${{ inputs.target_version }}" >> $GITHUB_ENV
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/cli-codegen-check.yaml
+++ b/.github/workflows/cli-codegen-check.yaml
@@ -16,7 +16,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v6.1.0

--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Checkout engineering-governance repository
         if: steps.detect-changes.outputs.has_changes == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: wso2/engineering-governance
           path: engineering-governance

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -15,10 +15,10 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -15,8 +15,8 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -36,10 +36,10 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -76,7 +76,7 @@ jobs:
         shell: bash
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
@@ -89,7 +89,7 @@ jobs:
         shell: bash
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/evaluation-job-pr-checks.yaml
+++ b/.github/workflows/evaluation-job-pr-checks.yaml
@@ -17,10 +17,10 @@ jobs:
         working-directory: evaluation-job
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -44,10 +44,10 @@ jobs:
         working-directory: evaluation-job
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -71,10 +71,10 @@ jobs:
         working-directory: evaluation-job
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/helm-charts-pr-check.yml
+++ b/.github/workflows/helm-charts-pr-check.yml
@@ -21,7 +21,7 @@ jobs:
       has-changes: ${{ steps.detect.outputs.has-changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
         chart: ${{ fromJson(needs.detect-changes.outputs.charts) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Helm and dependencies
         uses: ./.github/actions/setup-helm-chart
@@ -107,7 +107,7 @@ jobs:
         chart: ${{ fromJson(needs.detect-changes.outputs.charts) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Helm and dependencies
         uses: ./.github/actions/setup-helm-chart
@@ -155,7 +155,7 @@ jobs:
         chart: ${{ fromJson(needs.detect-changes.outputs.charts) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Helm and dependencies
         uses: ./.github/actions/setup-helm-chart

--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -56,8 +56,8 @@ jobs:
       cell_ids: ${{ steps.expand.outputs.cell_ids }}
       count: ${{ steps.expand.outputs.count }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install pyyaml
@@ -87,8 +87,8 @@ jobs:
       matrix:
         cell: ${{ fromJSON(needs.resolve-cells.outputs.cell_ids) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: |
             3.10
@@ -106,7 +106,7 @@ jobs:
         run: nox -s emission -- --cell-id=${{ matrix.cell }}
       # Artifact name is keyed by run-id + cell id so multiple manual runs
       # don't collide. The trailing slashes pull cells/ and cassettes/ both.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: manual-cell-${{ matrix.cell }}
@@ -122,10 +122,10 @@ jobs:
       contents: write        # push the refresh branch
       pull-requests: write   # open the cassette-refresh PR
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           # Download every manual-cell-* artifact into a single staging dir.
           # Each unpacks into manual-cell-<id>/cassettes/<framework>/...
@@ -169,11 +169,11 @@ jobs:
     # regardless (run-cells is skipped), so always() is needed to evaluate at all.
     if: ${{ always() && (inputs.heavy_only || (inputs.include_heavy_tier && needs.run-cells.result == 'success')) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Build AMP component images from this branch + stand up the stack on
       # k3d (build-from-source, not released images).
       - uses: ./.github/actions/amp-dev-stack
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       # requests: heavy/driver.py + amp_client/observer use it for the
@@ -234,7 +234,7 @@ jobs:
             | while read -r p; do echo "----- $p -----"; kubectl logs -n openchoreo-data-plane "$p" --tail=80 2>/dev/null; done
           echo "=== recent events ==="
           kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -80
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: manual-heavy

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: |
             3.10
@@ -39,7 +39,7 @@ jobs:
         working-directory: test/instrumentation-matrix
         run: nox -s emission
         continue-on-error: true   # advisory — failures surface in the report
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: nightly-emission
@@ -50,12 +50,12 @@ jobs:
     needs: full-emission-matrix
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Build the AMP component images from this branch and stand up the full
       # stack on k3d (NOT the released quick-start images — the matrix must
       # exercise the PR's observer + instrumentation changes).
       - uses: ./.github/actions/amp-dev-stack
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       # requests: heavy/driver.py + amp_client/observer use it for the
@@ -73,7 +73,7 @@ jobs:
           # The deployed customer-support-agent's web-search tool needs this.
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
         run: nox -s heavy
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: nightly-heavy
@@ -86,8 +86,8 @@ jobs:
       contents: read
       issues: write   # opens the "drop exemption" issue
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: |
             3.10
@@ -154,7 +154,7 @@ jobs:
               --label instrumentation-matrix-revalidate \
               --body-file /tmp/revalidate-body.md
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always() && steps.expand.outputs.have_cells == 'true'
         with:
           name: nightly-revalidate
@@ -171,18 +171,18 @@ jobs:
       counts_json: ${{ steps.metrics.outputs.counts_json }}
       has_failures: ${{ steps.metrics.outputs.has_failures }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install nox pyyaml
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: always()
         with:
           name: nightly-emission
           path: test/instrumentation-matrix/reports/cells/
         continue-on-error: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         if: always()
         with:
           name: nightly-heavy
@@ -214,7 +214,7 @@ jobs:
           print(f"counts_json={json.dumps(m)}")
           print(f"has_failures={'true' if m['counts'].get('fail', 0) > 0 else 'false'}")
           PY
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: nightly-summary
@@ -237,8 +237,8 @@ jobs:
     outputs:
       issue_url: ${{ steps.issue.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: nightly-summary
           path: /tmp/summary
@@ -280,8 +280,8 @@ jobs:
         needs.heavy-tier.result == 'failure'
       )
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install requests

--- a/.github/workflows/instrumentation-matrix-pr.yaml
+++ b/.github/workflows/instrumentation-matrix-pr.yaml
@@ -44,9 +44,9 @@ jobs:
   verify-contract-and-manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-go
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install pyyaml
@@ -57,8 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify-contract-and-manifest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install nox
@@ -81,7 +81,7 @@ jobs:
         run: nox -s emission -- --cell-id=${{ steps.default.outputs.cell }}
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: default-cell-report
           path: test/instrumentation-matrix/reports/
@@ -90,8 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify-contract-and-manifest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: |
             3.10
@@ -107,7 +107,7 @@ jobs:
         continue-on-error: true   # advisory; default-cell-required is the gating job
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: matrix-reports
           path: test/instrumentation-matrix/reports/
@@ -121,12 +121,12 @@ jobs:
     # force-cancelled. `!cancelled()` dies cleanly instead.
     if: ${{ !cancelled() }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - run: pip install nox pyyaml
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: matrix-reports
           path: test/instrumentation-matrix/reports/
@@ -146,5 +146,5 @@ jobs:
   scan-cassettes-for-secrets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: ./scripts/check-cassettes.py

--- a/.github/workflows/publish-core-ui-npm.yml
+++ b/.github/workflows/publish-core-ui-npm.yml
@@ -43,12 +43,12 @@ jobs:
         shell: bash
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.source_ref }}
 
       - name: Setup Node.js for npm registry
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/python_instrumentation_image_release.yaml
+++ b/.github/workflows/python_instrumentation_image_release.yaml
@@ -38,7 +38,7 @@ jobs:
       instrumentation-images: ${{ steps.set-matrix.outputs.instrumentation-images }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -85,7 +85,7 @@ jobs:
         image: ${{ fromJson(needs.load-config.outputs.instrumentation-images) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -117,7 +117,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         shell: bash
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
@@ -236,7 +236,7 @@ jobs:
       charts: ${{ steps.set-matrix.outputs.charts }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: amp/v${{ inputs.target_version }}
 
@@ -294,7 +294,7 @@ jobs:
         image: ${{ fromJson(needs.load-config.outputs.images) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: amp/v${{ inputs.target_version }}
 
@@ -333,7 +333,7 @@ jobs:
         image: ${{ fromJson(needs.load-config.outputs.instrumentation-images) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: amp/v${{ inputs.target_version }}
 
@@ -372,7 +372,7 @@ jobs:
         chart: ${{ fromJson(needs.load-config.outputs.charts) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: amp/v${{ inputs.target_version }}
 
@@ -384,7 +384,7 @@ jobs:
       - name: Cache Helm chart dependencies
         id: helm-cache
         if: hashFiles(format('{0}/Chart.lock', matrix.chart.path)) != ''
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ matrix.chart.path }}/charts
           key: helm-charts-${{ hashFiles(format('{0}/Chart.lock', matrix.chart.path)) }}
@@ -420,7 +420,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: amp/v${{ inputs.target_version }}

--- a/.github/workflows/traceloop-release-watch.yaml
+++ b/.github/workflows/traceloop-release-watch.yaml
@@ -36,7 +36,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # This workflow only reads files; it never uses git credentials, so
           # do not leave the runner token in the local git config.

--- a/.github/workflows/traces-observer-service-pr-checks.yaml
+++ b/.github/workflows/traces-observer-service-pr-checks.yaml
@@ -17,7 +17,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload test logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs
           path: traces-observer-service/data/test_output.log
@@ -68,7 +68,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -89,7 +89,7 @@ jobs:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
         uses: ./.github/actions/setup-go


### PR DESCRIPTION
## Summary

GitHub is deprecating the Node 20 runtime — Node-20 JavaScript actions are forced to Node 24 on **2026-06-02**, and Node 20 is removed from runners on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Every workflow still on the old action majors logs a deprecation warning today and will break once the runtime is removed. This bumps the affected first-party actions to their current Node-24 majors.

## What changed

Each action is referenced by **major tag** — matching the repo's existing `@v4`/`@v5` style and auto-tracking Node-24 patch releases:

| Action | From | To |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `actions/cache` | `@v4` | `@v5` |

Applied across all workflows + composite actions under `.github/`. Already-migrated files are left untouched: `e2e.yaml` (SHA-pinned to Node-24 versions) and `actions/setup-go` (already `@v6.1.0`).

This is a mechanical, behaviour-preserving bump — same actions, newer runtime; no workflow logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use newer, pinned GitHub Actions versions across the repository.
  * Standardized action usage for checkout, setup, artifact handling, and caching to improve build reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
