### PR TITLE
Coerce stringified numeric attributes in heavy tier

### DIFF
--- a/test/instrumentation-matrix/harness/validator.py
+++ b/test/instrumentation-matrix/harness/validator.py
@@ -16,6 +16,60 @@ _HERE = Path(__file__).resolve().parent.parent
 _CONTRACTS = _HERE / "contracts"
 
 
+def _str_to_number(value: str, *, integer_only: bool) -> int | float | None:
+    """Parse a numeric string to int/float, or None if it isn't numeric.
+
+    integer_only rejects non-integral values (e.g. "1.5" for an integer field)
+    so a genuine type mismatch still surfaces rather than being silently fixed.
+    """
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f.is_integer():
+        return int(f)
+    return None if integer_only else f
+
+
+def _coerce_numeric_attributes(
+    span: dict[str, Any], schema: dict[str, Any]
+) -> dict[str, Any]:
+    """Return a copy of *span* with string attribute values coerced to int/float
+    for the attributes the kind schema declares as number/integer.
+
+    Only schema-declared numeric attributes are touched — a string-typed
+    attribute that happens to hold "1" (an id, or literal content) is left
+    alone. Returns the span unchanged when there is nothing to coerce.
+    """
+    attr_props = (
+        schema.get("properties", {}).get("attributes", {}).get("properties", {})
+    )
+    attrs = span.get("attributes")
+    if not attr_props or not isinstance(attrs, dict):
+        return span
+
+    coerced: dict[str, Any] | None = None
+    for key, spec in attr_props.items():
+        declared = spec.get("type")
+        types = declared if isinstance(declared, list) else [declared]
+        if "number" not in types and "integer" not in types:
+            continue
+        value = attrs.get(key)
+        if not isinstance(value, str):
+            continue
+        integer_only = "integer" in types and "number" not in types
+        num = _str_to_number(value, integer_only=integer_only)
+        if num is None:
+            continue
+        if coerced is None:
+            coerced = dict(attrs)
+        coerced[key] = num
+
+    if coerced is None:
+        return span
+    return {**span, "attributes": coerced}
+
+
 @dataclass
 class ValidationResult:
     ok: bool
@@ -50,7 +104,9 @@ class ContractValidator:
             raise FileNotFoundError(f"no schemas under {bundle_dir}")
         return cls(schema_id, validators)
 
-    def validate(self, span: dict[str, Any], kind: str) -> ValidationResult:
+    def validate(
+        self, span: dict[str, Any], kind: str, *, coerce_numeric: bool = False
+    ) -> ValidationResult:
         validator = self._validators.get(kind)
         if validator is None:
             return ValidationResult(
@@ -59,6 +115,14 @@ class ContractValidator:
                 kind=kind,
                 message=f"no schema for kind '{kind}' in bundle {self.schema_id}",
             )
+        # Heavy tier reads spans back through the observer/OpenSearch round-trip,
+        # which returns every attribute value as a string. Coerce the
+        # schema-declared numeric attributes back to numbers before validating
+        # so the round-trip's stringification isn't reported as a type error.
+        # Off by default → the emission tier stays strict and still catches
+        # genuine instrumentation stringification (see FINDINGS F-001).
+        if coerce_numeric:
+            span = _coerce_numeric_attributes(span, validator.schema)
         errors = sorted(validator.iter_errors(span), key=lambda e: list(e.path))
         if not errors:
             return ValidationResult(ok=True, span_name=span.get("name", "?"), kind=kind)
@@ -71,8 +135,13 @@ class ContractValidator:
             path="/" + "/".join(str(p) for p in e.absolute_path),
         )
 
-    def validate_all(self, spans: list[dict[str, Any]]) -> list[ValidationResult]:
-        return [self.validate(s, classify_span(s)) for s in spans]
+    def validate_all(
+        self, spans: list[dict[str, Any]], *, coerce_numeric: bool = False
+    ) -> list[ValidationResult]:
+        return [
+            self.validate(s, classify_span(s), coerce_numeric=coerce_numeric)
+            for s in spans
+        ]
 
     def validate_resource(self, resource: dict[str, Any]) -> ValidationResult:
         path = _CONTRACTS / self.schema_id / "resource.schema.json"

