### PR TITLE
Disabling modifying permissions of predefined roles

### DIFF
--- a/agent-manager-service/clients/thundersvc/identity_types.go
+++ b/agent-manager-service/clients/thundersvc/identity_types.go
@@ -113,12 +113,12 @@ type GroupMembersRequest struct {
 
 // ThunderRole represents a role in Thunder.
 type ThunderRole struct {
-	ID        string                  `json:"id"`
-	OuID      string                  `json:"ouId,omitempty"`
-	Name      string                  `json:"name"`
+	ID          string                  `json:"id"`
+	OuID        string                  `json:"ouId,omitempty"`
+	Name        string                  `json:"name"`
 	Description string                  `json:"description,omitempty"`
 	Permissions []RolePermissionRequest `json:"permissions,omitempty"`
-	IsReadOnly bool                   `json:"isReadOnly"`
+	IsReadOnly  bool                    `json:"isReadOnly"`
 	CreatedAt   string                  `json:"createdAt,omitempty"`
 	UpdatedAt   string                  `json:"updatedAt,omitempty"`
 }

--- a/agent-manager-service/clients/thundersvc/identity_types.go
+++ b/agent-manager-service/clients/thundersvc/identity_types.go
@@ -113,11 +113,12 @@ type GroupMembersRequest struct {
 
 // ThunderRole represents a role in Thunder.
 type ThunderRole struct {
-	ID          string                  `json:"id"`
-	OuID        string                  `json:"ouId,omitempty"`
-	Name        string                  `json:"name"`
+	ID        string                  `json:"id"`
+	OuID      string                  `json:"ouId,omitempty"`
+	Name      string                  `json:"name"`
 	Description string                  `json:"description,omitempty"`
 	Permissions []RolePermissionRequest `json:"permissions,omitempty"`
+	IsReadOnly bool                   `json:"isReadOnly"`
 	CreatedAt   string                  `json:"createdAt,omitempty"`
 	UpdatedAt   string                  `json:"updatedAt,omitempty"`
 }

--- a/agent-manager-service/constants/roles.go
+++ b/agent-manager-service/constants/roles.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package constants
+
+var predefinedRoles = map[string]bool{
+	"admin":             true,
+	"developer":         true,
+	"ai-lead":           true,
+	"platform-engineer": true,
+	"Administrator":     true,
+}
+
+func IsPredefinedRole(roleName string) bool {
+	return predefinedRoles[roleName]
+}

--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/constants"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -769,9 +770,10 @@ func (c *identityController) ListRoles(w http.ResponseWriter, r *http.Request) {
 
 	// Filter roles to only include those belonging to the caller's OU
 	// Thunder's ListRoles endpoint returns all roles, not OU-scoped
+	// Also exclude the "Administrator" role from public visibility
 	filteredRoles := make([]thundersvc.ThunderRole, 0, len(roles))
 	for _, role := range roles {
-		if role.OuID == resolvedOrg.OUID {
+		if role.OuID == resolvedOrg.OUID && role.Name != "Administrator" {
 			filteredRoles = append(filteredRoles, role)
 		}
 	}
@@ -864,6 +866,10 @@ func (c *identityController) UpdateRole(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if !validatePredefinedRole(w, role.Name) {
+		return
+	}
+
 	var req thundersvc.UpdateRoleRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
@@ -906,6 +912,10 @@ func (c *identityController) DeleteRole(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if !validateRoleOwnership(w, ctx, role, resolvedOrg.OUID) {
+		return
+	}
+
+	if !validatePredefinedRole(w, role.Name) {
 		return
 	}
 
@@ -1176,6 +1186,18 @@ func validateGroupOwnership(w http.ResponseWriter, ctx context.Context, group *t
 func validateRoleOwnership(w http.ResponseWriter, ctx context.Context, role *thundersvc.ThunderRole, callerOuID string) bool {
 	if role.OuID != "" && role.OuID != callerOuID {
 		utils.WriteErrorResponse(w, http.StatusForbidden, "Role does not belong to your organization")
+		return false
+	}
+	return true
+}
+
+func isPredefinedRole(roleName string) bool {
+	return constants.IsPredefinedRole(roleName)
+}
+
+func validatePredefinedRole(w http.ResponseWriter, roleName string) bool {
+	if isPredefinedRole(roleName) {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "Predefined roles cannot be edited or deleted")
 		return false
 	}
 	return true

--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -355,6 +355,9 @@ func (c *identityController) GetUserRoles(w http.ResponseWriter, r *http.Request
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to get user roles")
 		return
 	}
+	for i := range roles {
+		roles[i].IsReadOnly = constants.IsPredefinedRole(roles[i].Name)
+	}
 	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"roles": roles})
 }
 
@@ -740,6 +743,9 @@ func (c *identityController) GetGroupRoles(w http.ResponseWriter, r *http.Reques
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to get group roles")
 		return
 	}
+	for i := range roles {
+		roles[i].IsReadOnly = constants.IsPredefinedRole(roles[i].Name)
+	}
 	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"roles": roles})
 }
 
