### PR TITLE
Bind OTEL ingest route via chart, drop dead manual apply

### DIFF
--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-otel-restapi.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-otel-restapi.yaml
@@ -31,6 +31,7 @@ spec:
           component_uid: x-user-component
           environment_uid: x-user-environment
           project_uid: x-user-project
+          namespace: x-user-namespace
   operations:
     - method: POST
       path: /v1/traces

--- a/deployments/scripts/setup-gateway.sh
+++ b/deployments/scripts/setup-gateway.sh
@@ -56,14 +56,20 @@ else
     echo "⚠️  Gateway did not become ready in time"
 fi
 
-kubectl apply -f "${SCRIPT_DIR}/../values/otel-collector-rest-api.yaml"
+# The OTEL ingest RestApi is provisioned by the gateway extension chart
+# (templates/gateway-otel-restapi.yaml) with the restapi-target label that
+# binds it to this gateway. Wait for that chart-managed route to program; it
+# carries the jwt-auth claim mappings agents need to export traces. (The
+# standalone values/otel-collector-rest-api.yaml is not applied here: it lacks
+# the restapi-target label, so it can never bind and stays GatewayNotReady.)
+OTEL_RESTAPI="api-platform-${ORG_NAME}-${ENV_NAME}-otel-restapi"
 
-echo "⏳ Waiting for RestApi to be programmed..."
-if kubectl wait --for=condition=Programmed restapi/amp-otel-collector-tracing-rest-api -n openchoreo-data-plane --timeout=300s; then
-    echo "✅ RestApi is programmed"
+echo "⏳ Waiting for OTEL ingest RestApi to be programmed..."
+if kubectl wait --for=condition=Programmed "restapi/${OTEL_RESTAPI}" -n openchoreo-data-plane --timeout=300s; then
+    echo "✅ OTEL ingest RestApi is programmed"
 else
-    echo "❌ RestApi amp-otel-collector-tracing-rest-api did not become Programmed in time"
-    kubectl describe restapi/amp-otel-collector-tracing-rest-api -n openchoreo-data-plane || true
+    echo "❌ RestApi ${OTEL_RESTAPI} did not become Programmed in time"
+    kubectl describe "restapi/${OTEL_RESTAPI}" -n openchoreo-data-plane || true
     exit 1
 fi
 


### PR DESCRIPTION
## Purpose

Follow-up to #1098. That PR turned the `setup-gateway.sh` wait on the OTEL ingest RestApi into a hard `exit 1`, which exposed — and then made fatal — a pre-existing bug: `setup-gateway` now fails on **every** run, taking the heavy instrumentation-matrix tier down at stack setup (e.g. run `27671208169`).

Root cause: `setup-gateway.sh` applied the standalone `deployments/values/otel-collector-rest-api.yaml` and waited for it to become `Programmed`. That manifest has **no `gateway.api-platform.wso2.com/restapi-target` label**, so the gateway-extension controller can never match it to a gateway — it stays `GatewayNotReady` ("No matching gateway available") indefinitely and is never requeued. Reproduced locally: the resource sat `GatewayNotReady` for 29 minutes, and a delete+recreate did not recover it. Before #1098 this was a harmless soft warning; with the hard fail it became a guaranteed setup failure.

The gateway extension chart already provisions the real ingest route (`templates/gateway-otel-restapi.yaml`) as `api-platform-<org>-<env>-otel-restapi`, correctly labeled with `restapi-target` and reliably `Programmed`. So the standalone apply in `setup-gateway.sh` was redundant *and* broken.

While investigating I also found the `namespace` trace-enrichment fix from `3eee076b` ("introduce missing namespace attribute for traces from choreo v1.1.1") was added only to the standalone manifest. On chart-based installs (the dev stack and the matrix), the agent JWT's `namespace` claim was therefore never mapped to the `x-user-namespace` header the collector's pipeline reads — the enrichment has been silently dead since that commit.

## Goals

Make `setup-gateway` gate on the RestApi that can actually program, and make the `namespace` enrichment take effect on chart-based installs.

## Approach

- `deployments/scripts/setup-gateway.sh`: stop applying the unlabeled standalone manifest; wait on the chart-managed `api-platform-${ORG_NAME}-${ENV_NAME}-otel-restapi` route's `Programmed` condition instead (keeping the hard fail + `kubectl describe` dump from #1098, now pointed at a route that genuinely programs).
- `deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-otel-restapi.yaml`: add `namespace: x-user-namespace` to the jwt-auth `claimMappings`, matching what `3eee076b` added to the standalone manifest.

The standalone `deployments/values/otel-collector-rest-api.yaml` is intentionally left in place — it is referenced by the documented manual-install guides and already carries the namespace mapping. Removing it is a separate, docs-coordinated cleanup.

## User stories

N/A — CI/infra reliability and a latent enrichment bug.

## Release note

Fix `setup-gateway` always failing on the OTEL ingest RestApi wait, and restore the `namespace` trace attribute on chart-based installs.

## Documentation

N/A — no behavior change to documented manual-install steps; the standalone manifest they reference is unchanged.

## Training

N/A

## Certification

N/A — internal setup script and helm template change.

## Marketing

N/A

## Automation tests
 - Unit tests
   > N/A — shell + helm template change. Verified with `bash -n` and `helm template --show-only`.
 - Integration tests
   > Validated on a local k3d dev stack: reproduced the standalone RestApi stuck `GatewayNotReady`; confirmed the chart route `api-platform-default-default-otel-restapi` is `Programmed`; and confirmed the controller accepts the added `namespace` claim mapping while keeping the route `Programmed`. End-to-end validation is the heavy instrumentation-matrix tier.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell/helm change, plugin not applicable
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Follow-up to #1098. Completes the `namespace` enrichment started in 3eee076b.

## Migrations (if applicable)

N/A

## Test environment

Local k3d (`k3d-openchoreo-local-setup`) dev stack; GitHub Actions `ubuntu` runners (instrumentation-matrix `amp-dev-stack`).

## Learning

The describe dump added in #1098 was what surfaced the real condition (`GatewayNotReady` / "No matching gateway available"), and comparing the stuck RestApi against the chart-provisioned one revealed the missing `restapi-target` label — which also led to finding the orphaned `namespace` claim mapping.