### PR TITLE
Surface typed CLIErrors from auth.Login for known failures

### DIFF
--- a/cli/pkg/auth/login.go
+++ b/cli/pkg/auth/login.go
@@ -18,13 +18,17 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/wso2/agent-manager/cli/pkg/browser"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/clients"
 	"github.com/wso2/agent-manager/cli/pkg/config"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
@@ -74,6 +78,9 @@ func loginClientCredentials(ctx context.Context, opts LoginOptions) (*config.Ins
 	}
 	tok, err := cc.Token(ctx)
 	if err != nil {
+		if ce := classifyTokenError(err); ce != nil {
+			return nil, ce
+		}
 		return nil, fmt.Errorf("client_credentials token exchange: %w", err)
 	}
 
@@ -90,6 +97,22 @@ func loginClientCredentials(ctx context.Context, opts LoginOptions) (*config.Ins
 			Scopes:       scopes,
 		},
 	}, nil
+}
+
+// classifyTokenError maps oauth2 token-endpoint errors to typed CLIErrors.
+// Returns nil for errors that don't have a known classification.
+func classifyTokenError(err error) error {
+	var re *oauth2.RetrieveError
+	if !errors.As(err, &re) {
+		return nil
+	}
+	if re.Response != nil && re.Response.StatusCode == http.StatusUnauthorized {
+		return clierr.New(clierr.Unauthorized, "token endpoint rejected the request (401)")
+	}
+	if re.ErrorCode == "invalid_grant" {
+		return clierr.Newf(clierr.Unauthorized, "invalid_grant: %s", re.ErrorDescription)
+	}
+	return nil
 }
 
 func loginPKCE(ctx context.Context, opts LoginOptions) (*config.Instance, error) {
@@ -131,6 +154,12 @@ func loginPKCE(ctx context.Context, opts LoginOptions) (*config.Instance, error)
 
 	tok, err := authCodePKCE(ctx, oauthCfg, opts.IO, openBrowser)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF) {
+			return nil, clierr.New(clierr.AuthLoginCancelled, "browser login cancelled")
+		}
+		if ce := classifyTokenError(err); ce != nil {
+			return nil, ce
+		}
 		return nil, fmt.Errorf("authorization code exchange: %w", err)
 	}
 

--- a/cli/pkg/auth/login.go
+++ b/cli/pkg/auth/login.go
@@ -28,8 +28,8 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 
 	"github.com/wso2/agent-manager/cli/pkg/browser"
-	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/clients"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/config"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
 )

--- a/cli/pkg/auth/login.go
+++ b/cli/pkg/auth/login.go
@@ -78,10 +78,7 @@ func loginClientCredentials(ctx context.Context, opts LoginOptions) (*config.Ins
 	}
 	tok, err := cc.Token(ctx)
 	if err != nil {
-		if ce := classifyTokenError(err); ce != nil {
-			return nil, ce
-		}
-		return nil, fmt.Errorf("client_credentials token exchange: %w", err)
+		return nil, wrapTokenError(err, "client_credentials token exchange")
 	}
 
 	return &config.Instance{
@@ -113,6 +110,15 @@ func classifyTokenError(err error) error {
 		return clierr.Newf(clierr.Unauthorized, "invalid_grant: %s", re.ErrorDescription)
 	}
 	return nil
+}
+
+// wrapTokenError classifies known token-endpoint errors into typed CLIErrors
+// and falls back to a fmt.Errorf wrap with the given context.
+func wrapTokenError(err error, fallbackContext string) error {
+	if ce := classifyTokenError(err); ce != nil {
+		return ce
+	}
+	return fmt.Errorf("%s: %w", fallbackContext, err)
 }
 
 func loginPKCE(ctx context.Context, opts LoginOptions) (*config.Instance, error) {
@@ -157,10 +163,7 @@ func loginPKCE(ctx context.Context, opts LoginOptions) (*config.Instance, error)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF) {
 			return nil, clierr.New(clierr.AuthLoginCancelled, "browser login cancelled")
 		}
