### PR TITLE
Fix empty-output templated LLM-judge scores

### DIFF
--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/base.py
@@ -541,6 +541,13 @@ class LLMAsJudgeEvaluator(BaseEvaluator):
     max_tokens: int = Param(default=1024, description="Max tokens for LLM response")
     max_retries: int = Param(default=2, description="Max retries on invalid LLM output")
 
+    # Trace/agent/LLM judges that score the agent's *response* cannot evaluate
+    # an empty output — scoring a blank response yields a templated, misleading
+    # result (often a default high score). Such judges skip instead. Judges that
+    # do not read the response (e.g. context_relevance, which assesses retrieved
+    # context against the query) set this False.
+    _requires_response_output: bool = True
+
     # Output format instructions — auto-appended to the user's prompt
     _OUTPUT_INSTRUCTIONS = """
 
@@ -593,6 +600,16 @@ The "explanation" field MUST be formatted as valid Markdown. Use headings, bulle
         """Internal: calls build_prompt() -> LLM -> validate -> EvalResult."""
         trace_or_span = args[0] if args else None
         task = args[1] if len(args) > 1 else kwargs.get("task")
+        # Guard: do not let the judge score an empty output. A blank response
+        # makes the model emit a templated skeleton and a default score, which
+        # is worse than an explicit skip. The message stays level-agnostic
+        # because this base class judges Trace, AgentTrace, and LLMSpan outputs.
+        if self._requires_response_output and trace_or_span is not None:
+            output = getattr(trace_or_span, "output", None)
+            if not (isinstance(output, str) and output.strip()):
+                return EvalResult.skip(
+                    "No output found to evaluate; skipping LLM judge to avoid scoring an empty response."
+                )
         # 1. Dispatch to build_prompt() (respects signature param count)
         prompt = self._dispatch_build_prompt(trace_or_span, task)
 

--- a/libs/amp-evaluation/src/amp_evaluation/evaluators/builtin/llm_judge.py
+++ b/libs/amp-evaluation/src/amp_evaluation/evaluators/builtin/llm_judge.py
@@ -267,6 +267,10 @@ class ContextRelevanceEvaluator(LLMAsJudgeEvaluator):
     )
     tags = ["llm-judge", "relevance"]
 
+    # Scores retrieved context against the query; never reads the agent
+    # response, so an empty trace.output must not skip it.
+    _requires_response_output = False
+
     on_missing_context: str = Param(
         default="skip",
         enum=["skip", "zero"],
@@ -574,6 +578,11 @@ class ReasoningQualityEvaluator(LLMAsJudgeEvaluator):
         "Scores whether the agent's execution steps are logical, purposeful, and well-reasoned. Runs per agent."
     )
     tags = ["llm-judge", "reasoning"]
+    # Agent-level judge: scores the execution trajectory (format_steps()), which
+    # is present even when the final response is empty, so an empty
+    # agent_trace.output must not skip it. instruction_following in particular
+    # is documented to always evaluate.
+    _requires_response_output = False
 
     def build_prompt(self, agent_trace: AgentTrace, task: Optional[Task] = None) -> str:
         task_section = f"\nTask: {task.description}" if task and task.description else ""
@@ -613,6 +622,11 @@ class PathEfficiencyEvaluator(LLMAsJudgeEvaluator):
         "Detects redundant steps, loops, and wasted work. Runs per agent."
     )
     tags = ["llm-judge", "efficiency"]
+    # Agent-level judge: scores the execution trajectory (format_steps()), which
+    # is present even when the final response is empty, so an empty
+    # agent_trace.output must not skip it. instruction_following in particular
+    # is documented to always evaluate.
+    _requires_response_output = False
 
     def build_prompt(self, agent_trace: AgentTrace, task: Optional[Task] = None) -> str:
         task_section = f"\nTask: {task.description}" if task and task.description else ""
@@ -653,6 +667,11 @@ class ErrorRecoveryEvaluator(LLMAsJudgeEvaluator):
         "Skips traces with no errors by default. Runs per agent."
     )
     tags = ["llm-judge", "reasoning"]
+    # Agent-level judge: scores the execution trajectory (format_steps()), which
+    # is present even when the final response is empty, so an empty
+    # agent_trace.output must not skip it. instruction_following in particular
+    # is documented to always evaluate.
+    _requires_response_output = False
 
     on_missing_context: str = Param(
         default="skip",
@@ -717,6 +736,11 @@ class InstructionFollowingEvaluator(LLMAsJudgeEvaluator):
         "Runs per agent. Always evaluates since user input is always available."
     )
     tags = ["llm-judge", "compliance"]
+    # Agent-level judge: scores the execution trajectory (format_steps()), which
+    # is present even when the final response is empty, so an empty
+    # agent_trace.output must not skip it. instruction_following in particular
+    # is documented to always evaluate.
+    _requires_response_output = False
 
     def build_prompt(self, agent_trace: AgentTrace, task: Optional[Task] = None) -> str:
         return f"""You are an expert evaluator. Your sole criterion is INSTRUCTION FOLLOWING: does the agent comply with all instructions — both from its system prompt and the user's request?

