### PR TITLE
Pin VM install docs to the release tag

### DIFF
--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -43,14 +43,15 @@ SSH into the VM, get the installer, and run it with `sudo`:
 # on the VM
 git clone https://github.com/wso2/agent-manager.git
 cd agent-manager/deployments/vm
+git checkout tags/amp/v0.0.0-dev
 
 sudo ./install-vm.sh \
   --host <VM_PUBLIC_IP> \
-  --version <amp-release> \
+  --version 0.0.0-dev \
   --email you@example.com
 ```
 
-Pass `--host` the VM's **public** IPv4 address — a cloud VM usually can't read its own public IP (it's NAT'd behind the address you used to SSH in), so the installer needs it to build the `*.amp.<IP>.sslip.io` hostnames. Set `--version` to the Agent Manager release you want (an existing `amp/v*` [tag](https://github.com/wso2/agent-manager/tags), e.g. `0.16.0`).
+Pass `--host` the VM's **public** IPv4 address — a cloud VM usually can't read its own public IP (it's NAT'd behind the address you used to SSH in), so the installer needs it to build the `*.amp.<IP>.sslip.io` hostnames.
 
 The installer runs in two phases — bootstrap (Docker + tools + firewall) and the platform install + Caddy startup. Allow 8–15 minutes. It needs `sudo` because it installs Docker, opens the firewall, and creates the cluster.
 
@@ -59,7 +60,7 @@ The installer runs in two phases — bootstrap (Docker + tools + firewall) and t
 | Flag | Default | Purpose |
 |---|---|---|
 | `--host` | _(required)_ | The VM's public IPv4 address |
-| `--version` | _(required)_ | Agent Manager release to install (an `amp/v*` tag, e.g. `0.16.0`) |
+| `--version` | _(required)_ | Agent Manager release to install — use the same `amp/v*` tag you checked out above |
 | `--email` | _(none)_ | ACME contact for expiry notices |
 | `--no-external-gateways` | off | Drop the gateway control-plane endpoint if you won't connect external gateways |
 
@@ -192,6 +193,7 @@ Generate an annotated config template and edit it:
 # on the VM
 git clone https://github.com/wso2/agent-manager.git
 cd agent-manager/deployments/vm
+git checkout tags/amp/v0.0.0-dev
 
 ./install-advanced.sh --init > amp-config.env
 # edit amp-config.env
@@ -201,7 +203,7 @@ The config file is plain shell (sourced by the installer). The keys are:
 
 | Key | Required | Purpose |
 |---|---|---|
-| `AMP_VERSION` | yes | Agent Manager release to install (an `amp/v*` [tag](https://github.com/wso2/agent-manager/tags), e.g. `0.16.0`) |
+| `AMP_VERSION` | yes | Agent Manager release to install — use the same `amp/v*` [tag](https://github.com/wso2/agent-manager/tags) you checked out above (`0.0.0-dev`) |
 | `DOMAIN_BASE` | yes | Base domain; service hosts are derived as `<svc>.<DOMAIN_BASE>` |
 | `TLS_MODE` | yes | `letsencrypt`, `byoc`, or `upstream` |
 | `ACME_EMAIL` | letsencrypt | ACME contact for expiry notices |

--- a/documentation/versioned_docs/version-v0.16.x/getting-started/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v0.16.x/getting-started/on-a-vm.mdx
@@ -43,14 +43,15 @@ SSH into the VM, get the installer, and run it with `sudo`:
 # on the VM
 git clone https://github.com/wso2/agent-manager.git
 cd agent-manager/deployments/vm
+git checkout tags/amp/v0.16.0
 
 sudo ./install-vm.sh \
   --host <VM_PUBLIC_IP> \
-  --version <amp-release> \
+  --version 0.16.0 \
   --email you@example.com
 ```
 
