### PR TITLE
Add amctl PR checks workflow

### DIFF
--- a/.github/workflows/amctl-pr-checks.yaml
+++ b/.github/workflows/amctl-pr-checks.yaml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   checks:
     name: PR Checks
+    timeout-minutes: 30
     runs-on:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     defaults:
@@ -22,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@v6.1.0

--- a/.github/workflows/amctl-pr-checks.yaml
+++ b/.github/workflows/amctl-pr-checks.yaml
@@ -1,0 +1,73 @@
+name: amctl CLI
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "cli/**"
+      - "scripts/build-amctl.sh"
+      - ".github/workflows/amctl-pr-checks.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    name: PR Checks
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6.1.0
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Check formatting
+        run: |
+          UNFORMATTED="$(gofmt -l .)"
+          if [ -n "$UNFORMATTED" ]; then
+            echo "Code is not formatted. Run 'gofmt -w .' from cli/."
+            echo "$UNFORMATTED"
+            exit 1
+          fi
+
+      - name: Check module metadata
+        if: ${{ !cancelled() }}
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Verify modules
+        if: ${{ !cancelled() }}
+        run: go mod verify
+
+      - name: Run golangci-lint
+        if: ${{ !cancelled() }}
+        uses: golangci/golangci-lint-action@v9
+        with:
+          working-directory: cli
+          args: --modules-download-mode=readonly
+
+      - name: Run go vet
+        if: ${{ !cancelled() }}
+        run: go vet -mod=readonly ./...
+
+      - name: Run tests
+        if: ${{ !cancelled() }}
+        run: go test -mod=readonly -race ./...
+
+      - name: Build CLI
+        if: ${{ !cancelled() }}
+        run: go build -mod=readonly ./...
+
+      - name: Validate build script syntax
+        if: ${{ !cancelled() }}
+        working-directory: .
+        run: sh -n scripts/build-amctl.sh

--- a/.github/workflows/amctl-pr-checks.yaml
+++ b/.github/workflows/amctl-pr-checks.yaml
@@ -1,4 +1,4 @@
-name: amctl CLI
+name: Agent Manager CLI
 
 on:
   pull_request:

--- a/.github/workflows/amctl-pr-checks.yaml
+++ b/.github/workflows/amctl-pr-checks.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install staticcheck
         if: ${{ !cancelled() }}
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
       - name: Run staticcheck
         if: ${{ !cancelled() }}

--- a/.github/workflows/amctl-pr-checks.yaml
+++ b/.github/workflows/amctl-pr-checks.yaml
@@ -48,12 +48,13 @@ jobs:
         if: ${{ !cancelled() }}
         run: go mod verify
 
-      - name: Run golangci-lint
+      - name: Install staticcheck
         if: ${{ !cancelled() }}
-        uses: golangci/golangci-lint-action@v9
-        with:
-          working-directory: cli
-          args: --modules-download-mode=readonly
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Run staticcheck
+        if: ${{ !cancelled() }}
+        run: staticcheck ./...
 
       - name: Run go vet
         if: ${{ !cancelled() }}

--- a/cli/pkg/cmd/agent/deploy_test.go
+++ b/cli/pkg/cmd/agent/deploy_test.go
@@ -321,14 +321,14 @@ func newTestDeployIO(canPrompt, jsonMode bool) (*iostreams.IOStreams, *bytes.Buf
 
 func stubBuildableAgent() map[string]any {
 	return map[string]any{
-		"name":        "order-bot",
-		"displayName": "Order Bot",
-		"description": "",
-		"projectName": "triage",
-		"createdAt":   "2026-05-13T10:00:00Z",
+		"name":         "order-bot",
+		"displayName":  "Order Bot",
+		"description":  "",
+		"projectName":  "triage",
+		"createdAt":    "2026-05-13T10:00:00Z",
 		"provisioning": map[string]any{"type": "internal"},
-		"agentType":   map[string]any{"type": "chat"},
-		"uuid":        "00000000-0000-0000-0000-000000000001",
+		"agentType":    map[string]any{"type": "chat"},
+		"uuid":         "00000000-0000-0000-0000-000000000001",
 	}
 }
 
@@ -369,10 +369,13 @@ func stubConfigurations(items []map[string]any) map[string]any {
 		items = []map[string]any{}
 	}
 	return map[string]any{
-		"agentName":      "order-bot",
-		"projectName":    "triage",
-		"environment":    "dev",
-		"configurations": items,
+		"agentName":   "order-bot",
+		"projectName": "triage",
+		"environment": "dev",
+		"configurations": map[string]any{
+			"env":   items,
+			"files": []map[string]any{},
+		},
 	}
 }
 
