### PR TITLE
Make CrewAI sample docs outsider-friendly

### DIFF
--- a/samples/crewai-agent/README.md
+++ b/samples/crewai-agent/README.md
@@ -1,21 +1,85 @@
-# CrewAI Agent Sample
+# CrewAI Agent - Deployment Guide
 
-A buildpack-deployable chat agent built on [CrewAI](https://github.com/crewAIInc/crewAI),
-exposing `POST /chat` via FastAPI. A researcher agent (with a capital-lookup
-tool) and an editor agent run two sequential tasks, so each request emits
-`llm`, `agent`, and `crewaitask` spans.
+## Overview
 
-This sample exists so the instrumentation-matrix **heavy tier** can deploy a
-real CrewAI app and validate CrewAI auto-instrumentation through the full
-pipeline (auto-instrumentation → gateway → collector → OpenSearch → observer).
-See `test/instrumentation-matrix/RUNBOOK.md` §7.
+A multi-agent sample built with [CrewAI](https://github.com/crewAIInc/crewAI) and FastAPI. Two agents work together to answer each question: the first answers it using a capital-city lookup tool, and the second rewrites that answer into a single short sentence. The service exposes `POST /chat`.
 
-## Run locally
+Because the request flows through two agents and the underlying model, a single call produces a small but complete trace — useful for seeing how a multi-agent CrewAI app appears in the Agent Manager console.
+
+## Prerequisites
+
+### Required API Keys
+
+- **OpenAI API Key**: for model inference (the agents use `gpt-4o-mini`)
+
+## Deployment Instructions
+
+### Step 1: Access Agent Manager
+
+1. Navigate to the **Default** project
+2. Click **"Add Agent"**
+3. Select **Platform-Hosted Agent** Card
+
+### Step 2: Configure Agent Details
+
+Fill in the agent creation form with these values:
+
+| Field                 | Value                                     |
+| --------------------- | ----------------------------------------- |
+| **Display Name**      | `CrewAI Agent`                            |
+| **Description**       | `Multi-agent CrewAI sample`               |
+| **GitHub Repository** | `https://github.com/wso2/agent-manager`   |
+| **Branch**            | `main`                                    |
+| **App Path**          | `samples/crewai-agent`                    |
+| **Language**          | `Python`                                  |
+| **Language Version**  | `3.11`                                    |
+| **Start Command**     | `python main.py`                          |
+| **Port**              | `8000`                                    |
+
+### Step 3: Select Agent Interface
+
+- Choose **"Chat Agent"** as the agent interface type
+
+### Step 4: Configure Environment Variables
+
+Add the following environment variable in the create form:
+
+```env
+OPENAI_API_KEY=<your-openai-api-key>
+```
+
+### Step 5: Deploy the Agent
+
+1. Review all configuration details
+2. Click **"Deploy"**
+3. Wait for the build to complete
+
+## Testing Your Agent
+
+### Step 1: Navigate to Chat Interface
+
+Click on the **"Try It"** section on the left navigation.
+
+### Step 2: Test Sample Interactions
+
+Try this question in the chat interface:
+
+```text
+What is the capital of France?
+```
+
+### Step 3: Observe Traces
+
+1. Click on the **"Observability"** tab on the left navigation and select **Traces**
+2. Open a trace to see the two agents and the model call for each interaction
+
+## Run Locally
 
 ```bash
+cd samples/crewai-agent
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-export OPENAI_API_KEY=sk-...
+export OPENAI_API_KEY=<your-openai-api-key>
 python main.py    # serves on http://localhost:8000
 ```
 
@@ -27,8 +91,5 @@ curl -s localhost:8000/chat \
 
 ## Notes
 
-- Pinned to `crewai==1.1.0` (1.14 is unresolvable against the matrix's
-  `traceloop-sdk 0.60`; see `test/instrumentation-matrix/FINDINGS.md` F-004).
-- The app sets `CREWAI_TRACING_ENABLED=false`,
-  `CREWAI_DISABLE_TRACING_PROMPT=true`, and `LITELLM_LOCAL_MODEL_COST_MAP=True`
-  so it runs non-interactively and avoids cold-start network fetches.
+- Pinned to `crewai==1.1.0` for dependency compatibility.
+- The app disables CrewAI's hosted tracing and its interactive trace prompt so it runs non-interactively, and it uses the bundled model pricing data to avoid a network fetch on startup.

--- a/samples/crewai-agent/README.md
+++ b/samples/crewai-agent/README.md
@@ -42,11 +42,15 @@ Fill in the agent creation form with these values:
 
 ### Step 4: Configure Environment Variables
 
-Add the following environment variable in the create form:
+Add the following environment variables in the create form:
 
 ```env
 OPENAI_API_KEY=<your-openai-api-key>
+HOME=/tmp
+CREWAI_STORAGE_DIR=/tmp/crewai
 ```
+
+`HOME` and `CREWAI_STORAGE_DIR` are required. CrewAI writes files under `$HOME` when it is first imported, and with auto-instrumentation enabled that import happens at process startup — before the app runs — while the build container's default `HOME` is read-only. Pointing both at a writable path (`/tmp`) avoids a `Read-only file system: '/nonexistent'` crash and the restart loop it causes.
 
 ### Step 5: Deploy the Agent
 

--- a/samples/crewai-agent/agent/crew.py
+++ b/samples/crewai-agent/agent/crew.py
@@ -1,11 +1,10 @@
-"""Two-agent CrewAI crew for the deployable matrix sample.
+"""A two-agent CrewAI crew.
 
-A researcher (with one tool) and an editor run two sequential tasks. Each
-/chat invocation drives LLM calls plus tasks, so the deployed agent emits
-llm + agent + crewaitask spans for the heavy tier to assert. Mirrors the
-emission-tier test/instrumentation-matrix/cells/crewai_sample.py so both tiers
-exercise the same shape. Pinned to crewai 1.1.0 (see that suite's FINDINGS
-F-004: 1.14 is unresolvable against traceloop-sdk 0.60).
+A researcher (with one tool) and an editor run two sequential tasks. The
+researcher answers the question using the lookup tool, and the editor shortens
+the answer. Each /chat call runs both agents and the model behind them, so a
+single request produces a small multi-agent trace. Pinned to crewai 1.1.0 for
+dependency compatibility.
 """
 from __future__ import annotations
 

--- a/samples/crewai-agent/app.py
+++ b/samples/crewai-agent/app.py
@@ -1,20 +1,16 @@
 import os
 
-# Keep CrewAI non-interactive and offline-friendly inside the deployed pod, and
-# set these BEFORE importing crewai (litellm reads them at import): no hosted-
-# trace upload, no interactive trace prompt, and use litellm's bundled model
-# cost map instead of fetching it from GitHub on cold start. Mirrors the
-# emission-tier cells/crewai_sample.py.
+# Keep CrewAI non-interactive and offline-friendly, and set these BEFORE
+# importing crewai (they are read at import time): no hosted-trace upload, no
+# interactive trace prompt, and use the bundled model pricing data instead of
+# fetching it over the network on startup.
 os.environ.setdefault("CREWAI_TRACING_ENABLED", "false")
 os.environ.setdefault("CREWAI_DISABLE_TRACING_PROMPT", "true")
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-# CrewAI writes under $HOME at import (a chromadb storage dir) and at Crew()
-# construction (a credentials dir). Under AMP the deployed workload already
-# sets HOME + CREWAI_STORAGE_DIR to writable paths (see
-# harness/deployable_samples.py) — required because the instrumentation
-# provider imports crewai at interpreter startup, before this app runs. This
-# block is a fallback so the sample also runs standalone under a read-only
-# HOME; it no-ops when HOME is already writable or the env is preset.
+# CrewAI writes under $HOME at import (a storage dir) and at Crew() construction
+# (a credentials dir). When deployed, the platform sets HOME + CREWAI_STORAGE_DIR
+# to writable paths. This block is a fallback so the sample also runs standalone
+# under a read-only HOME; it no-ops when HOME is already writable or preset.
 os.environ.setdefault("CREWAI_STORAGE_DIR", "/tmp/crewai")
 if not os.access(os.path.expanduser("~"), os.W_OK):
     os.environ["HOME"] = "/tmp"

--- a/samples/crewai-agent/openapi.yaml
+++ b/samples/crewai-agent/openapi.yaml
@@ -3,8 +3,7 @@ info:
   title: CrewAI Agent Service
   description: |
     A FastAPI service exposing a multi-agent CrewAI crew (a researcher with a
-    lookup tool plus an editor). Used by the instrumentation-matrix heavy tier
-    to validate CrewAI auto-instrumentation through the full deployed pipeline.
+    lookup tool plus an editor) behind a single POST /chat endpoint.
   version: 1.0.0
   contact:
     name: API Support


### PR DESCRIPTION
## Purpose
The CrewAI sample's README only documented a local run and, along with `crew.py`, `app.py`, and `openapi.yaml`, leaned on internal terms (heavy/emission tier, instrumentation-matrix, RUNBOOK, FINDINGS references) that mean nothing to an external reader. 

## Goals
Make the sample stand on its own for someone deploying it through Agent Manager, with concise deploy steps and no internal jargon.

## Approach
- **README**: rewritten to follow the other samples' structure (Overview, Prerequisites, Deployment Instructions with the create-agent table, Testing, Observe Traces), so it gives concise steps to deploy in Agent Manager rather than only a local run. Prose is soft-wrapped (no hard line caps).
- **Removed internal jargon** from the README, `crew.py`, and `openapi.yaml`: heavy/emission tier, instrumentation-matrix, RUNBOOK, FINDINGS F-004, and traceloop-sdk version notes.

## User stories
N/A — documentation/comment cleanup for a sample.

## Release note
Improve the CrewAI sample documentation with concise Agent Manager deployment steps and clearer, jargon-free comments.

## Documentation
N/A — this change is itself sample documentation; no external product docs are affected.

## Training
N/A — no training content impact.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — no marketing content impact.

## Automation tests
 - Unit tests
   > N/A — documentation and code-comment changes only; no behavior change.
 - Integration tests
   > N/A — no functional change to the sample.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no compiled/source logic changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
Updates the `samples/crewai-agent` sample: README, `crew.py` docstring, `app.py` comments, and `openapi.yaml` description. No runtime behavior change.

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A — documentation/comment changes only.

## Learning
Modeled the README on the existing `customer-support-agent`, `hotel-booking-agent`, `it-helpdesk-agent`, and `manual-instrumentation-agent` sample READMEs for a consistent deploy-guide structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the sample README into a Deployment Guide for a Platform-Hosted Agent with step-by-step configuration, environment variable setup, deployment and testing instructions; clarified local run guidance and the single POST /chat service endpoint.
* **Chores**
  * Made offline-friendly configuration clearer and non-interactive: tracing is disabled by default and bundled model pricing is used to avoid network fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->