### PR TITLE
Bump instrumentation to 0.3.0 (traceloop-sdk 0.61.0)

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -28,8 +28,8 @@
 
   "python-instrumentation-provider": [
     {
-      "instrumentation_version": "0.2.1",
-      "traceloop_version": "0.60.0",
+      "instrumentation_version": "0.3.0",
+      "traceloop_version": "0.61.0",
       "python_versions": ["3.10", "3.11", "3.12", "3.13"]
     }
   ],

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -114,7 +114,7 @@ func loadEnvs() {
 		SDKVolumeName: r.readOptionalString("OTEL_SDK_VOLUME_NAME", "otel-tracing-sdk-volume"),
 		SDKMountPath:  r.readOptionalString("OTEL_SDK_MOUNT_PATH", "/otel-tracing-sdk"),
 
-		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.2.1"),
+		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.3.0"),
 
 		InstrumentationExtensionPath: r.readOptionalString("INSTRUMENTATION_EXTENSION_PATH", "/etc/amp/instrumentation-extension.yaml"),
 

--- a/agent-manager-service/instrumentation/baseline.json
+++ b/agent-manager-service/instrumentation/baseline.json
@@ -1,7 +1,7 @@
 [
   {
-    "version": "0.2.1",
-    "traceloopSdk": "0.60.0",
+    "version": "0.3.0",
+    "traceloopSdk": "0.61.0",
     "pythonVersions": [
       "3.10",
       "3.11",

--- a/agent-manager-service/instrumentation/catalog_test.go
+++ b/agent-manager-service/instrumentation/catalog_test.go
@@ -21,32 +21,32 @@ import (
 )
 
 func TestLoad_BaselineOnly(t *testing.T) {
-	c, err := Load("", "0.2.1")
+	c, err := Load("", "0.3.0")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if c.Default() != "0.2.1" {
-		t.Errorf("Default = %q, want 0.2.1", c.Default())
+	if c.Default() != "0.3.0" {
+		t.Errorf("Default = %q, want 0.3.0", c.Default())
 	}
 	all := c.All()
 	if len(all) != 1 {
 		t.Fatalf("len(All) = %d, want 1", len(all))
 	}
-	if all[0].Version != "0.2.1" {
-		t.Errorf("All[0].Version = %q, want 0.2.1", all[0].Version)
+	if all[0].Version != "0.3.0" {
+		t.Errorf("All[0].Version = %q, want 0.3.0", all[0].Version)
 	}
 	if all[0].Source != SourceBundled {
 		t.Errorf("All[0].Source = %q, want bundled", all[0].Source)
 	}
-	if !c.Has("0.2.1") {
-		t.Error("Has(0.2.1) = false, want true")
+	if !c.Has("0.3.0") {
+		t.Error("Has(0.3.0) = false, want true")
 	}
 	if c.Has("99.0.0") {
 		t.Error("Has(99.0.0) = true, want false")
 	}
-	got, ok := c.Get("0.2.1")
+	got, ok := c.Get("0.3.0")
 	if !ok || got.ImageRepository != "ghcr.io/wso2/amp-python-instrumentation-provider" {
-		t.Errorf("Get(0.2.1) = %+v, ok=%v", got, ok)
+		t.Errorf("Get(0.3.0) = %+v, ok=%v", got, ok)
 	}
 }
 
@@ -57,7 +57,7 @@ func TestLoad_DefaultNotInSet(t *testing.T) {
 }
 
 func TestLoad_ExtensionAdds(t *testing.T) {
-	c, err := Load("testdata/extension_valid.yaml", "0.2.1")
+	c, err := Load("testdata/extension_valid.yaml", "0.3.0")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -71,18 +71,18 @@ func TestLoad_ExtensionAdds(t *testing.T) {
 	if got.TraceloopSDK != "0.65.0" {
 		t.Errorf("Get(0.4.0).TraceloopSDK = %q, want 0.65.0", got.TraceloopSDK)
 	}
-	bundled, _ := c.Get("0.2.1")
+	bundled, _ := c.Get("0.3.0")
 	if bundled.Source != SourceBundled {
-		t.Errorf("Get(0.2.1).Source = %q, want bundled", bundled.Source)
+		t.Errorf("Get(0.3.0).Source = %q, want bundled", bundled.Source)
 	}
 }
 
 func TestLoad_ExtensionOverridesBundled(t *testing.T) {
-	c, err := Load("testdata/extension_override.yaml", "0.2.1")
+	c, err := Load("testdata/extension_override.yaml", "0.3.0")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	got, _ := c.Get("0.2.1")
+	got, _ := c.Get("0.3.0")
 	if got.Source != SourceExtension {
 		t.Errorf("expected extension override; Source = %q", got.Source)
 	}
@@ -92,7 +92,7 @@ func TestLoad_ExtensionOverridesBundled(t *testing.T) {
 }
 
 func TestLoad_ExtensionFileAbsent(t *testing.T) {
-	c, err := Load("testdata/does_not_exist.yaml", "0.2.1")
+	c, err := Load("testdata/does_not_exist.yaml", "0.3.0")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -102,19 +102,19 @@ func TestLoad_ExtensionFileAbsent(t *testing.T) {
 }
 
 func TestLoad_ExtensionMalformedYAML(t *testing.T) {
-	if _, err := Load("testdata/extension_malformed.yaml", "0.2.1"); err == nil {
+	if _, err := Load("testdata/extension_malformed.yaml", "0.3.0"); err == nil {
 		t.Fatal("expected error for malformed YAML")
 	}
 }
 
 func TestLoad_ExtensionMissingRequiredFields(t *testing.T) {
-	if _, err := Load("testdata/extension_missing_fields.yaml", "0.2.1"); err == nil {
+	if _, err := Load("testdata/extension_missing_fields.yaml", "0.3.0"); err == nil {
 		t.Fatal("expected error for missing imageRepository")
 	}
 }
 
 func TestAllAndGet_ReturnDefensiveCopies(t *testing.T) {
-	c, err := Load("", "0.2.1")
+	c, err := Load("", "0.3.0")
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -137,12 +137,12 @@ func TestAllAndGet_ReturnDefensiveCopies(t *testing.T) {
 	}
 
 	// Get(): same contract.
-	got, ok := c.Get("0.2.1")
+	got, ok := c.Get("0.3.0")
 	if !ok {
-		t.Fatal("Get(0.2.1) missing")
+		t.Fatal("Get(0.3.0) missing")
 	}
 	got.PythonVersions[0] = "tampered"
-	again, _ := c.Get("0.2.1")
+	again, _ := c.Get("0.3.0")
 	if again.PythonVersions[0] == "tampered" {
 		t.Error("Get() mutation leaked into catalog")
 	}

--- a/agent-manager-service/instrumentation/testdata/extension_override.yaml
+++ b/agent-manager-service/instrumentation/testdata/extension_override.yaml
@@ -1,5 +1,5 @@
 additionalInstrumentationVersions:
-  - version: "0.2.1"
-    traceloopSdk: "0.60.0"
+  - version: "0.3.0"
+    traceloopSdk: "0.61.0"
     pythonVersions: ["3.10", "3.11", "3.12", "3.13"]
     imageRepository: "internal.registry.example/amp-python-instrumentation-provider"

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -130,7 +130,7 @@ agentManagerService:
       # Platform default AMP instrumentation version. Must exist in the
       # effective catalog (embedded baseline ∪ additionalInstrumentationVersions);
       # otherwise the server fails to start.
-      defaultInstrumentationVersion: "0.2.1"
+      defaultInstrumentationVersion: "0.3.0"
       # Operator-supplied catalog extension entries, added on top of the
       # bundled baseline. For air-gapped installs, point imageRepository
       # at the internal mirror.

--- a/documentation/docs/administration/instrumentation-catalog.mdx
+++ b/documentation/docs/administration/instrumentation-catalog.mdx
@@ -152,7 +152,7 @@ Bundled-baseline entries can't be removed via Helm; they ship with the AMP relea
 
 ## The platform default
 
-`OTEL_DEFAULT_INSTRUMENTATION_VERSION` (chart value: `agentManagerService.config.otel.defaultInstrumentationVersion`) is the version pre-selected on the create-agent form when a user doesn't override it. It defaults to `0.2.1`.
+`OTEL_DEFAULT_INSTRUMENTATION_VERSION` (chart value: `agentManagerService.config.otel.defaultInstrumentationVersion`) is the version pre-selected on the create-agent form when a user doesn't override it. It defaults to `0.3.0`.
 
 This value has to exist in the effective catalog at startup. If it doesn't, the server exits with:
 

--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -177,7 +177,7 @@ These are the versions that ship with this AMP release:
 
 | AMP instrumentation version | Traceloop SDK (`traceloop-sdk`) | Supported Python versions | Init-container image tag |
 |---|---|---|---|
-| 0.2.1 | 0.60.0 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.2.1-python<X.Y>` |
+| 0.3.0 | 0.61.0 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python<X.Y>` |
 
 The canonical source for this table is [`.github/release-config.json`](https://github.com/wso2/agent-manager/blob/main/.github/release-config.json) under the `python-instrumentation-provider` key. Maintainers cutting a new version: see [`python-instrumentation-provider/RELEASING.md`](https://github.com/wso2/agent-manager/blob/main/python-instrumentation-provider/RELEASING.md) for the release runbook.
 

--- a/libs/amp-instrumentation/pyproject.toml
+++ b/libs/amp-instrumentation/pyproject.toml
@@ -15,13 +15,13 @@ maintainers = [
 # amp-instrumentation version maps to exactly one OpenLLMetry version. Bumping it
 # is a new amp-instrumentation release. See the AMP instrumentation version mapping.
 dependencies = [
-    "traceloop-sdk==0.60.0",
+    "traceloop-sdk==0.61.0",
      # Pin wrapt below 2.0: wrapt 2.x removed the `module=` kwarg on
-    # wrap_function_wrapper that opentelemetry-instrumentation-* 0.60.0 still calls.
+    # wrap_function_wrapper that opentelemetry-instrumentation-* 0.61.0 still calls.
     "wrapt<2.0.0",
     "httpx>=0.25.0",
     # Imported directly by amp_instrumentation.otel.init_otel. Left unconstrained
-    # on purpose: their version is determined by traceloop-sdk==0.60.0, which
+    # on purpose: their version is determined by traceloop-sdk==0.61.0, which
     # already requires both (kept here only to declare the direct import).
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-http",

--- a/python-instrumentation-provider/Dockerfile
+++ b/python-instrumentation-provider/Dockerfile
@@ -5,7 +5,7 @@
 ARG PYTHON_VERSION=3.11
 # traceloop-sdk (OpenLLMetry) version pinned into this image. One pinned version
 # per AMP instrumentation image; bump it by building a new AMP instrumentation version.
-ARG TRACELOOP_VERSION=0.60.0
+ARG TRACELOOP_VERSION=0.61.0
 
 ############### STAGE 1 — BUILD INSTRUMENTATION PACKAGES ###############
 FROM public.ecr.aws/docker/library/python:${PYTHON_VERSION}-slim AS otel-tracing

--- a/python-instrumentation-provider/RELEASING.md
+++ b/python-instrumentation-provider/RELEASING.md
@@ -47,13 +47,13 @@ stay on the version they were pinned to — bumping the default never moves them
 `workflow_dispatch`-only — they run when someone *manually* dispatches them:
 
 - **PyPI package** — `.github/workflows/amp_instrumentation_release.yaml`. Type the
-  `target_version` (e.g. `0.3.0`) and the chosen `branch` (usually `main`); the
+  `target_version` (e.g. `0.4.0`) and the chosen `branch` (usually `main`); the
   workflow `sed`s `pyproject.toml`'s `version`, builds, publishes to PyPI, and tags
   `amp-instrumentation/v<target_version>`. **Run this when** you've merged the
   `traceloop-sdk` pin update and want to publish a new PyPI version.
 - **Init-container images — standalone (primary path)**:
   `.github/workflows/python_instrumentation_image_release.yaml`. Inputs: `branch`
-  and `instrumentation_version` (a specific version like `0.3.0`, or `all`). It reads
+  and `instrumentation_version` (a specific version like `0.4.0`, or `all`). It reads
   `release-config.json`, filters to the requested version, and builds & pushes the
   matching `(instr × python)` matrix as
   `amp-python-instrumentation-provider:<instr_version>-python<X.Y>`. **Use this
@@ -122,23 +122,23 @@ a leftover closed test issue would suppress a future real notification).
 
 ## Scenario A — bump `traceloop-sdk` (new OpenLLMetry version)
 
-Example: `traceloop-sdk` `0.60.0` → `0.65.0`, cutting AMP-instr version `0.3.0`.
+Example: `traceloop-sdk` `0.61.0` → `0.65.0`, cutting AMP-instr version `0.4.0`.
 
 1. **Validate** `traceloop-sdk==0.65.0` against the frontier frameworks (existing
    validation process — out of scope here). Only cut a version for releases we've validated.
 2. **Pick the new AMP-instr semver.** Minor bump if there's a behaviour change (a new
-   OpenLLMetry usually is); patch for trivial fixes. Say `0.3.0`.
+   OpenLLMetry usually is); patch for trivial fixes. Say `0.4.0`.
 3. **PyPI package** (`libs/amp-instrumentation/`):
    - Edit `pyproject.toml` → `dependencies` → `"traceloop-sdk==0.65.0"`. (Leave `version = "0.0.0-dev"` alone.)
    - PR → review → merge to `main`.
    - Run the **`AMP Instrumentation Release`** workflow (`amp_instrumentation_release.yaml`,
-     `workflow_dispatch`) with `branch = main`, `target_version = 0.3.0`. It updates
-     `pyproject.toml`'s `version`, builds, publishes `amp-instrumentation==0.3.0` to PyPI,
-     and tags `amp-instrumentation/v0.3.0`.
+     `workflow_dispatch`) with `branch = main`, `target_version = 0.4.0`. It updates
+     `pyproject.toml`'s `version`, builds, publishes `amp-instrumentation==0.4.0` to PyPI,
+     and tags `amp-instrumentation/v0.4.0`.
 4. **Init-container images** (`.github/release-config.json`): **add a new entry** to the
    `python-instrumentation-provider` array (keep the old ones — see "Retention" below):
    ```json
-   { "instrumentation_version": "0.3.0", "traceloop_version": "0.65.0", "python_versions": ["3.10", "3.11", "3.12", "3.13"] }
+   { "instrumentation_version": "0.4.0", "traceloop_version": "0.65.0", "python_versions": ["3.10", "3.11", "3.12", "3.13"] }
    ```
    No Dockerfile change needed.
 5. **Regenerate the server's embedded catalog**. The `agent-manager-service` binary
@@ -153,22 +153,22 @@ Example: `traceloop-sdk` `0.60.0` → `0.65.0`, cutting AMP-instr version `0.3.0
    the chart's default from drifting. Merge the PR.
 6. **Publish the images** by dispatching the **`AMP Python Instrumentation Image Release`**
    workflow (`python_instrumentation_image_release.yaml`) with `branch = main`,
-   `instrumentation_version = 0.3.0`. It builds & pushes the `(0.3.0 × supported python)`
-   matrix to `amp-python-instrumentation-provider:0.3.0-python{X.Y}`. (You don't have to
+   `instrumentation_version = 0.4.0`. It builds & pushes the `(0.4.0 × supported python)`
+   matrix to `amp-python-instrumentation-provider:0.4.0-python{X.Y}`. (You don't have to
    wait for an AMP product release — that workflow is independent. The next product
    release will also rebuild this matrix, refreshing the base layers — that's fine.)
-7. **Make it the platform default** (when you want *new* agents to get `0.3.0`).
+7. **Make it the platform default** (when you want *new* agents to get `0.4.0`).
    In `deployments/helm-charts/wso2-agent-manager/values.yaml`:
    ```yaml
    agentManagerService:
      config:
        otel:
-         defaultInstrumentationVersion: "0.3.0"
+         defaultInstrumentationVersion: "0.4.0"
    ```
    The next AMP product release ships this default. Operators can still override it
    per install via the same chart value. Existing agents are unaffected — the default
    only applies to *new* agents created without an explicit pin.
-8. **Docs / mapping table**: add a `0.3.0 → traceloop-sdk 0.65.0 → python 3.10–3.13` row
+8. **Docs / mapping table**: add a `0.4.0 → traceloop-sdk 0.65.0 → python 3.10–3.13` row
    to the "Bundled baseline" table in `documentation/docs/components/amp-instrumentation.mdx`.
    (Console dropdowns are populated from the runtime catalog at the agent-build-options
    endpoint, so no Console-side edit is needed.)
@@ -209,7 +209,7 @@ Only prune a very old entry after confirming no agent pins it.
 
 ## Verifying a release
 
-- **PyPI:** `pip install amp-instrumentation==0.3.0 && pip show traceloop-sdk` (expect the pinned version) and `python -c "import amp_instrumentation; print(amp_instrumentation.__version__)"` (expect `0.3.0`).
-- **Image:** `docker run --rm ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python3.11 sh -c 'cat /instrumentations/otel-tracing/traceloop_sdk-*.dist-info/METADATA | grep ^Version'` (or just `ls /instrumentations/otel-tracing/`).
+- **PyPI:** `pip install amp-instrumentation==0.4.0 && pip show traceloop-sdk` (expect the pinned version) and `python -c "import amp_instrumentation; print(amp_instrumentation.__version__)"` (expect `0.4.0`).
+- **Image:** `docker run --rm ghcr.io/wso2/amp-python-instrumentation-provider:0.4.0-python3.11 sh -c 'cat /instrumentations/otel-tracing/traceloop_sdk-*.dist-info/METADATA | grep ^Version'` (or just `ls /instrumentations/otel-tracing/`).
 - **agent-manager-service:** deploy a Python agent with auto-instrumentation on; confirm the init container in the pod is `…:<expected version>-python<agent's Python>`.
 

--- a/python-instrumentation-provider/requirements.txt
+++ b/python-instrumentation-provider/requirements.txt
@@ -2,6 +2,6 @@
 # TRACELOOP_VERSION build arg, so the pinned version is set per AMP
 # instrumentation image. This file holds only the always-needed extras.
 # Pin wrapt below 2.0: wrapt 2.x removed the `module=` kwarg on
-# wrap_function_wrapper that opentelemetry-instrumentation-* 0.60.0 still calls.
+# wrap_function_wrapper that opentelemetry-instrumentation-* 0.61.0 still calls.
 wrapt<2.0.0
 httpx>=0.25.0

--- a/test/instrumentation-matrix/FINDINGS.md
+++ b/test/instrumentation-matrix/FINDINGS.md
@@ -191,3 +191,23 @@ reused, so removed numbers just leave a gap.)
 - **Re-tighten when**: not applicable — these are forward pins to currently-
   compatible versions; if either SDK regresses or Traceloop pins httpx tight
   enough to require an older SDK, the matrix will surface it.
+
+## F-011 — vcrpy 8.1.1 breaks against aiohttp 3.14.0
+
+- **Status**: mitigated
+- **Combo**: any cell (test-infra only) — `vcrpy 8.1.1` × `aiohttp 3.14.0`
+- **Discovered**: 2026-06-02 (first fresh-venv run after aiohttp 3.14.0 released)
+- **Symptom**: every emission cell errors at collection with
+  `AttributeError: module 'aiohttp.streams' has no attribute
+  'AsyncStreamReaderMixin'` from `vcr/stubs/aiohttp_stubs.py`. vcrpy's aiohttp
+  stub does `class MockStream(asyncio.StreamReader, streams.AsyncStreamReaderMixin)`
+  at import time; aiohttp 3.14.0 removed that mixin.
+- **Cause**: test-infra deps (`vcrpy`, `aiohttp`) are unpinned, so a fresh
+  resolve picks the just-released aiohttp 3.14.0 that current vcrpy doesn't
+  support. Independent of the traceloop version — it was masked only because
+  older cell venvs were cached from before 3.14.0.
+- **Mitigation**: pin `aiohttp<3.14` in `noxfile.py`'s test-infra install
+  block. aiohttp is only a transitive dep (LLM calls go over httpx), so the
+  cap doesn't change what's under test.
+- **Re-tighten when**: vcrpy ships a release whose aiohttp stub supports
+  aiohttp 3.14 — then drop the `aiohttp<3.14` cap and let it float again.

--- a/test/instrumentation-matrix/FINDINGS.md
+++ b/test/instrumentation-matrix/FINDINGS.md
@@ -53,6 +53,9 @@ reused, so removed numbers just leave a gap.)
 - **Re-tighten when**: Traceloop's CrewAI instrumentation emits native types.
   Check by inspecting a fresh CrewAI cell's `capturedSpans` and grepping for
   any `[int]`/`[bool]` typed `crewai.*` value.
+- **2026-06-02 (traceloop 0.61.0)**: still stringified — `crewai.agent.max_iter
+  = '25'`, `crewai.task.delegations = '0'`, `crewai.task.async_execution =
+  'False'`, ids all `str`. Not fixed; concession stays.
 
 ## F-002 — Observer's `CrewAITaskData.Name` has no upstream source
 
@@ -105,6 +108,11 @@ reused, so removed numbers just leave a gap.)
   that wraps CrewAI tool execution as separate spans, OR OpenInference is
   added as a second instrumentation provider and its CrewAI cell asserts
   `tool` kind.
+- **2026-06-02 (F-009 now fixed; traceloop 0.60.0 + 0.61.0)**: re-ran with
+  event capture on. The CrewAI cell emits **zero span events** on both
+  versions, and no separate `tool` span — so this is a **confirmed real
+  upstream gap**, not a harness blind spot. Status upgraded from
+  open/unconfirmed to **open/confirmed**.
 
 ## F-004 — `crewai 1.14.x` × `traceloop-sdk 0.60` is unresolvable
 
@@ -121,6 +129,10 @@ reused, so removed numbers just leave a gap.)
 - **Re-tighten when**: Traceloop ships a 0.61+ release with looser
   `opentelemetry-api` requirements; or CrewAI relaxes its `opentelemetry-api`
   pin. At that point we can bump the matrix pin and re-record.
+- **2026-06-02 (traceloop 0.61.0)**: still unresolvable — `traceloop-sdk
+  0.61.0` requires `opentelemetry-api>=1.38,<2`, `crewai 1.14.5` requires
+  `>=1.34,<1.35`. The 0.61 release did **not** loosen the pin; crewai stays at
+  1.1.0.
 
 ## F-006 — Traceloop's LlamaIndex `OpenAIEmbedding` instrumentation omits vendor
 
@@ -134,6 +146,9 @@ reused, so removed numbers just leave a gap.)
   LLM kind still requires vendor.
 - **Re-tighten when**: Traceloop's LlamaIndex instrumentation emits
   `gen_ai.provider.name` on embedding spans.
+- **2026-06-02 (traceloop 0.61.0)**: embedding spans still carry no vendor
+  (neither `gen_ai.system` nor `gen_ai.provider.name`). Not fixed; concession
+  stays.
 
 ## F-008 — Traceloop's LangGraph 0.60 may not emit separate tool spans
 
@@ -153,6 +168,15 @@ reused, so removed numbers just leave a gap.)
   signal (then this is a real upstream gap), OR Traceloop adds tool-call
   wrapping for LangChain/LangGraph tools, OR OpenInference is added as a
   second provider.
+- **2026-06-02 (F-009 now fixed; traceloop 0.60.0 + 0.61.0)**: **contradicted.**
+  With the current sample/cassette, the LangGraph cell emits a *separate*
+  `execute_tool double` span (`traceloop.span.kind=tool`,
+  `gen_ai.operation.name=execute_tool`) on **both** 0.60.0 and 0.61.0 — the
+  classifier already counts it as `tool`. No events are involved. The original
+  "no tool span" observation no longer holds (likely the sample/cassette
+  exercises the tool now). **Recommend resolving F-008 by adding `tool` to
+  `frameworks[langgraph].spanKinds`** — note this is true independent of the
+  0.61.0 bump.
 
 ## F-009 — Harness doesn't capture span events
 

--- a/test/instrumentation-matrix/FINDINGS.md
+++ b/test/instrumentation-matrix/FINDINGS.md
@@ -78,9 +78,9 @@ reused, so removed numbers just leave a gap.)
   `crewai.task.description`, or (b) `CrewAITaskData.Name` is removed from the
   observer's data model.
 
-## F-003 — Traceloop's CrewAI 0.60 may not emit separate tool spans
+## F-003 — Traceloop's CrewAI does not emit separate tool spans
 
-- **Status**: open / unconfirmed (blocked on F-009)
+- **Status**: open / confirmed (see the 2026-06-02 note; F-009 resolved)
 - **Combo**: `traceloop-sdk 0.60.0` × `crewai 1.1.0`
 - **Discovered**: 2026-05-27
 - **Symptom**: CrewAI cell with a tool-using agent never produces a span
@@ -149,54 +149,6 @@ reused, so removed numbers just leave a gap.)
 - **2026-06-02 (traceloop 0.61.0)**: embedding spans still carry no vendor
   (neither `gen_ai.system` nor `gen_ai.provider.name`). Not fixed; concession
   stays.
-
-## F-008 — Traceloop's LangGraph 0.60 may not emit separate tool spans
-
-- **Status**: open / unconfirmed (blocked on F-009; same shape as F-003)
-- **Combo**: `traceloop-sdk 0.60.0` × `langgraph 0.2.74` (+ `langchain-core` `@tool`)
-- **Discovered**: 2026-05-27
-- **Symptom**: a LangGraph agent that uses a `@tool` function invoked via
-  `ToolNode` produces no captured span carrying any tool signal (no
-  `traceloop.span.kind=tool`, no `gen_ai.tool.name`, no
-  `gen_ai.operation.name=execute_tool`). The graph chose to call the tool —
-  the cassette captures a `finish_reason: tool_calls` response.
-- **Why open / unconfirmed**: same as F-003 — the tool call could be on the
-  LLM span as a `gen_ai.tool.call` event that our `_to_dict` drops. F-009
-  must be fixed before this finding can be confirmed.
-- **Mitigation (temporary)**: `matrix.yaml.frameworks[langgraph].spanKinds = [llm]`.
-- **Re-tighten when**: F-009 is resolved AND a re-run still shows no tool-kind
-  signal (then this is a real upstream gap), OR Traceloop adds tool-call
-  wrapping for LangChain/LangGraph tools, OR OpenInference is added as a
-  second provider.
-- **2026-06-02 (F-009 now fixed; traceloop 0.60.0 + 0.61.0)**: **contradicted.**
-  With the current sample/cassette, the LangGraph cell emits a *separate*
-  `execute_tool double` span (`traceloop.span.kind=tool`,
-  `gen_ai.operation.name=execute_tool`) on **both** 0.60.0 and 0.61.0 — the
-  classifier already counts it as `tool`. No events are involved. The original
-  "no tool span" observation no longer holds (likely the sample/cassette
-  exercises the tool now). **Recommend resolving F-008 by adding `tool` to
-  `frameworks[langgraph].spanKinds`** — note this is true independent of the
-  0.61.0 bump.
-
-## F-009 — Harness doesn't capture span events
-
-- **Status**: open (harness bug)
-- **Combo**: any
-- **Discovered**: 2026-05-27 while investigating F-008
-- **Symptom**: `harness/test_cell.py:_to_dict` flattens a `ReadableSpan` into
-  a dict with `name`, `kind`, `attributes`, `resource`, `traceId`, `spanId`,
-  `parentSpanId` — but not `events`. If a provider encodes a logical
-  sub-operation (a tool call inside an LLM span, say) as a span event rather
-  than a child span, the matrix sees nothing and misclassifies coverage as
-  "missing-span-kind" when the data is actually present.
-- **Suspected cause**: my own code.
-- **Mitigation**: none yet — the missing tool-spans are being treated as
-  upstream gaps (F-003, F-008) but could be in-event in some cases. Need to
-  verify before tightening the upstream stories.
-- **Fix when**: add `events` to the `_to_dict` output, augment the classifier
-  to recognize a tool-call event on an LLM span as evidence of a tool-kind
-  sub-operation, and add a matching JSON-schema validation slot for span
-  events. Reconfirm F-003 and F-008 with the new harness before closing.
 
 ## F-010 — Old SDK pins blow up against the httpx the matrix resolves
 

--- a/test/instrumentation-matrix/FINDINGS.md
+++ b/test/instrumentation-matrix/FINDINGS.md
@@ -2,8 +2,8 @@
 
 Every time the matrix exposes a gap that requires either an upstream change, an
 observer change, or a schema concession, an entry lands here. Each entry has an
-ID, the affected combo, the symptom, what we did about it, and what would let
-us undo the concession.
+ID, the affected combo, the symptom, what was done about it, and what would let
+the concession be undone.
 
 The schema rules in `contracts/traceloop/v1/` and `cmd/gen-contract/contract.go`
 should never relax silently — every relaxation has an `F-NNN` entry justifying
@@ -18,16 +18,16 @@ reused, so removed numbers just leave a gap.)
 - **ID**: `F-NNN`, monotonically increasing, never reused. Reference from
   commit messages, contract.go, and code comments.
 - **Status**: `open` (no fix yet) or `mitigated` (a workaround/concession on
-  our side is in force without the upstream being fixed). A genuinely
+  the AMP side is in force without the upstream being fixed). A genuinely
   resolved finding is removed rather than kept.
 - **Combo**: `(provider × version) × (framework × version)` whose emission
   exhibits the gap. If the gap is provider-only, omit the framework half.
 - **Symptom**: what the matrix observes — a missing kind, a wrong type,
   spans that don't validate, install failures, etc.
-- **Mitigation**: what we changed locally — schema concession, observer fallback,
+- **Mitigation**: what was changed locally — schema concession, observer fallback,
   classifier rule, skipped cell. Cross-reference the commit SHA.
-- **Re-tighten when**: the precise upstream change that would let us drop the
-  mitigation.
+- **Re-tighten when**: the precise upstream change that would let the
+  mitigation be dropped.
 
 ---
 
@@ -92,27 +92,19 @@ reused, so removed numbers just leave a gap.)
   "openinference-instrumentation-crewai" as the source of agent-spans for
   multi-agent traces, suggesting OpenInference may emit separate tool spans
   where Traceloop does not.
-- **Why open / unconfirmed**: F-009 — the harness's `_to_dict` strips span
-  *events*. The OTel GenAI semconv allows tool calls to be encoded as
-  `gen_ai.tool.call` events on the assistant LLM span rather than as
-  separate spans. The captured cassette shows `finish_reason: tool_calls`
-  on the LLM response, so the data flow exists; whether Traceloop attaches
-  the per-tool-call detail as an event we can't see is unknown until F-009
-  is resolved. The "missing tool spans" conclusion may be a harness blind
-  spot, not a real upstream gap.
-- **Mitigation (temporary)**: `matrix.yaml.frameworks[crewai].spanKinds` set
-  to `[llm, agent, crewaitask]` (omits `tool`) so the cell passes today.
-  Re-evaluate once F-009 is fixed.
-- **Re-tighten when**: F-009 is resolved AND a re-run still shows no tool-kind
-  signal (then this remains a real upstream gap), OR Traceloop ships a release
-  that wraps CrewAI tool execution as separate spans, OR OpenInference is
-  added as a second instrumentation provider and its CrewAI cell asserts
-  `tool` kind.
-- **2026-06-02 (F-009 now fixed; traceloop 0.60.0 + 0.61.0)**: re-ran with
-  event capture on. The CrewAI cell emits **zero span events** on both
-  versions, and no separate `tool` span — so this is a **confirmed real
-  upstream gap**, not a harness blind spot. Status upgraded from
-  open/unconfirmed to **open/confirmed**.
+- **Why confirmed**: the OTel GenAI semconv allows tool calls to be encoded as
+  `gen_ai.tool.call` events on the assistant LLM span rather than as separate
+  spans, so an early concern was that the tool signal was simply not being
+  captured. The 2026-06-02 revalidation — run after the harness was taught to
+  capture span events — settled it: the CrewAI cell emits **zero span events**
+  and no separate `tool` span on both 0.60.0 and 0.61.0. The missing tool span
+  is a real upstream gap, not a harness blind spot.
+- **Mitigation**: `matrix.yaml.frameworks[crewai].spanKinds` is set to
+  `[llm, agent, crewaitask]` (omits `tool`) so the cell passes.
+- **Re-tighten when**: Traceloop ships a release that wraps CrewAI tool
+  execution as separate spans (or as tool-call events the classifier counts),
+  OR OpenInference is added as a second instrumentation provider and its CrewAI
+  cell asserts the `tool` kind.
 
 ## F-004 — `crewai 1.14.x` × `traceloop-sdk 0.60` is unresolvable
 
@@ -128,7 +120,7 @@ reused, so removed numbers just leave a gap.)
   whose OTel deps are still compatible with traceloop 0.60.
 - **Re-tighten when**: Traceloop ships a 0.61+ release with looser
   `opentelemetry-api` requirements; or CrewAI relaxes its `opentelemetry-api`
