### PR TITLE
Adopt any-llm as the LLM-as-judge client

### DIFF
--- a/agent-manager-service/catalog/provider_prefixes.go
+++ b/agent-manager-service/catalog/provider_prefixes.go
@@ -16,9 +16,10 @@
 
 package catalog
 
-// liteLLMProviderPrefixes maps gateway LLM provider template handles to the
-// model prefix expected by LiteLLM (e.g. "bedrock", "azure", "openai").
-var liteLLMProviderPrefixes = map[string]string{
+// providerModelPrefixes maps gateway LLM provider template handles to the
+// provider segment of the "provider/model" identifier the evaluation job's
+// LLM client expects (e.g. "bedrock", "openai", "anthropic").
+var providerModelPrefixes = map[string]string{
 	"openai":          "openai",
 	"anthropic":       "anthropic",
 	"gemini":          "gemini",
@@ -26,14 +27,15 @@ var liteLLMProviderPrefixes = map[string]string{
 	"mistral":         "mistral",
 	"mistralai":       "mistral",
 	"awsbedrock":      "bedrock",
-	"azure-openai":    "azure",
-	"azureai-foundry": "azure_ai",
+	"azure-openai":    "azureopenai",
+	"azureai-foundry": "azure",
 }
 
-// GetLiteLLMPrefix resolves a gateway provider TemplateHandle to the LiteLLM
-// model prefix string. Returns ("", false) for unknown handles — the caller
-// should store the bare model name and let the evaluation job apply its default.
-func GetLiteLLMPrefix(templateHandle string) (string, bool) {
-	prefix, ok := liteLLMProviderPrefixes[templateHandle]
+// GetProviderPrefix resolves a gateway provider TemplateHandle to the
+// "provider/model" prefix string. Returns ("", false) for unknown handles — the
+// caller should store the bare model name and let the evaluation job apply its
+// default.
+func GetProviderPrefix(templateHandle string) (string, bool) {
+	prefix, ok := providerModelPrefixes[templateHandle]
 	return prefix, ok
 }

--- a/agent-manager-service/scripts/generate-builtin-evaluators.sh
+++ b/agent-manager-service/scripts/generate-builtin-evaluators.sh
@@ -96,7 +96,7 @@ if [[ "${DEV_MODE}" == "true" ]]; then
 
     if [[ -d "${LOCAL_AMP_EVAL}" ]]; then
         log_info "Installing amp-evaluation from local source (dev mode)..."
-        pip install --quiet -e "${LOCAL_AMP_EVAL}[litellm]"
+        pip install --quiet -e "${LOCAL_AMP_EVAL}[any-llm]"
     else
         log_error "Local amp-evaluation not found at ${LOCAL_AMP_EVAL}"
         log_error "Run from repository root or use --amp-eval-version for production"
@@ -104,10 +104,10 @@ if [[ "${DEV_MODE}" == "true" ]]; then
     fi
 elif [[ -n "${AMP_EVAL_VERSION}" ]]; then
     log_info "Installing amp-evaluation==${AMP_EVAL_VERSION} from PyPI..."
-    pip install --quiet "amp-evaluation[litellm]==${AMP_EVAL_VERSION}"
+    pip install --quiet "amp-evaluation[any-llm]==${AMP_EVAL_VERSION}"
 else
     log_info "Installing latest amp-evaluation from PyPI..."
-    pip install --quiet "amp-evaluation[litellm]"
+    pip install --quiet "amp-evaluation[any-llm]"
 fi
 
 # Generate the Go source file

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -199,7 +199,7 @@ func (e *monitorExecutor) UpdateNextRunTime(ctx context.Context, monitorID uuid.
 	return nil
 }
 
-// resolveLLMProxyConfig returns the secret KV path, gateway proxy URL, and LiteLLM
+// resolveLLMProxyConfig returns the secret KV path, gateway proxy URL, and
 // provider template handle for the monitor's LLM proxy mapping.
 // Returns empty strings if no proxy mapping exists.
 // The KV path and secret key are read from the persisted mapping (set during provisioning
@@ -374,7 +374,7 @@ type evalJobEvaluator struct {
 
 // serializeEvaluators converts evaluators to a JSON string for the evaluation job workflow parameter.
 // For custom evaluators, it resolves their full definitions from the DB.
-// templateHandle is used to prepend the LiteLLM provider prefix to the "model" config field
+// templateHandle is used to prepend the provider prefix to the "model" config field
 // just before serialization — the stored evaluator config is not modified.
 // Returns the JSON string, whether any evaluator is type "llm_judge", and any error.
 func (e *monitorExecutor) serializeEvaluators(orgName string, evaluators []models.MonitorEvaluator, templateHandle string) (string, bool, error) {
@@ -398,7 +398,7 @@ func (e *monitorExecutor) serializeEvaluators(orgName string, evaluators []model
 		}
 	}
 
-	liteLLMPrefix, hasPrefix := catalog.GetLiteLLMPrefix(templateHandle)
+	providerPrefix, hasPrefix := catalog.GetProviderPrefix(templateHandle)
 
 	var hasLLMJudge bool
 	jobEvaluators := make([]evalJobEvaluator, len(evaluators))
@@ -409,14 +409,14 @@ func (e *monitorExecutor) serializeEvaluators(orgName string, evaluators []model
 			jobConfig[k] = v
 		}
 		// When a proxy is in use, always normalise the model to a bare name first,
-		// then optionally prepend the LiteLLM provider prefix. This prevents a stale
+		// then optionally prepend the provider prefix. This prevents a stale
 		// "oldprovider/model" value from leaking through when the provider changes.
 		if model, ok := jobConfig["model"].(string); ok && model != "" && templateHandle != "" {
 			if idx := strings.Index(model, "/"); idx != -1 {
 				model = model[idx+1:]
 			}
 			if hasPrefix {
-				jobConfig["model"] = liteLLMPrefix + "/" + model
+				jobConfig["model"] = providerPrefix + "/" + model
 			} else {
 				jobConfig["model"] = model
 			}

--- a/console/workspaces/pages/eval/scripts/generate-evaluator-models.sh
+++ b/console/workspaces/pages/eval/scripts/generate-evaluator-models.sh
@@ -321,10 +321,9 @@ for line in lines:
     line = line.strip()
     if not line or line.startswith('#'):
         continue
-    name = re.split(r'[><=!~;\s]', line)[0].strip()
-    # Packages that are installed but intentionally not advertised in the
-    # editor's package list.
-    if name and name.lower() not in {'litellm'}:
+    # Drop version/marker specifiers and any extras bracket (e.g. "foo[bar]==1").
+    name = re.split(r'[><=!~;\s\[]', line)[0].strip()
+    if name:
         names.append(name)
 
 # Include WSO2 library first

--- a/console/workspaces/pages/eval/src/generated/evaluator-models.generated.ts
+++ b/console/workspaces/pages/eval/src/generated/evaluator-models.generated.ts
@@ -3232,6 +3232,7 @@ export const LLM_JUDGE_BASE_CONFIG_SCHEMA: EvaluatorConfigParam[] = [
 export const SUPPORTED_PACKAGES: string[] = [
   "amp-evaluation",
   "requests",
+  "any-llm-sdk",
   "numpy",
   "pandas",
 ];

--- a/evaluation-job/Dockerfile.dev
+++ b/evaluation-job/Dockerfile.dev
@@ -35,7 +35,7 @@ COPY libs/amp-evaluation/src/ ./sdk/src/
 RUN pip install --no-cache-dir -e ./sdk
 
 # Install additional dependencies
-RUN pip install --no-cache-dir requests litellm==1.81.14
+RUN pip install --no-cache-dir requests "any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0"
 
 # Copy the job entrypoint
 COPY evaluation-job/main.py ./

--- a/evaluation-job/main.py
+++ b/evaluation-job/main.py
@@ -134,14 +134,6 @@ def configure_logging() -> None:
     handler.setFormatter(JsonFormatter(datefmt="%Y-%m-%dT%H:%M:%S"))
     logging.basicConfig(level=logging.INFO, handlers=[handler])
     logging.getLogger(__name__).setLevel(level)
-    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
-
-    try:
-        import litellm
-
-        litellm.suppress_debug_info = True
-    except ImportError:
-        pass
 
 
 def parse_args() -> argparse.Namespace:
@@ -516,30 +508,16 @@ def main() -> None:
 
     gateway_enabled = bool(llm_api_key and llm_api_base)
     if gateway_enabled:
-        import warnings
+        assert llm_api_base and llm_api_key
 
-        import litellm as _litellm
+        # Route every judge completion through the WSO2 gateway: the SDK sends
+        # each request to this base URL and the gateway api-key is injected as a
+        # request header on the underlying provider client by the evaluation lib.
+        from amp_evaluation.config import get_config
 
-        _litellm.api_key = "dummy-key"  # suppress Authorization: Bearer header
-        _litellm.api_base = llm_api_base
-        _litellm.headers = {"api-key": llm_api_key}  # type: ignore[assignment]  # WSO2 gateway auth header
-
-        # LiteLLM's Anthropic provider does not pick up litellm.headers (unlike every other
-        # provider which has `headers = headers or litellm.headers`). Wrap completion() so
-        # the gateway api-key is injected via extra_headers, which all providers honour.
-        _orig_completion = _litellm.completion
-        _gateway_extra_headers = {"api-key": llm_api_key}
-
-        def _completion_with_gateway_headers(*args, **kwargs):  # type: ignore[no-untyped-def]
-            eh = kwargs.get("extra_headers") or {}
-            kwargs["extra_headers"] = {**_gateway_extra_headers, **eh}
-            return _orig_completion(*args, **kwargs)
-
-        _litellm.completion = _completion_with_gateway_headers  # type: ignore[assignment]
-
-        # LiteLLM passes non-conforming objects to pydantic (wrong Choices subtype, 6-field
-        # Message vs the expected 10-field schema). Response content is unaffected.
-        warnings.filterwarnings("ignore", module="pydantic")
+        judge_cfg = get_config().llm_judge
+        judge_cfg.api_base = llm_api_base
+        judge_cfg.api_key = llm_api_key
 
         logger.info("Configured LLM client to route through OpenAI-compatible gateway at %s", llm_api_base)
 
@@ -619,7 +597,7 @@ def main() -> None:
         eval_type = evaluator.get("type")  # None for built-in, "code" or "llm_judge" for custom
 
         try:
-            # Ensure model has a LiteLLM provider prefix for LLM-judge evaluators.
+            # Ensure model has a provider prefix for LLM-judge evaluators.
             # Known providers have the prefix stored in the DB at creation time.
             # Unknown/legacy providers fall back to openai/ with a warning.
             if eval_type == "llm_judge" and gateway_enabled and "model" in config:

--- a/evaluation-job/main.py
+++ b/evaluation-job/main.py
@@ -506,6 +506,13 @@ def main() -> None:
     llm_api_key = os.environ.get("LLM_API_KEY")
     llm_api_base = os.environ.get("LLM_API_BASE")
 
+    # The two are injected together (URL as a workflow parameter, key from the
+    # Secret); exactly one being set means a broken deployment, so fail fast
+    # rather than silently running judges with no gateway and no provider key.
+    if bool(llm_api_key) != bool(llm_api_base):
+        logger.error("LLM_API_BASE and LLM_API_KEY must be set together for gateway routing")
+        sys.exit(1)
+
     gateway_enabled = bool(llm_api_key and llm_api_base)
     if gateway_enabled:
         assert llm_api_base and llm_api_key

--- a/evaluation-job/pyproject.toml
+++ b/evaluation-job/pyproject.toml
@@ -6,7 +6,7 @@ target-version = "py311"
 python_version = "3.11"
 
 [[tool.mypy.overrides]]
-module = ["litellm.*"]
+module = ["any_llm.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/evaluation-job/requirements.txt
+++ b/evaluation-job/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.31.0
-litellm==1.81.14
+any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0
 numpy>=2.2.0
 pandas>=2.2.0

--- a/libs/amp-evaluation/README.md
+++ b/libs/amp-evaluation/README.md
@@ -14,7 +14,7 @@ pip install amp-evaluation
 
 ```bash
 # For LLM-as-judge evaluators (multi-vendor LLM support)
-pip install litellm
+pip install 'any-llm-sdk[openai]'
 
 # For DeepEval evaluators
 pip install deepeval>=3.8.4
@@ -251,7 +251,7 @@ Use an LLM to evaluate agent outputs for subjective criteria that rule-based che
 2. **Level** auto-detected from first parameter type hint (`Trace`, `AgentTrace`, `LLMSpan`)
 3. **Mode** auto-detected from task parameter (same rules as regular evaluators)
 4. Framework auto-appends output format instructions to your prompt
-5. LLM called via [LiteLLM](https://docs.litellm.ai/) (supports 100+ providers)
+5. LLM called via [any-llm](https://github.com/mozilla-ai/any-llm) (supports many providers)
 6. Response validated with Pydantic (`score: 0.0–1.0`, `explanation: str`)
 7. On invalid output, retries with Pydantic error as context (like [Instructor](https://python.useinstructor.com/))
 
@@ -341,7 +341,7 @@ Response: {llm.output}"""
 
 ### Custom LLM Client
 
-Override `_call_llm_with_retry()` to use any LLM client instead of LiteLLM:
+Override `_call_llm_with_retry()` to use any LLM client instead of the default one:
 
 ```python
 class CustomLLMJudge(LLMAsJudgeEvaluator):
@@ -368,16 +368,16 @@ LLM-as-judge evaluators use `Param` descriptors:
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `model` | `gpt-4o-mini` | LiteLLM model identifier |
+| `model` | `gpt-4o-mini` | provider/model identifier |
 | `provider` | `openai` | LLM provider name |
 | `criteria` | `quality, accuracy, and helpfulness` | Evaluation criteria |
 | `temperature` | `0.0` | LLM temperature |
 | `max_tokens` | `1024` | Max tokens for response |
 | `max_retries` | `2` | Retries on invalid output |
 
-### LiteLLM Model Identifiers
+### Model Identifiers
 
-LiteLLM uses a `provider/model` format:
+Models use a `provider/model` format:
 
 | Provider | Example |
 |----------|---------|
@@ -552,7 +552,7 @@ Deterministic, fast, and free. No LLM calls required.
 
 #### LLM-as-Judge Evaluators
 
-Use an LLM to assess subjective quality. Require a configured LLM provider (see [LiteLLM Model Identifiers](#litellm-model-identifiers)). All accept a `threshold` param (default 0.5).
+Use an LLM to assess subjective quality. Require a configured LLM provider (see [Model Identifiers](#model-identifiers)). All accept a `threshold` param (default 0.5).
 
 **Quality** — Response clarity, structure, and communication effectiveness:
 

--- a/libs/amp-evaluation/pyproject.toml
+++ b/libs/amp-evaluation/pyproject.toml
@@ -24,14 +24,14 @@ dependencies = [
 
 [project.optional-dependencies]
 deepeval = ["deepeval>=3.8.4"]
-litellm = ["litellm==1.81.14"]
+any-llm = ["any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0"]
 dev = [
   "pytest>=7.0",
   "pytest-cov>=4.0",
   "black>=23.0",
   "ruff>=0.1.0",
   "deepeval>=3.8.4",
-  "litellm==1.81.14",
+  "any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0",
 ]
 
 [project.urls]
@@ -56,7 +56,7 @@ target-version = "py39"
 exclude = ["samples/"]
 
 [[tool.mypy.overrides]]
-module = ["deepeval.*", "litellm.*"]
+module = ["deepeval.*", "any_llm.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/libs/amp-evaluation/samples/07-llm-as-judge/README.md
+++ b/libs/amp-evaluation/samples/07-llm-as-judge/README.md
@@ -16,7 +16,7 @@ Shows how to use LLMs to evaluate agent outputs. Covers both class-based (`LLMAs
 
 1. You write `build_prompt()` -- return the evaluation prompt as a string
 2. The framework appends output format instructions automatically (JSON with `score` and `explanation`)
-3. The LLM is called via LiteLLM with JSON mode enabled
+3. The LLM is called via the configured LLM client with JSON mode enabled
 4. The response is validated with a Pydantic `JudgeOutput` model (`score: float`, `explanation: str`)
 5. On invalid output, the framework retries with the Pydantic error as context (like Instructor)
 6. The validated output becomes an `EvalResult`
@@ -24,11 +24,11 @@ Shows how to use LLMs to evaluate agent outputs. Covers both class-based (`LLMAs
 ## Prerequisites
 
 ```bash
-pip install amp-evaluation litellm
+pip install amp-evaluation 'any-llm-sdk[openai]'
 export OPENAI_API_KEY=sk-...  # or another LLM provider key
 ```
 
-LiteLLM supports many providers (OpenAI, Anthropic, Azure, etc.). Set the model identifier accordingly:
+The LLM client supports many providers (OpenAI, Anthropic, Azure, etc.). Install the matching extra (e.g. `any-llm-sdk[anthropic]`) and set the model identifier accordingly:
 - `gpt-4o`, `gpt-4o-mini` (OpenAI)
 - `anthropic/claude-sonnet-4-20250514` (Anthropic)
 - `azure/gpt-4o` (Azure OpenAI)
@@ -79,7 +79,7 @@ class MyJudge(LLMAsJudgeEvaluator):
 ## How to run
 
 ```bash
-pip install amp-evaluation litellm
+pip install amp-evaluation 'any-llm-sdk[openai]'
 export OPENAI_API_KEY=sk-...
 python run.py
 ```
@@ -106,6 +106,6 @@ Scores:
       [PASS] trace=... score=0.85
               Good accuracy
       [ SKIP] trace=...
-              litellm.AuthenticationError: ...
+              AuthenticationError: ...
   ...
 ```

--- a/libs/amp-evaluation/samples/07-llm-as-judge/evaluators.py
+++ b/libs/amp-evaluation/samples/07-llm-as-judge/evaluators.py
@@ -27,7 +27,7 @@ Demonstrates five patterns:
 LLM-as-judge evaluators write a build_prompt() method (or a prompt-building
 function for the decorator). The framework handles:
 - Appending output format instructions
-- Calling the LLM via LiteLLM
+- Calling the LLM via the configured LLM client
 - Validating the response with Pydantic (JudgeOutput model)
 - Retrying on invalid output with error context
 """
@@ -48,7 +48,7 @@ class ResponseQualityJudge(LLMAsJudgeEvaluator):
     """Uses an LLM to judge response quality."""
 
     name = "response-quality-judge"
-    model = "gpt-4o-mini"  # LiteLLM model identifier
+    model = "gpt-4o-mini"  # provider/model identifier
     criteria = "helpfulness, accuracy, and completeness"
 
     def build_prompt(self, trace: Trace, task: Optional[Task] = None) -> str:
@@ -128,7 +128,7 @@ class CustomClientJudge(LLMAsJudgeEvaluator):
         return f"Evaluate: {trace.input} -> {trace.output}"
 
     def _call_llm_with_retry(self, prompt: str) -> EvalResult:
-        """Override to use your own LLM client instead of LiteLLM.
+        """Override to use your own LLM client instead of the default one.
 
         Example with OpenAI client:
             import openai

--- a/libs/amp-evaluation/samples/07-llm-as-judge/requirements.txt
+++ b/libs/amp-evaluation/samples/07-llm-as-judge/requirements.txt
@@ -1,2 +1,2 @@
 amp-evaluation
-litellm
+any-llm-sdk[openai]

--- a/libs/amp-evaluation/samples/07-llm-as-judge/run.py
+++ b/libs/amp-evaluation/samples/07-llm-as-judge/run.py
@@ -18,7 +18,7 @@
 LLM-as-judge evaluators: Discover evaluators, run Monitor, handle missing API keys.
 
 This sample requires:
-  pip install litellm
+  pip install 'any-llm-sdk[openai]'
   export OPENAI_API_KEY=...  (or another LLM provider key)
 
 If the LLM API key is not set, the sample will still run but LLM-based
@@ -63,8 +63,8 @@ def main():
             print("Set OPENAI_API_KEY (or another provider key) to run LLM judges.")
     except Exception as e:
         print(f"Error running monitor: {e}")
-        print("\nEnsure litellm is installed and an API key is set:")
-        print("  pip install litellm")
+        print("\nEnsure the LLM client is installed and an API key is set:")
+        print("  pip install 'any-llm-sdk[openai]'")
         print("  export OPENAI_API_KEY=sk-...")
 
 

--- a/libs/amp-evaluation/src/amp_evaluation/config.py
+++ b/libs/amp-evaluation/src/amp_evaluation/config.py
@@ -85,6 +85,16 @@ class LLMJudgeConfig(BaseSettings):
         description="Default LLM model for all LLM-as-judge evaluators (overridable per-evaluator)",
     )
 
+    api_base: str = Field(
+        default="",
+        description="Optional gateway base URL all judge completions are routed through (empty = call providers directly)",
+    )
+
+    api_key: str = Field(
+        default="",
+        description="Optional gateway API key, injected as the 'api-key' auth header when api_base is set",
+    )
+
     model_config = SettingsConfigDict(
         env_prefix="AMP_LLM_JUDGE_",
         env_file=".env",

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -498,7 +498,7 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
     2. Level auto-detected from build_prompt() first param type hint
     3. Mode auto-detected from build_prompt() task param
     4. Framework appends output format instructions automatically
-    5. LLM called via LiteLLM, response validated with Pydantic JudgeOutput
+    5. LLM called via the configured LLM client, response validated with Pydantic JudgeOutput
     6. Retries on invalid output with Pydantic error as context (like Instructor)
 
     Example:
@@ -613,12 +613,45 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
             raise TypeError(f"build_prompt() must return a str, got {type(prompt).__name__}")
         return prompt
 
-    def _call_llm_with_retry(self, prompt: str) -> EvalResult:
-        """Call LLM via LiteLLM, validate with Pydantic, retry on failure."""
+    @staticmethod
+    def _gateway_kwargs() -> dict:
+        """Build per-call routing kwargs when a gateway is configured.
+
+        When ``llm_judge.api_base`` is set, every completion is routed through
+        that gateway and the configured key is injected as the ``api-key``
+        header on the underlying provider client. With no gateway configured
+        the providers are called directly (auth via their own env vars).
+        """
         try:
-            from litellm import completion
+            from ..config import get_config
+
+            cfg = get_config().llm_judge
+        except Exception:
+            return {}
+
+        if not cfg.api_base:
+            return {}
+
+        kwargs: dict = {"api_base": cfg.api_base}
+        if cfg.api_key:
+            # The gateway authenticates via the api-key header, but the provider
+            # SDK still requires a non-empty api_key to construct its client. Pass
+            # a placeholder bearer token (the gateway ignores it) and send the real
+            # key only in the api-key header.
+            kwargs["api_key"] = "gateway"
+            kwargs["client_args"] = {"default_headers": {"api-key": cfg.api_key}}
+        return kwargs
+
+    def _call_llm_with_retry(self, prompt: str) -> EvalResult:
+        """Call the LLM client, validate with Pydantic, retry on failure."""
+        try:
+            from any_llm import completion
         except ImportError:
-            raise ImportError("LiteLLM is required for LLM-as-judge evaluators. Install with: pip install litellm")
+            raise ImportError(
+                "The any-llm SDK is required for LLM-as-judge evaluators. Install with: pip install 'any-llm-sdk'"
+            )
+
+        gateway_kwargs = self._gateway_kwargs()
 
         last_error = None
         for attempt in range(self.max_retries + 1):
@@ -637,8 +670,8 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
                     messages=[{"role": "user", "content": prompt + retry_ctx}],
                     temperature=self.temperature,
                     max_tokens=self.max_tokens,
-                    response_format={"type": "json_object"},
-                    drop_params=True,
+                    response_format=JudgeOutput,
+                    **gateway_kwargs,
                 )
             except Exception as e:
                 last_error = str(e)

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -640,6 +640,9 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
             # key only in the api-key header.
             kwargs["api_key"] = "gateway"
             kwargs["client_args"] = {"default_headers": {"api-key": cfg.api_key}}
+        # When api_base is set without a gateway key, auth is intentionally left
+        # to the provider's own env vars — no placeholder is forced, so an
+        # env-based provider key is not overridden.
         return kwargs
 
     def _call_llm_with_retry(self, prompt: str) -> EvalResult:

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/builtin/__init__.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/builtin/__init__.py
@@ -233,9 +233,9 @@ def builtin_evaluator_catalog(mode: Optional[str] = None) -> List[EvaluatorInfo]
 
 # Supported LLM providers for LLM-as-judge evaluation.
 # Models are curated chat/completion models only — no audio/realtime/vision/embedding/image.
-# Model names use provider/model format (litellm-compatible identifiers).
+# Model names use provider/model format.
 # Ordered powerful → lightweight within each provider.
-# Curated from litellm.model_cost (2026-02). Review periodically when major model releases are announced.
+# Curated from each provider's published model catalog (2026-02). Review periodically when major model releases are announced.
 _SUPPORTED_PROVIDERS: Dict[str, dict] = {
     "openai": {
         "display_name": "OpenAI",
@@ -322,7 +322,7 @@ def get_llm_provider_catalog() -> List[LLMProviderInfo]:
 
     Provider metadata (env vars, models, display names) is defined in _SUPPORTED_PROVIDERS.
     The env_var on each LLMConfigField is the environment variable the platform must set
-    on the evaluation job process — litellm reads these natively.
+    on the evaluation job process — the LLM client reads these natively.
 
     Returns:
         List of LLMProviderInfo, one per supported provider.

--- a/libs/amp-evaluation/src/amp_evaluation/models.py
+++ b/libs/amp-evaluation/src/amp_evaluation/models.py
@@ -459,8 +459,8 @@ class LLMConfigField:
       "password"  -> secret (mask in UI, do not log, treat as credential)
       "text"      -> plain text (e.g. api_base URL, api_version string)
 
-    Values come from litellm's provider_create_fields.json — no custom
-    secret detection logic needed.
+    Values are curated from each provider's credential requirements — no
+    custom secret detection logic needed.
     """
 
     key: str  # "api_key", "api_base"

--- a/libs/amp-evaluation/tests/test_llm_as_judge.py
+++ b/libs/amp-evaluation/tests/test_llm_as_judge.py
@@ -17,7 +17,7 @@
 """
 Tests for the LLM-as-judge evaluator redesign.
 
-All tests mock litellm.completion — no actual LLM calls.
+All tests mock any_llm.completion — no actual LLM calls.
 """
 
 import json
@@ -27,9 +27,9 @@ from pydantic import ValidationError
 from unittest.mock import patch, MagicMock
 from typing import Optional
 
-# Create a mock litellm module so we can patch it
-_mock_litellm = MagicMock()
-sys.modules.setdefault("litellm", _mock_litellm)
+# Create a mock LLM client module so we can patch it
+_mock_any_llm = MagicMock()
+sys.modules.setdefault("any_llm", _mock_any_llm)
 
 from amp_evaluation.evaluators.base import (  # noqa: E402
     LLMAsJudgeEvaluator,
@@ -60,16 +60,16 @@ def _make_trace(**overrides):
     return Trace(**defaults)
 
 
-def _mock_litellm_response(score: float, explanation: str = "Good"):
-    """Create a mock litellm completion response."""
+def _mock_response(score: float, explanation: str = "Good"):
+    """Create a mock completion response."""
     mock_response = MagicMock()
     mock_response.choices = [MagicMock()]
     mock_response.choices[0].message.content = json.dumps({"score": score, "explanation": explanation})
     return mock_response
 
 
-def _mock_litellm_raw_response(content: str):
-    """Create a mock litellm response with raw content string."""
+def _mock_raw_response(content: str):
+    """Create a mock response with raw content string."""
     mock_response = MagicMock()
     mock_response.choices = [MagicMock()]
     mock_response.choices[0].message.content = content
@@ -255,16 +255,16 @@ class TestPydanticOutputValidation:
 
 
 # =============================================================================
-# End-to-end pipeline (mocked LiteLLM)
+# End-to-end pipeline (mocked LLM client)
 # =============================================================================
 
 
 class TestEndToEnd:
-    """Test full LLM-as-judge pipeline with mocked LiteLLM."""
+    """Test full LLM-as-judge pipeline with mocked LLM client."""
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_full_pipeline(self, mock_completion):
-        mock_completion.return_value = _mock_litellm_response(0.85, "Well done")
+        mock_completion.return_value = _mock_response(0.85, "Well done")
 
         evaluator = _SimpleJudge()
         trace = _make_trace()
@@ -276,10 +276,10 @@ class TestEndToEnd:
         assert "model=gpt-4o-mini" in result.explanation
         mock_completion.assert_called_once()
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_output_format_auto_appended(self, mock_completion):
         """Verify prompt sent to LLM contains JSON format instructions."""
-        mock_completion.return_value = _mock_litellm_response(0.9, "Great")
+        mock_completion.return_value = _mock_response(0.9, "Great")
 
         evaluator = _SimpleJudge()
         trace = _make_trace()
@@ -291,7 +291,7 @@ class TestEndToEnd:
         assert '"explanation"' in prompt_sent
         assert "JSON" in prompt_sent
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_build_prompt_receives_correct_types(self, mock_completion):
         """Verify build_prompt receives correct types."""
         received_args = []
@@ -303,7 +303,7 @@ class TestEndToEnd:
                 received_args.append({"trace": trace, "task": task})
                 return "Evaluate this"
 
-        mock_completion.return_value = _mock_litellm_response(0.9, "OK")
+        mock_completion.return_value = _mock_response(0.9, "OK")
 
         evaluator = TraceJudge()
         trace = _make_trace()
@@ -315,13 +315,13 @@ class TestEndToEnd:
         assert isinstance(received_args[0]["trace"], Trace)
         assert isinstance(received_args[0]["task"], Task)
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_retry_on_invalid_output(self, mock_completion):
         """Test retry sends Pydantic error on invalid first response."""
         # First call: invalid, second call: valid
         mock_completion.side_effect = [
-            _mock_litellm_raw_response('{"score": 99}'),  # Invalid
-            _mock_litellm_response(0.8, "Retry worked"),  # Valid
+            _mock_raw_response('{"score": 99}'),  # Invalid
+            _mock_response(0.8, "Retry worked"),  # Valid
         ]
 
         evaluator = _SimpleJudge()
@@ -337,10 +337,10 @@ class TestEndToEnd:
         second_prompt = mock_completion.call_args_list[1][1]["messages"][0]["content"]
         assert "invalid" in second_prompt.lower() or "Previous response" in second_prompt
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_all_retries_exhausted(self, mock_completion):
         """Test skipped result when all retries fail."""
-        mock_completion.return_value = _mock_litellm_raw_response('{"bad": "json"}')
+        mock_completion.return_value = _mock_raw_response('{"bad": "json"}')
 
         evaluator = _SimpleJudge(max_retries=1)
         trace = _make_trace()
@@ -351,10 +351,10 @@ class TestEndToEnd:
         assert "failed after 2 attempts" in result.skip_reason.lower()
         assert mock_completion.call_count == 2  # 1 initial + 1 retry
 
-    @patch("litellm.completion")
-    def test_custom_model_passed_to_litellm(self, mock_completion):
+    @patch("any_llm.completion")
+    def test_custom_model_passed_to_client(self, mock_completion):
         """Test that custom model identifier is passed through."""
-        mock_completion.return_value = _mock_litellm_response(0.7, "OK")
+        mock_completion.return_value = _mock_response(0.7, "OK")
 
         evaluator = _SimpleJudge(model="anthropic/claude-sonnet-4-20250514")
         trace = _make_trace()
@@ -363,10 +363,10 @@ class TestEndToEnd:
         call_args = mock_completion.call_args
         assert call_args[1]["model"] == "anthropic/claude-sonnet-4-20250514"
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_temperature_and_max_tokens_passed(self, mock_completion):
         """Test that temperature and max_tokens are forwarded."""
-        mock_completion.return_value = _mock_litellm_response(0.7, "OK")
+        mock_completion.return_value = _mock_response(0.7, "OK")
 
         evaluator = _SimpleJudge(temperature=0.5, max_tokens=2048)
         trace = _make_trace()
@@ -423,9 +423,9 @@ class TestLLMJudgeDecorator:
 
         assert experiment_judge._supported_eval_modes == [EvalMode.EXPERIMENT]
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_decorator_end_to_end(self, mock_completion):
-        mock_completion.return_value = _mock_litellm_response(0.9, "Excellent")
+        mock_completion.return_value = _mock_response(0.9, "Excellent")
 
         @llm_judge
         def quality_judge(trace: Trace) -> str:
@@ -447,9 +447,9 @@ class TestLLMJudgeDecorator:
 class TestSubclassing:
     """Test subclassing LLMAsJudgeEvaluator."""
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_custom_build_prompt_called(self, mock_completion):
-        mock_completion.return_value = _mock_litellm_response(0.75, "Custom")
+        mock_completion.return_value = _mock_response(0.75, "Custom")
 
         class CustomJudge(LLMAsJudgeEvaluator):
             name = "custom"
@@ -474,7 +474,7 @@ class TestSubclassing:
                 return f"Evaluate: {trace.output}"
 
             def _call_llm_with_retry(self, prompt: str) -> EvalResult:
-                # Custom LLM logic — no litellm needed
+                # Custom LLM logic — no shared LLM client needed
                 return EvalResult(
                     score=0.95,
                     passed=True,
@@ -724,10 +724,10 @@ class TestFunctionLLMJudgeParams:
 
         assert my_judge.description == "Check response quality."
 
-    @patch("litellm.completion")
+    @patch("any_llm.completion")
     def test_end_to_end_with_params(self, mock_completion):
         """Full evaluate() call with Param injection into prompt."""
-        mock_completion.return_value = _mock_litellm_response(0.9, "Great")
+        mock_completion.return_value = _mock_response(0.9, "Great")
 
         @llm_judge
         def my_judge(

--- a/libs/amp-evaluation/tests/test_llm_as_judge_builtins.py
+++ b/libs/amp-evaluation/tests/test_llm_as_judge_builtins.py
@@ -28,9 +28,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Ensure litellm is mocked before imports
-_mock_litellm = MagicMock()
-sys.modules.setdefault("litellm", _mock_litellm)
+# Ensure the LLM client is mocked before imports
+_mock_any_llm = MagicMock()
+sys.modules.setdefault("any_llm", _mock_any_llm)
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -1173,7 +1173,7 @@ class TestScoreRangeAndPolarity:
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = json.dumps({"score": 0.8, "explanation": "ok"})
 
-        with patch("litellm.completion", return_value=mock_response) as mock_completion:
+        with patch("any_llm.completion", return_value=mock_response) as mock_completion:
             ev = HelpfulnessEvaluator()
             ev.evaluate(_make_trace())
 

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Gateway-routing tests for LLM-as-judge.
+
+When the framework is configured with a gateway base URL and API key, the
+judge must route every completion through that gateway: the base URL is passed
+as ``api_base`` and the key is injected as a per-provider auth header via
+``client_args``. No actual LLM calls are made — the LLM client is mocked.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock the LLM client module so base.py's import resolves to a stub we control.
+_mock_any_llm = MagicMock()
+sys.modules.setdefault("any_llm", _mock_any_llm)
+
+from amp_evaluation.config import reload_config  # noqa: E402
+from amp_evaluation.evaluators.base import JudgeOutput, LLMAsJudgeEvaluator  # noqa: E402
+from amp_evaluation.trace import TokenUsage, Trace, TraceMetrics  # noqa: E402
+
+
+def _make_trace() -> Trace:
+    return Trace(
+        trace_id="t-1",
+        input="What is AI?",
+        output="AI is artificial intelligence.",
+        metrics=TraceMetrics(
+            total_duration_ms=100.0,
+            token_usage=TokenUsage(input_tokens=10, output_tokens=20, total_tokens=30),
+        ),
+        spans=[],
+    )
+
+
+def _response(score: float = 0.9, explanation: str = "ok") -> MagicMock:
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = json.dumps({"score": score, "explanation": explanation})
+    return resp
+
+
+class _SimpleJudge(LLMAsJudgeEvaluator):
+    name = "simple-judge"
+
+    def build_prompt(self, trace: Trace, task=None) -> str:
+        return f"Evaluate: {trace.output}"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_gateway_env():
+    """Ensure a clean gateway config around each test, then restore."""
+    keys = ("AMP_LLM_JUDGE_API_BASE", "AMP_LLM_JUDGE_API_KEY")
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    reload_config()
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    reload_config()
+
+
+@patch("any_llm.completion")
+def test_gateway_config_routes_via_api_base_and_auth_header(mock_completion):
+    mock_completion.return_value = _response()
+    os.environ["AMP_LLM_JUDGE_API_BASE"] = "https://gateway.example/v1"
+    os.environ["AMP_LLM_JUDGE_API_KEY"] = "secret-key"
+    reload_config()
+
+    _SimpleJudge(model="anthropic/claude-sonnet-4-6").evaluate(_make_trace())
+
+    mock_completion.assert_called_once()
+    kwargs = mock_completion.call_args.kwargs
+    # Structured output is requested via the Pydantic model (portable across
+    # providers) rather than {"type": "json_object"} (rejected by some, e.g.
+    # Anthropic).
+    assert kwargs["response_format"] is JudgeOutput
+    assert kwargs["api_base"] == "https://gateway.example/v1"
+    assert kwargs["client_args"] == {"default_headers": {"api-key": "secret-key"}}
+    # The provider SDK requires a non-empty api_key to construct even though the
+    # gateway authenticates via the api-key header; a placeholder is passed and
+    # the real key is never sent as the bearer token.
+    assert kwargs["api_key"]
+    assert kwargs["api_key"] != "secret-key"
+
+
+@patch("any_llm.completion")
+def test_without_gateway_config_no_api_base_or_client_args(mock_completion):
+    mock_completion.return_value = _response()
+
+    _SimpleJudge(model="openai/gpt-4o-mini").evaluate(_make_trace())
+
+    mock_completion.assert_called_once()
+    kwargs = mock_completion.call_args.kwargs
+    assert "api_base" not in kwargs
+    assert "client_args" not in kwargs


### PR DESCRIPTION
## Purpose
The LLM-as-judge evaluators depended on a single monolithic multi-provider client wired in through global state and a runtime monkeypatch. This moves them onto the any-llm SDK, which wraps the official provider SDKs behind one OpenAI-compatible `completion()` interface, and makes the gateway routing explicit and configuration-driven.

Related issue: https://github.com/wso2/agent-manager/issues/1012

## Goals
Run LLM-as-judge evaluations through the any-llm client across all supported providers, with gateway routing (base URL + auth header) carried in configuration rather than global client state, and with no behavioural regression for existing judges.

## Approach
- `libs/amp-evaluation/.../evaluators/base.py` now calls `any_llm.completion`. Structured output is requested with the `JudgeOutput` Pydantic model instead of `{"type": "json_object"}` — the latter is rejected by some providers (e.g. Anthropic) while the Pydantic schema is honoured across all of them and still returns JSON content the existing validator parses.
- Gateway routing moves into `LLMJudgeConfig` (`api_base`, `api_key`). The evaluator reads them per call and passes `api_base` plus a `client_args` default-headers entry so the `api-key` header reaches each provider's client natively. A placeholder bearer token is also passed because the provider SDK requires a non-empty `api_key` to construct, even though the gateway authenticates via the header. The job wiring in `evaluation-job/main.py` drops to a few lines (the previous global config + `completion()` monkeypatch + warning suppression are gone).
- Packaging swaps the provider dependency to `any-llm-sdk` with the provider extras the gateway supports (OpenAI, Anthropic, Gemini, Groq, Mistral, Bedrock, Azure OpenAI, Azure AI Foundry) across the job image, the SDK extras, and the dev tooling. The catalog provider-prefix map is updated to the matching provider identifiers, and the evaluator editor's advertised package list now lists the new client.

No user-facing UI changes beyond one entry in the evaluator editor's supported-packages list.

## User stories
N/A — internal/runtime change to how judge evaluations call the model.

## Release note
LLM-as-judge evaluations now run through the any-llm client, with gateway routing carried in configuration and portable structured-output handling across providers.

## Documentation
N/A — no documented behaviour changes; the SDK README and the LLM-as-judge sample were updated in-tree.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Full `amp-evaluation` suite passes. The LLM-as-judge mocks were re-pointed to the new client, and a new `test_llm_judge_gateway.py` adds coverage for gateway `api_base`, the auth header, the placeholder bearer, and Pydantic structured-output routing.
 - Integration tests
   > Validated against live models out of band: OpenAI (`gpt-4o-mini`) and Anthropic (`claude-haiku-4-5`) judges return correct scores (good answer 1.0, bad answer 0.0), and a local OpenAI-compatible mock-gateway run confirms the real key reaches the server in the `api-key` header (not the bearer). A smoke test against the deployed gateway remains as a pre-release check.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed. Go builds and `gofmt`/`gofumpt` are clean on the touched files.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
The `07-llm-as-judge` sample's install instructions and docstrings were updated to the new client.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no schema or data migration. Provider/model identifiers are unchanged (still `provider/model`).

## Test environment
Verified locally on macOS (Darwin) with Python 3.13; any-llm-sdk 1.16.0 with the OpenAI and Anthropic provider extras.

## Learning
any-llm exposes each provider through its official SDK, so behaviour is provider-specific: `response_format` JSON-object mode is not universal (Anthropic rejects it) and the provider clients require a non-empty api_key to construct even when auth rides in a custom header. Both were surfaced by running real provider and mock-gateway calls rather than relying on mocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gateway-based routing for LLM judge evaluations with configurable API base URL and authentication credentials

* **Refactor**
  * LLM-as-judge evaluators migrated to use any-llm SDK instead of LiteLLM for model inference

* **Documentation**
  * Updated sample code, configuration guides, and prerequisites documentation for LLM-as-judge evaluators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->