### PR TITLE
[amctl] add llm provider management

### DIFF
--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -447,12 +447,9 @@ func (s *LLMProviderService) Delete(ctx context.Context, providerID, orgName str
 		return utils.ErrLLMProviderNotFound
 	}
 
-	// Get all deployed gateways for this provider
-	providerUUID, err := uuid.Parse(providerID)
-	if err != nil {
-		slog.Error("LLMProviderService.Delete: invalid provider UUID", "providerID", providerID, "error", err)
-		return fmt.Errorf("invalid provider UUID: %w", err)
-	}
+	// Get all deployed gateways for this provider. providerID may be a handle, so
+	// use the UUID resolved above rather than re-parsing the raw identifier.
+	providerUUID := provider.UUID
 
 	gatewayIDs, err := deploymentService.deploymentRepo.GetDeployedGatewaysByProvider(providerUUID, orgName)
 	if err != nil {
@@ -514,7 +511,7 @@ func (s *LLMProviderService) Delete(ctx context.Context, providerID, orgName str
 
 	// Now delete the provider from database (cascade deletes mappings)
 	slog.Info("LLMProviderService.Delete: deleting provider from database", "orgName", orgName, "providerID", providerID)
-	if err := s.providerRepo.Delete(providerID, orgName); err != nil {
+	if err := s.providerRepo.Delete(provider.UUID.String(), orgName); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			slog.Warn("LLMProviderService.Delete: provider not found", "orgName", orgName, "providerID", providerID)
 			return utils.ErrLLMProviderNotFound

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/wso2/agent-manager/cli
 go 1.25.7
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
@@ -13,7 +14,6 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 )

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -87,14 +88,17 @@ func validateCreate(opts *CreateOptions) error {
 
 	if opts.ID == "" {
 		v = append(v, "id argument is required")
-	} else if strings.Contains(opts.ID, "/") {
-		v = append(v, "id must not contain '/'")
+	} else if msg := handleViolation(opts.ID); msg != "" {
+		v = append(v, msg)
 	}
 	if opts.DisplayName == "" {
 		v = append(v, "--display-name is required")
 	}
 	if opts.Template == "" {
 		v = append(v, "--template is required")
+	}
+	if msg := contextViolation(opts.Context); msg != "" {
+		v = append(v, msg)
 	}
 	if !isValidAuthType(opts.AuthType) {
 		v = append(v, fmt.Sprintf("--auth-type must be one of: %s", strings.Join(validAuthTypes, ", ")))
@@ -117,6 +121,37 @@ func validateCreate(opts *CreateOptions) error {
 
 func isValidAuthType(t string) bool {
 	return slices.Contains(validAuthTypes, t)
+}
+
+// handleRegex matches a valid resource handle: letters, digits, '-' and '_'.
+// It mirrors the server-side rule (utils.ValidateTemplateHandle).
+var handleRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// handleViolation returns a validation message when id is not a valid resource
+// handle, or "" when it is valid: at most 255 characters and limited to
+// letters, digits, '-' and '_'. The empty case is reported separately so the
+// caller can emit the "id argument is required" message.
+func handleViolation(id string) string {
+	if len(id) > 255 {
+		return "id must be at most 255 characters"
+	}
+	if !handleRegex.MatchString(id) {
+		return "id must contain only letters, digits, '-' or '_'"
+	}
+	return ""
+}
+
+// contextViolation returns a validation message when the API context path is
+// malformed, or "" when valid. The path must start with '/' and must not end
+// with '/', except the root path "/". This mirrors the console's validation.
+func contextViolation(ctx string) string {
+	if !strings.HasPrefix(ctx, "/") {
+		return "--context must start with '/'"
+	}
+	if ctx != "/" && strings.HasSuffix(ctx, "/") {
+		return "--context must not end with '/'"
+	}
+	return ""
 }
 
 // parseGateways converts the raw --gateways values into typed UUIDs, reporting
@@ -149,7 +184,10 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 		Long: "Create a new LLM provider in an organization.\n\n" +
 			"The endpoint URL and auth scheme are inherited from the chosen --template; " +
 			"override them with --upstream-url/--auth-type/--auth-header only when needed. " +
-			"Supply the provider credential with --api-key-stdin (recommended) or --api-key.",
+			"Supply the provider credential with --api-key-stdin (recommended) or --api-key.\n\n" +
+			"Built-in --template handles: anthropic, awsbedrock, azure-openai, azureai-foundry, " +
+			"gemini, mistralai, openai. Shell completion on --template lists the live set " +
+			"(built-in plus any custom templates) for your org.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
@@ -174,7 +212,7 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.DisplayName, "display-name", "", "Human-readable display name (required)")
 	cmd.Flags().StringVar(&opts.Template, "template", "", "Provider template handle, e.g. openai, anthropic, mistralai (required)")
 	cmd.Flags().StringVar(&opts.Version, "version", defaultVersion, "Provider version")
-	cmd.Flags().StringVar(&opts.Context, "context", defaultContext, "API context path (must start with /)")
+	cmd.Flags().StringVar(&opts.Context, "context", defaultContext, "API context path (must start with /, no trailing slash)")
 	cmd.Flags().StringVar(&opts.Description, "description", "", "Provider description")
 	cmd.Flags().StringVar(&opts.UpstreamURL, "upstream-url", "", "Override the template's upstream endpoint URL")
 	cmd.Flags().StringVar(&opts.AuthType, "auth-type", defaultAuthType, "Upstream auth type: api-key, basic, bearer, or none")

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -1,0 +1,287 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+const (
+	defaultVersion = "v1"
+	defaultContext = "/"
+	// defaultAuthType matches the auth scheme of the built-in templates that
+	// require a credential (openai, anthropic, mistralai, …). It is only sent
+	// when the user also supplies a key or an explicit auth override.
+	defaultAuthType = "api-key"
+)
+
+// validAuthTypes are the upstream auth schemes accepted by the service.
+var validAuthTypes = []string{"api-key", "basic", "bearer", "none"}
+
+type CreateOptions struct {
+	IO           *iostreams.IOStreams
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj string) render.Scope
+
+	Org   string
+	Scope render.Scope
+
+	ID          string
+	DisplayName string
+	Version     string
+	Context     string
+	Template    string
+	Description string
+
+	// Upstream overrides. When omitted, the provider inherits the template's
+	// endpoint URL and auth scheme.
+	UpstreamURL   string
+	AuthType      string
+	AuthHeader    string
+	AuthTypeSet   bool
+	AuthHeaderSet bool
+
+	APIKey      string
+	APIKeyStdin bool
+
+	Gateways []string
+}
+
+// keyRequested reports whether the user asked to attach a credential, without
+// reading stdin (so it is safe to call during validation).
+func (o *CreateOptions) keyRequested() bool {
+	return o.APIKey != "" || o.APIKeyStdin
+}
+
+func validateCreate(opts *CreateOptions) error {
+	var v []string
+
+	if opts.ID == "" {
+		v = append(v, "id argument is required")
+	} else if strings.Contains(opts.ID, "/") {
+		v = append(v, "id must not contain '/'")
+	}
+	if opts.DisplayName == "" {
+		v = append(v, "--display-name is required")
+	}
+	if opts.Template == "" {
+		v = append(v, "--template is required")
+	}
+	if !isValidAuthType(opts.AuthType) {
+		v = append(v, fmt.Sprintf("--auth-type must be one of: %s", strings.Join(validAuthTypes, ", ")))
+	}
+	if opts.APIKey != "" && opts.APIKeyStdin {
+		v = append(v, "--api-key and --api-key-stdin are mutually exclusive")
+	}
+	if opts.keyRequested() && opts.AuthType == "none" {
+		v = append(v, "an API key cannot be used with --auth-type none")
+	}
+	if _, err := parseGateways(opts.Gateways); err != nil {
+		v = append(v, err.Error())
+	}
+
+	if len(v) == 0 {
+		return nil
+	}
+	return cmdutil.FlagErrors(v)
+}
+
+func isValidAuthType(t string) bool {
+	return slices.Contains(validAuthTypes, t)
+}
+
+// parseGateways converts the raw --gateways values into typed UUIDs, reporting
+// the first malformed value.
+func parseGateways(raw []string) ([]openapi_types.UUID, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]openapi_types.UUID, 0, len(raw))
+	for _, g := range raw {
+		id, err := uuid.Parse(strings.TrimSpace(g))
+		if err != nil {
+			return nil, fmt.Errorf("invalid gateway id %q: must be a UUID", g)
+		}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &CreateOptions{
+		IO:           f.IOStreams,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.Scope,
+	}
+	cmd := &cobra.Command{
+		Use:   "create <id>",
+		Short: "Create a new LLM provider",
+		Long: "Create a new LLM provider in an organization.\n\n" +
+			"The endpoint URL and auth scheme are inherited from the chosen --template; " +
+			"override them with --upstream-url/--auth-type/--auth-header only when needed. " +
+			"Supply the provider credential with --api-key-stdin (recommended) or --api-key.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.ID = args[0]
+			}
+			opts.AuthTypeSet = cmd.Flags().Changed("auth-type")
+			opts.AuthHeaderSet = cmd.Flags().Changed("auth-header")
+
+			if err := validateCreate(opts); err != nil {
+				return render.Error(opts.IO, render.Scope{}, err)
+			}
+			org, _, err := opts.ResolveScope(cmd, true, false)
+			scope := opts.MakeScope(org, "")
+			if err != nil {
+				return render.Error(opts.IO, scope, err)
+			}
+			opts.Org, opts.Scope = org, scope
+			return runCreate(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.DisplayName, "display-name", "", "Human-readable display name (required)")
+	cmd.Flags().StringVar(&opts.Template, "template", "", "Provider template handle, e.g. openai, anthropic, mistralai (required)")
+	cmd.Flags().StringVar(&opts.Version, "version", defaultVersion, "Provider version")
+	cmd.Flags().StringVar(&opts.Context, "context", defaultContext, "API context path (must start with /)")
+	cmd.Flags().StringVar(&opts.Description, "description", "", "Provider description")
+	cmd.Flags().StringVar(&opts.UpstreamURL, "upstream-url", "", "Override the template's upstream endpoint URL")
+	cmd.Flags().StringVar(&opts.AuthType, "auth-type", defaultAuthType, "Upstream auth type: api-key, basic, bearer, or none")
+	cmd.Flags().StringVar(&opts.AuthHeader, "auth-header", "", "Override the template's auth header name")
+	cmd.Flags().StringVar(&opts.APIKey, "api-key", "", "Provider API key (leaks into shell history; prefer --api-key-stdin)")
+	cmd.Flags().BoolVar(&opts.APIKeyStdin, "api-key-stdin", false, "Read the provider API key from stdin")
+	cmd.Flags().StringSliceVar(&opts.Gateways, "gateways", nil, "Gateway UUIDs to deploy the provider to (repeatable)")
+
+	_ = cmd.RegisterFlagCompletionFunc("auth-type", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return validAuthTypes, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("template", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return cmdutil.CompleteLLMProviderTemplates(cmd, f), cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+func runCreate(ctx context.Context, o *CreateOptions) error {
+	key := o.APIKey
+	if o.APIKeyStdin {
+		data, err := io.ReadAll(o.IO.In)
+		if err != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.InvalidFlag, "read API key from stdin: %v", err))
+		}
+		key = strings.TrimSpace(string(data))
+		if key == "" {
+			return render.Error(o.IO, o.Scope, clierr.New(clierr.InvalidFlag, "no API key provided on stdin"))
+		}
+	}
+
+	req, err := buildCreateRequest(o, key)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	resp, err := client.CreateLLMProviderWithResponse(ctx, o.Org, req)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.JSON201 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON409, resp.JSON500)))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, resp.JSON201)
+	}
+
+	printProviderSummary(o.IO, resp.JSON201)
+	return nil
+}
+
+// buildCreateRequest maps the resolved options into the create payload. The
+// upstream block is attached only when the user supplies a URL or an auth input,
+// so a bare `create <id> --display-name --template` defers entirely to the template.
+func buildCreateRequest(o *CreateOptions, key string) (amsvc.CreateLLMProviderRequest, error) {
+	req := amsvc.CreateLLMProviderRequest{
+		Id:       o.ID,
+		Name:     o.DisplayName,
+		Version:  o.Version,
+		Context:  o.Context,
+		Template: o.Template,
+	}
+	if o.Description != "" {
+		req.Description = &o.Description
+	}
+
+	keyProvided := key != ""
+	attachAuth := keyProvided || o.AuthTypeSet || o.AuthHeaderSet
+	if attachAuth || o.UpstreamURL != "" {
+		main := &amsvc.UpstreamEndpoint{}
+		if o.UpstreamURL != "" {
+			main.Url = &o.UpstreamURL
+		}
+		if attachAuth {
+			auth := &amsvc.UpstreamAuth{Type: amsvc.UpstreamAuthType(o.AuthType)}
+			if o.AuthHeader != "" {
+				auth.Header = &o.AuthHeader
+			}
+			if keyProvided {
+				auth.Value = &key
+			}
+			main.Auth = auth
+		}
+		req.Upstream = amsvc.UpstreamConfig{Main: main}
+	}
+
+	gws, err := parseGateways(o.Gateways)
+	if err != nil {
+		return req, cmdutil.FlagErrors([]string{err.Error()})
+	}
+	if len(gws) > 0 {
+		req.Gateways = &gws
+	}
+
+	return req, nil
+}
+
+func printProviderSummary(ios *iostreams.IOStreams, p *amsvc.LLMProviderResponse) {
+	cs := ios.StderrColorScheme()
+	fmt.Fprintf(ios.ErrOut, "%s Created LLM provider %s\n\n", cs.SuccessIcon(), p.Id)
+	fmt.Fprintf(ios.ErrOut, "  Name:     %s\n", p.Name)
+	fmt.Fprintf(ios.ErrOut, "  Template: %s\n", p.Template)
+	fmt.Fprintf(ios.ErrOut, "  Status:   %s\n", string(p.Status))
+}

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -106,6 +106,9 @@ func validateCreate(opts *CreateOptions) error {
 	if opts.APIKey != "" && opts.APIKeyStdin {
 		v = append(v, "--api-key and --api-key-stdin are mutually exclusive")
 	}
+	if opts.APIKey != "" && strings.TrimSpace(opts.APIKey) == "" {
+		v = append(v, "--api-key must not be blank")
+	}
 	if opts.keyRequested() && opts.AuthType == "none" {
 		v = append(v, "an API key cannot be used with --auth-type none")
 	}

--- a/cli/pkg/cmd/llmprovider/create_test.go
+++ b/cli/pkg/cmd/llmprovider/create_test.go
@@ -254,6 +254,11 @@ func TestCreate_KeyWithAuthNone(t *testing.T) {
 		"an API key cannot be used with --auth-type none")
 }
 