-		if ce := classifyTokenError(err); ce != nil {
-			return nil, ce
-		}
-		return nil, fmt.Errorf("authorization code exchange: %w", err)
+		return nil, wrapTokenError(err, "authorization code exchange")
 	}
 
 	return &config.Instance{

--- a/cli/pkg/auth/login_test.go
+++ b/cli/pkg/auth/login_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+)
+
+func TestClassifyTokenError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode string // empty means expect nil return
+		wantMsg  string // substring expected in message
+	}{
+		{
+			name:     "401 from token endpoint",
+			err:      &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusUnauthorized}},
+			wantCode: clierr.Unauthorized,
+			wantMsg:  "401",
+		},
+		{
+			name: "invalid_grant with description",
+			err: &oauth2.RetrieveError{
+				Response:         &http.Response{StatusCode: http.StatusBadRequest},
+				ErrorCode:        "invalid_grant",
+				ErrorDescription: "token has expired",
+			},
+			wantCode: clierr.Unauthorized,
+			wantMsg:  "invalid_grant",
+		},
+		{
+			name: "invalid_grant on 400 response",
+			err: &oauth2.RetrieveError{
+				Response:  &http.Response{StatusCode: http.StatusBadRequest},
+				ErrorCode: "invalid_grant",
+			},
+			wantCode: clierr.Unauthorized,
+		},
+		{
+			name:     "403 forbidden — not classified",
+			err:      &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusForbidden}},
+			wantCode: "",
+		},
+		{
+			name:     "other oauth error code — not classified",
+			err:      &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusBadRequest}, ErrorCode: "unsupported_grant_type"},
+			wantCode: "",
+		},
+		{
+			name:     "plain error — not classified",
+			err:      errors.New("connection refused"),
+			wantCode: "",
+		},
+		{
+			name:     "nil response on RetrieveError — not classified",
+			err:      &oauth2.RetrieveError{Response: nil, ErrorCode: ""},
+			wantCode: "",
+		},
+		{
+			name:     "wrapped RetrieveError with 401 — still classified",
+			err:      fmt.Errorf("outer wrapper: %w", &oauth2.RetrieveError{Response: &http.Response{StatusCode: http.StatusUnauthorized}}),
+			wantCode: clierr.Unauthorized,
+			wantMsg:  "401",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyTokenError(tc.err)
+
+			if tc.wantCode == "" {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("expected classified error with code %q, got nil", tc.wantCode)
+			}
+
+			var ce clierr.CLIError
+			if !errors.As(got, &ce) {
+				t.Fatalf("returned error is not a clierr.CLIError: %T", got)
+			}
+			if ce.Code != tc.wantCode {
+				t.Errorf("code = %q, want %q", ce.Code, tc.wantCode)
+			}
+			if tc.wantMsg != "" && !strings.Contains(ce.Message, tc.wantMsg) {
+				t.Errorf("message = %q, want to contain %q", ce.Message, tc.wantMsg)
+			}
+		})
+	}
+}

--- a/cli/pkg/clierr/clierr.go
+++ b/cli/pkg/clierr/clierr.go
@@ -61,6 +61,7 @@ const (
 	SkillInstallFailed   = "SKILL_INSTALL_FAILED"
 	SkillRemoveFailed    = "SKILL_REMOVE_FAILED"
 	SkillListFailed      = "SKILL_LIST_FAILED"
+	AuthLoginCancelled   = "AUTH_LOGIN_CANCELLED"
 )
 
 // CLIError is both the wire body of an error envelope and a Go error value.

--- a/cli/pkg/cmd/login.go
+++ b/cli/pkg/cmd/login.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -105,11 +104,7 @@ func runLogin(ctx context.Context, opts *LoginOptions) error {
 		OpenBrowser:  opts.OpenBrowser,
 	})
 	if err != nil {
-		var ce clierr.CLIError
-		if errors.As(err, &ce) {
-			return render.Error(opts.IO, scope, ce)
-		}
-		return render.Error(opts.IO, scope, clierr.Newf(clierr.Transport, "%v", err))
+		return render.Error(opts.IO, scope, err)
 	}
 
 	cfg, err := opts.Config()

--- a/cli/pkg/cmd/login.go
+++ b/cli/pkg/cmd/login.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -104,6 +105,10 @@ func runLogin(ctx context.Context, opts *LoginOptions) error {
 		OpenBrowser:  opts.OpenBrowser,
 	})
 	if err != nil {
+		var ce clierr.CLIError
+		if errors.As(err, &ce) {
+			return render.Error(opts.IO, scope, ce)
+		}
 		return render.Error(opts.IO, scope, clierr.Newf(clierr.Transport, "%v", err))
 	}
 