-  pin. At that point we can bump the matrix pin and re-record.
+  pin. At that point the matrix pin can be bumped and the cassette re-recorded.
 - **2026-06-02 (traceloop 0.61.0)**: still unresolvable — `traceloop-sdk
   0.61.0` requires `opentelemetry-api>=1.38,<2`, `crewai 1.14.5` requires
   `>=1.34,<1.35`. The 0.61 release did **not** loosen the pin; crewai stays at
@@ -162,8 +154,8 @@ reused, so removed numbers just leave a gap.)
   (current). Old SDK pins predate that breaking change.
 - **Mitigation**: matrix pins `openai 2.38.0` and `anthropic 0.45.0` — both
   support httpx 0.28+. The original `1.55.0` / `0.40.0` numbers in the plan
-  were speculative pins I made up, not validated against current httpx; the
-  matrix has now done its job by catching that.
+  were speculative, not validated against current httpx; the matrix caught
+  that.
 - **Re-tighten when**: not applicable — these are forward pins to currently-
   compatible versions; if either SDK regresses or Traceloop pins httpx tight
   enough to require an older SDK, the matrix will surface it.

--- a/test/instrumentation-matrix/RUNBOOK.md
+++ b/test/instrumentation-matrix/RUNBOOK.md
@@ -61,21 +61,21 @@ call — copy `cells/langchain_sample.py`) and record its cassette:
 OPENAI_API_KEY=sk-... python scripts/record_cassette.py haystack llm
 ```
 
-**Example — add a Traceloop version (`0.61.0`):**
+**Example — add a Traceloop version (`0.62.0`):**
 
 ```yaml
 # matrix.yaml → providers.traceloop:
