### PR TITLE
Add declarative agent create with manifest file and template modes

### DIFF
--- a/.github/workflows/cli-codegen-check.yaml
+++ b/.github/workflows/cli-codegen-check.yaml
@@ -42,3 +42,10 @@ jobs:
       - name: Build CLI against regenerated client
         working-directory: ./cli
         run: go build ./...
+
+      # Catches CLI artifacts that track the OpenAPI spec beyond compilation —
+      # e.g. the agent manifest template round-trip test — in the same PR that
+      # changes the spec.
+      - name: Run CLI tests against regenerated client
+        working-directory: ./cli
+        run: go test ./...

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -41,6 +41,9 @@ type CreateOptions struct {
 	Proj  string
 	Scope render.Scope
 
+	Template bool
+	File     string
+
 	Name        string
 	DisplayName string
 	Description string
@@ -89,13 +92,39 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Create an agent",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				opts.Name = args[0]
+			if opts.Template {
+				if err := validateTemplateMode(cmd, args); err != nil {
+					return render.Error(opts.IO, render.Scope{}, err)
+				}
+				// Only the manifest goes to stdout so `>` yields a clean file.
+				fmt.Fprint(opts.IO.Out, agentTemplate)
+				return nil
 			}
-			opts.PortSet = cmd.Flags().Changed("port")
 
-			if err := validate(opts); err != nil {
-				return render.Error(opts.IO, render.Scope{}, err)
+			var req amsvc.CreateAgentRequest
+			if opts.File != "" {
+				if err := validateFileMode(cmd, args); err != nil {
+					return render.Error(opts.IO, render.Scope{}, err)
+				}
+				loaded, err := loadManifest(opts.File)
+				if err != nil {
+					return render.Error(opts.IO, render.Scope{}, cmdutil.FlagErrorWrap(err))
+				}
+				if v := validateRequest(loaded); len(v) > 0 {
+					return render.Error(opts.IO, render.Scope{}, cmdutil.FlagErrorsHeader("invalid agent spec", v))
+				}
+				req = loaded
+			} else {
+				if len(args) > 0 {
+					opts.Name = args[0]
+				}
+				opts.PortSet = cmd.Flags().Changed("port")
+
+				built, err := prepare(opts)
+				if err != nil {
+					return render.Error(opts.IO, render.Scope{}, err)
+				}
+				req = built
 			}
 
 			org, proj, err := opts.ResolveScope(cmd, true, true)
@@ -105,9 +134,12 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 			opts.Org, opts.Proj, opts.Scope = org, proj, scope
 
-			return runCreate(cmd.Context(), opts)
+			return runCreate(cmd.Context(), opts, req)
 		},
 	}
+
+	cmd.Flags().BoolVar(&opts.Template, "template", false, "Print an agent manifest template and exit (takes no other input)")
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Create the agent from a YAML manifest file")
 
 	cmd.Flags().StringVar(&opts.DisplayName, "display-name", "", "Human-readable name (required)")
 	cmd.Flags().StringVar(&opts.Type, "type", "", "Agent type (auto-derived from --provisioning)")