--- a/test/instrumentation-matrix/heavy/driver.py
+++ b/test/instrumentation-matrix/heavy/driver.py
@@ -260,7 +260,11 @@ def _run_cell(
     provider = PROVIDERS[cell.provider_name]
     validator = ContractValidator.load(provider.contract_schema_id())
     coverage = validator.assert_coverage(spans, expected_kinds=expected)
-    shape_results = validator.validate_all(spans)
+    # Heavy spans round-trip through the observer/OpenSearch, which returns
+    # numeric attributes as strings; coerce the schema-declared numeric
+    # attributes back before shape-validating. The emission tier validates
+    # native-typed cassette spans and stays strict (coerce_numeric=False).
+    shape_results = validator.validate_all(spans, coerce_numeric=True)
     violations = [
         {
             "spanName": r.span_name,

--- a/test/instrumentation-matrix/tests/test_validator.py
+++ b/test/instrumentation-matrix/tests/test_validator.py
@@ -268,3 +268,51 @@ def test_assert_coverage_counts_tool_event_as_tool_kind():
     cov = v.assert_coverage([llm_span_with_tool_event], expected_kinds=["llm", "tool"])
     assert cov.ok is True
     assert "tool" in cov.actual
+
+
+# ---------- Heavy-tier numeric coercion (observer/OpenSearch round-trip) ----------
+
+
+def test_heavy_round_trip_stringifies_numbers_fails_without_coercion():
+    # The observer returns numeric attributes as strings; without coercion the
+    # heavy tier sees a type error — exactly the matrix's "'1' is not of type
+    # 'number'" / "'301' is not of type 'integer'" failures.
+    v = ContractValidator.load("traceloop/v1")
+    span = _llm_span(
+        extra={
+            "gen_ai.usage.input_tokens": "301",
+            "gen_ai.usage.output_tokens": "12",
+            "gen_ai.request.temperature": "1",
+        }
+    )
+    assert not v.validate(span, kind="llm").ok
+
+
+def test_heavy_coercion_accepts_stringified_numbers():
+    v = ContractValidator.load("traceloop/v1")
+    span = _llm_span(
+        extra={
+            "gen_ai.usage.input_tokens": "301",
+            "gen_ai.usage.output_tokens": "12",
+            "gen_ai.request.temperature": "1",
+        }
+    )
+    assert v.validate(span, kind="llm", coerce_numeric=True).ok
+
+
+def test_heavy_coercion_only_touches_schema_numeric_attributes():
+    # A string-typed attribute holding digits (here the model name) must NOT be
+    # coerced — coercion is schema-driven, not value-shape-driven.
+    v = ContractValidator.load("traceloop/v1")
+    span = _llm_span(extra={"gen_ai.request.model": "123"})
+    r = v.validate(span, kind="llm", coerce_numeric=True)
+    assert r.ok
+    assert span["attributes"]["gen_ai.request.model"] == "123"
+
+
+def test_heavy_coercion_preserves_genuine_integer_type_error():
+    # A non-integral value for an integer field is a real mismatch and must
+    # still fail even with coercion enabled.
+    v = ContractValidator.load("traceloop/v1")
+    span = _llm_span(extra={"gen_ai.usage.input_tokens": "1.5"})
+    assert not v.validate(span, kind="llm", coerce_numeric=True).ok


### PR DESCRIPTION
## Purpose

Follow-up to #1099. With the OTEL ingest path fixed, the heavy instrumentation-matrix tier finally received spans (`captured 8 span(s)` on every cell) and then failed all 8 with `'1' is not of type 'number'` and `'301' is not of type 'integer'`.

Root cause is the observer read path, not the harness or the trace-export change. OpenSearch stores span attributes with native types (verified directly: `gen_ai.request.temperature => 1` int, `data_stream => {object}`), but the upstream OpenChoreo observer returns every attribute value as a string (the tell-tale being `data_stream` surfacing as the Go-`fmt` string `"map[dataset:default namespace:namespace type:span]"`), and `traces-observer-service` passes them through. So the heavy tier validates `temperature="1"` and token counts `="301"` against contracts that correctly declare those fields numeric.

This only affects consumers that read the **raw** attribute map and expect native types — the heavy contract validation (here) and the UI (cosmetic). The evaluation pipeline is unaffected: it reads the enriched `AmpAttributes`, whose extractors already coerce string→number (`extractIntValue` / `extractFloatValue` have explicit string cases).

## Goals

Get the heavy tier green against the real observer round-trip without weakening the emission tier's strict type checks.

## Approach

- `harness/validator.py`: add an opt-in `coerce_numeric` flag to `validate` / `validate_all`. When set, string attribute values are parsed back to int/float **only for attributes the kind schema declares `number`/`integer`** (`_coerce_numeric_attributes`). The coercion is narrow by design: string-typed attributes are never touched (an id or literal `"1"` stays a string), and a non-integral value for an integer field still fails so genuine type errors surface.
- `heavy/driver.py`: enable `coerce_numeric=True` for heavy shape validation.
- The emission tier (`harness/test_cell.py`) is untouched — it validates native-typed cassette spans and stays strict, so it still catches genuine instrumentation stringification (see FINDINGS F-001).
- Tests: added cases for fail-without-coercion, pass-with-coercion, schema-only scope (digit-valued string field not coerced), and preserved integer type error.

This is a stopgap for the matrix. The underlying fix belongs in the OpenChoreo observer, which should preserve attribute types in its span responses (it also affects the UI and any raw-attribute consumer).

## User stories

N/A — test-harness reliability fix.

## Release note

Heavy instrumentation-matrix tier coerces the observer's stringified numeric span attributes before contract validation; emission tier remains strict.

## Documentation

N/A — internal test harness.

## Training

N/A

## Certification

N/A — internal test harness change.

## Marketing

N/A

## Automation tests
 - Unit tests
   > `tests/test_validator.py` — 4 new cases (fail without coercion, pass with coercion, schema-scoped coercion, preserved integer error). Full unit suite green (`pytest tests/`).
 - Integration tests
   > End-to-end validation is the heavy tier itself; the prior run showed all 8 cells capturing spans and failing only on these numeric type mismatches, which this addresses.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Python test-harness change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Follow-up to #1099 (OTEL ingest route binding). Both stem from triaging the heavy-tier `collector-not-received` failure.

## Migrations (if applicable)

N/A

## Test environment

Local: `test/instrumentation-matrix/.venv` (Python 3.13, pytest + jsonschema). Diagnosed against the local k3d dev stack and the heavy-tier run artifact.

## Learning

The `violations` block in the heavy run artifact pinned the exact attributes (`/attributes/gen_ai.request.temperature`, `/attributes/gen_ai.usage.input_tokens`), and a direct OpenSearch `_source` query plus the upstream-observer `MISSING_TOKEN` boundary isolated the stringification to the OpenChoreo observer rather than storage or this repo.