--- a/cli/pkg/cmd/login_test.go
+++ b/cli/pkg/cmd/login_test.go
@@ -28,120 +28,71 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
 )
 
-func TestRunLogin_TypedErrorPassthrough(t *testing.T) {
-	io, _, out, _ := iostreams.Test()
-	io.JSON = true
-
-	opts := &LoginOptions{
-		IO:  io,
-		URL: "https://example.com",
-		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
-			return nil, clierr.New(clierr.Unauthorized, "client credentials rejected (401)")
+func TestRunLogin(t *testing.T) {
+	cases := []struct {
+		name         string
+		url          string
+		authErr      error
+		wantErrCode  string
+	}{
+		{
+			name:        "typed CLIError passes through unchanged",
+			url:         "https://example.com",
+			authErr:     clierr.New(clierr.Unauthorized, "client credentials rejected (401)"),
+			wantErrCode: clierr.Unauthorized,
+		},
+		{
+			name:        "plain error becomes Transport",
+			url:         "https://example.com",
+			authErr:     errors.New("dial tcp: connection refused"),
+			wantErrCode: clierr.Transport,
+		},
+		{
+			name:        "AuthLoginCancelled passes through unchanged",
+			url:         "https://example.com",
+			authErr:     clierr.New(clierr.AuthLoginCancelled, "browser login cancelled"),
+			wantErrCode: clierr.AuthLoginCancelled,
+		},
+		{
+			name:        "missing --url returns InvalidFlag without calling Authenticate",
+			url:         "",
+			authErr:     nil,
+			wantErrCode: clierr.InvalidFlag,
 		},
 	}
 
-	err := runLogin(context.Background(), opts)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			io, _, out, _ := iostreams.Test()
+			io.JSON = true
 
-	env := decodeLoginEnvelope(t, out.String())
-	errBody, ok := env["error"].(map[string]any)
-	if !ok {
-		t.Fatalf("envelope missing 'error' field: %v", env)
-	}
-	if got := errBody["code"]; got != clierr.Unauthorized {
-		t.Errorf("code = %q, want %q (typed error must not be re-wrapped as Transport)", got, clierr.Unauthorized)
-	}
-}
+			opts := &LoginOptions{
+				IO:  io,
+				URL: tc.url,
+				Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
+					if tc.url == "" {
+						t.Fatal("Authenticate should not be called when --url is missing")
+					}
+					return nil, tc.authErr
+				},
+			}
 
-func TestRunLogin_PlainErrorBecomesTransport(t *testing.T) {
-	io, _, out, _ := iostreams.Test()
-	io.JSON = true
+			err := runLogin(context.Background(), opts)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
 
-	opts := &LoginOptions{
-		IO:  io,
-		URL: "https://example.com",
-		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
-			return nil, errors.New("dial tcp: connection refused")
-		},
+			var env map[string]any
+			if jerr := json.Unmarshal([]byte(out.String()), &env); jerr != nil {
+				t.Fatalf("decode envelope: %v\nbody=%q", jerr, out.String())
+			}
+			errBody, ok := env["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("envelope missing 'error' field: %v", env)
+			}
+			if got := errBody["code"]; got != tc.wantErrCode {
+				t.Errorf("code = %q, want %q", got, tc.wantErrCode)
+			}
+		})
 	}
