### PR TITLE
Add private-network VM install modes (DNS-01, self-signed)

### DIFF
--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -22,6 +22,8 @@ source "${VM_DIR}/lib-vm.sh"
 source "${VM_DIR}/lib-advanced.sh"
 # shellcheck source=lib-bootstrap.sh
 source "${VM_DIR}/lib-bootstrap.sh"
+# shellcheck source=lib-tls.sh
+source "${VM_DIR}/lib-tls.sh"
 
 print_template() {
   cat <<'TEMPLATE'
@@ -31,10 +33,29 @@ print_template() {
 # --- Required ---
 AMP_VERSION=0.15.0                 # amp/v* release tag (see github.com/wso2/agent-manager/tags)
 DOMAIN_BASE=amp.mycompany.com      # service hosts derived as <svc>.<DOMAIN_BASE>
-TLS_MODE=letsencrypt               # letsencrypt | byoc | upstream
+TLS_MODE=letsencrypt               # letsencrypt | letsencrypt-dns | byoc | selfsigned | upstream
 
 # --- letsencrypt mode ---
 ACME_EMAIL=ops@mycompany.com       # ACME contact (recommended)
+
+# --- letsencrypt-dns mode (DNS-01: public-trusted certs on a PRIVATE VM) ---
+# The ACME CA never connects to the VM; it reads a DNS TXT record, so no public
+# ingress is needed (egress only). Requires a public DNS zone you control — A records
+# may point at the VM's private IP (split-horizon is fine). ACME_EMAIL (above) is
+# required in this mode. Set DNS_PROVIDER to a lego provider and supply that provider's
+# credentials as env vars in this file (lego reads them natively). Documented
+# providers: route53 (AWS) | cloudflare | gcloud (Google Cloud DNS) | azuredns.
+# DNS_PROVIDER=route53
+#   AWS:        AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_REGION=us-east-1
+#   Cloudflare: CF_DNS_API_TOKEN=...
+#   Google:     GCE_PROJECT=... GCE_SERVICE_ACCOUNT_FILE=/opt/amp/gcp-sa.json
+#   Azure:      AZURE_TENANT_ID=... AZURE_CLIENT_ID=... AZURE_CLIENT_SECRET=... AZURE_SUBSCRIPTION_ID=...
+# ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory  # optional: LE staging for testing
+
+# --- selfsigned mode (fully offline: no public zone, no internal CA) ---
+# Generates a local CA + leaf covering every service host + the *.<AGENTS_BASE>
+# wildcard. The CA is written to /opt/amp/certs/ca.crt — import it into client trust
+# stores (MDM/GPO) so browsers trust the console/API without warnings. No extra keys.
 
 # --- byoc mode (operator-supplied cert/key) ---
 # The cert MUST carry SANs covering *.<DOMAIN_BASE> AND *.<AGENTS_BASE>.
@@ -89,6 +110,13 @@ AMP_HOST_CONSOLE="" AMP_HOST_API="" AMP_HOST_THUNDER="" AMP_HOST_OBSERVER=""
 AMP_HOST_GATEWAY="" AMP_HOST_CP="" AMP_AGENTS_BASE=""
 derive_hosts
 
+# letsencrypt-dns and selfsigned both produce a cert/key and reuse the byoc serving
+# path, so default the served paths to the canonical cert dir when unset.
+if [[ "$TLS_MODE" == letsencrypt-dns || "$TLS_MODE" == selfsigned ]]; then
+  TLS_CERT_FILE="${TLS_CERT_FILE:-/opt/amp/certs/fullchain.pem}"
+  TLS_KEY_FILE="${TLS_KEY_FILE:-/opt/amp/certs/privkey.pem}"
+fi
+
 # BYOC cert validation happens before any cluster work.
 if [[ "$TLS_MODE" == byoc ]]; then
   if ! validate_cert "$TLS_CERT_FILE" "$TLS_KEY_FILE"; then
@@ -100,13 +128,14 @@ fi
 render_active_caddyfile() {   # echoes the Caddyfile for the active TLS_MODE
   case "$TLS_MODE" in
     letsencrypt) caddyfile letsencrypt "${ACME_EMAIL:-}" "" "" "" ;;
-    byoc)        caddyfile byoc "" "$TLS_CERT_FILE" "$TLS_KEY_FILE" "" ;;
+    byoc|letsencrypt-dns|selfsigned) caddyfile byoc "" "$TLS_CERT_FILE" "$TLS_KEY_FILE" "" ;;
     upstream)    caddyfile upstream "" "" "" "${UPSTREAM_LISTEN_PORT:-80}" "${UPSTREAM_TRUSTED_PROXIES:-0.0.0.0/0}" ;;
   esac
 }
 
 # start_caddy_advanced — render the active Caddyfile and (re)start the Caddy container.
