### PR TITLE
Use generic LLM wording in eval user-facing surfaces

### DIFF
--- a/console/workspaces/pages/eval/scripts/generate-evaluator-models.sh
+++ b/console/workspaces/pages/eval/scripts/generate-evaluator-models.sh
@@ -322,7 +322,9 @@ for line in lines:
     if not line or line.startswith('#'):
         continue
     name = re.split(r'[><=!~;\s]', line)[0].strip()
-    if name:
+    # Packages that are installed but intentionally not advertised in the
+    # editor's package list.
+    if name and name.lower() not in {'litellm'}:
         names.append(name)
 
 # Include WSO2 library first

--- a/console/workspaces/pages/eval/src/generated/evaluator-models.generated.ts
+++ b/console/workspaces/pages/eval/src/generated/evaluator-models.generated.ts
@@ -3232,7 +3232,6 @@ export const LLM_JUDGE_BASE_CONFIG_SCHEMA: EvaluatorConfigParam[] = [
 export const SUPPORTED_PACKAGES: string[] = [
   "amp-evaluation",
   "requests",
-  "litellm",
   "numpy",
   "pandas",
 ];

--- a/evaluation-job/main.py
+++ b/evaluation-job/main.py
@@ -541,7 +541,7 @@ def main() -> None:
         # Message vs the expected 10-field schema). Response content is unaffected.
         warnings.filterwarnings("ignore", module="pydantic")
 
-        logger.info("Configured LiteLLM to route through OpenAI-compatible gateway at %s", llm_api_base)
+        logger.info("Configured LLM client to route through OpenAI-compatible gateway at %s", llm_api_base)
 
     logger.info(
         "Starting monitor evaluation monitor=%s organization=%s project=%s agent=%s env=%s time_range=%s..%s sampling=%.1f",

--- a/test/instrumentation-matrix/cells/crewai_sample.py
+++ b/test/instrumentation-matrix/cells/crewai_sample.py
@@ -18,7 +18,7 @@ def run_scenario() -> str:
     # app.crewai.com (which would embed a one-time access code).
     os.environ.setdefault("CREWAI_TRACING_ENABLED", "false")
     os.environ.setdefault("CREWAI_DISABLE_TRACING_PROMPT", "true")
-    # Use LiteLLM's bundled model cost map instead of fetching from GitHub.
+    # Use bundled model cost map instead of fetching from GitHub.
     # Otherwise the cell makes an HTTP call to raw.githubusercontent.com on
     # cold start, which isn't in the cassette and breaks replay.
     os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")


### PR DESCRIPTION
## Purpose
The evaluation job log line and the evaluator editor's "Supported packages" list referred to the specific underlying LLM library by name. That library is an internal implementation detail of the built-in judge evaluators, not a package users are expected to import directly, so naming it in user-facing logs and UI is misleading and unnecessary.

## Goals
Keep user-facing surfaces (job logs and the evaluator editor UI) referring to the generic "LLM client" / the packages users actually import, rather than internal dependencies.

## Approach
- Reworded the evaluation job log line to say "Configured LLM client to route through OpenAI-compatible gateway" instead of naming the underlying library.
- The editor's "Supported packages" list is generated from `evaluation-job/requirements.txt`; the generator (`generate-evaluator-models.sh`) now filters out the internal-only dependency, and the regenerated `evaluator-models.generated.ts` follows. The library remains installed and usable — it is just no longer advertised as a user-importable package.
- Generalized an incidental comment in the CrewAI instrumentation sample.

No visual UI changes beyond one entry being removed from a comma-separated package list rendered in the evaluator form.

## User stories
N/A — internal wording/cleanup change.

## Release note
Refer to the LLM client generically in evaluation job logs and trim the evaluator editor's supported-packages list to packages users import directly.

## Documentation
N/A — no documented behavior changes.

## Training
N/A

## Certification
N/A — no impact on certification exams; this is a non-functional wording change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > No new tests. Verified the generator filter keeps `requests`/`numpy`/`pandas` and drops the internal entry; `evaluation-job/main.py` and the CrewAI sample compile; the only consumer of `SUPPORTED_PACKAGES` simply joins and renders the list.
 - Integration tests
   > N/A — no behavioral change; the dependency stays installed in the job image.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — only an incidental comment in the CrewAI sample was reworded.

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Verified locally on macOS (Darwin) with Python 3.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined package support listing and updated internal logging messages for clarity.
  * Updated documentation comments in test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->