--- a/libs/amp-evaluation/tests/test_llm_as_judge.py
+++ b/libs/amp-evaluation/tests/test_llm_as_judge.py
@@ -744,3 +744,192 @@ class TestFunctionLLMJudgeParams:
         call_args = mock_completion.call_args
         prompt_sent = call_args[1]["messages"][0]["content"]
         assert "strictness=0.8" in prompt_sent
+
+
+# =============================================================================
+# Empty-response guard
+# =============================================================================
+
+
+class TestEmptyResponseGuard:
+    """A judge that scores the response must skip when there is no response."""
+
+    def test_skips_when_output_empty(self):
+        evaluator = _SimpleJudge()
+        trace = _make_trace(output="")
+        result = evaluator.evaluate(trace)
+        assert result.is_skipped is True
+        assert "no output found" in result.skip_reason.lower()
+
+    def test_skips_when_output_whitespace(self):
+        evaluator = _SimpleJudge()
+        trace = _make_trace(output="   \n  ")
+        result = evaluator.evaluate(trace)
+        assert result.is_skipped is True
+
+    def test_does_not_skip_when_output_present(self):
+        evaluator = _SimpleJudge()
+        trace = _make_trace(output="AI is artificial intelligence.")
+        with patch("any_llm.completion", return_value=_mock_response(0.8)):
+            result = evaluator.evaluate(trace)
+        assert result.is_skipped is False
+        assert result.score == 0.8
+
+    def test_opt_out_evaluator_does_not_skip_on_empty_output(self):
+        class _InputOnlyJudge(LLMAsJudgeEvaluator):
+            _requires_response_output = False
+
+            def build_prompt(self, trace: Trace) -> str:
+                return f"Query only: {trace.input}"
+
+        evaluator = _InputOnlyJudge()
+        trace = _make_trace(output="")
+        with patch("any_llm.completion", return_value=_mock_response(0.5)):
+            result = evaluator.evaluate(trace)
+        assert result.is_skipped is False
+        assert result.score == 0.5
+
+    def test_guard_handles_non_str_output(self):
+        """Guard must not raise AttributeError when output is not a str."""
+
+        class _NonStrOutputJudge(LLMAsJudgeEvaluator):
+            """Judge with _requires_response_output=True (default) receiving a non-str output."""
+
+            def build_prompt(self, trace: Trace) -> str:
+                return f"Evaluate: {trace.input}"
+
+        evaluator = _NonStrOutputJudge()
+        # Simulate a trace whose output is an int (unexpected but must not crash)
+        trace = _make_trace(output="placeholder")
+        trace.output = 42  # bypass pydantic validation via direct assignment
+        result = evaluator.evaluate(trace)
+        # int is not a str → guard treats it as "no output" → skip
+        assert result.is_skipped is True
+
+
+# =============================================================================
+# Agent-level judge regression: must NOT skip on empty agent_trace.output
+# =============================================================================
+
+
+class TestAgentLevelJudgeEmptyOutputRegression:
+    """
+    Agent-level judges score the execution trajectory (format_steps()), not
+    the final response. They must NOT be skipped when agent_trace.output == "".
+    """
+
+    @patch("any_llm.completion")
+    def test_instruction_following_does_not_skip_on_empty_output(self, mock_completion):
+        """InstructionFollowingEvaluator must evaluate even when output is empty."""
+        from amp_evaluation.evaluators.builtin.llm_judge import InstructionFollowingEvaluator
+        from amp_evaluation.trace.models import AgentTrace, TraceMetrics, TokenUsage
+
+        mock_completion.return_value = _mock_response(0.7)
+
+        evaluator = InstructionFollowingEvaluator()
+        agent_trace = AgentTrace(
+            agent_id="agent-1",
+            input="Summarise the attached document.",
+            output="",  # empty — agent did not emit a final response
+            steps=[],
+            metrics=TraceMetrics(token_usage=TokenUsage(input_tokens=5, output_tokens=0, total_tokens=5)),
+        )
+        result = evaluator.evaluate(agent_trace)
+        assert result.is_skipped is False, (
+            f"InstructionFollowingEvaluator must not skip on empty output; got skip_reason={result.skip_reason!r}"
+        )
+        assert result.score == 0.7
+
+    @patch("any_llm.completion")
+    def test_reasoning_quality_does_not_skip_on_empty_output(self, mock_completion):
+        """ReasoningQualityEvaluator must evaluate even when output is empty."""
+        from amp_evaluation.evaluators.builtin.llm_judge import ReasoningQualityEvaluator
+        from amp_evaluation.trace.models import AgentTrace, TraceMetrics, TokenUsage
+
+        mock_completion.return_value = _mock_response(0.6)
+
+        evaluator = ReasoningQualityEvaluator()
+        agent_trace = AgentTrace(
+            agent_id="agent-2",
+            input="Find the latest exchange rate.",
+            output="",
+            steps=[],
+            metrics=TraceMetrics(token_usage=TokenUsage(input_tokens=5, output_tokens=0, total_tokens=5)),
+        )
+        result = evaluator.evaluate(agent_trace)
+        assert result.is_skipped is False, (
+            f"ReasoningQualityEvaluator must not skip on empty output; got skip_reason={result.skip_reason!r}"
+        )
+        assert result.score == 0.6
+
+    @patch("any_llm.completion")
+    def test_path_efficiency_does_not_skip_on_empty_output(self, mock_completion):
+        """PathEfficiencyEvaluator must evaluate even when output is empty."""
+        from amp_evaluation.evaluators.builtin.llm_judge import PathEfficiencyEvaluator
+        from amp_evaluation.trace.models import AgentTrace, TraceMetrics, TokenUsage
+
+        mock_completion.return_value = _mock_response(0.8)
+
+        evaluator = PathEfficiencyEvaluator()
+        agent_trace = AgentTrace(
+            agent_id="agent-3",
+            input="List all open issues.",
+            output="",
+            steps=[],
+            metrics=TraceMetrics(token_usage=TokenUsage(input_tokens=5, output_tokens=0, total_tokens=5)),
+        )
+        result = evaluator.evaluate(agent_trace)
+        assert result.is_skipped is False, (
+            f"PathEfficiencyEvaluator must not skip on empty output; got skip_reason={result.skip_reason!r}"
+        )
+        assert result.score == 0.8
+
+    @patch("any_llm.completion")
+    def test_error_recovery_with_errors_does_not_skip_on_empty_output(self, mock_completion):
+        """ErrorRecoveryEvaluator (with errors present) must evaluate even when output is empty."""
+        from amp_evaluation.evaluators.builtin.llm_judge import ErrorRecoveryEvaluator
+        from amp_evaluation.trace.models import AgentTrace, TraceMetrics, TokenUsage, ToolExecutionStep
+
+        mock_completion.return_value = _mock_response(0.5)
+
+        evaluator = ErrorRecoveryEvaluator()
+        error_step = ToolExecutionStep(tool_name="api_call", error="Timeout")
+        agent_trace = AgentTrace(
+            agent_id="agent-4",
+            input="Fetch weather data.",
+            output="",
+            steps=[error_step],
+            metrics=TraceMetrics(
+                error_count=1,
+                token_usage=TokenUsage(input_tokens=5, output_tokens=0, total_tokens=5),
+            ),
+        )
+        result = evaluator.evaluate(agent_trace)
+        assert result.is_skipped is False, (
+            f"ErrorRecoveryEvaluator must not skip on empty output when errors are present; "
+            f"got skip_reason={result.skip_reason!r}"
+        )
+        assert result.score == 0.5
+
+    def test_context_relevance_skip_reason_is_not_guard_message(self):
+        """ContextRelevanceEvaluator skips because there are NO retrievals, not because
+        output is empty. The skip_reason must reference retrievals, not the guard message.
+
+        Choice: asserting skip_reason is NOT the guard message is the most reliable
+        approach here — constructing a RetrievalSpan with valid docs just to pass the
+        retrieval-check and then verify non-skip would couple this test to the span
+        constructor internals. Instead we verify that the guard is NOT what causes the
+        skip: the 'no output found' guard message must be absent from skip_reason.
+        """
+        from amp_evaluation.evaluators.builtin.llm_judge import ContextRelevanceEvaluator
+
+        evaluator = ContextRelevanceEvaluator()
+        trace = _make_trace(output="")  # empty output AND no retrieval spans
+
+        result = evaluator.evaluate(trace)
+        # Must skip — but for the right reason (no retrievals), not the empty-output guard
+        assert result.is_skipped is True
+        assert "no output found" not in (result.skip_reason or "").lower(), (
+            f"ContextRelevanceEvaluator must not be stopped by the empty-output guard; "
+            f"got skip_reason={result.skip_reason!r}"
+        )