+func TestCreate_BlankAPIKey(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--api-key", "   "},
+		"--api-key must not be blank")
+}
+
 func TestCreate_BadGateway(t *testing.T) {
 	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--gateways", "not-a-uuid"},
 		"invalid gateway id")

--- a/cli/pkg/cmd/llmprovider/create_test.go
+++ b/cli/pkg/cmd/llmprovider/create_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+)
+
+func sampleProviderResponse() amsvc.LLMProviderResponse {
+	return amsvc.LLMProviderResponse{
+		Uuid:     "11111111-1111-1111-1111-111111111111",
+		Id:       "openai",
+		Name:     "OpenAI",
+		Version:  "v1",
+		Context:  "/",
+		Template: "openai",
+		Status:   amsvc.LLMProviderResponseStatus("pending"),
+	}
+}
+
+// authValue digs out upstream.main.auth.value from a captured create body.
+func authValue(t *testing.T, raw []byte) (string, bool) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal body: %v\nbody=%s", err, raw)
+	}
+	up, ok := m["upstream"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	main, ok := up["main"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	auth, ok := main["auth"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	v, ok := auth["value"].(string)
+	return v, ok
+}
+
+func TestCreate_SuccessWithAPIKey(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusCreated, sampleProviderResponse())
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: "v1", Context: "/",
+		Template: "openai", AuthType: "api-key", APIKey: "sk-test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != "POST" {
+		t.Errorf("method = %q, want POST", captured.method)
+	}
+	if captured.path != "/orgs/acme/llm-providers" {
+		t.Errorf("path = %q, want /orgs/acme/llm-providers", captured.path)
+	}
+	if v, ok := authValue(t, captured.body); !ok || v != "sk-test" {
+		t.Errorf("upstream auth value = %q (ok=%v), want sk-test", v, ok)
+	}
+	env := decodeEnvelope(t, out.String())
+	data := env["data"].(map[string]any)
+	if data["id"] != "openai" {
+		t.Errorf("id = %v, want openai", data["id"])
+	}
+}
+
+func TestCreate_MinimalDefersToTemplate(t *testing.T) {
+	io, _, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusCreated, sampleProviderResponse())
+	defer closeFn()
+
+	// No key, no upstream overrides, no explicit auth flags: the request must
+	// not carry an upstream auth block — the template supplies it.
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: "v1", Context: "/",
+		Template: "openai", AuthType: "api-key",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := authValue(t, captured.body); ok {
+		t.Errorf("expected no upstream auth block, body=%s", captured.body)
+	}
+}
+
+func TestCreate_APIKeyStdin(t *testing.T) {
+	io, _, _ := newTestIOWithStdin(true, "sk-stdin\n")
+	clientFn, captured, closeFn := newTestClient(t, http.StatusCreated, sampleProviderResponse())
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: "v1", Context: "/",
+		Template: "openai", AuthType: "api-key", APIKeyStdin: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v, ok := authValue(t, captured.body); !ok || v != "sk-stdin" {
+		t.Errorf("upstream auth value = %q (ok=%v), want sk-stdin", v, ok)
+	}
+}
+
+func TestCreate_EmptyStdinKey(t *testing.T) {
+	io, out, _ := newTestIOWithStdin(true, "   \n")
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: io, Client: unreachableClient, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: "v1", Context: "/",
+		Template: "openai", AuthType: "api-key", APIKeyStdin: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for empty stdin key")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.InvalidFlag {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.InvalidFlag)
+	}
+}
+
+func TestCreate_Conflict(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusConflict, amsvc.ErrorResponse{
+		Code:    "LLM_PROVIDER_ALREADY_EXISTS",
+		Message: "provider 'openai' already exists",
+	})
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: "v1", Context: "/",
+		Template: "openai", AuthType: "api-key", APIKey: "sk-test",
+	})
+	if err == nil {
+		t.Fatal("expected error for 409")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != "LLM_PROVIDER_ALREADY_EXISTS" {
+		t.Errorf("code = %v, want LLM_PROVIDER_ALREADY_EXISTS", errBody["code"])
+	}
+}
+
+// --- flag-parsing / validation via the cobra tree ---
+
+func runTreeExpectViolation(t *testing.T, args []string, wants ...string) {
+	t.Helper()
+	ios, out, _ := newTestIO(true)
+	cmd := testLLMProviderCmd(t, ios, nil)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected validation error")
+	}
+	env := decodeEnvelope(t, out.String())
+	errMap := env["error"].(map[string]any)
+	if errMap["code"] != clierr.InvalidFlag {
+		t.Fatalf("code = %v, want %s", errMap["code"], clierr.InvalidFlag)
+	}
+	additional := errMap["additionalData"].(map[string]any)
+	details, ok := additional["details"].([]any)
+	if !ok {
+		t.Fatalf("details type = %T", additional["details"])
+	}
+	for _, want := range wants {
+		found := false
+		for _, d := range details {
+			if strings.Contains(d.(string), want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in details, got %v", want, details)
+		}
+	}
+}
+
+func TestCreate_MissingRequired(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create"},
+		"id argument is required", "--display-name is required", "--template is required")
+}
+
+func TestCreate_IDWithSlash(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "bad/id", "--display-name", "X", "--template", "openai"},
+		"id must not contain '/'")
+}
+
+func TestCreate_BadAuthType(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--auth-type", "weird"},
+		"--auth-type must be one of")
+}
+
+func TestCreate_MutuallyExclusiveKeys(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--api-key", "k", "--api-key-stdin"},
+		"--api-key and --api-key-stdin are mutually exclusive")
+}
+
+func TestCreate_KeyWithAuthNone(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--auth-type", "none", "--api-key", "k"},
+		"an API key cannot be used with --auth-type none")
+}
+
+func TestCreate_BadGateway(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--gateways", "not-a-uuid"},
+		"invalid gateway id")
+}