@@ -458,9 +461,9 @@ func TestDeploy_NoBuilds_ReturnsBuildNotDeployable(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: prompter,
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -491,9 +494,9 @@ func TestDeploy_NotBuildable_PassthroughError(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -524,9 +527,9 @@ func TestDeploy_EmptyPipeline_ReturnsInternal(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -586,9 +589,9 @@ func TestDeploy_BuildNameSuccess_PreservesExistingEnv(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 		BuildName: "specific-b",
 	})
 	if err != nil {
@@ -633,9 +636,9 @@ func deployStatusErrorTest(t *testing.T, status, wantSubstr string) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -684,9 +687,9 @@ func TestDeploy_BuildCompletedButNoImageID_Errors(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -744,10 +747,10 @@ func TestDeploy_EnvNewKey_NoConflict(t *testing.T) {
 	prompter := &fakeDeployPrompter{}
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: prompter,
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"NEW_KEY=hello"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"NEW_KEY=hello"},
 	})
 	if err != nil {
 		t.Fatalf("runDeploy: %v", err)
@@ -778,11 +781,11 @@ func TestDeploy_EnvConflict_YesFlagBypassesPrompt(t *testing.T) {
 	prompter := &fakeDeployPrompter{}
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: prompter,
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"A=2"},
-		Yes:       true,
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"A=2"},
+		Yes:      true,
 	})
 	if err != nil {
 		t.Fatalf("runDeploy: %v", err)
@@ -813,10 +816,10 @@ func TestDeploy_EnvConflict_PromptAccepted(t *testing.T) {
 	prompter := &fakeDeployPrompter{confirmAnswer: true}
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: prompter,
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"A=2"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"A=2"},
 	})
 	if err != nil {
 		t.Fatalf("runDeploy: %v", err)
@@ -845,10 +848,10 @@ func TestDeploy_EnvConflict_PromptDeclined(t *testing.T) {
 	prompter := &fakeDeployPrompter{confirmAnswer: false}
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: prompter,
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"A=2"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"A=2"},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -880,10 +883,10 @@ func TestDeploy_EnvConflict_JSONModeWithoutYes_Errors(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"A=2"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"A=2"},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -913,10 +916,10 @@ func TestDeploy_EnvConflict_NonTTYWithoutYes_Errors(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"A=2"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"A=2"},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -936,8 +939,11 @@ func sensitiveConfigsRoute() (string, stubResponse) {
 			"agentName":   "order-bot",
 			"projectName": "triage",
 			"environment": "dev",
-			"configurations": []any{
-				map[string]any{"key": "PINECONE_API_KEY", "value": "", "isSensitive": true},
+			"configurations": map[string]any{
+				"env": []any{
+					map[string]any{"key": "PINECONE_API_KEY", "value": "", "isSensitive": true},
+				},
+				"files": []any{},
 			},
 		}}
 }