--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -701,13 +701,12 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 				return
 			}
 
-			// Extract input/output
-			var input, output interface{}
-			if opensearch.IsCrewAISpan(rootSpan.Attributes) {
-				input, output = opensearch.ExtractCrewAIRootSpanInputOutput(rootSpan)
-			} else {
-				input, output = opensearch.ExtractRootSpanInputOutput(rootSpan)
-			}
+			// Extract input/output. Agent-rooted traces (e.g. a LangGraph
+			// invoke_agent wrapper) carry no traceloop.entity.output on the
+			// root, so fall back through the child chain span and leaf-LLM
+			// spans — otherwise the exported trace has a blank response and the
+			// LLM judge scores nothing. All spans are already in memory here.
+			input, output := opensearch.ExtractTraceInputOutputWithFallback(rootSpan, spans)
 
 			tokenUsage := opensearch.ExtractTokenUsage(spans)
 			traceStatus := opensearch.ExtractTraceStatus(spans)

--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -967,6 +967,80 @@ func ExtractRootSpanInputOutput(rootSpan *Span) (input interface{}, output inter
 	return extractSpanInputOutput(rootSpan.Attributes)
 }
 
+// ExtractTraceInputOutputWithFallback derives trace-level input/output from a
+// fully-fetched span set, following the same root → child → leaf cascade as
+// enrichTraceOverview:
+//  1. the root span's own entity input/output
+//  2. the earliest non-leaf direct child of the root (chain/agent wrapper,
+//     e.g. LangGraph.workflow under an invoke_agent root)
+//  3. first/last leaf-LLM (*.chat) span previews
+//
+// Unlike enrichTraceOverview, this runs entirely in memory (the export path
+// already holds every span) and applies no leaf cap: the overview throttles
+// leaf aggregation for trace-list latency, whereas export wants the true
+// first/last leaf, so on very large traces the two can pick different leaves.
+//
+// Used by ExportTraces so agent-rooted traces — whose root wrapper carries no
+// traceloop.entity.output — still export a usable response for downstream
+// evaluation, instead of handing the LLM judge a blank response.
+func ExtractTraceInputOutputWithFallback(rootSpan *Span, spans []Span) (input interface{}, output interface{}) {
+	if rootSpan == nil {
+		return nil, nil
+	}
+
+	// Step 1: the root span itself.
+	if IsCrewAISpan(rootSpan.Attributes) {
+		input, output = ExtractCrewAIRootSpanInputOutput(rootSpan)
+	} else {
+		input, output = ExtractRootSpanInputOutput(rootSpan)
+	}
+	if input != nil && output != nil {
+		return input, output
+	}
+
+	// Step 2: earliest non-leaf direct child of the root.
+	var child *Span
+	for i := range spans {
+		s := &spans[i]
+		if s.ParentSpanID != rootSpan.SpanID || IsLLMLeafSpan(s.Name) {
+			continue
+		}
+		if child == nil || s.StartTime.Before(child.StartTime) {
+			child = s
+		}
+	}
+	if child != nil {
+		ci, co := ExtractRootSpanInputOutput(child)
+		if input == nil {
+			input = ci
+		}
+		if output == nil {
+			output = co
+		}
+		if input != nil && output != nil {
+			return input, output
+		}
+	}
+
+	// Step 3: leaf-LLM spans — first leaf's input, last leaf's output.
+	var leaves []*Span
+	for i := range spans {
+		if IsLLMLeafSpan(spans[i].Name) {
+			leaves = append(leaves, &spans[i])
+		}
+	}
+	if len(leaves) > 0 {
+		slices.SortFunc(leaves, func(a, b *Span) int { return a.StartTime.Compare(b.StartTime) })
+		if input == nil {
+			input = ExtractInputPreviewFromLeaf(leaves[0])
+		}
+		if output == nil {
+			output = ExtractOutputPreviewFromLeaf(leaves[len(leaves)-1])
+		}
+	}
+	return input, output
+}
+
 // ExtractPromptMessages extracts and orders prompt messages from LLM span attributes
 // Handles two formats:
 // 1. OTEL format: gen_ai.input.messages (JSON array)

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseSpans(t *testing.T) {
@@ -1793,6 +1794,94 @@ func TestTokenUsage_PartialSerialization(t *testing.T) {
 		got := string(buf)
 		if !strings.Contains(got, `"partial":true`) {
 			t.Errorf("partial=true should serialise, got %q", got)
+		}
+	})
+}
+
+func TestExtractTraceInputOutputWithFallback(t *testing.T) {
+	base := time.Date(2026, 2, 9, 17, 41, 15, 0, time.UTC)
+
+	t.Run("uses root span when it carries entity output", func(t *testing.T) {
+		root := Span{
+			SpanID:    "root",
+			Name:      "invoke_agent LangGraph",
+			StartTime: base,
+			Attributes: map[string]interface{}{
+				"traceloop.entity.input":  "hello",
+				"traceloop.entity.output": "root answer",
+			},
+		}
+		input, output := ExtractTraceInputOutputWithFallback(&root, []Span{root})
+		if output != "root answer" {
+			t.Errorf("expected root output, got %v", output)
+		}
+		if input != "hello" {
+			t.Errorf("expected root input, got %v", input)
+		}
+	})
+
+	t.Run("falls back to leaf LLM span when root agent wrapper has no output", func(t *testing.T) {
+		// Mirrors the reported trace: invoke_agent root + LangGraph.workflow
+		// chain, neither carrying traceloop.entity.output; only the leaf
+		// *.chat span has gen_ai messages.
+		root := Span{SpanID: "root", Name: "invoke_agent LangGraph", StartTime: base}
+		workflow := Span{SpanID: "wf", ParentSpanID: "root", Name: "LangGraph.workflow", StartTime: base.Add(time.Millisecond)}
+		leaf := Span{
+			SpanID:       "leaf",
+			ParentSpanID: "wf",
+			Name:         "ChatOpenAI.chat",
+			StartTime:    base.Add(2 * time.Millisecond),
+			Attributes: map[string]interface{}{
+				"gen_ai.input.messages":  `[{"role":"user","content":"find accommodations"}]`,
+				"gen_ai.output.messages": `[{"role":"assistant","content":"Here are some hotels."}]`,
+			},
+		}
+		spans := []Span{root, workflow, leaf}
+		input, output := ExtractTraceInputOutputWithFallback(&root, spans)
+		if output != "Here are some hotels." {
+			t.Errorf("expected leaf assistant output, got %v", output)
+		}
+		if input != "find accommodations" {
+			t.Errorf("expected leaf user input, got %v", input)
+		}
+	})
+
+	t.Run("falls back to non-leaf child chain span when root has no output", func(t *testing.T) {
+		// Root carries nothing; the direct LangGraph.workflow child carries the
+		// entity I/O. Step 2 (child chain) must supply it, before any leaf path.
+		root := Span{SpanID: "root", Name: "invoke_agent LangGraph", StartTime: base}
+		workflow := Span{
+			SpanID:       "wf",
+			ParentSpanID: "root",
+			Name:         "LangGraph.workflow",
+			StartTime:    base.Add(time.Millisecond),
+			Attributes: map[string]interface{}{
+				"traceloop.entity.input":  "child question",
+				"traceloop.entity.output": "child answer",
+			},
+		}
+		leaf := Span{
+			SpanID:       "leaf",
+			ParentSpanID: "wf",
+			Name:         "ChatOpenAI.chat",
+			StartTime:    base.Add(2 * time.Millisecond),
+			Attributes: map[string]interface{}{
+				"gen_ai.output.messages": `[{"role":"assistant","content":"leaf answer"}]`,
+			},
+		}
+		input, output := ExtractTraceInputOutputWithFallback(&root, []Span{root, workflow, leaf})
+		if output != "child answer" {
+			t.Errorf("expected child chain output, got %v", output)
+		}
+		if input != "child question" {
+			t.Errorf("expected child chain input, got %v", input)
+		}
+	})
+
+	t.Run("nil root returns nil", func(t *testing.T) {
+		input, output := ExtractTraceInputOutputWithFallback(nil, nil)
+		if input != nil || output != nil {
+			t.Errorf("expected nil,nil got %v,%v", input, output)
 		}
 	})
 }


