### PR TITLE
Fix the deployed CrewAI agent crashing on a read-only HOME

### DIFF
--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -187,6 +187,9 @@ jobs:
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           # Optional single-cell run for cheap iteration; empty = full subset.
           HEAVY_CELL_ID: ${{ inputs.heavy_cell_id }}
+          # Build each deployed sample from the ref under test, so a PR can
+          # validate a new/changed sample before it merges to main.
+          AMP_AGENT_REPO_BRANCH: ${{ github.ref_name }}
         run: nox -s heavy
       - name: Dump cluster diagnostics on failure
         if: failure()

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -67,6 +67,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           # The deployed customer-support-agent's web-search tool needs this.
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          # Build each deployed sample from the ref under test. Nightly runs on
+          # main, so this is main; on a manual branch run it's that branch.
+          AMP_AGENT_REPO_BRANCH: ${{ github.ref_name }}
         run: nox -s heavy
       - uses: actions/upload-artifact@v7
         if: always()

--- a/samples/crewai-agent/app.py
+++ b/samples/crewai-agent/app.py
@@ -8,6 +8,14 @@ import os
 os.environ.setdefault("CREWAI_TRACING_ENABLED", "false")
 os.environ.setdefault("CREWAI_DISABLE_TRACING_PROMPT", "true")
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+# CrewAI writes under $HOME at import time (a chromadb storage dir) and again
+# at Crew() construction (a credentials dir). The deployed buildpack container
+# runs with HOME=/nonexistent on a read-only filesystem, so both writes crash
+# the pod (CrashLoopBackOff). Redirect storage explicitly and, when HOME isn't
+# writable, repoint it at /tmp — both before importing crewai.
+os.environ.setdefault("CREWAI_STORAGE_DIR", "/tmp/crewai")
+if not os.access(os.path.expanduser("~"), os.W_OK):
+    os.environ["HOME"] = "/tmp"
 
 import dotenv
 from fastapi import FastAPI

--- a/samples/crewai-agent/app.py
+++ b/samples/crewai-agent/app.py
@@ -8,11 +8,13 @@ import os
 os.environ.setdefault("CREWAI_TRACING_ENABLED", "false")
 os.environ.setdefault("CREWAI_DISABLE_TRACING_PROMPT", "true")
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-# CrewAI writes under $HOME at import time (a chromadb storage dir) and again
-# at Crew() construction (a credentials dir). The deployed buildpack container
-# runs with HOME=/nonexistent on a read-only filesystem, so both writes crash
-# the pod (CrashLoopBackOff). Redirect storage explicitly and, when HOME isn't
-# writable, repoint it at /tmp — both before importing crewai.
+# CrewAI writes under $HOME at import (a chromadb storage dir) and at Crew()
+# construction (a credentials dir). Under AMP the deployed workload already
+# sets HOME + CREWAI_STORAGE_DIR to writable paths (see
+# harness/deployable_samples.py) — required because the instrumentation
+# provider imports crewai at interpreter startup, before this app runs. This
+# block is a fallback so the sample also runs standalone under a read-only
+# HOME; it no-ops when HOME is already writable or the env is preset.
 os.environ.setdefault("CREWAI_STORAGE_DIR", "/tmp/crewai")
 if not os.access(os.path.expanduser("~"), os.W_OK):
     os.environ["HOME"] = "/tmp"

--- a/test/instrumentation-matrix/harness/deployable_samples.py
+++ b/test/instrumentation-matrix/harness/deployable_samples.py
@@ -27,6 +27,14 @@ class DeployableSample:
     app_path: str  # repo-relative path the buildpack builds (leading slash)
     run_command: str  # buildpack run command, e.g. "python main.py"
     expected_kinds: tuple[str, ...]  # span kinds the driver asserts coverage of
+    # Non-sensitive env vars set on the deployed workload. Needed when a sample
+    # (or the instrumentation provider's sitecustomize, which imports the
+    # framework at interpreter startup — before the app runs) requires
+    # environment that must exist before the process starts. CrewAI writes
+    # under $HOME at import; the buildpack container's HOME=/nonexistent is
+    # read-only, so both the CrewAI instrumentor and the app crash without
+    # these. Tuple of pairs (not a dict) to keep the dataclass frozen-friendly.
+    env: tuple[tuple[str, str], ...] = ()
 
 
 DEPLOYABLE_SAMPLES: dict[str, DeployableSample] = {
@@ -39,5 +47,6 @@ DEPLOYABLE_SAMPLES: dict[str, DeployableSample] = {
         app_path="/samples/crewai-agent",
         run_command="python main.py",
         expected_kinds=("llm", "agent", "crewaitask"),
+        env=(("HOME", "/tmp"), ("CREWAI_STORAGE_DIR", "/tmp/crewai")),
     ),
 }

--- a/test/instrumentation-matrix/heavy/amp_client.py
+++ b/test/instrumentation-matrix/heavy/amp_client.py
@@ -219,6 +219,13 @@ class AmpClient:
             "value": f"{framework_package}=={framework_version}",
             "isSensitive": False,
         })
