### PR TITLE
Enhance Protected component to resolve landing organization 

### DIFF
--- a/console/workspaces/core-ui/src/Providers/Protected/Protected.tsx
+++ b/console/workspaces/core-ui/src/Providers/Protected/Protected.tsx
@@ -19,25 +19,63 @@
 import { useAuthHooks } from "@agent-management-platform/auth";
 import { FullPageLoader } from "@agent-management-platform/views";
 import { absoluteRouteMap } from "@agent-management-platform/types";
-import { useNavigate, useLocation, generatePath, useParams } from "react-router-dom";
-import { useListOrganizations } from "@agent-management-platform/api-client";
+import { Navigate, useLocation, generatePath, useParams } from "react-router-dom";
+import { useListOrganizations, useListProjects } from "@agent-management-platform/api-client";
 
 export const Protected = ({ children }: { children: React.ReactNode }) => {
     const { isAuthenticated, isLoadingIsAuthenticated } = useAuthHooks();
-    const navigate = useNavigate();
-    const { pathname } = useLocation();
-    const { data: organizations } = useListOrganizations();
+    const location = useLocation();
+    const { data: organizations, isLoading: isLoadingOrganizations } = useListOrganizations();
     const {orgId} = useParams();
+
+    // When authenticated without an org in the URL, land the user inside their
+    // first organization. We only resolve this once organizations have loaded;
+    // the project list query stays skipped (empty orgName) until then.
+    const targetOrg = organizations?.organizations?.[0]?.name;
+    const shouldResolveLanding =
+        isAuthenticated && !isLoadingOrganizations && !!targetOrg && !orgId;
+    const { data: projectList, isLoading: isLoadingProjects } = useListProjects({
+        orgName: shouldResolveLanding ? targetOrg : "",
+    });
+
+    // Preserve the full location so the login flow can restore the original
+    // destination (Login reads state.from.pathname).
+    const navigationState = { from: location };
 
     if (isLoadingIsAuthenticated) {
         return <FullPageLoader />;
     }
 
     if (!isAuthenticated) {
-        navigate(generatePath(absoluteRouteMap.children.login.path), { state: { from: pathname } });
-    } else if (organizations?.organizations?.length && !orgId) {
-        navigate(generatePath(absoluteRouteMap.children.org.children.projects.path, 
-            { orgId: organizations?.organizations[0].name, projectId: 'default' }), { state: { from: pathname } });
+        return (
+            <Navigate
+                to={generatePath(absoluteRouteMap.children.login.path)}
+                state={navigationState}
+            />
+        );
+    }
+
+    // Authenticated without an org in the URL: wait for orgs (and the project
+    // list) to load, then redirect to the resolved landing location instead of
+    // rendering children prematurely.
+    if (!orgId) {
+        if (isLoadingOrganizations || (shouldResolveLanding && isLoadingProjects)) {
+            return <FullPageLoader />;
+        }
+        if (shouldResolveLanding) {
+            const projects = projectList?.projects ?? [];
+            // Prefer the default project, fall back to the first available
+            // project, and if the org has no projects yet, land on the org
+            // overview (project listing) so the user can create one.
+            const landingProject = projects.find((p) => p.name === "default") ?? projects[0];
+            const landingPath = landingProject
+                ? generatePath(absoluteRouteMap.children.org.children.projects.path, {
+                      orgId: targetOrg,
+                      projectId: landingProject.name,
+                  })
+                : generatePath(absoluteRouteMap.children.org.path, { orgId: targetOrg });
+            return <Navigate to={landingPath} state={navigationState} />;
+        }
     }
 
     return (


### PR DESCRIPTION

## Purpose
This pull request updates the `Protected` component to improve the user landing experience after authentication. Now, when an authenticated user accesses the app without specifying an organization in the URL, the code ensures they are redirected to the most relevant project or organization page, with a preference for the default project if available.

**Enhanced user redirection after authentication:**

* When an authenticated user lands without an `orgId` in the URL, the app now waits for the user's project list and redirects them to their default project if it exists, otherwise to the first available project, or to the organization's overview page if no projects exist. This provides a smoother and more intuitive onboarding flow.

* The `useListProjects` hook is now conditionally invoked to fetch projects only when resolving the user's landing page, optimizing unnecessary API calls.

* Navigation logic is refactored for clarity and maintainability, and a loading spinner is shown while determining the appropriate landing page.

Issue: https://github.com/wso2/agent-manager/issues/729

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authenticated user landing behavior to wait for project data before navigating.
  * Added a full-page loading indicator while authentication and project resolution occur.
  * Improved routing so users go to their default project when available, otherwise the first project or the organization overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->