### PR TITLE
Request RBAC scopes in heavy matrix token call

### DIFF
--- a/test/instrumentation-matrix/heavy/amp_client.py
+++ b/test/instrumentation-matrix/heavy/amp_client.py
@@ -42,6 +42,22 @@ _DEPLOY_FAILED_STREAK = 3
 _HTTP_TIMEOUT_S = 30
 _TOKEN_REFRESH_SKEW_S = 30
 
+# OAuth2 scopes requested in the client_credentials grant. With RBAC_ENABLED=true
+# the service authorizes every route against the token's scopes, and Thunder only
+# puts a scope in a client_credentials token when it is *explicitly requested*
+# (and the app is registered for it + assigned a role that grants it — both done
+# for amp-api-client in the Thunder bootstrap). Omitting `scope` yields a token
+# with no scope claim, so every call 403s. Request exactly the permissions this
+# provisioning flow exercises (create project/agent, read builds+deployments,
+# mint API key, and the teardown deletes). Mirrors how the console requests its
+# scope list. Unauthorised/unknown scopes are silently filtered by Thunder, so
+# this stays a tight, intention-revealing set.
+_TOKEN_SCOPES = (
+    "project:create project:read project:delete "
+    "agent:create agent:read agent:delete agent:build "
+    "agent:deploy:non-production agent:api-key:manage"
+)
+
 # The deployed agent's source is cloned from this repo ref by the in-cluster
 # buildpack. Defaults to wso2/agent-manager@main; overridable (see
 # heavy/driver.py AMP_AGENT_REPO_*) so a PR can validate a new/changed sample
@@ -127,15 +143,17 @@ class AmpClient:
     def access_token(self) -> str:
         """Return a current access token, refreshing within 30s of expiry.
 
-        Mirrors test/e2e/framework/auth.go: POST the token endpoint with
-        `grant_type=client_credentials` and HTTP Basic client credentials.
+        Follows test/e2e/framework/auth.go: POST the token endpoint with
+        `grant_type=client_credentials` and HTTP Basic client credentials, plus
+        an explicit `scope` (see _TOKEN_SCOPES) so the token carries the
+        permissions RBAC checks against.
         """
         if self._token and time.monotonic() < self._token_expires_at - _TOKEN_REFRESH_SKEW_S:
             return self._token
 
         resp = self._session.post(
             self.idp.token_url,
-            data={"grant_type": "client_credentials"},
+            data={"grant_type": "client_credentials", "scope": _TOKEN_SCOPES},
             auth=(self.idp.client_id, self.idp.client_secret),
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=_HTTP_TIMEOUT_S,

--- a/test/instrumentation-matrix/tests/test_heavy_client.py
+++ b/test/instrumentation-matrix/tests/test_heavy_client.py
@@ -51,6 +51,22 @@ def test_access_token_fetches_and_caches():
 
 
 @responses.activate
+def test_access_token_requests_rbac_scopes():
+    # Thunder only puts a scope in a client_credentials token when it's requested,
+    # and the service authorizes routes against it under RBAC_ENABLED=true. The
+    # token call must therefore send the provisioning scopes, or every API call 403s.
+    import urllib.parse as _u
+
+    _mock_token()
+    _client().access_token()
+    body = _u.parse_qs([r for r in responses.calls if r.request.url.startswith(TOKEN_URL)][0].request.body)
+    assert body["grant_type"] == ["client_credentials"]
+    requested = body["scope"][0].split()
+    for required in ("project:create", "agent:create", "agent:api-key:manage", "project:delete"):
+        assert required in requested
+
+
+@responses.activate
 def test_access_token_raises_on_failure():
     responses.add(responses.POST, TOKEN_URL, json={"error": "nope"}, status=401)
     with pytest.raises(AmpError, match="token fetch failed"):


### PR DESCRIPTION
## Purpose
The `Instrumentation matrix tests - nightly` heavy tier is red. Every cell 403s on its first API call — `POST /api/v1/orgs/default/projects → 403 {"code":"FORBIDDEN","message":"insufficient permissions"}` ([failing run](https://github.com/wso2/agent-manager/actions/runs/27167266968/job/80200252389)). Under `RBAC_ENABLED=true`, `middleware/authorization.go` authorizes every route against the token's scopes, but the heavy driver's `amp-api-client` M2M `client_credentials` token carries **no scope claim at all**, so every call is denied.

This supersedes the stop-gap in #1032 (which disabled RBAC for the matrix dev-stack). This PR fixes the root cause instead, so the heavy tier runs with RBAC **enabled**.

Related to #1024

## Goals
Make the heavy tier's `amp-api-client` token actually carry the permissions it needs, so the matrix exercises the real RBAC path and goes green.

## Approach
Root cause, verified against a live Thunder (decoded the issued JWT and exercised the API end to end):

- Thunder issues a `client_credentials` token with a `scope` claim **only when the scope is explicitly requested**. With no `scope` param, the token has an empty scope set.
- The app-side preconditions are already in place from the Thunder bootstrap: `amp-api-client` is registered with the scope list (261cf16b) and assigned the `admin` role (#1024). The only missing piece was the **request**.
- Confirmed: registering the scopes + assigning the role and then requesting `scope=project:create …` yields a token with that scope, and the same `POST /projects` that returned **403** returns **202**. Requesting nothing returns 403 (the original failure, reproduced as a control).

The fix sends an explicit `scope` on the heavy driver's token request (`heavy/amp_client.py`), covering exactly the permissions the provisioning flow exercises:

`project:create project:read project:delete agent:create agent:read agent:delete agent:build agent:deploy:non-production agent:api-key:manage`

This mirrors how the console requests its scope list (`AUTH_SCOPES` in `docker-compose.yml`). Thunder silently filters any scope the app isn't authorised for, so the set stays tight and intention-revealing.

## User stories
N/A — CI/test-infra fix.

## Release note
N/A — no product/runtime behavior change; affects the instrumentation-matrix heavy tier only.

## Documentation
N/A — no doc impact.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Added `test_access_token_requests_rbac_scopes` asserting the token call sends `grant_type=client_credentials` plus the required scopes. Full `tests/test_heavy_client.py` suite passes (14 passed).
 - Integration tests
   > Proven end to end against a live local stack: scoped token → `POST /projects` returns 202; unscoped token → 403. Final confirmation is the heavy tier going green on the nightly/manual matrix run once merged.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #1032 — stop-gap (disable RBAC for the matrix dev-stack); superseded by this PR and being closed.
- #1024 — Assign admin role to amp-api-client application (one of the app-side preconditions this fix relies on).

## Migrations (if applicable)
N/A

## Test environment
macOS local stack (k3d + Thunder 0.34.0 + compose) for the end-to-end proof; GitHub Actions `ubuntu-24.04` for the matrix run.

## Learning
Decoded the `amp-api-client` JWT (no `scope` claim), then used `amp-system-client` (`scope=system`) as a Thunder admin to introspect the app/role state and reproduce the fix end to end, confirming Thunder only emits requested scopes for `client_credentials`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced OAuth2 token request handling to explicitly include authorization scopes required for proper role-based access control enforcement

* **Tests**
  * Added test verification to ensure authentication token requests correctly include all necessary RBAC scopes for resource provisioning and API management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->