### PR TITLE
Add component assessment to design proposal template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/design-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/design-proposals.yml
@@ -55,6 +55,22 @@ body:
       required: true
 
   - type: textarea
+    id: component-assessment
+    attributes:
+      label: MCP, CLI, and Skill Components
+      description: Does this feature need MCP, CLI, or skill components? Provide an argument for and against each relevant component.
+      value: |
+        | Component | Needed? | Argument for | Argument against |
+        |-----------|---------|--------------|------------------|
+        | MCP       | Yes/No  |              |                  |
+        | CLI       | Yes/No  |              |                  |
+        | Skill     | Yes/No  |              |                  |
+
+        **Decision**: Summarize which components are in scope and why.
+    validations:
+      required: true
+
+  - type: textarea
     id: alternatives
     attributes:
       label: Alternatives Considered

--- a/.github/DISCUSSION_TEMPLATE/design-proposals.yml
+++ b/.github/DISCUSSION_TEMPLATE/design-proposals.yml
@@ -60,11 +60,11 @@ body:
       label: MCP, CLI, and Skill Components
       description: Does this feature need MCP, CLI, or skill components? Provide an argument for and against each relevant component.
       value: |
-        | Component | Needed? | Argument for | Argument against |
-        |-----------|---------|--------------|------------------|
-        | MCP       | Yes/No  |              |                  |
-        | CLI       | Yes/No  |              |                  |
-        | Skill     | Yes/No  |              |                  |
+        | Component | Required (yes/no) | Reason |
+        |-----------|-------------------|--------|
+        | MCP       |                   |        |
+        | CLI       |                   |        |
+        | Skill     |                   |        |
 
         **Decision**: Summarize which components are in scope and why.
     validations:


### PR DESCRIPTION
## Purpose
Design proposal discussions should explicitly evaluate whether a feature needs MCP, CLI, or skill components. This change adds that prompt to the GitHub discussion template so proposal authors capture those trade-offs up front.

## Goals
Add a required section to the design proposal template that asks authors to state whether MCP, CLI, and skill components are needed, with arguments for and against each.

## Approach
Added a `component-assessment` textarea to `.github/DISCUSSION_TEMPLATE/design-proposals.yml` after the proposed solution section. The default content is a table for MCP, CLI, and Skill rows plus a short decision summary.

## User stories
As a feature proposal reviewer, I want MCP, CLI, and skill component trade-offs called out explicitly so that design discussions cover the implementation surfaces affected by the feature.

## Release note
N/A - this updates an internal GitHub discussion template.

## Documentation
N/A - this only changes the repository discussion template.

## Training
N/A - no training content impact.

## Certification
N/A - no certification exam impact.

## Marketing
N/A - no marketing content impact.

## Automation tests
 - Unit tests
   N/A - no executable code changed.
 - Integration tests
   N/A - no executable code changed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes - template-only change with no executable code.
 - Ran FindSecurityBugs plugin and verified report? no - not applicable for a GitHub discussion template change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes.

## Samples
N/A - no samples are affected.

## Related PRs
N/A.

## Migrations (if applicable)
N/A - no migration required.

## Test environment
Darwin arm64. Validated the discussion template parses as YAML with Ruby 2.6.10.

## Learning
N/A - no new libraries, patterns, or add-ons were needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the design proposal discussion template to add a required "component assessment" section, including a checklist table for component needs (MCP, CLI, Skill) and a mandatory Decision field summarizing scope and rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->