### PR TITLE
Use dedicated instrumentation test secrets in matrix workflows

### DIFF
--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -97,8 +97,8 @@ jobs:
         env:
           # `once` records missing interactions; `none` is replay-only.
           VCR_RECORD_MODE: ${{ inputs.include_record_mode && 'once' || 'none' }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_ANTHROPIC_API_KEY }}
         run: nox -s emission -- --cell-id=${{ matrix.cell }}
       # Artifact name is keyed by run-id + cell id so multiple manual runs
       # don't collide. The trailing slashes pull cells/ and cassettes/ both.
@@ -181,8 +181,8 @@ jobs:
         # URLs + IDP creds default to the dev bring-up's values; only the LLM
         # keys are secrets, forwarded into each deployed agent.
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_ANTHROPIC_API_KEY }}
           # The deployed customer-support-agent's web-search tool needs this.
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           # Optional single-cell run for cheap iteration; empty = full subset.

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -63,8 +63,8 @@ jobs:
         # (see heavy/driver.py); only the LLM keys are real secrets, and
         # they're forwarded into each deployed agent so it can make calls.
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_ANTHROPIC_API_KEY }}
           # The deployed customer-support-agent's web-search tool needs this.
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           # Build each deployed sample from the ref under test. Nightly runs on
@@ -120,8 +120,8 @@ jobs:
           # Route reports into a side directory so they don't overwrite the
           # main emission run; the noxfile honors REPORTS_DIR.
           REPORTS_DIR: reports/revalidate
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_ANTHROPIC_API_KEY }}
         run: |
           mkdir -p reports/revalidate
           while read cell; do


### PR DESCRIPTION
## Purpose
The instrumentation matrix workflows were using the shared `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` repo secrets. These are generic catch-all keys that are also used by other workflows/tools. Scoping them to dedicated secrets for the instrumentation tests isolates credential blast radius.

## Goals
- Prevent instrumentation tests from consuming or exposing the shared LLM keys.
- Allow the test-specific secrets to be rotated independently without affecting other workflows.

## Approach
Replaced `secrets.OPENAI_API_KEY` → `secrets.INSTRUMENTATION_TEST_OPENAI_API_KEY` and `secrets.ANTHROPIC_API_KEY` → `secrets.INSTRUMENTATION_TEST_ANTHROPIC_API_KEY` in all four relevant `env:` blocks across both `instrumentation-matrix-manual.yaml` and `instrumentation-matrix-nightly.yaml`. No logic changes.

The new secrets must be added to the repository before the workflows can run successfully.

## User stories
N/A — infrastructure/security hardening.

## Release note
N/A — internal CI workflow change, no user-visible impact.

## Documentation
N/A — no product documentation impact.

## Training
N/A

## Certification
N/A — no certification exam impact.

## Marketing
N/A

## Automation tests
- Unit tests: N/A — workflow YAML change only.
- Integration tests: Workflows will pass once the two new secrets (`INSTRUMENTATION_TEST_OPENAI_API_KEY`, `INSTRUMENTATION_TEST_ANTHROPIC_API_KEY`) are provisioned in the repo.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — YAML only
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A — add the two new repo secrets before merging.

## Test environment
GitHub Actions runner — no local environment dependency.

## Learning
N/A