-Pass `--host` the VM's **public** IPv4 address — a cloud VM usually can't read its own public IP (it's NAT'd behind the address you used to SSH in), so the installer needs it to build the `*.amp.<IP>.sslip.io` hostnames. Set `--version` to the Agent Manager release you want (an existing `amp/v*` [tag](https://github.com/wso2/agent-manager/tags), e.g. `0.16.0`).
+Pass `--host` the VM's **public** IPv4 address — a cloud VM usually can't read its own public IP (it's NAT'd behind the address you used to SSH in), so the installer needs it to build the `*.amp.<IP>.sslip.io` hostnames.
 
 The installer runs in two phases — bootstrap (Docker + tools + firewall) and the platform install + Caddy startup. Allow 8–15 minutes. It needs `sudo` because it installs Docker, opens the firewall, and creates the cluster.
 
@@ -59,7 +60,7 @@ The installer runs in two phases — bootstrap (Docker + tools + firewall) and t
 | Flag | Default | Purpose |
 |---|---|---|
 | `--host` | _(required)_ | The VM's public IPv4 address |
-| `--version` | _(required)_ | Agent Manager release to install (an `amp/v*` tag, e.g. `0.16.0`) |
+| `--version` | _(required)_ | Agent Manager release to install — use the same `amp/v*` tag you checked out above |
 | `--email` | _(none)_ | ACME contact for expiry notices |
 | `--no-external-gateways` | off | Drop the gateway control-plane endpoint if you won't connect external gateways |
 
@@ -192,6 +193,7 @@ Generate an annotated config template and edit it:
 # on the VM
 git clone https://github.com/wso2/agent-manager.git
 cd agent-manager/deployments/vm
+git checkout tags/amp/v0.16.0
 
 ./install-advanced.sh --init > amp-config.env
 # edit amp-config.env
@@ -201,7 +203,7 @@ The config file is plain shell (sourced by the installer). The keys are:
 
 | Key | Required | Purpose |
 |---|---|---|
-| `AMP_VERSION` | yes | Agent Manager release to install (an `amp/v*` [tag](https://github.com/wso2/agent-manager/tags), e.g. `0.16.0`) |
+| `AMP_VERSION` | yes | Agent Manager release to install — use the same `amp/v*` [tag](https://github.com/wso2/agent-manager/tags) you checked out above (`0.16.0`) |
 | `DOMAIN_BASE` | yes | Base domain; service hosts are derived as `<svc>.<DOMAIN_BASE>` |
 | `TLS_MODE` | yes | `letsencrypt`, `byoc`, or `upstream` |
 | `ACME_EMAIL` | letsencrypt | ACME contact for expiry notices |


### PR DESCRIPTION
## Purpose
The **Run Agent Manager on a VM with Docker** guide told readers to `git clone` the repo and run `install-vm.sh` / `install-advanced.sh` **without checking out a release tag**, so they ran whatever was on `main` regardless of which documentation version they were viewing — meaning the installer could contain changes unrelated to the released docs they were following. The `--version` / `AMP_VERSION` guidance was also generic (`<amp-release>`, a hardcoded "e.g. `0.16.0`"), so the versioned snapshots never carried a concrete tag (the published `version-v0.16.x` still literally said `<amp-release>`).

N/A — no related issue.

## Goals
Make the VM install guide pin to the documentation's own release, and have that pin populate automatically on each release with no hand-editing, consistent with how the rest of getting-started already works.

## Approach
Reuse the existing `0.0.0-dev` placeholder convention already used by `quick-start.mdx`, `on-k3d.mdx`, and `on-your-environment.mdx`, which `make version` rewrites to the real tag (`vX.Y.0` / `X.Y.0`) when a versioned snapshot is created — and which the docs-release workflow verifies leaves no placeholder behind.

In `documentation/docs/getting-started/on-a-vm.mdx` (current/dev docs):
- Add a `git checkout tags/amp/v0.0.0-dev` step after the clone in both the **Simple** and **Advanced** tabs.
- Pin `--version 0.0.0-dev` and point the `--version` / `AMP_VERSION` table rows at "the same tag you checked out".

Retro-patch the frozen `documentation/versioned_docs/version-v0.16.x/getting-started/on-a-vm.mdx` with the concrete `tags/amp/v0.16.0` / `0.16.0`, since the release `sed` does not rewrite already-published snapshots.

The `git checkout` step is the VM path's equivalent of pulling a tagged image: unlike the quick-start (a single pre-pinned container image), the VM installer is multi-file and clone-distributed, so the checkout is what pins it to the release.

## User stories
As an operator following a versioned VM install guide, I run that release's installer (not `main`'s), so the script matches the docs I'm reading.

## Release note
Documentation: the "Run on a VM" guide now pins to the documentation's release tag (`git checkout tags/amp/v<release>`), and the install version auto-populates per release.

## Documentation
This PR is the documentation change. Affected pages:
- `documentation/docs/getting-started/on-a-vm.mdx`
- `documentation/versioned_docs/version-v0.16.x/getting-started/on-a-vm.mdx`

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams; this is a docs-only change to install instructions.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > N/A — documentation-only change.
 - Integration tests
   > N/A — documentation-only change. Verified manually that the release `sed` (`s/v0.0.0-dev/.../; s/0.0.0-dev/.../`) rewrites every placeholder cleanly to the real tag and leaves no `0.0.0-dev` behind (which the docs-release workflow's verification step requires).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — documentation-only change, no code.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples.

## Related PRs
N/A.

## Migrations (if applicable)
N/A — no migrations.

## Test environment
N/A — documentation-only change.

## Learning
Traced the existing docs versioning pipeline (`documentation/Makefile` `version` target, `.github/workflows/docs-release.yml`) to confirm the `0.0.0-dev` placeholder is the established auto-population mechanism, and reused it rather than introducing new tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VM installation instructions to include explicit version tags for both simple and advanced setup paths.
  * Clarified `--version` option references to use specific release tags (`amp/v0.0.0-dev` for development and `amp/v0.16.0` for released versions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->