@@ -947,9 +953,9 @@ func TestDeploy_EnvSensitiveConflict_WithYes_JSONReportsKeyOnly(t *testing.T) {
 	requests := []recordedRequest{}
 	sk, sv := sensitiveConfigsRoute()
 	routes := map[string]stubResponse{
-		"GET /orgs/acme/projects/triage/agents/order-bot":              {200, stubBuildableAgent()},
-		"GET /orgs/acme/projects/triage/agents/order-bot/builds":       {200, stubBuildsListLatest("b1", "img1", "Completed")},
-		"GET /orgs/acme/projects/triage/deployment-pipeline":           {200, stubPipelineDevToProd()},
+		"GET /orgs/acme/projects/triage/agents/order-bot":        {200, stubBuildableAgent()},
+		"GET /orgs/acme/projects/triage/agents/order-bot/builds": {200, stubBuildsListLatest("b1", "img1", "Completed")},
+		"GET /orgs/acme/projects/triage/deployment-pipeline":     {200, stubPipelineDevToProd()},
 		sk: sv,
 		"POST /orgs/acme/projects/triage/agents/order-bot/deployments": {202, stubDeployAccepted("img1")},
 	}
@@ -959,11 +965,11 @@ func TestDeploy_EnvSensitiveConflict_WithYes_JSONReportsKeyOnly(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"PINECONE_API_KEY=newval"},
-		Yes:       true,
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"PINECONE_API_KEY=newval"},
+		Yes:      true,
 	})
 	if err != nil {
 		t.Fatalf("runDeploy: %v", err)
@@ -999,10 +1005,10 @@ func TestDeploy_EnvSensitiveConflict_JSONWithoutYes_ErrorsKeyOnly(t *testing.T) 
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"PINECONE_API_KEY=newval"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"PINECONE_API_KEY=newval"},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -1035,10 +1041,10 @@ func TestDeploy_EnvFlag_MalformedEmptyKey(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"=foo"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"=foo"},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -1065,10 +1071,10 @@ func TestDeploy_EnvFlag_MalformedNoEquals(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
-		EnvFlags:  []string{"FOO"},
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
+		EnvFlags: []string{"FOO"},
 	})
 	if err == nil {
 		t.Fatal("expected error")
@@ -1103,9 +1109,9 @@ func TestDeploy_StatusCompleted_IsDeployable(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 	})
 	if err != nil {
 		t.Fatalf("runDeploy: %v", err)
@@ -1131,9 +1137,9 @@ func TestDeploy_StatusSucceeded_IsDeployable(t *testing.T) {
 
 	err := runDeploy(context.Background(), &DeployOptions{
 		IO: io, Prompter: &fakeDeployPrompter{},
-		Client:    func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
-		Scope:     baseScope(),
-		Org:       "acme", Proj: "triage", AgentName: "order-bot",
+		Client: func(context.Context) (*gen.ClientWithResponses, error) { return client, nil },
+		Scope:  baseScope(),
+		Org:    "acme", Proj: "triage", AgentName: "order-bot",
 	})
 	if err != nil {
 		t.Fatalf("runDeploy: %v", err)

--- a/cli/pkg/cmd/project/create_test.go
+++ b/cli/pkg/cmd/project/create_test.go
@@ -114,7 +114,7 @@ func TestCreate_NoDescription(t *testing.T) {
 func testProjectCreateCmd(t *testing.T, ios *iostreams.IOStreams, clientFn func(context.Context) (*amsvc.ClientWithResponses, error)) *cobra.Command {
 	t.Helper()
 	f := &cmdutil.Factory{
-		IOStreams:     ios,
+		IOStreams:    ios,
 		AgentManager: clientFn,
 		Config: func() (*config.Config, error) {
 			return &config.Config{

--- a/cli/pkg/render/render_test.go
+++ b/cli/pkg/render/render_test.go
@@ -132,4 +132,3 @@ func TestIsRendered_Unwrap(t *testing.T) {
 		t.Errorf("code = %q, want %q", cli.Code, clierr.NoOrg)
 	}
 }
-

--- a/scripts/build-amctl.sh
+++ b/scripts/build-amctl.sh
@@ -57,7 +57,6 @@ BUILD_TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$BUILD_TMPDIR"' EXIT
 
 cd "${REPO_ROOT}/cli"
-go mod tidy
 
 for target in $TARGETS; do
     os="${target%/*}"


### PR DESCRIPTION
## Purpose
Add a PR gate for amctl CLI changes so formatting, module metadata, static analysis, tests, and buildability are validated before merge.

## Goals
- Expose one GitHub-visible `PR Checks` job for amctl-related changes.
- Run all applicable Go verification steps without adding dependencies to the product module.
- Keep release packaging read-only with respect to Go module metadata.

## Approach
- Add `.github/workflows/amctl-pr-checks.yaml`, scoped to `cli/**`, `scripts/build-amctl.sh`, and the workflow itself.
- Run formatting, module tidy drift, module verification, `golangci-lint`, `go vet`, race-enabled tests, `go build`, and shell syntax validation as sequential steps in one job.
- Guard later verification steps with `!cancelled()` so the single check still reports diagnostics after an earlier failure.
- Remove the implicit `go mod tidy` mutation from `scripts/build-amctl.sh`.

## User stories
N/A - CI quality gate for amctl contributors.

## Release note
N/A - internal CI workflow change only.

## Documentation
N/A - no product documentation impact.

## Training
N/A - no training content impact.

## Certification
N/A - no certification exam impact.

## Marketing
N/A - no marketing impact.

## Automation tests
 - Unit tests
   - `go test -mod=readonly -race ./...` currently exposes 14 pre-existing deploy fixture failures in `cli/pkg/cmd/agent`; a follow-up will fix them.
 - Integration tests
   - Parsed the workflow YAML locally and verified one `PR Checks` job with the intended trigger paths and 10 ordered steps.
   - `go mod tidy`, `git diff --exit-code -- go.mod go.sum`, and `go mod verify` pass.
   - `go vet -mod=readonly ./...` passes.
   - `go build -mod=readonly ./...` passes.
   - `sh -n scripts/build-amctl.sh` passes.
   - The formatting step currently exposes 3 pre-existing unformatted CLI test files; a follow-up will fix them.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no - not applicable to this CI-only Go workflow change
 - Confirmed that this PR does not commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - no sample impact.

## Related PRs
N/A.

## Migrations (if applicable)
N/A - no migration required.

## Test environment
Local macOS environment with the Go toolchain declared by `cli/go.mod`. GitHub Actions validation will run on the repository CodeBuild runner.

## Learning
Followed the existing repository PR workflow conventions for path-scoped CodeBuild jobs and CI-only lint tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CI checks on PRs to run formatting, linting, vetting, testing, build verification, and shell script validation.
  * Streamlined the CLI build process by removing a redundant module tidy step to improve build efficiency.
* **Tests**
  * Updated unit tests to accept a revised configuration payload shape (nested env/files) and applied cosmetic formatting adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->