@@ -774,6 +780,7 @@ func (c *identityController) ListRoles(w http.ResponseWriter, r *http.Request) {
 	filteredRoles := make([]thundersvc.ThunderRole, 0, len(roles))
 	for _, role := range roles {
 		if role.OuID == resolvedOrg.OUID && role.Name != "Administrator" {
+			role.IsReadOnly = constants.IsPredefinedRole(role.Name)
 			filteredRoles = append(filteredRoles, role)
 		}
 	}
@@ -807,6 +814,7 @@ func (c *identityController) GetRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	role.IsReadOnly = constants.IsPredefinedRole(role.Name)
 	utils.WriteSuccessResponse(w, http.StatusOK, role)
 }
 
@@ -837,6 +845,7 @@ func (c *identityController) CreateRole(w http.ResponseWriter, r *http.Request) 
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to create role")
 		return
 	}
+	role.IsReadOnly = constants.IsPredefinedRole(role.Name)
 	utils.WriteSuccessResponse(w, http.StatusCreated, role)
 }
 
@@ -886,6 +895,7 @@ func (c *identityController) UpdateRole(w http.ResponseWriter, r *http.Request) 
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to update role")
 		return
 	}
+	updatedRole.IsReadOnly = constants.IsPredefinedRole(updatedRole.Name)
 	utils.WriteSuccessResponse(w, http.StatusOK, updatedRole)
 }
 

