### PR TITLE
Fix Azure and Bedrock judge routing through the gateway

### DIFF
--- a/libs/amp-evaluation/pyproject.toml
+++ b/libs/amp-evaluation/pyproject.toml
@@ -61,7 +61,7 @@ target-version = "py39"
 exclude = ["samples/"]
 
 [[tool.mypy.overrides]]
-module = ["deepeval.*", "any_llm.*", "boto3.*", "httpx.*"]
+module = ["deepeval.*", "any_llm.*", "boto3.*", "botocore.*", "httpx.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/libs/amp-evaluation/src/amp_evaluation/config.py
+++ b/libs/amp-evaluation/src/amp_evaluation/config.py
@@ -95,12 +95,20 @@ class LLMJudgeConfig(BaseSettings):
         description="Optional gateway API key, injected as the 'api-key' auth header when api_base is set",
     )
 
-    azure_api_version: str = Field(
+    azure_openai_api_version: str = Field(
         default="2024-10-21",
         description=(
-            "Azure OpenAI/Foundry api-version for judge routing. The default 'preview' alias the SDK "
-            "uses is incompatible with the deployment-path URL; a dated GA version is required and may "
+            "Azure OpenAI api-version for judge routing. The SDK's default 'preview' alias is "
+            "incompatible with the deployment-path URL, so a dated GA version is pinned; it may "
             "differ per Azure resource."
+        ),
+    )
+
+    azure_foundry_api_version: str = Field(
+        default="",
+        description=(
+            "Azure AI Foundry (azure-ai-inference) api-version. Empty leaves the SDK default in place; "
+            "set it only if a Foundry resource requires a specific version."
         ),
     )
 

--- a/libs/amp-evaluation/src/amp_evaluation/config.py
+++ b/libs/amp-evaluation/src/amp_evaluation/config.py
@@ -95,6 +95,15 @@ class LLMJudgeConfig(BaseSettings):
         description="Optional gateway API key, injected as the 'api-key' auth header when api_base is set",
     )
 
+    azure_api_version: str = Field(
+        default="2024-10-21",
+        description=(
+            "Azure OpenAI/Foundry api-version for judge routing. The default 'preview' alias the SDK "
+            "uses is incompatible with the deployment-path URL; a dated GA version is required and may "
+            "differ per Azure resource."
+        ),
+    )
+
     model_config = SettingsConfigDict(
         env_prefix="AMP_LLM_JUDGE_",
         env_file=".env",

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -644,14 +644,20 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
         # Azure SDKs send their api_key in the "api-key" header natively, which
         # is exactly the gateway's auth header — pass the real key straight
         # through (a placeholder would be sent as the gateway credential). The
-        # api-version is pinned because the SDK's default ("preview") is
-        # incompatible with the deployment-path URL and 404s.
-        if provider in ("azureopenai", "azure"):
+        # two Azure providers use different APIs, hence different api-versions.
+        if provider == "azureopenai":
+            # Pin a dated version: the SDK default ("preview") is incompatible
+            # with the deployment-path URL and 404s.
             return {
                 "api_base": cfg.api_base,
                 "api_key": cfg.api_key,
-                "client_args": {"api_version": cfg.azure_api_version},
+                "client_args": {"api_version": cfg.azure_openai_api_version},
             }
+        if provider == "azure":  # Azure AI Foundry (azure-ai-inference)
+            azure_kwargs: dict = {"api_base": cfg.api_base, "api_key": cfg.api_key}
+            if cfg.azure_foundry_api_version:
+                azure_kwargs["client_args"] = {"api_version": cfg.azure_foundry_api_version}
+            return azure_kwargs
 
         # Other providers authenticate elsewhere (bearer / x-api-key / query
         # param), so the gateway api-key must be injected as an explicit request

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -676,20 +676,24 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
             return {"api_key": "gateway", "client_args": {"base_url": cfg.api_base, "default_headers": header}}
         elif provider == "bedrock":
             # boto3 has no default_headers hook. Build a client pointed at the
-            # gateway with dummy credentials (the gateway ignores the SigV4
-            # signature and authenticates via the api-key header) and inject that
-            # header through a botocore before-send handler.
+            # gateway and inject the gateway api-key via a botocore before-send
+            # handler. Use UNSIGNED so boto3 sends no SigV4 Authorization — the
+            # gateway authenticates the caller with the api-key header and signs
+            # the upstream AWS call with its own stored credentials. (A dummy
+            # SigV4 signature would be passed through to AWS and rejected with
+            # UnrecognizedClientException.)
             import os
 
             import boto3
+            from botocore import UNSIGNED
+            from botocore.config import Config
 
             key = cfg.api_key
             bedrock_client = boto3.client(
                 "bedrock-runtime",
                 endpoint_url=cfg.api_base,
                 region_name=os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1",
-                aws_access_key_id="gateway",
-                aws_secret_access_key="gateway",
+                config=Config(signature_version=UNSIGNED),
             )
 
             def _inject_gateway_header(request, **_):

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -708,6 +708,11 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
 
         gateway_kwargs = self._gateway_kwargs(self.model)
 
+        # Bedrock (via any-llm) rejects response_format; fall back to the prompt's
+        # JSON instructions + Pydantic validation + retries for that provider.
+        provider = self.model.replace(":", "/").split("/", 1)[0].lower()
+        use_response_format = provider != "bedrock"
+
         try:
             last_error = None
             for attempt in range(self.max_retries + 1):
@@ -720,15 +725,18 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
                         f"The 'score' MUST be a top-level numeric field in the JSON, NOT embedded in the explanation text.]"
                     )
 