-# byoc mode bind-mounts the operator cert/key read-only into the container.
+# The cert-file modes (byoc, letsencrypt-dns, selfsigned) bind-mount the cert/key
+# read-only into the container.
 start_caddy_advanced() {
   mkdir -p /opt/amp
   render_active_caddyfile >/opt/amp/Caddyfile
@@ -114,7 +143,7 @@ start_caddy_advanced() {
 
   local mounts=(-v amp-caddy-data:/data -v amp-caddy-config:/config
                 -v /opt/amp/Caddyfile:/etc/caddy/Caddyfile:ro)
-  if [[ "$TLS_MODE" == byoc ]]; then
+  if [[ "$TLS_MODE" == byoc || "$TLS_MODE" == letsencrypt-dns || "$TLS_MODE" == selfsigned ]]; then
     mounts+=(-v "${TLS_CERT_FILE}:${TLS_CERT_FILE}:ro" -v "${TLS_KEY_FILE}:${TLS_KEY_FILE}:ro")
   fi
 
@@ -140,7 +169,16 @@ preflight_dns() {
     return 0
   fi
   if validate_dns "${cand[@]}"; then
-    [[ "$mode" == advisory ]] && log "DNS check: all hostnames resolve to this VM."
+    # validate_dns returns 0 in advisory modes even when some hosts did not resolve,
+    # so only claim success when it actually recorded no errors; otherwise tell the
+    # operator to point their private DNS / client hosts at this VM.
+    if [[ "$mode" == advisory ]]; then
+      if (( ${#DNS_ERRORS[@]} == 0 )); then
+        log "DNS check: all hostnames resolve to this VM."
+      else
+        log "DNS check: some hostnames do not resolve to this VM yet (advisory; see above). Point your private DNS, or client /etc/hosts entries, at this VM before connecting."
+      fi
+    fi
     return 0
   fi
   # validate_dns already printed the per-host details + (letsencrypt) remediation.
@@ -158,8 +196,25 @@ run_advanced_install() {
 
   log "Phase 1/2: bootstrap (Docker + tools + firewall)"
   ensure_prerequisites
+  ensure_inotify_limits
   if [[ "$TLS_MODE" == upstream ]]; then ensure_firewall "${UPSTREAM_LISTEN_PORT:-80}"; else ensure_firewall 443; fi
   ensure_disk
+
+  # Produce the cert before the cluster work for the cert-file modes; both then reuse
+  # the byoc serving path in start_caddy_advanced below.
+  case "$TLS_MODE" in
+    selfsigned)
+      log "Generating local CA + leaf (offline TLS)"
+      generate_selfsigned_ca "$(dirname "$TLS_CERT_FILE")"
+      validate_cert "$TLS_CERT_FILE" "$TLS_KEY_FILE" \
+        || { printf '%s\n' "${CERT_ERRORS[@]}" >&2; die "generated self-signed cert failed validation"; }
+      ;;
+    letsencrypt-dns)
+      mkdir -p /opt/amp
+      install -m 600 "$CONFIG_FILE" /opt/amp/amp-config.env
+      issue_dns01_cert "$(dirname "$TLS_CERT_FILE")"
+      ;;
+  esac
 
   log "Phase 2/2: install Agent Manager + start Caddy (this takes 8-15 min)"
   # Build the override arrays install.sh honors, from the hostname-driven cores.
@@ -192,6 +247,12 @@ run_advanced_install() {
 
   start_caddy_advanced
 
+  # DNS-01 certs are short-lived; install a daily renewal timer (lego renew + Caddy
+  # reload). The timer reads provider creds from the saved config copy.
+  if [[ "$TLS_MODE" == letsencrypt-dns ]]; then
+    install_renewal_timer "$(dirname "$TLS_CERT_FILE")" /opt/amp/amp-config.env
+  fi
+
   log "Done. Access URLs:"
   cat <<EOF
 
@@ -203,6 +264,12 @@ run_advanced_install() {
   Deployed agents: https://<org>-<project>.${AMP_AGENTS_BASE}/...
 EOF
   [[ -n "$AMP_HOST_CP" ]] && echo "  Gateway control plane: https://${AMP_HOST_CP}  (connect external gateways here; registration token is secret-bearing)"
+  [[ "$TLS_MODE" == selfsigned ]] && cat <<EOF
+
+  Self-signed mode: import the CA into client trust stores so browsers trust these
+  hosts without warnings:
+    CA cert: $(dirname "$TLS_CERT_FILE")/ca.crt
+EOF
 }
 
 if [[ "$DRY_RUN" == "true" ]]; then
@@ -212,6 +279,16 @@ if [[ "$DRY_RUN" == "true" ]]; then
     "$AMP_HOST_GATEWAY" "${AMP_HOST_CP:-<none>}" "$AMP_AGENTS_BASE"
   log "DRY RUN — amp helm args:"; amp_helm_args
   log "DRY RUN — Caddyfile (${TLS_MODE}):"; render_active_caddyfile
+  case "$TLS_MODE" in
+    letsencrypt-dns)
+      log "DRY RUN — DNS-01 issuance plan (lego):"
+      build_lego_args "${ACME_EMAIL:-}" "$DNS_PROVIDER" "$(dirname "$TLS_CERT_FILE")" "${ACME_SERVER:-}" run
+      ;;
+    selfsigned)
+      log "DRY RUN — self-signed cert SANs:"
+      tls_san_list
+      ;;
+  esac
   log "DRY RUN — DNS pre-flight (advisory):"; preflight_dns advisory
   exit 0
 fi

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -120,6 +120,7 @@ run_install() {
 
 log "Phase 1/2: bootstrap (Docker + tools + firewall)"
 ensure_prerequisites
+ensure_inotify_limits
 ensure_firewall 443
 ensure_disk
 

--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -25,8 +25,12 @@ derive_hosts() {
 load_config() {
   local file="${1:?load_config requires a config file path}"
   [[ -f "$file" ]] || { printf 'config file not found: %s\n' "$file" >&2; return 1; }
+  # Export every assignment so DNS-provider credentials (CF_*, AWS_*, GCE_*, ...) reach
+  # the dockerized lego: _lego_cred_env_args lists them via `compgen -e` (exported only)
+  # and forwards them with `docker run -e`. A plain `source` leaves them unexported, so
+  # token-based providers (Cloudflare/route53/azuredns) would silently get no credentials.
   # shellcheck disable=SC1090
-  source "$file"
+  set -a; source "$file"; set +a
 }
 
 # validate_config — check required keys and mode-specific requirements. Populates the
@@ -61,11 +65,22 @@ validate_config() {
         fi
       fi
       ;;
+    letsencrypt-dns)
+      # DNS-01: the ACME CA never connects to the VM (reads a TXT record from public
+      # DNS), so this works on a private VM. lego needs a provider to write the TXT
+      # record and an account email to register.
+      [[ -n "${DNS_PROVIDER:-}" ]] || CONFIG_ERRORS+=("DNS_PROVIDER is required for letsencrypt-dns mode (a lego DNS provider, e.g. route53 | cloudflare | gcloud | azuredns)")
+      [[ -n "${ACME_EMAIL:-}" ]]   || CONFIG_ERRORS+=("ACME_EMAIL is required for letsencrypt-dns mode (lego registers an ACME account with it)")
+      ;;
+    selfsigned)
+      # Offline: a local CA + leaf is generated; no public zone, CA, or email needed.
+      :
+      ;;
     "")
-      CONFIG_ERRORS+=("TLS_MODE is required (letsencrypt | byoc | upstream)")
+      CONFIG_ERRORS+=("TLS_MODE is required (letsencrypt | letsencrypt-dns | byoc | selfsigned | upstream)")
       ;;
     *)
-      CONFIG_ERRORS+=("TLS_MODE must be one of: letsencrypt | byoc | upstream (got '${TLS_MODE}')")
+      CONFIG_ERRORS+=("TLS_MODE must be one of: letsencrypt | letsencrypt-dns | byoc | selfsigned | upstream (got '${TLS_MODE}')")
       ;;
   esac
   (( ${#CONFIG_ERRORS[@]} == 0 ))
@@ -191,7 +206,7 @@ validate_dns() {
       printf '[preflight] In letsencrypt mode every hostname (incl. *.%s) must A-record to this VM before ACME can issue. Create those records and re-run.\n' "$AMP_AGENTS_BASE" >&2
       return 1
     fi
-    printf '[preflight] (advisory in %s mode — a load balancer / proxy may front DNS)\n' "${TLS_MODE:-?}" >&2
+    printf '[preflight] (advisory in %s mode; ensure your DNS or client hosts entries point at this VM)\n' "${TLS_MODE:-?}" >&2
   fi
   return 0
 }

--- a/deployments/vm/lib-bootstrap.sh
+++ b/deployments/vm/lib-bootstrap.sh
@@ -73,6 +73,48 @@ ensure_disk() {
   fi
 }
 
+# inotify_bump_target <current> <floor> — echo <floor> when the current sysctl value is
+# below it (or empty/non-numeric, i.e. unreadable), else echo nothing. Pure: lets the
+# caller decide whether a bump is needed without touching sysctl, and keeps the
+# never-lower-an-existing-higher-value rule unit-testable.
+inotify_bump_target() {
+  local current="$1" floor="$2"
+  if [[ "$current" =~ ^[0-9]+$ ]] && (( current >= floor )); then return 0; fi
+  printf '%s' "$floor"
+}
+
+# ensure_inotify_limits — raise fs.inotify.max_user_{instances,watches} to the floors k3d
+# needs (kubelet + many containers each open watches) and persist them. A fresh
+# single-user install can otherwise exhaust the default instance ceiling: systemd logs
+# "Failed to allocate directory watch: Too many open files" and k3d configmap/secret
+# watches silently go stale. Only keys actually below their floor are touched/persisted,
+# so a host already tuned higher is never lowered.
+ensure_inotify_limits() {
+  local inst_floor=512 watch_floor=524288 cur tgt conf=/etc/sysctl.d/99-amp-inotify.conf
+  local -a lines=()
+
+  cur="$(sysctl -n fs.inotify.max_user_instances 2>/dev/null || true)"
+  tgt="$(inotify_bump_target "$cur" "$inst_floor")"
+  if [[ -n "$tgt" ]]; then
+    sysctl -w "fs.inotify.max_user_instances=$tgt" >/dev/null 2>&1 || true
+    lines+=("fs.inotify.max_user_instances=$tgt")
+  fi
+
+  cur="$(sysctl -n fs.inotify.max_user_watches 2>/dev/null || true)"
+  tgt="$(inotify_bump_target "$cur" "$watch_floor")"
+  if [[ -n "$tgt" ]]; then
+    sysctl -w "fs.inotify.max_user_watches=$tgt" >/dev/null 2>&1 || true
+    lines+=("fs.inotify.max_user_watches=$tgt")
+  fi
+
+  if (( ${#lines[@]} )); then
+    printf '%s\n' "${lines[@]}" > "$conf" 2>/dev/null || true
+    log "Raised inotify limits for k3d (${lines[*]})"
+  else
+    log "inotify limits already sufficient for k3d"
+  fi
+}
+
 # verify_caddy_up — fail loudly if the amp-caddy container isn't healthy shortly after
 # start. Caddy runs on the host network, so a port collision (e.g. an UPSTREAM_LISTEN_PORT
 # already bound by k3d) makes it crash-loop; without this check the installer would

--- a/deployments/vm/lib-tls.sh
+++ b/deployments/vm/lib-tls.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# lib-tls.sh — cert production for the private VM install modes (letsencrypt-dns,
+# selfsigned). Sourcing only defines functions (no side effects). The caller is
+# expected to define log()/die(); fallbacks are provided so this file is usable
+# standalone. The pure functions (tls_san_list, build_lego_args, render_renewal_units)
+# write only to stdout; issue_dns01_cert/generate_selfsigned_ca/install_renewal_timer
+# touch disk + docker and are the only side-effecting members.
+command -v log >/dev/null 2>&1 || log() { printf '\033[0;34m[tls]\033[0m %s\n' "$*"; }
+command -v die >/dev/null 2>&1 || die() { printf '\033[0;31m[tls] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# Pin the lego image. The v5 CLI dropped the global flags build_lego_args emits
+# (e.g. --accept-tos), so goacme/lego:latest (now v5.x) breaks DNS-01 issuance with
+# "flag provided but not defined". v4.x keeps the flag syntax. Override via env if needed.
+LEGO_IMAGE="${LEGO_IMAGE:-goacme/lego:v4.35.2}"
+
+# tls_san_list — print the SAN hostnames (one per line) the cert must cover: every
+# service host + the deployed-agent wildcard. AMP_HOST_CONSOLE is emitted first so it
+# is the cert's primary/CN and lego's output filename is deterministic. CP is omitted
+# when AMP_HOST_CP is empty (external gateways off). Reads AMP_HOST_*/AMP_AGENTS_BASE
+# from the caller's scope (dynamic scope), matching the lib-vm.sh cores.
+# shellcheck disable=SC2154,SC2153  # AMP_HOST_*/AMP_AGENTS_BASE come from the caller's scope by design.
+tls_san_list() {
+  printf '%s\n' "$AMP_HOST_CONSOLE" "$AMP_HOST_API" "$AMP_HOST_THUNDER" \
+    "$AMP_HOST_OBSERVER" "$AMP_HOST_GATEWAY"
+  [[ -n "${AMP_HOST_CP:-}" ]] && printf '%s\n' "$AMP_HOST_CP"
+  printf '*.%s\n' "$AMP_AGENTS_BASE"
+}
+
+# build_lego_args <email> <provider> <path> <server> <action> — print the lego CLI
+# args (one token per line) for a DNS-01 issuance/renewal covering tls_san_list.
+# Pure: no docker, no network. action is "run" (issue) or "renew". Consume with:
+#   mapfile -t ARGS < <(build_lego_args ...)
+build_lego_args() {
+  local email="$1" provider="$2" path="$3" server="$4" action="$5"
+  printf '%s\n' --accept-tos --path "$path" --dns "$provider"
+  [[ -n "$email" ]]  && printf '%s\n' --email "$email"
+  [[ -n "$server" ]] && printf '%s\n' --server "$server"
+  local d
+  while IFS= read -r d; do
+    [[ -n "$d" ]] && printf '%s\n' --domains "$d"
+  done < <(tls_san_list)
+  printf '%s\n' "$action"
+}
+
+# generate_selfsigned_ca <cert_dir> [days] — create a local CA + a leaf signed by it
+# covering tls_san_list. Writes ca.crt (distribute to client trust stores),
+# fullchain.pem (leaf + CA) and privkey.pem (leaf key) under <cert_dir>. Side-effecting
+# (openssl + disk). Reads AMP_HOST_*/AMP_AGENTS_BASE.
+generate_selfsigned_ca() {
+  local dir="${1:?generate_selfsigned_ca requires a cert dir}" days="${2:-3650}"
+  mkdir -p "$dir"
+  openssl req -x509 -newkey rsa:4096 -nodes -days "$days" \
+    -keyout "${dir}/ca.key" -out "${dir}/ca.crt" \
+    -subj "/CN=Agent Manager Internal CA/O=Agent Manager" >/dev/null 2>&1 \
+    || die "self-signed CA generation failed"
+  openssl req -newkey rsa:2048 -nodes \
+    -keyout "${dir}/privkey.pem" -out "${dir}/leaf.csr" \
+    -subj "/CN=${AMP_HOST_CONSOLE}" >/dev/null 2>&1 || die "leaf CSR generation failed"
+  local san; san="$(tls_san_list | sed 's/^/DNS:/' | paste -sd, -)"
+  openssl x509 -req -in "${dir}/leaf.csr" -CA "${dir}/ca.crt" -CAkey "${dir}/ca.key" \
+    -CAcreateserial -days "$days" \
+    -extfile <(printf 'subjectAltName=%s\n' "$san") \
+    -out "${dir}/leaf.crt" >/dev/null 2>&1 || die "leaf signing failed"
+  cat "${dir}/leaf.crt" "${dir}/ca.crt" > "${dir}/fullchain.pem"
+}
+
+# _lego_cred_env_args — print docker `-e NAME` args for every exported provider
+# credential var (lego reads these natively: Cloudflare CF_*, AWS AWS_*, Google GCE_*/
+# GOOGLE_*, Azure AZURE_*). Used for the initial issuance where the config is already
+# sourced into the environment.
+_lego_cred_env_args() {
+  local v
+  while IFS= read -r v; do
+    printf '%s\n' -e "$v"
+  done < <(compgen -e | grep -E '^(CF_|CLOUDFLARE_|AWS_|GCE_|GOOGLE_|AZURE_)' || true)
+}
+
+# issue_dns01_cert <cert_dir> — run dockerized lego to issue the cert into <cert_dir>,
+# then copy the issued primary pair to the byoc-served fullchain.pem/privkey.pem.
+# Reads ACME_EMAIL, DNS_PROVIDER, ACME_SERVER (optional), AMP_HOST_*/AMP_AGENTS_BASE.
+# Side-effecting (docker + disk).
+issue_dns01_cert() {
+  local cert_dir="${1:-/opt/amp/certs}"
+  mkdir -p "$cert_dir"
+  local -a args envargs
+  mapfile -t args    < <(build_lego_args "${ACME_EMAIL:-}" "$DNS_PROVIDER" "$cert_dir" "${ACME_SERVER:-}" run)
+  mapfile -t envargs < <(_lego_cred_env_args)
+  log "Issuing cert via DNS-01 (lego, provider=${DNS_PROVIDER})"
+  docker run --rm -v "${cert_dir}:${cert_dir}" "${envargs[@]}" \
+    "$LEGO_IMAGE" "${args[@]}" \
+    || die "lego DNS-01 issuance failed (check DNS_PROVIDER credentials and that the zone is delegated)"
+  cp "${cert_dir}/certificates/${AMP_HOST_CONSOLE}.crt" "${cert_dir}/fullchain.pem" \
+    || die "lego succeeded but the expected cert ${AMP_HOST_CONSOLE}.crt was not found"
+  cp "${cert_dir}/certificates/${AMP_HOST_CONSOLE}.key" "${cert_dir}/privkey.pem"
+}
+
+# render_renewal_units <cert_dir> <env_file> — print the systemd service + timer
+# (separated by a "---UNIT-SEPARATOR---" marker line) that renew the DNS-01 cert daily
+# and reload Caddy. Pure: writes only to stdout. The service reads provider creds from
+# <env_file> (a copy of amp-config.env) via docker --env-file. action=renew skips
+# re-issuing certs that are not near expiry.
+render_renewal_units() {
+  local cert_dir="$1" env_file="$2" cmd="" tok qtok
+  # Build the lego renew command as a single quoted string. A while-read loop (not
+  # mapfile) keeps this function runnable under bash 3.2 so the unit tests work on macOS.
+  while IFS= read -r tok; do
+    printf -v qtok ' %q' "$tok"
+    cmd+="$qtok"
+  done < <(build_lego_args "${ACME_EMAIL:-}" "$DNS_PROVIDER" "$cert_dir" "${ACME_SERVER:-}" renew)
+  cat <<EOF
+[Unit]
+Description=Agent Manager TLS cert renewal (lego DNS-01)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker run --rm --env-file ${env_file} -v ${cert_dir}:${cert_dir} ${LEGO_IMAGE}${cmd}
+ExecStartPost=/usr/bin/cp ${cert_dir}/certificates/${AMP_HOST_CONSOLE}.crt ${cert_dir}/fullchain.pem
+ExecStartPost=/usr/bin/cp ${cert_dir}/certificates/${AMP_HOST_CONSOLE}.key ${cert_dir}/privkey.pem
+ExecStartPost=/usr/bin/docker exec amp-caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+---UNIT-SEPARATOR---
+[Unit]
+Description=Run Agent Manager TLS cert renewal daily
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=3600
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+# install_renewal_timer <cert_dir> <env_file> — write the renewal service + timer to
+# /etc/systemd/system and enable the timer. Side-effecting (root).
+install_renewal_timer() {
+  local cert_dir="$1" env_file="$2" units svc timer
+  units="$(render_renewal_units "$cert_dir" "$env_file")"
+  svc="${units%%---UNIT-SEPARATOR---*}"
+  timer="${units#*---UNIT-SEPARATOR---$'\n'}"
+  printf '%s' "$svc"   > /etc/systemd/system/amp-cert-renew.service
+  printf '%s' "$timer" > /etc/systemd/system/amp-cert-renew.timer
+  systemctl daemon-reload
+  systemctl enable --now amp-cert-renew.timer
+  log "Installed daily cert-renewal timer (amp-cert-renew.timer)"
+}

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -9,6 +9,10 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../lib-advanced.sh disable=SC1091
 source "${SCRIPT_DIR}/../lib-advanced.sh"
+# shellcheck source=../lib-vm.sh disable=SC1091
+source "${SCRIPT_DIR}/../lib-vm.sh"
+# shellcheck source=../lib-tls.sh disable=SC1091
+source "${SCRIPT_DIR}/../lib-tls.sh"
 
 FAILLOG="$(mktemp)"
 TMP="$(mktemp -d)"
@@ -112,6 +116,17 @@ _resolve_host() { echo ""; }
 validate_dns 203.0.113.10; rc=$?
 assert_eq "LE unresolved rc=1" "1" "$rc"
 unset -f _resolve_host
+
+# --- generate_selfsigned_ca: produces a CA + leaf whose SANs cover every host ---
+generate_selfsigned_ca "$TMP/ssg" 365
+assert_eq "selfsigned writes ca.crt"      "yes" "$([[ -f "$TMP/ssg/ca.crt" ]] && echo yes || echo no)"
+assert_eq "selfsigned writes fullchain"   "yes" "$([[ -f "$TMP/ssg/fullchain.pem" ]] && echo yes || echo no)"
+# validate_cert reads AMP_HOST_* (set at top of this file) + checks SAN coverage incl.
+# the *.agents wildcard, so a passing rc proves the generated SANs are complete.
+validate_cert "$TMP/ssg/fullchain.pem" "$TMP/ssg/privkey.pem"; rc=$?
+assert_eq "selfsigned cert validates rc=0" "0" "$rc"
+ssg_sans="$(openssl x509 -noout -ext subjectAltName -in "$TMP/ssg/fullchain.pem" 2>/dev/null)"
+assert_eq "selfsigned covers agents wildcard" "yes" "$(grep -qF '*.agents.amp.mycompany.com' <<<"$ssg_sans" && echo yes || echo no)"
 
 if [[ -s "$FAILLOG" ]]; then echo "PREFLIGHT TESTS FAILED"; exit 1; fi
 echo "ALL PREFLIGHT TESTS PASSED"

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -14,6 +14,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib-vm.sh"
 # shellcheck source=../lib-advanced.sh disable=SC1091
 source "${SCRIPT_DIR}/../lib-advanced.sh"
+# shellcheck source=../lib-tls.sh disable=SC1091
+source "${SCRIPT_DIR}/../lib-tls.sh"
+# shellcheck source=../lib-bootstrap.sh disable=SC1091
+source "${SCRIPT_DIR}/../lib-bootstrap.sh"
 
 # Failures are recorded in a marker file (not just a shell var) so that assertions
 # inside subshells — used to scope AMP_HOST_* per test group — still fail the suite.
@@ -465,6 +469,10 @@ assert_eq "init has DOMAIN_BASE"  "yes" "$(has "$init_out" 'DOMAIN_BASE=')"
 assert_eq "init has TLS_MODE"     "yes" "$(has "$init_out" 'TLS_MODE=')"
 assert_eq "init mentions byoc keys" "yes" "$(has "$init_out" 'TLS_CERT_FILE=')"
 assert_eq "init mentions upstream port" "yes" "$(has "$init_out" 'UPSTREAM_LISTEN_PORT=')"
+assert_eq "init mentions letsencrypt-dns" "yes" "$(has "$init_out" 'letsencrypt-dns')"
+assert_eq "init mentions selfsigned"      "yes" "$(has "$init_out" 'selfsigned')"
+assert_eq "init mentions DNS_PROVIDER"    "yes" "$(has "$init_out" 'DNS_PROVIDER=')"
+assert_eq "init mentions ACME_SERVER"     "yes" "$(has "$init_out" 'ACME_SERVER=')"
 # The emitted template must be valid shell (sourceable without error).
 tmp_init="$(mktemp)"; printf '%s\n' "$init_out" > "$tmp_init"
 if bash -n "$tmp_init"; then assert_eq "init template is valid shell" "0" "0"; else assert_eq "init template is valid shell" "0" "1"; fi
@@ -524,6 +532,157 @@ rm -f "$tmp_cfg"
   assert_eq "upstream custom trusted_proxies" "yes" \
     "$(has "$cf_tp" 'trusted_proxies static 130.211.0.0/22 35.191.0.0/16')"
 )
+
+# --- tls_san_list: all hosts + agent wildcard, console first, cp gated ---
+(
+  AMP_HOST_CONSOLE=console.amp.example.com
+  AMP_HOST_API=api.amp.example.com
+  AMP_HOST_THUNDER=thunder.amp.example.com
+  AMP_HOST_OBSERVER=observer.amp.example.com
+  AMP_HOST_GATEWAY=gateway.amp.example.com
+  AMP_HOST_CP=cp.amp.example.com
+  AMP_AGENTS_BASE=agents.amp.example.com
+  sans="$(tls_san_list)"
+  assert_eq "san list console is first" "console.amp.example.com" "$(head -1 <<<"$sans")"
+  assert_eq "san list has api"      "yes" "$(has "$sans" 'api.amp.example.com')"
+  assert_eq "san list has cp"       "yes" "$(has "$sans" 'cp.amp.example.com')"
+  assert_eq "san list has agents wildcard" "yes" "$(has "$sans" '*.agents.amp.example.com')"
+)
+(
+  AMP_HOST_CONSOLE=console.amp.example.com
+  AMP_HOST_API=api.amp.example.com
+  AMP_HOST_THUNDER=thunder.amp.example.com
+  AMP_HOST_OBSERVER=observer.amp.example.com
+  AMP_HOST_GATEWAY=gateway.amp.example.com
+  AMP_HOST_CP=""
+  AMP_AGENTS_BASE=agents.amp.example.com
+  assert_eq "san list omits cp when empty" "no" "$(has "$(tls_san_list)" 'cp.amp.example.com')"
+)
+
+# --- build_lego_args: dns provider, email, domains per SAN, action last ---
+(
+  AMP_HOST_CONSOLE=console.amp.example.com
+  AMP_HOST_API=api.amp.example.com
+  AMP_HOST_THUNDER=thunder.amp.example.com
+  AMP_HOST_OBSERVER=observer.amp.example.com
+  AMP_HOST_GATEWAY=gateway.amp.example.com
+  AMP_HOST_CP=cp.amp.example.com
+  AMP_AGENTS_BASE=agents.amp.example.com
+  lego="$(build_lego_args ops@example.com route53 /opt/amp/certs "" run)"
+  assert_eq "lego dns provider" "yes" "$(printf '%s\n' "$lego" | grep -A1 -- '--dns' | grep -qxF 'route53' && echo yes || echo no)"
+  assert_eq "lego email"        "yes" "$(printf '%s\n' "$lego" | grep -A1 -- '--email' | grep -qxF 'ops@example.com' && echo yes || echo no)"
+  assert_eq "lego domains console" "yes" "$(has "$lego" 'console.amp.example.com')"
+  assert_eq "lego domains agent wildcard" "yes" "$(has "$lego" '*.agents.amp.example.com')"
+  assert_eq "lego action run is last" "run" "$(tail -1 <<<"$lego")"
+  assert_eq "lego no server when unset" "no" "$(has "$lego" '--server')"
+  lego_stg="$(build_lego_args ops@example.com route53 /opt/amp/certs https://acme-staging-v02.api.letsencrypt.org/directory renew)"
+  assert_eq "lego server when set" "yes" "$(printf '%s\n' "$lego_stg" | grep -A1 -- '--server' | grep -qxF 'https://acme-staging-v02.api.letsencrypt.org/directory' && echo yes || echo no)"
+  assert_eq "lego action renew is last" "renew" "$(tail -1 <<<"$lego_stg")"
+)
+
+# --- --dry-run, selfsigned: renders byoc-form Caddyfile, generates NOTHING ---
+tmp_ss="$(mktemp -d)"
+cat > "$tmp_ss/cfg" <<'CFG'
+AMP_VERSION=0.16.0
+DOMAIN_BASE=amp.mycompany.com
+TLS_MODE=selfsigned
+EXTERNAL_GATEWAYS=true
+CFG
+ss_out="$(bash "$ADV" --config "$tmp_ss/cfg" --dry-run 2>&1)"
+assert_eq "dry selfsigned serves cert file" "yes" "$(has "$ss_out" 'tls /opt/amp/certs/fullchain.pem /opt/amp/certs/privkey.pem')"
+assert_eq "dry selfsigned no acme issuer"   "no"  "$(has "$ss_out" 'issuer acme')"
+assert_eq "dry selfsigned does NOT install" "no"  "$(has "$ss_out" 'Running base installer')"
+assert_eq "dry selfsigned shows SAN plan"   "yes" "$(has "$ss_out" '*.agents.amp.mycompany.com')"
+rm -rf "$tmp_ss"
+
+# --- --dry-run, letsencrypt-dns: prints lego plan, no docker, no install ---
+tmp_dns="$(mktemp -d)"
+cat > "$tmp_dns/cfg" <<'CFG'
+AMP_VERSION=0.16.0
+DOMAIN_BASE=amp.mycompany.com
+TLS_MODE=letsencrypt-dns
+DNS_PROVIDER=route53
+ACME_EMAIL=ops@mycompany.com
+EXTERNAL_GATEWAYS=true
+CFG
+dns_out="$(bash "$ADV" --config "$tmp_dns/cfg" --dry-run 2>&1)"
+assert_eq "dry dns shows lego provider"  "yes" "$(has "$dns_out" '--dns')"
+assert_eq "dry dns shows route53"        "yes" "$(has "$dns_out" 'route53')"
+assert_eq "dry dns shows agent wildcard" "yes" "$(has "$dns_out" '*.agents.amp.mycompany.com')"
+assert_eq "dry dns serves cert file"     "yes" "$(has "$dns_out" 'tls /opt/amp/certs/fullchain.pem /opt/amp/certs/privkey.pem')"
+assert_eq "dry dns does NOT install"     "no"  "$(has "$dns_out" 'Running base installer')"
+rm -rf "$tmp_dns"
+
+# --- validate_config: letsencrypt-dns requires DNS_PROVIDER + ACME_EMAIL ---
+(
+  AMP_VERSION=0.16.0; DOMAIN_BASE=amp.mycompany.com; TLS_MODE=letsencrypt-dns
+  DNS_PROVIDER=route53; ACME_EMAIL=ops@mycompany.com
+  validate_config; rc=$?
+  assert_eq "validate complete dns config rc=0" "0" "$rc"
+)
+(
+  AMP_VERSION=0.16.0; DOMAIN_BASE=amp.mycompany.com; TLS_MODE=letsencrypt-dns
+  ACME_EMAIL=ops@mycompany.com
+  validate_config; rc=$?
+  assert_eq "validate dns without provider rc=1" "1" "$rc"
+  assert_eq "validate dns names DNS_PROVIDER" "yes" \
+    "$(printf '%s\n' "${CONFIG_ERRORS[@]}" | grep -qF 'DNS_PROVIDER' && echo yes || echo no)"
+)
+(
+  AMP_VERSION=0.16.0; DOMAIN_BASE=amp.mycompany.com; TLS_MODE=letsencrypt-dns
+  DNS_PROVIDER=route53
+  validate_config; rc=$?
+  assert_eq "validate dns without email rc=1" "1" "$rc"
+  assert_eq "validate dns names ACME_EMAIL" "yes" \
+    "$(printf '%s\n' "${CONFIG_ERRORS[@]}" | grep -qF 'ACME_EMAIL' && echo yes || echo no)"
+)
+
+# --- validate_config: selfsigned needs nothing beyond version + domain ---
+(
+  AMP_VERSION=0.16.0; DOMAIN_BASE=amp.mycompany.com; TLS_MODE=selfsigned
+  validate_config; rc=$?
+  assert_eq "validate selfsigned minimal rc=0" "0" "$rc"
+)
+
+# --- validate_config: bad-mode error lists the new modes ---
+(
+  AMP_VERSION=0.16.0; DOMAIN_BASE=amp.mycompany.com; TLS_MODE=banana
+  validate_config 2>/dev/null
+  assert_eq "bad-mode error mentions letsencrypt-dns" "yes" \
+    "$(printf '%s\n' "${CONFIG_ERRORS[@]}" | grep -qF 'letsencrypt-dns' && echo yes || echo no)"
+)
+
+# --- render_renewal_units: emits a renew service (lego renew + caddy reload) + timer ---
+(
+  AMP_HOST_CONSOLE=console.amp.example.com
+  AMP_HOST_API=api.amp.example.com
+  AMP_HOST_THUNDER=thunder.amp.example.com
+  AMP_HOST_OBSERVER=observer.amp.example.com
+  AMP_HOST_GATEWAY=gateway.amp.example.com
+  AMP_HOST_CP=cp.amp.example.com
+  AMP_AGENTS_BASE=agents.amp.example.com
+  ACME_EMAIL=ops@example.com DNS_PROVIDER=route53
+  units="$(render_renewal_units /opt/amp/certs /opt/amp/amp-config.env)"
+  assert_eq "renewal runs lego renew"   "yes" "$(has "$units" 'goacme/lego')"
+  # lego v5 dropped the global flags build_lego_args emits, so the image must stay
+  # pinned to v4.x; :latest (now v5) breaks issuance with "flag not defined".
+  assert_eq "renewal lego pinned not :latest" "no"  "$(has "$units" 'goacme/lego:latest')"
+  assert_eq "renewal lego pinned to v4"       "yes" "$(has "$units" 'goacme/lego:v4')"
+  assert_eq "renewal ExecStart action is renew" "yes" \
+    "$(grep '^ExecStart=' <<<"$units" | grep -qE ' renew$' && echo yes || echo no)"
+  assert_eq "renewal reloads caddy"     "yes" "$(has "$units" 'docker exec amp-caddy caddy reload')"
+  assert_eq "renewal reads env-file"    "yes" "$(has "$units" '--env-file /opt/amp/amp-config.env')"
+  assert_eq "renewal timer is daily"    "yes" "$(has "$units" 'OnCalendar=daily')"
+  assert_eq "renewal has unit separator" "yes" "$(has "$units" '---UNIT-SEPARATOR---')"
+)
+
+# --- inotify_bump_target: bump to floor only when below it (or unreadable) ---
+assert_eq "inotify below floor bumps"         "512"    "$(inotify_bump_target 128 512)"
+assert_eq "inotify at floor no bump"          ""       "$(inotify_bump_target 512 512)"
+assert_eq "inotify above floor never lowers"  ""       "$(inotify_bump_target 1024 512)"
+assert_eq "inotify empty current bumps"       "512"    "$(inotify_bump_target "" 512)"
+assert_eq "inotify non-numeric current bumps" "512"    "$(inotify_bump_target foo 512)"
+assert_eq "inotify watches floor"             "524288" "$(inotify_bump_target 8192 524288)"
 
 if [[ -s "$FAILLOG" ]]; then echo "TESTS FAILED"; exit 1; fi
 echo "ALL TESTS PASSED"

--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -17,8 +17,8 @@ For production, run Agent Manager on a properly operated Kubernetes platform wit
 
 Install Agent Manager on a Linux VM where Docker is the only host dependency. Pick the path that fits you:
 
-- **Simple** — give the installer the VM's public IP and it does everything else: hostnames are derived from the IP via [sslip.io](https://sslip.io) and TLS certificates are issued automatically by Let's Encrypt. No domain, no DNS setup, no certificate handling. Best for demos and quick evaluations.
-- **Advanced** — a config-file-driven installer for custom domains and operator-managed TLS: use your own **custom domain**, bring **your own certificates**, or front the VM with a **load balancer** that terminates TLS. Adds pre-flight validation of your config, certificates, and DNS.
+- **Simple**: give the installer the VM's public IP and it does everything else: hostnames are derived from the IP via [sslip.io](https://sslip.io) and TLS certificates are issued automatically by Let's Encrypt. No domain, no DNS setup, no certificate handling. Best for demos and quick evaluations.
+- **Advanced**: a config-file-driven installer for a **custom domain**, on a VM that is either publicly reachable or **private-network-only**. Choose how TLS is handled: automatic Let's Encrypt, the DNS-01 challenge for a private VM, your own certificate, a generated local CA, or a load balancer in front. Adds pre-flight validation of your config, certificates, and DNS.
 
 <Tabs groupId="vm-installer">
 <TabItem value="simple" label="Simple (IP + automatic TLS)" default>
@@ -29,11 +29,11 @@ The simple installer exposes the platform over HTTPS using [sslip.io](https://ss
 
 You only need an SSH client to log into the VM; everything else runs on the VM.
 - **Git** to clone this repository and fetch the installer. This is the one tool you need *before* running the script (the script can't install what you use to download it). Most images have it; on a minimal one install it with `sudo apt-get update && sudo apt-get install -y git` (Debian/Ubuntu).
-- **Docker** is required — the whole stack runs on it (k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container). If Docker isn't already installed, the script installs it for you, along with k3d, kubectl, helm, and lsof.
-- A Linux VM with a **static (reserved) public IP** and SSH access (sudo). The install derives every hostname, TLS certificate, and OAuth issuer from the IP (`*.amp.<IP>.sslip.io`), so a **changing IP breaks the install** — and stopping the VM (for example to resize its disk) releases an ephemeral IP. Reserve the address before installing. If the IP ever changes, reinstall against the new IP.
+- **Docker** is required; the whole stack runs on it (k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container). If Docker isn't already installed, the script installs it for you, along with k3d, kubectl, helm, and lsof.
+- A Linux VM with a **static (reserved) public IP** and SSH access (sudo). The install derives every hostname, TLS certificate, and OAuth issuer from the IP (`*.amp.<IP>.sslip.io`), so a **changing IP breaks the install**, and stopping the VM (for example to resize its disk) releases an ephemeral IP. Reserve the address before installing. If the IP ever changes, reinstall against the new IP.
 - **At least 50 GB of disk.** Building and running agents pushes the in-cluster image store past 13 GB; on a smaller disk the node hits `DiskPressure`, which evicts pods and can take cluster DNS down mid-build.
 - **At least 4 vCPUs and 8 GB of RAM** to run the full k3d + OpenChoreo + Agent Manager stack comfortably.
-- **Inbound `443/tcp` open** in the cloud security group / firewall — and only 443. Certificates issue via the TLS-ALPN-01 ACME challenge, which runs inside the `:443` TLS handshake, so no inbound port 80 is ever needed. The `:443` exposure must be **TCP passthrough** (not a TLS-terminating load balancer in front), since the challenge happens inside the handshake.
+- **Inbound `443/tcp` open** in the cloud security group / firewall, and only 443. Certificates issue via the TLS-ALPN-01 ACME challenge, which runs inside the `:443` TLS handshake, so no inbound port 80 is ever needed. The `:443` exposure must be **TCP passthrough** (not a TLS-terminating load balancer in front), since the challenge happens inside the handshake.
 
 ## Install
 
@@ -51,16 +51,16 @@ sudo ./install-vm.sh \
   --email you@example.com
 ```
 
-Pass `--host` the VM's **public** IPv4 address — a cloud VM usually can't read its own public IP (it's NAT'd behind the address you used to SSH in), so the installer needs it to build the `*.amp.<IP>.sslip.io` hostnames.
+Pass `--host` the VM's **public** IPv4 address. A cloud VM usually can't read its own public IP (it's NAT'd behind the address you used to SSH in), so the installer needs it to build the `*.amp.<IP>.sslip.io` hostnames.
 
-The installer runs in two phases — bootstrap (Docker + tools + firewall) and the platform install + Caddy startup. Allow 8–15 minutes. It needs `sudo` because it installs Docker, opens the firewall, and creates the cluster.
+The installer runs in two phases: bootstrap (Docker + tools + firewall) and the platform install + Caddy startup. Allow 8-15 minutes. It needs `sudo` because it installs Docker, opens the firewall, and creates the cluster.
 
 ### Options
 
 | Flag | Default | Purpose |
 |---|---|---|
 | `--host` | _(required)_ | The VM's public IPv4 address |
-| `--version` | _(required)_ | Agent Manager release to install — use the same `amp/v*` tag you checked out above |
+| `--version` | _(required)_ | Agent Manager release to install; use the same `amp/v*` tag you checked out above |
 | `--email` | _(none)_ | ACME contact for expiry notices |
 | `--no-external-gateways` | off | Drop the gateway control-plane endpoint if you won't connect external gateways |
 
@@ -75,10 +75,10 @@ flowchart TB
     browser["Browser / API client"]
     le["Let's Encrypt<br/>(ACME)"]
 
-    subgraph vm["VM — only :443 is public"]
+    subgraph vm["VM (only :443 is public)"]
         caddy["Caddy reverse proxy<br/>host network · :443 · terminates TLS"]
 
-        subgraph k3d["k3d cluster — host ports bound to 127.0.0.1"]
+        subgraph k3d["k3d cluster (host ports bound to 127.0.0.1)"]
             console["Console<br/>:3000"]
             api["amp-api<br/>:9000"]
             thunder["Thunder OAuth<br/>:8080"]
@@ -110,27 +110,27 @@ Every public hostname resolves to the VM's IP (via sslip.io) and arrives at Cadd
 | `https://observer.amp.<IP>.sslip.io` | Traces Observer |
 | `https://gateway.amp.<IP>.sslip.io/otel` | OTel trace ingest from deployed agents |
 | `https://<org>-<project>.agents.<IP>.sslip.io/...` | Deployed-agent invocation endpoints (one wildcard host per org/project) |
-| `https://cp.amp.<IP>.sslip.io` | Gateway control plane — connect external gateways here (on by default) |
+| `https://cp.amp.<IP>.sslip.io` | Gateway control plane; connect external gateways here (on by default) |
 
 ## Log in
 
 Open `https://console.amp.<IP>.sslip.io` and sign in as the seeded Agent Manager admin user **`amp-admin`** (password **`amp-admin`**). This user holds the AMP `admin` role, which grants every application permission.
 
-From the `0.16.0` release, role-based access control is enforced on the API (`rbacEnabled`), so the token must carry the right scopes. Note that Thunder's own system account (`admin` / `admin`, shown in the bootstrap logs) is **not** granted the Agent Manager application role — signing in with it lets you reach the console but every API call fails with `403 insufficient permissions`. Always use `amp-admin`.
+From the `0.16.0` release, role-based access control is enforced on the API (`rbacEnabled`), so the token must carry the right scopes. Note that Thunder's own system account (`admin` / `admin`, shown in the bootstrap logs) is **not** granted the Agent Manager application role. Signing in with it lets you reach the console, but every API call fails with `403 insufficient permissions`. Always use `amp-admin`.
 
 ## Deployed-agent invocation
 
 When you deploy an agent, its endpoint is published on a per-project host `<org>-<project>.agents.<IP>.sslip.io` and routed by Caddy to the OpenChoreo data-plane gateway. Because these hostnames are dynamic (a new one per org/project), Caddy issues their TLS certificates **on demand** at the first request (via the same ACME challenge as the fixed hosts), rather than up front. Invocations are authenticated with a user token that the gateway validates against the public Thunder issuer.
 
-Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error** — most visibly `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` in Chrome. That first connection is consumed by Caddy answering the ACME challenge, so the browser briefly sees the challenge certificate instead of the real one. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host — the certificate is then cached in the `amp-caddy-data` volume.
+Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error**, most visibly `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` in Chrome. That first connection is consumed by Caddy answering the ACME challenge, so the browser briefly sees the challenge certificate instead of the real one. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host; the certificate is then cached in the `amp-caddy-data` volume.
 
-amp-api advertises each agent endpoint with the `https://` scheme (the installer sets `tlsEnabled` on the service), so the console — and any other caller — invokes it over TLS directly through the wildcard site.
+amp-api advertises each agent endpoint with the `https://` scheme (the installer sets `tlsEnabled` on the service), so the console (and any other caller) invokes it over TLS directly through the wildcard site.
 
 ## TLS
 
-Caddy obtains and auto-renews trusted Let's Encrypt certificates on first start — no manual certificate steps. Issuance uses the **TLS-ALPN-01** challenge, which runs inside the `:443` TLS handshake, so only inbound 443 is ever required and there is no port-80 dependency. Certificates and the ACME account persist in the `amp-caddy-data` Docker volume, so restarts do not re-request them.
+Caddy obtains and auto-renews trusted Let's Encrypt certificates on first start, with no manual certificate steps. Issuance uses the **TLS-ALPN-01** challenge, which runs inside the `:443` TLS handshake, so only inbound 443 is ever required and there is no port-80 dependency. Certificates and the ACME account persist in the `amp-caddy-data` Docker volume, so restarts do not re-request them.
 
-Because the challenge happens inside the TLS handshake, the public `:443` must reach Caddy as **raw TCP** — do not put a TLS-terminating load balancer in front of the VM. There is no `:80` listener, so plain `http://` URLs are not served (no automatic http→https redirect); always use the `https://` URLs the installer prints.
+Because the challenge happens inside the TLS handshake, the public `:443` must reach Caddy as **raw TCP**; do not put a TLS-terminating load balancer in front of the VM. There is no `:80` listener, so plain `http://` URLs are not served (no automatic http→https redirect); always use the `https://` URLs the installer prints.
 
 ## Persistence and teardown
 
@@ -143,47 +143,43 @@ sudo docker rm -f amp-caddy                              # remove the Caddy fron
 sudo docker volume rm amp-caddy-data amp-caddy-config    # drop the cached certs + ACME account
 ```
 
-Use `sudo` — the installer runs Docker and k3d as root. Plain `./uninstall.sh` (without `--delete-cluster`) only removes the Helm releases and leaves the cluster running; `uninstall.sh` does not touch the Caddy container or its volumes, so remove those separately as shown.
+Use `sudo`; the installer runs Docker and k3d as root. Plain `./uninstall.sh` (without `--delete-cluster`) only removes the Helm releases and leaves the cluster running; `uninstall.sh` does not touch the Caddy container or its volumes, so remove those separately as shown.
 
 ## Connect an external gateway
 
-Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `https://cp.amp.<IP>.sslip.io` is exposed by default for this. In the console, open **Infrastructure → Gateways**, generate a registration token, and follow the generated commands — they point the gateway at `cp.amp.<IP>.sslip.io:443`, where it opens a control WebSocket and pulls its configuration. If you do not need external gateways, install with `--no-external-gateways` to drop this endpoint.
+Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `https://cp.amp.<IP>.sslip.io` is exposed by default for this. In the console, open **Infrastructure → Gateways**, generate a registration token, and follow the generated commands, which point the gateway at `cp.amp.<IP>.sslip.io:443`, where it opens a control WebSocket and pulls its configuration. If you do not need external gateways, install with `--no-external-gateways` to drop this endpoint.
 
 **Security:** the registration token grants a gateway your LLM-provider API keys and proxy credentials. Treat it as a secret, revoke/regenerate it from the Gateways page when a gateway is decommissioned, and optionally restrict `cp.amp...` to known gateway source IPs at the firewall.
 
 ## Troubleshooting
 
-- **Certificates never issue / hosts unreachable from outside** — open inbound `:443` in your cloud security group / NACL, and make sure the public `:443` reaches the VM as **raw TCP**: a TLS-terminating load balancer in front breaks the TLS-ALPN-01 challenge. The installer can't verify external reachability from inside the VM, so this surfaces as Caddy failing to obtain certificates (`docker logs amp-caddy`).
-- **Certificate not issued** — check `docker logs amp-caddy`. Let's Encrypt rate limits on sslip.io are high but not infinite; if hit, retry shortly.
-- **Login redirect mismatch** — confirm you reached the console via its `console.amp.<IP>.sslip.io` URL, not the raw IP.
-- **`403 insufficient permissions` on API calls** — you are signed in as Thunder's system `admin` account, which has no Agent Manager application role. Sign out and sign back in as `amp-admin` (see [Log in](#log-in)).
-- **Certificate error on first agent invocation** (`ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` or similar) — the per-agent certificate is issued on demand, and the first request races with that issuance. Reload the page after a second or two; it only happens once per new agent host (see [Deployed-agent invocation](#deployed-agent-invocation)).
+- **Certificates never issue / hosts unreachable from outside.** Open inbound `:443` in your cloud security group / NACL, and make sure the public `:443` reaches the VM as **raw TCP**: a TLS-terminating load balancer in front breaks the TLS-ALPN-01 challenge. The installer can't verify external reachability from inside the VM, so this surfaces as Caddy failing to obtain certificates (`docker logs amp-caddy`).
+- **Certificate not issued.** Check `docker logs amp-caddy`. Let's Encrypt rate limits on sslip.io are high but not infinite; if hit, retry shortly.
+- **Login redirect mismatch.** Confirm you reached the console via its `console.amp.<IP>.sslip.io` URL, not the raw IP.
+- **`403 insufficient permissions` on API calls.** You are signed in as Thunder's system `admin` account, which has no Agent Manager application role. Sign out and sign back in as `amp-admin` (see [Log in](#log-in)).
+- **Certificate error on first agent invocation** (`ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` or similar): the per-agent certificate is issued on demand, and the first request races with that issuance. Reload the page after a second or two; it only happens once per new agent host (see [Deployed-agent invocation](#deployed-agent-invocation)).
 
 </TabItem>
-<TabItem value="advanced" label="Advanced (custom domain / BYOC / load balancer)">
+<TabItem value="advanced" label="Advanced">
 
-The advanced installer (`install-advanced.sh`) is for deployments that need a real domain or operator-managed certificates. It is driven by a config file and supports three TLS modes. Like the simple installer, it runs **on the VM** with `sudo`.
+The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you need a real domain or operator-managed certificates. It supports a VM reachable from the public internet **and** a VM reachable only from your private network.
 
-Use the advanced installer when you want any of:
+The setup is the same for both: do the shared steps below ([Prerequisites](#adv-prerequisites), [Configure](#adv-configure)), then open the **Public network** or **Private network** tab, which is self-contained: it carries its own TLS modes, the exact config keys to set, an example config, and the DNS records for that case.
 
-- a **custom domain** (e.g. `console.amp.mycompany.com`) instead of an IP-derived `sslip.io` name;
-- **bring-your-own certificates** (BYOC) issued by a corporate CA or pulled from a secrets store, rather than Let's Encrypt;
-- **TLS terminated upstream** by a cloud load balancer or corporate proxy that already owns the public certificate.
-
-If none of those apply, prefer the **Simple** tab.
+If you just want a quick IP-based demo with automatic TLS, prefer the **Simple** tab.
 
 ## Prerequisites {#adv-prerequisites}
 
 The compute, disk, and tooling prerequisites are the same as the Simple tab:
 
 - **Git** to clone this repository and fetch the installer. This is the one tool you need *before* running the script (the script can't install what you use to download it); on a minimal image install it with `sudo apt-get update && sudo apt-get install -y git` (Debian/Ubuntu).
-- **Docker** — the whole stack runs on it. If it isn't already installed, the script installs it for you, along with k3d, kubectl, helm, lsof, and openssl.
+- **Docker.** The whole stack runs on it. If it isn't already installed, the script installs it for you, along with k3d, kubectl, helm, lsof, and openssl.
 - A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, with SSH access (sudo).
 
 In addition, the advanced installer needs:
 
-- **Control of your own DNS** for the chosen domain. The installer derives all service hostnames from a single base domain (`DOMAIN_BASE`), so you create DNS records under that domain (see [DNS](#adv-dns)).
-- **The right inbound port open**, depending on the TLS mode (see [TLS modes](#adv-tls-modes)): `443` for `letsencrypt` and `byoc`, or your chosen forward port for `upstream`.
+- **Control of your own DNS** for the chosen domain. The installer derives all service hostnames from a single base domain (`DOMAIN_BASE`), so you create DNS records under that domain (see the **Public network** or **Private network** tab below for the exact records).
+- **The right inbound port open**, depending on the TLS mode (see the TLS modes table in your network's tab below): `443` for `letsencrypt`, `letsencrypt-dns`, `byoc`, and `selfsigned`, or your chosen forward port for `upstream`. For a private deployment this `443` only needs to be reachable from your private network; the VM never needs inbound access from the public internet.
 
 ## Configure {#adv-configure}
 
@@ -199,14 +195,35 @@ git checkout tags/amp/v0.0.0-dev
 # edit amp-config.env
 ```
 
-The config file is plain shell (sourced by the installer). The keys are:
+The config file is plain shell (sourced by the installer). Generate the template, then open your network's tab below for the exact keys to set and an example config.
+
+## Choose your network {#adv-network}
+
+<Tabs groupId="vm-network">
+<TabItem value="public" label="Public network" default>
+
+Use this when the VM is reachable from the public internet. Point DNS at the VM's public IP and either let Caddy obtain certificates automatically, bring your own public certificate, or terminate TLS at a load balancer in front.
+
+### TLS modes (public) {#adv-public-tls}
+
+In every mode the URLs published to browsers and clients are `https://`; that is what the user sees. Only how TLS is terminated differs.
+
+| Mode | How TLS is handled | Inbound port to open | When to use |
+|---|---|---|---|
+| `letsencrypt` | Caddy obtains and renews trusted Let's Encrypt certificates automatically (TLS-ALPN-01, inside the `:443` handshake) | `443` (raw TCP, no proxy in front), reachable from the **public internet** | You control DNS for the domain and the VM is publicly reachable |
+| `byoc` | Caddy serves your supplied certificate and key on `:443`; no ACME | `443` | You have a certificate from a public or internal CA, or a secrets store |
+| `upstream` | A cloud load balancer / proxy in front terminates TLS; Caddy listens plain-HTTP on `UPSTREAM_LISTEN_PORT` and only routes by Host | the LB's forward port (the LB owns `443` publicly) | You already run an edge load balancer that holds the certificate |
+
+### Config keys (public) {#adv-public-config}
+
+The config file is plain shell (sourced by the installer). The keys for a public deployment are:
 
 | Key | Required | Purpose |
 |---|---|---|
-| `AMP_VERSION` | yes | Agent Manager release to install — use the same `amp/v*` [tag](https://github.com/wso2/agent-manager/tags) you checked out above (`0.0.0-dev`) |
+| `AMP_VERSION` | yes | Agent Manager release to install; use the same `amp/v*` [tag](https://github.com/wso2/agent-manager/tags) you checked out above (`0.0.0-dev`) |
 | `DOMAIN_BASE` | yes | Base domain; service hosts are derived as `<svc>.<DOMAIN_BASE>` |
 | `TLS_MODE` | yes | `letsencrypt`, `byoc`, or `upstream` |
-| `ACME_EMAIL` | letsencrypt | ACME contact for expiry notices |
+| `ACME_EMAIL` | recommended for letsencrypt | ACME contact for expiry notices |
 | `TLS_CERT_FILE` / `TLS_KEY_FILE` | byoc | Paths to the operator certificate and private key |
 | `UPSTREAM_LISTEN_PORT` | upstream | Plain-HTTP port Caddy listens on behind the LB (default `80`). Must not be a loopback-bound cluster port (3000/8080/9000/9098/9243/19080/22893); `80` is safe |
 | `UPSTREAM_TRUSTED_PROXIES` | upstream | Space-separated CIDRs of the LB whose `X-Forwarded-*` headers Caddy trusts (default `0.0.0.0/0`) |
@@ -216,17 +233,7 @@ The config file is plain shell (sourced by the installer). The keys are:
 
 With `DOMAIN_BASE=amp.mycompany.com`, the derived hosts are `console.amp.mycompany.com`, `api.amp.mycompany.com`, `thunder.amp.mycompany.com`, `observer.amp.mycompany.com`, `gateway.amp.mycompany.com`, `cp.amp.mycompany.com`, and deployed agents at `<org>-<project>.agents.amp.mycompany.com`.
 
-## TLS modes {#adv-tls-modes}
-
-In every mode the URLs published to browsers and clients are `https://` — that is what the user sees. Only how TLS is terminated differs.
-
-| Mode | How TLS is handled | Inbound port to open | When to use |
-|---|---|---|---|
-| `letsencrypt` | Caddy obtains and renews trusted Let's Encrypt certificates automatically (TLS-ALPN-01, inside the `:443` handshake) | `443` (raw TCP, no proxy in front) | You control DNS for the domain and want automatic certificates |
-| `byoc` | Caddy serves your supplied certificate and key on `:443`; no ACME | `443` | Certificates come from a corporate CA or a secrets store |
-| `upstream` | A cloud load balancer / proxy in front terminates TLS; Caddy listens plain-HTTP on `UPSTREAM_LISTEN_PORT` and only routes by Host | the LB's forward port (the LB owns `443` publicly) | You already run an edge load balancer that holds the public certificate |
-
-### BYOC certificate requirements {#adv-byoc-san}
+### BYOC certificate requirements {#adv-public-byoc}
 
 Deployed-agent endpoints live one DNS level deeper than the service hosts, at `<org>-<project>.<AGENTS_BASE>`. A standard `*.<DOMAIN_BASE>` wildcard does **not** cover that tier, and there is no ACME in `byoc` mode to issue per-host certificates on demand. So your single certificate must carry SANs covering **both** `*.<DOMAIN_BASE>` and `*.<AGENTS_BASE>`. The installer's pre-flight checks this and fails fast (naming the missing SAN) if it is absent, along with verifying the cert and key match and the cert is not expired.
 
@@ -240,26 +247,173 @@ openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
 
 ### Upstream (load-balancer) topology {#adv-upstream}
 
-In `upstream` mode the load balancer owns `:443` and the public certificate. Configure it to forward each derived hostname to the VM's `UPSTREAM_LISTEN_PORT` over plain HTTP, and to set the `X-Forwarded-Proto: https` header — Caddy trusts it so the backends still see the original `https` scheme. Because the LB fronts DNS, the installer's DNS check is advisory (not a hard failure) in this mode.
+In `upstream` mode the load balancer owns `:443` and the public certificate. Configure it to forward each derived hostname to the VM's `UPSTREAM_LISTEN_PORT` over plain HTTP, and to set the `X-Forwarded-Proto: https` header, which Caddy trusts so the backends still see the original `https` scheme. Because the LB fronts DNS, the installer's DNS check is advisory (not a hard failure) in this mode.
 
-Because the listen port carries plain HTTP and Caddy trusts the forwarded scheme, lock down who can reach it: **restrict `UPSTREAM_LISTEN_PORT` to the load balancer at the firewall**, and set `UPSTREAM_TRUSTED_PROXIES` to the LB's source CIDRs so only the LB can set `X-Forwarded-*`. The default (`0.0.0.0/0`) trusts any source and relies solely on the firewall — fine if the port is firewalled to the LB, but scoping both is safer. For a GCP Application Load Balancer the source ranges are `130.211.0.0/22` and `35.191.0.0/16`, so:
+Because the listen port carries plain HTTP and Caddy trusts the forwarded scheme, lock down who can reach it: **restrict `UPSTREAM_LISTEN_PORT` to the load balancer at the firewall**, and set `UPSTREAM_TRUSTED_PROXIES` to the LB's source CIDRs so only the LB can set `X-Forwarded-*`. The default (`0.0.0.0/0`) trusts any source and relies solely on the firewall, which is fine if the port is firewalled to the LB, but scoping both is safer. For a GCP Application Load Balancer the source ranges are `130.211.0.0/22` and `35.191.0.0/16`, so:
 
 ```sh
 UPSTREAM_TRUSTED_PROXIES="130.211.0.0/22 35.191.0.0/16"
 ```
 
-## DNS {#adv-dns}
+### DNS (public) {#adv-public-dns}
 
-For `letsencrypt` and `byoc`, point A records for every service host at the VM's public IP, plus a wildcard for the deployed-agent tier. Two wildcard records are the simplest:
+Point A records for every service host at the VM's public IP, plus a wildcard for the deployed-agent tier. Two wildcard records are the simplest:
 
 ```
 *.amp.mycompany.com          A  <VM_PUBLIC_IP>   # covers console/api/thunder/observer/gateway/cp
 *.agents.amp.mycompany.com   A  <VM_PUBLIC_IP>   # covers deployed agents (one level deeper)
 ```
 
-The second record is separate because deployed-agent hostnames sit one level below the service hosts, and a `*.amp.mycompany.com` wildcard does not match `x.agents.amp.mycompany.com`. If you use a proxying DNS provider (for example Cloudflare's orange-cloud), set these records to **DNS-only** — a proxy that terminates TLS in front of the VM breaks the TLS-ALPN-01 challenge.
+The second record is separate because deployed-agent hostnames sit one level below the service hosts, and a `*.amp.mycompany.com` wildcard does not match `x.agents.amp.mycompany.com`. If you use a proxying DNS provider (for example Cloudflare's orange-cloud), set these records to **DNS-only**, since a proxy that terminates TLS in front of the VM breaks the TLS-ALPN-01 challenge. In `letsencrypt` mode these records must resolve to the VM **before** you install; the DNS pre-flight hard-fails otherwise, naming the exact records to create. In `upstream` mode, point DNS at the load balancer instead; the VM-side check is advisory.
 
-In `letsencrypt` mode these records must resolve to the VM **before** you run the installer — ACME issuance fails otherwise, and the installer's DNS pre-flight hard-fails with the exact records to create. (The check accepts the VM's public egress IP as well as its local interface IPs, so it works correctly on NAT'd cloud VMs.) In `upstream` mode, point DNS at the load balancer instead; the VM-side check is advisory.
+### Example configs (public) {#adv-public-examples}
+
+Automatic Let's Encrypt (recommended):
+
+```sh
+AMP_VERSION=0.0.0-dev
+DOMAIN_BASE=amp.mycompany.com
+TLS_MODE=letsencrypt
+ACME_EMAIL=ops@mycompany.com
+```
+
+Behind a load balancer that terminates TLS (`upstream`):
+
+```sh
+AMP_VERSION=0.0.0-dev
+DOMAIN_BASE=amp.mycompany.com
+TLS_MODE=upstream
+UPSTREAM_LISTEN_PORT=80
+UPSTREAM_TRUSTED_PROXIES="130.211.0.0/22 35.191.0.0/16"   # example: GCP load balancer ranges
+```
+
+For a publicly trusted certificate you supply yourself, use `byoc` (see [BYOC certificate requirements](#adv-public-byoc) for the SAN rules):
+
+```sh
+AMP_VERSION=0.0.0-dev
+DOMAIN_BASE=amp.mycompany.com
+TLS_MODE=byoc
+TLS_CERT_FILE=/opt/amp/certs/fullchain.pem
+TLS_KEY_FILE=/opt/amp/certs/privkey.pem
+```
+
+</TabItem>
+<TabItem value="private" label="Private network">
+
+Use this when the VM is reachable only from your private network (private subnet, VPN, or security-group rules). The VM still needs **outbound** internet access (to pull images and charts and, for `letsencrypt-dns`, to reach the ACME and DNS-provider APIs), but it never needs inbound access from the public internet. Reachability is governed by your cloud network configuration, not the installer; the installer only opens inbound `443/tcp` on the host firewall for clients on your network.
+
+The diagram shows the recommended `letsencrypt-dns` flow. The key idea: Let's Encrypt proves you own the domain by reading a DNS `TXT` record, so it **never connects to the VM**; that is what lets a firewalled, private-only VM still obtain public-trusted certificates.
+
+```mermaid
+flowchart TB
+    le["Let's Encrypt (ACME)<br/>public CA"]
+    dns["Public DNS zone you control<br/>(TXT for validation;<br/>A records may point at the private IP)"]
+
+    subgraph priv["Private network (no public ingress)"]
+        client["Browser / API client<br/>on the private network"]
+
+        subgraph vm["VM (:443 reachable only from the private network)"]
+            lego["lego (DNS-01)<br/>issues + renews the cert"]
+            caddy["Caddy reverse proxy<br/>:443 · terminates TLS · serves the cert"]
+
+            subgraph k3d["k3d cluster (host ports bound to 127.0.0.1)"]
+                svc["Console · amp-api · Thunder ·<br/>Observer · Gateway · Deployed agents"]
+            end
+        end
+    end
+
+    client -->|"HTTPS :443 (private only)"| caddy
+    lego -->|"1 · write _acme-challenge TXT (outbound)"| dns
+    le -->|"2 · read TXT, never connects to the VM"| dns
+    le -->|"3 · issue cert (outbound)"| lego
+    lego -.->|"cert + key on disk"| caddy
+    caddy --> svc
+```
+
+### TLS modes (private) {#adv-private-tls}
+
+In every mode the URLs published to browsers and clients are `https://`; that is what the user sees. Only how TLS is terminated differs.
+
+| Mode | How TLS is handled | Inbound port to open | When to use |
+|---|---|---|---|
+| `letsencrypt-dns` | `lego` obtains trusted Let's Encrypt certificates via the **DNS-01** challenge (a DNS TXT record); the ACME CA never connects to the VM. A daily timer renews them | `443` reachable from your **private network** only (egress to ACME + DNS APIs required) | A private VM with no public ingress, where you control a public DNS zone (the recommended private mode) |
+| `selfsigned` | The installer generates a local CA + leaf and serves it on `:443`; the CA is written to `/opt/amp/certs/ca.crt` for distribution | `443` (private network) | Self-contained TLS: no public DNS zone and no external CA (the host still needs outbound internet to pull images) |
+| `byoc` | Caddy serves your supplied certificate and key on `:443`; no ACME | `443` | You have a certificate from a public or internal CA, or a secrets store |
+
+### Config keys (private) {#adv-private-config}
+
+The config file is plain shell (sourced by the installer). The keys for a private deployment are:
+
+| Key | Required | Purpose |
+|---|---|---|
+| `AMP_VERSION` | yes | Agent Manager release to install; use the same `amp/v*` [tag](https://github.com/wso2/agent-manager/tags) you checked out above (`0.0.0-dev`) |
+| `DOMAIN_BASE` | yes | Base domain; service hosts are derived as `<svc>.<DOMAIN_BASE>` |
+| `TLS_MODE` | yes | `letsencrypt-dns`, `selfsigned`, or `byoc` |
+| `ACME_EMAIL` | letsencrypt-dns | ACME contact; **required** for `letsencrypt-dns` (the ACME account is registered with it) |
+| `DNS_PROVIDER` | letsencrypt-dns | [lego](https://go-acme.github.io/lego/dns/) DNS provider that writes the DNS-01 TXT record, e.g. `route53`, `cloudflare`, `gcloud`, `azuredns`. Supply that provider's credential env vars in the same file |
+| `ACME_SERVER` | no | Override the ACME directory URL (e.g. Let's Encrypt staging) while testing `letsencrypt-dns` to avoid rate limits |
+| `TLS_CERT_FILE` / `TLS_KEY_FILE` | byoc | Paths to the operator certificate and private key. For `letsencrypt-dns` and `selfsigned` these default to `/opt/amp/certs/fullchain.pem` and `/opt/amp/certs/privkey.pem` |
+| `EXTERNAL_GATEWAYS` | no | `true` (default) exposes the `cp` endpoint for external data-plane gateways |
+| `HOST_CONSOLE`, `HOST_API`, `HOST_THUNDER`, `HOST_OBSERVER`, `HOST_GATEWAY`, `HOST_CP` | no | Override an individual service hostname (default `<svc>.<DOMAIN_BASE>`) |
+| `AGENTS_BASE` | no | Base for deployed-agent hostnames (default `agents.<DOMAIN_BASE>`) |
+
+With `DOMAIN_BASE=amp.internal.mycompany.com`, the derived hosts are `console.amp.internal.mycompany.com`, `api.amp.internal.mycompany.com`, `thunder.amp.internal.mycompany.com`, `observer.amp.internal.mycompany.com`, `gateway.amp.internal.mycompany.com`, `cp.amp.internal.mycompany.com`, and deployed agents at `<org>-<project>.agents.amp.internal.mycompany.com`.
+
+### BYOC certificate requirements {#adv-private-byoc}
+
+In `byoc` mode the installer serves a certificate you supply, typically issued by your internal CA. Deployed-agent endpoints live one DNS level deeper than the service hosts, at `<org>-<project>.<AGENTS_BASE>`. A standard `*.<DOMAIN_BASE>` wildcard does **not** cover that tier, and there is no ACME in `byoc` mode to issue per-host certificates on demand. So your single certificate must carry SANs covering **both** `*.<DOMAIN_BASE>` and `*.<AGENTS_BASE>`. The installer's pre-flight checks this and fails fast (naming the missing SAN) if it is absent, along with verifying the cert and key match and the cert is not expired.
+
+For example, a cert request covering both tiers:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -keyout privkey.pem -out fullchain.pem -subj "/CN=amp.internal.mycompany.com" \
+  -addext "subjectAltName=DNS:*.amp.internal.mycompany.com,DNS:*.agents.amp.internal.mycompany.com"
+```
+
+### DNS (private) {#adv-private-dns}
+
+For `letsencrypt-dns`, the `A` records may point at the VM's **private** IP, because Let's Encrypt only reads the `_acme-challenge` TXT records during validation, not the `A` records, so split-horizon DNS works. The zone must still be a public zone your `DNS_PROVIDER` credentials can write TXT records in. The VM-side DNS pre-flight is advisory in this mode (it will not hard-fail on a private IP). For `selfsigned`, no public DNS is involved at all; resolve the hostnames however your private network does (internal DNS, or `/etc/hosts` on clients).
+
+### Example configs (private) {#adv-private-examples}
+
+Public-trusted certificates via DNS-01, using Google Cloud DNS (recommended):
+
+```sh
+AMP_VERSION=0.0.0-dev
+DOMAIN_BASE=amp.internal.mycompany.com
+TLS_MODE=letsencrypt-dns
+ACME_EMAIL=ops@mycompany.com
+DNS_PROVIDER=gcloud
+GCE_PROJECT=my-gcp-project
+GCE_SERVICE_ACCOUNT_FILE=/opt/amp/certs/gcp-dns-sa.json
+# ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory   # LE staging while testing
+```
+
+`lego` runs as a container that mounts `/opt/amp/certs`, so a credential **file** (such as the Google service-account key) must live under that directory to be readable from the container. Place the key at `/opt/amp/certs/gcp-dns-sa.json` as shown. Token-based providers (`route53`, `cloudflare`, `azuredns`) instead set credential env vars in the same config file and need no mounted file. See the [`lego` provider list](https://go-acme.github.io/lego/dns/) for any other provider and its variables.
+
+Self-contained TLS with a generated local CA (`selfsigned`):
+
+```sh
+AMP_VERSION=0.0.0-dev
+DOMAIN_BASE=amp.internal.mycompany.com
+TLS_MODE=selfsigned
+```
+
+After install, import `/opt/amp/certs/ca.crt` into your clients' trust stores (via MDM/GPO) so browsers trust the console and API without warnings.
+
+For a certificate from your internal CA, use `byoc` (see [BYOC certificate requirements](#adv-private-byoc) for the SAN rules):
+
+```sh
+AMP_VERSION=0.0.0-dev
+DOMAIN_BASE=amp.internal.mycompany.com
+TLS_MODE=byoc
+TLS_CERT_FILE=/opt/amp/certs/fullchain.pem
+TLS_KEY_FILE=/opt/amp/certs/privkey.pem
+```
+
+</TabItem>
+</Tabs>
 
 ## Install {#adv-install}
 
@@ -275,7 +429,7 @@ This loads the config, runs the cert and (in `letsencrypt`) DNS pre-flight, and 
 sudo ./install-advanced.sh --config amp-config.env
 ```
 
-It runs in two phases — bootstrap (Docker + tools + firewall) and the platform install + Caddy startup — and takes 8–15 minutes. It needs `sudo` because it installs Docker, opens the firewall, and creates the cluster. On completion it prints the access URLs.
+It runs in two phases: bootstrap (Docker + tools + firewall) and the platform install + Caddy startup, and takes 8-15 minutes. It needs `sudo` because it installs Docker, opens the firewall, and creates the cluster. On completion it prints the access URLs.
 
 ## Persistence and teardown {#adv-persistence}
 
@@ -290,20 +444,21 @@ sudo docker volume rm amp-caddy-data amp-caddy-config    # drop the cached certs
 
 Use `sudo` (Docker and k3d run as root). Plain `./uninstall.sh` without `--delete-cluster` only removes the Helm releases and leaves the cluster running; `uninstall.sh` does not touch the Caddy container or its volumes, so remove those separately as shown.
 
-**Changing the domain or hostnames after install requires a teardown first.** The platform install is idempotent in the "create if missing" sense — on a re-run it skips releases that already exist, so editing `DOMAIN_BASE` (or the `HOST_*` overrides) and re-running does **not** reconfigure the already-installed services; only Caddy's front-door TLS changes, leaving the apps advertising the old hostnames. To move an existing install to a different domain, tear it down (`sudo ./uninstall.sh --delete-cluster`, then remove `amp-caddy` and its volumes as in [Persistence and teardown](#adv-persistence)) and install again with the new config. (Switching only the `TLS_MODE` between `letsencrypt`/`byoc`/`upstream` while keeping the same hostnames is fine — that only re-renders Caddy.)
+**Changing the domain or hostnames after install requires a teardown first.** The platform install is idempotent in the "create if missing" sense: on a re-run it skips releases that already exist, so editing `DOMAIN_BASE` (or the `HOST_*` overrides) and re-running does **not** reconfigure the already-installed services; only Caddy's front-door TLS changes, leaving the apps advertising the old hostnames. To move an existing install to a different domain, tear it down (`sudo ./uninstall.sh --delete-cluster`, then remove `amp-caddy` and its volumes as in [Persistence and teardown](#adv-persistence)) and install again with the new config. (Switching only the `TLS_MODE` between `letsencrypt`/`letsencrypt-dns`/`byoc`/`selfsigned`/`upstream` while keeping the same hostnames is fine; that only re-renders Caddy and re-issues or regenerates the certificate.)
 
 ## Connect an external gateway {#adv-external-gw}
 
-This works the same as in the Simple tab: the control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Generate a registration token from **Infrastructure → Gateways** and follow the generated commands. Set `EXTERNAL_GATEWAYS=false` to drop the endpoint if you do not connect external gateways. The registration token grants a gateway your LLM-provider API keys — treat it as a secret and revoke it when a gateway is decommissioned.
+This works the same as in the Simple tab: the control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Generate a registration token from **Infrastructure → Gateways** and follow the generated commands. Set `EXTERNAL_GATEWAYS=false` to drop the endpoint if you do not connect external gateways. The registration token grants a gateway your LLM-provider API keys, so treat it as a secret and revoke it when a gateway is decommissioned.
 
 ## Troubleshooting {#adv-troubleshooting}
 
-- **Config rejected before install** — the installer prints which key is missing or invalid (e.g. an unknown `TLS_MODE`, or `byoc` without `TLS_CERT_FILE`). Fix `amp-config.env` and re-run.
-- **Certificate validation failed (byoc)** — the cert and key do not match, the cert is expired, or its SANs do not cover a service host or the `*.<AGENTS_BASE>` wildcard. The message names the specific problem; reissue the certificate with the required SANs (see [BYOC certificate requirements](#adv-byoc-san)).
-- **DNS pre-flight failed (letsencrypt)** — one or more hostnames do not resolve to the VM. Create the A records listed under [DNS](#adv-dns) and re-run. The message names the hosts and the expected IP.
-- **Certificates never issue / hosts unreachable (letsencrypt)** — open inbound `:443` in your cloud security group, and ensure it reaches the VM as **raw TCP**; a TLS-terminating load balancer in front breaks TLS-ALPN-01. If you have such a load balancer, use `upstream` mode instead. Check `docker logs amp-caddy`.
-- **Changed the domain but the console still shows the old hostnames** — re-running with a new `DOMAIN_BASE` does not reconfigure existing releases. Tear down and reinstall (see [Persistence and teardown](#adv-persistence)).
-- **`403 insufficient permissions` on API calls** — sign in as `amp-admin`, not Thunder's system `admin` account.
+- **Config rejected before install.** The installer prints which key is missing or invalid (e.g. an unknown `TLS_MODE`, or `byoc` without `TLS_CERT_FILE`). Fix `amp-config.env` and re-run.
+- **Certificate validation failed (byoc).** The cert and key do not match, the cert is expired, or its SANs do not cover a service host or the `*.<AGENTS_BASE>` wildcard. The message names the specific problem; reissue the certificate with the required SANs (see BYOC certificate requirements in your network's tab: [public](#adv-public-byoc) or [private](#adv-private-byoc)).
+- **DNS pre-flight failed (letsencrypt).** One or more hostnames do not resolve to the VM. Create the A records listed under the **Public network** tab ([DNS (public)](#adv-public-dns)) and re-run. The message names the hosts and the expected IP.
+- **Certificates never issue / hosts unreachable (letsencrypt).** Open inbound `:443` in your cloud security group, and ensure it reaches the VM as **raw TCP**; a TLS-terminating load balancer in front breaks TLS-ALPN-01. If you have such a load balancer, use `upstream` mode instead. If the VM has no public ingress at all, use `letsencrypt-dns` (DNS-01) instead. Check `docker logs amp-caddy`.
+- **DNS-01 issuance failed (letsencrypt-dns).** `lego` could not create or validate the `_acme-challenge` TXT record. Check that `DNS_PROVIDER` is correct and its credential env vars are set in `amp-config.env`, that those credentials can write to the zone, and that the zone is delegated to that provider. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate without hitting rate limits.
+- **Changed the domain but the console still shows the old hostnames.** Re-running with a new `DOMAIN_BASE` does not reconfigure existing releases. Tear down and reinstall (see [Persistence and teardown](#adv-persistence)).
+- **`403 insufficient permissions` on API calls.** Sign in as `amp-admin`, not Thunder's system `admin` account.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The VM installer has two entry points today — the simple installer (`install-vm.sh`, sslip.io + Let's Encrypt on `:443`) and the advanced installer (`install-advanced.sh` with `letsencrypt | byoc | upstream`). Both assume the VM is reachable from the public internet. Many companies will not expose the console/API publicly and want Agent Manager reachable only from their private network. The blocker is TLS: public `letsencrypt` (TLS-ALPN-01) needs the ACME CA to connect inbound to the VM on `:443`, which a private VM cannot accept.

Related to #1017 (VM standalone install).
Resolves https://github.com/wso2/agent-manager/issues/1081

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Add two TLS modes to the advanced installer so a VM with **private ingress and internet egress** can run Agent Manager without ever being publicly reachable:

- `letsencrypt-dns` (recommended) — public-trusted certificates via the ACME **DNS-01** challenge. The CA validates a DNS TXT record and never connects to the VM, so it works behind a firewall. `A` records may point at the VM's private IP (split-horizon).
- `selfsigned` — fully offline: a generated local CA + leaf for teams with neither a public DNS zone nor an internal CA.

`byoc` (internal-CA cert) and `upstream` (internal LB) already cover the remaining private variants and are unchanged.

## Approach
> Describe how you are implementing the solutions.

Both new modes only **produce** a cert/key on disk and then reuse the existing `byoc` serving path (Caddyfile rendering, container cert mounts, and `validate_cert`'s SAN/wildcard coverage checks) — so `lib-vm.sh` is untouched and the serving logic is shared.

- New `deployments/vm/lib-tls.sh`: pure helpers (`tls_san_list`, `build_lego_args`, `render_renewal_units`) plus side-effecting issuance (`issue_dns01_cert` via the dockerized `goacme/lego` image, `generate_selfsigned_ca` via openssl, `install_renewal_timer`).
- `letsencrypt-dns` issues a cert covering every service host + the `*.<AGENTS_BASE>` wildcard, copies it to `/opt/amp/certs/`, and installs a daily `systemd` timer (`lego renew` + `caddy reload`).
- `selfsigned` generates a local CA + leaf and writes the CA to `/opt/amp/certs/ca.crt` for distribution to client trust stores.
- `validate_config` learns the two modes (`letsencrypt-dns` requires `DNS_PROVIDER` + `ACME_EMAIL`; `selfsigned` requires nothing extra), the `--init` template documents them, and `--dry-run` previews the issuance/generation plan without doing it.

## User stories
> Summary of user stories addressed by this change

As a platform operator at a security-conscious company, I can install Agent Manager on a private-network-only VM with trustworthy TLS — either public-trusted certificates via DNS-01 (no public ingress) or a generated local CA when fully offline.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

The advanced VM installer now supports private-network-only deployments via two new TLS modes: `letsencrypt-dns` (public-trusted certificates through the ACME DNS-01 challenge, with automatic renewal) and `selfsigned` (a generated local CA for fully offline installs).

## Documentation
> Link(s) to product documentation that addresses the changes of this PR.

Updated `documentation/docs/getting-started/on-a-vm.mdx`: new "Private network (no public exposure)" section, the two new modes added to the TLS-modes and config-key tables, DNS split-horizon guidance for DNS-01, and troubleshooting entries.

## Training
> Link to the PR for changes to the training content, if applicable

N/A — no training content impact.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — no marketing content for this change.

## Automation tests
 - Unit tests
   > Code coverage information

Extended `deployments/vm/tests/run.sh` (SAN list, lego arg builder, renewal-unit rendering, `validate_config` for both modes, `--init` template, and `--dry-run` for both modes) and `deployments/vm/tests/preflight.sh` (local-CA generation produces a cert whose SANs cover every host + the agent wildcard, verified via `validate_cert` + openssl). Both suites pass; the changed scripts are shellcheck-clean.
 - Integration tests
   > Details about the test cases and coverage

The suites are hermetic (no Docker/cluster). A live DNS-01 issuance against a real zone and a `selfsigned` browser-trust check on a GCP VM are planned as an out-of-band smoke test, mirroring the earlier VM-install smoke tests (this PR is a draft pending that).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell scripts only, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — DNS-provider credentials are supplied by the operator in `amp-config.env` at install time and the renewal config copy is written `0600`; none are committed.

## Samples
> Provide high-level details about the samples related to this feature

N/A — no new samples. The docs include a DNS-01 (AWS Route 53) walkthrough.

## Related PRs
> List any other related PRs

Builds on the VM standalone (#1017) and advanced-install work in `deployments/vm/`.

## Migrations (if applicable)
N/A — additive feature; no migration required. Switching `TLS_MODE` on an existing install only re-renders Caddy and re-issues/regenerates the certificate.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Unit + preflight suites run locally on macOS (bash 3.2). The installer targets Linux VMs (Ubuntu/Debian, bash 4+); the real-VM smoke test is pending (see Automation tests).

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Key insight: the ACME **DNS-01** challenge validates a DNS TXT record rather than connecting to the host, so it can issue public-trusted (and wildcard) certificates for a server with no public ingress. Used `lego` (single-binary ACME client, ~150 DNS providers) to keep the stock `caddy:2` image and reuse the existing `byoc` serving path rather than building a custom Caddy image with DNS plugins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Let's Encrypt DNS-01 automatic certificate issuance with daily renewal
  * Added self-signed certificate generation mode with local CA support
  * Automatic system kernel optimization during installation for improved stability

* **Improvements**
  * Enhanced DNS preflight validation with improved advisory messaging
  * Improved certificate validation with comprehensive SAN inspection
  * Better error reporting for TLS configuration validation

* **Documentation**
  * Updated VM deployment guide with clearer TLS configuration and networking instructions
  * Expanded troubleshooting section with certificate validation and DNS diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->