### PR DESCRIPTION
## Purpose
LLM-as-judge evaluation scores rendered templated placeholder text (`[insert claim]`, `[insert specific claims made in the agent response]`) and a misleading 100% score for agent-rooted traces. Root cause: the `/api/v1/traces/export` endpoint (consumed by the evaluation job) derived trace-level `output` from the **root span only**. Agent-rooted traces — e.g. a LangGraph `invoke_agent` wrapper — carry no `traceloop.entity.output` on the root span, so the exported response was empty and the judge scored a blank response. The trace-list/overview endpoint already had a root→child→leaf fallback; the export endpoint did not. (This is not the any-llm judge-client migration — that only changed gateway/`response_format` wiring; it merely made the judge run successfully, which exposed this pre-existing export gap.)

Resolves: N/A — no tracking issue was filed for this bug.

## Goals
- The export endpoint returns the same real agent response the console already shows, so the judge evaluates actual content instead of a blank response.
- As defense-in-depth, the judge no longer fabricates a templated, high score from an empty response — it skips with an explicit reason.

## Approach
1. **`traces-observer-service`** — new pure helper `ExtractTraceInputOutputWithFallback(rootSpan, spans)` that mirrors `enrichTraceOverview`'s root → earliest non-leaf child → first/last leaf-LLM (`*.chat`) fallback, run entirely in memory (the export path already holds every span, so no extra fetches). Wired into `ExportTraces` in place of the root-only extraction. It intentionally applies no leaf cap (the overview throttles leaf aggregation for trace-list latency; export wants the true first/last leaf).
2. **`libs/amp-evaluation`** — `LLMAsJudgeEvaluator.evaluate()` now returns `EvalResult.skip(...)` when the evaluated object's `.output` is empty/blank, gated by an overridable `_requires_response_output` flag (default `True`). Response-scoring judges (trace-level + LLM-span) skip on empty output; the four agent-level trajectory judges (`reasoning_quality`, `path_efficiency`, `error_recovery`, `instruction_following`) and `ContextRelevanceEvaluator` opt out because they score the execution trajectory / retrieved context, not the final response.

