### PR TITLE
Show OpenLLMetry version in instrumentation list

### DIFF
--- a/agent-manager-service/controllers/agent_build_options_controller.go
+++ b/agent-manager-service/controllers/agent_build_options_controller.go
@@ -71,10 +71,14 @@ func (c *agentBuildOptionsController) GetAgentBuildOptions(w http.ResponseWriter
 
 	entries := make([]spec.AgentBuildOptionsInstrumentationEntry, 0, len(sorted))
 	for _, v := range sorted {
-		entries = append(entries, spec.AgentBuildOptionsInstrumentationEntry{
+		entry := spec.AgentBuildOptionsInstrumentationEntry{
 			Version:        v.Version,
 			PythonVersions: v.PythonVersions,
-		})
+		}
+		if v.TraceloopSDK != "" {
+			entry.TraceloopSdk = &v.TraceloopSDK
+		}
+		entries = append(entries, entry)
 	}
 
 	resp := spec.AgentBuildOptionsResponse{

--- a/agent-manager-service/controllers/agent_build_options_controller_test.go
+++ b/agent-manager-service/controllers/agent_build_options_controller_test.go
@@ -29,7 +29,7 @@ import (
 func TestAgentBuildOptions_ResponseShape(t *testing.T) {
 	cat := instrumentation.NewForTest([]instrumentation.Version{
 		{Version: "0.2.1", PythonVersions: []string{"3.10", "3.11"}, ImageRepository: "x"},
-		{Version: "0.4.0", PythonVersions: []string{"3.11", "3.12"}, ImageRepository: "x"},
+		{Version: "0.4.0", TraceloopSDK: "0.61.0", PythonVersions: []string{"3.11", "3.12"}, ImageRepository: "x"},
 	}, "0.2.1")
 	c := NewAgentBuildOptionsController(cat, []string{"3.10", "3.11", "3.12"}, "3.11")
 
@@ -59,6 +59,14 @@ func TestAgentBuildOptions_ResponseShape(t *testing.T) {
 	// Sorted newest-first.
 	if got.Instrumentation.Versions[0].Version != "0.4.0" || got.Instrumentation.Versions[1].Version != "0.2.1" {
 		t.Errorf("versions = %v, want [0.4.0, 0.2.1]", got.Instrumentation.Versions)
+	}
+	// traceloopSdk is carried through when present and omitted otherwise.
+	if got.Instrumentation.Versions[0].TraceloopSdk == nil ||
+		*got.Instrumentation.Versions[0].TraceloopSdk != "0.61.0" {
+		t.Errorf("versions[0].traceloopSdk = %v, want 0.61.0", got.Instrumentation.Versions[0].TraceloopSdk)
+	}
+	if got.Instrumentation.Versions[1].TraceloopSdk != nil {
+		t.Errorf("versions[1].traceloopSdk = %v, want nil", *got.Instrumentation.Versions[1].TraceloopSdk)
 	}
 }
 

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -12564,6 +12564,13 @@ components:
           type: string
           description: The amp-instrumentation semver.
           example: "0.2.1"
+        traceloopSdk:
+          type: string
+          description: |
+            The bundled OpenLLMetry (Traceloop) SDK version this
+            instrumentation release ships. Optional: operator-supplied
+            extension entries may omit it.
+          example: "0.61.0"
         pythonVersions:
           type: array
           description: |

--- a/agent-manager-service/spec/model_agent_build_options_instrumentation_entry.go
+++ b/agent-manager-service/spec/model_agent_build_options_instrumentation_entry.go
@@ -21,6 +21,8 @@ var _ MappedNullable = &AgentBuildOptionsInstrumentationEntry{}
 type AgentBuildOptionsInstrumentationEntry struct {
 	// The amp-instrumentation semver.
 	Version string `json:"version"`
+	// The bundled OpenLLMetry (Traceloop) SDK version this instrumentation release ships. Optional: operator-supplied extension entries may omit it.
+	TraceloopSdk *string `json:"traceloopSdk,omitempty"`
 	// Bare-minor Python versions this instrumentation version supports. The init-container image is ABI-locked to the Python runtime, so a selection outside this list will fail to pull at deploy time.
 	PythonVersions []string `json:"pythonVersions"`
 }
@@ -68,6 +70,38 @@ func (o *AgentBuildOptionsInstrumentationEntry) SetVersion(v string) {
 	o.Version = v
 }
 
+// GetTraceloopSdk returns the TraceloopSdk field value if set, zero value otherwise.
+func (o *AgentBuildOptionsInstrumentationEntry) GetTraceloopSdk() string {
+	if o == nil || IsNil(o.TraceloopSdk) {
+		var ret string
+		return ret
+	}
+	return *o.TraceloopSdk
+}
+
+// GetTraceloopSdkOk returns a tuple with the TraceloopSdk field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AgentBuildOptionsInstrumentationEntry) GetTraceloopSdkOk() (*string, bool) {
+	if o == nil || IsNil(o.TraceloopSdk) {
+		return nil, false
+	}
+	return o.TraceloopSdk, true
+}
+
+// HasTraceloopSdk returns a boolean if a field has been set.
+func (o *AgentBuildOptionsInstrumentationEntry) HasTraceloopSdk() bool {
+	if o != nil && !IsNil(o.TraceloopSdk) {
+		return true
+	}
+
+	return false
+}
+
+// SetTraceloopSdk gets a reference to the given string and assigns it to the TraceloopSdk field.
+func (o *AgentBuildOptionsInstrumentationEntry) SetTraceloopSdk(v string) {
+	o.TraceloopSdk = &v
+}
+
 // GetPythonVersions returns the PythonVersions field value
 func (o *AgentBuildOptionsInstrumentationEntry) GetPythonVersions() []string {
 	if o == nil {
@@ -103,6 +137,9 @@ func (o AgentBuildOptionsInstrumentationEntry) MarshalJSON() ([]byte, error) {
 func (o AgentBuildOptionsInstrumentationEntry) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["version"] = o.Version
+	if !IsNil(o.TraceloopSdk) {
+		toSerialize["traceloopSdk"] = o.TraceloopSdk
+	}
 	toSerialize["pythonVersions"] = o.PythonVersions
 	return toSerialize, nil
 }

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -1116,6 +1116,11 @@ type AgentBuildOptionsInstrumentationEntry struct {
 	// selection outside this list will fail to pull at deploy time.
 	PythonVersions []string `json:"pythonVersions"`
 
+	// TraceloopSdk The bundled OpenLLMetry (Traceloop) SDK version this
+	// instrumentation release ships. Optional: operator-supplied
+	// extension entries may omit it.
+	TraceloopSdk *string `json:"traceloopSdk,omitempty"`
+
 	// Version The amp-instrumentation semver.
 	Version string `json:"version"`
 }

--- a/console/workspaces/libs/types/src/api/instrumentation.ts
+++ b/console/workspaces/libs/types/src/api/instrumentation.ts
@@ -29,6 +29,8 @@ export type AgentBuildOptions = {
     defaultVersion: string;
     versions: Array<{
       version: string;
+      /** Bundled OpenLLMetry (Traceloop) SDK version, when known. */
+      traceloopSdk?: string;
       pythonVersions: string[];
     }>;
   };

--- a/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
+++ b/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
@@ -92,7 +92,12 @@ export const InternalAgentForm = ({
   // Empty list when no AMP-provided instrumentation covers that Python —
   // the form then offers the manual-instrumentation fallback.
   const compatibleInstrumentation = useMemo(() => {
-    if (!buildOptions) return [] as { version: string; pythonVersions: string[] }[];
+    if (!buildOptions)
+      return [] as {
+        version: string;
+        traceloopSdk?: string;
+        pythonVersions: string[];
+      }[];
     const py = formData.languageVersion;
     if (!py) return buildOptions.instrumentation.versions;
     return buildOptions.instrumentation.versions.filter((v) =>
@@ -418,7 +423,9 @@ export const InternalAgentForm = ({
                       >
                         {compatibleInstrumentation.map((v) => (
                           <MenuItem key={v.version} value={v.version}>
-                            {v.version}
+                            {v.traceloopSdk
+                              ? `${v.version} (OpenLLMetry v${v.traceloopSdk})`
+                              : v.version}
                           </MenuItem>
                         ))}
                       </Select>


### PR DESCRIPTION
## Purpose
The **AMP Instrumentation Version** dropdown in the create-agent form listed only the `amp-instrumentation` semver (e.g. `0.3.0`), with no indication of which OpenLLMetry (Traceloop) SDK version each release bundles. Users could not correlate a pinned instrumentation version with the tracing SDK it ships.

Old:
<img width="1728" height="801" alt="old" src="https://github.com/user-attachments/assets/70e49278-c23f-4dd0-aabd-8e1e1879d9f9" />

New:
<img width="1728" height="801" alt="new" src="https://github.com/user-attachments/assets/c5b606ba-06dd-4031-b215-b34fe011dd9d" />


Resolves https://github.com/wso2/agent-manager/issues/1059

## Goals
Surface the bundled OpenLLMetry SDK version alongside the instrumentation version in the dropdown so each option reads like `0.3.0 (OpenLLMetry v0.61.0)`.

## Approach
The SDK version already existed in the instrumentation catalog as the `traceloopSdk` field (sourced from `.github/release-config.json` → `instrumentation/baseline.json`) but was dropped at the build-options controller before reaching the API. This PR carries it through the whole chain:

- **OpenAPI schema** (`api_v1_openapi.yaml`): added an optional `traceloopSdk` property to `AgentBuildOptionsInstrumentationEntry`, and regenerated `spec/` via `make spec`.
- **Controller** (`agent_build_options_controller.go`): copies `TraceloopSDK` into the response entry when present.
- **Frontend type** (`instrumentation.ts`): added optional `traceloopSdk?: string`.
- **Dropdown render** (`InternalAgentForm.tsx`): renders `${version} (OpenLLMetry v${traceloopSdk})`, falling back to the bare version when the field is absent.

The field is optional end to end, so operator-supplied extension catalog entries that omit it degrade gracefully to the bare version label.

## User stories
As a platform user creating an agent, I can see which OpenLLMetry SDK version a given AMP instrumentation release bundles, so I can pick a version with confidence.

## Release note
The AMP Instrumentation Version selector now shows the bundled OpenLLMetry SDK version, e.g. `0.3.0 (OpenLLMetry v0.61.0)`.

## Documentation
N/A — no doc impact; this is an in-product label enhancement on an existing field.

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams; this is a minor UI label change.

## Marketing
N/A — no marketing content associated with this change.

## Automation tests
 - Unit tests
   > Extended `agent_build_options_controller_test.go` to assert `traceloopSdk` is carried through when set on a catalog entry and is `nil` when absent. Existing controller/instrumentation Go tests and the `add-new-agent` frontend unit tests pass.
 - Integration tests
   > N/A — no new integration tests; the change is covered by the controller unit test and verified manually on the local cluster (dropdown renders `0.3.0 (OpenLLMetry v0.61.0)`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable to this change (no new attack surface; an existing field is propagated to an authenticated, read-only response).
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples associated with this change.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no schema or data migration; the new response field is additive and optional.

## Test environment
 - Go 1.25, macOS (Darwin), local k3d + docker-compose dev stack
 - Console built with Node.js 20 / Rush, verified in a Chromium-based browser at `http://localhost:3000`

## Learning
The instrumentation catalog already modeled `traceloopSdk`; the only gap was the controller's response mapping silently dropping it. No external research required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added optional `traceloopSdk` details to instrumentation version entries when the bundled SDK version is known.
  * Updated the Python “AMP Instrumentation Version” dropdown to display the Traceloop SDK version alongside the instrumentation version when present.

* **Documentation**
  * Extended the public API/OpenAPI schema for instrumentation entries to include the new optional `traceloopSdk` field.

* **Tests**
  * Updated instrumentation response shape checks to verify `traceloopSdk` is correctly set or omitted by version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->