### PR TITLE
Update lingering 0.60.0/0.2.1 references to 0.61.0/0.3.0

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -2289,7 +2289,7 @@ func (c *openChoreoClient) buildEnvInjectionTraitParameters(opts ...TraitOption)
 
 // getInstrumentationImage builds the pre-built init-container image reference for
 // the given AMP instrumentation version and the agent's Python runtime version,
-// e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.2.1-python3.11.
+// e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python3.11.
 func getInstrumentationImage(languageVersion, instrumentationVersion string) (string, error) {
 	parts := strings.Split(languageVersion, ".")
 	if len(parts) < 2 {

--- a/agent-manager-service/mcp/tools/agents.go
+++ b/agent-manager-service/mcp/tools/agents.go
@@ -204,7 +204,7 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
 			"openapi_path":   stringProperty("Required when interface_type is CUSTOM. OpenAPI specification file path within the repository (must start with /)."),
 
 			"enable_auto_instrumentation": boolProperty("Automatically enables OTEL tracing instrumentation to your agent for observability."),
-			"instrumentation_version":     stringProperty("Optional. AMP instrumentation version to pin for the agent (e.g., '0.2.1'). Selects the matching pre-built init-container image and the bundled traceloop-sdk version. Omit to use the platform default; only versions supported by the deployment are accepted."),
+			"instrumentation_version":     stringProperty("Optional. AMP instrumentation version to pin for the agent (e.g., '0.3.0'). Selects the matching pre-built init-container image and the bundled traceloop-sdk version. Omit to use the platform default; only versions supported by the deployment are accepted."),
 			"env": arrayProperty("Required. Environment variables and other configurations for the agent.(eg: api keys, database URLs, support service URLs). Can be obtained from the .env file in the project repository", map[string]any{
 				"type": "object",
 				"properties": map[string]any{

--- a/documentation/versioned_docs/version-cloud/components/amp-instrumentation.mdx
+++ b/documentation/versioned_docs/version-cloud/components/amp-instrumentation.mdx
@@ -173,6 +173,6 @@ When AMP raises the platform default, existing agents stay on the version they w
 
 | AMP instrumentation version | Traceloop SDK (`traceloop-sdk`) | Supported Python versions | Init-container image tag |
 |---|---|---|---|
-| 0.2.1 | 0.60.0 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.2.1-python<X.Y>` |
+| 0.3.0 | 0.61.0 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python<X.Y>` |
 
 The canonical source for this matrix is [`.github/release-config.json`](https://github.com/wso2/agent-manager/blob/main/.github/release-config.json) under the `python-instrumentation-provider` key. Maintainers cutting a new version: see [`python-instrumentation-provider/RELEASING.md`](https://github.com/wso2/agent-manager/blob/main/python-instrumentation-provider/RELEASING.md) for the release runbook.

--- a/test/instrumentation-matrix/DESIGN.md
+++ b/test/instrumentation-matrix/DESIGN.md
@@ -231,7 +231,7 @@ python:
 
 defaultCell:
   provider: traceloop
-  providerVersion: "0.60.0"                # mirrors OTEL_DEFAULT_INSTRUMENTATION_VERSION's traceloop pin
+  providerVersion: "0.61.0"                # mirrors OTEL_DEFAULT_INSTRUMENTATION_VERSION's traceloop pin
   framework: langchain
   frameworkVersion: "0.3.27"
   python: "3.11"

--- a/test/instrumentation-matrix/FINDINGS.md
+++ b/test/instrumentation-matrix/FINDINGS.md
@@ -34,7 +34,7 @@ reused, so removed numbers just leave a gap.)
 ## F-001 — Traceloop stringifies every `crewai.*` attribute
 
 - **Status**: mitigated
-- **Combo**: `traceloop-sdk 0.60.0` × `crewai 1.1.0`
+- **Combo**: `traceloop-sdk 0.61.0` × `crewai 1.1.0`
 - **Discovered**: 2026-05-27 (CrewAI cell first record + replay)
 - **Symptom**: every attribute under the `crewai.*` namespace arrives on the
   captured span as a Python `str`, even values that are logically `int` /
@@ -81,7 +81,7 @@ reused, so removed numbers just leave a gap.)
 ## F-003 — Traceloop's CrewAI does not emit separate tool spans
 
 - **Status**: open / confirmed (see the 2026-06-02 note; F-009 resolved)
-- **Combo**: `traceloop-sdk 0.60.0` × `crewai 1.1.0`
+- **Combo**: `traceloop-sdk 0.61.0` × `crewai 1.1.0`
 - **Discovered**: 2026-05-27
 - **Symptom**: CrewAI cell with a tool-using agent never produces a span
   classified as `tool`. Tool execution appears at least as
@@ -106,12 +106,12 @@ reused, so removed numbers just leave a gap.)
   OR OpenInference is added as a second instrumentation provider and its CrewAI
   cell asserts the `tool` kind.
 
-## F-004 — `crewai 1.14.x` × `traceloop-sdk 0.60` is unresolvable
+## F-004 — `crewai 1.14.x` × `traceloop-sdk 0.61` is unresolvable
 
 - **Status**: mitigated
-- **Combo**: `traceloop-sdk 0.60.0` × `crewai 1.14.5`
+- **Combo**: `traceloop-sdk 0.61.0` × `crewai 1.14.5`
 - **Discovered**: 2026-05-27
-- **Symptom**: `pip install` returns `ResolutionImpossible`. `traceloop-sdk 0.60.0`
+- **Symptom**: `pip install` returns `ResolutionImpossible`. `traceloop-sdk 0.61.0`
   requires `opentelemetry-api >=1.38, <2`; `crewai 1.14.5` requires
   `opentelemetry-api ~=1.34`.
 - **Suspected cause**: crewai 1.x tightened its OTel pin between 1.1 and 1.14,
@@ -129,7 +129,7 @@ reused, so removed numbers just leave a gap.)
 ## F-006 — Traceloop's LlamaIndex `OpenAIEmbedding` instrumentation omits vendor
 
 - **Status**: mitigated
-- **Combo**: `traceloop-sdk 0.60.0` × `llama-index 0.12.0`
+- **Combo**: `traceloop-sdk 0.61.0` × `llama-index 0.12.0`
 - **Discovered**: 2026-05-26
 - **Symptom**: embedding-kind spans from LlamaIndex have
   `gen_ai.operation.name=embeddings` and `gen_ai.request.model=text-embedding-3-small`

--- a/test/instrumentation-matrix/README.md
+++ b/test/instrumentation-matrix/README.md
@@ -32,7 +32,7 @@ across 3.10–3.13.)
 
 ```bash
 # one cell (cassette replay — no real API key needed)
-nox -s emission -- --cell-id=traceloop-0.60.0-langchain-0.3.27-py3.11
+nox -s emission -- --cell-id=traceloop-0.61.0-langchain-0.3.27-py3.11
 
 # all cells for one framework
 nox -s emission -k langchain


### PR DESCRIPTION
## Summary

Follow-up to #987. Sweeps the remaining active references to the retired
`0.60.0` / `0.2.1` versions that #987 didn't touch, pointing them at the
current `0.61.0` / `0.3.0` baseline. Documentation and metadata only — no
behavioural change.

## Changes

- **`FINDINGS.md`** — the `Combo:` fields for F-001/F-003/F-004/F-006 and the
  F-004 title now say `traceloop-sdk 0.61.0`. These are *active* findings, and
  the 0.61.0 revalidation in #987 reconfirmed each gap on the (now 0.61.0-only)
  matrix. The single historical "on both 0.60.0 and 0.61.0" note is kept.
- **`README.md`** — quickstart `--cell-id` uses `traceloop-0.61.0-...` (the
  0.60.0 cell no longer exists after the retire).
- **`DESIGN.md`** — the `defaultCell.providerVersion` mirror line → `0.61.0`.
- **`mcp/tools/agents.go`** — the `instrumentation_version` tool-schema example
  → `'0.3.0'`.
- **`components.go`** — the instrumentation-image helper comment example →
  `0.3.0-python3.11`.

## Deliberately left unchanged

- `documentation/versioned_docs/*` — frozen Docusaurus snapshots documenting
  what those releases shipped.
- Matrix `tests/*.py` + `fixtures/manifest_minimal.yaml` — self-contained
  sample data; the full suite stays green.
- Synthetic Go `*_test.go` catalogs (`NewForTest(..., "0.2.1")`) — arbitrary
  fixture labels.
- `process.go`/`process_test.go` comments — record the version where a parser
  quirk was first observed.

## Test plan

- [x] `go build ./mcp/... ./clients/openchoreosvc/...`, gofumpt-clean
- [x] Matrix python suite green (103 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation examples, configuration references, and test matrices to reflect the latest instrumentation and SDK versions.
  * Refreshed quickstart guides and test findings documentation to align with current release versions.
  * Synchronized version references across all documentation and test scenarios to ensure consistency with current SDK baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->