+        # Sample-declared env (non-sensitive). Set on the workload so it exists
+        # before the interpreter starts — the instrumentation provider's
+        # sitecustomize imports the framework at startup, so env the framework
+        # needs at import (e.g. CrewAI's writable HOME/CREWAI_STORAGE_DIR) must
+        # be present before the app's own code runs.
+        for k, v in sample.env:
+            env.append({"key": k, "value": v, "isSensitive": False})
 
         # (2) project
         self._request(

--- a/test/instrumentation-matrix/heavy/amp_client.py
+++ b/test/instrumentation-matrix/heavy/amp_client.py
@@ -42,6 +42,14 @@ _DEPLOY_FAILED_STREAK = 3
 _HTTP_TIMEOUT_S = 30
 _TOKEN_REFRESH_SKEW_S = 30
 
+# The deployed agent's source is cloned from this repo ref by the in-cluster
+# buildpack. Defaults to wso2/agent-manager@main; overridable (see
+# heavy/driver.py AMP_AGENT_REPO_*) so a PR can validate a new/changed sample
+# on its own branch before it merges to main — the build pulls the agent code
+# from GitHub, not from the working tree the platform is built from.
+_DEFAULT_AGENT_REPO_URL = "https://github.com/wso2/agent-manager"
+_DEFAULT_AGENT_REPO_BRANCH = "main"
+
 # AMP caps resource names at 25 chars (utils.MaxResourceNameLength); when a
 # cell id exceeds it, _safe_name keeps a prefix plus this many hash chars.
 _MAX_NAME_LEN = 25
@@ -174,6 +182,8 @@ class AmpClient:
         framework_version: str,
         python_version: str,
         agent_env: dict[str, str] | None = None,
+        repo_url: str = _DEFAULT_AGENT_REPO_URL,
+        repo_branch: str = _DEFAULT_AGENT_REPO_BRANCH,
     ) -> DeployedAgent:
         """Create project + agent + build + deploy + API key; return the
         endpoint and key. Raises AmpError / TimeoutError on failure.
@@ -183,7 +193,10 @@ class AmpClient:
         `framework_name` selects which deployable sample to build (its
         `appPath`/`runCommand` come from harness.deployable_samples).
         `agent_env` (LLM keys) is injected as sensitive env on the agent so
-        the deployed pod can make real provider calls.
+        the deployed pod can make real provider calls. `repo_url`/`repo_branch`
+        are the GitHub source the buildpack clones the sample from (default
+        wso2/agent-manager@main); override to validate a sample on its own
+        branch before it merges.
         """
         name = _safe_name(cell_id)
         org = self.org
@@ -227,8 +240,8 @@ class AmpClient:
                 "provisioning": {
                     "type": "internal",
                     "repository": {
-                        "url": "https://github.com/wso2/agent-manager",
-                        "branch": "main",
+                        "url": repo_url,
+                        "branch": repo_branch,
                         "appPath": sample.app_path,
                     },
                 },

--- a/test/instrumentation-matrix/heavy/driver.py
+++ b/test/instrumentation-matrix/heavy/driver.py
@@ -54,6 +54,12 @@ _DEFAULTS = {
     "IDP_TOKEN_URL": "http://localhost:8090/oauth2/token",
     "IDP_CLIENT_ID": "amp-api-client",
     "IDP_CLIENT_SECRET": "amp-api-client-secret",
+    # GitHub source the in-cluster buildpack clones each deployed sample from.
+    # Defaults to wso2/agent-manager@main; the CI workflows set
+    # AMP_AGENT_REPO_BRANCH to the ref under test so a PR can validate a
+    # new/changed sample on its own branch before it merges to main.
+    "AMP_AGENT_REPO_URL": "https://github.com/wso2/agent-manager",
+    "AMP_AGENT_REPO_BRANCH": "main",
 }
 
 # Secrets the deployed sample agent needs to start and make real calls:
@@ -190,6 +196,8 @@ def _run_cell(
         framework_version=cell.framework_version,
         python_version=cell.python,
         agent_env=agent_env,
+        repo_url=_env("AMP_AGENT_REPO_URL"),
+        repo_branch=_env("AMP_AGENT_REPO_BRANCH"),
     )
     _log(f"      deployed {deployed.agent_name}; invoking /chat…")
     try:

--- a/test/instrumentation-matrix/tests/test_deployable_samples.py
+++ b/test/instrumentation-matrix/tests/test_deployable_samples.py
@@ -21,3 +21,16 @@ def test_crewai_maps_to_crewai_agent_asserting_framework_kinds():
     assert s.app_path == "/samples/crewai-agent"
     assert s.run_command == "python main.py"
     assert s.expected_kinds == ("llm", "agent", "crewaitask")