--- a/cli/pkg/cmd/llmprovider/create_test.go
+++ b/cli/pkg/cmd/llmprovider/create_test.go
@@ -209,7 +209,34 @@ func TestCreate_MissingRequired(t *testing.T) {
 
 func TestCreate_IDWithSlash(t *testing.T) {
 	runTreeExpectViolation(t, []string{"llm-provider", "create", "bad/id", "--display-name", "X", "--template", "openai"},
-		"id must not contain '/'")
+		"id must contain only letters, digits, '-' or '_'")
+}
+
+func TestCreate_BadID(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "DX Test Bad!", "--display-name", "X", "--template", "openai"},
+		"id must contain only letters, digits, '-' or '_'")
+}
+
+func TestCreate_ContextMissingLeadingSlash(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--context", "v1/api"},
+		"--context must start with '/'")
+}
+
+func TestCreate_ContextTrailingSlash(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--context", "/v1/api/"},
+		"--context must not end with '/'")
+}
+
+// TestValidateCreate_RootContextOK guards that the default root context "/" is
+// not caught by the trailing-slash rule.
+func TestValidateCreate_RootContextOK(t *testing.T) {
+	err := validateCreate(&CreateOptions{
+		ID: "openai", DisplayName: "OpenAI", Template: "openai",
+		Context: "/", AuthType: "api-key",
+	})
+	if err != nil {
+		t.Fatalf("expected valid options, got %v", err)
+	}
 }
 
 func TestCreate_BadAuthType(t *testing.T) {

--- a/cli/pkg/cmd/llmprovider/delete.go
+++ b/cli/pkg/cmd/llmprovider/delete.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/prompter"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+type DeleteOptions struct {
+	IO           *iostreams.IOStreams
+	Prompter     prompter.Prompter
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj string) render.Scope
+
+	Org      string
+	Scope    render.Scope
+	Provider string
+	Yes      bool
+}
+
+type DeleteResult struct {
+	Name    string `json:"name"`
+	Deleted bool   `json:"deleted"`
+}
+
+func NewDeleteCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &DeleteOptions{
+		IO:           f.IOStreams,
+		Prompter:     f.Prompter,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.Scope,
+	}
+	cmd := &cobra.Command{
+		Use:   "delete <provider>",
+		Short: "Delete an LLM provider",
+		Long:  "Delete an LLM provider by its handle or UUID.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, _, err := opts.ResolveScope(cmd, true, false)
+			scope := opts.MakeScope(org, "")
+			if err != nil {
+				return render.Error(opts.IO, scope, err)
+			}
+			opts.Org, opts.Scope = org, scope
+			opts.Provider = args[0]
+			return runDelete(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip confirmation prompt")
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return cmdutil.CompleteLLMProviders(cmd, f), cobra.ShellCompDirectiveNoFileComp
+	}
+	return cmd
+}
+
+func runDelete(ctx context.Context, o *DeleteOptions) error {
+	if err := cmdutil.ValidatePathParam("provider", o.Provider); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	if !o.Yes {
+		if !o.IO.CanPrompt() {
+			return render.Error(o.IO, o.Scope, clierr.New(clierr.ConfirmationRequired, "deletion requires --yes when stdin is not a terminal"))
+		}
+		if err := o.Prompter.ConfirmDeletion(o.Provider); err != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.ConfirmationRequired, "%v", err))
+		}
+	}
+
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	resp, err := client.DeleteLLMProviderWithResponse(ctx, o.Org, o.Provider)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.HTTPResponse == nil || resp.HTTPResponse.StatusCode != http.StatusNoContent {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON404, resp.JSON500)))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, DeleteResult{Name: o.Provider, Deleted: true})
+	}
+
+	cs := o.IO.StderrColorScheme()
+	fmt.Fprintf(o.IO.ErrOut, "%s Deleted LLM provider %s\n", cs.SuccessIcon(), o.Provider)
+	return nil
+}

