### PR TITLE
Default amctl login to production URL

### DIFF
--- a/cli/pkg/cmd/login.go
+++ b/cli/pkg/cmd/login.go
@@ -32,10 +32,16 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
-// orgPeekLimit is the page size used when probing organizations after login.
-// Two is enough to distinguish "exactly one" from "more than one" without
-// fetching the full list.
-const orgPeekLimit = 2
+const (
+	// defaultAgentPlatformURL is the SaaS Agent Platform URL used when login does
+	// not receive an explicit URL.
+	defaultAgentPlatformURL = "https://production-wso2cloud.gateway.cloud.wso2.com/agent-manager-service-agent-manager-api"
+
+	// orgPeekLimit is the page size used when probing organizations after login.
+	// Two is enough to distinguish "exactly one" from "more than one" without
+	// fetching the full list.
+	orgPeekLimit = 2
+)
 
 type loginData struct {
 	URL           string                       `json:"url"`
@@ -74,7 +80,7 @@ func NewLoginCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.URL, "url", "", "Agent Manager instance URL")
+	cmd.Flags().StringVar(&opts.URL, "url", defaultAgentPlatformURL, "Agent Platform or Agent Manager instance URL")
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Agent Manager instance name")
 	cmd.Flags().StringVar(&opts.ClientID, "client-id", "", "OAuth client ID (default \"amctl\" for interactive login)")
 	cmd.Flags().StringVar(&opts.ClientSecret, "client-secret", "", "OAuth client secret; when set, uses client_credentials grant instead of browser login")
