### PR TITLE
Localize heavy-tier span-delivery failures to a pipeline boundary

### DIFF
--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -191,6 +191,27 @@ jobs:
           # validate a new/changed sample before it merges to main.
           AMP_AGENT_REPO_BRANCH: ${{ github.ref_name }}
         run: nox -s heavy
+      - name: Heavy summary
+        if: always()
+        working-directory: test/instrumentation-matrix
+        shell: bash
+        run: |
+          [ -d reports/heavy ] || exit 0
+          {
+            echo "### Heavy-tier results"
+            echo "| cell | result | category | evidence |"
+            echo "| --- | --- | --- | --- |"
+            for f in reports/heavy/*.json; do
+              [ -e "$f" ] || continue
+              python - "$f" <<'PY'
+          import json, sys
+          d = json.load(open(sys.argv[1]))
+          ev = d.get("evidence") or {}
+          summ = ev.get("summary") or (("agent: " + ev["agent"][:80]) if ev.get("agent") else "")
+          print(f"| {d['cellId']} | {d['result']} | {d.get('category') or ''} | {summ.replace('|', '/')} |")
+          PY
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Dump cluster diagnostics on failure
         if: failure()
         shell: bash

--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -205,10 +205,13 @@ jobs:
               [ -e "$f" ] || continue
               python - "$f" <<'PY'
           import json, sys
-          d = json.load(open(sys.argv[1]))
-          ev = d.get("evidence") or {}
-          summ = ev.get("summary") or (("agent: " + ev["agent"][:80]) if ev.get("agent") else "")
-          print(f"| {d['cellId']} | {d['result']} | {d.get('category') or ''} | {summ.replace('|', '/')} |")
+          try:
+              d = json.load(open(sys.argv[1]))
+              ev = d.get("evidence") or {}
+              summ = ev.get("summary") or (("agent: " + ev["agent"][:80]) if ev.get("agent") else "")
+              print(f"| {d['cellId']} | {d['result']} | {d.get('category') or ''} | {summ.replace('|', '/')} |")
+          except Exception as e:  # a malformed report must not blank the whole table
+              print(f"| {sys.argv[1]} | ERROR | | {str(e)[:80].replace('|', '/')} |")
           PY
             done
           } >> "$GITHUB_STEP_SUMMARY"

--- a/test/instrumentation-matrix/harness/categorize.py
+++ b/test/instrumentation-matrix/harness/categorize.py
@@ -35,6 +35,11 @@ class FailureCategory(str, Enum):
     # SCHEMA_VIOLATION, to preserve that distinction in triage.
     PIPELINE_ERROR = "pipeline-error"
     INFRA_ERROR = "infra-error"
+    # Heavy-tier span-delivery boundaries (set by heavy/diagnostics.py's
+    # classify_no_spans when a cell captures 0 spans).
+    INGEST_REJECTED = "ingest-rejected"            # gateway returned 401/403 to the agent's OTLP export
+    EXPORT_FAILED = "export-failed"                # agent never exported (init failed / 5xx / no-status error)
+    COLLECTOR_NOT_RECEIVED = "collector-not-received"  # agent exported OK but the collector saw nothing
     UNKNOWN = "unknown"
 
 

--- a/test/instrumentation-matrix/harness/reports.py
+++ b/test/instrumentation-matrix/harness/reports.py
@@ -19,6 +19,7 @@ class CellResult:
     coverage: dict[str, Any] = field(default_factory=dict)
     violations: list[dict[str, Any]] = field(default_factory=list)
     captured_spans: list[dict[str, Any]] = field(default_factory=list)
+    evidence: dict[str, Any] | None = None
 
 
 def write_cell_report(result: CellResult, reports_dir: Path) -> Path:
@@ -36,6 +37,7 @@ def write_cell_report(result: CellResult, reports_dir: Path) -> Path:
         "coverage": result.coverage,
         "violations": result.violations,
         "capturedSpans": spans_blob,
+        "evidence": result.evidence,
     }
     out = reports_dir / f"{result.cell_id}.json"
     out.write_text(json.dumps(payload, indent=2))

--- a/test/instrumentation-matrix/heavy/diagnostics.py
+++ b/test/instrumentation-matrix/heavy/diagnostics.py
@@ -8,9 +8,15 @@ without a cluster.
 """
 from __future__ import annotations
 
+import re
+import subprocess
 from dataclasses import dataclass, field
 
 from harness.categorize import FailureCategory
+from heavy.amp_client import DeployedAgent
+
+_COLLECTOR_DEPLOY = "opentelemetry-collector"
+_LOG_TAIL = "300"
 
 
 @dataclass
@@ -36,3 +42,84 @@ def classify_no_spans(ev: Evidence) -> FailureCategory:
     if ev.agent_init == "ok" and ev.agent_export_error is None and ev.collector_received is False:
         return FailureCategory.COLLECTOR_NOT_RECEIVED
     return FailureCategory.NO_SPANS_CAPTURED
+
+
+def _kubectl(args: list[str]) -> tuple[int, str]:
+    """Run a kubectl command best-effort; return (returncode, stdout+stderr)."""
+    try:
+        proc = subprocess.run(
+            ["kubectl", *args], capture_output=True, text=True, timeout=30
+        )
+        return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+    except Exception:  # noqa: BLE001 - diagnostics must never raise
+        return 127, ""
+
+
+def _find_pod(agent_name: str) -> tuple[str, str] | None:
+    """Return (namespace, pod) for the deployed agent's pod, or None."""
+    rc, out = _kubectl([
+        "get", "pods", "-A", "--no-headers",
+        "-o", "custom-columns=NS:.metadata.namespace,NAME:.metadata.name",
+    ])
+    if rc != 0:
+        return None
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and agent_name in parts[1]:
+            return parts[0], parts[1]
+    return None
+
+
+def _agent_signals(agent_name: str, ev: Evidence) -> None:
+    pod = _find_pod(agent_name)
+    if pod is None:
+        return
+    ns, name = pod
+    rc, log = _kubectl(["logs", "-n", ns, name, "--all-containers", "--tail", _LOG_TAIL])
+    if rc != 0 or not log:
+        return
+    ev.raw["agent"] = log[-2000:]
+    if "Automatic Tracing initialized successfully" in log:
+        ev.agent_init = "ok"
+    if "Failed to initialize Automatic Tracing" in log:
+        ev.agent_init = "failed"
+    for line in log.splitlines():
+        if "failed to export" in line.lower():
+            ev.agent_export_error = line.strip()[:300]
+            m = re.search(r"\b(\d{3})\b", line)
+            if m:
+                ev.agent_export_status = int(m.group(1))
+            break
+
+
+def _collector_signals(ev: Evidence) -> None:
+    rc, out = _kubectl([
+        "get", "deploy", "-A", "--no-headers",
+        "-o", "custom-columns=NS:.metadata.namespace,NAME:.metadata.name",
+    ])
+    if rc != 0:
+        return
+    ns = None
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and _COLLECTOR_DEPLOY in parts[1]:
+            ns = parts[0]
+            break
+    if ns is None:
+        return
+    rc, log = _kubectl(["logs", "-n", ns, f"deploy/{_COLLECTOR_DEPLOY}", "--tail", _LOG_TAIL])
+    if rc != 0:
+        return
+    ev.raw["collector"] = log[-2000:]
+    # The collector logs span receipt; absence of any receipt marker means it
+    # never got the agent's spans. Keep the marker list narrow and reviewable.
+    ev.collector_received = ("TracesExporter" in log) or ("spans" in log.lower())
+
+
+def collect_failure_evidence(deployed: DeployedAgent) -> Evidence:
+    """Gather agent + collector log signals for a 0-span cell. Best-effort:
+    each probe is independent and any failure leaves its fields None."""
+    ev = Evidence()
+    _agent_signals(deployed.agent_name, ev)
+    _collector_signals(ev)
+    return ev

--- a/test/instrumentation-matrix/heavy/diagnostics.py
+++ b/test/instrumentation-matrix/heavy/diagnostics.py
@@ -1,0 +1,38 @@
+"""Heavy-tier failure diagnostics: capture pipeline-boundary evidence when a
+cell captures 0 spans, and classify which boundary the trail went cold at.
+
+Evidence is gathered best-effort from `kubectl logs` (agent pod + otel
+collector); any kubectl failure leaves the corresponding field None
+(indeterminate) and never raises. The classifier is pure so it unit-tests
+without a cluster.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from harness.categorize import FailureCategory
+
+
+@dataclass
+class Evidence:
+    agent_init: str | None = None          # "ok" | "failed" | None (marker not found)
+    agent_export_status: int | None = None # HTTP status parsed from an OTLP exporter error line
+    agent_export_error: str | None = None  # short excerpt of the exporter error
+    collector_received: bool | None = None # True / False / None (indeterminate)
+    raw: dict[str, str] = field(default_factory=dict)  # truncated log excerpts, for the report
+
+
+def classify_no_spans(ev: Evidence) -> FailureCategory:
+    """Map boundary evidence to a failure category. Order matters: a gateway
+    rejection (401/403) is the most specific and actionable signal."""
+    if ev.agent_export_status in (401, 403):
+        return FailureCategory.INGEST_REJECTED
+    if (
+        ev.agent_init == "failed"
+        or (ev.agent_export_status is not None and ev.agent_export_status >= 500)
+        or (ev.agent_export_error is not None and ev.agent_export_status is None)
+    ):
+        return FailureCategory.EXPORT_FAILED
+    if ev.agent_init == "ok" and ev.agent_export_error is None and ev.collector_received is False:
+        return FailureCategory.COLLECTOR_NOT_RECEIVED
+    return FailureCategory.NO_SPANS_CAPTURED

--- a/test/instrumentation-matrix/heavy/diagnostics.py
+++ b/test/instrumentation-matrix/heavy/diagnostics.py
@@ -86,7 +86,11 @@ def _agent_signals(agent_name: str, ev: Evidence) -> None:
     for line in log.splitlines():
         if "failed to export" in line.lower():
             ev.agent_export_error = line.strip()[:300]
-            m = re.search(r"\b(\d{3})\b", line)
+            # Only read a 3-digit number that appears in an HTTP-status context
+            # (the OTLP/HTTP exporter logs "... code: 401, reason: ...").
+            # A bare \d{3} would grab a span count/port and a bogus 401/403
+            # would mis-classify as ingest-rejected — which aborts every cell.
+            m = re.search(r"(?:code|status(?:\s*code)?|http)[:=\s]+(\d{3})\b", line, re.I)
             if m:
                 ev.agent_export_status = int(m.group(1))
             break

--- a/test/instrumentation-matrix/heavy/driver.py
+++ b/test/instrumentation-matrix/heavy/driver.py
@@ -35,8 +35,17 @@ from harness.reports import CellResult, write_cell_report
 from harness.validator import ContractValidator
 from heavy import k3d
 from heavy.amp_client import AmpClient, DeployedAgent, IdpCredentials
+from heavy.diagnostics import classify_no_spans, collect_failure_evidence
 from heavy.observer import poll_traces
 from providers import PROVIDERS
+
+# Categories that indicate a pipeline-wide (not cell-specific) breakage: once
+# one cell hits these, the rest will fail identically, so abort and report.
+_SYSTEMIC = {"ingest-rejected", "collector-not-received"}
+
+
+def _is_systemic(category: str | None) -> bool:
+    return category in _SYSTEMIC
 
 HERE = Path(__file__).resolve().parent.parent
 
@@ -164,6 +173,20 @@ def main() -> int:
             skipped += 1
         else:
             passed += 1
+        if result.result == "fail" and _is_systemic(result.category):
+            reason = f"aborted: pipeline failure ({result.category}) in {cell.id}"
+            _log(f"      ⏭  {reason} — skipping remaining cells")
+            for rest in cells[idx:]:
+                skipped += 1
+                write_cell_report(
+                    CellResult(
+                        cell_id=rest.id, result="skipped", category=None,
+                        skip_reason=reason,
+                        coverage={"expected": _expected_kinds(rest), "actual": [], "missing": []},
+                    ),
+                    reports_dir=reports_dir,
+                )
+            break
     _log(f"heavy summary: {passed} passed, {failed} failed, {skipped} skipped")
     return 1 if failed else 0
 
@@ -204,15 +227,19 @@ def _run_cell(
         _invoke_agent(deployed)
         _log("      invoked; polling observer for spans…")
         spans = poll_traces(client, deployed, observer_base_url)
+        # Gather boundary evidence while the agent pod still exists (teardown
+        # in the finally below removes it), so a 0-span failure can be localized.
+        evidence = collect_failure_evidence(deployed) if not spans else None
     finally:
         client.teardown_agent(deployed)
     _log(f"      captured {len(spans)} span(s)")
 
     if not spans:
+        category = classify_no_spans(evidence).value
         return CellResult(
             cell_id=cell.id,
             result="fail",
-            category="no-spans-captured",
+            category=category,
             skip_reason=None,
             durations={},
             coverage={
@@ -222,6 +249,11 @@ def _run_cell(
             },
             violations=[],
             captured_spans=[],
+            evidence=evidence.raw or {
+                "summary": f"agent_init={evidence.agent_init} "
+                           f"export_status={evidence.agent_export_status} "
+                           f"collector_received={evidence.collector_received}"
+            },
         )
 
     provider = PROVIDERS[cell.provider_name]

--- a/test/instrumentation-matrix/heavy/driver.py
+++ b/test/instrumentation-matrix/heavy/driver.py
@@ -249,10 +249,11 @@ def _run_cell(
             },
             violations=[],
             captured_spans=[],
-            evidence=evidence.raw or {
+            evidence={
                 "summary": f"agent_init={evidence.agent_init} "
                            f"export_status={evidence.agent_export_status} "
-                           f"collector_received={evidence.collector_received}"
+                           f"collector_received={evidence.collector_received}",
+                **(evidence.raw or {}),
             },
         )
 

--- a/test/instrumentation-matrix/heavy/k3d.py
+++ b/test/instrumentation-matrix/heavy/k3d.py
@@ -10,36 +10,48 @@ from __future__ import annotations
 
 import subprocess
 
+_NS = "openchoreo-observability-plane"
+_warned = False
+
+
+def _find_opensearch_pod() -> str | None:
+    """Return the OpenSearch pod name, or None. OpenSearch is not a Deployment
+    named 'opensearch' (the old `deploy/opensearch` handle always 404'd), so
+    discover the pod by name and skip the dashboards pod."""
+    proc = subprocess.run(
+        ["kubectl", "-n", _NS, "get", "pods", "--no-headers",
+         "-o", "custom-columns=NAME:.metadata.name"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    for name in proc.stdout.split():
+        if "opensearch" in name and "dashboard" not in name:
+            return name
+    return None
+
 
 def reset_opensearch_indices() -> None:
     """Delete the spans-* indices so each cell starts from a clean slate.
 
-    OpenSearch is installed by the openchoreo bring-up into the
-    openchoreo-observability-plane namespace. Best-effort: a failure here
-    means the index reset didn't land, which the driver detects later when
-    polling traces returns stale results.
+    Best-effort: discovers the OpenSearch pod by name and warns at most once if
+    it can't be found or the delete fails, so a missing handle is visible
+    without spamming an identical per-cell warning.
     """
+    global _warned
+    pod = _find_opensearch_pod()
+    if pod is None:
+        if not _warned:
+            print(f"::warning::OpenSearch pod not found in {_NS}; per-cell index "
+                  "reset skipped (cells may see stale spans)")
+            _warned = True
+        return
     proc = subprocess.run(
-        [
-            "kubectl",
-            "-n",
-            "openchoreo-observability-plane",
-            "exec",
-            "deploy/opensearch",
-            "--",
-            "curl",
-            "-s",
-            "-X",
-            "DELETE",
-            "http://localhost:9200/spans-*",
-        ],
-        capture_output=True,
-        text=True,
+        ["kubectl", "-n", _NS, "exec", pod, "--",
+         "curl", "-s", "-X", "DELETE", "http://localhost:9200/spans-*"],
+        capture_output=True, text=True,
     )
-    if proc.returncode != 0:
-        # Best-effort, but don't swallow silently — a failed reset means the
-        # next cell may see stale spans, which is worth a visible warning.
-        print(
-            f"::warning::OpenSearch index reset failed (rc={proc.returncode}): "
-            f"{(proc.stderr or proc.stdout).strip()[:300]}"
-        )
+    if proc.returncode != 0 and not _warned:
+        print(f"::warning::OpenSearch index reset failed (rc={proc.returncode}): "
+              f"{(proc.stderr or proc.stdout).strip()[:200]}")
+        _warned = True

--- a/test/instrumentation-matrix/heavy/k3d.py
+++ b/test/instrumentation-matrix/heavy/k3d.py
@@ -48,7 +48,7 @@ def reset_opensearch_indices() -> None:
         return
     proc = subprocess.run(
         ["kubectl", "-n", _NS, "exec", pod, "--",
-         "curl", "-s", "-X", "DELETE", "http://localhost:9200/spans-*"],
+         "curl", "-sf", "-X", "DELETE", "http://localhost:9200/spans-*"],
         capture_output=True, text=True,
     )
     if proc.returncode != 0 and not _warned:

--- a/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
+++ b/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
@@ -1,0 +1,7 @@
+from harness.categorize import FailureCategory
+
+
+def test_boundary_categories_exist():
+    assert FailureCategory.INGEST_REJECTED.value == "ingest-rejected"
+    assert FailureCategory.EXPORT_FAILED.value == "export-failed"
+    assert FailureCategory.COLLECTOR_NOT_RECEIVED.value == "collector-not-received"

--- a/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
+++ b/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
@@ -1,5 +1,12 @@
 from harness.categorize import FailureCategory
+from heavy import diagnostics
+from heavy.amp_client import DeployedAgent
 from heavy.diagnostics import Evidence, classify_no_spans
+
+
+def _agent(name="traceloop-0-61-0-l-1476e2"):
+    return DeployedAgent(org="default", project_name="p", agent_name=name,
+                         environment="dev", endpoint_url="http://x", api_key="k")
 
 
 def test_boundary_categories_exist():
@@ -40,3 +47,39 @@ def test_classify_collector_not_received_when_agent_ok_but_collector_empty():
 
 def test_classify_falls_back_to_no_spans_when_inconclusive():
     assert classify_no_spans(Evidence()) is FailureCategory.NO_SPANS_CAPTURED
+
+
+def test_collect_evidence_parses_401_from_agent_log(monkeypatch):
+    def fake_kubectl(args):
+        if args[:3] == ["get", "pods", "-A"]:
+            return 0, "amp-dp traceloop-0-61-0-l-1476e2-abc123\n"
+        if args[0] == "logs" and "traceloop-0-61-0-l-1476e2-abc123" in args:
+            return 0, ("Automatic Tracing initialized successfully.\n"
+                       "Failed to export batch code: 401, reason: Unauthorized\n")
+        if args[0] == "get" and "deploy" in args:
+            return 0, "observability opentelemetry-collector\n"
+        if args[0] == "logs" and "deploy/opentelemetry-collector" in args:
+            return 0, "no spans here\n"
+        return 1, ""
+    monkeypatch.setattr(diagnostics, "_kubectl", fake_kubectl)
+    ev = diagnostics.collect_failure_evidence(_agent())
+    assert ev.agent_init == "ok"
+    assert ev.agent_export_status == 401
+
+
+def test_collect_evidence_detects_init_failure(monkeypatch):
+    def fake_kubectl(args):
+        if args[:3] == ["get", "pods", "-A"]:
+            return 0, "amp-dp traceloop-0-61-0-l-1476e2-abc123\n"
+        if args[0] == "logs":
+            return 0, "Failed to initialize Automatic Tracing: boom\n"
+        return 1, ""
+    monkeypatch.setattr(diagnostics, "_kubectl", fake_kubectl)
+    ev = diagnostics.collect_failure_evidence(_agent())
+    assert ev.agent_init == "failed"
+
+
+def test_collect_evidence_never_raises_when_kubectl_unavailable(monkeypatch):
+    monkeypatch.setattr(diagnostics, "_kubectl", lambda args: (127, ""))
+    ev = diagnostics.collect_failure_evidence(_agent())
+    assert ev.agent_init is None and ev.agent_export_status is None

--- a/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
+++ b/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
@@ -83,3 +83,15 @@ def test_collect_evidence_never_raises_when_kubectl_unavailable(monkeypatch):
     monkeypatch.setattr(diagnostics, "_kubectl", lambda args: (127, ""))
     ev = diagnostics.collect_failure_evidence(_agent())
     assert ev.agent_init is None and ev.agent_export_status is None
+
+
+def test_systemic_categories_trigger_abort():
+    from heavy import driver
+    assert driver._is_systemic("ingest-rejected") is True
+    assert driver._is_systemic("collector-not-received") is True
+
+
+def test_per_cell_categories_do_not_abort():
+    from heavy import driver
+    for c in ("export-failed", "missing-span-kind", "pipeline-error", "no-spans-captured"):
+        assert driver._is_systemic(c) is False

--- a/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
+++ b/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
@@ -79,6 +79,22 @@ def test_collect_evidence_detects_init_failure(monkeypatch):
     assert ev.agent_init == "failed"
 
 
+def test_collect_evidence_ignores_non_status_3digit(monkeypatch):
+    # A 3-digit number that is NOT an HTTP status (a span count here) must not
+    # be read as a status — otherwise a bogus 401/403 would mis-classify as
+    # ingest-rejected and abort every remaining cell.
+    def fake_kubectl(args):
+        if args[:3] == ["get", "pods", "-A"]:
+            return 0, "amp-dp traceloop-0-61-0-l-1476e2-abc123\n"
+        if args[0] == "logs":
+            return 0, "Failed to export 250 spans to the collector: timed out\n"
+        return 1, ""
+    monkeypatch.setattr(diagnostics, "_kubectl", fake_kubectl)
+    ev = diagnostics.collect_failure_evidence(_agent())
+    assert ev.agent_export_error is not None
+    assert ev.agent_export_status is None
+
+
 def test_collect_evidence_never_raises_when_kubectl_unavailable(monkeypatch):
     monkeypatch.setattr(diagnostics, "_kubectl", lambda args: (127, ""))
     ev = diagnostics.collect_failure_evidence(_agent())

--- a/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
+++ b/test/instrumentation-matrix/tests/test_heavy_diagnostics.py
@@ -1,7 +1,42 @@
 from harness.categorize import FailureCategory
+from heavy.diagnostics import Evidence, classify_no_spans
 
 
 def test_boundary_categories_exist():
     assert FailureCategory.INGEST_REJECTED.value == "ingest-rejected"
     assert FailureCategory.EXPORT_FAILED.value == "export-failed"
     assert FailureCategory.COLLECTOR_NOT_RECEIVED.value == "collector-not-received"
+
+
+def test_classify_ingest_rejected_on_401():
+    ev = Evidence(agent_init="ok", agent_export_status=401, agent_export_error="401 Unauthorized")
+    assert classify_no_spans(ev) is FailureCategory.INGEST_REJECTED
+
+
+def test_classify_ingest_rejected_on_403():
+    ev = Evidence(agent_init="ok", agent_export_status=403)
+    assert classify_no_spans(ev) is FailureCategory.INGEST_REJECTED
+
+
+def test_classify_export_failed_on_init_failure():
+    ev = Evidence(agent_init="failed")
+    assert classify_no_spans(ev) is FailureCategory.EXPORT_FAILED
+
+
+def test_classify_export_failed_on_5xx():
+    ev = Evidence(agent_init="ok", agent_export_status=503, agent_export_error="503")
+    assert classify_no_spans(ev) is FailureCategory.EXPORT_FAILED
+
+
+def test_classify_export_failed_on_error_without_status():
+    ev = Evidence(agent_init="ok", agent_export_error="connection refused")
+    assert classify_no_spans(ev) is FailureCategory.EXPORT_FAILED
+
+
+def test_classify_collector_not_received_when_agent_ok_but_collector_empty():
+    ev = Evidence(agent_init="ok", collector_received=False)
+    assert classify_no_spans(ev) is FailureCategory.COLLECTOR_NOT_RECEIVED
+
+
+def test_classify_falls_back_to_no_spans_when_inconclusive():
+    assert classify_no_spans(Evidence()) is FailureCategory.NO_SPANS_CAPTURED

--- a/test/instrumentation-matrix/tests/test_reports.py
+++ b/test/instrumentation-matrix/tests/test_reports.py
@@ -114,3 +114,16 @@ def test_load_cell_report_feeds_triage_without_false_missing(tmp_path):
     assert "| `gen_ai.provider.name` | present |" in md
     assert "| `gen_ai.request.model` | present |" in md
     assert "MISSING" not in md
+
+
+def test_report_round_trips_evidence(tmp_path):
+    from harness.reports import CellResult, write_cell_report
+    import json
+    r = CellResult(
+        cell_id="traceloop-0.61.0-langchain-0.3.27-py3.11",
+        result="fail", category="ingest-rejected", skip_reason=None,
+        evidence={"agent": "Failed to export batch code: 401"},
+    )
+    out = write_cell_report(r, reports_dir=tmp_path)
+    payload = json.loads(out.read_text())
+    assert payload["evidence"] == {"agent": "Failed to export batch code: 401"}


### PR DESCRIPTION
## Purpose

Makes the instrumentation-matrix heavy tier self-diagnosing. The heavy tier validates that a deployed agent's spans survive the full pipeline (agent → gateway → otel-collector → OpenSearch → observer). When that pipeline broke on 2026-06-02 — a gateway auth-header-scheme regression returned 401 on the OTLP ingest route (fixed separately by #991) — every cell reported only the undifferentiated symptom `no-spans-captured`: the suite could say *that* spans were missing but never *where* the trail went cold, so diagnosis required out-of-band knowledge. This change closes that observability gap.

Related to #991 (the gateway `authheaderscheme` fix for the incident that motivated this) and #987/#990 (the traceloop 0.61.0 onboarding whose heavy run surfaced the blind spot).

## Goals

Localize a heavy-tier span-delivery failure to a specific pipeline boundary, fail fast when the breakage is systemic (so it surfaces on the first cell rather than after the whole subset), and surface the reason in both the per-cell report and the CI step summary.

## Approach

- **Boundary classification** (`heavy/diagnostics.py`, new): on a 0-span cell, capture the agent and otel-collector pod logs best-effort (via `kubectl`, before teardown) and classify into `ingest-rejected` (gateway 401/403), `export-failed` (agent init/export never succeeded), or `collector-not-received` (agent exported but collector saw nothing), falling back to `no-spans-captured` when evidence is inconclusive. The classifier is pure; the log scrape goes through an injectable `_kubectl` so it unit-tests without a cluster and never raises.
- **Fail-fast** (`heavy/driver.py`): the first cell that hits a systemic category (`ingest-rejected` / `collector-not-received`) aborts the remaining cells (marked `skipped` with the reason), since they would fail identically.
- **Evidence surfaced** (`harness/reports.py`, workflow): the category and a one-line evidence summary land in `reports/heavy/<cell>.json` and the GitHub step summary.
- **OpenSearch reset fixed** (`heavy/k3d.py`): it targeted `deploy/opensearch`, which 404'd in every run (green and failing) and spammed a misleading per-cell warning; it now discovers the OpenSearch pod by name, warns at most once, and uses `curl -f` so an HTTP-level delete failure actually trips the warning.

For the 2026-06-02 incident this would have produced, on cell #1: `❌ ingest-rejected: agent OTLP export got HTTP 401 from gateway` plus `aborted 7 remaining cells` — in ~3 minutes instead of ~45.

## User stories

As an engineer triaging a heavy-tier failure, I want the run to tell me which pipeline boundary dropped the spans, and to stop fast on a systemic failure, so I can fix the right component without reproducing the run or relying on out-of-band knowledge.

## Release note

N/A — internal test-infrastructure change; no user-facing behavior.

## Documentation

N/A — no product-documentation impact. The heavy-tier design and operation are covered by the in-repo `test/instrumentation-matrix/DESIGN.md` / `RUNBOOK.md` and this PR's code comments.

## Training

N/A — no training-content impact.

## Certification

N/A — no certification impact.

## Marketing

N/A — no marketing impact.

## Automation tests

 - Unit tests
   > New `tests/test_heavy_diagnostics.py` covers the classifier (401 → `ingest-rejected`, init-failure → `export-failed`, agent-ok + collector-empty → `collector-not-received`, inconclusive → `no-spans-captured`, and a non-HTTP-status 3-digit number is ignored), the evidence parser over fake `kubectl` output (and that it never raises when `kubectl` is absent), and the `_is_systemic` abort predicate. `tests/test_reports.py` covers the `evidence` round-trip. The full matrix unit suite is green (118 tests).
 - Integration tests
   > The real-cluster behavior — the `kubectl` selectors, the collector "received" marker, and the OpenSearch pod-name match — is exercised only by the heavy tier against a live k3d stack, so that validation is pending the next heavy-tier run. Each probe is best-effort and tolerant: a wrong guess degrades to today's behavior rather than breaking the run.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — this change is Python test-harness code, not Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no samples related to this change.

## Related PRs

- #991 — gateway `authheaderscheme` (the fix for the incident that motivated this work).
- #987, #990 — traceloop 0.61.0 onboarding, whose heavy run surfaced this blind spot.

## Migrations (if applicable)

N/A — no migration steps.

## Test environment

Python 3.11 matrix harness unit tests, run locally on macOS via `uv`/`pytest`. The heavy-tier live run executes on `ubuntu-latest` CI against a build-from-source k3d stack (pending re-trigger).

## Learning

The emission tier uses an in-memory span exporter, so it structurally cannot exercise OTLP egress — only the heavy tier (real OTLP path) can catch a gateway/transport failure, which is why emission stayed green while every heavy cell failed. This PR encodes the systematic-debugging principle "gather evidence at each component boundary" directly into the harness, so a delivery failure localizes itself instead of collapsing to one opaque symptom.