--- a/cli/pkg/cmd/llmprovider/delete_test.go
+++ b/cli/pkg/cmd/llmprovider/delete_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+)
+
+func TestDelete_SuccessByHandle(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusNoContent, nil)
+	defer closeFn()
+	prompter := &fakePrompter{}
+
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: io, Prompter: prompter, Client: clientFn, Scope: baseScope(),
+		Org: "acme", Provider: "openai", Yes: false,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != "DELETE" {
+		t.Errorf("method = %q, want DELETE", captured.method)
+	}
+	if captured.path != "/orgs/acme/llm-providers/openai" {
+		t.Errorf("path = %q, want /orgs/acme/llm-providers/openai", captured.path)
+	}
+	if prompter.calls != 1 {
+		t.Errorf("prompter calls = %d, want 1", prompter.calls)
+	}
+	env := decodeEnvelope(t, out.String())
+	data := env["data"].(map[string]any)
+	if data["name"] != "openai" || data["deleted"] != true {
+		t.Errorf("data = %v, want {name=openai, deleted=true}", data)
+	}
+}
+
+func TestDelete_ByUUID(t *testing.T) {
+	io, _, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusNoContent, nil)
+	defer closeFn()
+
+	uuid := "11111111-1111-1111-1111-111111111111"
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: io, Prompter: &fakePrompter{}, Client: clientFn, Scope: baseScope(),
+		Org: "acme", Provider: uuid, Yes: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.path != "/orgs/acme/llm-providers/"+uuid {
+		t.Errorf("path = %q, want /orgs/acme/llm-providers/%s", captured.path, uuid)
+	}
+}
+
+func TestDelete_YesSkipsPrompt(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusNoContent, nil)
+	defer closeFn()
+	prompter := &fakePrompter{}
+
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: io, Prompter: prompter, Client: clientFn, Scope: baseScope(),
+		Org: "acme", Provider: "openai", Yes: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prompter.calls != 0 {
+		t.Errorf("prompter calls = %d, want 0 with --yes", prompter.calls)
+	}
+	if !captured.called {
+		t.Fatal("server should have been called")
+	}
+}
+
+func TestDelete_NonTTYWithoutYes(t *testing.T) {
+	io, out, _ := newTestIO(false)
+
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: io, Prompter: &fakePrompter{}, Client: unreachableClient, Scope: baseScope(),
+		Org: "acme", Provider: "openai", Yes: false,
+	})
+	if err == nil {
+		t.Fatal("expected error for non-TTY without --yes")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
+	}
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusNotFound, amsvc.ErrorResponse{
+		Code:    "LLM_PROVIDER_NOT_FOUND",
+		Message: "LLM provider not found",
+	})
+	defer closeFn()
+
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: io, Prompter: &fakePrompter{}, Client: clientFn, Scope: baseScope(),
+		Org: "acme", Provider: "openai", Yes: true,
+	})
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != "LLM_PROVIDER_NOT_FOUND" {
+		t.Errorf("code = %v, want LLM_PROVIDER_NOT_FOUND", errBody["code"])
+	}
+}
+
+func TestDelete_ConfirmationMismatch(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	prompter := &fakePrompter{confirmDeletionErr: errors.New("confirmation mismatch")}
+
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: io, Prompter: prompter, Client: unreachableClient, Scope: baseScope(),
+		Org: "acme", Provider: "openai", Yes: false,
+	})
+	if err == nil {
+		t.Fatal("expected error from confirmation mismatch")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Errorf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
+	}
+}