-
-	err := runLogin(context.Background(), opts)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	env := decodeLoginEnvelope(t, out.String())
-	errBody, ok := env["error"].(map[string]any)
-	if !ok {
-		t.Fatalf("envelope missing 'error' field: %v", env)
-	}
-	if got := errBody["code"]; got != clierr.Transport {
-		t.Errorf("code = %q, want %q (untyped errors must be wrapped as Transport)", got, clierr.Transport)
-	}
-}
-
-func TestRunLogin_CancelledErrorPassthrough(t *testing.T) {
-	io, _, out, _ := iostreams.Test()
-	io.JSON = true
-
-	opts := &LoginOptions{
-		IO:  io,
-		URL: "https://example.com",
-		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
-			return nil, clierr.New(clierr.AuthLoginCancelled, "browser login cancelled")
-		},
-	}
-
-	err := runLogin(context.Background(), opts)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-
-	env := decodeLoginEnvelope(t, out.String())
-	errBody, ok := env["error"].(map[string]any)
-	if !ok {
-		t.Fatalf("envelope missing 'error' field: %v", env)
-	}
-	if got := errBody["code"]; got != clierr.AuthLoginCancelled {
-		t.Errorf("code = %q, want %q", got, clierr.AuthLoginCancelled)
-	}
-}
-
-func TestRunLogin_MissingURL(t *testing.T) {
-	io, _, out, _ := iostreams.Test()
-	io.JSON = true
-
-	opts := &LoginOptions{
-		IO:  io,
-		URL: "",
-		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
-			t.Fatal("Authenticate should not be called when --url is missing")
-			return nil, nil
-		},
-	}
-
-	err := runLogin(context.Background(), opts)
-	if err == nil {
-		t.Fatal("expected error for missing --url")
-	}
-
-	env := decodeLoginEnvelope(t, out.String())
-	errBody, ok := env["error"].(map[string]any)
-	if !ok {
-		t.Fatalf("envelope missing 'error' field: %v", env)
-	}
-	if got := errBody["code"]; got != clierr.InvalidFlag {
-		t.Errorf("code = %q, want %q", got, clierr.InvalidFlag)
-	}
-}
-
-func decodeLoginEnvelope(t *testing.T, raw string) map[string]any {
-	t.Helper()
-	var m map[string]any
-	if err := json.Unmarshal([]byte(raw), &m); err != nil {
-		t.Fatalf("decode envelope: %v\nbody=%q", err, raw)
-	}
-	return m
 }

--- a/cli/pkg/cmd/login_test.go
+++ b/cli/pkg/cmd/login_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/auth"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/config"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+func TestRunLogin_TypedErrorPassthrough(t *testing.T) {
+	io, _, out, _ := iostreams.Test()
+	io.JSON = true
+
+	opts := &LoginOptions{
+		IO:  io,
+		URL: "https://example.com",
+		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
+			return nil, clierr.New(clierr.Unauthorized, "client credentials rejected (401)")
+		},
+	}
+
+	err := runLogin(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	env := decodeLoginEnvelope(t, out.String())
+	errBody, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope missing 'error' field: %v", env)
+	}
+	if got := errBody["code"]; got != clierr.Unauthorized {
+		t.Errorf("code = %q, want %q (typed error must not be re-wrapped as Transport)", got, clierr.Unauthorized)
+	}
+}
+
+func TestRunLogin_PlainErrorBecomesTransport(t *testing.T) {
+	io, _, out, _ := iostreams.Test()
+	io.JSON = true
+
+	opts := &LoginOptions{
+		IO:  io,
+		URL: "https://example.com",
+		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
+			return nil, errors.New("dial tcp: connection refused")
+		},
+	}
+
+	err := runLogin(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	env := decodeLoginEnvelope(t, out.String())
+	errBody, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope missing 'error' field: %v", env)
+	}
+	if got := errBody["code"]; got != clierr.Transport {
+		t.Errorf("code = %q, want %q (untyped errors must be wrapped as Transport)", got, clierr.Transport)
+	}
+}
+
+func TestRunLogin_CancelledErrorPassthrough(t *testing.T) {
+	io, _, out, _ := iostreams.Test()
+	io.JSON = true
+
+	opts := &LoginOptions{
+		IO:  io,
+		URL: "https://example.com",
+		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
+			return nil, clierr.New(clierr.AuthLoginCancelled, "browser login cancelled")
+		},
+	}
+
+	err := runLogin(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	env := decodeLoginEnvelope(t, out.String())
+	errBody, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope missing 'error' field: %v", env)
+	}
+	if got := errBody["code"]; got != clierr.AuthLoginCancelled {
+		t.Errorf("code = %q, want %q", got, clierr.AuthLoginCancelled)
+	}
+}
+
+func TestRunLogin_MissingURL(t *testing.T) {
+	io, _, out, _ := iostreams.Test()
+	io.JSON = true
+
+	opts := &LoginOptions{
+		IO:  io,
+		URL: "",
+		Authenticate: func(_ context.Context, _ auth.LoginOptions) (*config.Instance, error) {
+			t.Fatal("Authenticate should not be called when --url is missing")
+			return nil, nil
+		},
+	}
+
+	err := runLogin(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error for missing --url")
+	}
+
+	env := decodeLoginEnvelope(t, out.String())
+	errBody, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope missing 'error' field: %v", env)
+	}
+	if got := errBody["code"]; got != clierr.InvalidFlag {
+		t.Errorf("code = %q, want %q", got, clierr.InvalidFlag)
+	}
+}
+
+func decodeLoginEnvelope(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("decode envelope: %v\nbody=%q", err, raw)
+	}
+	return m
+}

