### PR TITLE
Write CoreDNS host aliases before k3d restart

### DIFF
--- a/deployments/scripts/setup-k3d.sh
+++ b/deployments/scripts/setup-k3d.sh
@@ -58,6 +58,15 @@ if ! kubectl get configmap coredns-custom -n kube-system --context "${CLUSTER_CO
     exit 1
 fi
 
+# Add host.k3d.internal / host.docker.internal to the coredns NodeHosts file.
+# This must run BEFORE the rollout restart below: the coredns Deployment mounts
+# NodeHosts as a non-optional configmap key, and on a freshly (re)started k3s
+# server that key may not exist yet, leaving the restarted pod stuck in
+# ContainerCreating until the rollout times out.
+if ! ensure_coredns_host_aliases; then
+    exit 1
+fi
+
 # CoreDNS's reload plugin can miss the override files if the configmap is mounted
 # after the pod's initial parse. Restart CoreDNS so the rewrite rules take effect
 # before any client (e.g. observer) caches a wrong resolution.

--- a/deployments/scripts/utils.sh
+++ b/deployments/scripts/utils.sh
@@ -153,6 +153,62 @@ generate_machine_ids() {
     echo "✅ Machine ID generation complete"
 }
 
+# Util: Make host.k3d.internal / host.docker.internal resolve inside pods
+#
+# k3d injects these aliases only into the nodes' /etc/hosts, not into pod DNS,
+# so in-cluster clients (gateway controller, observability, helm bootstrap
+# Jobs) cannot reach the host through them. We add both to the CoreDNS
+# NodeHosts file, which the k3s node controller preserves across restarts.
+#
+# This also closes a setup race: NodeHosts is NOT shipped in the coredns Addon
+# manifest — k3s populates it asynchronously after a server (re)start. The
+# coredns Deployment mounts NodeHosts as a *non-optional* configmap key, so
+# until k3s writes it a freshly restarted CoreDNS pod cannot mount and the
+# rollout times out. Writing the key here guarantees it exists before the
+# subsequent `kubectl rollout restart deployment/coredns`.
+ensure_coredns_host_aliases() {
+    echo "🔧 Ensuring host.k3d.internal / host.docker.internal resolve in-cluster..."
+
+    local host_ip
+    host_ip=$(docker network inspect "k3d-${CLUSTER_NAME}" \
+        --format '{{ (index .IPAM.Config 0).Gateway }}' 2>/dev/null)
+    if [[ -z "$host_ip" ]]; then
+        echo "❌ Could not determine k3d host gateway IP for network k3d-${CLUSTER_NAME}"
+        return 1
+    fi
+
+    # Node entries already written by k3s's node controller. Empty during the
+    # post-restart race window — that is fine: k3s re-adds them later and keeps
+    # the alias lines we append.
+    local existing
+    existing=$(kubectl get configmap coredns -n kube-system \
+        --context "${CLUSTER_CONTEXT}" -o jsonpath='{.data.NodeHosts}' 2>/dev/null)
+
+    # Drop any alias lines from a previous run so re-runs stay idempotent.
+    local node_lines
+    node_lines=$(printf '%s\n' "$existing" \
+        | grep -vE '[[:space:]](host\.k3d\.internal|host\.docker\.internal)$' \
+        | sed '/^[[:space:]]*$/d' || true)
+
+    local desired
+    desired=$(printf '%s\n%s host.k3d.internal\n%s host.docker.internal\n' \
+        "$node_lines" "$host_ip" "$host_ip" \
+        | sed '/^[[:space:]]*$/d')
+
+    # Escape each line into a literal \n for the JSON merge patch (awk keeps
+    # this portable across BSD/macOS and GNU sed). out ends with a trailing \n
+    # to match the file format coredns writes.
+    local patch_value
+    patch_value=$(printf '%s\n' "$desired" | awk '{ out = out $0 "\\n" } END { printf "%s", out }')
+
+    if ! kubectl patch configmap coredns -n kube-system --context "${CLUSTER_CONTEXT}" \
+        --type merge -p "{\"data\":{\"NodeHosts\":\"${patch_value}\"}}"; then
+        echo "❌ Failed to patch CoreDNS NodeHosts"
+        return 1
+    fi
+    echo "✅ CoreDNS NodeHosts updated (host.k3d.internal, host.docker.internal -> ${host_ip})"
+}
+
 # Util: Refresh kubeconfig for k3d cluster
 refresh_kubeconfig() {
     echo "🔄 Refreshing kubeconfig..."


### PR DESCRIPTION
## What

Fixes an intermittent `make setup` failure where `setup-k3d.sh` times out
restarting CoreDNS:

```
deployment.apps/coredns restarted
Waiting for deployment "coredns" rollout to finish: 0 of 1 updated replicas are available...
error: timed out waiting for the condition
❌ CoreDNS deployment failed to become ready
```

## Why

On a freshly (re)started k3s server the `kube-system/coredns` ConfigMap can
lack the `NodeHosts` key. k3s ships only `Corefile` in the coredns Addon
manifest and populates `NodeHosts` asynchronously via its node controller. The
coredns Deployment mounts `NodeHosts` as a **non-optional** configmap item, so
the restarted pod is stuck in `ContainerCreating` (`configmap references
non-existent config key: NodeHosts`) until k3s writes the key. When that takes
longer than the script's 60s wait, `rollout status` fails and `make setup`
aborts. It self-heals once k3s writes the key, which is why it's intermittent —
it mainly bites when setup runs against a recently restarted cluster.

## Changes

- Add `ensure_coredns_host_aliases` to `utils.sh`. It derives the host gateway
  IP from the k3d docker network (no hardcoded `172.18.0.1`) and writes
  `host.k3d.internal` / `host.docker.internal` into the coredns `NodeHosts`
  file, guaranteeing the key exists.
- Call it from `setup-k3d.sh` **before** the coredns rollout restart, so the
  restarted pod can mount on the first try.
- This also bakes in the durable in-cluster host-alias resolution previously
  applied by hand (`LOCAL_DEV_GUIDE` §13), so it now survives
  `make teardown && make setup`.

The helper is idempotent (strips prior alias lines on re-run) and uses `awk`
rather than the GNU-only `sed` idiom to escape newlines, keeping it portable
across macOS and Linux CI.

## Test plan

- [x] `bash -n` and `shellcheck` clean on both scripts
- [x] `make setup` (with Docker up) passes the CoreDNS step
- [x] `kubectl get configmap coredns -n kube-system -o jsonpath='{.data.NodeHosts}'` shows `host.k3d.internal` and `host.docker.internal` entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed CoreDNS pod restart issues in k3d local development deployments by improving host alias configuration
* Enhanced in-cluster DNS resolution for local development network hosts
* Improved setup validation to ensure CoreDNS configuration is correctly applied before pod restart

<!-- end of auto-generated comment: release notes by coderabbit.ai -->