--- a/cli/pkg/cmd/llmprovider/helpers_test.go
+++ b/cli/pkg/cmd/llmprovider/helpers_test.go
@@ -39,6 +39,7 @@ type capturedRequest struct {
 	called      bool
 	method      string
 	path        string
+	rawQuery    string
 	contentType string
 	body        []byte
 }
@@ -50,6 +51,7 @@ func newTestClient(t *testing.T, status int, body any) (func(context.Context) (*
 		captured.called = true
 		captured.method = r.Method
 		captured.path = r.URL.Path
+		captured.rawQuery = r.URL.RawQuery
 		captured.contentType = r.Header.Get("Content-Type")
 		if r.Body != nil {
 			raw, err := io.ReadAll(r.Body)

--- a/cli/pkg/cmd/llmprovider/helpers_test.go
+++ b/cli/pkg/cmd/llmprovider/helpers_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/config"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+type capturedRequest struct {
+	called      bool
+	method      string
+	path        string
+	contentType string
+	body        []byte
+}
+
+func newTestClient(t *testing.T, status int, body any) (func(context.Context) (*amsvc.ClientWithResponses, error), *capturedRequest, func()) {
+	t.Helper()
+	captured := &capturedRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.called = true
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.contentType = r.Header.Get("Content-Type")
+		if r.Body != nil {
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read request body: %v", err)
+			} else {
+				captured.body = raw
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != nil {
+			if err := json.NewEncoder(w).Encode(body); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+		}
+	}))
+	client, err := amsvc.NewClientWithResponses(server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("new client: %v", err)
+	}
+	return func(context.Context) (*amsvc.ClientWithResponses, error) { return client, nil }, captured, server.Close
+}
+
+func unreachableClient(context.Context) (*amsvc.ClientWithResponses, error) {
+	return nil, errors.New("client should not be constructed")
+}
+
+type fakePrompter struct {
+	confirmDeletionErr error
+	confirmDeletionArg string
+	calls              int
+}
+
+func (p *fakePrompter) ConfirmDeletion(required string) error {
+	p.calls++
+	p.confirmDeletionArg = required
+	return p.confirmDeletionErr
+}
+
+func (p *fakePrompter) Confirm(prompt string) (bool, error) { return false, nil }
+
+func newTestIO(canPrompt bool) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	io, _, out, errOut := iostreams.Test()
+	io.SetTerminal(canPrompt, canPrompt, canPrompt)
+	io.JSON = true
+	return io, out, errOut
+}
+
+// newTestIOWithStdin is newTestIO with stdin pre-filled, for the
+// --api-key-stdin path.
+func newTestIOWithStdin(canPrompt bool, stdin string) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	io, in, out, errOut := iostreams.Test()
+	in.WriteString(stdin)
+	io.SetTerminal(canPrompt, canPrompt, canPrompt)
+	io.JSON = true
+	return io, out, errOut
+}
+
+func decodeEnvelope(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("decode envelope: %v\nbody=%q", err, raw)
+	}
+	return m
+}
+
+func baseScope() render.Scope {
+	return render.Scope{Instance: "default", Org: "acme"}
+}
+
+// testLLMProviderCmd builds a root → llm-provider cobra tree for integration
+// tests that exercise flag parsing and validation via the RunE path.
+func testLLMProviderCmd(t *testing.T, ios *iostreams.IOStreams, clientFn func(context.Context) (*amsvc.ClientWithResponses, error)) *cobra.Command {
+	t.Helper()
+	f := &cmdutil.Factory{
+		IOStreams:    ios,
+		Prompter:     &fakePrompter{},
+		AgentManager: clientFn,
+		Config: func() (*config.Config, error) {
+			return &config.Config{
+				CurrentInstance: "default",
+				Instances: map[string]config.Instance{
+					"default": {URL: "http://test", CurrentOrg: "acme"},
+				},
+			}, nil
+		},
+	}
+	root := &cobra.Command{Use: "amctl", SilenceErrors: true, SilenceUsage: true}
+	cmdutil.EnableOrgOverride(root, f)
+	root.AddCommand(NewLLMProviderCmd(f))
+	return root
+}