--- a/cli/pkg/cmd/login_test.go
+++ b/cli/pkg/cmd/login_test.go
@@ -30,10 +30,10 @@ import (
 
 func TestRunLogin(t *testing.T) {
 	cases := []struct {
-		name         string
-		url          string
-		authErr      error
-		wantErrCode  string
+		name        string
+		url         string
+		authErr     error
+		wantErrCode string
 	}{
 		{
 			name:        "typed CLIError passes through unchanged",
@@ -83,7 +83,7 @@ func TestRunLogin(t *testing.T) {
 			}
 
 			var env map[string]any
-			if jerr := json.Unmarshal([]byte(out.String()), &env); jerr != nil {
+			if jerr := json.Unmarshal(out.Bytes(), &env); jerr != nil {
 				t.Fatalf("decode envelope: %v\nbody=%q", jerr, out.String())
 			}
 			errBody, ok := env["error"].(map[string]any)


### PR DESCRIPTION
## Purpose
`auth.Login` returned plain `fmt.Errorf`-wrapped errors on all failure paths, so `cmd/login.go` could not distinguish a known auth failure from a transport error — both became `CLI_TRANSPORT`.

Resolves #786

## Goals
- Map HTTP 401 and `invalid_grant` token-endpoint errors to `clierr.Unauthorized`
- Map user-cancelled PKCE flow (context cancellation, stdin EOF) to a new `clierr.AuthLoginCancelled` code
- Pass typed `clierr.CLIError` values through `cmd/login.go` unchanged instead of always wrapping as `CLI_TRANSPORT`

## Approach
- Add `classifyTokenError` in `auth/login.go` that inspects `*oauth2.RetrieveError` and returns a typed `CLIError` for known cases; returns `nil` for anything else so the existing `fmt.Errorf` wrap still applies
- In `loginPKCE`, check for `context.Canceled`, `context.DeadlineExceeded`, and `io.EOF` before calling `classifyTokenError`
- In `cmd/login.go`, use `errors.As` to pass through a `clierr.CLIError` from `auth.Login` before falling back to the `CLI_TRANSPORT` wrap
- Add `AuthLoginCancelled = "AUTH_LOGIN_CANCELLED"` constant to `clierr`

## User stories
As a script author using `amctl login`, I want the JSON error `code` field to distinguish auth rejections from transport failures so I can handle each case without parsing message strings.

## Release note
`amctl login` now emits `UNAUTHORIZED` for 401/`invalid_grant` errors and `AUTH_LOGIN_CANCELLED` when the browser login is cancelled, instead of always emitting `CLI_TRANSPORT`.

## Documentation
N/A — internal CLI error code change, no user-facing doc impact.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests
  - `pkg/auth/login_test.go` (new): 8 table-driven cases for `classifyTokenError` covering 401, `invalid_grant`, wrapped errors, 403, unknown codes, plain errors, nil response
  - `pkg/cmd/login_test.go` (new): 4 cases verifying typed `CLIError` passthrough, plain errors become `CLI_TRANSPORT`, cancelled login passes `AuthLoginCancelled`, missing `--url` returns `INVALID_FLAG`
- Integration tests
  - N/A

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go CLI)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#753 — original `amctl` CLI PR where this fix was deferred

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 26.04, Go 1.26.0

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification and clearer JSON error codes/messages for OAuth/login failures (unauthorized, invalid credentials).
  * Browser-based login cancellations are now detected and reported with a dedicated error code.
  * Authentication failures are rendered consistently in command output.

* **Tests**
  * Added unit and command tests validating the new login error classifications and JSON error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->