@@ -150,12 +182,7 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func runCreate(ctx context.Context, opts *CreateOptions) error {
-	req, err := Build(opts)
-	if err != nil {
-		return render.Error(opts.IO, opts.Scope, err)
-	}
-
+func runCreate(ctx context.Context, opts *CreateOptions, req amsvc.CreateAgentRequest) error {
 	client, err := opts.Client(ctx)
 	if err != nil {
 		return render.Error(opts.IO, opts.Scope, err)
@@ -173,7 +200,9 @@ func runCreate(ctx context.Context, opts *CreateOptions) error {
 		printAgentSummary(opts.IO, resp.JSON202)
 	}
 
-	if opts.Provisioning != provisioningExternal {
+	// Branch on the request body, not the --provisioning flag — in file mode
+	// the manifest is the only source of truth.
+	if req.Provisioning.Type != amsvc.ProvisioningTypeExternal {
 		if opts.IO.JSON {
 			return render.JSONSuccess(opts.IO, opts.Scope, resp.JSON202)
 		}

--- a/cli/pkg/cmd/agent/create/create.go
+++ b/cli/pkg/cmd/agent/create/create.go
@@ -140,6 +140,7 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.Template, "template", false, "Print an agent manifest template and exit (takes no other input)")
 	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Create the agent from a YAML manifest file")
+	_ = cmd.MarkFlagFilename("file", "yaml", "yml")
 
 	cmd.Flags().StringVar(&opts.DisplayName, "display-name", "", "Human-readable name (required)")
 	cmd.Flags().StringVar(&opts.Type, "type", "", "Agent type (auto-derived from --provisioning)")

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -452,11 +452,11 @@ func TestCreate_ValidationError_Text(t *testing.T) {
 	}
 
 	output := errOut.String()
-	if !strings.Contains(output, "invalid flags") {
-		t.Errorf("output missing 'invalid flags', got:\n%s", output)
+	if !strings.Contains(output, "invalid agent spec") {
+		t.Errorf("output missing 'invalid agent spec', got:\n%s", output)
 	}
-	if !strings.Contains(output, "name argument is required") {
-		t.Errorf("output missing 'name argument is required', got:\n%s", output)
+	if !strings.Contains(output, "spec.name is required") {
+		t.Errorf("output missing 'spec.name is required', got:\n%s", output)
 	}
 }
 
@@ -512,18 +512,18 @@ func TestCreate_MissingName_BatchedError(t *testing.T) {
 	foundDisplayName := false
 	for _, d := range details {
 		s := d.(string)
-		if strings.Contains(s, "name argument is required") {
+		if strings.Contains(s, "spec.name is required") {
 			foundName = true
 		}
-		if strings.Contains(s, "--display-name is required") {
+		if strings.Contains(s, "spec.displayName is required") {
 			foundDisplayName = true
 		}
 	}
 	if !foundName {
-		t.Errorf("expected 'name argument is required' in details, got %v", details)
+		t.Errorf("expected 'spec.name is required' in details, got %v", details)
 	}
 	if !foundDisplayName {
-		t.Errorf("expected '--display-name is required' in details, got %v", details)
+		t.Errorf("expected 'spec.displayName is required' in details, got %v", details)
 	}
 }
 

--- a/cli/pkg/cmd/agent/create/create_test.go
+++ b/cli/pkg/cmd/agent/create/create_test.go
@@ -139,6 +139,10 @@ func testCreateCmd(t *testing.T, ios *iostreams.IOStreams, clientFn func(context
 		},
 	}
 	root := &cobra.Command{Use: "amctl", SilenceErrors: true, SilenceUsage: true}
+	// Mirror the production root's persistent --json flag (pkg/cmd/root.go) so
+	// mode gating that checks Changed("json") is exercisable. Output JSON mode
+	// is still driven by newTestIO, not this flag.
+	root.PersistentFlags().Bool("json", false, "Output as JSON envelopes")
 	cmdutil.EnableOrgOverride(root, f)
 
 	agentCmd := &cobra.Command{Use: "agent"}

--- a/cli/pkg/cmd/agent/create/manifest.go
+++ b/cli/pkg/cmd/agent/create/manifest.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+const (
+	manifestAPIVersion = "agent-manager.wso2.com/v1alpha1"
+	manifestKind       = "Agent"
+)
+
+// Manifest is the versioned wrapper around the create-agent request body.
+// Spec stays raw so the envelope can be validated before the payload.
+type Manifest struct {
+	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string          `json:"kind"       yaml:"kind"`
+	Spec       json.RawMessage `json:"spec"       yaml:"spec"`
+}
+
+func loadManifest(path string) (amsvc.CreateAgentRequest, error) {
+	var req amsvc.CreateAgentRequest
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return req, fmt.Errorf("read manifest: %w", err)
+	}
+
+	var m Manifest
+	if err := DecodeStrict(data, &m); err != nil {
+		return req, fmt.Errorf("parse manifest: %w", err)
+	}
+	if m.APIVersion != manifestAPIVersion {
+		return req, fmt.Errorf("manifest apiVersion must be %q, got %q", manifestAPIVersion, m.APIVersion)
+	}
+	if m.Kind != manifestKind {
+		return req, fmt.Errorf("manifest kind must be %q, got %q", manifestKind, m.Kind)
+	}
+	if len(m.Spec) == 0 {
+		return req, fmt.Errorf("manifest spec is required")
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(m.Spec))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		return req, fmt.Errorf("parse manifest spec: %w", err)
+	}
+
+	if err := strictBuildUnion(req.Build); err != nil {
+		return req, fmt.Errorf("parse manifest spec: %w", err)
+	}
+	return req, nil
+}
+
+// strictBuildUnion extends unknown-field rejection into the build block:
+// Build.UnmarshalJSON stores raw bytes without field checking, so the
+// top-level strict decode cannot see inside the union. An unknown
+// discriminator is not an error here — validateRequest reports it so it
+// lands in the aggregated violation list.
+func strictBuildUnion(b *amsvc.Build) error {
+	if b == nil {
+		return nil
+	}
+	disc, err := b.Discriminator()
+	if err != nil {
+		return nil
+	}
+	raw, err := b.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	switch disc {
+	case buildTypeBuildpack:
+		var v amsvc.BuildpackBuild
+		return dec.Decode(&v)
+	case buildTypeDocker:
+		var v amsvc.DockerBuild
+		return dec.Decode(&v)
+	}
+	return nil
+}

--- a/cli/pkg/cmd/agent/create/manifest_test.go
+++ b/cli/pkg/cmd/agent/create/manifest_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return path
+}
+
+const internalManifest = `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: my-agent
+  displayName: My Agent
+  agentType:
+    type: agent-api
+    subType: chat-api
+  provisioning:
+    type: internal
+    repository:
+      url: https://github.com/example/repo
+      branch: main
+      appPath: /app
+  build:
+    type: buildpack
+    buildpack:
+      language: python
+      languageVersion: "3.12"
+      runCommand: python main.py
+`
+
+func TestLoadManifest_Internal(t *testing.T) {
+	path := writeManifest(t, internalManifest)
+	req, err := loadManifest(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Name != "my-agent" || req.DisplayName != "My Agent" {
+		t.Errorf("name/displayName = %q/%q", req.Name, req.DisplayName)
+	}
+	if req.Provisioning.Repository == nil || req.Provisioning.Repository.Url != "https://github.com/example/repo" {
+		t.Errorf("repository = %+v", req.Provisioning.Repository)
+	}
+	bp, err := req.Build.AsBuildpackBuild()
+	if err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	if bp.Buildpack.Language != "python" {
+		t.Errorf("language = %q", bp.Buildpack.Language)
+	}
+}
+
+func TestLoadManifest_AgentKind(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: prebuilt
+  displayName: Prebuilt
+  provisioning:
+    type: internal
+    agentKind:
+      name: rag-bot
+      version: 1.2.0
+`)
+	req, err := loadManifest(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Provisioning.AgentKind == nil || req.Provisioning.AgentKind.Name != "rag-bot" || req.Provisioning.AgentKind.Version != "1.2.0" {
+		t.Errorf("agentKind = %+v", req.Provisioning.AgentKind)
+	}
+}
+
+func TestLoadManifest_WrongAPIVersion(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: nope/v1
+kind: Agent
+spec:
+  name: x
+`)
+	_, err := loadManifest(path)
+	if err == nil || !strings.Contains(err.Error(), "apiVersion") {
+		t.Fatalf("expected apiVersion error, got %v", err)
+	}
+}
+
+func TestLoadManifest_WrongKind(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Project
+spec:
+  name: x
+`)
+	_, err := loadManifest(path)
+	if err == nil || !strings.Contains(err.Error(), "kind") {
+		t.Fatalf("expected kind error, got %v", err)
+	}
+}
+
+func TestLoadManifest_UnknownSpecField(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: x
+  displayNam: typo
+`)
+	_, err := loadManifest(path)
+	if err == nil || !strings.Contains(err.Error(), "displayNam") {
+		t.Fatalf("expected unknown-field error naming the field, got %v", err)
+	}
+}
+
+// The Build union stores raw bytes, so top-level DisallowUnknownFields cannot
+// see inside it — loadManifest must strict-decode the concrete variant.
+func TestLoadManifest_UnknownFieldInsideBuildUnion(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: x
+  displayName: X
+  provisioning:
+    type: internal
+    repository:
+      url: https://github.com/example/repo
+      branch: main
+      appPath: /
+  build:
+    type: buildpack
+    buildpack:
+      language: go
+      runCmd: typo
+`)
+	_, err := loadManifest(path)
+	if err == nil || !strings.Contains(err.Error(), "runCmd") {
+		t.Fatalf("expected unknown-field error inside build union, got %v", err)
+	}
+}
+
+// An unknown build.type is not a decode error — it falls through to
+// validateRequest so it lands in the aggregated report.
+func TestLoadManifest_UnknownBuildTypePassesDecode(t *testing.T) {
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: x
+  displayName: X
+  provisioning:
+    type: internal
+    repository:
+      url: https://github.com/example/repo
+      branch: main
+      appPath: /
+  build:
+    type: nix
+`)
+	if _, err := loadManifest(path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadManifest_FileNotFound(t *testing.T) {
+	_, err := loadManifest(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/cli/pkg/cmd/agent/create/manifest_test.go
+++ b/cli/pkg/cmd/agent/create/manifest_test.go
@@ -53,6 +53,8 @@ spec:
       language: python
       languageVersion: "3.12"
       runCommand: python main.py
+  inputInterface:
+    type: HTTP
 `
 
 func TestLoadManifest_Internal(t *testing.T) {

--- a/cli/pkg/cmd/agent/create/mode_test.go
+++ b/cli/pkg/cmd/agent/create/mode_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+// --- template mode ---
+
+// --template writes exactly the manifest to stdout (clean for `>` redirects),
+// makes no API call (nil client would panic), and resolves no scope.
+func TestCreate_TemplateMode(t *testing.T) {
+	ios, out, errOut := newTestIO(false)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "--template"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.String() != agentTemplate {
+		t.Errorf("stdout is not exactly the template:\n%s", out.String())
+	}
+	if errOut.String() != "" {
+		t.Errorf("stderr should be empty, got %q", errOut.String())
+	}
+}
+
+func TestCreate_TemplateMode_RejectsNameArg(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "my-agent", "--template"})
+	err := cmd.Execute()
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "name argument is not allowed with --template")
+}
+
+func TestCreate_TemplateMode_RejectsContentFlags(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "--template", "--display-name", "X", "--repo-url", "https://x"})
+	err := cmd.Execute()
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "--display-name is not allowed with --template")
+	assertContains(t, details, "--repo-url is not allowed with --template")
+}
+
+func TestCreate_TemplateMode_RejectsFile(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "--template", "-f", "agent.yaml"})
+	err := cmd.Execute()
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "--file is not allowed with --template")
+}
+
+// --- file mode ---
+
+func TestCreate_FileMode_Internal(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	clientFn, captured, cleanup := newTestClient(t, 202, agentResponse())
+	defer cleanup()
+
+	path := writeManifest(t, internalManifest)
+	cmd := testCreateCmd(t, ios, clientFn, "")
+	cmd.SetArgs([]string{"agent", "create", "-f", path, "--project", "triage"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", captured.method)
+	}
+	if !strings.HasSuffix(captured.path, "/orgs/acme/projects/triage/agents") {
+		t.Errorf("path = %q", captured.path)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(captured.body, &body); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if body["name"] != "my-agent" || body["displayName"] != "My Agent" {
+		t.Errorf("body name/displayName = %v/%v", body["name"], body["displayName"])
+	}
+	build := body["build"].(map[string]any)
+	if build["type"] != "buildpack" {
+		t.Errorf("build.type = %v", build["type"])
+	}
+	bp := build["buildpack"].(map[string]any)
+	if bp["language"] != "python" {
+		t.Errorf("buildpack.language = %v", bp["language"])
+	}
+}
+
+// File-mode external agents get the token + instrumentation flow: the
+// post-create branch keys off the request body, not the --provisioning flag.
+func TestCreate_FileMode_External_TokenFlow(t *testing.T) {
+	ios, _, errOut := newTestIO(false)
+	routes := map[string]routeResponse{
+		"/orgs/acme/projects/triage/agents/testing/token": {
+			Status: 200,
+			Body:   amsvc.TokenResponse{Token: "tok-abc", ExpiresAt: 1700000000, IssuedAt: 1690000000, TokenType: "Bearer"},
+		},
+		"/orgs/acme/projects/triage/agents": {
+			Status: 202,
+			Body: amsvc.AgentResponse{
+				Name:         "testing",
+				DisplayName:  "Testing",
+				AgentType:    amsvc.AgentType{Type: "external-agent-api"},
+				Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
+				ProjectName:  "triage",
+				Uuid:         "u",
+				CreatedAt:    time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	clientFn, captured, cleanup := newTestRouter(t, routes)
+	defer cleanup()
+
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: testing
+  displayName: Testing
+  agentType:
+    type: external-agent-api
+  provisioning:
+    type: external
+`)
+	cmd := testCreateCmd(t, ios, clientFn, "https://otel.example")
+	cmd.SetArgs([]string{"agent", "create", "-f", path, "--project", "triage"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := captured["/orgs/acme/projects/triage/agents/testing/token"]; !ok {
+		t.Error("no token request captured — external flow must run for file mode")
+	}
+	if !strings.Contains(errOut.String(), `export AMP_AGENT_API_KEY="tok-abc"`) {
+		t.Errorf("missing instrumentation block:\n%s", errOut.String())
+	}
+}
+
+func TestCreate_FileMode_RejectsNameArg(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "my-agent", "-f", "agent.yaml", "--project", "triage"})
+	err := cmd.Execute()
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "name argument is not allowed with --file")
+}
+
+func TestCreate_FileMode_RejectsContentFlags(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{
+		"agent", "create", "-f", "agent.yaml", "--project", "triage",
+		"--display-name", "X", "--env", "A=1", "--port", "9000",
+	})
+	err := cmd.Execute()
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "--display-name is not allowed with --file")
+	assertContains(t, details, "--env is not allowed with --file")
+	assertContains(t, details, "--port is not allowed with --file")
+}
+
+func TestCreate_FileMode_InvalidSpecAggregated(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: my-agent
+  provisioning:
+    type: internal
+    repository:
+      url: https://github.com/example/repo
+`)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "-f", path, "--project", "triage"})
+	err := cmd.Execute()
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "spec.displayName is required")
+	assertContains(t, details, "spec.provisioning.repository.branch is required")
+	assertContains(t, details, "spec.provisioning.repository.appPath is required")
+	assertContains(t, details, "spec.build is required for internal provisioning")
+	if !strings.Contains(err.Error(), "invalid agent spec") {
+		t.Errorf("error %q missing 'invalid agent spec' header", err.Error())
+	}
+}
+
+func TestCreate_FileMode_EnvelopeMismatch(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	path := writeManifest(t, `
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Project
+spec:
+  name: x
+`)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "-f", path, "--project", "triage"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "kind") {
+		t.Fatalf("expected kind mismatch error, got %v", err)
+	}
+}
+
+func TestCreate_FileMode_FileNotFound(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "-f", "/nonexistent/agent.yaml", "--project", "triage"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing manifest file")
+	}
+}

--- a/cli/pkg/cmd/agent/create/mode_test.go
+++ b/cli/pkg/cmd/agent/create/mode_test.go
@@ -64,6 +64,17 @@ func TestCreate_TemplateMode_RejectsContentFlags(t *testing.T) {
 	assertContains(t, details, "--repo-url is not allowed with --template")
 }
 
+// --template prints a YAML document; --json promises a JSON envelope on
+// stdout, so the combination is rejected rather than silently emitting YAML.
+func TestCreate_TemplateMode_RejectsJSON(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	cmd := testCreateCmd(t, ios, nil, "")
+	cmd.SetArgs([]string{"agent", "create", "--template", "--json"})
+	err := cmd.Execute()
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "--json is not allowed with --template")
+}
+
 func TestCreate_TemplateMode_RejectsFile(t *testing.T) {
 	ios, _, _ := newTestIO(true)
 	cmd := testCreateCmd(t, ios, nil, "")
@@ -204,6 +215,8 @@ spec:
 	assertContains(t, details, "spec.provisioning.repository.branch is required")
 	assertContains(t, details, "spec.provisioning.repository.appPath is required")
 	assertContains(t, details, "spec.build is required for internal provisioning")
+	assertContains(t, details, "spec.agentType.type is required for internal provisioning")
+	assertContains(t, details, "spec.inputInterface is required for internal provisioning")
 	if !strings.Contains(err.Error(), "invalid agent spec") {
 		t.Errorf("error %q missing 'invalid agent spec' header", err.Error())
 	}

--- a/cli/pkg/cmd/agent/create/request.go
+++ b/cli/pkg/cmd/agent/create/request.go
@@ -17,6 +17,7 @@
 package create
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -40,7 +41,13 @@ const (
 	interfaceTypeHTTP = "HTTP"
 )
 
-func Build(opts *CreateOptions) (amsvc.CreateAgentRequest, error) {
+// Build converts flag input into the API request type. It is total: it never
+// hard-fails. Inputs that cannot be represented in the request — or that the
+// builder would otherwise silently drop — are returned as flag-phrased
+// violations; everything else passes through and is judged by validateRequest.
+func Build(opts *CreateOptions) (amsvc.CreateAgentRequest, []string) {
+	var v []string
+
 	agentType := opts.Type
 	if agentType == "" {
 		switch opts.Provisioning {
@@ -67,20 +74,26 @@ func Build(opts *CreateOptions) (amsvc.CreateAgentRequest, error) {
 		req.AgentType.SubType = &opts.SubType
 	}
 
-	if opts.Provisioning == provisioningExternal {
-		return req, nil
+	switch opts.Provisioning {
+	case provisioningExternal:
+		return req, append(v, droppedExternalFlags(opts)...)
+	case provisioningInternal, "":
+	default:
+		// Unknown provisioning passes through for validateRequest to report;
+		// no internal sections can be built for it.
+		return req, v
 	}
 
-	b, err := buildBuild(opts)
-	if err != nil {
-		return amsvc.CreateAgentRequest{}, err
-	}
+	b, bv := buildBuild(opts)
+	v = append(v, bv...)
 	req.Build = b
 	req.InputInterface = buildInterface(opts)
-	req.Configurations = buildConfig(opts)
+	cfg, cv := buildConfig(opts)
+	v = append(v, cv...)
+	req.Configurations = cfg
 	req.ModelConfig = buildModelConfig(opts)
 
-	return req, nil
+	return req, append(v, droppedInternalFlags(opts)...)
 }
 
 func ensureLeadingSlash(s string) string {
@@ -91,24 +104,28 @@ func ensureLeadingSlash(s string) string {
 }
 
 func buildProvisioning(opts *CreateOptions) amsvc.Provisioning {
-	if opts.Provisioning == provisioningExternal {
+	switch opts.Provisioning {
+	case provisioningExternal:
 		return amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal}
-	}
-	repo := &amsvc.RepositoryConfig{
-		Url:     opts.RepoURL,
-		Branch:  opts.RepoBranch,
-		AppPath: ensureLeadingSlash(opts.RepoPath),
-	}
-	if opts.RepoSecret != "" {
-		repo.SecretRef = &opts.RepoSecret
-	}
-	return amsvc.Provisioning{
-		Type:       amsvc.ProvisioningTypeInternal,
-		Repository: repo,
+	case provisioningInternal, "":
+		repo := &amsvc.RepositoryConfig{
+			Url:     opts.RepoURL,
+			Branch:  opts.RepoBranch,
+			AppPath: ensureLeadingSlash(opts.RepoPath),
+		}
+		if opts.RepoSecret != "" {
+			repo.SecretRef = &opts.RepoSecret
+		}
+		return amsvc.Provisioning{
+			Type:       amsvc.ProvisioningTypeInternal,
+			Repository: repo,
+		}
+	default:
+		return amsvc.Provisioning{Type: amsvc.ProvisioningType(opts.Provisioning)}
 	}
 }
 
-func buildBuild(opts *CreateOptions) (*amsvc.Build, error) {
+func buildBuild(opts *CreateOptions) (*amsvc.Build, []string) {
 	var b amsvc.Build
 	switch opts.BuildType {
 	case buildTypeBuildpack:
@@ -125,7 +142,7 @@ func buildBuild(opts *CreateOptions) (*amsvc.Build, error) {
 			bp.Buildpack.RunCommand = &opts.RunCommand
 		}
 		if err := b.FromBuildpackBuild(bp); err != nil {
-			return nil, fmt.Errorf("buildpack: %w", err)
+			return nil, []string{fmt.Sprintf("--build-type=buildpack: %v", err)}
 		}
 	case buildTypeDocker:
 		d := amsvc.DockerBuild{
@@ -135,7 +152,19 @@ func buildBuild(opts *CreateOptions) (*amsvc.Build, error) {
 			},
 		}
 		if err := b.FromDockerBuild(d); err != nil {
-			return nil, fmt.Errorf("docker: %w", err)
+			return nil, []string{fmt.Sprintf("--build-type=docker: %v", err)}
+		}
+	case "":
+		return nil, nil
+	default:
+		// Unknown build type survives as the raw union discriminator so
+		// validateRequest reports it alongside everything else.
+		raw, err := json.Marshal(map[string]string{"type": opts.BuildType})
+		if err != nil {
+			return nil, []string{fmt.Sprintf("--build-type: %v", err)}
+		}
+		if err := b.UnmarshalJSON(raw); err != nil {
+			return nil, []string{fmt.Sprintf("--build-type: %v", err)}
 		}
 	}
 	return &b, nil
@@ -161,27 +190,35 @@ func buildInterface(opts *CreateOptions) *amsvc.InputInterface {
 	return iface
 }
 
-func buildConfig(opts *CreateOptions) *amsvc.Configurations {
+func buildConfig(opts *CreateOptions) (*amsvc.Configurations, []string) {
 	var envs []amsvc.EnvironmentVariable
+	var v []string
 
-	for _, entry := range opts.Env {
-		k, v := splitEnv(entry)
-		envs = append(envs, amsvc.EnvironmentVariable{Key: k, Value: &v})
+	appendEnvs := func(entries []string, flag string, mk func(k, val string) amsvc.EnvironmentVariable) {
+		for _, entry := range entries {
+			k, val, ok := strings.Cut(entry, "=")
+			if !ok {
+				v = append(v, fmt.Sprintf("%s %q: missing '=' separator", flag, entry))
+				continue
+			}
+			envs = append(envs, mk(k, val))
+		}
 	}
-	for _, entry := range opts.EnvSecret {
-		k, v := splitEnv(entry)
+	appendEnvs(opts.Env, "--env", func(k, val string) amsvc.EnvironmentVariable {
+		return amsvc.EnvironmentVariable{Key: k, Value: &val}
+	})
+	appendEnvs(opts.EnvSecret, "--env-secret", func(k, val string) amsvc.EnvironmentVariable {
 		tr := true
-		envs = append(envs, amsvc.EnvironmentVariable{Key: k, Value: &v, IsSensitive: &tr})
-	}
-	for _, entry := range opts.EnvFromSecret {
-		k, v := splitEnv(entry)
-		envs = append(envs, amsvc.EnvironmentVariable{Key: k, SecretRef: &v})
-	}
+		return amsvc.EnvironmentVariable{Key: k, Value: &val, IsSensitive: &tr}
+	})
+	appendEnvs(opts.EnvFromSecret, "--env-from-secret", func(k, val string) amsvc.EnvironmentVariable {
+		return amsvc.EnvironmentVariable{Key: k, SecretRef: &val}
+	})
 
 	hasEnv := len(envs) > 0
 	hasInstr := opts.DisableAutoInstrumentation
 	if !hasEnv && !hasInstr {
-		return nil
+		return nil, v
 	}
 
 	cfg := &amsvc.Configurations{}
@@ -192,7 +229,7 @@ func buildConfig(opts *CreateOptions) *amsvc.Configurations {
 		f := false
 		cfg.EnableAutoInstrumentation = &f
 	}
-	return cfg
+	return cfg, v
 }
 
 func buildModelConfig(opts *CreateOptions) *[]amsvc.ModelConfigRequest {
@@ -213,7 +250,80 @@ func buildModelConfig(opts *CreateOptions) *[]amsvc.ModelConfigRequest {
 	return &[]amsvc.ModelConfigRequest{mc}
 }
 
-func splitEnv(entry string) (string, string) {
-	k, v, _ := strings.Cut(entry, "=")
-	return k, v
+// droppedInternalFlags reports internal-mode flag input the builder dropped:
+// chat-api never carries base-path/openapi-spec (and the port is fixed), the
+// build union holds exactly one variant's fields, and LLM env names without a
+// provider never reach modelConfig.
+func droppedInternalFlags(opts *CreateOptions) []string {
+	var v []string
+
+	if opts.SubType == subTypeChatAPI {
+		if opts.PortSet {
+			v = append(v, "--port is not allowed for subtype chat-api")
+		}
+		if opts.BasePath != "" {
+			v = append(v, "--base-path is not allowed for subtype chat-api")
+		}
+		if opts.OpenAPISpec != "" {
+			v = append(v, "--openapi-spec is not allowed for subtype chat-api")
+		}
+	}
+
+	switch opts.BuildType {
+	case buildTypeBuildpack:
+		if opts.Dockerfile != "" {
+			v = append(v, "--build-type=buildpack conflicts with --dockerfile")
+		}
+	case buildTypeDocker:
+		if opts.Language != "" {
+			v = append(v, "--build-type=docker conflicts with --language")
+		}
+		if opts.LanguageVersion != "" {
+			v = append(v, "--build-type=docker conflicts with --language-version")
+		}
+		if opts.RunCommand != "" {
+			v = append(v, "--build-type=docker conflicts with --run-command")
+		}
+	}
+
+	if (opts.LLMURLEnv != "" || opts.LLMAPIKeyEnv != "") && opts.LLMProvider == "" {
+		v = append(v, "--llm-url-env/--llm-api-key-env require --llm-provider")
+	}
+
+	return v
+}
+
+// droppedExternalFlags reports internal-only flag input that the builder
+// drops entirely for external provisioning.
+func droppedExternalFlags(opts *CreateOptions) []string {
+	var v []string
+	disallow := func(flag string, set bool) {
+		if set {
+			v = append(v, flag+" is not allowed for external provisioning")
+		}
+	}
+
+	disallow("--subtype", opts.SubType != "")
+	disallow("--repo-url", opts.RepoURL != "")
+	disallow("--repo-branch", opts.RepoBranch != "")
+	disallow("--repo-path", opts.RepoPath != "")
+	disallow("--repo-secret", opts.RepoSecret != "")
+	disallow("--build-type", opts.BuildType != "")
+	disallow("--language", opts.Language != "")
+	disallow("--language-version", opts.LanguageVersion != "")
+	disallow("--run-command", opts.RunCommand != "")
+	disallow("--dockerfile", opts.Dockerfile != "")
+	// PortSet (not Port != 0) — the --port flag defaults to 8000.
+	disallow("--port", opts.PortSet)
+	disallow("--base-path", opts.BasePath != "")
+	disallow("--openapi-spec", opts.OpenAPISpec != "")
+	disallow("--env", len(opts.Env) > 0)
+	disallow("--env-secret", len(opts.EnvSecret) > 0)
+	disallow("--env-from-secret", len(opts.EnvFromSecret) > 0)
+	disallow("--no-auto-instrumentation", opts.DisableAutoInstrumentation)
+	disallow("--llm-provider", opts.LLMProvider != "")
+	disallow("--llm-url-env", opts.LLMURLEnv != "")
+	disallow("--llm-api-key-env", opts.LLMAPIKeyEnv != "")
+
+	return v
 }

--- a/cli/pkg/cmd/agent/create/request.go
+++ b/cli/pkg/cmd/agent/create/request.go
@@ -38,6 +38,9 @@ const (
 	agentTypeInternal = "agent-api"
 	agentTypeExternal = "external-agent-api"
 
+	// The server exempts only Ballerina from languageVersion/runCommand.
+	langBallerina = "ballerina"
+
 	interfaceTypeHTTP = "HTTP"
 )
 
@@ -148,7 +151,7 @@ func buildBuild(opts *CreateOptions) (*amsvc.Build, []string) {
 		d := amsvc.DockerBuild{
 			Type: amsvc.Docker,
 			Docker: amsvc.DockerConfig{
-				DockerfilePath: opts.Dockerfile,
+				DockerfilePath: ensureLeadingSlash(opts.Dockerfile),
 			},
 		}
 		if err := b.FromDockerBuild(d); err != nil {

--- a/cli/pkg/cmd/agent/create/request_test.go
+++ b/cli/pkg/cmd/agent/create/request_test.go
@@ -118,9 +118,9 @@ func TestBuildBuild_Buildpack(t *testing.T) {
 		LanguageVersion: "1.22",
 		RunCommand:      "go run .",
 	}
-	b, err := buildBuild(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	b, v := buildBuild(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	disc, err := b.Discriminator()
 	if err != nil {
@@ -146,9 +146,9 @@ func TestBuildBuild_Buildpack(t *testing.T) {
 
 func TestBuildBuild_BuildpackLowercasesLanguage(t *testing.T) {
 	opts := &CreateOptions{BuildType: "buildpack", Language: "Python"}
-	b, err := buildBuild(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	b, v := buildBuild(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	bp, _ := b.AsBuildpackBuild()
 	if bp.Buildpack.Language != "python" {
@@ -158,9 +158,9 @@ func TestBuildBuild_BuildpackLowercasesLanguage(t *testing.T) {
 
 func TestBuildBuild_BuildpackMinimal(t *testing.T) {
 	opts := &CreateOptions{BuildType: "buildpack", Language: "python"}
-	b, err := buildBuild(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	b, v := buildBuild(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	bp, _ := b.AsBuildpackBuild()
 	if bp.Buildpack.LanguageVersion != nil {
@@ -173,9 +173,9 @@ func TestBuildBuild_BuildpackMinimal(t *testing.T) {
 
 func TestBuildBuild_Docker(t *testing.T) {
 	opts := &CreateOptions{BuildType: "docker", Dockerfile: "build/Dockerfile"}
-	b, err := buildBuild(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	b, v := buildBuild(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	disc, _ := b.Discriminator()
 	if disc != "docker" {
@@ -241,7 +241,7 @@ func TestBuildInterface_ChatAPI(t *testing.T) {
 
 func TestBuildConfig_None(t *testing.T) {
 	opts := &CreateOptions{}
-	cfg := buildConfig(opts)
+	cfg, _ := buildConfig(opts)
 	if cfg != nil {
 		t.Errorf("expected nil, got %+v", cfg)
 	}
@@ -249,7 +249,7 @@ func TestBuildConfig_None(t *testing.T) {
 
 func TestBuildConfig_DisableAutoInstrumentation(t *testing.T) {
 	opts := &CreateOptions{DisableAutoInstrumentation: true}
-	cfg := buildConfig(opts)
+	cfg, _ := buildConfig(opts)
 	if cfg == nil {
 		t.Fatal("expected non-nil config")
 	}
@@ -264,7 +264,7 @@ func TestBuildConfig_EnvVariables(t *testing.T) {
 		EnvSecret:     []string{"SECRET=hunter2"},
 		EnvFromSecret: []string{"DB_PASS=my-secret"},
 	}
-	cfg := buildConfig(opts)
+	cfg, _ := buildConfig(opts)
 	if cfg == nil {
 		t.Fatal("expected non-nil config")
 	}
@@ -288,7 +288,7 @@ func TestBuildConfig_EnvVariables(t *testing.T) {
 
 func TestBuildConfig_EnvAutoInstrumentationOmittedByDefault(t *testing.T) {
 	opts := &CreateOptions{Env: []string{"A=1"}}
-	cfg := buildConfig(opts)
+	cfg, _ := buildConfig(opts)
 	if cfg.EnableAutoInstrumentation != nil {
 		t.Errorf("EnableAutoInstrumentation = %v, want nil", cfg.EnableAutoInstrumentation)
 	}
@@ -308,9 +308,9 @@ func TestBuild_FullBuildpack(t *testing.T) {
 		Language:     "go",
 		Port:         8000,
 	}
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	if req.AgentType.Type != "agent-api" {
 		t.Errorf("AgentType.Type = %q, want agent-api (derived from internal provisioning)", req.AgentType.Type)
@@ -363,9 +363,9 @@ func TestBuild_ExplicitTypeOverride(t *testing.T) {
 		Language:     "go",
 		Port:         8000,
 	}
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	if req.AgentType.Type != "custom-type" {
 		t.Errorf("AgentType.Type = %q, want custom-type (explicit override)", req.AgentType.Type)
@@ -384,9 +384,9 @@ func TestBuild_FullDocker(t *testing.T) {
 		Dockerfile:   "Dockerfile.prod",
 		Port:         8000,
 	}
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	if req.AgentType.Type != "agent-api" {
 		t.Errorf("AgentType.Type = %q, want agent-api", req.AgentType.Type)
@@ -400,9 +400,9 @@ func TestBuild_FullDocker(t *testing.T) {
 func TestBuild_ModelConfig_ProviderOnly(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.LLMProvider = "openai"
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	if req.ModelConfig == nil || len(*req.ModelConfig) != 1 {
 		t.Fatalf("ModelConfig = %v, want 1 entry", req.ModelConfig)
@@ -421,9 +421,9 @@ func TestBuild_ModelConfig_WithEnvOverrides(t *testing.T) {
 	opts.LLMProvider = "openai"
 	opts.LLMURLEnv = "MY_URL"
 	opts.LLMAPIKeyEnv = "MY_KEY"
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	mc := (*req.ModelConfig)[0]
 	if mc.EnvironmentVariables == nil {
@@ -440,9 +440,9 @@ func TestBuild_ModelConfig_WithEnvOverrides(t *testing.T) {
 
 func TestBuild_ModelConfig_OmittedWhenNoProvider(t *testing.T) {
 	opts := validBuildpackOpts()
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	if req.ModelConfig != nil {
 		t.Errorf("ModelConfig = %v, want nil when --llm-provider unset", req.ModelConfig)
@@ -451,9 +451,9 @@ func TestBuild_ModelConfig_OmittedWhenNoProvider(t *testing.T) {
 
 func TestBuild_NoConfigWhenUnset(t *testing.T) {
 	opts := validBuildpackOpts()
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
 	}
 	if req.Configurations != nil {
 		t.Errorf("Configurations = %v, want nil", req.Configurations)
@@ -478,9 +478,9 @@ func TestBuild_External(t *testing.T) {
 		Description:  "dssdf",
 		Provisioning: "external",
 	}
-	req, err := Build(opts)
-	if err != nil {
-		t.Fatalf("Build returned error: %v", err)
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("Build returned violations: %v", v)
 	}
 	if req.Name != "testing" || req.DisplayName != "Testing" {
 		t.Errorf("name/displayName mismatch: %+v", req)
@@ -508,6 +508,70 @@ func TestBuild_External(t *testing.T) {
 	}
 	if req.Configurations != nil {
 		t.Errorf("Configurations should be nil for external, got %+v", req.Configurations)
+	}
+}
+
+// An unknown --build-type survives conversion as the raw union discriminator
+// so validateRequest reports it as a field-path violation instead of the
+// builder hard-failing.
+func TestBuildBuild_UnknownTypePassesThrough(t *testing.T) {
+	opts := &CreateOptions{BuildType: "nix"}
+	b, v := buildBuild(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
+	}
+	if b == nil {
+		t.Fatal("Build is nil, want raw union carrying the unknown type")
+	}
+	disc, err := b.Discriminator()
+	if err != nil {
+		t.Fatalf("discriminator: %v", err)
+	}
+	if disc != "nix" {
+		t.Errorf("discriminator = %q, want nix", disc)
+	}
+}
+
+func TestBuildBuild_EmptyTypeReturnsNil(t *testing.T) {
+	b, v := buildBuild(&CreateOptions{})
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
+	}
+	if b != nil {
+		t.Errorf("Build = %+v, want nil when --build-type unset", b)
+	}
+}
+
+// Entries without '=' are reported and skipped — they must not be smuggled
+// into the request as KEY="".
+func TestBuildConfig_MissingSeparatorSkipsEntry(t *testing.T) {
+	opts := &CreateOptions{Env: []string{"NOEQUALS", "GOOD=1"}}
+	cfg, v := buildConfig(opts)
+	if len(v) != 1 {
+		t.Fatalf("violations = %v, want exactly one", v)
+	}
+	if cfg == nil || cfg.Env == nil || len(*cfg.Env) != 1 || (*cfg.Env)[0].Key != "GOOD" {
+		t.Errorf("Env = %+v, want only GOOD", cfg.Env)
+	}
+}
+
+// An unknown --provisioning passes through so validateRequest reports it;
+// internal-only sections are not built for it.
+func TestBuild_UnknownProvisioningPassesThrough(t *testing.T) {
+	opts := &CreateOptions{
+		Name:         "x",
+		DisplayName:  "X",
+		Provisioning: "cloud",
+	}
+	req, v := Build(opts)
+	if len(v) != 0 {
+		t.Fatalf("unexpected violations: %v", v)
+	}
+	if string(req.Provisioning.Type) != "cloud" {
+		t.Errorf("Provisioning.Type = %q, want cloud (passthrough)", req.Provisioning.Type)
+	}
+	if req.Provisioning.Repository != nil || req.Build != nil || req.InputInterface != nil {
+		t.Errorf("internal sections should not be built for unknown provisioning: %+v", req)
 	}
 }
 

--- a/cli/pkg/cmd/agent/create/request_test.go
+++ b/cli/pkg/cmd/agent/create/request_test.go
@@ -182,8 +182,8 @@ func TestBuildBuild_Docker(t *testing.T) {
 		t.Fatalf("discriminator = %q, want docker", disc)
 	}
 	d, _ := b.AsDockerBuild()
-	if d.Docker.DockerfilePath != "build/Dockerfile" {
-		t.Errorf("DockerfilePath = %q, want build/Dockerfile", d.Docker.DockerfilePath)
+	if d.Docker.DockerfilePath != "/build/Dockerfile" {
+		t.Errorf("DockerfilePath = %q, want /build/Dockerfile (leading slash normalized)", d.Docker.DockerfilePath)
 	}
 }
 

--- a/cli/pkg/cmd/agent/create/template.go
+++ b/cli/pkg/cmd/agent/create/template.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+// agentTemplate is the manifest scaffold emitted by `amctl agent create
+// --template`. It is a static document (not a marshalled struct) so it can
+// carry comments documenting the variants; TestAgentTemplate_RoundTrip keeps
+// it in lockstep with the generated request types.
+const agentTemplate = `# Agent manifest for: amctl agent create -f <file>
+# Replace <placeholders>. Commented blocks document optional fields and variants.
+apiVersion: agent-manager.wso2.com/v1alpha1
+kind: Agent
+spec:
+  name: <agent-name>            # unique resource name
+  displayName: <Display Name>
+  # description: <optional description>
+  agentType:
+    type: agent-api             # external provisioning: external-agent-api
+    subType: chat-api           # or: custom-api (see inputInterface below)
+  provisioning:
+    type: internal              # or: external (then omit repository, build,
+                                #     inputInterface and configurations)
+    repository:
+      url: <https://github.com/org/repo>
+      branch: <main>
+      appPath: </path/within/repo>
+      # secretRef: <git-secret-name>    # private repositories
+    # --- prebuilt Agent Kind variant: replace repository with ---
+    # agentKind:
+    #   name: <agent-kind-name>
+    #   version: <version>
+  build:
+    type: buildpack             # or: docker
+    buildpack:
+      language: <python>
+      languageVersion: "<3.11>"         # optional (e.g. ballerina needs none)
+      runCommand: <python main.py>      # optional (e.g. ballerina needs none)
+    # --- docker variant: replace buildpack with ---
+    # docker:
+    #   dockerfilePath: </Dockerfile>
+  inputInterface:
+    type: HTTP
+    # --- custom-api only ---
+    # port: 8000
+    # basePath: </api>
+    # schema:
+    #   path: </openapi.yaml>
+  # configurations:
+  #   env:
+  #     - key: <KEY>
+  #       value: <value>
+  #     - key: <SECRET_KEY>             # sensitive value, stored as a secret
+  #       value: <secret-value>
+  #       isSensitive: true
+  #     - key: <FROM_SECRET>            # reference an existing secret
+  #       secretRef: <secret-name>
+  #   enableAutoInstrumentation: false
+  # modelConfig:                        # attach a configured LLM provider
+  #   - providerName: <provider-handle>
+  #     environmentVariables:
+  #       - key: url
+  #         name: <ENV_VAR_FOR_URL>
+  #       - key: apikey
+  #         name: <ENV_VAR_FOR_API_KEY>
+`

--- a/cli/pkg/cmd/agent/create/template.go
+++ b/cli/pkg/cmd/agent/create/template.go
@@ -37,7 +37,7 @@ spec:
     repository:
       url: <https://github.com/org/repo>
       branch: <main>
-      appPath: </path/within/repo>
+      appPath: /<path-within-repo>    # must start with /
       # secretRef: <git-secret-name>    # private repositories
     # --- prebuilt Agent Kind variant: replace repository with ---
     # agentKind:
@@ -47,18 +47,18 @@ spec:
     type: buildpack             # or: docker
     buildpack:
       language: <python>
-      languageVersion: "<3.11>"         # optional (e.g. ballerina needs none)
-      runCommand: <python main.py>      # optional (e.g. ballerina needs none)
+      languageVersion: "<3.11>"         # required (only ballerina needs none)
+      runCommand: <python main.py>      # required (only ballerina needs none)
     # --- docker variant: replace buildpack with ---
     # docker:
     #   dockerfilePath: </Dockerfile>
   inputInterface:
     type: HTTP
-    # --- custom-api only ---
+    # --- custom-api only (all three required) ---
     # port: 8000
     # basePath: </api>
     # schema:
-    #   path: </openapi.yaml>
+    #   path: /<openapi.yaml>          # must start with /
   # configurations:
   #   env:
   #     - key: <KEY>

--- a/cli/pkg/cmd/agent/create/template_test.go
+++ b/cli/pkg/cmd/agent/create/template_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"strings"
+	"testing"
+)
+
+// Anti-drift: the embedded template must round-trip through the exact
+// file-mode path (strict decode, envelope check, build-union strictness)
+// into the generated request type. If an OpenAPI regen renames or removes a
+// field the template mentions, this test fails — keeping the template in
+// lockstep with agent-manager-service/docs/api_v1_openapi.yaml via the
+// cli-codegen-check workflow.
+func TestAgentTemplate_RoundTrip(t *testing.T) {
+	path := writeManifest(t, agentTemplate)
+	req, err := loadManifest(path)
+	if err != nil {
+		t.Fatalf("template does not round-trip through file mode: %v", err)
+	}
+
+	if req.Name != "<agent-name>" {
+		t.Errorf("Name = %q, want placeholder <agent-name>", req.Name)
+	}
+	if req.Provisioning.Repository == nil || req.Provisioning.Repository.Url == "" {
+		t.Errorf("repository not decoded: %+v", req.Provisioning.Repository)
+	}
+	bp, err := req.Build.AsBuildpackBuild()
+	if err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	if bp.Buildpack.Language == "" {
+		t.Error("buildpack.language placeholder missing")
+	}
+}
+
+// The active (uncommented) template content must be structurally valid:
+// a user filling in the placeholders gets zero client-side violations.
+func TestAgentTemplate_StructurallyValid(t *testing.T) {
+	path := writeManifest(t, agentTemplate)
+	req, err := loadManifest(path)
+	if err != nil {
+		t.Fatalf("load template: %v", err)
+	}
+	if v := validateRequest(req); len(v) != 0 {
+		t.Errorf("template has violations: %v", v)
+	}
+}
+
+// The commented-out variants must document every reachable top-level spec
+// section so manifest authors discover them without reading the API spec.
+func TestAgentTemplate_DocumentsVariants(t *testing.T) {
+	for _, want := range []string{
+		"apiVersion: agent-manager.wso2.com/v1alpha1",
+		"kind: Agent",
+		"agentKind:",
+		"dockerfilePath:",
+		"external",
+		"secretRef:",
+		"isSensitive:",
+		"modelConfig:",
+		"basePath:",
+	} {
+		if !strings.Contains(agentTemplate, want) {
+			t.Errorf("template missing %q", want)
+		}
+	}
+}

--- a/cli/pkg/cmd/agent/create/validate_request_test.go
+++ b/cli/pkg/cmd/agent/create/validate_request_test.go
@@ -217,6 +217,19 @@ func TestValidateRequest_BallerinaNeedsNoVersionOrRunCommand(t *testing.T) {
 	assertNoViolations(t, validateRequest(req))
 }
 
+func TestValidateRequest_BallerinaNeedsNoVersionOrRunCommand_CaseInsensitive(t *testing.T) {
+	req := validInternalReq(t)
+	var b amsvc.Build
+	if err := b.FromBuildpackBuild(amsvc.BuildpackBuild{
+		Type:      amsvc.Buildpack,
+		Buildpack: amsvc.BuildpackConfig{Language: "Ballerina"},
+	}); err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	req.Build = &b
+	assertNoViolations(t, validateRequest(req))
+}
+
 func TestValidateRequest_BuildpackRequiresVersionAndRunCommand(t *testing.T) {
 	req := validInternalReq(t)
 	var b amsvc.Build

--- a/cli/pkg/cmd/agent/create/validate_request_test.go
+++ b/cli/pkg/cmd/agent/create/validate_request_test.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+func intPtr(i int) *int { return &i }
+
+func validInternalReq(t *testing.T) amsvc.CreateAgentRequest {
+	t.Helper()
+	subType := "chat-api"
+	var b amsvc.Build
+	if err := b.FromBuildpackBuild(amsvc.BuildpackBuild{
+		Type: amsvc.Buildpack,
+		Buildpack: amsvc.BuildpackConfig{
+			Language:        "python",
+			LanguageVersion: strPtr("3.12"),
+			RunCommand:      strPtr("python main.py"),
+		},
+	}); err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	return amsvc.CreateAgentRequest{
+		Name:        "my-agent",
+		DisplayName: "My Agent",
+		AgentType:   &amsvc.AgentType{Type: "agent-api", SubType: &subType},
+		Provisioning: amsvc.Provisioning{
+			Type: amsvc.ProvisioningTypeInternal,
+			Repository: &amsvc.RepositoryConfig{
+				Url:     "https://github.com/example/repo",
+				Branch:  "main",
+				AppPath: "/app",
+			},
+		},
+		Build: &b,
+		InputInterface: &amsvc.InputInterface{
+			Type: "HTTP",
+			Port: intPtr(8000),
+		},
+	}
+}
+
+func validExternalReq() amsvc.CreateAgentRequest {
+	return amsvc.CreateAgentRequest{
+		Name:         "my-agent",
+		DisplayName:  "My Agent",
+		AgentType:    &amsvc.AgentType{Type: "external-agent-api"},
+		Provisioning: amsvc.Provisioning{Type: amsvc.ProvisioningTypeExternal},
+	}
+}
+
+func assertViolation(t *testing.T, violations []string, want string) {
+	t.Helper()
+	for _, v := range violations {
+		if strings.Contains(v, want) {
+			return
+		}
+	}
+	t.Errorf("violations %v do not contain %q", violations, want)
+}
+
+func assertNoViolations(t *testing.T, violations []string) {
+	t.Helper()
+	if len(violations) != 0 {
+		t.Errorf("expected no violations, got %v", violations)
+	}
+}
+
+func TestValidateRequest_ValidInternal(t *testing.T) {
+	assertNoViolations(t, validateRequest(validInternalReq(t)))
+}
+
+func TestValidateRequest_ValidExternal(t *testing.T) {
+	assertNoViolations(t, validateRequest(validExternalReq()))
+}
+
+func TestValidateRequest_ValidAgentKind(t *testing.T) {
+	req := validExternalReq()
+	req.AgentType = nil
+	req.Provisioning = amsvc.Provisioning{
+		Type: amsvc.ProvisioningTypeInternal,
+		AgentKind: &struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		}{Name: "rag-bot", Version: "1.2.0"},
+	}
+	assertNoViolations(t, validateRequest(req))
+}
+
+func TestValidateRequest_RequiredCore(t *testing.T) {
+	v := validateRequest(amsvc.CreateAgentRequest{})
+	assertViolation(t, v, "spec.name is required")
+	assertViolation(t, v, "spec.displayName is required")
+	assertViolation(t, v, "spec.provisioning.type is required")
+}
+
+func TestValidateRequest_UnknownProvisioningType(t *testing.T) {
+	req := validInternalReq(t)
+	req.Provisioning.Type = "cloud"
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.provisioning.type must be "internal" or "external", got "cloud"`)
+}
+
+func TestValidateRequest_AgentTypeMismatch(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType.Type = "external-agent-api"
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.agentType.type must be "agent-api" for internal provisioning, got "external-agent-api"`)
+
+	ext := validExternalReq()
+	ext.AgentType.Type = "agent-api"
+	v = validateRequest(ext)
+	assertViolation(t, v, `spec.agentType.type must be "external-agent-api" for external provisioning, got "agent-api"`)
+}
+
+func TestValidateRequest_InternalRequiresRepositoryOrAgentKind(t *testing.T) {
+	req := validInternalReq(t)
+	req.Provisioning.Repository = nil
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.provisioning requires exactly one of repository or agentKind for internal provisioning")
+}
+
+func TestValidateRequest_RepositoryAndAgentKindConflict(t *testing.T) {
+	req := validInternalReq(t)
+	req.Provisioning.AgentKind = &struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}{Name: "rag-bot", Version: "1.0.0"}
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.provisioning requires exactly one of repository or agentKind for internal provisioning")
+}
+
+func TestValidateRequest_RepositoryRequiredFields(t *testing.T) {
+	req := validInternalReq(t)
+	req.Provisioning.Repository = &amsvc.RepositoryConfig{}
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.provisioning.repository.url is required")
+	assertViolation(t, v, "spec.provisioning.repository.branch is required")
+	assertViolation(t, v, "spec.provisioning.repository.appPath is required")
+}
+
+func TestValidateRequest_AgentKindRequiredFields(t *testing.T) {
+	req := validExternalReq()
+	req.AgentType = nil
+	req.Provisioning = amsvc.Provisioning{
+		Type: amsvc.ProvisioningTypeInternal,
+		AgentKind: &struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		}{},
+	}
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.provisioning.agentKind.name is required")
+	assertViolation(t, v, "spec.provisioning.agentKind.version is required")
+}
+
+func TestValidateRequest_RepositoryRequiresBuild(t *testing.T) {
+	req := validInternalReq(t)
+	req.Build = nil
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.build is required for internal provisioning")
+}
+
+func TestValidateRequest_UnknownBuildType(t *testing.T) {
+	req := validInternalReq(t)
+	var b amsvc.Build
+	if err := b.UnmarshalJSON([]byte(`{"type":"nix"}`)); err != nil {
+		t.Fatalf("seed union: %v", err)
+	}
+	req.Build = &b
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.build.type must be "buildpack" or "docker", got "nix"`)
+}
+
+func TestValidateRequest_BuildpackRequiresLanguage(t *testing.T) {
+	req := validInternalReq(t)
+	var b amsvc.Build
+	if err := b.FromBuildpackBuild(amsvc.BuildpackBuild{Type: amsvc.Buildpack}); err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	req.Build = &b
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.build.buildpack.language is required")
+}
+
+// languageVersion and runCommand are optional in the API (Ballerina needs
+// neither) — the old flag-mode rule requiring both is intentionally relaxed.
+func TestValidateRequest_BuildpackVersionAndRunCommandOptional(t *testing.T) {
+	req := validInternalReq(t)
+	var b amsvc.Build
+	if err := b.FromBuildpackBuild(amsvc.BuildpackBuild{
+		Type:      amsvc.Buildpack,
+		Buildpack: amsvc.BuildpackConfig{Language: "ballerina"},
+	}); err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	req.Build = &b
+	assertNoViolations(t, validateRequest(req))
+}
+
+func TestValidateRequest_DockerRequiresDockerfilePath(t *testing.T) {
+	req := validInternalReq(t)
+	var b amsvc.Build
+	if err := b.FromDockerBuild(amsvc.DockerBuild{Type: amsvc.Docker}); err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	req.Build = &b
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.build.docker.dockerfilePath is required")
+}
+
+func TestValidateRequest_UnknownSubType(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType.SubType = strPtr("grpc")
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.agentType.subType must be "chat-api" or "custom-api", got "grpc"`)
+}
+
+func TestValidateRequest_SubTypeRequiredForRepository(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType.SubType = nil
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.agentType.subType is required for internal provisioning")
+}
+
+func TestValidateRequest_CustomAPIRequiresBasePathAndSchema(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType.SubType = strPtr("custom-api")
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.inputInterface.basePath is required for subtype custom-api")
+	assertViolation(t, v, "spec.inputInterface.schema.path is required for subtype custom-api")
+}
+
+func TestValidateRequest_CustomAPIValid(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType.SubType = strPtr("custom-api")
+	req.InputInterface.BasePath = strPtr("/v1")
+	req.InputInterface.Schema = &amsvc.InputInterfaceSchema{Path: "/openapi.yaml"}
+	assertNoViolations(t, validateRequest(req))
+}
+
+func TestValidateRequest_InterfaceTypeMustBeHTTP(t *testing.T) {
+	req := validInternalReq(t)
+	req.InputInterface.Type = "grpc"
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.inputInterface.type must be "HTTP", got "grpc"`)
+}
+
+func TestValidateRequest_PortRange(t *testing.T) {
+	for _, tt := range []struct {
+		port    int
+		wantErr bool
+	}{{0, true}, {1, false}, {8000, false}, {65535, false}, {65536, true}, {-1, true}} {
+		req := validInternalReq(t)
+		req.InputInterface.Port = intPtr(tt.port)
+		v := validateRequest(req)
+		hasPortViolation := false
+		for _, s := range v {
+			if strings.Contains(s, "spec.inputInterface.port must be 1..65535") {
+				hasPortViolation = true
+			}
+		}
+		if hasPortViolation != tt.wantErr {
+			t.Errorf("port %d: violation=%v, want %v (all: %v)", tt.port, hasPortViolation, tt.wantErr, v)
+		}
+	}
+}
+
+func TestValidateRequest_EnvKeys(t *testing.T) {
+	req := validInternalReq(t)
+	req.Configurations = &amsvc.Configurations{
+		Env: &[]amsvc.EnvironmentVariable{
+			{Key: "GOOD", Value: strPtr("v")},
+			{Key: "1BAD", Value: strPtr("v")},
+			{Key: "", Value: strPtr("v")},
+			{Key: "GOOD", Value: strPtr("dup")},
+		},
+	}
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.configurations.env: invalid key "1BAD"`)
+	assertViolation(t, v, `spec.configurations.env: invalid key ""`)
+	assertViolation(t, v, `spec.configurations.env: duplicate key "GOOD"`)
+}
+
+func TestValidateRequest_ModelConfigProviderRequired(t *testing.T) {
+	req := validInternalReq(t)
+	req.ModelConfig = &[]amsvc.ModelConfigRequest{{}}
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.modelConfig[0].providerName is required")
+}
+
+func TestValidateRequest_ExternalRejectsInternalSections(t *testing.T) {
+	req := validInternalReq(t)
+	req.Provisioning.Type = amsvc.ProvisioningTypeExternal
+	req.AgentType.Type = "external-agent-api"
+	req.AgentType.SubType = nil
+	req.Configurations = &amsvc.Configurations{}
+	req.ModelConfig = &[]amsvc.ModelConfigRequest{{ProviderName: "openai"}}
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.provisioning.repository is not allowed for external provisioning")
+	assertViolation(t, v, "spec.build is not allowed for external provisioning")
+	assertViolation(t, v, "spec.inputInterface is not allowed for external provisioning")
+	assertViolation(t, v, "spec.configurations is not allowed for external provisioning")
+	assertViolation(t, v, "spec.modelConfig is not allowed for external provisioning")
+}
+
+func TestValidateRequest_ExternalRejectsAgentKind(t *testing.T) {
+	req := validExternalReq()
+	req.Provisioning.AgentKind = &struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}{Name: "x", Version: "1"}
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.provisioning.agentKind is not allowed for external provisioning")
+}
+
+// Aggregation: one pass reports across sections.
+func TestValidateRequest_Aggregates(t *testing.T) {
+	req := amsvc.CreateAgentRequest{
+		Provisioning: amsvc.Provisioning{
+			Type:       amsvc.ProvisioningTypeInternal,
+			Repository: &amsvc.RepositoryConfig{},
+		},
+	}
+	v := validateRequest(req)
+	if len(v) < 5 {
+		t.Errorf("expected >=5 aggregated violations, got %d: %v", len(v), v)
+	}
+}