--- a/cli/pkg/cmd/llmprovider/list.go
+++ b/cli/pkg/cmd/llmprovider/list.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+	"github.com/wso2/agent-manager/cli/pkg/tableprinter"
+)
+
+type ListOptions struct {
+	IO           *iostreams.IOStreams
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj string) render.Scope
+
+	Org   string
+	Scope render.Scope
+}
+
+func NewListCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &ListOptions{
+		IO:           f.IOStreams,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.Scope,
+	}
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List LLM providers in an organization",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, _, err := opts.ResolveScope(cmd, true, false)
+			scope := opts.MakeScope(org, "")
+			if err != nil {
+				return render.Error(opts.IO, scope, err)
+			}
+			opts.Org, opts.Scope = org, scope
+			return runList(cmd.Context(), opts)
+		},
+	}
+}
+
+func runList(ctx context.Context, o *ListOptions) error {
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	// TODO: paginate
+	resp, err := client.ListLLMProvidersWithResponse(ctx, o.Org, &amsvc.ListLLMProvidersParams{})
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON500)))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, resp.JSON200)
+	}
+
+	tp := tableprinter.New(o.IO, "id", "name", "template", "status", "created")
+	cs := o.IO.ColorScheme()
+	for _, p := range resp.JSON200.Providers {
+		tp.AddField(p.Id, tableprinter.WithColor(cs.Bold))
+		tp.AddField(p.Name)
+		tp.AddField(p.Template)
+		tp.AddField(string(p.Status))
+		created := ""
+		if p.CreatedAt != nil {
+			created = p.CreatedAt.Format("2006-01-02")
+		}
+		tp.AddField(created, tableprinter.WithColor(cs.Gray))
+		tp.EndRow()
+	}
+	return tp.Render()
+}

