### PR TITLE
Disable RBAC in matrix dev-stack to unblock nightly

### DIFF
--- a/.github/actions/amp-dev-stack/action.yaml
+++ b/.github/actions/amp-dev-stack/action.yaml
@@ -42,6 +42,13 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        # STOP-GAP: disable RBAC scope enforcement for the matrix dev-stack. With
+        # RBAC_ENABLED=true the heavy tier 403s on the first API call because the
+        # amp-api-client M2M client_credentials token doesn't carry the required
+        # scopes (e.g. project:create). docker-compose.yml reads this via
+        # ${RBAC_ENABLED:-true}, so local dev keeps RBAC on. Remove this once the
+        # Thunder bootstrap grants the amp-api-client token its admin scopes.
+        export RBAC_ENABLED=false
         # k3d cluster + prerequisites (Gateway API, cert-manager, …)
         make setup-k3d
         # OpenChoreo + builds & loads traces-observer + instrumentation images

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -39,7 +39,10 @@ services:
       - SERVER_PORT=8080
       - SERVER_PUBLIC_URL=http://localhost:9000
       - OAUTH_AUTHORIZATION_SERVERS=http://thunder.amp.localhost:8080
-      - RBAC_ENABLED=true
+      # Defaults to on for local dev; overridable via the environment so the
+      # instrumentation-matrix CI dev-stack can disable it (the amp-api-client
+      # M2M token doesn't yet carry the RBAC scopes the heavy tier needs).
+      - RBAC_ENABLED=${RBAC_ENABLED:-true}
       # Kubernetes Configuration
       - KUBECONFIG=/app/.kube/config
       - IS_LOCAL_DEV_ENV=true


### PR DESCRIPTION
## Purpose
The `Instrumentation matrix tests - nightly` heavy tier is red. Every cell 403s on its very first API call — `POST /api/v1/orgs/default/projects → 403 {"code":"FORBIDDEN","message":"insufficient permissions"}` ([failing run](https://github.com/wso2/agent-manager/actions/runs/27167266968/job/80200252389)). With `RBAC_ENABLED=true`, `middleware/authorization.go` now requires the caller's token to carry the route's scope (`project:create`), but the heavy driver's `amp-api-client` M2M `client_credentials` token doesn't carry it, so the first call fails and cascades to all 8 cells.

The matrix test config is **not** the problem: the harness authenticates as the intended `amp-api-client` and mirrors the Go e2e and gateway-bootstrap auth flows. The gap is server-side — `#1024` (assign `amp-api-client` → admin role) and `261cf16b` (ampScopes in the Thunder bootstrap) tried to grant the M2M token its scopes, but neither fixed the `client_credentials` path, and both were already on `main` in the failing nightly's checkout.

Related to #1024

## Goals
Get the nightly green again without lowering local-dev fidelity or touching the (correct) matrix test files, while the real server-side fix is worked out.

## Approach
Disable RBAC enforcement for the instrumentation-matrix dev-stack only:

- `.github/actions/amp-dev-stack/action.yaml` — `export RBAC_ENABLED=false` before the dev-stack bring-up.
- `deployments/docker-compose.yml` — read `RBAC_ENABLED=${RBAC_ENABLED:-true}` for `agent-manager-service`, so local dev (and anything that doesn't set the var) keeps RBAC **on**; only the CI action overrides it.

This scopes the disable to the nightly + manual matrix workflows (both use this action). The console's `RBAC_ENABLED` and the PR matrix workflow (no heavy tier) are untouched.

**This is a stop-gap.** The `export RBAC_ENABLED=false` should be removed once the Thunder bootstrap actually grants the `amp-api-client` M2M token its admin scopes.

## User stories
N/A — CI/test-infra fix.

## Release note
N/A — no product/runtime behavior change; affects matrix CI dev-stack only.

## Documentation
N/A — no doc impact; internal test-infra change.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — no application code changed.
 - Integration tests
   > Verified statically: the action's `export RBAC_ENABLED=false` propagates through `make setup-platform` → `setup-platform.sh` (`docker compose up`) → the new `${RBAC_ENABLED:-true}` interpolation, so `agent-manager-service` boots with RBAC off and `RequirePermission` short-circuits. Full confirmation is the next nightly/manual matrix run going green.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/app code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #1024 — Assign admin role to amp-api-client application (server-side attempt at the same root cause)

## Migrations (if applicable)
N/A

## Test environment
GitHub Actions `ubuntu-24.04` runner (the matrix nightly/manual dev-stack).

## Learning
Traced the 403 backward from the failing job through `authorization.go` (scope enforcement), `heavy/amp_client.py` + `heavy/driver.py` (auth as `amp-api-client`), and the Thunder bootstrap (`wso2-amp-thunder-extension`), confirming `#1024`/`261cf16b` were present-but-ineffective in the failing run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved development environment setup issues preventing API calls from failing with authentication errors.

* **Chores**
  * Improved configuration flexibility for RBAC settings in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->