### PR TITLE
Add mcp proxy documentation

### DIFF
--- a/documentation/docs/tutorials/configure-agent-mcp-proxies.mdx
+++ b/documentation/docs/tutorials/configure-agent-mcp-proxies.mdx
@@ -1,0 +1,163 @@
+---
+sidebar_position: 9
+---
+
+# Configure MCP Proxies for an Agent
+
+Agents can be configured to use one or more [MCP Proxies](./register-mcp-proxy.mdx) registered at the organization level. Each binding — called an **MCP configuration** — maps an org-level MCP proxy to the agent and exposes the proxy's invoke URL and API key to the agent's code. The configuration process differs slightly between **Platform-hosted** and **External** agents, but both follow the same pattern: attach an org-level proxy to the agent.
+
+## Prerequisites
+
+- At least one MCP Proxy registered at the org level (see [Register an MCP Proxy](./register-mcp-proxy.mdx))
+- An agent created in a project (Platform-hosted or External)
+
+---
+
+## Overview: Agent Types
+
+| Type | Description |
+|---|---|
+| **Platform** | Agent code is built and deployed by the platform from a GitHub repository. The platform injects the MCP server URL and API key as environment variables. |
+| **External** | Agent is deployed and managed externally. The platform provides the gateway endpoint URL + API key for the MCP proxy so the agent can connect to it. |
+
+---
+
+## Configuring an MCP Proxy for a Platform-Hosted Agent
+
+### Step 1: Open the Agent
+
+1. Navigate to your project (**Projects** → select project → **Agents**).
+2. Click on a **Platform**-tagged agent.
+3. In the left sidebar, click **Configure**.
+
+### Step 2: Add an MCP Configuration
+
+The **Configure** page displays the **MCP Configurations** section listing all MCP configurations currently attached to this agent.
+
+1. Click **Add MCP Configuration**.
+2. Under **MCP Server**, click **Select an MCP Server**.
+   - A side panel titled **Select MCP Server** opens, listing all org-level MCP proxies with their name, description, context, and version. Use the **Search MCP servers** box to filter.
+   - Select the desired proxy. The panel closes automatically.
+   - If none are listed, the panel prompts you to *"Add MCP servers from the organization MCP Proxies page first."*
+3. Click **Save**.
+
+> **Multiple environments**: If your organization has more than one environment, tabs appear above the server selector — one per environment, with the helper text *"Select which MCP server to use in each environment."* Select a server for each environment tab before saving. Tabs with no server selected are marked with a warning indicator.
+
+### Step 3: Set Environment Variable Names
+
+Selecting a server reveals the **Environment Variable Names** section, showing the two environment variables the platform will inject into the agent at runtime:
+
+| Variable Key | Default Name (example) | Description |
+|---|---|---|
+| `url` | `MY_PROXY_URL` | Base URL of the MCP server endpoint |
+| `apikey` | `MY_PROXY_API_KEY` | API key for authenticating with the MCP server endpoint |
+
+The names are auto-generated from the selected proxy's ID (uppercased, non-alphanumeric characters replaced with `_`; e.g., a proxy `my-proxy` yields `MY_PROXY_URL` and `MY_PROXY_API_KEY`). If your agent code already reads different names, edit them directly in the table.
+
+> **Note**: These names are shared across all environments — the platform injects the environment-specific URL and API key values at runtime. Edit only if your code uses different names.
+
+### Step 4: Use the Proxy in Agent Code
+
+After saving, the **Environment Variables & Integration Guide** panel opens automatically. It shows the injected variable names (editable here too) and an **Integration Guide** with a ready-to-use Python snippet that loads the MCP tools through the injected proxy URL and API key:
+
+```python
+import os
+from typing import Any
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+raw_urls = os.environ.get("MY_PROXY_URL", "")
+mcp_server_urls = [url.strip() for url in raw_urls.split(",") if url.strip()]
+mcp_api_key = os.environ.get("MY_PROXY_API_KEY", "").strip()
+
+server_configs: dict[str, dict[str, Any]] = {
+    f"mcp_server_{i}": {
+        "url": url,
+        "transport": "streamable_http",
+        "headers": {
+            "API-Key": mcp_api_key,
+            "Authorization": "",
+        },
+    }
+    for i, url in enumerate(mcp_server_urls)
+} if mcp_server_urls and mcp_api_key else {}
+
+mcp_client = MultiServerMCPClient(server_configs)
+tools = await mcp_client.get_tools()
+```
+
+The variable names in the snippet match whatever you set in Step 3. You can reopen this panel at any time from the MCP configuration detail page by clicking **Environment Variables & Integration Guide** in the top-right corner.
+
+> **Note**: Variable names are shared across all environments. If the agent is in a deployed state, the updated configuration is injected into the running pod automatically — no rebuild or redeploy is required.
+
+---
+
+## Configuring an MCP Proxy for an External Agent
+
+### Step 1: Open the Agent and Add an MCP Configuration
+
+1. Navigate to your project (**Projects** → select project → **Agents**) and open an **External** agent.
+2. In the left sidebar, click **Configure**.
+3. In the **MCP Configurations** section, click **Add MCP Configuration**.
+4. Under **MCP Server**, click **Select an MCP Server**, choose a proxy from the drawer, and click **Save**.
+
+> External agents do not show the **Environment Variable Names** section — the platform provides the connection details directly instead of injecting environment variables.
+
+### Step 2: Connect Your Agent Code to the Proxy
+
+After saving, the **Connect to MCP Server** panel opens automatically with everything needed to reach the proxy from your agent code:
+
+| Field | Description |
+|---|---|
+| **Endpoint URL** | The gateway invoke URL for this MCP proxy — use it as the server URL in your MCP client |
+| **Header Name** | The HTTP header to pass the API key (default `X-API-Key`) |
+| **API Key** | The generated client key — **copy it now**, it will not be shown again |
+| **Example cURL** | A ready-to-use cURL command combining the Endpoint URL, Header Name, and API Key |
+
+Example cURL:
+
+```bash
+curl -N <endpoint-url> \
+  --header "X-API-Key: <your-api-key>"
+```
+
+Configure your agent's MCP client using the Endpoint URL and pass the API Key in the configured header on every request.
+
+You can reopen the connection details panel at any time from the MCP configuration detail page by clicking **Connect to MCP Server** in the top-right corner. However, the API Key is only displayed once at creation time — if lost, delete the configuration and re-add it to generate a new key.
+
+---
+
+## Attaching an MCP Proxy During Agent Creation
+
+You can also attach MCP proxies while creating a new agent, without visiting the Configure page afterward.
+
+1. During agent creation, find the **MCP Proxies (Optional)** section.
+2. Click **Add**, then select a proxy from the **Select MCP Proxy** drawer (searchable, with an **Add MCP Proxy** link to register a new one).
+3. For each selected proxy, define the **URL variable name** and **API key variable name** (auto-suggested, customizable). Names must match `^[A-Za-z_][A-Za-z0-9_]*$`, be unique across the agent's configuration, and differ from each other.
+4. If the agent spans multiple environments, use the per-environment tabs to select a proxy for each environment.
+
+The proxies you attach here appear afterward as MCP configurations on the agent's **Configure** page.
+
+---
+
+## Managing MCP Configurations
+
+From the **Configure** page, the **MCP Configurations** table shows all attached configurations with:
+
+- **Name**: The configuration name (derived from the linked proxy). Click a row to open the detail page.
+- **Description**: The configuration's description.
+- **Created**: When the binding was created.
+- **Actions**: A delete icon (tooltip *"Remove MCP configuration"*) to detach the proxy. Confirm in the **Remove MCP Configuration** dialog.
+
+Use the **Search by name or description...** box to filter. Multiple configurations can be attached to a single agent, letting the agent code use different MCP servers by referencing their respective environment variable names (platform agents) or endpoint URLs and API keys (external agents).
+
+> To change the linked proxy, remove the configuration and add a new one with the desired proxy.
+
+---
+
+## Notes
+
+- MCP proxy credentials are **never exposed** to agent code directly — only the injected environment variables (platform agents) or the gateway endpoint + API key (external agents) are available at runtime.
+- For platform agents, if the agent is in a deployed state, the updated MCP configuration is injected into the running pod automatically — no rebuild or redeploy is required.
+- For external agents, the Endpoint URL routes traffic through the AI Gateway, applying any security, access control, and rewrite rules configured on the proxy.
+- The external agent API Key shown after saving is a **one-time display** — it cannot be retrieved again. If lost, delete the MCP configuration and re-add it to generate a new key.
+- Each environment uses a separate MCP server mapping; in a multi-environment organization, select a proxy per environment.