+                completion_kwargs = {
+                    "model": self.model,
+                    "messages": [{"role": "user", "content": prompt + retry_ctx}],
+                    "temperature": self.temperature,
+                    "max_tokens": self.max_tokens,
+                    **gateway_kwargs,
+                }
+                if use_response_format:
+                    completion_kwargs["response_format"] = JudgeOutput
+
                 try:
-                    response = completion(
-                        model=self.model,
-                        messages=[{"role": "user", "content": prompt + retry_ctx}],
-                        temperature=self.temperature,
-                        max_tokens=self.max_tokens,
-                        response_format=JudgeOutput,
-                        **gateway_kwargs,
-                    )
+                    response = completion(**completion_kwargs)
                 except Exception as e:
                     last_error = str(e)
                     continue

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -643,9 +643,15 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
 
         # Azure SDKs send their api_key in the "api-key" header natively, which
         # is exactly the gateway's auth header — pass the real key straight
-        # through (a placeholder would be sent as the gateway credential).
+        # through (a placeholder would be sent as the gateway credential). The
+        # api-version is pinned because the SDK's default ("preview") is
+        # incompatible with the deployment-path URL and 404s.
         if provider in ("azureopenai", "azure"):
-            return {"api_base": cfg.api_base, "api_key": cfg.api_key}
+            return {
+                "api_base": cfg.api_base,
+                "api_key": cfg.api_key,
+                "client_args": {"api_version": cfg.azure_api_version},
+            }
 
         # Other providers authenticate elsewhere (bearer / x-api-key / query
         # param), so the gateway api-key must be injected as an explicit request

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -201,25 +201,35 @@ def test_gateway_kwargs_azureopenai_passes_real_key_and_pinned_api_version():
     }
 
 
-def test_gateway_kwargs_azure_foundry_passes_real_key_and_pinned_api_version():
+def test_gateway_kwargs_azure_foundry_defaults_to_sdk_api_version():
+    # Foundry (azure-ai-inference) uses its own api-version; we don't pin one by
+    # default (empty config), so no client_args is emitted — the SDK default applies.
     _set_gateway()
     kw = LLMAsJudgeEvaluator._gateway_kwargs("azure/some-model")
-    assert kw == {
-        "api_base": "https://gw.example/v1",
-        "api_key": "secret-key",
-        "client_args": {"api_version": "2024-10-21"},
-    }
+    assert kw == {"api_base": "https://gw.example/v1", "api_key": "secret-key"}
 
 
-def test_gateway_kwargs_azure_api_version_is_configurable():
+def test_gateway_kwargs_azureopenai_api_version_is_configurable():
     _set_gateway()
-    os.environ["AMP_LLM_JUDGE_AZURE_API_VERSION"] = "2025-01-01-preview"
+    os.environ["AMP_LLM_JUDGE_AZURE_OPENAI_API_VERSION"] = "2025-01-01-preview"
     reload_config()
     try:
         kw = LLMAsJudgeEvaluator._gateway_kwargs("azureopenai/gpt-4o-mini")
         assert kw["client_args"] == {"api_version": "2025-01-01-preview"}
     finally:
-        os.environ.pop("AMP_LLM_JUDGE_AZURE_API_VERSION", None)
+        os.environ.pop("AMP_LLM_JUDGE_AZURE_OPENAI_API_VERSION", None)
+        reload_config()
+
+
+def test_gateway_kwargs_azure_foundry_api_version_is_configurable():
+    _set_gateway()
+    os.environ["AMP_LLM_JUDGE_AZURE_FOUNDRY_API_VERSION"] = "2024-05-01-preview"
+    reload_config()
+    try:
+        kw = LLMAsJudgeEvaluator._gateway_kwargs("azure/some-model")
+        assert kw["client_args"] == {"api_version": "2024-05-01-preview"}
+    finally:
+        os.environ.pop("AMP_LLM_JUDGE_AZURE_FOUNDRY_API_VERSION", None)
         reload_config()
 
 

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -119,6 +119,22 @@ def test_without_gateway_config_no_api_base_or_client_args(mock_completion):
     assert "client_args" not in kwargs
 
 
+@patch("any_llm.completion")
+def test_bedrock_omits_response_format(mock_completion):
+    # any-llm's Bedrock provider rejects response_format; it must be omitted and
+    # the JSON-instruction prompt + Pydantic validation used instead.
+    mock_completion.return_value = _response()
+    _SimpleJudge(model="bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0").evaluate(_make_trace())
+    assert "response_format" not in mock_completion.call_args.kwargs
+
+
+@patch("any_llm.completion")
+def test_non_bedrock_includes_response_format(mock_completion):
+    mock_completion.return_value = _response()
+    _SimpleJudge(model="openai/gpt-4o-mini").evaluate(_make_trace())
+    assert mock_completion.call_args.kwargs["response_format"] is JudgeOutput
+
+
 # ---------------------------------------------------------------------------
 # Per-provider header injection. The api-key header must reach every provider's
 # client, but the constructor kwarg differs by SDK (verified against real

--- a/libs/amp-evaluation/tests/test_llm_judge_gateway.py
+++ b/libs/amp-evaluation/tests/test_llm_judge_gateway.py
@@ -172,18 +172,39 @@ def test_gateway_kwargs_groq_routes_via_base_url():
     assert kw["client_args"]["default_headers"] == {"api-key": "secret-key"}
 
 
-def test_gateway_kwargs_azureopenai_passes_real_key_as_apikey():
+def test_gateway_kwargs_azureopenai_passes_real_key_and_pinned_api_version():
     # Azure OpenAI sends api_key in the api-key header natively, so the real
-    # gateway key is passed through directly (no placeholder, no client_args).
+    # gateway key is passed through directly. The api-version is pinned (the
+    # SDK default "preview" 404s against the deployment-path URL).
     _set_gateway()
     kw = LLMAsJudgeEvaluator._gateway_kwargs("azureopenai/gpt-4o-mini")
-    assert kw == {"api_base": "https://gw.example/v1", "api_key": "secret-key"}
+    assert kw == {
+        "api_base": "https://gw.example/v1",
+        "api_key": "secret-key",
+        "client_args": {"api_version": "2024-10-21"},
+    }
 
 
-def test_gateway_kwargs_azure_foundry_passes_real_key_as_apikey():
+def test_gateway_kwargs_azure_foundry_passes_real_key_and_pinned_api_version():
     _set_gateway()
     kw = LLMAsJudgeEvaluator._gateway_kwargs("azure/some-model")
-    assert kw == {"api_base": "https://gw.example/v1", "api_key": "secret-key"}
+    assert kw == {
+        "api_base": "https://gw.example/v1",
+        "api_key": "secret-key",
+        "client_args": {"api_version": "2024-10-21"},
+    }
+
+
+def test_gateway_kwargs_azure_api_version_is_configurable():
+    _set_gateway()
+    os.environ["AMP_LLM_JUDGE_AZURE_API_VERSION"] = "2025-01-01-preview"
+    reload_config()
+    try:
+        kw = LLMAsJudgeEvaluator._gateway_kwargs("azureopenai/gpt-4o-mini")
+        assert kw["client_args"] == {"api_version": "2025-01-01-preview"}
+    finally:
+        os.environ.pop("AMP_LLM_JUDGE_AZURE_API_VERSION", None)
+        reload_config()
 
 
 def test_gateway_kwargs_bedrock_injects_header_via_boto3_client():


