### PR TITLE
Add duplicate action for monitors

### DIFF
--- a/console/workspaces/pages/eval/src/CreateMonitor.Component.tsx
+++ b/console/workspaces/pages/eval/src/CreateMonitor.Component.tsx
@@ -17,14 +17,18 @@
  */
 
 import React, { useCallback, useMemo } from "react";
-import { generatePath, useNavigate, useParams } from "react-router-dom";
+import { generatePath, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
   absoluteRouteMap,
   type CreateMonitorRequest,
 } from "@agent-management-platform/types";
-import { useCreateMonitor } from "@agent-management-platform/api-client";
+import { useCreateMonitor, useGetMonitor } from "@agent-management-platform/api-client";
+import { Alert, Skeleton, Stack } from "@wso2/oxygen-ui";
+import { PageLayout } from "@agent-management-platform/views";
+import { getErrorMessage } from "@agent-management-platform/shared-component";
 import { type CreateMonitorFormValues } from "./form/schema";
 import { MonitorFormWizard } from "./subComponents/MonitorFormWizard";
+import { slugifyMonitorName } from "./utils/monitorFormUtils";
 
 export const CreateMonitorComponent: React.FC = () => {
   const { agentId, orgId, projectId, envId } = useParams<{
@@ -34,6 +38,8 @@ export const CreateMonitorComponent: React.FC = () => {
     envId: string;
   }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const duplicateFrom = searchParams.get("duplicateFrom") ?? undefined;
 
   const {
     mutate: createMonitor,
@@ -45,14 +51,45 @@ export const CreateMonitorComponent: React.FC = () => {
     agentName: agentId,
   });
 
+  const {
+    data: sourceMonitor,
+    isLoading: isLoadingSource,
+    error: sourceError,
+  } = useGetMonitor({
+    monitorName: duplicateFrom ?? "",
+    orgName: orgId ?? "",
+    projName: projectId ?? "",
+    agentName: agentId ?? "",
+  });
+
   const defaultTimeRange = useMemo(() => {
     const end = new Date();
     const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
     return { start, end };
   }, []);
 
-  const initialValues = useMemo<CreateMonitorFormValues>(
-    () => ({
+  const initialValues = useMemo<CreateMonitorFormValues>(() => {
+    if (duplicateFrom && sourceMonitor) {
+      const displayName = `${sourceMonitor.displayName} (Copy)`;
+      const samplingRatePercent =
+        sourceMonitor.samplingRate !== undefined
+          ? Math.min(100, Math.max(0, Math.round(sourceMonitor.samplingRate * 100)))
+          : 25;
+      return {
+        displayName,
+        name: slugifyMonitorName(displayName),
+        description: sourceMonitor.description ?? "",
+        type: sourceMonitor.type,
+        traceStart: sourceMonitor.traceStart ? new Date(sourceMonitor.traceStart) : null,
+        traceEnd: sourceMonitor.traceEnd ? new Date(sourceMonitor.traceEnd) : null,
+        intervalMinutes: sourceMonitor.intervalMinutes ?? undefined,
+        samplingRate: samplingRatePercent,
+        evaluators: sourceMonitor.evaluators ?? [],
+        // llmProvider intentionally omitted — user must select/create a new provider
+      };
+    }
+
+    return {
       displayName: "",
       name: "",
       description: "",
@@ -62,9 +99,8 @@ export const CreateMonitorComponent: React.FC = () => {
       intervalMinutes: 60,
       samplingRate: 25,
       evaluators: [],
-    }),
-    [defaultTimeRange],
-  );
+    };
+  }, [duplicateFrom, sourceMonitor, defaultTimeRange]);
 
   const missingParamsMessage = useMemo(() => {
     if (!orgId) return "Organization is required to create a monitor.";
@@ -73,6 +109,7 @@ export const CreateMonitorComponent: React.FC = () => {
     if (!envId) return "Select an environment before creating a monitor.";
     return null;
   }, [agentId, orgId, projectId, envId]);
+
   const backHref = useMemo(() => {
     if (!orgId || !projectId || !agentId || !envId) {
       return "#";
@@ -115,9 +152,47 @@ export const CreateMonitorComponent: React.FC = () => {
     [agentId, backHref, createMonitor, envId, navigate, orgId, projectId],
   );
 
+  const title = duplicateFrom && sourceMonitor
+    ? `Duplicate "${sourceMonitor.displayName}"`
+    : "Create Monitor";
+
+  const description = duplicateFrom && sourceMonitor
+    ? `Pre-filled from "${sourceMonitor.displayName}". Make your changes and submit to create a new monitor.`
+    : undefined;
+
+  if (duplicateFrom && isLoadingSource) {
+    return (
+      <PageLayout
+        title="Create Monitor"
+        disableIcon
+        backLabel="Back to Monitors"
+        backHref={backHref}
+      >
+        <Stack spacing={3}>
+          <Skeleton variant="rounded" height={60} />
+          <Skeleton variant="rounded" height={360} />
+        </Stack>
+      </PageLayout>
+    );
+  }
+
+  if (duplicateFrom && sourceError) {
+    return (
+      <PageLayout
+        title="Create Monitor"
+        disableIcon
+        backLabel="Back to Monitors"
+        backHref={backHref}
+      >
+        <Alert severity="error">{getErrorMessage(sourceError)}</Alert>
+      </PageLayout>
+    );
+  }
+
   return (
     <MonitorFormWizard
-      title="Create Monitor"
+      title={title}
+      description={description}
       backHref={backHref}
       submitLabel="Create Monitor"
       initialValues={initialValues}

--- a/console/workspaces/pages/eval/src/CreateMonitor.Component.tsx
+++ b/console/workspaces/pages/eval/src/CreateMonitor.Component.tsx
@@ -22,10 +22,16 @@ import {
   absoluteRouteMap,
   type CreateMonitorRequest,
 } from "@agent-management-platform/types";
-import { useCreateMonitor, useGetMonitor } from "@agent-management-platform/api-client";
+import {
+  useCreateMonitor,
+  useGetMonitor,
+} from "@agent-management-platform/api-client";
 import { Alert, Skeleton, Stack } from "@wso2/oxygen-ui";
 import { PageLayout } from "@agent-management-platform/views";
-import { getErrorMessage } from "@agent-management-platform/shared-component";
+import {
+  getErrorMessage,
+  usePipelineEnvironments,
+} from "@agent-management-platform/shared-component";
 import { type CreateMonitorFormValues } from "./form/schema";
 import { MonitorFormWizard } from "./subComponents/MonitorFormWizard";
 import { slugifyMonitorName } from "./utils/monitorFormUtils";
@@ -62,6 +68,8 @@ export const CreateMonitorComponent: React.FC = () => {
     agentName: agentId ?? "",
   });
 
+  const environments = usePipelineEnvironments(orgId, projectId);
+
   const defaultTimeRange = useMemo(() => {
     const end = new Date();
     const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
@@ -79,6 +87,7 @@ export const CreateMonitorComponent: React.FC = () => {
         displayName,
         name: slugifyMonitorName(displayName),
         description: sourceMonitor.description ?? "",
+        environmentName: sourceMonitor.environmentName,
         type: sourceMonitor.type,
         traceStart: sourceMonitor.traceStart ? new Date(sourceMonitor.traceStart) : null,
         traceEnd: sourceMonitor.traceEnd ? new Date(sourceMonitor.traceEnd) : null,
@@ -93,6 +102,7 @@ export const CreateMonitorComponent: React.FC = () => {
       displayName: "",
       name: "",
       description: "",
+      environmentName: envId ?? "",
       type: "past",
       traceStart: defaultTimeRange.start,
       traceEnd: defaultTimeRange.end,
@@ -100,7 +110,7 @@ export const CreateMonitorComponent: React.FC = () => {
       samplingRate: 25,
       evaluators: [],
     };
-  }, [duplicateFrom, sourceMonitor, defaultTimeRange]);
+  }, [duplicateFrom, sourceMonitor, defaultTimeRange, envId]);
 
   const missingParamsMessage = useMemo(() => {
     if (!orgId) return "Organization is required to create a monitor.";
@@ -131,7 +141,7 @@ export const CreateMonitorComponent: React.FC = () => {
         name: values.name.trim(),
         displayName: values.displayName.trim(),
         description: values.description?.trim() || undefined,
-        environmentName: envId,
+        environmentName: values.environmentName,
         evaluators: values.evaluators,
         llmProvider: values.llmProvider,
         type: values.type,
@@ -145,11 +155,25 @@ export const CreateMonitorComponent: React.FC = () => {
 
       createMonitor(payload, {
         onSuccess: () => {
-          navigate(backHref);
+          // Land on the monitor list for whichever environment it was actually
+          // created in, which may differ from the page's originating envId.
+          navigate(
+            generatePath(
+              absoluteRouteMap.children.org.children.projects.children.agents
+                .children.environment.children.evaluation.children.monitor
+                .path,
+              {
+                orgId,
+                projectId,
+                agentId,
+                envId: values.environmentName,
+              },
+            ),
+          );
         },
       });
     },
-    [agentId, backHref, createMonitor, envId, navigate, orgId, projectId],
+    [agentId, createMonitor, envId, navigate, orgId, projectId],
   );
 
   const title = duplicateFrom && sourceMonitor
@@ -200,6 +224,7 @@ export const CreateMonitorComponent: React.FC = () => {
       isSubmitting={isPending}
       serverError={error}
       missingParamsMessage={missingParamsMessage}
+      environments={environments}
     />
   );
 };

--- a/console/workspaces/pages/eval/src/EditMonitor.Component.tsx
+++ b/console/workspaces/pages/eval/src/EditMonitor.Component.tsx
@@ -98,6 +98,7 @@ export const EditMonitorComponent: React.FC = () => {
       displayName: monitorData.displayName ?? "",
       name: monitorData.name,
       description: "",
+      environmentName: monitorData.environmentName,
       type: monitorData.type,
       traceStart: toDate(monitorData.traceStart),
       traceEnd: toDate(monitorData.traceEnd),

--- a/console/workspaces/pages/eval/src/form/schema.ts
+++ b/console/workspaces/pages/eval/src/form/schema.ts
@@ -53,6 +53,7 @@ export const createMonitorSchema = z
       .trim()
       .max(512, "Description cannot exceed 512 characters")
       .optional(),
+    environmentName: z.string().trim().min(1, "Environment is required"),
     type: z.enum(["past", "future"]) as z.ZodType<MonitorType>,
     traceStart: z.date().nullable().optional(),
     traceEnd: z.date().nullable().optional(),

--- a/console/workspaces/pages/eval/src/subComponents/CreateMonitorForm.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/CreateMonitorForm.tsx
@@ -21,6 +21,8 @@ import {
   Collapse,
   DatePickers,
   Form,
+  MenuItem,
+  Select,
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
@@ -29,11 +31,17 @@ import type { MonitorType } from "@agent-management-platform/types";
 import type { CreateMonitorFormValues } from "../form/schema";
 import { getMonitorTypeFieldPatch } from "../utils/monitorFormUtils";
 
+export interface EnvironmentOption {
+  name: string;
+  displayName?: string;
+}
+
 interface CreateMonitorFormProps {
   formData: CreateMonitorFormValues;
   errors: Partial<Record<keyof CreateMonitorFormValues, string | undefined>>;
   onFieldChange: (field: keyof CreateMonitorFormValues, value: unknown) => void;
   isTypeEditable?: boolean;
+  environments?: EnvironmentOption[];
 }
 
 export function CreateMonitorForm({
@@ -41,6 +49,7 @@ export function CreateMonitorForm({
   errors,
   onFieldChange,
   isTypeEditable = true,
+  environments = [],
 }: CreateMonitorFormProps) {
   const handleTypeChange = (nextType: MonitorType) => {
     if (!isTypeEditable || formData.type === nextType) {
@@ -88,6 +97,30 @@ export function CreateMonitorForm({
             helperText={errors.description}
           />
         </Form.ElementWrapper>
+        {environments.length > 1 && (
+          <Form.ElementWrapper name="environmentName" label="Environment">
+            <Select
+              id="environmentName"
+              fullWidth
+              value={formData.environmentName ?? ""}
+              onChange={(event) =>
+                onFieldChange("environmentName", event.target.value)
+              }
+              error={!!errors.environmentName}
+            >
+              {environments.map((env) => (
+                <MenuItem key={env.name} value={env.name}>
+                  {env.displayName ?? env.name}
+                </MenuItem>
+              ))}
+            </Select>
+            {errors.environmentName && (
+              <Typography variant="caption" color="error">
+                {errors.environmentName}
+              </Typography>
+            )}
+          </Form.ElementWrapper>
+        )}
       </Form.Section>
       <Form.Section>
         <Form.Header>Data Collection</Form.Header>

--- a/console/workspaces/pages/eval/src/subComponents/MonitorFormWizard.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/MonitorFormWizard.tsx
@@ -25,7 +25,7 @@ import {
   type CreateMonitorFormValues,
 } from "../form/schema";
 import type { EvaluatorResponse } from "@agent-management-platform/types";
-import { CreateMonitorForm } from "./CreateMonitorForm";
+import { CreateMonitorForm, type EnvironmentOption } from "./CreateMonitorForm";
 import { SelectPresetMonitors } from "./SelectPresetMonitors";
 import { slugifyMonitorName } from "../utils/monitorFormUtils";
 import { useValidatedForm } from "../hooks/useValidatedForm";
@@ -42,6 +42,7 @@ interface MonitorFormWizardProps {
   missingParamsMessage?: string | null;
   backLabel?: string;
   isTypeEditable?: boolean;
+  environments?: EnvironmentOption[];
 }
 
 export function MonitorFormWizard({
@@ -56,6 +57,7 @@ export function MonitorFormWizard({
   missingParamsMessage,
   backLabel = "Back to Monitors",
   isTypeEditable = true,
+  environments = [],
 }: MonitorFormWizardProps) {
   const [page, setPage] = useState<1 | 2>(1);
   const [formData, setFormData] =
@@ -277,6 +279,7 @@ export function MonitorFormWizard({
             errors={errors}
             onFieldChange={handleFieldChange}
             isTypeEditable={isTypeEditable}
+            environments={environments}
           />
         )}
 

--- a/console/workspaces/pages/eval/src/subComponents/MonitorTable.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/MonitorTable.tsx
@@ -33,6 +33,7 @@ import {
   Monitor,
   AlertTriangle,
   Edit,
+  Copy,
 } from "@wso2/oxygen-ui-icons-react";
 import { useConfirmationDialog } from "@agent-management-platform/shared-component";
 import { generatePath, useNavigate, useParams } from "react-router-dom";
@@ -292,6 +293,24 @@ export function MonitorTable() {
                   >
                     <Edit size={16} />
                   </IconButton>
+                  <Tooltip title="Duplicate">
+                    <IconButton
+                      aria-label={`Duplicate monitor ${monitor.displayName}`}
+                      onClick={() =>
+                        navigate({
+                          pathname: generatePath(
+                            absoluteRouteMap.children.org.children.projects
+                              .children.agents.children.environment.children
+                              .evaluation.children.monitor.children.create.path,
+                            { agentId, orgId, projectId, envId },
+                          ),
+                          search: `?duplicateFrom=${encodeURIComponent(monitor.name)}`,
+                        })
+                      }
+                    >
+                      <Copy size={16} />
+                    </IconButton>
+                  </Tooltip>
                   <Tooltip title="Delete Monitor">
                     <IconButton
                       color="error"


### PR DESCRIPTION
## Summary
- Adds a "Duplicate" icon button to the monitor list row actions, next to Edit/Delete.
- Clicking it opens the existing Create Monitor wizard, pre-filled with the source monitor's settings (display name, description, type, trace window/interval, sampling rate, evaluators).
- The LLM provider reference is intentionally **not** carried over — the user must select or create a new provider for the duplicate, so no provider credentials/ids are reused.
- No backend or API changes: this reuses the existing get-monitor and create-monitor endpoints/hooks.

Closes #1100

## Test plan
- [x] Build/lint pass (`rush build`, `eslint`) for the eval package
- [x] From the monitor list, click Duplicate on an existing monitor and confirm the wizard opens with title `Duplicate "<name>"` and fields pre-filled
- [x] Confirm the LLM Provider selection is empty even if the source monitor had one, and that submitting without picking one is blocked when an LLM-judge evaluator is selected (same validation as normal create)
- [x] Submit and confirm a new, independent monitor is created without modifying the original
- [x] Navigate to the create route without `duplicateFrom` and confirm normal create flow is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate monitor capability: Users can duplicate existing monitors via a new **Duplicate** button in the monitor list.
  * Duplicated monitors open a pre-filled creation wizard (including details like schedule, evaluators, description, and sampling rate) for faster setup.
* **Enhancements**
  * Monitor creation now includes environment selection when multiple environments are available.
* **Bug Fixes**
  * Environment is correctly pre-populated when editing and used during creation navigation for the selected environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->