--- a/documentation/docs/tutorials/register-mcp-proxy.mdx
+++ b/documentation/docs/tutorials/register-mcp-proxy.mdx
@@ -1,0 +1,199 @@
+---
+sidebar_position: 6
+---
+
+# Register an MCP Proxy
+
+An **MCP Proxy** is an organization-level resource that fronts an upstream [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server. It connects to the upstream server's endpoint, discovers the tools, resources, and prompts it exposes, and republishes them through an AI Gateway. Once registered, an MCP proxy can be secured, access-controlled, rewritten, and attached to agents across any project in the organization.
+
+Proxying an MCP server through the platform lets you:
+
+- Authenticate clients (agents) with platform-issued API keys instead of upstream credentials.
+- Restrict which tools, resources, and prompts are visible to agents (access control).
+- Rename or remap capabilities for end users (rewrite) without changing the upstream server.
+- Apply additional gateway policies and expose a single, governed invoke URL.
+
+## Prerequisites
+
+- Admin access to the WSO2 Agent Manager Console
+- At least one AI Gateway registered and active (see [Register an AI Gateway](./register-ai-gateway.mdx))
+- A reachable upstream MCP server endpoint (e.g., `https://api.example.com/mcp`)
+- Any credential the upstream MCP server requires (e.g., an API key passed in an HTTP header)
+
+---
+
+## Step 1: Navigate to MCP Proxies
+
+1. Log in to the WSO2 Agent Manager Console (`http://localhost:3000`).
+2. Go to the Organization level by closing the projects section from the top navigation.
+3. In the left sidebar, click **MCP Proxies** under the **Resources** section.
+
+   > The MCP Proxies page lists all registered proxies with their Name, Description, Version, and Last Updated time. Use the search bar to filter by name, version, context, or status.
+
+---
+
+## Step 2: Create a Proxy from an Endpoint
+
+1. Click the **Add MCP Proxy** button. The **Create MCP Proxy from Endpoint** page opens.
+2. Under **Endpoint Details**, enter the **MCP Proxy Endpoint URL** *(required)* — the URL of the upstream MCP server you want to proxy.
+
+   | Field | Description | Example |
+   |---|---|---|
+   | **MCP Proxy Endpoint URL** *(required)* | The upstream MCP server endpoint the proxy connects to | `https://api.example.com/mcp` |
+
+3. *(Optional)* If the upstream server requires authentication, expand **Advanced Configurations** and fill in the authentication header sent to the endpoint:
+
+   | Field | Description | Example |
+   |---|---|---|
+   | **Header** | The HTTP header name used to pass the upstream credential | `Authorization` |
+   | **Value** | The credential value (hidden by default; toggle visibility with the eye icon) | `Bearer sk-...` |
+
+   > **Header** and **Value** must be provided together — supply both or neither.
+
+4. Click **Fetch Server Info**. The proxy connects to the endpoint and discovers its capabilities.
+
+   - On success, a preview panel appears on the right showing the **Tools**, **Resources**, and **Prompts** exposed by the server, each with a total count. Click **Next** to continue.
+   - If the server returns `401 Unauthorized`, the **Advanced Configurations** section opens automatically with the message *"This server requires authentication. Enter the credentials above."* Add the header and value, then fetch again.
+
+---
+
+## Step 3: Provide Proxy Details
+
+After a successful fetch, the form advances to **Proxy Details**. Several fields are pre-populated from the server info — review and adjust them.
+
+| Field | Description | Example |
+|---|---|---|
+| **Name** *(required)* | A descriptive name for the proxy (defaults to the upstream server name) | `Production Weather MCP` |
+| **Version** *(required)* | Version identifier (auto-derived from the URL or server info) | `v1.0` |
+| **Description** | Optional description of the proxy's purpose | `Weather tools for production agents` |
+| **Context** | The API path segment used to build the invoke URL (auto-set to `/default/{name}`) | `/default/weather` |
+| **Target** *(required)* | The upstream MCP server URL (pre-filled from Step 2, read-only) | `https://api.example.com/mcp` |
+| **Gateway** *(required)* | One or more **active** AI Gateways that will expose this proxy | `Production Gateway` |
+
+> If no active gateways exist, the message *"No active gateways available."* appears. Register and activate an AI Gateway first.
+
+Click **Create**. The proxy is created and you are returned to the MCP Proxies list.
+
+---
+
+## Step 4: Configure Proxy Settings
+
+Click a proxy in the list to open its detail page. The header shows the proxy name, version, context, and description (click the edit icon to rename or re-version). Configuration is organized into the tabs below. When you change a setting, an **unsaved changes** banner appears — click **Save** to persist or **Cancel** to revert.
+
+### Overview Tab
+
+Displays a summary of the proxy and lets you generate client API keys:
+
+| Field | Description |
+|---|---|
+| **Context** | The context path used in the invoke URL |
+| **Upstream URL** | The backend MCP server endpoint |
+| **Auth Type** | Authentication used toward the upstream server (e.g., `api-key`) |
+| **Access Control** | `Allow all` (default) or `Configured` |
+| **In Catalog** | Whether the proxy is published to the catalog |
+
+The **Invoke URL** section lets you:
+
+- **Gateway**: Select which AI Gateway exposes this proxy.
+- **Invoke URL**: The full URL agents use to reach the proxy through the gateway (auto-generated as `<gateway-vhost><context>/mcp`). Use the copy button to copy it.
+- **Generate API Key**: Generate (or rotate) a client API key for agents to authenticate against this proxy on the selected gateway. The key is shown only once — copy it immediately.
+
+> If the proxy has not been deployed to any gateway, the message *"No invoke URLs available. Deploy this MCP proxy to an AI gateway to see invoke URLs and generate API keys."* appears.
+
+---
+
+### Capabilities Tab
+
+Lists everything the proxy exposes, grouped into three expandable sections — **Tools**, **Resources**, and **Prompts** — each with a total count. Expand a section to browse individual items and their descriptions.
+
+---
+
+### Connection Tab
+
+Manage the upstream connection:
+
+| Field | Description | Example |
+|---|---|---|
+| **MCP Proxy Endpoint URL** *(required)* | The upstream MCP server endpoint | `https://api.example.com/mcp` |
+| **Header** | *(under Advanced Configurations)* HTTP header sent to the upstream server | `Authorization` |
+| **Value** | The credential value for that header | `Bearer sk-...` |
+
+> A stored credential is shown masked (`••••••••••••`). Leave it unchanged to keep the current credential, or enter a new value to replace it.
+
+Click **Save** to persist changes, or **Discard** to revert.
+
+---
+
+### Access Control Tab
+
+Control which capabilities are reachable through the proxy:
+
+- **Mode**: Choose `Allow all` (default – every tool, resource, and prompt is permitted) or `Deny all` (block everything except listed exceptions).
+- **Exceptions**: Tools, resources, and prompts to exclude from the selected mode. In `Allow all` mode these are denied; in `Deny all` mode these are the only items allowed. Items are grouped and color-coded by kind (Tools, Resources, Prompts).
+
+Click **Save** to apply. This is backed by the managed `mcp-acl-list` policy.
+
+> If the proxy has no capabilities, access control is unavailable. If the active gateway does not report the `mcp-acl-list` policy as available, saving is disabled.
+
+---
+
+### Security Tab
+
+Configure how clients (agents) authenticate to the proxy through the gateway:
+
+| Field | Description | Example |
+|---|---|---|
+| **Authentication** | `apiKey` (default, enabled on create) or `None` | `apiKey` |
+| **Header Key** | *(when `apiKey` is selected)* The HTTP header carrying the API key | `X-API-Key` |
+| **Key Location** | *(when `apiKey` is selected)* Where the key is passed — `header` or `query` | `header` |
+
+Click **Save** to persist.
+
+---
+
+### Rewrite Tab
+
+Customize the user-facing names of the capabilities exposed by the proxy without modifying the upstream server. Toggle **Rewrite** on to enable editing.
+
+When enabled, the left panel lists the capabilities (Tools, Resources, Prompts). Select an item to edit its presented values in the right panel:
+
+- **Tools**: Name, Description, Input Schema, and (under **Advanced**) Output Schema and **Target** (the backend tool name calls are forwarded to).
+- **Resources**: URI, Description, and (under **Advanced**) **Target** (the backend resource URI reads are forwarded to).
+- **Prompts**: Name, Description, and (under **Advanced**) **Target** (the backend prompt name requests are forwarded to).
+
+> The backend identifier is what is sent to the upstream MCP server. Rewriting the values controls only what clients see.
+
+Click **Save** to apply. This is backed by the managed `mcp-rewrite` policy.
+
+> If the active gateway does not report the `mcp-rewrite` policy as available, saving is disabled.
+
+---
+
+### Policies Tab
+
+Attach additional gateway policies beyond the managed ones (access control, security, and rewrite are managed through their dedicated tabs and do not appear here).
+
+- Click **Add Policy** to choose and configure a policy.
+- Use the edit and remove controls on each policy, and drag policies to change their execution order.
+
+---
+
+## Verifying the Proxy
+
+The registered proxy appears in the **MCP Proxies** list with its name, description, and version. From the **Overview** tab, select your active AI Gateway to see the **Invoke URL** — this is the endpoint agents use to reach the proxied MCP server through the gateway. Generate an API key and confirm the proxy responds with the expected tools, resources, and prompts on the **Capabilities** tab.
+
+---
+
+## Notes
+
+- A proxy must be deployed to at least one **active** AI Gateway before its invoke URL and API keys become available.
+- The **context** forms part of the invoke URL: `<gateway-vhost><context>/mcp`. Keep it unique per organization.
+- Upstream credentials entered on the **Connection** tab are stored securely and shown masked; they are never returned in plain text.
+- Access control (`mcp-acl-list`) and rewrite (`mcp-rewrite`) require the corresponding policy to be available on the active gateway; otherwise saving on those tabs is disabled.
+- The proxy is published using MCP specification version `2025-06-18`.
+
+---
+
+## Next Steps
+
+Once a proxy is registered, attach it to an agent so the agent can use its tools, resources, and prompts — see [Configure MCP Proxies for an Agent](./configure-agent-mcp-proxies.mdx).

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -99,9 +99,11 @@ const sidebars: SidebarsConfig = {
         'tutorials/custom-evaluators',
         'tutorials/register-ai-gateway',
         'tutorials/register-llm-service-provider',
+        'tutorials/register-mcp-proxy',
         'tutorials/secure-agent-endpoints-with-api-keys',
         'tutorials/configure-cors-for-agent-endpoints',
-        'tutorials/configure-agent-llm-configuration'
+        'tutorials/configure-agent-llm-configuration',
+        'tutorials/configure-agent-mcp-proxies'
       ],
     },
     {


### PR DESCRIPTION
Added 2 pages for mcp proxy creation and configuration with agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for registering MCP Proxies and attaching them to Platform-hosted and External agents.
  * Includes prerequisites, step-by-step configuration, proxy settings, access control, security options, and operational best practices.
  * Updated tutorial navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->