-    versions: ["0.60.0", "0.61.0"]          # add the new one
+    versions: ["0.61.0", "0.62.0"]          # add the new one
     instrumentationVersions:
-      "0.60.0": "0.2.1"
-      "0.61.0": "0.3.0"                      # ← the init-container instr version
+      "0.61.0": "0.3.0"
+      "0.62.0": "0.4.0"                      # ← the init-container instr version
 ```
 
 After any edit, sanity-check locally:
 
 ```bash
 cd test/instrumentation-matrix
-nox -s emission -- --cell-id=traceloop-0.61.0-langchain-0.3.27-py3.11   # one cell
+nox -s emission -- --cell-id=traceloop-0.62.0-langchain-0.3.27-py3.11   # one cell
 nox -s emission -k haystack                                             # by framework
 ```
 
@@ -129,10 +129,10 @@ The `category` tells you whose problem it likely is (design §12.1):
 **Example — a red row + its diff.** The summary shows:
 
 ```text
-| ❌ traceloop-0.60.0-crewai-1.1.0-py3.11 | fail | missing-span-kind: missing ['tool'] |
+| ❌ traceloop-0.61.0-crewai-1.1.0-py3.11 | fail | missing-span-kind: missing ['tool'] |
 ```
 
-and `reports/diffs/traceloop-0.60.0-crewai-1.1.0-py3.11.diff.md` shows which
+and `reports/diffs/traceloop-0.61.0-crewai-1.1.0-py3.11.diff.md` shows which
 required keys were present vs missing:
 
 ```