--- a/cli/pkg/cmd/agent/create/validate_request_test.go
+++ b/cli/pkg/cmd/agent/create/validate_request_test.go
@@ -202,9 +202,9 @@ func TestValidateRequest_BuildpackRequiresLanguage(t *testing.T) {
 	assertViolation(t, v, "spec.build.buildpack.language is required")
 }
 
-// languageVersion and runCommand are optional in the API (Ballerina needs
-// neither) — the old flag-mode rule requiring both is intentionally relaxed.
-func TestValidateRequest_BuildpackVersionAndRunCommandOptional(t *testing.T) {
+// Ballerina is the only language the server exempts from languageVersion and
+// runCommand (utils.validateLanguage / validateBuildConfiguration).
+func TestValidateRequest_BallerinaNeedsNoVersionOrRunCommand(t *testing.T) {
 	req := validInternalReq(t)
 	var b amsvc.Build
 	if err := b.FromBuildpackBuild(amsvc.BuildpackBuild{
@@ -217,6 +217,21 @@ func TestValidateRequest_BuildpackVersionAndRunCommandOptional(t *testing.T) {
 	assertNoViolations(t, validateRequest(req))
 }
 
+func TestValidateRequest_BuildpackRequiresVersionAndRunCommand(t *testing.T) {
+	req := validInternalReq(t)
+	var b amsvc.Build
+	if err := b.FromBuildpackBuild(amsvc.BuildpackBuild{
+		Type:      amsvc.Buildpack,
+		Buildpack: amsvc.BuildpackConfig{Language: "python"},
+	}); err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	req.Build = &b
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.build.buildpack.languageVersion is required for language "python"`)
+	assertViolation(t, v, `spec.build.buildpack.runCommand is required for language "python"`)
+}
+
 func TestValidateRequest_DockerRequiresDockerfilePath(t *testing.T) {
 	req := validInternalReq(t)
 	var b amsvc.Build
@@ -226,6 +241,61 @@ func TestValidateRequest_DockerRequiresDockerfilePath(t *testing.T) {
 	req.Build = &b
 	v := validateRequest(req)
 	assertViolation(t, v, "spec.build.docker.dockerfilePath is required")
+}
+
+// The server rejects dockerfilePath without a leading / (utils.go) — file mode
+// must report it locally instead of after the API call.
+func TestValidateRequest_DockerfilePathLeadingSlash(t *testing.T) {
+	req := validInternalReq(t)
+	var b amsvc.Build
+	if err := b.FromDockerBuild(amsvc.DockerBuild{
+		Type:   amsvc.Docker,
+		Docker: amsvc.DockerConfig{DockerfilePath: "Dockerfile"},
+	}); err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	req.Build = &b
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.build.docker.dockerfilePath must start with "/"`)
+}
+
+func TestValidateRequest_AppPathLeadingSlash(t *testing.T) {
+	req := validInternalReq(t)
+	req.Provisioning.Repository.AppPath = "app"
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.provisioning.repository.appPath must start with "/"`)
+}
+
+// Internal source agents require agentType server-side (utils.go); only
+// agentKind-sourced agents may omit it (enriched from the kind).
+func TestValidateRequest_SourceRequiresAgentType(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType = nil
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.agentType.type is required for internal provisioning")
+}
+
+func TestValidateRequest_ExternalRequiresAgentType(t *testing.T) {
+	req := validExternalReq()
+	req.AgentType = nil
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.agentType.type is required for external provisioning")
+}
+
+// Internal source agents require inputInterface for every subtype — chat-api
+// included (utils.validateInputInterface).
+func TestValidateRequest_SourceRequiresInputInterface(t *testing.T) {
+	req := validInternalReq(t)
+	req.InputInterface = nil
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.inputInterface is required for internal provisioning")
+}
+
+func TestValidateRequest_SourceRequiresInterfaceType(t *testing.T) {
+	req := validInternalReq(t)
+	req.InputInterface.Type = ""
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.inputInterface.type is required (must be "HTTP")`)
 }
 
 func TestValidateRequest_UnknownSubType(t *testing.T) {
@@ -248,6 +318,25 @@ func TestValidateRequest_CustomAPIRequiresBasePathAndSchema(t *testing.T) {
 	v := validateRequest(req)
 	assertViolation(t, v, "spec.inputInterface.basePath is required for subtype custom-api")
 	assertViolation(t, v, "spec.inputInterface.schema.path is required for subtype custom-api")
+}
+
+func TestValidateRequest_CustomAPIRequiresPort(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType.SubType = strPtr("custom-api")
+	req.InputInterface.BasePath = strPtr("/v1")
+	req.InputInterface.Schema = &amsvc.InputInterfaceSchema{Path: "/openapi.yaml"}
+	req.InputInterface.Port = nil
+	v := validateRequest(req)
+	assertViolation(t, v, "spec.inputInterface.port is required for subtype custom-api")
+}
+
+func TestValidateRequest_CustomAPISchemaPathLeadingSlash(t *testing.T) {
+	req := validInternalReq(t)
+	req.AgentType.SubType = strPtr("custom-api")
+	req.InputInterface.BasePath = strPtr("/v1")
+	req.InputInterface.Schema = &amsvc.InputInterfaceSchema{Path: "openapi.yaml"}
+	v := validateRequest(req)
+	assertViolation(t, v, `spec.inputInterface.schema.path must start with "/"`)
 }
 
 func TestValidateRequest_CustomAPIValid(t *testing.T) {

--- a/cli/pkg/cmd/agent/create/validation.go
+++ b/cli/pkg/cmd/agent/create/validation.go
@@ -19,187 +19,255 @@ package create
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 )
 
 var envKeyRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-func validate(opts *CreateOptions) error {
+// contentFlags carry request content. They are owned by flag mode: --template
+// takes no input at all, and with --file the manifest is the source of truth.
+// Contextual flags (--org, --project, --json) stay allowed in every mode.
+var contentFlags = []string{
+	"display-name", "description", "provisioning", "subtype", "type",
+	"repo-url", "repo-branch", "repo-path", "repo-secret",
+	"build-type", "language", "language-version", "run-command", "dockerfile",
+	"port", "base-path", "openapi-spec", "no-auto-instrumentation",
+	"env", "env-secret", "env-from-secret",
+	"llm-provider", "llm-url-env", "llm-api-key-env",
+}
+
+// changedContentFlags uses Changed (not zero-value checks) because --port
+// defaults to 8000.
+func changedContentFlags(cmd *cobra.Command) []string {
+	var changed []string
+	for _, name := range contentFlags {
+		if cmd.Flags().Changed(name) {
+			changed = append(changed, name)
+		}
+	}
+	return changed
+}
+
+func validateTemplateMode(cmd *cobra.Command, args []string) error {
 	var v []string
-
-	if opts.Name == "" {
-		v = append(v, "name argument is required")
-	} else if strings.Contains(opts.Name, "/") {
-		v = append(v, "name must not contain '/'")
+	if len(args) > 0 {
+		v = append(v, "name argument is not allowed with --template")
 	}
-	if opts.DisplayName == "" {
-		v = append(v, "--display-name is required")
+	if cmd.Flags().Changed("file") {
+		v = append(v, "--file is not allowed with --template")
 	}
-
-	switch opts.Provisioning {
-	case provisioningExternal:
-		v = append(v, validateExternal(opts)...)
-	case provisioningInternal:
-		v = append(v, validateInternal(opts)...)
-	default:
-		v = append(v, fmt.Sprintf("--provisioning must be %q or %q, got %q", provisioningInternal, provisioningExternal, opts.Provisioning))
+	for _, name := range changedContentFlags(cmd) {
+		v = append(v, "--"+name+" is not allowed with --template")
 	}
-
 	if len(v) == 0 {
 		return nil
 	}
 	return cmdutil.FlagErrors(v)
 }
 
-func validateInternal(opts *CreateOptions) []string {
+func validateFileMode(cmd *cobra.Command, args []string) error {
+	var v []string
+	if len(args) > 0 {
+		v = append(v, "name argument is not allowed with --file (set spec.name in the manifest)")
+	}
+	for _, name := range changedContentFlags(cmd) {
+		v = append(v, "--"+name+" is not allowed with --file (the manifest is the source of truth)")
+	}
+	if len(v) == 0 {
+		return nil
+	}
+	return cmdutil.FlagErrors(v)
+}
+
+// prepare is the flag-mode entry point: convert the flags into the API
+// request type, then validate the request. Conversion-layer violations
+// (flag input that cannot survive the conversion) and request-layer
+// violations are aggregated into a single error.
+func prepare(opts *CreateOptions) (amsvc.CreateAgentRequest, error) {
+	req, v := Build(opts)
+	v = append(v, validateRequest(req)...)
+	if len(v) > 0 {
+		return req, cmdutil.FlagErrorsHeader("invalid agent spec", v)
+	}
+	return req, nil
+}
+
+// validateRequest is the shared semantic rule set for both flag mode and file
+// mode, defined against the request type the server receives. Messages are
+// phrased as manifest field paths. Coverage is structural (required fields,
+// enum validity, variant shape); server-owned business rules (name format,
+// repo URL format, supported languages) are deliberately not mirrored.
+func validateRequest(req amsvc.CreateAgentRequest) []string {
 	var v []string
 
-	if opts.RepoURL == "" {
-		v = append(v, "--repo-url is required for internal provisioning")
+	if req.Name == "" {
+		v = append(v, "spec.name is required")
 	}
-	if opts.RepoBranch == "" {
-		v = append(v, "--repo-branch is required for internal provisioning")
-	}
-	if opts.RepoPath == "" {
-		v = append(v, "--repo-path is required for internal provisioning")
+	if req.DisplayName == "" {
+		v = append(v, "spec.displayName is required")
 	}
 
-	switch opts.BuildType {
+	switch req.Provisioning.Type {
+	case amsvc.ProvisioningTypeInternal:
+		v = append(v, internalRequestViolations(req)...)
+	case amsvc.ProvisioningTypeExternal:
+		v = append(v, externalRequestViolations(req)...)
+	case "":
+		v = append(v, "spec.provisioning.type is required")
+	default:
+		v = append(v, fmt.Sprintf("spec.provisioning.type must be %q or %q, got %q", provisioningInternal, provisioningExternal, req.Provisioning.Type))
+	}
+
+	return v
+}
+
+func internalRequestViolations(req amsvc.CreateAgentRequest) []string {
+	var v []string
+
+	if req.AgentType != nil && req.AgentType.Type != "" && req.AgentType.Type != agentTypeInternal {
+		v = append(v, fmt.Sprintf("spec.agentType.type must be %q for internal provisioning, got %q", agentTypeInternal, req.AgentType.Type))
+	}
+
+	hasRepo := req.Provisioning.Repository != nil
+	hasKind := req.Provisioning.AgentKind != nil
+	if hasRepo == hasKind {
+		v = append(v, "spec.provisioning requires exactly one of repository or agentKind for internal provisioning")
+	}
+	if hasRepo {
+		repo := req.Provisioning.Repository
+		if repo.Url == "" {
+			v = append(v, "spec.provisioning.repository.url is required")
+		}
+		if repo.Branch == "" {
+			v = append(v, "spec.provisioning.repository.branch is required")
+		}
+		if repo.AppPath == "" {
+			v = append(v, "spec.provisioning.repository.appPath is required")
+		}
+		if req.Build == nil {
+			v = append(v, "spec.build is required for internal provisioning")
+		}
+	}
+	if hasKind {
+		kind := req.Provisioning.AgentKind
+		if kind.Name == "" {
+			v = append(v, "spec.provisioning.agentKind.name is required")
+		}
+		if kind.Version == "" {
+			v = append(v, "spec.provisioning.agentKind.version is required")
+		}
+	}
+
+	if req.Build != nil {
+		v = append(v, buildViolations(req.Build)...)
+	}
+
+	subType := ""
+	if req.AgentType != nil && req.AgentType.SubType != nil {
+		subType = *req.AgentType.SubType
+	}
+	switch subType {
+	case subTypeChatAPI:
+	case subTypeCustomAPI:
+		if req.InputInterface == nil || req.InputInterface.BasePath == nil || *req.InputInterface.BasePath == "" {
+			v = append(v, "spec.inputInterface.basePath is required for subtype custom-api")
+		}
+		if req.InputInterface == nil || req.InputInterface.Schema == nil || req.InputInterface.Schema.Path == "" {
+			v = append(v, "spec.inputInterface.schema.path is required for subtype custom-api")
+		}
+	case "":
+		if hasRepo {
+			v = append(v, "spec.agentType.subType is required for internal provisioning (chat-api or custom-api)")
+		}
+	default:
+		v = append(v, fmt.Sprintf("spec.agentType.subType must be %q or %q, got %q", subTypeChatAPI, subTypeCustomAPI, subType))
+	}
+
+	if iface := req.InputInterface; iface != nil {
+		if iface.Type != "" && iface.Type != interfaceTypeHTTP {
+			v = append(v, fmt.Sprintf("spec.inputInterface.type must be %q, got %q", interfaceTypeHTTP, iface.Type))
+		}
+		if iface.Port != nil && (*iface.Port < 1 || *iface.Port > 65535) {
+			v = append(v, fmt.Sprintf("spec.inputInterface.port must be 1..65535, got %d", *iface.Port))
+		}
+	}
+
+	if req.Configurations != nil && req.Configurations.Env != nil {
+		v = append(v, envViolations(*req.Configurations.Env)...)
+	}
+
+	if req.ModelConfig != nil {
+		for i, mc := range *req.ModelConfig {
+			if mc.ProviderName == "" {
+				v = append(v, fmt.Sprintf("spec.modelConfig[%d].providerName is required", i))
+			}
+		}
+	}
+
+	return v
+}
+
+func buildViolations(b *amsvc.Build) []string {
+	disc, err := b.Discriminator()
+	if err != nil {
+		disc = ""
+	}
+	switch disc {
 	case buildTypeBuildpack:
-		if opts.Language == "" {
-			v = append(v, "--build-type=buildpack requires --language")
-		}
-		if opts.LanguageVersion == "" {
-			v = append(v, "--build-type=buildpack requires --language-version")
-		}
-		if opts.RunCommand == "" {
-			v = append(v, "--build-type=buildpack requires --run-command")
-		}
-		if opts.Dockerfile != "" {
-			v = append(v, "--build-type=buildpack conflicts with --dockerfile")
+		bp, err := b.AsBuildpackBuild()
+		if err == nil && bp.Buildpack.Language == "" {
+			return []string{"spec.build.buildpack.language is required"}
 		}
 	case buildTypeDocker:
-		if opts.Dockerfile == "" {
-			v = append(v, "--build-type=docker requires --dockerfile")
+		d, err := b.AsDockerBuild()
+		if err == nil && d.Docker.DockerfilePath == "" {
+			return []string{"spec.build.docker.dockerfilePath is required"}
 		}
-		if opts.Language != "" {
-			v = append(v, "--build-type=docker conflicts with --language")
-		}
-		if opts.LanguageVersion != "" {
-			v = append(v, "--build-type=docker conflicts with --language-version")
-		}
-		if opts.RunCommand != "" {
-			v = append(v, "--build-type=docker conflicts with --run-command")
-		}
-	case "":
-		v = append(v, "--build-type is required for internal provisioning")
 	default:
-		v = append(v, fmt.Sprintf("--build-type must be %q or %q, got %q", buildTypeBuildpack, buildTypeDocker, opts.BuildType))
+		return []string{fmt.Sprintf("spec.build.type must be %q or %q, got %q", buildTypeBuildpack, buildTypeDocker, disc)}
 	}
-
-	switch opts.SubType {
-	case subTypeChatAPI, subTypeCustomAPI:
-	case "":
-		v = append(v, "--subtype is required (chat-api or custom-api)")
-	default:
-		v = append(v, fmt.Sprintf("--subtype must be %q or %q, got %q", subTypeChatAPI, subTypeCustomAPI, opts.SubType))
-	}
-	if opts.SubType == subTypeChatAPI {
-		if opts.PortSet {
-			v = append(v, "--port is not allowed for subtype chat-api")
-		}
-		if opts.BasePath != "" {
-			v = append(v, "--base-path is not allowed for subtype chat-api")
-		}
-		if opts.OpenAPISpec != "" {
-			v = append(v, "--openapi-spec is not allowed for subtype chat-api")
-		}
-	} else {
-		if opts.Port < 1 || opts.Port > 65535 {
-			v = append(v, fmt.Sprintf("--port must be 1..65535, got %d", opts.Port))
-		}
-		if opts.SubType == subTypeCustomAPI {
-			if opts.BasePath == "" {
-				v = append(v, "--subtype=custom-api requires --base-path")
-			}
-			if opts.OpenAPISpec == "" {
-				v = append(v, "--subtype=custom-api requires --openapi-spec")
-			}
-		}
-	}
-
-	seen := map[string]string{}
-	v = append(v, validateEnvSlice(opts.Env, "--env", seen)...)
-	v = append(v, validateEnvSlice(opts.EnvSecret, "--env-secret", seen)...)
-	v = append(v, validateEnvSlice(opts.EnvFromSecret, "--env-from-secret", seen)...)
-
-	if (opts.LLMURLEnv != "" || opts.LLMAPIKeyEnv != "") && opts.LLMProvider == "" {
-		v = append(v, "--llm-url-env/--llm-api-key-env require --llm-provider")
-	}
-
-	return v
+	return nil
 }
 
-func validateEnvSlice(entries []string, flag string, seen map[string]string) []string {
+func envViolations(envs []amsvc.EnvironmentVariable) []string {
 	var v []string
-	for _, entry := range entries {
-		key, err := parseEnvKey(entry)
-		if err != nil {
-			v = append(v, fmt.Sprintf("%s %q: %s", flag, entry, err))
+	seen := map[string]bool{}
+	for _, e := range envs {
+		if !envKeyRE.MatchString(e.Key) {
+			v = append(v, fmt.Sprintf("spec.configurations.env: invalid key %q (must match [A-Za-z_][A-Za-z0-9_]*)", e.Key))
 			continue
 		}
-		if prev, dup := seen[key]; dup {
-			v = append(v, fmt.Sprintf("duplicate env key %q (set by %s and %s)", key, prev, flag))
+		if seen[e.Key] {
+			v = append(v, fmt.Sprintf("spec.configurations.env: duplicate key %q", e.Key))
 			continue
 		}
-		seen[key] = flag
+		seen[e.Key] = true
 	}
 	return v
 }
 
-func parseEnvKey(entry string) (string, error) {
-	idx := strings.IndexByte(entry, '=')
-	if idx < 0 {
-		return "", fmt.Errorf("missing '=' separator")
-	}
-	key := entry[:idx]
-	if !envKeyRE.MatchString(key) {
-		return "", fmt.Errorf("invalid key %q (must match [A-Za-z_][A-Za-z0-9_]*)", key)
-	}
-	return key, nil
-}
-
-func validateExternal(opts *CreateOptions) []string {
+func externalRequestViolations(req amsvc.CreateAgentRequest) []string {
 	var v []string
-	disallow := func(flag string, set bool) {
-		if set {
-			v = append(v, flag+" is not allowed for external provisioning")
+
+	if req.AgentType != nil && req.AgentType.Type != "" && req.AgentType.Type != agentTypeExternal {
+		v = append(v, fmt.Sprintf("spec.agentType.type must be %q for external provisioning, got %q", agentTypeExternal, req.AgentType.Type))
+	}
+
+	disallow := func(path string, present bool) {
+		if present {
+			v = append(v, path+" is not allowed for external provisioning")
 		}
 	}
-
-	disallow("--subtype", opts.SubType != "")
-	disallow("--repo-url", opts.RepoURL != "")
-	disallow("--repo-branch", opts.RepoBranch != "")
-	disallow("--repo-path", opts.RepoPath != "")
-	disallow("--repo-secret", opts.RepoSecret != "")
-	disallow("--build-type", opts.BuildType != "")
-	disallow("--language", opts.Language != "")
-	disallow("--language-version", opts.LanguageVersion != "")
-	disallow("--run-command", opts.RunCommand != "")
-	disallow("--dockerfile", opts.Dockerfile != "")
-	// PortSet (not Port != 0) — the --port flag defaults to 8000.
-	disallow("--port", opts.PortSet)
-	disallow("--base-path", opts.BasePath != "")
-	disallow("--openapi-spec", opts.OpenAPISpec != "")
-	disallow("--env", len(opts.Env) > 0)
-	disallow("--env-secret", len(opts.EnvSecret) > 0)
-	disallow("--env-from-secret", len(opts.EnvFromSecret) > 0)
-	disallow("--no-auto-instrumentation", opts.DisableAutoInstrumentation)
-	disallow("--llm-provider", opts.LLMProvider != "")
-	disallow("--llm-url-env", opts.LLMURLEnv != "")
-	disallow("--llm-api-key-env", opts.LLMAPIKeyEnv != "")
+	disallow("spec.provisioning.repository", req.Provisioning.Repository != nil)
+	disallow("spec.provisioning.agentKind", req.Provisioning.AgentKind != nil)
+	disallow("spec.build", req.Build != nil)
+	disallow("spec.inputInterface", req.InputInterface != nil)
+	disallow("spec.configurations", req.Configurations != nil)
+	disallow("spec.modelConfig", req.ModelConfig != nil)
 
 	return v
 }

--- a/cli/pkg/cmd/agent/create/validation.go
+++ b/cli/pkg/cmd/agent/create/validation.go
@@ -251,7 +251,7 @@ func buildViolations(b *amsvc.Build) []string {
 		// Ballerina is the only language the server exempts from
 		// languageVersion and runCommand.
 		var v []string
-		if cfg.Language != langBallerina {
+		if !strings.EqualFold(cfg.Language, langBallerina) {
 			if cfg.LanguageVersion == nil || *cfg.LanguageVersion == "" {
 				v = append(v, fmt.Sprintf("spec.build.buildpack.languageVersion is required for language %q", cfg.Language))
 			}

--- a/cli/pkg/cmd/agent/create/validation.go
+++ b/cli/pkg/cmd/agent/create/validation.go
@@ -19,6 +19,7 @@ package create
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -59,6 +60,9 @@ func validateTemplateMode(cmd *cobra.Command, args []string) error {
 	}
 	if cmd.Flags().Changed("file") {
 		v = append(v, "--file is not allowed with --template")
+	}
+	if cmd.Flags().Changed("json") {
+		v = append(v, "--json is not allowed with --template (the template is YAML)")
 	}
 	for _, name := range changedContentFlags(cmd) {
 		v = append(v, "--"+name+" is not allowed with --template")
@@ -147,9 +151,21 @@ func internalRequestViolations(req amsvc.CreateAgentRequest) []string {
 		}
 		if repo.AppPath == "" {
 			v = append(v, "spec.provisioning.repository.appPath is required")
+		} else if !strings.HasPrefix(repo.AppPath, "/") {
+			v = append(v, `spec.provisioning.repository.appPath must start with "/"`)
 		}
 		if req.Build == nil {
 			v = append(v, "spec.build is required for internal provisioning")
+		}
+		// Only agentKind-sourced agents may omit agentType and inputInterface
+		// (the server enriches them from the kind); source agents need both.
+		if req.AgentType == nil || req.AgentType.Type == "" {
+			v = append(v, fmt.Sprintf("spec.agentType.type is required for internal provisioning (%s)", agentTypeInternal))
+		}
+		if req.InputInterface == nil {
+			v = append(v, "spec.inputInterface is required for internal provisioning")
+		} else if req.InputInterface.Type == "" {
+			v = append(v, fmt.Sprintf("spec.inputInterface.type is required (must be %q)", interfaceTypeHTTP))
 		}
 	}
 	if hasKind {
@@ -176,8 +192,14 @@ func internalRequestViolations(req amsvc.CreateAgentRequest) []string {
 		if req.InputInterface == nil || req.InputInterface.BasePath == nil || *req.InputInterface.BasePath == "" {
 			v = append(v, "spec.inputInterface.basePath is required for subtype custom-api")
 		}
-		if req.InputInterface == nil || req.InputInterface.Schema == nil || req.InputInterface.Schema.Path == "" {
+		switch {
+		case req.InputInterface == nil || req.InputInterface.Schema == nil || req.InputInterface.Schema.Path == "":
 			v = append(v, "spec.inputInterface.schema.path is required for subtype custom-api")
+		case !strings.HasPrefix(req.InputInterface.Schema.Path, "/"):
+			v = append(v, `spec.inputInterface.schema.path must start with "/"`)
+		}
+		if req.InputInterface != nil && req.InputInterface.Port == nil {
+			v = append(v, "spec.inputInterface.port is required for subtype custom-api")
 		}
 	case "":
 		if hasRepo {
@@ -219,13 +241,35 @@ func buildViolations(b *amsvc.Build) []string {
 	switch disc {
 	case buildTypeBuildpack:
 		bp, err := b.AsBuildpackBuild()
-		if err == nil && bp.Buildpack.Language == "" {
+		if err != nil {
+			return nil
+		}
+		cfg := bp.Buildpack
+		if cfg.Language == "" {
 			return []string{"spec.build.buildpack.language is required"}
 		}
+		// Ballerina is the only language the server exempts from
+		// languageVersion and runCommand.
+		var v []string
+		if cfg.Language != langBallerina {
+			if cfg.LanguageVersion == nil || *cfg.LanguageVersion == "" {
+				v = append(v, fmt.Sprintf("spec.build.buildpack.languageVersion is required for language %q", cfg.Language))
+			}
+			if cfg.RunCommand == nil || *cfg.RunCommand == "" {
+				v = append(v, fmt.Sprintf("spec.build.buildpack.runCommand is required for language %q", cfg.Language))
+			}
+		}
+		return v
 	case buildTypeDocker:
 		d, err := b.AsDockerBuild()
-		if err == nil && d.Docker.DockerfilePath == "" {
+		if err != nil {
+			return nil
+		}
+		if d.Docker.DockerfilePath == "" {
 			return []string{"spec.build.docker.dockerfilePath is required"}
+		}
+		if !strings.HasPrefix(d.Docker.DockerfilePath, "/") {
+			return []string{`spec.build.docker.dockerfilePath must start with "/"`}
 		}
 	default:
 		return []string{fmt.Sprintf("spec.build.type must be %q or %q, got %q", buildTypeBuildpack, buildTypeDocker, disc)}
@@ -253,7 +297,9 @@ func envViolations(envs []amsvc.EnvironmentVariable) []string {
 func externalRequestViolations(req amsvc.CreateAgentRequest) []string {
 	var v []string
 
-	if req.AgentType != nil && req.AgentType.Type != "" && req.AgentType.Type != agentTypeExternal {
+	if req.AgentType == nil || req.AgentType.Type == "" {
+		v = append(v, fmt.Sprintf("spec.agentType.type is required for external provisioning (%s)", agentTypeExternal))
+	} else if req.AgentType.Type != agentTypeExternal {
 		v = append(v, fmt.Sprintf("spec.agentType.type must be %q for external provisioning, got %q", agentTypeExternal, req.AgentType.Type))
 	}
 

--- a/cli/pkg/cmd/agent/create/validation_test.go
+++ b/cli/pkg/cmd/agent/create/validation_test.go
@@ -59,34 +59,6 @@ func validDockerOpts() *CreateOptions {
 	}
 }
 
-func TestValidate_ValidBuildpack(t *testing.T) {
-	if err := validate(validBuildpackOpts()); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidate_ValidDocker(t *testing.T) {
-	if err := validate(validDockerOpts()); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValidate_MissingRequiredFlags(t *testing.T) {
-	opts := &CreateOptions{
-		Provisioning: "internal",
-		Port:         8000,
-	}
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, "name argument is required")
-	assertContains(t, details, "--display-name is required")
-	assertContains(t, details, "--repo-url is required for internal provisioning")
-	assertContains(t, details, "--repo-branch is required for internal provisioning")
-	assertContains(t, details, "--repo-path is required for internal provisioning")
-	assertContains(t, details, "--build-type is required for internal provisioning")
-	assertContains(t, details, "--subtype is required")
-}
-
 // validExternalOpts returns a CreateOptions for external that passes validation.
 func validExternalOpts() *CreateOptions {
 	return &CreateOptions{
@@ -96,13 +68,59 @@ func validExternalOpts() *CreateOptions {
 	}
 }
 
-func TestValidate_ValidExternal(t *testing.T) {
-	if err := validate(validExternalOpts()); err != nil {
+func mustPrepareErr(t *testing.T, opts *CreateOptions) error {
+	t.Helper()
+	_, err := prepare(opts)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	return err
+}
+
+func TestPrepare_ValidBuildpack(t *testing.T) {
+	if _, err := prepare(validBuildpackOpts()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
+func TestPrepare_ValidDocker(t *testing.T) {
+	if _, err := prepare(validDockerOpts()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepare_ValidExternal(t *testing.T) {
+	if _, err := prepare(validExternalOpts()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// The aggregated error header distinguishes spec problems from flag-usage
+// problems and is shared by flag mode and file mode.
+func TestPrepare_HeaderIsInvalidAgentSpec(t *testing.T) {
+	err := mustPrepareErr(t, &CreateOptions{Provisioning: "internal", Port: 8000})
+	if !strings.Contains(err.Error(), "invalid agent spec") {
+		t.Errorf("error %q missing header 'invalid agent spec'", err.Error())
+	}
+}
+
+func TestPrepare_MissingRequiredFlags(t *testing.T) {
+	opts := &CreateOptions{
+		Provisioning: "internal",
+		Port:         8000,
+	}
+	err := mustPrepareErr(t, opts)
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "spec.name is required")
+	assertContains(t, details, "spec.displayName is required")
+	assertContains(t, details, "spec.provisioning.repository.url is required")
+	assertContains(t, details, "spec.provisioning.repository.branch is required")
+	assertContains(t, details, "spec.provisioning.repository.appPath is required")
+	assertContains(t, details, "spec.build is required for internal provisioning")
+	assertContains(t, details, "spec.agentType.subType is required for internal provisioning")
+}
+
+func TestPrepare_ExternalRejectsInternalOnlyFlags(t *testing.T) {
 	opts := validExternalOpts()
 	opts.SubType = "custom-api"
 	opts.RepoURL = "https://x"
@@ -124,7 +142,7 @@ func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
 	opts.DisableAutoInstrumentation = true
 	opts.LLMProvider = "openai"
 
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	for _, msg := range []string{
 		"--subtype is not allowed for external provisioning",
@@ -150,135 +168,132 @@ func TestValidate_ExternalRejectsInternalOnlyFlags(t *testing.T) {
 	}
 }
 
-func TestValidate_UnknownProvisioning(t *testing.T) {
+func TestPrepare_UnknownProvisioning(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.Provisioning = "magic"
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, `--provisioning must be "internal" or "external", got "magic"`)
+	assertContains(t, details, `spec.provisioning.type must be "internal" or "external", got "magic"`)
 }
 
-func TestValidate_BuildpackRequiresLanguage(t *testing.T) {
+func TestPrepare_BuildpackRequiresLanguage(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.Language = ""
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--build-type=buildpack requires --language")
+	assertContains(t, details, "spec.build.buildpack.language is required")
 }
 
-func TestValidate_BuildpackRequiresLanguageVersion(t *testing.T) {
-	opts := validBuildpackOpts()
-	opts.LanguageVersion = ""
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--build-type=buildpack requires --language-version")
-}
-
-func TestValidate_BuildpackRequiresRunCommand(t *testing.T) {
-	opts := validBuildpackOpts()
-	opts.RunCommand = ""
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--build-type=buildpack requires --run-command")
-}
-
-func TestValidate_BuildpackRequiresBothLanguageVersionAndRunCommand(t *testing.T) {
+// languageVersion and runCommand are optional in the API (Ballerina needs
+// neither); the old flag rule requiring both is intentionally relaxed.
+func TestPrepare_BuildpackVersionAndRunCommandOptional(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.LanguageVersion = ""
 	opts.RunCommand = ""
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--build-type=buildpack requires --language-version")
-	assertContains(t, details, "--build-type=buildpack requires --run-command")
+	if _, err := prepare(opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
-func TestValidate_BuildpackRejectsDockerfile(t *testing.T) {
+func TestPrepare_BuildpackRejectsDockerfile(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.Dockerfile = "Dockerfile"
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	assertContains(t, details, "--build-type=buildpack conflicts with --dockerfile")
 }
 
-func TestValidate_DockerRequiresDockerfile(t *testing.T) {
+func TestPrepare_DockerRequiresDockerfile(t *testing.T) {
 	opts := validDockerOpts()
 	opts.Dockerfile = ""
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--build-type=docker requires --dockerfile")
+	assertContains(t, details, "spec.build.docker.dockerfilePath is required")
 }
 
-func TestValidate_DockerRejectsBuildpackFlags(t *testing.T) {
+func TestPrepare_DockerRejectsBuildpackFlags(t *testing.T) {
 	opts := validDockerOpts()
 	opts.Language = "go"
 	opts.LanguageVersion = "1.22"
 	opts.RunCommand = "go run ."
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	assertContains(t, details, "--build-type=docker conflicts with --language")
 	assertContains(t, details, "--build-type=docker conflicts with --language-version")
 	assertContains(t, details, "--build-type=docker conflicts with --run-command")
 }
 
-func TestValidate_UnknownBuildType(t *testing.T) {
+func TestPrepare_UnknownBuildType(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.BuildType = "nix"
 	opts.Language = ""
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, `--build-type must be "buildpack" or "docker", got "nix"`)
+	assertContains(t, details, `spec.build.type must be "buildpack" or "docker", got "nix"`)
 }
 
-func TestValidate_ChatAPIRejectsInterfaceFlags(t *testing.T) {
+func TestPrepare_MissingBuildType(t *testing.T) {
+	opts := validBuildpackOpts()
+	opts.BuildType = ""
+	opts.Language = ""
+	opts.LanguageVersion = ""
+	opts.RunCommand = ""
+	err := mustPrepareErr(t, opts)
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "spec.build is required for internal provisioning")
+}
+
+func TestPrepare_ChatAPIRejectsInterfaceFlags(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.SubType = "chat-api"
 	opts.PortSet = true
 	opts.Port = 9000
 	opts.BasePath = "/v1"
 	opts.OpenAPISpec = "spec.yaml"
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	assertContains(t, details, "--port is not allowed for subtype chat-api")
 	assertContains(t, details, "--base-path is not allowed for subtype chat-api")
 	assertContains(t, details, "--openapi-spec is not allowed for subtype chat-api")
 }
 
-func TestValidate_ChatAPIPortSetTo8000Rejected(t *testing.T) {
+func TestPrepare_ChatAPIPortSetTo8000Rejected(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.SubType = "chat-api"
 	opts.PortSet = true
 	opts.Port = 8000
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	assertContains(t, details, "--port is not allowed for subtype chat-api")
 }
 
-func TestValidate_ChatAPIPortUnsetAllowed(t *testing.T) {
+func TestPrepare_ChatAPIPortUnsetAllowed(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.SubType = "chat-api"
 	opts.PortSet = false
-	if err := validate(opts); err != nil {
+	if _, err := prepare(opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestValidate_NameWithSlash(t *testing.T) {
+// Name format (including '/') is server-owned; the client only requires presence.
+func TestPrepare_NameWithSlashAccepted(t *testing.T) {
 	opts := validBuildpackOpts()
-	opts.Name = "bad/name"
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, "name must not contain '/'")
+	opts.Name = "weird/name"
+	if _, err := prepare(opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
-func TestValidate_RepoPathWithoutSlashPasses(t *testing.T) {
+func TestPrepare_RepoPathWithoutSlashPasses(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.RepoPath = "src/app"
-	if err := validate(opts); err != nil {
+	if _, err := prepare(opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestValidate_PortRange(t *testing.T) {
+func TestPrepare_PortRange(t *testing.T) {
 	tests := []struct {
 		name    string
 		port    int
@@ -298,7 +313,7 @@ func TestValidate_PortRange(t *testing.T) {
 			opts.BasePath = "/v1"
 			opts.OpenAPISpec = "/spec.yaml"
 			opts.Port = tt.port
-			err := validate(opts)
+			_, err := prepare(opts)
 			if tt.wantErr && err == nil {
 				t.Error("expected error")
 			}
@@ -309,138 +324,144 @@ func TestValidate_PortRange(t *testing.T) {
 	}
 }
 
-func TestValidate_EnvKeyFormat(t *testing.T) {
+// Missing '=' cannot survive conversion (splitEnv would smuggle the whole
+// entry through as a key), so it is reported flag-phrased at the conversion
+// layer. Key format and duplicates survive into the request and are reported
+// as field paths.
+func TestPrepare_EnvMissingSeparator(t *testing.T) {
 	tests := []struct {
-		name    string
-		env     []string
+		flag    string
+		mutate  func(*CreateOptions)
 		wantSub string
 	}{
-		{"missing separator", []string{"NOEQUALS"}, `--env "NOEQUALS": missing '=' separator`},
-		{"bad key start", []string{"1BAD=val"}, `--env "1BAD=val": invalid key "1BAD"`},
-		{"hyphen in key", []string{"NO-DASH=val"}, `--env "NO-DASH=val": invalid key "NO-DASH"`},
-		{"empty key", []string{"=val"}, `--env "=val": invalid key ""`},
+		{"--env", func(o *CreateOptions) { o.Env = []string{"NOEQUALS"} }, `--env "NOEQUALS": missing '=' separator`},
+		{"--env-secret", func(o *CreateOptions) { o.EnvSecret = []string{"NOSEP"} }, `--env-secret "NOSEP": missing '=' separator`},
+		{"--env-from-secret", func(o *CreateOptions) { o.EnvFromSecret = []string{"NOSEP"} }, `--env-from-secret "NOSEP": missing '=' separator`},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.flag, func(t *testing.T) {
 			opts := validBuildpackOpts()
-			opts.Env = tt.env
-			err := validate(opts)
+			tt.mutate(opts)
+			err := mustPrepareErr(t, opts)
 			details := mustFlagDetails(t, err)
 			assertContains(t, details, tt.wantSub)
 		})
 	}
 }
 
-func TestValidate_EnvSecretKeyFormat(t *testing.T) {
+func TestPrepare_EnvInvalidKey(t *testing.T) {
 	opts := validBuildpackOpts()
-	opts.EnvSecret = []string{"BAD KEY=val"}
-	err := validate(opts)
+	opts.Env = []string{"1BAD=val"}
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, `--env-secret "BAD KEY=val": invalid key "BAD KEY"`)
+	assertContains(t, details, `spec.configurations.env: invalid key "1BAD"`)
 }
 
-func TestValidate_EnvFromSecretKeyFormat(t *testing.T) {
-	opts := validBuildpackOpts()
-	opts.EnvFromSecret = []string{"NOSEP"}
-	err := validate(opts)
-	details := mustFlagDetails(t, err)
-	assertContains(t, details, `--env-from-secret "NOSEP": missing '=' separator`)
-}
-
-func TestValidate_DuplicateEnvKey(t *testing.T) {
+func TestPrepare_DuplicateEnvKey(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.Env = []string{"FOO=bar"}
 	opts.EnvSecret = []string{"FOO=secret"}
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, `duplicate env key "FOO"`)
+	assertContains(t, details, `spec.configurations.env: duplicate key "FOO"`)
 }
 
-func TestValidate_DuplicateEnvKeyAcrossThreeFlags(t *testing.T) {
+func TestPrepare_DuplicateEnvKeyAcrossThreeFlags(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.Env = []string{"DB_HOST=localhost"}
 	opts.EnvSecret = []string{"API_KEY=secret"}
 	opts.EnvFromSecret = []string{"DB_HOST=my-secret"}
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, `duplicate env key "DB_HOST"`)
+	assertContains(t, details, `spec.configurations.env: duplicate key "DB_HOST"`)
 }
 
-func TestValidate_ValidEnv(t *testing.T) {
+func TestPrepare_ValidEnv(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.Env = []string{"FOO=bar", "BAZ=qux"}
 	opts.EnvSecret = []string{"SECRET_KEY=hunter2"}
 	opts.EnvFromSecret = []string{"DB_PASS=my-secret"}
-	if err := validate(opts); err != nil {
+	if _, err := prepare(opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestValidate_LLMEnvFlagsRequireProvider(t *testing.T) {
+func TestPrepare_LLMEnvFlagsRequireProvider(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.LLMURLEnv = "MY_URL"
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	assertContains(t, details, "--llm-url-env/--llm-api-key-env require --llm-provider")
 }
 
-func TestValidate_LLMProviderValid(t *testing.T) {
+func TestPrepare_LLMProviderValid(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.LLMProvider = "openai"
 	opts.LLMURLEnv = "MY_URL"
 	opts.LLMAPIKeyEnv = "MY_KEY"
-	if err := validate(opts); err != nil {
+	if _, err := prepare(opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestValidate_ExternalRejectsLLMEnvFlags(t *testing.T) {
+func TestPrepare_ExternalRejectsLLMEnvFlags(t *testing.T) {
 	opts := validExternalOpts()
 	opts.LLMURLEnv = "MY_URL"
 	opts.LLMAPIKeyEnv = "MY_KEY"
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	assertContains(t, details, "--llm-url-env is not allowed for external provisioning")
 	assertContains(t, details, "--llm-api-key-env is not allowed for external provisioning")
 }
 
-func TestValidate_CustomAPIRequiresBasePathAndOpenAPISpec(t *testing.T) {
+func TestPrepare_CustomAPIRequiresBasePathAndOpenAPISpec(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.SubType = "custom-api"
 	opts.BasePath = ""
 	opts.OpenAPISpec = ""
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, "--subtype=custom-api requires --base-path")
-	assertContains(t, details, "--subtype=custom-api requires --openapi-spec")
+	assertContains(t, details, "spec.inputInterface.basePath is required for subtype custom-api")
+	assertContains(t, details, "spec.inputInterface.schema.path is required for subtype custom-api")
 }
 
-func TestValidate_CustomAPIValid(t *testing.T) {
+func TestPrepare_CustomAPIValid(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.SubType = "custom-api"
 	opts.BasePath = "/v1"
 	opts.OpenAPISpec = "openapi.yaml"
-	if err := validate(opts); err != nil {
+	if _, err := prepare(opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestValidate_UnknownSubType(t *testing.T) {
+func TestPrepare_UnknownSubType(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.SubType = "grpc"
-	err := validate(opts)
+	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
-	assertContains(t, details, `--subtype must be "chat-api" or "custom-api", got "grpc"`)
+	assertContains(t, details, `spec.agentType.subType must be "chat-api" or "custom-api", got "grpc"`)
 }
 
-func TestValidate_CustomAPIWithoutSlashPasses(t *testing.T) {
+func TestPrepare_CustomAPIWithoutSlashPasses(t *testing.T) {
 	opts := validBuildpackOpts()
 	opts.SubType = "custom-api"
 	opts.BasePath = "v1"
 	opts.OpenAPISpec = "spec.yaml"
-	if err := validate(opts); err != nil {
+	if _, err := prepare(opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+// Conversion-layer and request-layer violations surface in one aggregated error.
+func TestPrepare_MergesConversionAndRequestViolations(t *testing.T) {
+	opts := validBuildpackOpts()
+	opts.DisplayName = ""           // request layer
+	opts.Env = []string{"NOEQUALS"} // conversion layer
+	err := mustPrepareErr(t, opts)
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, "spec.displayName is required")
+	assertContains(t, details, `--env "NOEQUALS": missing '=' separator`)
 }
 
 // --- helpers ---

--- a/cli/pkg/cmd/agent/create/validation_test.go
+++ b/cli/pkg/cmd/agent/create/validation_test.go
@@ -184,10 +184,21 @@ func TestPrepare_BuildpackRequiresLanguage(t *testing.T) {
 	assertContains(t, details, "spec.build.buildpack.language is required")
 }
 
-// languageVersion and runCommand are optional in the API (Ballerina needs
-// neither); the old flag rule requiring both is intentionally relaxed.
-func TestPrepare_BuildpackVersionAndRunCommandOptional(t *testing.T) {
+// The server requires languageVersion and runCommand for every buildpack
+// language except Ballerina — flag mode must report both locally.
+func TestPrepare_BuildpackRequiresVersionAndRunCommand(t *testing.T) {
 	opts := validBuildpackOpts()
+	opts.LanguageVersion = ""
+	opts.RunCommand = ""
+	err := mustPrepareErr(t, opts)
+	details := mustFlagDetails(t, err)
+	assertContains(t, details, `spec.build.buildpack.languageVersion is required for language "go"`)
+	assertContains(t, details, `spec.build.buildpack.runCommand is required for language "go"`)
+}
+
+func TestPrepare_BallerinaNeedsNoVersionOrRunCommand(t *testing.T) {
+	opts := validBuildpackOpts()
+	opts.Language = "ballerina"
 	opts.LanguageVersion = ""
 	opts.RunCommand = ""
 	if _, err := prepare(opts); err != nil {
@@ -209,6 +220,24 @@ func TestPrepare_DockerRequiresDockerfile(t *testing.T) {
 	err := mustPrepareErr(t, opts)
 	details := mustFlagDetails(t, err)
 	assertContains(t, details, "spec.build.docker.dockerfilePath is required")
+}
+
+// --dockerfile is normalized like --repo-path: the server requires a leading
+// slash, so the builder prepends one instead of round-tripping a 400.
+func TestPrepare_DockerfileWithoutSlashNormalized(t *testing.T) {
+	opts := validDockerOpts()
+	opts.Dockerfile = "build/Dockerfile"
+	req, err := prepare(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d, err := req.Build.AsDockerBuild()
+	if err != nil {
+		t.Fatalf("build union: %v", err)
+	}
+	if d.Docker.DockerfilePath != "/build/Dockerfile" {
+		t.Errorf("DockerfilePath = %q, want /build/Dockerfile", d.Docker.DockerfilePath)
+	}
 }
 
 func TestPrepare_DockerRejectsBuildpackFlags(t *testing.T) {

--- a/cli/pkg/cmd/agent/create/yamlx.go
+++ b/cli/pkg/cmd/agent/create/yamlx.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DecodeStrict decodes YAML into target via a JSON bridge. The generated
+// amsvc types carry json tags only, so direct yaml.Unmarshal would match
+// lowercased Go field names and mangle every camelCase key. Unknown fields
+// are rejected.
+func DecodeStrict(data []byte, target any) error {
+	var generic any
+	if err := yaml.Unmarshal(data, &generic); err != nil {
+		return err
+	}
+	jsonBytes, err := json.Marshal(generic)
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(jsonBytes))
+	dec.DisallowUnknownFields()
+	return dec.Decode(target)
+}

--- a/cli/pkg/cmd/agent/create/yamlx_test.go
+++ b/cli/pkg/cmd/agent/create/yamlx_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package create
+
+import (
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+// DecodeStrict must honour json tags (the generated types have no yaml tags),
+// so camelCase YAML keys land in the right fields.
+func TestDecodeStrict_JSONTags(t *testing.T) {
+	yaml := `
+name: my-agent
+displayName: My Agent
+provisioning:
+  type: internal
+  repository:
+    url: https://github.com/example/repo
+    branch: main
+    appPath: /app
+`
+	var req amsvc.CreateAgentRequest
+	if err := DecodeStrict([]byte(yaml), &req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.DisplayName != "My Agent" {
+		t.Errorf("DisplayName = %q, want %q (yaml must map via json tags)", req.DisplayName, "My Agent")
+	}
+	if req.Provisioning.Repository == nil || req.Provisioning.Repository.AppPath != "/app" {
+		t.Errorf("Repository = %+v, want appPath=/app", req.Provisioning.Repository)
+	}
+}
+
+func TestDecodeStrict_UnknownFieldRejected(t *testing.T) {
+	yaml := `
+name: my-agent
+displayNam: typo
+`
+	var req amsvc.CreateAgentRequest
+	err := DecodeStrict([]byte(yaml), &req)
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "displayNam") {
+		t.Errorf("error %q should name the unknown field", err)
+	}
+}
+
+func TestDecodeStrict_NestedUnknownFieldRejected(t *testing.T) {
+	yaml := `
+name: my-agent
+provisioning:
+  type: internal
+  repository:
+    url: https://github.com/example/repo
+    branche: typo
+`
+	var req amsvc.CreateAgentRequest
+	if err := DecodeStrict([]byte(yaml), &req); err == nil {
+		t.Fatal("expected error for nested unknown field")
+	}
+}
+
+func TestDecodeStrict_InvalidYAML(t *testing.T) {
+	var req amsvc.CreateAgentRequest
+	if err := DecodeStrict([]byte("a: [unclosed"), &req); err == nil {
+		t.Fatal("expected error for invalid yaml")
+	}
+}

--- a/cli/pkg/cmdutil/errors.go
+++ b/cli/pkg/cmdutil/errors.go
@@ -57,8 +57,14 @@ func FlagErrorWrap(err error) error {
 // The message is newline-delimited for text rendering; AdditionalData["details"]
 // carries the structured list for JSON consumers.
 func FlagErrors(violations []string) error {
+	return FlagErrorsHeader("invalid flags", violations)
+}
+
+// FlagErrorsHeader is FlagErrors with a custom first-line header, for
+// violation sets that aren't about flag usage (e.g. an invalid agent spec).
+func FlagErrorsHeader(header string, violations []string) error {
 	var buf strings.Builder
-	buf.WriteString("invalid flags")
+	buf.WriteString(header)
 	for _, v := range violations {
 		buf.WriteString("\n    ")
 		buf.WriteString(v)


### PR DESCRIPTION
## Purpose
`amctl agent create` only supports flag-driven creation, which is hard to review, version, and reproduce. There is no machine-readable scaffold for the create payload, and client-side validation reports flag-level errors that diverge from the request body the server actually receives. Related discussion: wso2/agent-manager#996.

Issue: https://github.com/wso2/agent-manager/issues/1077

## Goals
- Declarative agent creation: `amctl agent create -f <manifest.yaml>` with the file as the single source of truth for the request body.
- `amctl agent create --template` emitting a self-documenting manifest template (no other input accepted).
- One shared, aggregated client-side validation pass defined against the API request type (`CreateAgentRequest`), used by both flag mode and file mode. No server-side validation changes.

## Approach
- **Manifest**: a versioned wrapper (`apiVersion: agent-manager.wso2.com/v1alpha1`, `kind: Agent`) around `CreateAgentRequest` verbatim. Decoding bridges YAML→JSON (generated types carry json tags only) with `DisallowUnknownFields`, including a strict re-decode inside the `Build` discriminated union.
- **Validation refactor**: flag mode now converts flags into `CreateAgentRequest` first (`Build` is total — it never hard-fails; flag input that cannot survive conversion is collected as flag-phrased violations), then a shared `validateRequest` applies structural rules with manifest field-path messages (`spec.displayName is required`) under an `invalid agent spec` header. All violations are aggregated into one error. Server-owned business rules (name format, repo URL format, language lists) are intentionally not mirrored.
- **Template**: a static annotated YAML constant; an anti-drift round-trip test strict-decodes it through the exact file-mode path into the generated request type.
- **Submit path**: the external-agent token/instrumentation flow now branches on `req.Provisioning.Type` instead of the `--provisioning` flag, so file-mode external agents get it too.
- **CI**: `cli-codegen-check.yaml` now runs `go test ./...` against the regenerated client, so an OpenAPI spec change that leaves the template stale (or any spec-tracking artifact) fails in the same PR.

Behavior changes (both intentional): buildpack `--language-version`/`--run-command` are no longer required client-side (the API marks them optional — Ballerina needs neither), and the client no longer pre-checks `name` for `/` (server owns name format).

## User stories
- As a platform engineer, I can keep agent definitions as reviewable, versionable YAML and create agents reproducibly with `-f`.
- As a CLI user, I can scaffold a correct manifest with `--template` and get all validation errors in a single pass before any API call.

## Release note
`amctl agent create` now supports declarative creation from a YAML manifest (`-f`) and manifest scaffolding (`--template`), with aggregated client-side spec validation shared between flag and file modes.

## Documentation
N/A — CLI help text is updated in-command (`amctl agent create --help`); no product documentation page exists yet for amctl declarative workflows.

## Training
N/A — no training content impact.

## Certification
N/A — CLI-only enhancement; no impact on certification exam scope.

## Marketing
N/A.

## Automation tests
 - Unit tests
   > 100+ table-driven tests in `cli/pkg/cmd/agent/create` covering: strict YAML decode (unknown fields, build-union strictness), manifest envelope checks, every `validateRequest` rule, conversion-layer violations, template round-trip/anti-drift, template/file mode flag exclusion, and end-to-end request-body capture via httptest for internal, external (token flow), and agentKind manifests. Full suite passes with `-race`.
 - Integration tests
   > N/A — covered by httptest-backed command tests matching the existing suite's idiom.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no (Go codebase; FindSecurityBugs is a Java tool — `go vet` and staticcheck CI checks apply instead)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
The `--template` output itself is the sample: an annotated manifest documenting the buildpack/docker, repository/agentKind, internal/external, env, and modelConfig variants.

## Related PRs
N/A.

## Migrations (if applicable)
N/A — additive CLI change; existing flag-driven usage keeps working (two validation relaxations noted under Approach).

## Test environment
Go 1.x (per `cli/go.mod`), macOS (darwin/arm64). CI runs the suite on the repo's standard runners.

## Learning
Followed the Kubernetes resource-envelope pattern (`apiVersion`/`kind`/`spec`) for manifest versioning; worked around oapi-codegen's json-tag-only types and `json.RawMessage`-backed unions with a YAML→JSON strict-decode bridge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * amctl agent create --template prints a documented agent manifest scaffold.
  * amctl agent create --file accepts YAML manifests to create agents (internal & external flows); external flow emits agent token snippet.

* **Validation / UX**
  * Centralized prepare+validate with aggregated "invalid agent spec" header and clearer field messages.
  * Template/file mode gates reject incompatible flags (e.g., --template rejects --json, name/content flags blocked in file mode).

* **Behavior**
  * File manifests determine provisioning and post-create behavior; unknown/empty build or provisioning types are preserved for server-side validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->