### PR TITLE
Support all providers for gateway-routed LLM judges

### DIFF
--- a/evaluation-job/Dockerfile.dev
+++ b/evaluation-job/Dockerfile.dev
@@ -35,7 +35,7 @@ COPY libs/amp-evaluation/src/ ./sdk/src/
 RUN pip install --no-cache-dir -e ./sdk
 
 # Install additional dependencies
-RUN pip install --no-cache-dir requests "any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0"
+RUN pip install --no-cache-dir requests "any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0" "aiohttp>=3.9"
 
 # Copy the job entrypoint
 COPY evaluation-job/main.py ./

--- a/evaluation-job/requirements.txt
+++ b/evaluation-job/requirements.txt
@@ -1,4 +1,6 @@
 requests>=2.31.0
 any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0
+# any-llm's azure (Azure AI Foundry) provider makes async calls but does not pull an async HTTP backend.
+aiohttp>=3.9
 numpy>=2.2.0
 pandas>=2.2.0

--- a/libs/amp-evaluation/pyproject.toml
+++ b/libs/amp-evaluation/pyproject.toml
@@ -61,7 +61,7 @@ target-version = "py39"
 exclude = ["samples/"]
 
 [[tool.mypy.overrides]]
-module = ["deepeval.*", "any_llm.*"]
+module = ["deepeval.*", "any_llm.*", "boto3.*", "httpx.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/libs/amp-evaluation/pyproject.toml
+++ b/libs/amp-evaluation/pyproject.toml
@@ -24,7 +24,11 @@ dependencies = [
 
 [project.optional-dependencies]
 deepeval = ["deepeval>=3.8.4"]
-any-llm = ["any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0"]
+any-llm = [
+  "any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0",
+  # any-llm's azure (Azure AI Foundry) provider makes async calls but does not pull an async HTTP backend.
+  "aiohttp>=3.9",
+]
 dev = [
   "pytest>=7.0",
   "pytest-cov>=4.0",
@@ -32,6 +36,7 @@ dev = [
   "ruff>=0.1.0",
   "deepeval>=3.8.4",
   "any-llm-sdk[openai,anthropic,gemini,groq,mistral,bedrock,azureopenai,azure]==1.16.0",
+  "aiohttp>=3.9",
 ]
 
 [project.urls]

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -662,6 +662,29 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
         elif provider == "groq":
             # any-llm's Groq provider ignores api_base; route via base_url instead.
             return {"api_key": "gateway", "client_args": {"base_url": cfg.api_base, "default_headers": header}}
+        elif provider == "bedrock":
+            # boto3 has no default_headers hook. Build a client pointed at the
+            # gateway with dummy credentials (the gateway ignores the SigV4
+            # signature and authenticates via the api-key header) and inject that
+            # header through a botocore before-send handler.
+            import os
+
+            import boto3
+
+            key = cfg.api_key
+            bedrock_client = boto3.client(
+                "bedrock-runtime",
+                endpoint_url=cfg.api_base,
+                region_name=os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1",
+                aws_access_key_id="gateway",
+                aws_secret_access_key="gateway",
+            )
+
+            def _inject_gateway_header(request, **_):
+                request.headers["api-key"] = key
+
+            bedrock_client.meta.events.register("before-send.bedrock-runtime", _inject_gateway_header)
+            return {"client_args": {"client": bedrock_client}}
         else:
             # openai, anthropic, and other OpenAI-style clients accept default_headers.
             client_args = {"default_headers": header}

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -614,12 +614,13 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
         return prompt
 
     @staticmethod
-    def _gateway_kwargs() -> dict:
+    def _gateway_kwargs(model: str) -> dict:
         """Build per-call routing kwargs when a gateway is configured.
 
         When ``llm_judge.api_base`` is set, every completion is routed through
-        that gateway and the configured key is injected as the ``api-key``
-        header on the underlying provider client. With no gateway configured
+        that gateway, authenticated with the gateway ``api-key`` header. The
+        mechanism for attaching that header differs by provider SDK, so this
+        dispatches on the model's provider prefix. With no gateway configured
         the providers are called directly (auth via their own env vars).
         """
         try:
@@ -632,18 +633,40 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
         if not cfg.api_base:
             return {}
 
-        kwargs: dict = {"api_base": cfg.api_base}
-        if cfg.api_key:
-            # The gateway authenticates via the api-key header, but the provider
-            # SDK still requires a non-empty api_key to construct its client. Pass
-            # a placeholder bearer token (the gateway ignores it) and send the real
-            # key only in the api-key header.
-            kwargs["api_key"] = "gateway"
-            kwargs["client_args"] = {"default_headers": {"api-key": cfg.api_key}}
-        # When api_base is set without a gateway key, auth is intentionally left
-        # to the provider's own env vars — no placeholder is forced, so an
-        # env-based provider key is not overridden.
-        return kwargs
+        # No gateway key: auth is intentionally left to the provider's own env
+        # vars — don't force a placeholder that would override an env-based key.
+        if not cfg.api_key:
+            return {"api_base": cfg.api_base}
+
+        provider = model.replace(":", "/").split("/", 1)[0].lower()
+        header = {"api-key": cfg.api_key}
+
+        # Azure SDKs send their api_key in the "api-key" header natively, which
+        # is exactly the gateway's auth header — pass the real key straight
+        # through (a placeholder would be sent as the gateway credential).
+        if provider in ("azureopenai", "azure"):
+            return {"api_base": cfg.api_base, "api_key": cfg.api_key}
+
+        # Other providers authenticate elsewhere (bearer / x-api-key / query
+        # param), so the gateway api-key must be injected as an explicit request
+        # header. The SDK still needs a non-empty api_key to construct its
+        # client, so pass a placeholder; the header carries the real key.
+        if provider == "gemini":
+            # google-genai takes custom headers via http_options, not default_headers.
+            client_args: dict = {"http_options": {"headers": header}}
+        elif provider == "mistral":
+            # The Mistral SDK only accepts headers through a custom http client.
+            import httpx
+
+            client_args = {"async_client": httpx.AsyncClient(headers=header)}
+        elif provider == "groq":
+            # any-llm's Groq provider ignores api_base; route via base_url instead.
+            return {"api_key": "gateway", "client_args": {"base_url": cfg.api_base, "default_headers": header}}
+        else:
+            # openai, anthropic, and other OpenAI-style clients accept default_headers.
+            client_args = {"default_headers": header}
+
+        return {"api_base": cfg.api_base, "api_key": "gateway", "client_args": client_args}
 
     def _call_llm_with_retry(self, prompt: str) -> EvalResult:
         """Call the LLM client, validate with Pydantic, retry on failure."""
@@ -654,7 +677,7 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
                 "The any-llm SDK is required for LLM-as-judge evaluators. Install with: pip install 'any-llm-sdk'"
             )
 
-        gateway_kwargs = self._gateway_kwargs()
+        gateway_kwargs = self._gateway_kwargs(self.model)
 
         last_error = None
         for attempt in range(self.max_retries + 1):

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -702,40 +702,70 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
 
         gateway_kwargs = self._gateway_kwargs(self.model)
 
-        last_error = None
-        for attempt in range(self.max_retries + 1):
-            retry_ctx = ""
-            if last_error and attempt > 0:
-                retry_ctx = (
-                    f"\n\n[IMPORTANT: Your previous response was invalid: {last_error}. "
-                    f"You MUST respond with ONLY a JSON object containing exactly two fields:\n"
-                    f'{{"explanation": "<your analysis>", "score": <float between 0.0 and 1.0>}}\n'
-                    f"The 'score' MUST be a top-level numeric field in the JSON, NOT embedded in the explanation text.]"
-                )
+        try:
+            last_error = None
+            for attempt in range(self.max_retries + 1):
+                retry_ctx = ""
+                if last_error and attempt > 0:
+                    retry_ctx = (
+                        f"\n\n[IMPORTANT: Your previous response was invalid: {last_error}. "
+                        f"You MUST respond with ONLY a JSON object containing exactly two fields:\n"
+                        f'{{"explanation": "<your analysis>", "score": <float between 0.0 and 1.0>}}\n'
+                        f"The 'score' MUST be a top-level numeric field in the JSON, NOT embedded in the explanation text.]"
+                    )
 
+                try:
+                    response = completion(
+                        model=self.model,
+                        messages=[{"role": "user", "content": prompt + retry_ctx}],
+                        temperature=self.temperature,
+                        max_tokens=self.max_tokens,
+                        response_format=JudgeOutput,
+                        **gateway_kwargs,
+                    )
+                except Exception as e:
+                    last_error = str(e)
+                    continue
+
+                content = response.choices[0].message.content
+                result, error = self._parse_and_validate(content)
+                if result is not None:
+                    return result
+                last_error = error
+
+            # All retries exhausted — this is an infrastructure failure, not a genuine score
+            return EvalResult.skip(
+                f"LLM judge failed after {self.max_retries + 1} attempts: {last_error} [model={self.model}]"
+            )
+        finally:
+            self._close_gateway_client(gateway_kwargs)
+
+    @staticmethod
+    def _close_gateway_client(gateway_kwargs: dict) -> None:
+        """Release any per-call client built for gateway routing.
+
+        The Mistral path supplies a custom ``httpx.AsyncClient`` and the Bedrock
+        path a boto3 client; any-llm does not take ownership of either, so they
+        must be closed here to avoid leaking sockets across repeated judge runs.
+        """
+        client_args = gateway_kwargs.get("client_args") or {}
+
+        async_client = client_args.get("async_client")
+        if async_client is not None:
             try:
-                response = completion(
-                    model=self.model,
-                    messages=[{"role": "user", "content": prompt + retry_ctx}],
-                    temperature=self.temperature,
-                    max_tokens=self.max_tokens,
-                    response_format=JudgeOutput,
-                    **gateway_kwargs,
-                )
-            except Exception as e:
-                last_error = str(e)
-                continue
+                import asyncio
 
-            content = response.choices[0].message.content
-            result, error = self._parse_and_validate(content)
-            if result is not None:
-                return result
-            last_error = error
+                asyncio.run(async_client.aclose())
+            except Exception:
+                pass
 
-        # All retries exhausted — this is an infrastructure failure, not a genuine score
-        return EvalResult.skip(
-            f"LLM judge failed after {self.max_retries + 1} attempts: {last_error} [model={self.model}]"
-        )
+        boto_client = client_args.get("client")
+        close = getattr(boto_client, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
 
     def _parse_and_validate(self, content: str) -> Tuple[Optional[EvalResult], Optional[str]]:
         """

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -187,6 +187,22 @@ def test_gateway_kwargs_azure_foundry_passes_real_key_as_apikey():
     assert kw == {"api_base": "https://gw.example/v1", "api_key": "secret-key"}
 
 
+def test_gateway_kwargs_bedrock_injects_header_via_boto3_client():
+    boto3 = pytest.importorskip("boto3")  # noqa: F841 -- skip when bedrock extra absent
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("bedrock/anthropic.claude-3-5-sonnet")
+    client = kw["client_args"]["client"]
+    assert client.meta.endpoint_url == "https://gw.example/v1"
+
+    # The before-send handler injects the gateway api-key header.
+    class _Req:
+        headers: dict = {}
+
+    req = _Req()
+    client.meta.events.emit("before-send.bedrock-runtime", request=req)
+    assert req.headers["api-key"] == "secret-key"
+
+
 def test_gateway_kwargs_supports_colon_separator():
     _set_gateway()
     kw = LLMAsJudgeEvaluator._gateway_kwargs("gemini:gemini-2.5-flash")

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -157,8 +157,7 @@ def test_gateway_kwargs_gemini_uses_http_options():
 
 
 def test_gateway_kwargs_mistral_uses_async_client_headers():
-    import httpx
-
+    httpx = pytest.importorskip("httpx")  # skip when the mistral extra is absent
     _set_gateway()
     kw = LLMAsJudgeEvaluator._gateway_kwargs("mistral/mistral-small-latest")
     client = kw["client_args"]["async_client"]

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -117,3 +117,85 @@ def test_without_gateway_config_no_api_base_or_client_args(mock_completion):
     kwargs = mock_completion.call_args.kwargs
     assert "api_base" not in kwargs
     assert "client_args" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Per-provider header injection. The api-key header must reach every provider's
+# client, but the constructor kwarg differs by SDK (verified against real
+# clients): default_headers for OpenAI/Anthropic, http_options for Gemini, a
+# custom async http client for Mistral, and base_url+default_headers for Groq
+# (whose any-llm provider ignores api_base).
+# ---------------------------------------------------------------------------
+
+
+def _set_gateway(base="https://gw.example/v1", key="secret-key"):
+    os.environ["AMP_LLM_JUDGE_API_BASE"] = base
+    os.environ["AMP_LLM_JUDGE_API_KEY"] = key
+    reload_config()
+
+
+def test_gateway_kwargs_openai_uses_default_headers():
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("openai/gpt-4o-mini")
+    assert kw["api_base"] == "https://gw.example/v1"
+    assert kw["api_key"] == "gateway"
+    assert kw["client_args"] == {"default_headers": {"api-key": "secret-key"}}
+
+
+def test_gateway_kwargs_anthropic_uses_default_headers():
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("anthropic/claude-haiku-4-5")
+    assert kw["api_base"] == "https://gw.example/v1"
+    assert kw["client_args"] == {"default_headers": {"api-key": "secret-key"}}
+
+
+def test_gateway_kwargs_gemini_uses_http_options():
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("gemini/gemini-2.5-flash")
+    assert kw["api_base"] == "https://gw.example/v1"
+    assert kw["client_args"] == {"http_options": {"headers": {"api-key": "secret-key"}}}
+
+
+def test_gateway_kwargs_mistral_uses_async_client_headers():
+    import httpx
+
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("mistral/mistral-small-latest")
+    client = kw["client_args"]["async_client"]
+    assert isinstance(client, httpx.AsyncClient)
+    assert client.headers["api-key"] == "secret-key"
+
+
+def test_gateway_kwargs_groq_routes_via_base_url():
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("groq/llama-3.3-70b-versatile")
+    assert kw["client_args"]["base_url"] == "https://gw.example/v1"
+    assert kw["client_args"]["default_headers"] == {"api-key": "secret-key"}
+
+
+def test_gateway_kwargs_azureopenai_passes_real_key_as_apikey():
+    # Azure OpenAI sends api_key in the api-key header natively, so the real
+    # gateway key is passed through directly (no placeholder, no client_args).
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("azureopenai/gpt-4o-mini")
+    assert kw == {"api_base": "https://gw.example/v1", "api_key": "secret-key"}
+
+
+def test_gateway_kwargs_azure_foundry_passes_real_key_as_apikey():
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("azure/some-model")
+    assert kw == {"api_base": "https://gw.example/v1", "api_key": "secret-key"}
+
+
+def test_gateway_kwargs_supports_colon_separator():
+    _set_gateway()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("gemini:gemini-2.5-flash")
+    assert kw["client_args"] == {"http_options": {"headers": {"api-key": "secret-key"}}}
+
+
+def test_gateway_kwargs_no_key_defers_to_provider_env():
+    os.environ["AMP_LLM_JUDGE_API_BASE"] = "https://gw.example/v1"
+    os.environ.pop("AMP_LLM_JUDGE_API_KEY", None)
+    reload_config()
+    kw = LLMAsJudgeEvaluator._gateway_kwargs("openai/gpt-4o-mini")
+    assert kw == {"api_base": "https://gw.example/v1"}

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -202,6 +202,19 @@ def test_gateway_kwargs_bedrock_injects_header_via_boto3_client():
     assert req.headers["api-key"] == "secret-key"
 
 
+def test_close_gateway_client_closes_mistral_async_client():
+    httpx = pytest.importorskip("httpx")
+    client = httpx.AsyncClient()
+    LLMAsJudgeEvaluator._close_gateway_client({"client_args": {"async_client": client}})
+    assert client.is_closed
+
+
+def test_close_gateway_client_is_noop_without_a_client():
+    # Providers that use default_headers (no async_client/client) must not error.
+    LLMAsJudgeEvaluator._close_gateway_client({"client_args": {"default_headers": {"api-key": "x"}}})
+    LLMAsJudgeEvaluator._close_gateway_client({})
+
+
 def test_gateway_kwargs_supports_colon_separator():
     _set_gateway()
     kw = LLMAsJudgeEvaluator._gateway_kwargs("gemini:gemini-2.5-flash")


### PR DESCRIPTION
## Purpose
Follow-up to #1010. When LLM-as-judge evaluations run through the gateway, the auth key must be attached to every provider's request, but the underlying SDKs expose no common mechanism for it. The initial migration only emitted the OpenAI/Anthropic shape, so judges on the other providers failed at client construction (e.g. `Client.__init__() got an unexpected keyword argument 'default_headers'` for Gemini/Mistral). This makes gateway routing work for all supported providers and adds Bedrock.

Resolves the gateway-routing gap left by #1010.

## Goals
Run gateway-routed LLM-as-judge evaluations on every supported provider — OpenAI, Anthropic, Gemini, Groq, Mistral, Azure OpenAI, Azure AI Foundry, and Bedrock — with the gateway auth header correctly delivered for each.

## Approach
`_gateway_kwargs()` now dispatches on the model's provider prefix, because the way to attach a custom request header differs by SDK (each was verified against the real provider client over a local mock gateway):
- **OpenAI / Anthropic** and other OpenAI-style clients → `default_headers`.
- **Gemini** → `http_options.headers` (google-genai ignores `default_headers`).
- **Mistral** → a custom async HTTP client carrying the header (its client accepts headers no other way).
- **Groq** → `base_url` in `client_args`, because the provider ignores `api_base`.
- **Azure OpenAI / Azure AI Foundry** → the real key is passed as `api_key`, which those SDKs send in the `api-key` header natively (a placeholder would be sent as the gateway credential instead).
- **Bedrock** → boto3 has no header hook, so a `bedrock-runtime` client is built against the gateway with dummy credentials (the gateway ignores the SigV4 signature) and the header is injected via a botocore `before-send` handler, passed to the client as a pre-built instance.

Also pulls `aiohttp`, which the Azure AI Foundry provider needs for its async calls but does not declare.

No UI changes.

## User stories
N/A — runtime change to how judge evaluations authenticate to the gateway.

## Release note
Gateway-routed LLM-as-judge evaluations now work across all supported providers (OpenAI, Anthropic, Gemini, Groq, Mistral, Azure OpenAI, Azure AI Foundry, Bedrock).

## Documentation
N/A — no documented behaviour changes.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `test_llm_judge_gateway.py` adds per-provider coverage asserting the exact routing/header shape produced for OpenAI, Anthropic, Gemini, Mistral, Groq, both Azure options, and Bedrock (the Bedrock test emits the botocore before-send event and asserts the header is injected). Full amp-evaluation suite passes.
 - Integration tests
   > Each provider's header delivery was verified against its real SDK client over a local OpenAI-compatible mock gateway. OpenAI, Anthropic, Gemini, and Mistral judges were additionally confirmed end-to-end against the deployed gateway in a local stack.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#1010 (the migration this builds on).

## Migrations (if applicable)
N/A — no schema or data migration. Provider/model identifiers are unchanged.

## Test environment
Verified locally on macOS (Darwin) with Python 3.13; any-llm-sdk 1.16.0 with the provider extras, against a local k3d-deployed gateway.

## Learning
any-llm wraps each provider's official SDK, so there is no single hook for custom request headers — each SDK attaches them differently (constructor kwarg, http options, custom client, or native credential header), and a couple of providers route or authenticate in non-obvious ways (Groq ignores `api_base`; Azure sends its key in the `api-key` header). These were only discoverable by exercising the real clients rather than mocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced LLM judge routing to support multiple providers (OpenAI, Anthropic, Gemini, Mistral, Groq, Azure, Bedrock) with provider-aware gateway authentication.

* **Chores**
  * Added aiohttp dependency to support async HTTP operations.

* **Tests**
  * Added comprehensive gateway routing and auth tests across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->