### PR TITLE
Re-create OTEL ingest RestApi until gateway matches

### DIFF
--- a/deployments/scripts/setup-gateway.sh
+++ b/deployments/scripts/setup-gateway.sh
@@ -59,10 +59,12 @@ fi
 kubectl apply -f "${SCRIPT_DIR}/../values/otel-collector-rest-api.yaml"
 
 echo "⏳ Waiting for RestApi to be programmed..."
-if kubectl wait --for=condition=Programmed restapi/amp-otel-collector-tracing-rest-api  -n openchoreo-data-plane --timeout=120s; then
+if kubectl wait --for=condition=Programmed restapi/amp-otel-collector-tracing-rest-api -n openchoreo-data-plane --timeout=300s; then
     echo "✅ RestApi is programmed"
 else
-    echo "⚠️  RestApi did not become ready in time"
+    echo "❌ RestApi amp-otel-collector-tracing-rest-api did not become Programmed in time"
+    kubectl describe restapi/amp-otel-collector-tracing-rest-api -n openchoreo-data-plane || true
+    exit 1
 fi
 
 echo ""


### PR DESCRIPTION
## Purpose

The heavy `instrumentation-matrix` tier has been failing every run (06-16 nightly `27649313637`, 06-17 manual `27669459199`) with `captured 0 span(s)` → `❌ fail (collector-not-received)`. The root cause is in stack setup, not in the test harness or the trace-query path.

During `make setup-gateway`, the `amp-otel-collector-tracing-rest-api` gateway route (the collector's OTLP tracing ingest endpoint) can take ~5 min to become `Programmed` — in the failing run it was created at 06:18:43 and the gateway only logged `Configuration deployed successfully` for it at 06:23:34. `setup-gateway.sh` waited only `120s`, then printed `⚠️ RestApi did not become ready in time` and continued exit-0. So setup reported success while the ingest path was not yet wired up; the heavy cell then exported spans into a dead endpoint and recorded the misleading `collector-not-received` category instead of a setup failure pointing at the real boundary.

## Goals

Make the OTEL ingest RestApi wait both long enough for the observed programming latency and fail-fast when the route genuinely never programs, so the failure surfaces at the correct boundary (stack setup) rather than as a misleading test-tier result.

## Approach

In `deployments/scripts/setup-gateway.sh`:
- Bump the `kubectl wait --for=condition=Programmed` timeout for `amp-otel-collector-tracing-rest-api` from `120s` to `300s` to cover the ~5 min programming latency seen in CI.
- On timeout, `kubectl describe` the RestApi and `exit 1` instead of warning and continuing, so a broken ingest route fails setup loudly.

Note: `deployments/quick-start/install.sh` has the same soft-wait pattern for released-image installs; left out of scope here since it's a separate path, but it carries the same latent defect.

## User stories

N/A — CI/infra reliability fix.

## Release note

Fix heavy instrumentation-matrix flakiness by waiting longer for, and hard-failing on, the OTEL collector tracing ingest RestApi during gateway setup.

## Documentation

N/A — no user-facing or product behavior change; internal dev-stack setup script only.

## Training

N/A

## Certification

N/A — no impact on certification exams; internal CI setup script change.

## Marketing

N/A

## Automation tests
 - Unit tests
   > N/A — shell setup script; change verified with `bash -n` syntax check.
 - Integration tests
   > Validation is the heavy instrumentation-matrix tier itself: with the route given time to program (or a hard failure when it does not), the `collector-not-received` false negative should no longer occur.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell script change, plugin not applicable
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

GitHub Actions `ubuntu` runners, k3d-based dev stack (the matrix `amp-dev-stack` action).

## Learning

Diagnosed from the matrix run logs: the `RestApi did not become ready in time` warning during setup correlated with the gateway programming the route ~3 min after the wait gave up, and gateway port 22893 reading `000` at diagnostics time — confirming an ingest-path timing issue rather than a regression in the read/query path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment setup reliability by extending initialization timeout and enhancing error handling to fail explicitly with diagnostic information rather than silently continuing on startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->