### PR TITLE
Use bulk attribute fetching in traces export endpoint

### DIFF
--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -530,9 +530,9 @@ func (c *TracingController) GetSpanDetail(ctx context.Context, traceID, spanID s
 }
 
 // ExportTraces fetches complete traces with all spans fully enriched for export.
-// Observer calls: 1 QueryTraces + N QueryTraceSpans + N×M GetSpanDetails.
-// Concurrency is bounded: maxConcurrentTraces outer goroutines, maxConcurrentFetches
-// inner span-detail goroutines. Any single failure aborts the entire export.
+// Observer calls: 1 QueryTraces + N QueryTraceSpans (spans carry attributes
+// inline via includeAttributes). Concurrency is bounded by maxConcurrentTraces
+// outer goroutines. Any single failure aborts the entire export.
 func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryParams) (*opensearch.TraceExportResponse, error) {
 	log := logger.GetLogger(ctx)
 
@@ -577,7 +577,6 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 	var errOnce sync.Once
 
 	outerSem := make(chan struct{}, maxConcurrentTraces)
-	innerSem := make(chan struct{}, maxConcurrentFetches)
 	var wg sync.WaitGroup
 
 	for i, t := range tracesResp.Traces {
@@ -598,9 +597,10 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 			}
 
 			spansResp, err := c.observerClient.QueryTraceSpans(ctx, traceInfo.TraceID, observer.TracesQueryRequest{
-				StartTime: params.StartTime,
-				EndTime:   params.EndTime,
-				Limit:     &spanLimit,
+				StartTime:         params.StartTime,
+				EndTime:           params.EndTime,
+				Limit:             &spanLimit,
+				IncludeAttributes: true,
 				SearchScope: observer.ComponentSearchScope{
 					Namespace:   params.Organization,
 					Project:     params.Project,
@@ -620,54 +620,13 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 				truncated.Store(true)
 			}
 
-			// Fetch full details for each span in parallel, bounded by innerSem.
-			type spanResult struct {
-				idx  int
-				span *opensearch.Span
-			}
-			spanResults := make([]spanResult, len(spansResp.Spans))
-			var spanWg sync.WaitGroup
-
-		spanLoop:
-			for j, s := range spansResp.Spans {
-				select {
-				case innerSem <- struct{}{}:
-				case <-ctx.Done():
-					break spanLoop
-				}
-				spanWg.Add(1)
-				go func(spanIdx int, spanID string) {
-					defer spanWg.Done()
-					defer func() { <-innerSem }()
-
-					if ctx.Err() != nil {
-						return
-					}
-
-					details, err := c.observerClient.GetSpanDetails(ctx, traceInfo.TraceID, spanID)
-					if err != nil {
-						errOnce.Do(func() {
-							firstErr = fmt.Errorf("trace %s span %s: get details: %w", traceInfo.TraceID, spanID, err)
-							cancel()
-						})
-						return
-					}
-					enriched := opensearch.ProcessSpan(observer.ConvertSpanDetailsToSpan(traceInfo.TraceID, details))
-					spanResults[spanIdx] = spanResult{idx: spanIdx, span: &enriched}
-				}(j, s.SpanID)
-			}
-			spanWg.Wait()
-
-			if ctx.Err() != nil {
-				return
-			}
-
-			// Collect non-nil spans and sort by start time.
-			spans := make([]opensearch.Span, 0, len(spanResults))
-			for _, sr := range spanResults {
-				if sr.span != nil {
-					spans = append(spans, *sr.span)
-				}
+			// Spans already carry attributes/kind/status from the bulk
+			// QueryTraceSpans call (includeAttributes=true), so convert them
+			// directly — no per-span GetSpanDetails round-trips.
+			spans := make([]opensearch.Span, 0, len(spansResp.Spans))
+			for _, s := range spansResp.Spans {
+				enriched := opensearch.ProcessSpan(observer.ConvertSpanInfoToSpan(traceInfo.TraceID, s))
+				spans = append(spans, enriched)
 			}
 			sort.Slice(spans, func(i, j int) bool {
 				return spans[i].StartTime.Before(spans[j].StartTime)

--- a/traces-observer-service/controllers/controller_test.go
+++ b/traces-observer-service/controllers/controller_test.go
@@ -34,22 +34,29 @@ import (
 type fakeObserverClient struct {
 	// rootSpan is returned by GetSpanDetails when called for the root span.
 	rootSpan *observer.SpanDetailsResponse
+	// traces is the list returned by QueryTraces (export path).
+	traces []observer.TraceInfo
 	// spans is the list returned by QueryTraceSpans.
 	spans []observer.SpanInfo
 	// spanDetails maps spanID → detail response for GetSpanDetails lookups
 	// (excluding root, which is rootSpan).
 	spanDetails map[string]*observer.SpanDetailsResponse
 
+	// lastSpansReq records the request passed to the most recent
+	// QueryTraceSpans call so export tests can assert IncludeAttributes.
+	lastSpansReq observer.TracesQueryRequest
+
 	getSpanDetailsCalls  int32
 	queryTraceSpansCalls int32
 }
 
 func (f *fakeObserverClient) QueryTraces(_ context.Context, _ observer.TracesQueryRequest) (*observer.TracesQueryResponse, error) {
-	return nil, fmt.Errorf("not used by enrichTraceOverview tests")
+	return &observer.TracesQueryResponse{Traces: f.traces, Total: len(f.traces)}, nil
 }
 
-func (f *fakeObserverClient) QueryTraceSpans(_ context.Context, _ string, _ observer.TracesQueryRequest) (*observer.TraceSpansQueryResponse, error) {
+func (f *fakeObserverClient) QueryTraceSpans(_ context.Context, _ string, req observer.TracesQueryRequest) (*observer.TraceSpansQueryResponse, error) {
 	atomic.AddInt32(&f.queryTraceSpansCalls, 1)
+	f.lastSpansReq = req
 	return &observer.TraceSpansQueryResponse{Spans: f.spans, Total: len(f.spans)}, nil
 }
 
@@ -305,5 +312,63 @@ func TestEnrichTraceOverview_SkipsLeafAggregationForHugeTraces(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&fake.getSpanDetailsCalls); got != 0 {
 		t.Errorf("expected no GetSpanDetails calls (skip), got %d", got)
+	}
+}
+
+// TestExportTraces_UsesBulkAttributes verifies the export path fetches span
+// attributes inline via QueryTraceSpans(includeAttributes=true) and makes zero
+// GetSpanDetails calls, while preserving span kind/status/attributes.
+func TestExportTraces_UsesBulkAttributes(t *testing.T) {
+	now := time.Now()
+	rootAttrs := map[string]interface{}{
+		"traceloop.entity.input":  `{"inputs":"hello"}`,
+		"traceloop.entity.output": `{"outputs":{"messages":[{"kwargs":{"content":"hi"}}]}}`,
+	}
+	fake := &fakeObserverClient{
+		traces: []observer.TraceInfo{{
+			TraceID:    "trace-1",
+			RootSpanID: "root",
+			StartTime:  now.Add(-time.Minute),
+			EndTime:    now,
+			SpanCount:  2,
+		}},
+		spans: []observer.SpanInfo{
+			{SpanID: "root", SpanName: "invoke_agent", Kind: "SERVER", Status: "ok", StartTime: now.Add(-time.Minute), EndTime: now, Attributes: rootAttrs},
+			{SpanID: "child", SpanName: "llm", ParentSpanID: "root", Kind: "INTERNAL", Status: "ok", StartTime: now.Add(-30 * time.Second), EndTime: now},
+		},
+	}
+	c := NewTracingController(fake)
+
+	resp, err := c.ExportTraces(context.Background(), baseParams())
+	if err != nil {
+		t.Fatalf("ExportTraces returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&fake.getSpanDetailsCalls); got != 0 {
+		t.Errorf("expected 0 GetSpanDetails calls, got %d", got)
+	}
+	if !fake.lastSpansReq.IncludeAttributes {
+		t.Error("expected QueryTraceSpans to request IncludeAttributes=true")
+	}
+	if len(resp.Traces) != 1 {
+		t.Fatalf("expected 1 exported trace, got %d", len(resp.Traces))
+	}
+	tr := resp.Traces[0]
+	if len(tr.Spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(tr.Spans))
+	}
+	var root *opensearch.Span
+	for i := range tr.Spans {
+		if tr.Spans[i].SpanID == "root" {
+			root = &tr.Spans[i]
+		}
+	}
+	if root == nil {
+		t.Fatal("root span missing from export")
+	}
+	if root.Kind != "SERVER" {
+		t.Errorf("expected root Kind SERVER, got %q", root.Kind)
+	}
+	if _, ok := root.Attributes["traceloop.entity.input"]; !ok {
+		t.Error("expected root span to retain bulk-fetched attributes")
 	}
 }

--- a/traces-observer-service/observer/convert.go
+++ b/traces-observer-service/observer/convert.go
@@ -57,3 +57,33 @@ func ConvertSpanDetailsToSpan(traceID string, d *SpanDetailsResponse) opensearch
 		Resource:        d.ResourceAttributes,
 	}
 }
+
+// ConvertSpanInfoToSpan builds an opensearch.Span from a SpanInfo returned by
+// the spans-query endpoint with includeAttributes=true. It mirrors
+// ConvertSpanDetailsToSpan: the spans-query response carries the same fields
+// (spanKind, status, attributes, resourceAttributes) the per-span details
+// endpoint does, so the export path needs no GetSpanDetails round-trip.
+//
+// Service is extracted from resourceAttributes["openchoreo.dev/component-uid"]
+// and Resource is set to resourceAttributes so process.go lookups keep working.
+func ConvertSpanInfoToSpan(traceID string, s SpanInfo) opensearch.Span {
+	service := ""
+	if uid, ok := s.ResourceAttributes[componentUIDResourceKey].(string); ok {
+		service = uid
+	}
+
+	return opensearch.Span{
+		TraceID:         traceID,
+		SpanID:          s.SpanID,
+		ParentSpanID:    s.ParentSpanID,
+		Name:            s.SpanName,
+		Service:         service,
+		StartTime:       s.StartTime,
+		EndTime:         s.EndTime,
+		DurationInNanos: s.DurationNs,
+		Kind:            s.Kind,
+		Status:          s.Status,
+		Attributes:      s.Attributes,
+		Resource:        s.ResourceAttributes,
+	}
+}

--- a/traces-observer-service/observer/convert_test.go
+++ b/traces-observer-service/observer/convert_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package observer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConvertSpanInfoToSpan(t *testing.T) {
+	start := time.Now().Add(-time.Minute)
+	end := time.Now()
+	info := SpanInfo{
+		SpanID:       "span-1",
+		SpanName:     "llm call",
+		ParentSpanID: "root",
+		StartTime:    start,
+		EndTime:      end,
+		DurationNs:   42,
+		Kind:         "INTERNAL",
+		Status:       "error",
+		Attributes:   map[string]interface{}{"gen_ai.system": "openai"},
+		ResourceAttributes: map[string]interface{}{
+			"openchoreo.dev/component-uid": "comp-abc",
+		},
+	}
+
+	span := ConvertSpanInfoToSpan("trace-1", info)
+
+	if span.TraceID != "trace-1" || span.SpanID != "span-1" || span.ParentSpanID != "root" {
+		t.Errorf("identity fields not mapped: %+v", span)
+	}
+	if span.Name != "llm call" {
+		t.Errorf("expected Name from SpanName, got %q", span.Name)
+	}
+	if span.Kind != "INTERNAL" || span.Status != "error" {
+		t.Errorf("expected Kind/Status mapped, got Kind=%q Status=%q", span.Kind, span.Status)
+	}
+	if span.DurationInNanos != 42 {
+		t.Errorf("expected DurationInNanos 42, got %d", span.DurationInNanos)
+	}
+	if span.Service != "comp-abc" {
+		t.Errorf("expected Service from component-uid, got %q", span.Service)
+	}
+	if span.Attributes["gen_ai.system"] != "openai" {
+		t.Errorf("expected attributes preserved, got %+v", span.Attributes)
+	}
+	if span.Resource["openchoreo.dev/component-uid"] != "comp-abc" {
+		t.Errorf("expected resource preserved, got %+v", span.Resource)
+	}
+}

--- a/traces-observer-service/observer/types.go
+++ b/traces-observer-service/observer/types.go
@@ -36,6 +36,10 @@ type TracesQueryRequest struct {
 	Limit       *int                 `json:"limit,omitempty"`
 	SortOrder   *string              `json:"sortOrder,omitempty"`
 	SearchScope ComponentSearchScope `json:"searchScope"`
+	// IncludeAttributes requests inline span attributes on the spans-query
+	// endpoint. A plain bool with omitempty: false is dropped from the wire,
+	// so trace-list queries that leave it unset send nothing.
+	IncludeAttributes bool `json:"includeAttributes,omitempty"`
 }
 
 // TraceInfo represents a single trace entry in TracesQueryResponse.
@@ -58,15 +62,22 @@ type TracesQueryResponse struct {
 	TookMs int         `json:"tookMs"`
 }
 
-// SpanInfo represents a single span summary in TraceSpansQueryResponse.
-// Attributes are not included; use GetSpanDetails for the full span.
+// SpanInfo represents a single span in TraceSpansQueryResponse.
+// Kind and Status are always returned by the observer; Attributes and
+// ResourceAttributes are populated only when the request set
+// IncludeAttributes=true. Note the observer uses the wire key "spanKind"
+// here, whereas SpanDetailsResponse uses "kind".
 type SpanInfo struct {
-	SpanID       string    `json:"spanId"`
-	SpanName     string    `json:"spanName"`
-	ParentSpanID string    `json:"parentSpanId"`
-	StartTime    time.Time `json:"startTime"`
-	EndTime      time.Time `json:"endTime"`
-	DurationNs   int64     `json:"durationNs"`
+	SpanID             string                 `json:"spanId"`
+	SpanName           string                 `json:"spanName"`
+	ParentSpanID       string                 `json:"parentSpanId"`
+	StartTime          time.Time              `json:"startTime"`
+	EndTime            time.Time              `json:"endTime"`
+	DurationNs         int64                  `json:"durationNs"`
+	Kind               string                 `json:"spanKind,omitempty"`
+	Status             string                 `json:"status,omitempty"`
+	Attributes         map[string]interface{} `json:"attributes,omitempty"`
+	ResourceAttributes map[string]interface{} `json:"resourceAttributes,omitempty"`
 }
 
 // TraceSpansQueryResponse is the response from


### PR DESCRIPTION
## Purpose
The traces observer export endpoint (`GET /api/v1/traces/export`) builds each full trace with an N+1 fan-out against the observer: `1 × QueryTraces + N × QueryTraceSpans + N×M × GetSpanDetails`, where the innermost loop issues one `GetSpanDetails` call per span solely to fetch its attributes. This is costly, and the endpoint is hit heavily by the evaluation monitors (`evaluation-job` → `amp-evaluation` `TraceFetcher`).

Resolves #1015

## Goals
Eliminate the per-span `GetSpanDetails` fan-out by requesting span attributes inline on the spans-query call, collapsing the observer calls from `1 + N + N×M` to `1 + N` with no loss of exported data.

## Approach
OpenChoreo [observer PR #3231](https://github.com/openchoreo/openchoreo/pull/3231) added an `includeAttributes` flag to `TracesQueryRequest` on `POST /api/v1alpha1/traces/{traceId}/spans/query`; when set, each returned span carries `attributes`/`resourceAttributes` inline. The spans-query response already returns `spanKind` and `status`, so it provides everything `GetSpanDetails` did.

Changes:
- `observer/types.go`: add `IncludeAttributes` to `TracesQueryRequest`; add `Kind` (`spanKind`), `Status`, `Attributes`, `ResourceAttributes` to `SpanInfo`.
- `observer/convert.go`: add `ConvertSpanInfoToSpan`, mirroring `ConvertSpanDetailsToSpan` for the bulk span shape.
- `controllers/controller.go`: `ExportTraces` now sets `IncludeAttributes: true` on `QueryTraceSpans` and converts the returned spans directly, dropping the inner per-span `GetSpanDetails` goroutine loop (and the unused `innerSem`).

`GetSpanDetails` is retained on the client — it is still used by the trace-list/overview flow and the input/output enrichment fallbacks, which are unchanged.

## User stories
N/A — internal performance improvement to an existing endpoint; no new user-facing capability.

## Release note
Improve traces export performance by fetching span attributes in bulk, removing per-span observer round-trips.

## Documentation
N/A — no public API or behavior change; the export response shape is unchanged.

## Training
N/A — no training content impact.

## Certification
N/A — no certification exam impact; internal refactor of an existing endpoint.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > Added `TestConvertSpanInfoToSpan` (observer) and `TestExportTraces_UsesBulkAttributes` (controllers; asserts 0 `GetSpanDetails` calls and `IncludeAttributes=true` on the spans-query request). Full suite green via `make test`.
 - Integration tests
   > Manually verified on a local k3d cluster: rebuilt/redeployed `amp-traces-observer`, exercised the traces endpoints, and confirmed exported spans retain attributes/kind/status.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Go service; relied on `go vet` and existing CI checks.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples affected.

## Related PRs
- Upstream dependency: https://github.com/openchoreo/openchoreo/pull/3231 (adds `includeAttributes` to the observer spans-query endpoint)

## Migrations (if applicable)
N/A — no schema or data migration. Note: this is a hard cutover that assumes the deployed observer honors `includeAttributes`; against an older observer, exported spans would return without attributes.

## Test environment
Local k3d cluster (`openchoreo-local-setup`); Go service built via project Dockerfile/Makefile. `make test` run locally.

## Learning
Reviewed the upstream observer PR #3231 and the merged tracing-adapter OpenAPI spec / handler (`convertSpansResponseToGen`) to confirm the spans-query response returns `spanKind`/`status` unconditionally and `attributes`/`resourceAttributes` under `includeAttributes`, ensuring full parity with `GetSpanDetails`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized trace export by fetching span attributes through a single bulk query operation, improving efficiency

* **Reliability**
  * Enhanced trace export stability by consolidating span data collection and reducing potential failure points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->