--- a/console/workspaces/libs/types/src/api/identities.ts
+++ b/console/workspaces/libs/types/src/api/identities.ts
@@ -85,20 +85,13 @@ export interface UpdateGroupRequest {
 
 // --- Roles ---
 
-export const PREDEFINED_ROLES = [
-  "admin",
-  "developer",
-  "ai-lead",
-  "platform-engineer",
-  "Administrator",
-] as const;
-
 export interface ThunderRole {
   id: string;
   ouId?: string;
   name: string;
   description?: string;
   permissions?: RolePermissionRequest[];
+  isReadOnly?: boolean;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/console/workspaces/libs/types/src/api/identities.ts
+++ b/console/workspaces/libs/types/src/api/identities.ts
@@ -85,6 +85,14 @@ export interface UpdateGroupRequest {
 
 // --- Roles ---
 
+export const PREDEFINED_ROLES = [
+  "admin",
+  "developer",
+  "ai-lead",
+  "platform-engineer",
+  "Administrator",
+] as const;
+
 export interface ThunderRole {
   id: string;
   ouId?: string;

--- a/console/workspaces/pages/identities/src/RoleEditPage.tsx
+++ b/console/workspaces/pages/identities/src/RoleEditPage.tsx
@@ -102,6 +102,7 @@ export const RoleEditPage: React.FC = () => {
     orgName: orgId,
     roleId: roleId ?? "",
   });
+  const isPermissionsReadOnly = roleData?.name ? isPredefinedRole(roleData.name) : false;
   const { data: assignmentsData, isLoading: isLoadingAssignments } = useGetRoleAssignments({
     orgName: orgId,
     roleId: roleId ?? "",
@@ -323,7 +324,6 @@ export const RoleEditPage: React.FC = () => {
   const isLoading =
     isLoadingRole || isLoadingAssignments || isLoadingUsers || isLoadingGroups || isLoadingCatalog;
 
-  const isPermissionsReadOnly = roleData?.name ? isPredefinedRole(roleData.name) : false;
   const pageTitle = roleData?.name ? `Edit Role: ${roleData.name}` : "Edit Role";
 
   if (isLoading) {
@@ -417,7 +417,9 @@ export const RoleEditPage: React.FC = () => {
                           sx={{ mr: 0.5, p: 0.5 }}
                           onClick={(e) => e.stopPropagation()}
                           onChange={
-                            handleGroupToggle as unknown as React.ChangeEventHandler<HTMLInputElement>
+                            handleGroupToggle as unknown as React.ChangeEventHandler<
+                              HTMLInputElement
+                            >
                           }
                         />
                         <Typography
@@ -478,7 +480,11 @@ export const RoleEditPage: React.FC = () => {
                               key={p.name}
                               label={permLabel(p)}
                               size="small"
-                              onDelete={!isPermissionsReadOnly ? () => handleRemovePermission(p.name) : undefined}
+                              onDelete={
+                                !isPermissionsReadOnly
+                                  ? () => handleRemovePermission(p.name)
+                                  : undefined
+                              }
                             />
                           ))}
                       </Stack>

--- a/console/workspaces/pages/identities/src/RoleEditPage.tsx
+++ b/console/workspaces/pages/identities/src/RoleEditPage.tsx
@@ -52,10 +52,15 @@ import {
 import { PageLayout } from "@agent-management-platform/views";
 import {
   absoluteRouteMap,
+  PREDEFINED_ROLES,
   type ThunderUser,
   type ThunderGroup,
   type ThunderPermission,
 } from "@agent-management-platform/types";
+
+const isPredefinedRole = (roleName: string): boolean => {
+  return (PREDEFINED_ROLES as readonly string[]).includes(roleName);
+};
 
 type ActiveTab = "permissions" | "users" | "groups";
 
@@ -282,8 +287,8 @@ export const RoleEditPage: React.FC = () => {
         await removeAssignees({ params, body: { groupIds: removeGroupIds } });
       }
 
-      // Permissions — diff selected vs initial
-      if (hasEditedPermissions.current && resourceServerId) {
+      // Permissions — diff selected vs initial (skip for predefined roles)
+      if (hasEditedPermissions.current && resourceServerId && !isPermissionsReadOnly) {
         const currentSet = new Set(initialPermissions);
         const nextSet = new Set(selectedPermissions.map((p) => p.name));
         const toAdd = [...nextSet].filter((n) => !currentSet.has(n));
@@ -318,6 +323,7 @@ export const RoleEditPage: React.FC = () => {
   const isLoading =
     isLoadingRole || isLoadingAssignments || isLoadingUsers || isLoadingGroups || isLoadingCatalog;
 
+  const isPermissionsReadOnly = roleData?.name ? isPredefinedRole(roleData.name) : false;
   const pageTitle = roleData?.name ? `Edit Role: ${roleData.name}` : "Edit Role";
 
   if (isLoading) {
@@ -352,93 +358,97 @@ export const RoleEditPage: React.FC = () => {
               Permissions
             </Typography>
             <Typography variant="body2" color="text.secondary" mb={2}>
-              Search and select permissions to assign to this role.
+              {isPermissionsReadOnly
+                ? "Permissions for predefined roles cannot be modified."
+                : "Search and select permissions to assign to this role."}
             </Typography>
             <Divider sx={{ mb: 2 }} />
 
-            <Autocomplete
-              multiple
-              disableCloseOnSelect
-              options={catalogPermissions}
-              value={selectedPermissions}
-              onChange={handlePermissionsChange}
-              getOptionLabel={(option) => permLabel(option as ThunderPermission)}
-              groupBy={(option) => permGroup(option as ThunderPermission)}
-              filterOptions={filterPermissions}
-              isOptionEqualToValue={(option, value) =>
-                (option as ThunderPermission).name === (value as ThunderPermission).name
-              }
-              renderTags={() => null}
-              renderGroup={(params) => {
-                const groupPerms = catalogPermissions.filter(
-                  (p) => permGroup(p) === params.group,
-                );
-                const allSelected = groupPerms.every((p) => selectedNames.has(p.name));
-                const someSelected = groupPerms.some((p) => selectedNames.has(p.name));
-                const handleGroupToggle = (e: React.MouseEvent) => {
-                  e.stopPropagation();
-                  hasEditedPermissions.current = true;
-                  if (allSelected) {
-                    setSelectedPermissions((prev) =>
-                      prev.filter((p) => permGroup(p) !== params.group),
-                    );
-                  } else {
-                    const toAdd = groupPerms.filter((p) => !selectedNames.has(p.name));
-                    setSelectedPermissions((prev) => [...prev, ...toAdd]);
-                  }
-                };
-                return (
-                  <li key={params.key}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        px: 1,
-                        py: 0.25,
-                        cursor: "pointer",
-                        userSelect: "none",
-                        "&:hover": { bgcolor: "action.hover" },
-                      }}
-                      onClick={handleGroupToggle}
-                    >
-                      <Checkbox
-                        checked={allSelected}
-                        indeterminate={someSelected && !allSelected}
-                        size="small"
-                        sx={{ mr: 0.5, p: 0.5 }}
-                        onClick={(e) => e.stopPropagation()}
-                        onChange={
-                          handleGroupToggle as unknown as React.ChangeEventHandler<HTMLInputElement>
-                        }
-                      />
-                      <Typography
-                        variant="caption"
-                        fontWeight={700}
-                        sx={{ textTransform: "uppercase", letterSpacing: 0.5 }}
+            {!isPermissionsReadOnly && (
+              <Autocomplete
+                multiple
+                disableCloseOnSelect
+                options={catalogPermissions}
+                value={selectedPermissions}
+                onChange={handlePermissionsChange}
+                getOptionLabel={(option) => permLabel(option as ThunderPermission)}
+                groupBy={(option) => permGroup(option as ThunderPermission)}
+                filterOptions={filterPermissions}
+                isOptionEqualToValue={(option, value) =>
+                  (option as ThunderPermission).name === (value as ThunderPermission).name
+                }
+                renderTags={() => null}
+                renderGroup={(params) => {
+                  const groupPerms = catalogPermissions.filter(
+                    (p) => permGroup(p) === params.group,
+                  );
+                  const allSelected = groupPerms.every((p) => selectedNames.has(p.name));
+                  const someSelected = groupPerms.some((p) => selectedNames.has(p.name));
+                  const handleGroupToggle = (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    hasEditedPermissions.current = true;
+                    if (allSelected) {
+                      setSelectedPermissions((prev) =>
+                        prev.filter((p) => permGroup(p) !== params.group),
+                      );
+                    } else {
+                      const toAdd = groupPerms.filter((p) => !selectedNames.has(p.name));
+                      setSelectedPermissions((prev) => [...prev, ...toAdd]);
+                    }
+                  };
+                  return (
+                    <li key={params.key}>
+                      <Box
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          px: 1,
+                          py: 0.25,
+                          cursor: "pointer",
+                          userSelect: "none",
+                          "&:hover": { bgcolor: "action.hover" },
+                        }}
+                        onClick={handleGroupToggle}
                       >
-                        {params.group}
-                      </Typography>
-                    </Box>
-                    <ul style={{ padding: 0 }}>{params.children}</ul>
+                        <Checkbox
+                          checked={allSelected}
+                          indeterminate={someSelected && !allSelected}
+                          size="small"
+                          sx={{ mr: 0.5, p: 0.5 }}
+                          onClick={(e) => e.stopPropagation()}
+                          onChange={
+                            handleGroupToggle as unknown as React.ChangeEventHandler<HTMLInputElement>
+                          }
+                        />
+                        <Typography
+                          variant="caption"
+                          fontWeight={700}
+                          sx={{ textTransform: "uppercase", letterSpacing: 0.5 }}
+                        >
+                          {params.group}
+                        </Typography>
+                      </Box>
+                      <ul style={{ padding: 0 }}>{params.children}</ul>
+                    </li>
+                  );
+                }}
+                renderOption={(props, option, { selected }) => (
+                  <li {...props}>
+                    <Checkbox checked={selected} size="small" sx={{ mr: 1 }} />
+                    {permLabel(option as ThunderPermission)}
                   </li>
-                );
-              }}
-              renderOption={(props, option, { selected }) => (
-                <li {...props}>
-                  <Checkbox checked={selected} size="small" sx={{ mr: 1 }} />
-                  {permLabel(option as ThunderPermission)}
-                </li>
-              )}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Add permissions"
-                  placeholder="Search by resource or action..."
-                />
-              )}
-              noOptionsText="No permissions available"
-              sx={{ mb: 3 }}
-            />
+                )}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Add permissions"
+                    placeholder="Search by resource or action..."
+                  />
+                )}
+                noOptionsText="No permissions available"
+                sx={{ mb: 3 }}
+              />
+            )}
 
             {selectedPermissions.length === 0 ? (
               <Typography variant="body2" color="text.secondary">
@@ -468,7 +478,7 @@ export const RoleEditPage: React.FC = () => {
                               key={p.name}
                               label={permLabel(p)}
                               size="small"
-                              onDelete={() => handleRemovePermission(p.name)}
+                              onDelete={!isPermissionsReadOnly ? () => handleRemovePermission(p.name) : undefined}
                             />
                           ))}
                       </Stack>
@@ -601,14 +611,16 @@ export const RoleEditPage: React.FC = () => {
           </Box>
         )}
 
-        <Stack direction="row" spacing={1} justifyContent="flex-end">
-          <Button variant="outlined" onClick={() => navigate(rolesPath)} disabled={isSaving}>
-            Cancel
-          </Button>
-          <Button variant="contained" onClick={handleSave} disabled={isSaving}>
-            {isSaving ? "Saving..." : "Save Changes"}
-          </Button>
-        </Stack>
+        {!(isPermissionsReadOnly && activeTab === "permissions") && (
+          <Stack direction="row" spacing={1} justifyContent="flex-end">
+            <Button variant="outlined" onClick={() => navigate(rolesPath)} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button variant="contained" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? "Saving..." : "Save Changes"}
+            </Button>
+          </Stack>
+        )}
       </Stack>
     </PageLayout>
   );

--- a/console/workspaces/pages/identities/src/RoleEditPage.tsx
+++ b/console/workspaces/pages/identities/src/RoleEditPage.tsx
@@ -52,15 +52,10 @@ import {
 import { PageLayout } from "@agent-management-platform/views";
 import {
   absoluteRouteMap,
-  PREDEFINED_ROLES,
   type ThunderUser,
   type ThunderGroup,
   type ThunderPermission,
 } from "@agent-management-platform/types";
-
-const isPredefinedRole = (roleName: string): boolean => {
-  return (PREDEFINED_ROLES as readonly string[]).includes(roleName);
-};
 
 type ActiveTab = "permissions" | "users" | "groups";
 
@@ -102,7 +97,7 @@ export const RoleEditPage: React.FC = () => {
     orgName: orgId,
     roleId: roleId ?? "",
   });
-  const isPermissionsReadOnly = roleData?.name ? isPredefinedRole(roleData.name) : false;
+  const isPermissionsReadOnly = roleData?.isReadOnly ?? false;
   const { data: assignmentsData, isLoading: isLoadingAssignments } = useGetRoleAssignments({
     orgName: orgId,
     roleId: roleId ?? "",

--- a/console/workspaces/pages/identities/src/RolesPage.tsx
+++ b/console/workspaces/pages/identities/src/RolesPage.tsx
@@ -35,7 +35,11 @@ import {
 } from "@agent-management-platform/api-client";
 import { useConfirmationDialog } from "@agent-management-platform/shared-component";
 import { PageLayout } from "@agent-management-platform/views";
-import { absoluteRouteMap, type ThunderRole } from "@agent-management-platform/types";
+import { absoluteRouteMap, PREDEFINED_ROLES, type ThunderRole } from "@agent-management-platform/types";
+
+const isPredefinedRole = (roleName: string): boolean => {
+  return (PREDEFINED_ROLES as readonly string[]).includes(roleName);
+};
 
 export const RolesPage: React.FC = () => {
   const { orgId } = useParams<{ orgId: string }>();
@@ -139,11 +143,13 @@ export const RolesPage: React.FC = () => {
                           <Edit size={16} />
                         </IconButton>
                       </Tooltip>
-                      <Tooltip title="Delete role">
-                        <IconButton size="small" onClick={() => handleDelete(role)}>
-                          <Trash size={16} />
-                        </IconButton>
-                      </Tooltip>
+                      {!isPredefinedRole(role.name) && (
+                        <Tooltip title="Delete role">
+                          <IconButton size="small" onClick={() => handleDelete(role)}>
+                            <Trash size={16} />
+                          </IconButton>
+                        </Tooltip>
+                      )}
                     </Stack>
                   </ListingTable.Cell>
                 </ListingTable.Row>

--- a/console/workspaces/pages/identities/src/RolesPage.tsx
+++ b/console/workspaces/pages/identities/src/RolesPage.tsx
@@ -35,11 +35,7 @@ import {
 } from "@agent-management-platform/api-client";
 import { useConfirmationDialog } from "@agent-management-platform/shared-component";
 import { PageLayout } from "@agent-management-platform/views";
-import { absoluteRouteMap, PREDEFINED_ROLES, type ThunderRole } from "@agent-management-platform/types";
-
-const isPredefinedRole = (roleName: string): boolean => {
-  return (PREDEFINED_ROLES as readonly string[]).includes(roleName);
-};
+import { absoluteRouteMap, type ThunderRole } from "@agent-management-platform/types";
 
 export const RolesPage: React.FC = () => {
   const { orgId } = useParams<{ orgId: string }>();
@@ -143,7 +139,7 @@ export const RolesPage: React.FC = () => {
                           <Edit size={16} />
                         </IconButton>
                       </Tooltip>
-                      {!isPredefinedRole(role.name) && (
+                      {!role.isReadOnly && (
                         <Tooltip title="Delete role">
                           <IconButton size="small" onClick={() => handleDelete(role)}>
                             <Trash size={16} />

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - IDP_CLIENT_SECRET=amp-api-client-secret
       # Key Manager / JWT validation configuration
       # Accepts Thunder-issued tokens (client_credentials for publisher)
+      - KEY_MANAGER_JWKS_URL=http://thunder.amp.localhost:8080/oauth2/jwks
       - KEY_MANAGER_ISSUER=Agent Management Platform Local,http://thunder.amp.localhost:8080
       - KEY_MANAGER_AUDIENCE=localhost,amp-publisher-*,amp-api-client,amp-console-client,amctl,am-mcp,http://localhost:9000/
       - AMP_VERSION=v0.8.0


### PR DESCRIPTION
## Purpose
> $subject

## Related Issue

- https://github.com/wso2/agent-manager/issues/1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Predefined roles are protected — they cannot be edited or deleted.
  * Permissions for predefined roles are read-only; modify actions and removal buttons disabled in the UI.
  * Role listings are scoped to your organizational unit and now exclude the Administrator role.
  * Roles now expose a read-only flag so the UI consistently prevents edits where applicable.
  * Role details and creation responses include the read-only indicator.

* **Chores**
  * Service configuration updated with the key manager JWKS endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->