No UI changes.

## User stories
N/A — internal correctness bugfix; no new user-facing story.

## Release note
Fix evaluation scores showing templated placeholder text and a false 100% for agent-rooted traces (e.g. LangGraph): trace export now derives the agent response via a root→child→leaf fallback, and the LLM judge skips instead of scoring an empty response.

## Documentation
N/A — no public API or behavioral contract change; internal trace-extraction and evaluator-guard fix.

## Training
N/A — no training-content impact.

## Certification
N/A — no certification-exam impact.

## Marketing
N/A — internal bugfix.

## Automation tests
 - Unit tests
   > Go (`traces-observer-service/opensearch`): `TestExtractTraceInputOutputWithFallback` covers root-hit short-circuit, child-chain fallback, leaf-LLM fallback, and nil-root. Python (`libs/amp-evaluation`): `TestEmptyResponseGuard` covers empty/whitespace/non-str output skip, present-output scoring, the opt-out flag, agent-level judges NOT skipping on empty output (instruction_following, reasoning_quality, path_efficiency, error_recovery), and ContextRelevance routing. Full suites green — Go `opensearch`+`controllers` pass; Python 698 passed / 25 skipped.
 - Integration tests
   > Manually verified on a local k3d cluster: rebuilt and loaded both images (`amp-traces-observer`, `amp-evaluation-monitor`), restarted `amp-traces-observer`. End-to-end confirmation requires a monitor re-run (pre-fix scores are stale snapshots).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable; change is Go/Python logic with no new security-sensitive surface.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples affected.

## Related PRs
N/A.

## Migrations (if applicable)
N/A — no schema or data migration. Existing pre-fix scores remain in the DB as stale history; re-running monitors regenerates correct scores.

## Test environment
> macOS (Apple Silicon); local k3d cluster `openchoreo-local-setup`. Go module toolchain for `traces-observer-service`; Python 3.13 for `amp-evaluation` tests.

## Learning
> Root-caused by tracing the evaluation job's data flow: the judge prompt embeds `Agent Response: {trace.output}`, so an empty `output` yields a templated skeleton with a default high score. Confirmed via the trace fetcher that the eval job uses `/api/v1/traces/export`, and that the export controller (unlike the overview controller) lacked the child/leaf fallback for agent-rooted traces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluators now skip when a response output is missing, with select evaluators allowed to opt out when they can evaluate from context or execution traces.
  * Trace export logic now falls back to other spans to populate input/output when the root span lacks them.

* **Bug Fixes**
  * Prevented exported traces from losing input/output in agent-rooted traces.

* **Tests**
  * Added tests for empty-response guarding and trace input/output fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->