@@ -85,7 +91,7 @@ func NewLoginCmd(f *cmdutil.Factory) *cobra.Command {
 
 func runLogin(ctx context.Context, opts *LoginOptions) error {
 	if opts.URL == "" {
-		return render.Error(opts.IO, render.Scope{}, cmdutil.FlagErrorf("--url is required"))
+		opts.URL = defaultAgentPlatformURL
 	}
 	if opts.ClientSecret != "" && opts.ClientID == "" {
 		return render.Error(opts.IO, render.Scope{}, cmdutil.FlagErrorf("--client-id is required when --client-secret is set"))

--- a/cli/pkg/cmd/login_test.go
+++ b/cli/pkg/cmd/login_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+)
+
+func TestNewLoginCmdURL(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "defaults to Agent Platform",
+			want: "https://production-wso2cloud.gateway.cloud.wso2.com/agent-manager-service-agent-manager-api",
+		},
+		{
+			name: "uses explicit override",
+			args: []string{"--url", "http://localhost:9000"},
+			want: "http://localhost:9000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewLoginCmd(&cmdutil.Factory{})
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("ParseFlags() error = %v", err)
+			}
+			got, err := cmd.Flags().GetString("url")
+			if err != nil {
+				t.Fatalf("GetString(%q) error = %v", "url", err)
+			}
+			if got != tt.want {
+				t.Errorf("url = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/documentation/docs/getting-started/cli-installation.mdx
+++ b/documentation/docs/getting-started/cli-installation.mdx
@@ -6,10 +6,10 @@ sidebar_position: 3
 
 `amctl` is the command-line interface for Agent Manager. Use it to manage organizations, projects, agents, runtime observability, and AI assistant skills from your terminal.
 
-This guide installs `amctl`, logs into a running Agent Manager instance, and verifies the setup.
+This guide installs `amctl`, logs into Agent Platform or an Agent Manager instance, and verifies the setup.
 
 :::info Prerequisites
-You need a reachable Agent Manager instance before logging in. Follow the [Quick Start](./quick-start.mdx) or [On k3d](./on-k3d.mdx) guide first if you have not installed one. The local install exposes the Agent Manager API at `http://localhost:9000`.
+By default, `amctl login` connects to Agent Platform, the SaaS offering. To log in to your own Agent Manager instance, you need its API URL. Follow the [Quick Start](./quick-start.mdx) or [On k3d](./on-k3d.mdx) guide first if you have not installed one. The local install exposes the Agent Manager API at `http://localhost:9000`.
 :::
 
 ## Step 1: Install amctl
@@ -83,13 +83,19 @@ amctl version
 
 ## Step 2: Log in to Agent Manager
 
-Run `amctl login` with the URL of your Agent Manager API. For a local install this is `http://localhost:9000`.
+Run `amctl login` to connect to Agent Platform:
+
+```bash
+amctl login
+```
+
+To connect to an Agent Manager instance, pass `--url`. For example, a local install exposes the Agent Manager API at `http://localhost:9000`:
 
 ```bash
 amctl login --url http://localhost:9000
 ```
 
-`amctl` opens a browser window for sign-in. Enter the default Agent Manager credentials:
+`amctl` opens a browser window for sign-in. On a fresh local install, enter the default Agent Manager credentials:
 
 | Field | Value |
 |-------|-------|
@@ -156,4 +162,4 @@ If `amctl` cannot open a browser (for example over SSH), it prints the login URL
 
 ### Re-authenticating
 
-Re-run `amctl login --url <url>` to refresh credentials. If you switch to a different Agent Manager instance, `amctl` clears any project links that pointed at the old instance and prompts you to re-link.
+Re-run `amctl login` to refresh credentials for Agent Platform. Pass `--url <url>` to log in to an Agent Manager instance. If you switch instances, `amctl` clears any project links that pointed at the old instance and prompts you to re-link.

--- a/documentation/docs/reference/cli/login.mdx
+++ b/documentation/docs/reference/cli/login.mdx
@@ -5,18 +5,11 @@ sidebar_label: Login
 
 # amctl login
 
-Authenticate against an Agent Manager instance.
+Authenticate against Agent Platform or an Agent Manager instance.
 
 ## Synopsis
 
-Log in to an Agent Manager instance. By default, the command opens a browser to complete an OAuth Authorization Code flow against the instance's identity provider. Pass `--client-id` and `--client-secret` to use the OAuth client-credentials grant instead — suitable for CI.
-
-On a fresh local install, sign in with the default credentials:
-
-| Field | Value |
-|-------|-------|
-| Username | `admin` |
-| Password | `admin` |
+Log in with `amctl`. By default, the command connects to Agent Platform, the SaaS offering, and opens a browser to complete an OAuth Authorization Code flow. Pass `--url` to connect to an Agent Manager instance, such as a local open-source install. Pass `--client-id` and `--client-secret` to use the OAuth client-credentials grant instead — suitable for CI.
 
 The resulting session is stored in `~/.amctl/config.yaml`. If only one organization is available, it is auto-selected as the current org. Otherwise, set one with `amctl context org use <name>` or pass `--org` per command.
 
@@ -27,7 +20,10 @@ amctl login [flags]
 ## Examples
 
 ```bash
-# Interactive browser login against a local install
+# Interactive browser login to Agent Platform
+amctl login
+
+# Interactive browser login to a local Agent Manager install
 amctl login --url http://localhost:9000
 
 # Name the instance so it can be switched to later
@@ -44,7 +40,7 @@ amctl login \
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `--url` | string | _required_ | Agent Manager instance URL (for example `http://localhost:9000`). |
+| `--url` | string | Agent Platform URL | Agent Platform or Agent Manager instance URL. Override it to connect to an Agent Manager instance, such as `http://localhost:9000` for a local install. |
 | `--name` | string | `default` | Local name for the instance. Use to distinguish multiple instances. |
 | `--client-id` | string | `amctl` | OAuth client ID. Defaults to `amctl` for the interactive browser flow. |
 | `--client-secret` | string | (none) | OAuth client secret. When set, uses the client-credentials grant instead of the browser flow. |


### PR DESCRIPTION
## Purpose

Make `amctl login` connect to Agent Platform, the SaaS offering, when `--url` is omitted.

## Approach

- Default the Cobra `--url` flag to the Agent Platform endpoint without a trailing slash.
- Apply the same default inside `runLogin` for direct callers.
- Preserve explicit `--url` values as overrides for Agent Manager instances, including `http://localhost:9000` for local open-source installs.
- Update the login reference and CLI installation guide to distinguish the default Agent Platform login from Agent Manager instance login.

## Automation tests

- Added one table-driven test function covering the Agent Platform default and explicit override.
- Ran `cd cli && go test ./...`.
- Ran `make -C documentation build`.
- Ran `git diff --check upstream/main...HEAD`.