--- a/cli/pkg/cmd/llmprovider/list.go
+++ b/cli/pkg/cmd/llmprovider/list.go
@@ -29,6 +29,9 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/tableprinter"
 )
 
+// defaultListLimit is the page size requested by `list`, matching `project list`.
+const defaultListLimit = 50
+
 type ListOptions struct {
 	IO           *iostreams.IOStreams
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
@@ -68,8 +71,10 @@ func runList(ctx context.Context, o *ListOptions) error {
 		return render.Error(o.IO, o.Scope, err)
 	}
 
-	// TODO: paginate
-	resp, err := client.ListLLMProvidersWithResponse(ctx, o.Org, &amsvc.ListLLMProvidersParams{})
+	// Request a 50-item page to match `project list`; --limit/--offset paging
+	// is not exposed yet.
+	limit := int32(defaultListLimit)
+	resp, err := client.ListLLMProvidersWithResponse(ctx, o.Org, &amsvc.ListLLMProvidersParams{Limit: &limit})
 	if err != nil {
 		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
 	}

--- a/cli/pkg/cmd/llmprovider/list_test.go
+++ b/cli/pkg/cmd/llmprovider/list_test.go
@@ -71,6 +71,22 @@ func TestList_SuccessJSON(t *testing.T) {
 	}
 }
 
+func TestList_RequestsPageSize50(t *testing.T) {
+	io, _, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := captured.rawQuery; !strings.Contains(got, "limit=50") {
+		t.Errorf("query = %q, want it to contain limit=50", got)
+	}
+}
+
 func TestList_Table(t *testing.T) {
 	io, out, _ := newTestIO(false)
 	io.JSON = false

--- a/cli/pkg/cmd/llmprovider/list_test.go
+++ b/cli/pkg/cmd/llmprovider/list_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+func sampleListResponse() amsvc.LLMProviderListResponse {
+	return amsvc.LLMProviderListResponse{
+		Providers: []amsvc.LLMProviderListItem{
+			{
+				Uuid:     "11111111-1111-1111-1111-111111111111",
+				Id:       "openai",
+				Name:     "OpenAI",
+				Template: "openai",
+				Status:   amsvc.LLMProviderListItemStatus("deployed"),
+			},
+		},
+		Total:  1,
+		Limit:  20,
+		Offset: 0,
+	}
+}
+
+func TestList_SuccessJSON(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != "GET" {
+		t.Errorf("method = %q, want GET", captured.method)
+	}
+	if captured.path != "/orgs/acme/llm-providers" {
+		t.Errorf("path = %q, want /orgs/acme/llm-providers", captured.path)
+	}
+	env := decodeEnvelope(t, out.String())
+	data := env["data"].(map[string]any)
+	providers := data["providers"].([]any)
+	if len(providers) != 1 {
+		t.Fatalf("providers len = %d, want 1", len(providers))
+	}
+	first := providers[0].(map[string]any)
+	if first["id"] != "openai" {
+		t.Errorf("id = %v, want openai", first["id"])
+	}
+}
+
+func TestList_Table(t *testing.T) {
+	io, out, _ := newTestIO(false)
+	io.JSON = false
+	clientFn, _, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"openai", "OpenAI", "deployed"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("table output missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+func TestList_ServerError(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusInternalServerError, amsvc.ErrorResponse{
+		Code:    "INTERNAL",
+		Message: "boom",
+	})
+	defer closeFn()
+
+	err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	})
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	env := decodeEnvelope(t, out.String())
+	if _, ok := env["error"]; !ok {
+		t.Fatalf("expected error envelope, got %v", env)
+	}
+}

--- a/cli/pkg/cmd/llmprovider/llmprovider.go
+++ b/cli/pkg/cmd/llmprovider/llmprovider.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+)
+
+// NewLLMProviderCmd builds the `llm-provider` command group. LLM providers are
+// org-scoped, so the group relies on the root persistent --org flag rather than
+// registering its own scope override.
+func NewLLMProviderCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "llm-provider",
+		Short:   "Manage LLM providers in an organization",
+		Aliases: []string{"llm-providers"},
+	}
+	cmd.AddCommand(NewListCmd(f))
+	cmd.AddCommand(NewCreateCmd(f))
+	cmd.AddCommand(NewDeleteCmd(f))
+	return cmd
+}