+
+
+def test_crewai_sets_writable_home_and_storage_env():
+    # CrewAI writes under $HOME at import; the deployed container's
+    # HOME=/nonexistent is read-only, so the workload must repoint both the
+    # home and the storage dir (before the interpreter/instrumentor starts).
+    env = dict(DEPLOYABLE_SAMPLES["crewai"].env)
+    assert env["HOME"] == "/tmp"
+    assert env["CREWAI_STORAGE_DIR"] == "/tmp/crewai"
+
+
+def test_langchain_declares_no_extra_env():
+    assert DEPLOYABLE_SAMPLES["langchain"].env == ()

--- a/test/instrumentation-matrix/tests/test_heavy_client.py
+++ b/test/instrumentation-matrix/tests/test_heavy_client.py
@@ -124,6 +124,11 @@ def test_deploy_agent_uses_framework_specific_sample_path():
     # Source ref defaults to wso2/agent-manager@main.
     assert repo["url"] == "https://github.com/wso2/agent-manager"
     assert repo["branch"] == "main"
+    # The crewai sample's writable-HOME/storage env is set on the workload
+    # (non-sensitive) so the instrumentor + app survive the read-only HOME.
+    env = {e["key"]: e for e in body["configurations"]["env"]}
+    assert env["HOME"]["value"] == "/tmp" and env["HOME"]["isSensitive"] is False
+    assert env["CREWAI_STORAGE_DIR"]["value"] == "/tmp/crewai"
 
 
 @responses.activate

--- a/test/instrumentation-matrix/tests/test_heavy_client.py
+++ b/test/instrumentation-matrix/tests/test_heavy_client.py
@@ -121,6 +121,37 @@ def test_deploy_agent_uses_framework_specific_sample_path():
     repo = body["provisioning"]["repository"]
     assert repo["appPath"] == "/samples/crewai-agent"
     assert body["build"]["buildpack"]["runCommand"] == "python main.py"
+    # Source ref defaults to wso2/agent-manager@main.
+    assert repo["url"] == "https://github.com/wso2/agent-manager"
+    assert repo["branch"] == "main"
+
+
+@responses.activate
+def test_deploy_agent_repo_ref_is_overridable():
+    """repo_url/repo_branch override the agent source the buildpack clones, so
+    a PR can validate a sample on its own branch before it merges to main."""
+    import json
+
+    _mock_token()
+    cell_id = "traceloop-0.60.0-langchain-0.3.27-py3.11"
+    _mock_happy_deploy(name=_safe_name(cell_id))
+    _client().deploy_agent(
+        cell_id=cell_id,
+        instrumentation_version="0.2.1",
+        framework_name="langchain",
+        framework_package="langchain",
+        framework_version="0.3.27",
+        python_version="3.11",
+        repo_url="https://github.com/acme/fork",
+        repo_branch="fix/my-branch",
+    )
+    agent_post = next(
+        c for c in responses.calls
+        if c.request.method == "POST" and c.request.url.rstrip("/").endswith("/agents")
+    )
+    repo = json.loads(agent_post.request.body)["provisioning"]["repository"]
+    assert repo["url"] == "https://github.com/acme/fork"
+    assert repo["branch"] == "fix/my-branch"
 
 
 @responses.activate


### PR DESCRIPTION
## Summary

The heavy-tier crewai cell (added in #980) failed: the deployed agent crash-looped (`CrashLoopBackOff` → `/chat` 503 → `TimeoutError`). Root cause, found by deploying the sample against a real k3d stack and reading the pod logs: **CrewAI writes under $HOME at import** (a chromadb storage dir) **and at `Crew()` construction** (a credentials dir), but the deployed buildpack container runs with `HOME=/nonexistent` on a read-only filesystem, so the process died before uvicorn bound. A second instance of the same bug hit the **Traceloop CrewAI instrumentor**, which runs in `sitecustomize` at interpreter startup (before the app) — it failed to initialize, which would have dropped the `agent`/`crewaitask` spans even once the app started.

## Changes

- **`samples/crewai-agent`**: set `HOME` + `CREWAI_STORAGE_DIR` to writable paths. The authoritative fix is workload env (below), set before the interpreter starts so both the instrumentor and the app see it; `app.py` keeps a small guard as a standalone-run fallback.
- **`harness/deployable_samples.py`**: `DeployableSample` gains a per-sample `env`; the crewai entry declares `HOME=/tmp` and `CREWAI_STORAGE_DIR=/tmp/crewai`. `heavy/amp_client.py` sets these as non-sensitive workload env at create time.
- **Heavy build ref is now configurable** (`AMP_AGENT_REPO_URL`/`AMP_AGENT_REPO_BRANCH`, default `wso2/agent-manager@main`); the manual and nightly workflows pass `github.ref_name`. The heavy build clones each deployed sample from GitHub, so without this a new/changed sample could only be validated after it merged to main. Nightly runs on main, so its behaviour is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR workflows now support custom branch validation for deployed samples before merging.
  * Deployment system now allows configurable agent-manager repository sources and branches.
  * CrewAI sample improved to handle read-only home environments with fallback storage configuration.

* **Tests**
  * Added verification tests for sample environment configuration and deployment repository settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2/agent-manager/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->