--- a/test/instrumentation-matrix/RUNBOOK.md
+++ b/test/instrumentation-matrix/RUNBOOK.md
@@ -129,10 +129,10 @@ The `category` tells you whose problem it likely is (design §12.1):
 **Example — a red row + its diff.** The summary shows:
 
 ```text
-| ❌ traceloop-0.61.0-crewai-1.1.0-py3.11 | fail | missing-span-kind: missing ['tool'] |
+| ❌ traceloop-0.61.0-langgraph-0.2.74-py3.11 | fail | missing-span-kind: missing ['tool'] |
 ```
 
-and `reports/diffs/traceloop-0.61.0-crewai-1.1.0-py3.11.diff.md` shows which
+and `reports/diffs/traceloop-0.61.0-langgraph-0.2.74-py3.11.diff.md` shows which
 required keys were present vs missing:
 
 ```

--- a/test/instrumentation-matrix/harness/classify.py
+++ b/test/instrumentation-matrix/harness/classify.py
@@ -78,3 +78,20 @@ def classify_span(span: dict[str, Any]) -> str:
         return "chain"
 
     return "unknown"
+
+
+# OTel GenAI semconv lets a tool call ride on the assistant LLM span as an
+# event (`gen_ai.tool.call`, or a choice event carrying gen_ai.tool.*) rather
+# than as a separate child span. F-009: the harness now captures `events`, so
+# the matrix can count that as tool-kind coverage instead of reporting a
+# missing tool span.
+_TOOL_EVENT_NAMES = {"gen_ai.tool.call", "gen_ai.execute_tool"}
+
+
+def span_has_tool_event(span: dict[str, Any]) -> bool:
+    for event in span.get("events", []) or []:
+        if event.get("name") in _TOOL_EVENT_NAMES:
+            return True
+        if any(k.startswith("gen_ai.tool.") for k in (event.get("attributes") or {})):
+            return True
+    return False

--- a/test/instrumentation-matrix/harness/test_cell.py
+++ b/test/instrumentation-matrix/harness/test_cell.py
@@ -189,6 +189,14 @@ def _to_dict(s) -> dict:
         "name": s.name,
         "kind": s.kind.name if hasattr(s.kind, "name") else str(s.kind),
         "attributes": dict(s.attributes or {}),
+        "events": [
+            {
+                "name": e.name,
+                "attributes": dict(e.attributes or {}),
+                "timestamp": e.timestamp,
+            }
+            for e in (s.events or [])
+        ],
         "traceId": format(ctx.trace_id, "032x"),
         "spanId": format(ctx.span_id, "016x"),
         "parentSpanId": format(s.parent.span_id, "016x") if s.parent else None,

--- a/test/instrumentation-matrix/harness/validator.py
+++ b/test/instrumentation-matrix/harness/validator.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
-from harness.classify import classify_span
+from harness.classify import classify_span, span_has_tool_event
 
 _HERE = Path(__file__).resolve().parent.parent
 _CONTRACTS = _HERE / "contracts"
@@ -93,6 +93,10 @@ class ContractValidator:
         self, spans: list[dict[str, Any]], expected_kinds: list[str]
     ) -> CoverageResult:
         actual = {classify_span(s) for s in spans}
+        # F-009: a tool call may be an event on an LLM span rather than its own
+        # span. Count that as tool-kind coverage.
+        if any(span_has_tool_event(s) for s in spans):
+            actual.add("tool")
         missing = set(expected_kinds) - actual
         return CoverageResult(
             ok=not missing, expected=expected_kinds, actual=actual, missing=missing

--- a/test/instrumentation-matrix/matrix.yaml
+++ b/test/instrumentation-matrix/matrix.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 
 providers:
   traceloop:
-    versions: ["0.60.0"]
+    versions: ["0.60.0", "0.61.0"]
     # Maps traceloop_version → init-container instrumentation_version. The
     # heavy tier resolves the image tag
     # `amp-python-instrumentation-provider:<instr>-python<X.Y>` from this map.
@@ -12,6 +12,7 @@ providers:
     # release-config.json currently lists.
     instrumentationVersions:
       "0.60.0": "0.2.1"
+      "0.61.0": "0.3.0"
     contractSchema: "v1"
 
   manual:

--- a/test/instrumentation-matrix/matrix.yaml
+++ b/test/instrumentation-matrix/matrix.yaml
@@ -112,7 +112,7 @@ python:
 
 defaultCell:
   provider: traceloop
-  providerVersion: "0.60.0"
+  providerVersion: "0.61.0"
   framework: langchain
   frameworkVersion: "0.3.27"
   python: "3.11"

--- a/test/instrumentation-matrix/matrix.yaml
+++ b/test/instrumentation-matrix/matrix.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 
 providers:
   traceloop:
-    versions: ["0.60.0", "0.61.0"]
+    versions: ["0.61.0"]
     # Maps traceloop_version → init-container instrumentation_version. The
     # heavy tier resolves the image tag
     # `amp-python-instrumentation-provider:<instr>-python<X.Y>` from this map.
@@ -11,7 +11,6 @@ providers:
     # `make check-matrix-manifest` to enforce that this map covers everything
     # release-config.json currently lists.
     instrumentationVersions:
-      "0.60.0": "0.2.1"
       "0.61.0": "0.3.0"
     contractSchema: "v1"
 
@@ -41,10 +40,12 @@ frameworks:
     package: langgraph
     versions: ["0.2.74"]
     samplePath: cells/langgraph_sample.py
-    # Tool execution is NOT emitted as a separate span by Traceloop 0.60's
-    # LangGraph instrumentation — see FINDINGS.md F-008. May also be missing
-    # because my harness doesn't capture span events (F-009).
-    spanKinds: [llm]
+    # Traceloop 0.61's LangGraph instrumentation emits tool execution as a
+    # separate `execute_tool` span (traceloop.span.kind=tool), so the cell
+    # asserts the tool kind. (This was previously gated under F-008 as
+    # "no tool span"; the 2026-06-02 revalidation with span-event capture
+    # confirmed a real tool span on both 0.60 and 0.61.)
+    spanKinds: [llm, tool]
     extras: [langchain-openai, langchain-core, openai]
 
   - name: llama-index
@@ -61,15 +62,15 @@ frameworks:
     # crewai 1.1.0 is the version that both:
     #   (a) Traceloop's CrewAI instrumentation accepts (>= 1.0), and
     #   (b) does not pin opentelemetry-api in a range incompatible with
-    #       traceloop-sdk 0.60.0.
+    #       traceloop-sdk 0.61.0.
     # crewai 1.14.x tightens opentelemetry-api to ~=1.34 which collides with
-    # traceloop-sdk's >=1.38 requirement; the matrix surfaced this during
-    # the first attempt at the CrewAI cell.
+    # traceloop-sdk's >=1.38 requirement (still true on 0.61.0; see F-004);
+    # the matrix surfaced this during the first attempt at the CrewAI cell.
     versions: ["1.1.0"]
     samplePath: cells/crewai_sample.py
-    # Traceloop 0.60's CrewAI instrumentation folds tool calls into events on
-    # the agent span rather than emitting a separate tool span, so the matrix
-    # only expects llm/agent/crewaitask kinds for CrewAI cells.
+    # Traceloop 0.61's CrewAI instrumentation emits no separate tool span (and
+    # no span events at all — confirmed 2026-06-02, F-003), so the matrix only
+    # expects llm/agent/crewaitask kinds for CrewAI cells.
     spanKinds: [llm, agent, crewaitask]
     extras: [crewai-tools==1.1.0, openai]
 

--- a/test/instrumentation-matrix/noxfile.py
+++ b/test/instrumentation-matrix/noxfile.py
@@ -55,6 +55,12 @@ def emission(session, cell):
         "pytest",
         "pytest-recording",
         "vcrpy",
+        # vcrpy 8.1.1's aiohttp stub subclasses
+        # aiohttp.streams.AsyncStreamReaderMixin, which aiohttp 3.14.0 removed —
+        # so an unpinned resolve breaks every cell at vcr import time (F-011).
+        # aiohttp is only a transitive dep here (LLM calls go over httpx), so
+        # capping it is safe. Drop the cap when vcrpy ships aiohttp-3.14 support.
+        "aiohttp<3.14",
         "jsonschema",
         "pyyaml",
     ]

--- a/test/instrumentation-matrix/providers/traceloop.py
+++ b/test/instrumentation-matrix/providers/traceloop.py
@@ -13,7 +13,7 @@ class TraceloopProvider:
             f"traceloop-sdk=={version}",
             # Mirrors python-instrumentation-provider/requirements.txt: wrapt 2.x
             # removed the `module=` kwarg that opentelemetry-instrumentation-*
-            # 0.60.0 still calls.
+            # 0.61.0 still calls.
             "wrapt<2.0.0",
             "opentelemetry-sdk",
             "opentelemetry-api",

--- a/test/instrumentation-matrix/tests/test_classify.py
+++ b/test/instrumentation-matrix/tests/test_classify.py
@@ -1,4 +1,4 @@
-from harness.classify import classify_span
+from harness.classify import classify_span, span_has_tool_event
 
 
 def _span(name, attrs, kind="CLIENT"):
@@ -102,3 +102,35 @@ def test_embedding_inside_task_wrapper_still_classified_as_embedding():
 def test_unknown_when_no_signals():
     s = _span("anonymous", {})
     assert classify_span(s) == "unknown"
+
+
+def test_tool_event_via_gen_ai_tool_call_event_name():
+    s = {
+        "name": "ChatOpenAI.chat",
+        "attributes": {"gen_ai.operation.name": "chat"},
+        "events": [{"name": "gen_ai.tool.call", "attributes": {"gen_ai.tool.name": "search"}}],
+    }
+    assert span_has_tool_event(s) is True
+
+
+def test_tool_event_via_gen_ai_tool_attribute_on_event():
+    s = {
+        "name": "ChatOpenAI.chat",
+        "attributes": {"gen_ai.operation.name": "chat"},
+        "events": [{"name": "choice", "attributes": {"gen_ai.tool.name": "search"}}],
+    }
+    assert span_has_tool_event(s) is True
+
+
+def test_no_tool_event_when_events_absent():
+    s = {"name": "ChatOpenAI.chat", "attributes": {"gen_ai.operation.name": "chat"}}
+    assert span_has_tool_event(s) is False
+
+
+def test_no_tool_event_for_plain_message_event():
+    s = {
+        "name": "ChatOpenAI.chat",
+        "attributes": {},
+        "events": [{"name": "gen_ai.user.message", "attributes": {"content": "hi"}}],
+    }
+    assert span_has_tool_event(s) is False

--- a/test/instrumentation-matrix/tests/test_validator.py
+++ b/test/instrumentation-matrix/tests/test_validator.py
@@ -252,3 +252,19 @@ def test_validator_rejects_resource_missing_service_name():
 def test_validator_passes_resource_with_service_name():
     v = ContractValidator.load("traceloop/v1")
     assert v.validate_resource({"service.name": "my-agent"}).ok
+
+
+# ---------- Coverage via span events (F-009) ----------
+
+
+def test_assert_coverage_counts_tool_event_as_tool_kind():
+    v = ContractValidator.load("traceloop/v1")
+    llm_span_with_tool_event = {
+        "name": "ChatOpenAI.chat",
+        "kind": "CLIENT",
+        "attributes": {"gen_ai.operation.name": "chat", "gen_ai.provider.name": "openai"},
+        "events": [{"name": "gen_ai.tool.call", "attributes": {"gen_ai.tool.name": "search"}}],
+    }
+    cov = v.assert_coverage([llm_span_with_tool_event], expected_kinds=["llm", "tool"])
+    assert cov.ok is True
+    assert "tool" in cov.actual


### PR DESCRIPTION
## Summary

Onboards `traceloop-sdk` 0.61.0 and cuts AMP instrumentation version **0.3.0**
as the sole shipped and platform-default version, retiring 0.2.1 / 0.60.0
(clean replace — nothing pins 0.2.1). Validated against the
instrumentation-matrix emission tier first; every open `FINDINGS.md` entry was
re-checked against 0.61.0.

Closes #984

## Validation result

- **All six 0.61.0 emission cells pass** (langchain, langgraph, llama-index,
  crewai, openai-direct, anthropic-direct) on py3.11 — no regressions vs 0.60.0.
- **0.61.0 changes none of the tracked findings**: F-001 (crewai attrs still
  stringified), F-006 (llama-index embedding still no vendor), and F-004
  (crewai 1.14.x still unresolvable — `opentelemetry-api>=1.38` vs `~=1.34`)
  all persist. So this is a mechanical bump with no schema tightening available.
- **F-009 fixed** — the matrix harness now captures span events. The
  revalidation showed traceloop emits *zero* span events on both versions, so
  F-003 (crewai has no tool span) is now a **confirmed** real upstream gap.
- **F-008 resolved** — with event capture on, the langgraph cell was shown to
  emit a real `execute_tool` span on both versions; the cell now asserts `tool`
  and the finding is removed.
- **F-011 (new, fixed)** — aiohttp 3.14.0's release broke `vcrpy 8.1.1` for the
  entire emission tier (independent of traceloop); capped `aiohttp<3.14` in the
  matrix test infra.

## Changes

- **Version cut**: `libs/amp-instrumentation/pyproject.toml` → `traceloop-sdk==0.61.0`;
  `.github/release-config.json` replaced with `0.3.0 / 0.61.0`; regenerated
  `agent-manager-service/instrumentation/baseline.json`.
- **Default promotion (lockstep)**: chart `defaultInstrumentationVersion`,
  `config_loader.go` fallback, and matrix `defaultCell` → 0.3.0 / 0.61.0;
  catalog test fixtures updated. `TestHelmDefaultInstrumentationVersionConsistent`
  keeps the chart value and embedded baseline aligned.
- **Matrix**: dropped 0.60.0 (now equals release-config), asserted langgraph
  `tool` kind, fixed the harness (events capture + tool-event coverage), capped
  aiohttp.
- **Docs**: refreshed the bundled-baseline table, default-version doc,
  Dockerfile/requirements/provider references; bumped the now-shipped example
  versions in RUNBOOK/RELEASING to future hypotheticals; rewrote `FINDINGS.md`
  in third person.

## Test plan

- [x] Six 0.61.0 emission cells green (`uvx nox -s emission`, py3.11)
- [x] `check-matrix-manifest` (matrix == release-config, 0.61.0 only)
- [x] `check-contract-drift` (contract up-to-date)
- [x] `gen-instrumentation-baseline` idempotent (no drift)
- [x] `go test ./instrumentation/...` incl. Helm-consistency test
- [x] gofumpt-clean Go change
- [x] CI: full matrix fan-out across py3.10–3.13

## Post-merge (maintainer, publishes externally)

1. Dispatch **AMP Instrumentation Release** (`amp_instrumentation_release.yaml`):
   `branch=main, target_version=0.3.0` → publishes `amp-instrumentation==0.3.0`
   to PyPI + tags `amp-instrumentation/v0.3.0`.
2. Dispatch **AMP Python Instrumentation Image Release**
   (`python_instrumentation_image_release.yaml`):
   `branch=main, instrumentation_version=0.3.0` → builds/pushes the
   `(0.3.0 × python3.10–3.13)` init-container images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect tool events in spans and include span events in serialized output for improved classification and coverage.

* **Bug Fixes**
  * Pin aiohttp to avoid a compatibility break impacting instrumentation tests.

* **Chores**
  * Bumped default instrumentation to 0.3.0 and traceloop SDK to 0.61.0.
  * Updated defaults, docs, release notes, and test matrix to reflect new versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->