--- a/cli/pkg/cmd/root.go
+++ b/cli/pkg/cmd/root.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/wso2/agent-manager/cli/pkg/cmd/agent"
 	amcontext "github.com/wso2/agent-manager/cli/pkg/cmd/context"
+	"github.com/wso2/agent-manager/cli/pkg/cmd/llmprovider"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/project"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/skills"
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
@@ -45,6 +46,7 @@ func NewRootCmd(f *cmdutil.Factory) (*cobra.Command, error) {
 	cmd.AddCommand(NewLoginCmd(f))
 	cmd.AddCommand(agent.NewAgentCmd(f))
 	cmd.AddCommand(amcontext.NewContextCmd(f))
+	cmd.AddCommand(llmprovider.NewLLMProviderCmd(f))
 	cmd.AddCommand(project.NewProjectCmd(f))
 	cmd.AddCommand(NewVersionCmd())
 	cmd.AddCommand(skills.NewSkillsCmd(f))

--- a/cli/pkg/cmdutil/completion.go
+++ b/cli/pkg/cmdutil/completion.go
@@ -241,6 +241,78 @@ func CompleteBuildWithAgentContext(cmd *cobra.Command, f *Factory, args []string
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
+// CompleteLLMProviders returns sorted LLM provider handles in the resolved org.
+// Org resolution follows ResolveOrgProject(cmd, true, false). Returns nil if org
+// cannot be resolved or on any API error.
+func CompleteLLMProviders(cmd *cobra.Command, f *Factory) []string {
+	const op = "CompleteLLMProviders"
+	org, _, err := f.ResolveOrgProject(cmd, true, false)
+	if err != nil {
+		logCompletionErr(op, nil, err)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	client, err := f.AgentManager(ctx)
+	if err != nil {
+		logCompletionErr(op, map[string]string{"org": org}, err)
+		return nil
+	}
+	resp, err := client.ListLLMProvidersWithResponse(ctx, org, &amsvc.ListLLMProvidersParams{})
+	if err != nil {
+		logCompletionErr(op, map[string]string{"org": org}, err)
+		return nil
+	}
+	if resp.JSON200 == nil {
+		logCompletionErr(op, map[string]string{"org": org}, fmt.Errorf("status %d", resp.StatusCode()))
+		return nil
+	}
+	out := make([]string, 0, len(resp.JSON200.Providers))
+	for _, p := range resp.JSON200.Providers {
+		out = append(out, p.Id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// CompleteLLMProviderTemplates returns sorted LLM provider template handles in
+// the resolved org (including built-in system templates). Returns nil if org
+// cannot be resolved or on any API error.
+func CompleteLLMProviderTemplates(cmd *cobra.Command, f *Factory) []string {
+	const op = "CompleteLLMProviderTemplates"
+	org, _, err := f.ResolveOrgProject(cmd, true, false)
+	if err != nil {
+		logCompletionErr(op, nil, err)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	client, err := f.AgentManager(ctx)
+	if err != nil {
+		logCompletionErr(op, map[string]string{"org": org}, err)
+		return nil
+	}
+	resp, err := client.ListLLMProviderTemplatesWithResponse(ctx, org, &amsvc.ListLLMProviderTemplatesParams{})
+	if err != nil {
+		logCompletionErr(op, map[string]string{"org": org}, err)
+		return nil
+	}
+	if resp.JSON200 == nil {
+		logCompletionErr(op, map[string]string{"org": org}, fmt.Errorf("status %d", resp.StatusCode()))
+		return nil
+	}
+	out := make([]string, 0, len(resp.JSON200.Templates))
+	for _, t := range resp.JSON200.Templates {
+		out = append(out, t.Id)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // CompleteOrgs returns sorted organization names. Returns nil on any error
 // (no instance, network, server). Times out at 2s.
 func CompleteOrgs(cmd *cobra.Command, f *Factory) []string {


### PR DESCRIPTION
## Purpose
Allow users to provision and manage org-scoped LLM providers directly from `amctl`.

Resolves #1078

## Goals
Add an `amctl llm-provider` command group with `list`, `create`, and `delete` subcommands, plus shell completion for provider handles.

## Approach
- New `llm-provider` command group (alias `llm-providers`), org-scoped via the root `--org` flag.
- `list` / `create` / `delete` subcommands backed by the agent-manager service client, with `delete` accepting both UUID and handle identifiers.
- Fixes server-side LLM provider lookup so the delete-by-handle path resolves correctly.

## User stories
As an operator, I can list, add, and remove my organization's LLM providers without leaving the CLI.

## Release note
Add `amctl llm-provider list/create/delete` commands for managing org-level LLM providers.

## Documentation
N/A — CLI reference docs to follow separately.

## Training
N/A — no training impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > Added unit tests for create, delete, list, and shared helpers under `cli/pkg/cmd/llmprovider/`.
 - Integration tests
   > N/A — covered by unit tests against the mocked service client.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A. Related issue: #1086 — the delete-by-handle path is fixed here.

## Migrations (if applicable)
N/A — no schema changes.

## Test environment
Go (CLI unit tests), macOS.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `llm-provider` CLI command group with `list`, `create`, and `delete` subcommands. Create supports display name, template selection, authentication options, and gateway assignment. List displays providers in table or JSON format.

* **Bug Fixes**
  * Fixed provider deletion to work correctly with non-UUID provider identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->