### PR DESCRIPTION
## Purpose
Follow-up to #1010 / #1014. Real-gateway testing of the per-provider judge routing surfaced provider-specific failures for Azure and Bedrock that the earlier work didn't cover. This makes Azure OpenAI judges work end-to-end and corrects the Bedrock client behaviour.

Resolves Azure OpenAI judge routing; documents the remaining Bedrock gateway limitation below.

## Goals
Run gateway-routed LLM-as-judge evaluations correctly on the Azure providers (Azure OpenAI verified working; Azure AI Foundry wired with its own api-version) and make the Bedrock client send what a credential-managing gateway expects.

## Approach
- **Azure api-version, per provider.** any-llm's Azure clients default the api-version to `preview`, which is incompatible with the deployment-path URL the SDK builds (`/openai/deployments/{dep}/chat/completions`) and 404s. Azure OpenAI now pins a dated GA version (default `2024-10-21`), and because Azure OpenAI and Azure AI Foundry are different APIs with different version schemes, the setting is split into `azure_openai_api_version` and `azure_foundry_api_version` (the latter empty by default, leaving the `azure-ai-inference` SDK default), each overridable via `AMP_LLM_JUDGE_AZURE_OPENAI_API_VERSION` / `AMP_LLM_JUDGE_AZURE_FOUNDRY_API_VERSION`.
- **Bedrock `response_format`.** any-llm's Bedrock provider rejects `response_format`, so it is omitted for Bedrock; the prompt's JSON-output instructions plus Pydantic validation and retries are used instead (the pre-structured-output path).
- **Bedrock signing.** The Bedrock client was sending dummy SigV4 credentials, which the gateway passed through to AWS and AWS rejected. It now uses `signature_version=UNSIGNED` so no SigV4 Authorization is sent — appropriate for a gateway that authenticates the caller via the `api-key` header and signs the upstream AWS call itself.

No UI changes.

## User stories
N/A — runtime change to how judge evaluations authenticate to and call the gateway.

## Release note
Azure OpenAI LLM-as-judge evaluations now route correctly through the gateway (pinned api-version), with Azure AI Foundry given its own api-version setting; Bedrock judges no longer pass an unsupported `response_format` or a dummy AWS signature.

## Documentation
N/A — no documented behaviour changes.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `test_llm_judge_gateway.py` adds per-provider coverage: Azure OpenAI pins the api-version, Azure AI Foundry defaults to the SDK version (and is configurable), Bedrock omits `response_format`, and the Bedrock client injects the api-key header. Full amp-evaluation suite passes; mypy clean.
 - Integration tests
   > Azure OpenAI verified working end-to-end against a real Azure OpenAI resource through the deployed gateway. Each provider's header/api-version shape was verified against the real SDK client over a local mock gateway.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#1010, #1014 (the migration and per-provider gateway routing this builds on).

## Migrations (if applicable)
N/A — no schema or data migration.

## Test environment
Verified locally on macOS (Darwin) with Python 3.13; any-llm-sdk 1.16.0 against a local k3d-deployed gateway and a real Azure OpenAI resource.

## Learning
**Known limitation — Bedrock judges are blocked gateway-side.** AWS Bedrock authenticates with SigV4, which is computed per-request from the AWS secret key and cryptographically bound to the destination host + path. Because the gateway rewrites the request to the AWS host/path before forwarding, no signature the eval job produces can be valid at AWS. The `awsbedrock` gateway template also has no `Auth` block (unlike the OpenAI/Anthropic/Azure templates), so the gateway does not sign the upstream call. Making Bedrock work therefore requires gateway-side AWS SigV4 signing with stored credentials — a platform/gateway change, not an eval-job change. The eval-job side in this PR is correct and ready for when that lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for Azure OpenAI and Foundry API versions via environment variables.

* **Improvements**
  * Enhanced multi-provider LLM gateway routing for Bedrock and Azure.
  * Expanded test coverage for provider-specific request handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->