### PR TITLE
Simplify agent create model config: flat --llm-* flags + provider check

### DIFF
--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -82,6 +82,9 @@ func handleCommonErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 	case errors.Is(err, utils.ErrAgentNotFound):
 		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
 			"Agent not found", err.Error(), utils.ErrCodeAgentNotFound)
+	case errors.Is(err, utils.ErrLLMProviderNotFound):
+		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
+			"LLM provider not found", err.Error(), utils.ErrCodeProviderNotFound)
 	case errors.Is(err, utils.ErrBuildNotFound):
 		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
 			"Build not found", err.Error(), utils.ErrCodeBuildNotFound)

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -7065,21 +7065,25 @@ components:
           $ref: "#/components/schemas/InputInterface"
         modelConfig:
           type: array
-          description: Optional LLM configurations to create atomically with the agent. Name and type are auto-generated.
+          description: >-
+            Optional LLM configurations to create atomically with the agent.
+            Applied to the component's initial (lowest) environment. Name and
+            type are auto-generated.
           items:
             $ref: "#/components/schemas/ModelConfigRequest"
 
     ModelConfigRequest:
       type: object
       required:
-        - envMappings
+        - providerName
       properties:
-        envMappings:
-          type: object
-          description: Map of environment names to their model configurations
-          additionalProperties:
-            $ref: "#/components/schemas/EnvModelConfigRequest"
-          minProperties: 1
+        providerName:
+          type: string
+          description: >-
+            Handle of an already-configured LLM provider. Applied to the
+            component's initial (lowest) environment.
+        configuration:
+          $ref: "#/components/schemas/EnvProviderConfiguration"
         environmentVariables:
           type: array
           description: Optional custom environment variable names exposed to the agent

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -464,6 +464,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Referenced LLM provider not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Internal server error
           content:

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -42,9 +42,6 @@ import (
 type AgentConfigurationService interface {
 	Create(ctx context.Context, orgName, projectName, agentID string,
 		req models.CreateAgentModelConfigRequest, createdBy string) (*models.AgentModelConfigResponse, error)
-	// ValidateProvidersInCatalog verifies each handle resolves to an existing provider
-	// that is in catalog. Returns ErrLLMProviderNotFound (missing) or ErrInvalidInput
-	// (empty handle / not in catalog). Handles are deduped.
 	ValidateProvidersInCatalog(ctx context.Context, orgName string, providerHandles []string) error
 	Get(ctx context.Context, configUUID uuid.UUID, orgName, projectName, agentName string) (*models.AgentModelConfigResponse, error)
 	GetByAgent(ctx context.Context, agentID, orgName string) (*models.AgentModelConfigResponse, error)

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -42,6 +42,10 @@ import (
 type AgentConfigurationService interface {
 	Create(ctx context.Context, orgName, projectName, agentID string,
 		req models.CreateAgentModelConfigRequest, createdBy string) (*models.AgentModelConfigResponse, error)
+	// ValidateProvidersInCatalog verifies each handle resolves to an existing provider
+	// that is in catalog. Returns ErrLLMProviderNotFound (missing) or ErrInvalidInput
+	// (empty handle / not in catalog). Handles are deduped.
+	ValidateProvidersInCatalog(ctx context.Context, orgName string, providerHandles []string) error
 	Get(ctx context.Context, configUUID uuid.UUID, orgName, projectName, agentName string) (*models.AgentModelConfigResponse, error)
 	GetByAgent(ctx context.Context, agentID, orgName string) (*models.AgentModelConfigResponse, error)
 	List(ctx context.Context, orgName, projectName, agentName string, limit, offset int) (*models.AgentModelConfigListResponse, error)
@@ -250,6 +254,36 @@ func (s *agentConfigurationService) compensatingDeleteConfig(ctx context.Context
 	}
 }
 
+// ValidateProvidersInCatalog verifies each handle resolves to an existing provider
+// that is in catalog. Returns ErrLLMProviderNotFound (missing) or ErrInvalidInput
+// (empty handle / not in catalog). Handles are deduped.
+func (s *agentConfigurationService) ValidateProvidersInCatalog(
+	_ context.Context, orgName string, providerHandles []string,
+) error {
+	seen := make(map[string]struct{}, len(providerHandles))
+	for _, handle := range providerHandles {
+		if handle == "" {
+			return fmt.Errorf("%w: provider name is required", utils.ErrInvalidInput)
+		}
+		if _, dup := seen[handle]; dup {
+			continue
+		}
+		seen[handle] = struct{}{}
+
+		provider, err := s.llmProviderRepo.GetByHandle(handle, orgName)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("provider %s not found: %w", handle, utils.ErrLLMProviderNotFound)
+			}
+			return fmt.Errorf("failed to validate provider %s: %w", handle, err)
+		}
+		if !provider.InCatalog {
+			return fmt.Errorf("%w: provider %s must be in catalog", utils.ErrInvalidInput, handle)
+		}
+	}
+	return nil
+}
+
 // Create creates a new agent model configuration
 func (s *agentConfigurationService) Create(ctx context.Context, orgName, projectName, agentID string,
 	req models.CreateAgentModelConfigRequest, createdBy string,
@@ -283,19 +317,13 @@ func (s *agentConfigurationService) Create(ctx context.Context, orgName, project
 		return nil, errors.Join(utils.ErrInvalidInput, err)
 	}
 
-	// Validate all providers exist and are in catalog
-	for envName, envMapping := range req.EnvMappings {
-		provider, err := s.llmProviderRepo.GetByHandle(envMapping.ProviderName, orgName)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				s.logger.Warn("Provider not found", "env", envName, "error", err)
-				return nil, fmt.Errorf("provider for environment %s not found: %w", envName, utils.ErrLLMProviderNotFound)
-			}
-			return nil, fmt.Errorf("failed to validate provider for environment %s: %w", envName, err)
-		}
-		if !provider.InCatalog {
-			return nil, fmt.Errorf("%w: provider %s must be in catalog for environment %s", utils.ErrInvalidInput, envMapping.ProviderName, envName)
-		}
+	// Validate all providers exist and are in catalog (shared with the create-time preflight).
+	handles := make([]string, 0, len(req.EnvMappings))
+	for _, envMapping := range req.EnvMappings {
+		handles = append(handles, envMapping.ProviderName)
+	}
+	if err := s.ValidateProvidersInCatalog(ctx, orgName, handles); err != nil {
+		return nil, err
 	}
 
 	// Validate environment UUIDs exist

--- a/agent-manager-service/services/agent_configuration_validate_test.go
+++ b/agent-manager-service/services/agent_configuration_validate_test.go
@@ -1,3 +1,19 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package services
 
 import (

--- a/agent-manager-service/services/agent_configuration_validate_test.go
+++ b/agent-manager-service/services/agent_configuration_validate_test.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// fakeLLMProviderRepo implements LLMProviderRepository for unit tests; only GetByHandle is used.
+type fakeLLMProviderRepo struct {
+	repositories.LLMProviderRepository
+	byHandle map[string]*models.LLMProvider
+}
+
+func (f *fakeLLMProviderRepo) GetByHandle(handle, _ string) (*models.LLMProvider, error) {
+	if p, ok := f.byHandle[handle]; ok {
+		return p, nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func TestValidateProvidersInCatalog(t *testing.T) {
+	s := &agentConfigurationService{
+		llmProviderRepo: &fakeLLMProviderRepo{byHandle: map[string]*models.LLMProvider{
+			"good":   {InCatalog: true},
+			"notcat": {InCatalog: false},
+		}},
+	}
+	ctx := context.Background()
+
+	require.NoError(t, s.ValidateProvidersInCatalog(ctx, "org", []string{"good", "good"}),
+		"valid handle (deduped) passes")
+	require.ErrorIs(t, s.ValidateProvidersInCatalog(ctx, "org", []string{"missing"}),
+		utils.ErrLLMProviderNotFound)
+	require.ErrorIs(t, s.ValidateProvidersInCatalog(ctx, "org", []string{"notcat"}),
+		utils.ErrInvalidInput)
+	require.ErrorIs(t, s.ValidateProvidersInCatalog(ctx, "org", []string{""}),
+		utils.ErrInvalidInput)
+}

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -987,6 +987,18 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, orgName,
 		return fmt.Errorf("no environment found in deployment pipeline")
 	}
 
+	// Preflight: validate referenced LLM providers before creating any secrets or
+	// the component, so a bad provider fails fast with no resources to roll back.
+	if len(req.ModelConfig) > 0 {
+		handles := make([]string, 0, len(req.ModelConfig))
+		for _, mc := range req.ModelConfig {
+			handles = append(handles, mc.ProviderName)
+		}
+		if err := s.agentConfigurationService.ValidateProvidersInCatalog(ctx, orgName, handles); err != nil {
+			return err
+		}
+	}
+
 	secretLocation := secretmanagersvc.SecretLocation{
 		OrgName:         orgName,
 		ProjectName:     projectName,

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1084,7 +1084,7 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, orgName,
 
 	// Create LLM configurations (applies to both internal and external agents)
 	if len(req.ModelConfig) > 0 {
-		if err := s.createAgentLLMConfigs(ctx, orgName, projectName, req); err != nil {
+		if err := s.createAgentLLMConfigs(ctx, orgName, projectName, firstEnv, req); err != nil {
 			s.logger.Error("Failed to create LLM configurations for agent", "agentName", req.Name, "error", err)
 			rollbackAgentCreate("LLM config failure")
 			return err
@@ -1192,17 +1192,26 @@ func (s *agentManagerService) triggerInitialBuild(ctx context.Context, orgName, 
 }
 
 func (s *agentManagerService) createAgentLLMConfigs(
-	ctx context.Context, orgName, projectName string, req *spec.CreateAgentRequest,
+	ctx context.Context, orgName, projectName, firstEnv string, req *spec.CreateAgentRequest,
 ) error {
 	for i, mc := range req.ModelConfig {
 		configName := fmt.Sprintf("%s-llm-config", req.Name)
 		if len(req.ModelConfig) > 1 {
 			configName = fmt.Sprintf("%s-llm-config-%d", req.Name, i+1)
 		}
+		cfg := models.EnvProviderConfiguration{}
+		if mc.Configuration != nil {
+			cfg = convertConfiguration(*mc.Configuration)
+		}
 		createReq := models.CreateAgentModelConfigRequest{
-			Name:                 configName,
-			Type:                 "llm",
-			EnvMappings:          convertEnvMappings(mc.EnvMappings),
+			Name: configName,
+			Type: "llm",
+			EnvMappings: map[string]models.EnvModelConfigRequest{
+				firstEnv: {
+					ProviderName:  mc.ProviderName,
+					Configuration: cfg,
+				},
+			},
 			EnvironmentVariables: convertEnvVars(mc.EnvironmentVariables),
 		}
 		if _, err := s.agentConfigurationService.Create(ctx, orgName, projectName, req.Name, createReq, "system"); err != nil {
@@ -1212,31 +1221,26 @@ func (s *agentManagerService) createAgentLLMConfigs(
 	return nil
 }
 
-func convertEnvMappings(specMappings map[string]spec.EnvModelConfigRequest) map[string]models.EnvModelConfigRequest {
-	result := make(map[string]models.EnvModelConfigRequest, len(specMappings))
-	for env, m := range specMappings {
-		policies := make([]models.LLMPolicy, 0, len(m.Configuration.Policies))
-		for _, p := range m.Configuration.Policies {
-			paths := make([]models.LLMPolicyPath, 0, len(p.Paths))
-			for _, pp := range p.Paths {
-				paths = append(paths, models.LLMPolicyPath{
-					Path:    pp.Path,
-					Methods: pp.Methods,
-					Params:  pp.Params,
-				})
-			}
-			policies = append(policies, models.LLMPolicy{
-				Name:    p.Name,
-				Version: p.Version,
-				Paths:   paths,
+// convertConfiguration maps a generated provider configuration to the model type,
+// preserving guardrail policies. Replaces the per-env conversion that convertEnvMappings did.
+func convertConfiguration(cfg spec.EnvProviderConfiguration) models.EnvProviderConfiguration {
+	policies := make([]models.LLMPolicy, 0, len(cfg.Policies))
+	for _, p := range cfg.Policies {
+		paths := make([]models.LLMPolicyPath, 0, len(p.Paths))
+		for _, pp := range p.Paths {
+			paths = append(paths, models.LLMPolicyPath{
+				Path:    pp.Path,
+				Methods: pp.Methods,
+				Params:  pp.Params,
 			})
 		}
-		result[env] = models.EnvModelConfigRequest{
-			ProviderName:  m.ProviderName,
-			Configuration: models.EnvProviderConfiguration{Policies: policies},
-		}
+		policies = append(policies, models.LLMPolicy{
+			Name:    p.Name,
+			Version: p.Version,
+			Paths:   paths,
+		})
 	}
-	return result
+	return models.EnvProviderConfiguration{Policies: policies}
 }
 
 func convertEnvVars(specVars []spec.EnvironmentVariableConfig) []models.EnvironmentVariableConfig {

--- a/agent-manager-service/services/agent_manager_llmconfig_test.go
+++ b/agent-manager-service/services/agent_manager_llmconfig_test.go
@@ -1,3 +1,19 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package services
 
 import (

--- a/agent-manager-service/services/agent_manager_llmconfig_test.go
+++ b/agent-manager-service/services/agent_manager_llmconfig_test.go
@@ -1,0 +1,43 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+)
+
+// spyConfigService records the request passed to Create. Only Create is exercised;
+// the embedded interface satisfies the rest (and panics if any other method is called).
+type spyConfigService struct {
+	AgentConfigurationService
+	lastReq models.CreateAgentModelConfigRequest
+}
+
+func (s *spyConfigService) Create(_ context.Context, _, _, _ string,
+	req models.CreateAgentModelConfigRequest, _ string,
+) (*models.AgentModelConfigResponse, error) {
+	s.lastReq = req
+	return &models.AgentModelConfigResponse{}, nil
+}
+
+func TestCreateAgentLLMConfigs_KeysUnderFirstEnv(t *testing.T) {
+	spy := &spyConfigService{}
+	s := &agentManagerService{agentConfigurationService: spy}
+
+	req := &spec.CreateAgentRequest{
+		Name:        "my-agent",
+		ModelConfig: []spec.ModelConfigRequest{{ProviderName: "openai"}},
+	}
+
+	err := s.createAgentLLMConfigs(context.Background(), "org", "proj", "Development", req)
+	require.NoError(t, err)
+
+	require.Len(t, spy.lastReq.EnvMappings, 1, "exactly one env mapping")
+	got, ok := spy.lastReq.EnvMappings["Development"]
+	require.True(t, ok, "config must be keyed under firstEnv")
+	require.Equal(t, "openai", got.ProviderName)
+}

--- a/agent-manager-service/spec/api_default.go
+++ b/agent-manager-service/spec/api_default.go
@@ -287,6 +287,17 @@ func (a *DefaultAPIService) CreateAgentExecute(r ApiCreateAgentRequest) (*AgentR
 			newErr.model = v
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 409 {
 			var v ErrorResponse
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))

--- a/agent-manager-service/spec/model_create_agent_request.go
+++ b/agent-manager-service/spec/model_create_agent_request.go
@@ -30,7 +30,7 @@ type CreateAgentRequest struct {
 	Build          *Build          `json:"build,omitempty"`
 	Configurations *Configurations `json:"configurations,omitempty"`
 	InputInterface *InputInterface `json:"inputInterface,omitempty"`
-	// Optional LLM configurations to create atomically with the agent. Name and type are auto-generated.
+	// Optional LLM configurations to create atomically with the agent. Applied to the component's initial (lowest) environment. Name and type are auto-generated.
 	ModelConfig []ModelConfigRequest `json:"modelConfig,omitempty"`
 }
 

--- a/agent-manager-service/spec/model_model_config_request.go
+++ b/agent-manager-service/spec/model_model_config_request.go
@@ -19,8 +19,9 @@ var _ MappedNullable = &ModelConfigRequest{}
 
 // ModelConfigRequest struct for ModelConfigRequest
 type ModelConfigRequest struct {
-	// Map of environment names to their model configurations
-	EnvMappings map[string]EnvModelConfigRequest `json:"envMappings"`
+	// Handle of an already-configured LLM provider. Applied to the component's initial (lowest) environment.
+	ProviderName  string                    `json:"providerName"`
+	Configuration *EnvProviderConfiguration `json:"configuration,omitempty"`
 	// Optional custom environment variable names exposed to the agent
 	EnvironmentVariables []EnvironmentVariableConfig `json:"environmentVariables,omitempty"`
 }
@@ -29,9 +30,9 @@ type ModelConfigRequest struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewModelConfigRequest(envMappings map[string]EnvModelConfigRequest) *ModelConfigRequest {
+func NewModelConfigRequest(providerName string) *ModelConfigRequest {
 	this := ModelConfigRequest{}
-	this.EnvMappings = envMappings
+	this.ProviderName = providerName
 	return &this
 }
 
@@ -43,28 +44,60 @@ func NewModelConfigRequestWithDefaults() *ModelConfigRequest {
 	return &this
 }
 
-// GetEnvMappings returns the EnvMappings field value
-func (o *ModelConfigRequest) GetEnvMappings() map[string]EnvModelConfigRequest {
+// GetProviderName returns the ProviderName field value
+func (o *ModelConfigRequest) GetProviderName() string {
 	if o == nil {
-		var ret map[string]EnvModelConfigRequest
+		var ret string
 		return ret
 	}
 
-	return o.EnvMappings
+	return o.ProviderName
 }
 
-// GetEnvMappingsOk returns a tuple with the EnvMappings field value
+// GetProviderNameOk returns a tuple with the ProviderName field value
 // and a boolean to check if the value has been set.
-func (o *ModelConfigRequest) GetEnvMappingsOk() (*map[string]EnvModelConfigRequest, bool) {
+func (o *ModelConfigRequest) GetProviderNameOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.EnvMappings, true
+	return &o.ProviderName, true
 }
 
-// SetEnvMappings sets field value
-func (o *ModelConfigRequest) SetEnvMappings(v map[string]EnvModelConfigRequest) {
-	o.EnvMappings = v
+// SetProviderName sets field value
+func (o *ModelConfigRequest) SetProviderName(v string) {
+	o.ProviderName = v
+}
+
+// GetConfiguration returns the Configuration field value if set, zero value otherwise.
+func (o *ModelConfigRequest) GetConfiguration() EnvProviderConfiguration {
+	if o == nil || IsNil(o.Configuration) {
+		var ret EnvProviderConfiguration
+		return ret
+	}
+	return *o.Configuration
+}
+
+// GetConfigurationOk returns a tuple with the Configuration field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ModelConfigRequest) GetConfigurationOk() (*EnvProviderConfiguration, bool) {
+	if o == nil || IsNil(o.Configuration) {
+		return nil, false
+	}
+	return o.Configuration, true
+}
+
+// HasConfiguration returns a boolean if a field has been set.
+func (o *ModelConfigRequest) HasConfiguration() bool {
+	if o != nil && !IsNil(o.Configuration) {
+		return true
+	}
+
+	return false
+}
+
+// SetConfiguration gets a reference to the given EnvProviderConfiguration and assigns it to the Configuration field.
+func (o *ModelConfigRequest) SetConfiguration(v EnvProviderConfiguration) {
+	o.Configuration = &v
 }
 
 // GetEnvironmentVariables returns the EnvironmentVariables field value if set, zero value otherwise.
@@ -109,7 +142,10 @@ func (o ModelConfigRequest) MarshalJSON() ([]byte, error) {
 
 func (o ModelConfigRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["envMappings"] = o.EnvMappings
+	toSerialize["providerName"] = o.ProviderName
+	if !IsNil(o.Configuration) {
+		toSerialize["configuration"] = o.Configuration
+	}
 	if !IsNil(o.EnvironmentVariables) {
 		toSerialize["environmentVariables"] = o.EnvironmentVariables
 	}

--- a/agent-manager-service/tests/create_agent_modelconfig_test.go
+++ b/agent-manager-service/tests/create_agent_modelconfig_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
+)
+
+// TestCreateAgent_BadProviderFailsBeforeProvisioning verifies the create-time preflight:
+// a modelConfig referencing a nonexistent LLM provider must fail with 404 BEFORE any
+// component is provisioned (no orphaned resources).
+func TestCreateAgent_BadProviderFailsBeforeProvisioning(t *testing.T) {
+	authMiddleware := jwtassertion.NewMockMiddleware(t)
+	openChoreoClient := apitestutils.CreateMockOpenChoreoClient()
+	// CreateMockOpenChoreoClient's GetProjectDeploymentPipelineFunc already returns a
+	// PromotionPath with SourceEnvironmentRef "Development", so findLowestEnvironment
+	// resolves a non-empty firstEnv and the preflight is reached.
+	app := apitestutils.MakeAppClientWithDeps(t, wiring.TestClients{OpenChoreoClient: openChoreoClient}, authMiddleware)
+
+	reqBody := new(bytes.Buffer)
+	require.NoError(t, json.NewEncoder(reqBody).Encode(map[string]any{
+		"name":        "mc-bad-provider-agent",
+		"displayName": "MC Bad Provider Agent",
+		"provisioning": map[string]any{
+			"type": "internal",
+			"repository": map[string]any{
+				"url": "https://github.com/test/test-repo", "branch": "main", "appPath": "/agent-sample",
+			},
+		},
+		"agentType": map[string]any{"type": "agent-api", "subType": "chat-api"},
+		"build": map[string]any{
+			"type": "buildpack",
+			"buildpack": map[string]any{
+				"language": "python", "languageVersion": "3.11", "runCommand": "uvicorn app:app --host 0.0.0.0 --port 8000",
+			},
+		},
+		"inputInterface": map[string]any{"type": "HTTP"},
+		"modelConfig":    []map[string]any{{"providerName": "does-not-exist-provider"}},
+	}))
+
+	url := fmt.Sprintf("/api/v1/orgs/%s/projects/%s/agents", testOrgName, testProjName)
+	req := httptest.NewRequest(http.MethodPost, url, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	app.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code, "missing provider must return 404")
+	// The preflight runs before any component is provisioned, so CreateComponent must
+	// never have been called. The moq-style mock records every call to CreateComponent.
+	require.Empty(t, openChoreoClient.CreateComponentCalls(),
+		"no component should be created when provider validation fails")
+}

--- a/cli/pkg/clients/amsvc/gen/client.gen.go
+++ b/cli/pkg/clients/amsvc/gen/client.gen.go
@@ -12408,6 +12408,7 @@ type CreateAgentResp struct {
 	HTTPResponse *http.Response
 	JSON202      *AgentResponse
 	JSON400      *ErrorResponse
+	JSON404      *ErrorResponse
 	JSON409      *ErrorResponse
 	JSON500      *ErrorResponse
 }
@@ -18756,6 +18757,13 @@ func ParseCreateAgentResp(rsp *http.Response) (*CreateAgentResp, error) {
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
 		var dest ErrorResponse

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -1808,7 +1808,7 @@ type CreateAgentRequest struct {
 	// InputInterface Endpoint configurations
 	InputInterface *InputInterface `json:"inputInterface,omitempty"`
 
-	// ModelConfig Optional LLM configurations to create atomically with the agent. Name and type are auto-generated.
+	// ModelConfig Optional LLM configurations to create atomically with the agent. Applied to the component's initial (lowest) environment. Name and type are auto-generated.
 	ModelConfig *[]ModelConfigRequest `json:"modelConfig,omitempty"`
 
 	// Name Unique name of the agent
@@ -3211,11 +3211,13 @@ type MetricsResponse struct {
 
 // ModelConfigRequest defines model for ModelConfigRequest.
 type ModelConfigRequest struct {
-	// EnvMappings Map of environment names to their model configurations
-	EnvMappings map[string]EnvModelConfigRequest `json:"envMappings"`
+	Configuration *EnvProviderConfiguration `json:"configuration,omitempty"`
 
 	// EnvironmentVariables Optional custom environment variable names exposed to the agent
 	EnvironmentVariables *[]EnvironmentVariableConfig `json:"environmentVariables,omitempty"`
+
+	// ProviderName Handle of an already-configured LLM provider. Applied to the component's initial (lowest) environment.
+	ProviderName string `json:"providerName"`
 }
 
 // MonitorEvaluator defines model for MonitorEvaluator.

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -69,9 +69,10 @@ type CreateOptions struct {
 	Env                        []string
 	EnvSecret                  []string
 	EnvFromSecret              []string
-	ModelConfigFile            string
 
-	modelConfig *[]amsvc.ModelConfigRequest
+	LLMProvider  string
+	LLMURLEnv    string
+	LLMAPIKeyEnv string
 }
 
 func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
@@ -132,7 +133,9 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.Env, "env", nil, "Environment variable as KEY=VALUE (repeatable)")
 	cmd.Flags().StringSliceVar(&opts.EnvSecret, "env-secret", nil, "Sensitive env variable as KEY=VALUE (repeatable)")
 	cmd.Flags().StringSliceVar(&opts.EnvFromSecret, "env-from-secret", nil, "Env variable from secret as KEY=SECRETNAME (repeatable)")
-	cmd.Flags().StringVar(&opts.ModelConfigFile, "model-config-file", "", "Path to model config YAML/JSON file")
+	cmd.Flags().StringVar(&opts.LLMProvider, "llm-provider", "", "Handle of a configured LLM provider to attach (internal only)")
+	cmd.Flags().StringVar(&opts.LLMURLEnv, "llm-url-env", "", "Env var name for the provider URL (default: auto-generated)")
+	cmd.Flags().StringVar(&opts.LLMAPIKeyEnv, "llm-api-key-env", "", "Env var name for the provider API key (default: auto-generated)")
 
 	_ = cmd.RegisterFlagCompletionFunc("provisioning", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{provisioningInternal, provisioningExternal}, cobra.ShellCompDirectiveNoFileComp
@@ -148,14 +151,6 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runCreate(ctx context.Context, opts *CreateOptions) error {
-	if opts.ModelConfigFile != "" {
-		mc, err := loadModelConfig(opts.ModelConfigFile)
-		if err != nil {
-			return render.Error(opts.IO, opts.Scope, clierr.Newf(clierr.InvalidFlag, "--model-config-file: %s", err))
-		}
-		opts.modelConfig = mc
-	}
-
 	req, err := Build(opts)
 	if err != nil {
 		return render.Error(opts.IO, opts.Scope, err)
@@ -171,7 +166,7 @@ func runCreate(ctx context.Context, opts *CreateOptions) error {
 		return render.Error(opts.IO, opts.Scope, clierr.Newf(clierr.Transport, "%v", err))
 	}
 	if resp.JSON202 == nil {
-		return render.Error(opts.IO, opts.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON409, resp.JSON500)))
+		return render.Error(opts.IO, opts.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON404, resp.JSON409, resp.JSON500)))
 	}
 
 	if !opts.IO.JSON {

--- a/cli/pkg/cmd/agent/create/request.go
+++ b/cli/pkg/cmd/agent/create/request.go
@@ -17,13 +17,10 @@
 package create
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -81,7 +78,7 @@ func Build(opts *CreateOptions) (amsvc.CreateAgentRequest, error) {
 	req.Build = b
 	req.InputInterface = buildInterface(opts)
 	req.Configurations = buildConfig(opts)
-	req.ModelConfig = opts.modelConfig
+	req.ModelConfig = buildModelConfig(opts)
 
 	return req, nil
 }
@@ -198,30 +195,25 @@ func buildConfig(opts *CreateOptions) *amsvc.Configurations {
 	return cfg
 }
 
+func buildModelConfig(opts *CreateOptions) *[]amsvc.ModelConfigRequest {
+	if opts.LLMProvider == "" {
+		return nil
+	}
+	mc := amsvc.ModelConfigRequest{ProviderName: opts.LLMProvider}
+	var evs []amsvc.EnvironmentVariableConfig
+	if opts.LLMURLEnv != "" {
+		evs = append(evs, amsvc.EnvironmentVariableConfig{Key: "url", Name: opts.LLMURLEnv})
+	}
+	if opts.LLMAPIKeyEnv != "" {
+		evs = append(evs, amsvc.EnvironmentVariableConfig{Key: "apikey", Name: opts.LLMAPIKeyEnv})
+	}
+	if len(evs) > 0 {
+		mc.EnvironmentVariables = &evs
+	}
+	return &[]amsvc.ModelConfigRequest{mc}
+}
+
 func splitEnv(entry string) (string, string) {
 	k, v, _ := strings.Cut(entry, "=")
 	return k, v
-}
-
-func loadModelConfig(path string) (*[]amsvc.ModelConfigRequest, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("%v", err)
-	}
-	// yaml.v3 doesn't honour json struct tags, so we unmarshal into a generic
-	// value first, re-encode as JSON, then decode using encoding/json which
-	// does honour json tags.
-	var raw interface{}
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("parse error: %v", err)
-	}
-	jsonBytes, err := json.Marshal(raw)
-	if err != nil {
-		return nil, fmt.Errorf("re-encode error: %v", err)
-	}
-	var configs []amsvc.ModelConfigRequest
-	if err := json.Unmarshal(jsonBytes, &configs); err != nil {
-		return nil, fmt.Errorf("parse error: %v", err)
-	}
-	return &configs, nil
 }

--- a/cli/pkg/cmd/agent/create/request_test.go
+++ b/cli/pkg/cmd/agent/create/request_test.go
@@ -18,8 +18,6 @@ package create
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 
 	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
@@ -296,48 +294,6 @@ func TestBuildConfig_EnvAutoInstrumentationOmittedByDefault(t *testing.T) {
 	}
 }
 
-func TestLoadModelConfig(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "model.yaml")
-	content := `- envMappings:
-    dev:
-      providerName: openai
-      configuration:
-        policies: []
-  environmentVariables:
-    - key: OPENAI_API_KEY
-      name: OpenAI API Key
-`
-	os.WriteFile(path, []byte(content), 0644)
-
-	configs, err := loadModelConfig(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if configs == nil || len(*configs) != 1 {
-		t.Fatalf("len = %v, want 1", configs)
-	}
-	c := (*configs)[0]
-	if _, ok := c.EnvMappings["dev"]; !ok {
-		t.Error("missing dev env mapping")
-	}
-}
-
-func TestLoadModelConfig_JSON(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "model.json")
-	content := `[{"envMappings":{"prod":{"providerName":"anthropic","configuration":{"policies":[]}}}}]`
-	os.WriteFile(path, []byte(content), 0644)
-
-	configs, err := loadModelConfig(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(*configs) != 1 {
-		t.Fatalf("len = %d, want 1", len(*configs))
-	}
-}
-
 func TestBuild_FullBuildpack(t *testing.T) {
 	opts := &CreateOptions{
 		Name:         "my-agent",
@@ -441,24 +397,55 @@ func TestBuild_FullDocker(t *testing.T) {
 	}
 }
 
-func TestBuild_WithModelConfig(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "mc.yaml")
-	os.WriteFile(path, []byte(`[{envMappings: {dev: {providerName: test, configuration: {}}}}]`), 0644)
-
-	mc, err := loadModelConfig(path)
-	if err != nil {
-		t.Fatalf("loadModelConfig: %v", err)
-	}
-
+func TestBuild_ModelConfig_ProviderOnly(t *testing.T) {
 	opts := validBuildpackOpts()
-	opts.modelConfig = mc
+	opts.LLMProvider = "openai"
 	req, err := Build(opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if req.ModelConfig == nil || len(*req.ModelConfig) != 1 {
-		t.Errorf("ModelConfig = %v, want 1 entry", req.ModelConfig)
+		t.Fatalf("ModelConfig = %v, want 1 entry", req.ModelConfig)
+	}
+	mc := (*req.ModelConfig)[0]
+	if mc.ProviderName != "openai" {
+		t.Errorf("ProviderName = %q, want openai", mc.ProviderName)
+	}
+	if mc.EnvironmentVariables != nil {
+		t.Errorf("EnvironmentVariables = %v, want nil (no overrides)", mc.EnvironmentVariables)
+	}
+}
+
+func TestBuild_ModelConfig_WithEnvOverrides(t *testing.T) {
+	opts := validBuildpackOpts()
+	opts.LLMProvider = "openai"
+	opts.LLMURLEnv = "MY_URL"
+	opts.LLMAPIKeyEnv = "MY_KEY"
+	req, err := Build(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mc := (*req.ModelConfig)[0]
+	if mc.EnvironmentVariables == nil {
+		t.Fatal("EnvironmentVariables is nil, want 2 entries")
+	}
+	got := map[string]string{}
+	for _, ev := range *mc.EnvironmentVariables {
+		got[ev.Key] = ev.Name
+	}
+	if got["url"] != "MY_URL" || got["apikey"] != "MY_KEY" {
+		t.Errorf("env overrides = %v, want url=MY_URL apikey=MY_KEY", got)
+	}
+}
+
+func TestBuild_ModelConfig_OmittedWhenNoProvider(t *testing.T) {
+	opts := validBuildpackOpts()
+	req, err := Build(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.ModelConfig != nil {
+		t.Errorf("ModelConfig = %v, want nil when --llm-provider unset", req.ModelConfig)
 	}
 }
 

--- a/cli/pkg/cmd/agent/create/validation.go
+++ b/cli/pkg/cmd/agent/create/validation.go
@@ -135,10 +135,8 @@ func validateInternal(opts *CreateOptions) []string {
 	v = append(v, validateEnvSlice(opts.EnvSecret, "--env-secret", seen)...)
 	v = append(v, validateEnvSlice(opts.EnvFromSecret, "--env-from-secret", seen)...)
 
-	if opts.ModelConfigFile != "" {
-		if _, err := loadModelConfig(opts.ModelConfigFile); err != nil {
-			v = append(v, fmt.Sprintf("--model-config-file: %s", err))
-		}
+	if (opts.LLMURLEnv != "" || opts.LLMAPIKeyEnv != "") && opts.LLMProvider == "" {
+		v = append(v, "--llm-url-env/--llm-api-key-env require --llm-provider")
 	}
 
 	return v
@@ -199,7 +197,9 @@ func validateExternal(opts *CreateOptions) []string {
 	disallow("--env-secret", len(opts.EnvSecret) > 0)
 	disallow("--env-from-secret", len(opts.EnvFromSecret) > 0)
 	disallow("--no-auto-instrumentation", opts.DisableAutoInstrumentation)
-	disallow("--model-config-file", opts.ModelConfigFile != "")
+	disallow("--llm-provider", opts.LLMProvider != "")
+	disallow("--llm-url-env", opts.LLMURLEnv != "")
+	disallow("--llm-api-key-env", opts.LLMAPIKeyEnv != "")
 
 	return v
 }

--- a/cli/pkg/cmd/agent/create/validation_test.go
+++ b/cli/pkg/cmd/agent/create/validation_test.go
@@ -18,8 +18,6 @@ package create
 
 import (
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -124,7 +122,7 @@ func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
 	opts.EnvSecret = []string{"BAZ=quux"}
 	opts.EnvFromSecret = []string{"QUUX=secret-name"}
 	opts.DisableAutoInstrumentation = true
-	opts.ModelConfigFile = "models.yaml"
+	opts.LLMProvider = "openai"
 
 	err := validate(opts)
 	details := mustFlagDetails(t, err)
@@ -146,7 +144,7 @@ func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
 		"--env-secret is not allowed for external provisioning",
 		"--env-from-secret is not allowed for external provisioning",
 		"--no-auto-instrumentation is not allowed for external provisioning",
-		"--model-config-file is not allowed for external provisioning",
+		"--llm-provider is not allowed for external provisioning",
 	} {
 		assertContains(t, details, msg)
 	}
@@ -378,44 +376,32 @@ func TestValidate_ValidEnv(t *testing.T) {
 	}
 }
 
-func TestValidate_ModelConfigFileMissing(t *testing.T) {
+func TestValidate_LLMEnvFlagsRequireProvider(t *testing.T) {
 	opts := validBuildpackOpts()
-	opts.ModelConfigFile = "/nonexistent/model-config.yaml"
+	opts.LLMURLEnv = "MY_URL"
 	err := validate(opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--model-config-file: ")
+	assertContains(t, details, "--llm-url-env/--llm-api-key-env require --llm-provider")
 }
 
-func TestValidate_ModelConfigFileInvalid(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "bad.yaml")
-	if err := os.WriteFile(path, []byte("not: a: list: ["), 0644); err != nil {
-		t.Fatalf("write temp file: %v", err)
-	}
+func TestValidate_LLMProviderValid(t *testing.T) {
 	opts := validBuildpackOpts()
-	opts.ModelConfigFile = path
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--model-config-file: ")
-}
-
-func TestValidate_ModelConfigFileValid(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "model.yaml")
-	content := `- envMappings:
-    dev:
-      providerName: openai
-      configuration:
-        policies: []
-`
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("write temp file: %v", err)
-	}
-	opts := validBuildpackOpts()
-	opts.ModelConfigFile = path
+	opts.LLMProvider = "openai"
+	opts.LLMURLEnv = "MY_URL"
+	opts.LLMAPIKeyEnv = "MY_KEY"
 	if err := validate(opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+func TestValidate_ExternalRejectsLLMEnvFlags(t *testing.T) {
+	opts := validExternalOpts()
+	opts.LLMURLEnv = "MY_URL"
+	opts.LLMAPIKeyEnv = "MY_KEY"
+	err := validate(opts)
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "--llm-url-env is not allowed for external provisioning")
+	assertContains(t, details, "--llm-api-key-env is not allowed for external provisioning")
 }
 
 func TestValidate_CustomAPIRequiresBasePathAndOpenAPISpec(t *testing.T) {

--- a/console/workspaces/libs/types/src/api/agents.ts
+++ b/console/workspaces/libs/types/src/api/agents.ts
@@ -20,7 +20,8 @@ import { type AgentPathParams, type Build, type Configurations, type ListQuery, 
 import type { EnvProviderConfiguration, EnvironmentVariableConfig } from './agent-model-configs';
 
 export interface ModelConfigRequest {
-  envMappings: Record<string, { providerName: string; configuration: EnvProviderConfiguration; }>;
+  providerName: string;
+  configuration?: EnvProviderConfiguration;
   environmentVariables?: EnvironmentVariableConfig[];
 }
 

--- a/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
@@ -21,10 +21,10 @@ import { Alert, Form, MenuItem, Select, SelectChangeEvent, Skeleton } from "@wso
 import { PageLayout, useFormValidation } from "@agent-management-platform/views";
 import { generatePath, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { absoluteRouteMap, type AgentKindVersionResponse, OrgProjPathParams } from "@agent-management-platform/types";
-import { useCreateAgent, useGetAgentKind } from "@agent-management-platform/api-client";
+import { useCreateAgent, useGetAgentKind, useGetDeploymentPipeline } from "@agent-management-platform/api-client";
 import { createAgentSchema, type CreateAgentFormValues, type LLMProviderFormEntry } from "../form/schema";
 import { CreateButtons } from "./CreateButtons";
-import { buildCatalogAgentPayload } from "../utils/buildAgentPayload";
+import { buildCatalogAgentPayload, findLowestEnvironmentName } from "../utils/buildAgentPayload";
 import { CatalogAgentForm } from "../forms/CatalogAgentForm";
 import { LLMProviderSection } from "./LLMProviderSection";
 import { EnvironmentVariable } from "./EnvironmentVariable";
@@ -123,6 +123,12 @@ export const CatalogAgentFlow: React.FC = () => {
     }),
     [orgId, projectId]
   );
+  const { data: deploymentPipeline, isLoading: isDeploymentPipelineLoading } =
+    useGetDeploymentPipeline(params);
+  const initialEnvironmentName = useMemo(
+    () => findLowestEnvironmentName(deploymentPipeline?.promotionPaths),
+    [deploymentPipeline?.promotionPaths],
+  );
 
   const llmReservedNames = useMemo(() => {
     const agentNameUpper = formData.displayName
@@ -158,7 +164,7 @@ export const CatalogAgentFlow: React.FC = () => {
   }, [navigate, orgId, projectId]);
 
   const [lastSubmittedValidationErrors, setLastSubmittedValidationErrors] = useState<
-    typeof errors
+    Record<string, string | undefined>
   >({});
 
   const handleDeploy = useCallback(() => {
@@ -169,7 +175,21 @@ export const CatalogAgentFlow: React.FC = () => {
       setLastSubmittedValidationErrors({});
     }
 
-    const payload = buildCatalogAgentPayload(formData, params, kindId ?? "", effectiveVersion, llmProviders);
+    if (llmProviders.length > 0 && !initialEnvironmentName) {
+      setLastSubmittedValidationErrors({
+        llmProvider: "Unable to resolve the initial deployment environment for LLM provider configuration.",
+      });
+      return;
+    }
+
+    const payload = buildCatalogAgentPayload(
+      formData,
+      params,
+      kindId ?? "",
+      effectiveVersion,
+      llmProviders,
+      initialEnvironmentName,
+    );
     createAgent(payload, {
       onSuccess: () => {
         navigate(
@@ -189,7 +209,7 @@ export const CatalogAgentFlow: React.FC = () => {
       },
     });
   }, [validateForm, formData, createAgent, navigate, params, errors, llmProviders, kindId,
-    effectiveVersion]);
+    effectiveVersion, initialEnvironmentName]);
 
   const backHref = useMemo(() => {
     return generatePath(
@@ -253,6 +273,8 @@ export const CatalogAgentFlow: React.FC = () => {
           llmProviders={llmProviders}
           setLLMProviders={setLLMProviders}
           agentDisplayName={formData.displayName}
+          initialEnvironmentName={initialEnvironmentName}
+          isInitialEnvironmentLoading={isDeploymentPipelineLoading}
           externalEnvKeys={
             new Set((formData.env ?? []).map((e) => e.key).filter((k): k is string => !!k))
           }
@@ -279,7 +301,7 @@ export const CatalogAgentFlow: React.FC = () => {
 
         <CreateButtons
           lastSubmittedValidationErrors={lastSubmittedValidationErrors}
-          isPending={isPending}
+          isPending={isPending || (llmProviders.length > 0 && isDeploymentPipelineLoading)}
           onCancel={handleCancel}
           onSubmit={handleDeploy}
           isNameEmpty={!formData.name.trim()}

--- a/console/workspaces/pages/add-new-agent/src/components/CreateButtons.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/CreateButtons.tsx
@@ -20,7 +20,7 @@ import { Alert, Box, Button, Collapse } from "@wso2/oxygen-ui";
 import { Rocket as RocketOutlined, Link } from "@wso2/oxygen-ui-icons-react";
 
 interface SummaryPanelProps {
-    lastSubmittedValidationErrors: Record<string, string>;
+    lastSubmittedValidationErrors: Record<string, string | undefined>;
     isPending: boolean;
     onCancel: () => void;
     onSubmit: () => void;
@@ -34,7 +34,8 @@ export const CreateButtons = (
 ) => {
     const isConnectMode = mode === 'connect';
 
-    const errorsList = Object.values(lastSubmittedValidationErrors);
+    const errorsList = Object.values(lastSubmittedValidationErrors)
+        .filter((error): error is string => !!error);
     const hasErrors = errorsList.length > 0;
 
     return (
@@ -66,4 +67,3 @@ export const CreateButtons = (
         </Box>
     );
 };
-

--- a/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
@@ -24,11 +24,11 @@ import {
   absoluteRouteMap,
   OrgProjPathParams,
 } from "@agent-management-platform/types";
-import { useCreateAgent } from "@agent-management-platform/api-client";
+import { useCreateAgent, useGetDeploymentPipeline } from "@agent-management-platform/api-client";
 import { createAgentSchema, type CreateAgentFormValues, type LLMProviderFormEntry } from "../form/schema";
 import { InternalAgentForm } from "../forms/InternalAgentForm";
 import { CreateButtons } from "./CreateButtons";
-import { buildAgentCreationPayload } from "../utils/buildAgentPayload";
+import { buildAgentCreationPayload, findLowestEnvironmentName } from "../utils/buildAgentPayload";
 
 export const InternalAgentFlow: React.FC = () => {
   const navigate = useNavigate();
@@ -75,6 +75,12 @@ export const InternalAgentFlow: React.FC = () => {
     }),
     [orgId, projectId]
   );
+  const { data: deploymentPipeline, isLoading: isDeploymentPipelineLoading } =
+    useGetDeploymentPipeline(params);
+  const initialEnvironmentName = useMemo(
+    () => findLowestEnvironmentName(deploymentPipeline?.promotionPaths),
+    [deploymentPipeline?.promotionPaths],
+  );
 
   const handleCancel = useCallback(() => {
     navigate(
@@ -86,7 +92,7 @@ export const InternalAgentFlow: React.FC = () => {
   }, [navigate, orgId, projectId]);
 
   const [lastSubmittedValidationErrors, setLastSubmittedValidationErrors] = useState<
-    typeof errors
+    Record<string, string | undefined>
   >({});
 
   const handleDeploy = useCallback(() => {
@@ -97,7 +103,19 @@ export const InternalAgentFlow: React.FC = () => {
       setLastSubmittedValidationErrors({});
     }
 
-    const payload = buildAgentCreationPayload(formData, params, llmProviders);
+    if (llmProviders.length > 0 && !initialEnvironmentName) {
+      setLastSubmittedValidationErrors({
+        llmProvider: "Unable to resolve the initial deployment environment for LLM provider configuration.",
+      });
+      return;
+    }
+
+    const payload = buildAgentCreationPayload(
+      formData,
+      params,
+      llmProviders,
+      initialEnvironmentName,
+    );
     createAgent(payload, {
       onSuccess: () => {
         navigate(
@@ -116,7 +134,16 @@ export const InternalAgentFlow: React.FC = () => {
         console.error("Failed to create agent:", e);
       },
     });
-  }, [validateForm, formData, createAgent, navigate, params, errors, llmProviders]);
+  }, [
+    validateForm,
+    formData,
+    createAgent,
+    navigate,
+    params,
+    errors,
+    llmProviders,
+    initialEnvironmentName,
+  ]);
 
 
   const backHref = generatePath(
@@ -141,6 +168,8 @@ export const InternalAgentFlow: React.FC = () => {
           validateField={validateField}
           llmProviders={llmProviders}
           setLLMProviders={setLLMProviders}
+          initialEnvironmentName={initialEnvironmentName}
+          isInitialEnvironmentLoading={isDeploymentPipelineLoading}
         />
 
         {!!error && (
@@ -151,7 +180,7 @@ export const InternalAgentFlow: React.FC = () => {
 
         <CreateButtons
           lastSubmittedValidationErrors={lastSubmittedValidationErrors}
-          isPending={isPending}
+          isPending={isPending || (llmProviders.length > 0 && isDeploymentPipelineLoading)}
           onCancel={handleCancel}
           onSubmit={handleDeploy}
           isNameEmpty={!formData.name.trim()}

--- a/console/workspaces/pages/add-new-agent/src/components/LLMProviderSection.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/LLMProviderSection.tsx
@@ -503,6 +503,8 @@ interface LLMProviderSectionProps {
   llmProviders: LLMProviderFormEntry[];
   setLLMProviders: React.Dispatch<React.SetStateAction<LLMProviderFormEntry[]>>;
   agentDisplayName: string;
+  initialEnvironmentName: string | undefined;
+  isInitialEnvironmentLoading?: boolean;
   externalEnvKeys?: Set<string>;
 }
 
@@ -510,6 +512,8 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
   llmProviders,
   setLLMProviders,
   agentDisplayName,
+  initialEnvironmentName,
+  isInitialEnvironmentLoading = false,
   externalEnvKeys = new Set(),
 }) => {
   const { orgId } = useParams<{ orgId: string }>();
@@ -526,8 +530,15 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
 
   const { data: environments = [], isLoading: envsLoading } =
     useListEnvironments({ orgName: orgId });
-  const drawerEnvironmentId =
-    editingIndex !== null ? environments.find((e) => e.name === drawerEnvName)?.id : undefined;
+  const targetEnvironments = useMemo(
+    () => initialEnvironmentName
+      ? environments.filter((env) => env.name === initialEnvironmentName)
+      : [],
+    [environments, initialEnvironmentName],
+  );
+  const drawerEnvironmentId = drawerEnvName
+    ? environments.find((e) => e.name === drawerEnvName)?.id
+    : undefined;
   const { data: catalogData, isLoading: catalogLoading } = useListCatalogLLMProviders(
     { orgName: orgId },
     { limit: 50, environmentId: drawerEnvironmentId },
@@ -578,9 +589,12 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
   }, []);
 
   const handleAddNew = useCallback(() => {
+    const targetEnvironmentName = targetEnvironments[0]?.name;
+    if (!targetEnvironmentName) return;
     setEditingIndex(null);
+    setDrawerEnvName(targetEnvironmentName);
     setProviderDrawerOpen(true);
-  }, []);
+  }, [targetEnvironments]);
 
   const handleDrawerClose = useCallback(() => {
     if (searchTimerRef.current) {
@@ -596,11 +610,9 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
     (providerUuid: string, providerHandle: string) => {
       setLLMProviders((prev) => {
         if (editingIndex === null) {
-          // Adding a new entry — assign this provider to all environments.
-          // Guard: environments must be loaded before creating env mappings.
-          if (environments.length === 0) return prev;
+          if (targetEnvironments.length === 0) return prev;
           const selectedProviderByEnv: LLMProviderFormEntry["selectedProviderByEnv"] = {};
-          for (const env of environments) {
+          for (const env of targetEnvironments) {
             selectedProviderByEnv[env.name] = { uuid: providerUuid, handle: providerHandle };
           }
           const newIndex = prev.length;
@@ -636,7 +648,7 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
       setProviderSearchQuery("");
       setDebouncedSearch("");
     },
-    [editingIndex, drawerEnvName, environments, agentNameUpper, setLLMProviders],
+    [editingIndex, drawerEnvName, targetEnvironments, agentNameUpper, setLLMProviders],
   );
 
   const handleRemoveEntry = useCallback(
@@ -686,7 +698,7 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
               index={index}
               providers={providers}
               templateMap={templateMap}
-              environments={environments}
+              environments={targetEnvironments}
               agentNameUpper={agentNameUpper}
               usedVarNames={usedVarNames}
               onOpenDrawer={handleOpenDrawer}
@@ -702,7 +714,12 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
               size="small"
               startIcon={<Plus size={16} />}
               onClick={handleAddNew}
-              disabled={envsLoading || catalogLoading }
+              disabled={
+                envsLoading ||
+                isInitialEnvironmentLoading ||
+                catalogLoading ||
+                targetEnvironments.length === 0
+              }
             >
               Add
             </Button>

--- a/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
+++ b/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
@@ -48,6 +48,8 @@ interface InternalAgentFormProps {
   ) => string | undefined;
   llmProviders: LLMProviderFormEntry[];
   setLLMProviders: React.Dispatch<React.SetStateAction<LLMProviderFormEntry[]>>;
+  initialEnvironmentName: string | undefined;
+  isInitialEnvironmentLoading?: boolean;
 }
 const languageOptions = [
   { label: "Python", value: "python" },
@@ -67,6 +69,8 @@ export const InternalAgentForm = ({
   validateField,
   llmProviders,
   setLLMProviders,
+  initialEnvironmentName,
+  isInitialEnvironmentLoading = false,
 }: InternalAgentFormProps) => {
   const { orgId, projectId } = useParams<{ orgId: string; projectId: string }>();
   const privateRepoConfigs = useExternalConfigModules("private-repo-support");
@@ -583,6 +587,8 @@ export const InternalAgentForm = ({
         llmProviders={llmProviders}
         setLLMProviders={setLLMProviders}
         agentDisplayName={formData.displayName}
+        initialEnvironmentName={initialEnvironmentName}
+        isInitialEnvironmentLoading={isInitialEnvironmentLoading}
         externalEnvKeys={
           new Set((formData.env ?? []).map((e) => e.key).filter((k): k is string => !!k))
         }

--- a/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.test.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { buildModelConfig } from "./buildAgentPayload";
+import type { LLMProviderFormEntry } from "../form/schema";
+
+function entry(over: Partial<LLMProviderFormEntry> = {}): LLMProviderFormEntry {
+  return {
+    selectedProviderByEnv: { Development: { uuid: "u1", handle: "openai" } },
+    urlVarName: undefined,
+    apikeyVarName: undefined,
+    guardrails: [],
+    ...over,
+  };
+}
+
+describe("buildModelConfig (flat shape)", () => {
+  it("maps a single provider with no env overrides", () => {
+    const out = buildModelConfig([entry()]);
+    expect(out).toEqual([{ providerName: "openai" }]);
+  });
+
+  it("includes env-var name overrides", () => {
+    const out = buildModelConfig([entry({ urlVarName: "MY_URL", apikeyVarName: "MY_KEY" })]);
+    expect(out?.[0]).toMatchObject({
+      providerName: "openai",
+      environmentVariables: [
+        { key: "url", name: "MY_URL" },
+        { key: "apikey", name: "MY_KEY" },
+      ],
+    });
+  });
+
+  it("preserves guardrail policies in configuration", () => {
+    const out = buildModelConfig([entry({
+      guardrails: [{ name: "pii", version: "v1", settings: { mode: "block" } }],
+    })]);
+    expect(out?.[0].configuration?.policies).toEqual([
+      { name: "pii", version: "v1", paths: [{ path: "/*", methods: ["*"], params: { mode: "block" } }] },
+    ]);
+  });
+
+  it("returns undefined when no providers", () => {
+    expect(buildModelConfig([])).toBeUndefined();
+  });
+});

--- a/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.test.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildModelConfig } from "./buildAgentPayload";
+import { buildModelConfig, findLowestEnvironmentName } from "./buildAgentPayload";
 import type { LLMProviderFormEntry } from "../form/schema";
 
 function entry(over: Partial<LLMProviderFormEntry> = {}): LLMProviderFormEntry {
@@ -14,12 +14,25 @@ function entry(over: Partial<LLMProviderFormEntry> = {}): LLMProviderFormEntry {
 
 describe("buildModelConfig (flat shape)", () => {
   it("maps a single provider with no env overrides", () => {
-    const out = buildModelConfig([entry()]);
+    const out = buildModelConfig([entry()], "Development");
+    expect(out).toEqual([{ providerName: "openai" }]);
+  });
+
+  it("uses the provider selected for the lowest environment", () => {
+    const out = buildModelConfig([
+      entry({
+        selectedProviderByEnv: {
+          Production: { uuid: "u2", handle: "anthropic" },
+          Development: { uuid: "u1", handle: "openai" },
+        },
+      }),
+    ], "Development");
+
     expect(out).toEqual([{ providerName: "openai" }]);
   });
 
   it("includes env-var name overrides", () => {
-    const out = buildModelConfig([entry({ urlVarName: "MY_URL", apikeyVarName: "MY_KEY" })]);
+    const out = buildModelConfig([entry({ urlVarName: "MY_URL", apikeyVarName: "MY_KEY" })], "Development");
     expect(out?.[0]).toMatchObject({
       providerName: "openai",
       environmentVariables: [
@@ -32,13 +45,30 @@ describe("buildModelConfig (flat shape)", () => {
   it("preserves guardrail policies in configuration", () => {
     const out = buildModelConfig([entry({
       guardrails: [{ name: "pii", version: "v1", settings: { mode: "block" } }],
-    })]);
+    })], "Development");
     expect(out?.[0].configuration?.policies).toEqual([
       { name: "pii", version: "v1", paths: [{ path: "/*", methods: ["*"], params: { mode: "block" } }] },
     ]);
   });
 
   it("returns undefined when no providers", () => {
-    expect(buildModelConfig([])).toBeUndefined();
+    expect(buildModelConfig([], "Development")).toBeUndefined();
+  });
+
+  it("returns undefined when no provider is selected for the lowest environment", () => {
+    expect(buildModelConfig([entry()], "Production")).toBeUndefined();
+  });
+});
+
+describe("findLowestEnvironmentName", () => {
+  it("returns the source environment that is not a promotion target", () => {
+    expect(findLowestEnvironmentName([
+      { sourceEnvironmentRef: "Development", targetEnvironmentRefs: [{ name: "Staging" }] },
+      { sourceEnvironmentRef: "Staging", targetEnvironmentRefs: [{ name: "Production" }] },
+    ])).toBe("Development");
+  });
+
+  it("returns undefined when no lowest environment can be resolved", () => {
+    expect(findLowestEnvironmentName([])).toBeUndefined();
   });
 });

--- a/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
@@ -26,26 +26,19 @@ import { AddAgentFormValues, CreateAgentFormValues, LLMProviderFormEntry } from 
 function buildOneModelConfig(
   entry: LLMProviderFormEntry,
 ): ModelConfigRequest | null {
-  const envMappings: ModelConfigRequest["envMappings"] = {};
+  // The create-side config applies to the component's lowest environment; pick the
+  // first selected provider. (On Add, all environments are seeded with the same provider.)
+  const provider = Object.values(entry.selectedProviderByEnv).find((p) => p != null);
+  if (!provider) return null;
 
-  for (const [envName, provider] of Object.entries(entry.selectedProviderByEnv)) {
-    if (!provider) continue;
-    envMappings[envName] = {
-      providerName: provider.handle,
-      configuration: {
-        policies:
-          entry.guardrails.length > 0
-            ? entry.guardrails.map((g) => ({
-              name: g.name,
-              version: g.version,
-              paths: [{ path: "/*", methods: ["*"], params: g.settings ?? {} }],
-            }))
-            : undefined,
-      },
-    };
-  }
-
-  if (Object.keys(envMappings).length === 0) return null;
+  const policies =
+    entry.guardrails.length > 0
+      ? entry.guardrails.map((g) => ({
+          name: g.name,
+          version: g.version,
+          paths: [{ path: "/*", methods: ["*"], params: g.settings ?? {} }],
+        }))
+      : undefined;
 
   const environmentVariables = [
     ...(entry.urlVarName ? [{ key: "url", name: entry.urlVarName }] : []),
@@ -53,12 +46,13 @@ function buildOneModelConfig(
   ];
 
   return {
-    envMappings,
+    providerName: provider.handle,
+    ...(policies ? { configuration: { policies } } : {}),
     ...(environmentVariables.length > 0 ? { environmentVariables } : {}),
   };
 }
 
-function buildModelConfig(
+export function buildModelConfig(
   llmProviders: LLMProviderFormEntry[],
 ): ModelConfigRequest[] | undefined {
   if (!llmProviders.length) return undefined;

--- a/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
@@ -20,15 +20,33 @@ import {
   CreateAgentRequest,
   ModelConfigRequest,
   OrgProjPathParams,
+  PromotionPath,
 } from "@agent-management-platform/types";
 import { AddAgentFormValues, CreateAgentFormValues, LLMProviderFormEntry } from "../form/schema";
 
+export function findLowestEnvironmentName(
+  promotionPaths: PromotionPath[] = [],
+): string | undefined {
+  const targetEnvironments = new Set<string>();
+  for (const path of promotionPaths) {
+    for (const target of path.targetEnvironmentRefs) {
+      targetEnvironments.add(target.name);
+    }
+  }
+
+  return promotionPaths.find(
+    (path) => !targetEnvironments.has(path.sourceEnvironmentRef),
+  )?.sourceEnvironmentRef;
+}
+
 function buildOneModelConfig(
   entry: LLMProviderFormEntry,
+  initialEnvironmentName: string | undefined,
 ): ModelConfigRequest | null {
-  // The create-side config applies to the component's lowest environment; pick the
-  // first selected provider. (On Add, all environments are seeded with the same provider.)
-  const provider = Object.values(entry.selectedProviderByEnv).find((p) => p != null);
+  // The create-side config applies only to the component's initial environment.
+  const provider = initialEnvironmentName
+    ? entry.selectedProviderByEnv[initialEnvironmentName]
+    : null;
   if (!provider) return null;
 
   const policies =
@@ -54,9 +72,10 @@ function buildOneModelConfig(
 
 export function buildModelConfig(
   llmProviders: LLMProviderFormEntry[],
+  initialEnvironmentName: string | undefined,
 ): ModelConfigRequest[] | undefined {
   if (!llmProviders.length) return undefined;
-  const configs = llmProviders.map(buildOneModelConfig)
+  const configs = llmProviders.map((entry) => buildOneModelConfig(entry, initialEnvironmentName))
     .filter((c): c is ModelConfigRequest => c !== null);
   return configs.length > 0 ? configs : undefined;
 }
@@ -65,7 +84,10 @@ export const buildAgentCreationPayload = (
   data: AddAgentFormValues,
   params: OrgProjPathParams,
   llmProviders: LLMProviderFormEntry[] = [],
+  initialEnvironmentName?: string,
 ): { params: OrgProjPathParams; body: CreateAgentRequest } => {
+  const modelConfig = buildModelConfig(llmProviders, initialEnvironmentName);
+
   if (data.deploymentType === "new") {
     return {
       params,
@@ -136,8 +158,7 @@ export const buildAgentCreationPayload = (
             }
             : {}),
         },
-        ...((buildModelConfig(llmProviders)) ?
-          { modelConfig: buildModelConfig(llmProviders) } : {}),
+        ...(modelConfig ? { modelConfig } : {}),
       },
     };
   }
@@ -155,7 +176,7 @@ export const buildAgentCreationPayload = (
         type: "external-agent-api",
         subType: "custom-api",
       },
-      ...((buildModelConfig(llmProviders)) ? { modelConfig: buildModelConfig(llmProviders) } : {}),
+      ...(modelConfig ? { modelConfig } : {}),
     },
   };
 };
@@ -166,7 +187,10 @@ export const buildCatalogAgentPayload = (
   kindName: string,
   version: string,
   llmProviders: LLMProviderFormEntry[] = [],
+  initialEnvironmentName?: string,
 ): { params: OrgProjPathParams; body: CreateAgentRequest } => {
+  const modelConfig = buildModelConfig(llmProviders, initialEnvironmentName);
+
   return {
     params,
     body: {
@@ -198,7 +222,7 @@ export const buildCatalogAgentPayload = (
           })),
         enableAutoInstrumentation: data.enableAutoInstrumentation,
       },
-      ...((buildModelConfig(llmProviders)) ? { modelConfig: buildModelConfig(llmProviders) } : {}),
+      ...(modelConfig ? { modelConfig } : {}),
     },
   };
 };

--- a/documentation/docs/reference/cli/agent.mdx
+++ b/documentation/docs/reference/cli/agent.mdx
@@ -115,7 +115,9 @@ amctl agent create payments \
 | `--env` | strings | (none) | Environment variable as `KEY=VALUE`. Repeatable. Stored as plain text. |
 | `--env-secret` | strings | (none) | Sensitive env variable as `KEY=VALUE`. Repeatable. |
 | `--env-from-secret` | strings | (none) | Env variable sourced from a managed secret: `KEY=SECRETNAME`. Repeatable. |
-| `--model-config-file` | string | (none) | Path to a model-config YAML/JSON file. |
+| `--llm-provider` | string | (none) | Handle of a configured LLM provider to attach (internal only). |
+| `--llm-url-env` | string | (none) | Env var name for the provider URL (default: auto-generated). |
+| `--llm-api-key-env` | string | (none) | Env var name for the provider API key (default: auto-generated). |
 
 ---
 

--- a/test/e2e/framework/types.go
+++ b/test/e2e/framework/types.go
@@ -152,8 +152,9 @@ type EnvironmentVariableConfig struct {
 }
 
 type ModelConfigRequest struct {
-	EnvMappings          map[string]EnvModelConfigRequest `json:"envMappings"`
-	EnvironmentVariables []EnvironmentVariableConfig      `json:"environmentVariables,omitempty"`
+	ProviderName         string                      `json:"providerName"`
+	Configuration        map[string]interface{}      `json:"configuration,omitempty"`
+	EnvironmentVariables []EnvironmentVariableConfig `json:"environmentVariables,omitempty"`
 }
 
 type CreateAgentRequest struct {

--- a/test/e2e/tests/llmprovider/internal_agent_test.go
+++ b/test/e2e/tests/llmprovider/internal_agent_test.go
@@ -114,11 +114,7 @@ var _ = Describe("Internal Agent with LLM Provider Config", Label("llm-provider"
 		// Add model config referencing the LLM provider with custom env var names
 		createReq.ModelConfig = []framework.ModelConfigRequest{
 			{
-				EnvMappings: map[string]framework.EnvModelConfigRequest{
-					Cfg.DefaultEnv: {
-						ProviderName: providerID,
-					},
-				},
+				ProviderName: providerID,
 				EnvironmentVariables: []framework.EnvironmentVariableConfig{
 					{Key: "apikey", Name: "LLM_API_KEY"},
 					{Key: "url", Name: "LLM_BASE_URL"},


### PR DESCRIPTION
## Purpose
The create-side LLM model-config flow was awkward on several fronts: `amctl agent create` required a hand-written `--model-config-file` (YAML/JSON); the wire schema nested config under a per-environment `envMappings` map even though create only ever applies to the initial environment; and referencing a non-existent provider was only caught *after* secrets and the component had already been created, surfacing as an unmapped 500. This PR simplifies the developer-facing flags, flattens the wire schema, and fails fast on a bad provider.

## Goals
- Replace `--model-config-file` with three flat flags: `--llm-provider`, `--llm-url-env`, `--llm-api-key-env`.
- Flatten the create-side `ModelConfigRequest` from `{ envMappings: map, ... }` to `{ providerName, configuration?, environmentVariables? }`, applied to the component's lowest (initial) environment.
- Validate referenced providers in a preflight *before* any secrets/component are created: missing provider → **404**, empty or non-catalog provider → **400** (previously an unmapped 500 after partial provisioning).
- Keep guardrail policies working (the web console sets them at create time).
- Migrate all create-side callers (CLI, web console, e2e framework) and update CLI docs.

## Approach
Six focused commits, one per module/concern:
1. **Server schema** — flatten `ModelConfigRequest` in `api_v1_openapi.yaml`, regenerate server types, and rewrite `createAgentLLMConfigs` to key the single config under the resolved lowest environment, preserving guardrail policies via a new `convertConfiguration`.
2. **Server preflight + error contract** — add `ValidateProvidersInCatalog` (dedupes handles; missing → `ErrLLMProviderNotFound`/404, empty or not-in-catalog → `ErrInvalidInput`/400), run it after `firstEnv` is resolved and before secret/component creation, map the error to 404 in the controller, and document the 404 response in OpenAPI.
3. **CLI** — replace the flag and delete the file loader; assemble the flat request from the three flags; regenerate the `amsvc` client; surface the new 404.
4. **Web console** — flatten the hand-written TS type and payload builder, preserving guardrails.
5. **e2e framework** — flatten the framework type and the internal-agent scenario.
6. **Docs** — document the three new flags.

## User stories
As a developer using `amctl agent create`, I can attach a configured LLM provider with a single `--llm-provider` flag (optionally overriding the URL / API-key env-var names) instead of authoring a config file, and I get a clear 404 immediately if the provider doesn't exist — with no half-provisioned resources left behind.

## Release note
`amctl agent create` now attaches an LLM provider via `--llm-provider` (with optional `--llm-url-env` / `--llm-api-key-env`), replacing `--model-config-file`. Referenced providers are validated before provisioning, so a missing provider now returns 404 instead of failing mid-create. The create-side `modelConfig` request body is now flat (`providerName` / `configuration` / `environmentVariables`).

## Documentation
Updated `documentation/docs/reference/cli/agent.mdx` with the three new flags. The versioned snapshot (`version-v0.15.x`) is intentionally left unchanged (historical).

## Training
N/A — no training-content impact.

## Certification
N/A — no certification-exam impact.

## Marketing
N/A — internal DX / API refinement, no marketing content.

## Automation tests
 - Unit tests
   > Added — server: `TestCreateAgentLLMConfigs_KeysUnderFirstEnv` (lowest-env keying), `TestValidateProvidersInCatalog` (404 / 400 / dedup branches). CLI: `TestBuild_ModelConfig_ProviderOnly|WithEnvOverrides|OmittedWhenNoProvider`, `TestValidate_LLMEnvFlagsRequireProvider|LLMProviderValid|ExternalRejectsLLMEnvFlags`. Console: `buildAgentPayload.test.ts` (flat shape, env overrides, guardrail preservation, empty case). CLI unit tests pass locally.
 - Integration tests
   > Added server `TestCreateAgent_BadProviderFailsBeforeProvisioning` — asserts 404 and that no component is created. This and the server unit tests require a Postgres test DB and were **not** run in this branch's environment; please run `cd agent-manager-service && make test` (DB up) in CI. Console `rushx build/test/lint` and the internal-agent e2e scenario are likewise pending a full environment.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes** — followed existing repo patterns; the change adds input validation (provider preflight) and commits no secrets.
 - Ran FindSecurityBugs plugin and verified report? **no** — FindSecurityBugs is a Java/SpotBugs tool; this change is Go + TypeScript, so it is not applicable.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**.

## Samples
N/A — no sample changes.

## Related PRs
N/A.

## Migrations (if applicable)
No DB migrations. This is an API/CLI wire-shape change: the **create-side** `ModelConfigRequest` body changed from the per-env `envMappings` map to the flat `{ providerName, configuration?, environmentVariables? }`. All in-repo create-side callers (CLI, web console, e2e framework) are migrated in this PR. The standalone `model-configs` management endpoint and its `EnvModelConfigRequest`/`envMappings` shape are unchanged.

## Test environment
Not yet exercised on a full environment. Local checks performed: `go build` and `go vet` clean across `agent-manager-service`, `cli`, and `test/e2e`; CLI unit tests pass; `amctl agent create --help` confirms the three new flags (and `--model-config-file` removed). macOS, Go toolchain.

## Learning
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added --llm-provider, --llm-url-env, --llm-api-key-env for agent creation
  * Console: simplified model-config shape (providerName + configuration); UI now derives an initial environment and gates LLM provider wiring accordingly

* **Bug Fixes**
  * API: returns 404 when referenced LLM provider is missing
  * Prevents provisioning when referenced LLM providers are invalid (preflight validation)

* **Documentation**
  * Updated CLI docs to reflect new LLM flags
<!-- end of auto-generated comment: release notes by coderabbit.ai -->