### PR TITLE
Add amctl api low-level API passthrough command

### DIFF
--- a/cli/pkg/cmd/api/api.go
+++ b/cli/pkg/cmd/api/api.go
@@ -178,6 +178,10 @@ func runAPI(ctx context.Context, o *APIOptions) error {
 		return render.Error(o.IO, render.Scope{}, clierr.Newf(code, format, args...))
 	}
 
+	if o.RequestInputFile == "-" && fieldReadsStdin(o.MagicFields) {
+		return bail(clierr.InvalidFlag, "cannot read stdin for both --input - and an @- field")
+	}
+
 	params, err := parseFields(o.RawFields, o.MagicFields, o.IO.In)
 	if err != nil {
 		return bail(clierr.InvalidFlag, "%v", err)
@@ -232,15 +236,15 @@ func runAPI(ctx context.Context, o *APIOptions) error {
 		return bail(clierr.Transport, "build request: %v", err)
 	}
 
-	token, err := o.Token(ctx)
-	if err != nil {
-		return render.Error(o.IO, render.Scope{}, err)
-	}
-
 	if err := applyHeaders(req, o.RequestHeaders); err != nil {
 		return bail(clierr.InvalidFlag, "%v", err)
 	}
+	// Only resolve a token when the user gave no Authorization header.
 	if req.Header.Get("Authorization") == "" {
+		token, err := o.Token(ctx)
+		if err != nil {
+			return render.Error(o.IO, render.Scope{}, err)
+		}
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	if bodyIsJSON && req.Header.Get("Content-Type") == "" {
@@ -436,6 +440,9 @@ func parseField(raw string, magic bool, stdin io.Reader) (string, any, error) {
 	if !found {
 		return "", nil, fmt.Errorf("field %q requires a value separated by '='", raw)
 	}
+	if strings.TrimSpace(key) == "" {
+		return "", nil, fmt.Errorf("field %q has an empty key", raw)
+	}
 	if magic {
 		v, err := magicFieldValue(val, stdin)
 		if err != nil {
@@ -444,6 +451,17 @@ func parseField(raw string, magic bool, stdin io.Reader) (string, any, error) {
 		return key, v, nil
 	}
 	return key, val, nil
+}
+
+// fieldReadsStdin reports whether any -F field reads its value from stdin (a
+// value of exactly "@-"). Raw -f fields are literal, so they never read stdin.
+func fieldReadsStdin(magicFields []string) bool {
+	for _, f := range magicFields {
+		if _, val, found := strings.Cut(f, "="); found && val == "@-" {
+			return true
+		}
+	}
+	return false
 }
 
 // parseFields collects raw (-f) and magic (-F) fields into a single map.

--- a/cli/pkg/cmd/api/api.go
+++ b/cli/pkg/cmd/api/api.go
@@ -1,0 +1,489 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package api implements `amctl api`, a low-level passthrough to the Agent
+// Manager HTTP API — the escape hatch for endpoints that do not yet have a
+// dedicated command. Output and error bodies are streamed verbatim; the
+// endpoint path is resolved relative to the instance's /api/v1 base.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+const apiBasePath = "api/v1"
+
+// NewAPICmd builds the `amctl api` command — a low-level authenticated
+// passthrough to the Agent Manager HTTP API.
+func NewAPICmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &APIOptions{
+		IO:         f.IOStreams,
+		HTTPClient: f.HTTPClient,
+		Token:      f.Token,
+		BaseURL: func() (string, error) {
+			cfg, err := f.Config()
+			if err != nil {
+				return "", clierr.Newf(clierr.ConfigNotLoaded, "%v", err)
+			}
+			inst, err := cfg.Current()
+			if err != nil {
+				return "", clierr.New(clierr.NoInstance, err.Error())
+			}
+			return inst.URL, nil
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "api <endpoint>",
+		Short: "Make an authenticated request to the Agent Manager API",
+		Long: heredoc(`
+			Make an authenticated HTTP request to the Agent Manager API and print
+			the response verbatim.
+
+			The endpoint is resolved relative to the current instance's API base, so
+			"/api/v1" may be omitted: "amctl api /orgs" and "amctl api /api/v1/orgs"
+			are equivalent. The current instance's access token is attached automatically.
+
+			Resources are scoped under /orgs/{org}/projects/{project}/...; there are no
+			flat top-level resources. The {org} and {project} placeholders are filled from
+			the current context (--org/--project, then the linked project, then the active
+			org), so "amctl api /orgs/{org}/projects/{project}/agents" works from a linked
+			directory without spelling out names. An unknown placeholder, or one that
+			cannot be resolved, is reported as an error.
+
+			The HTTP method defaults to GET, switching to POST when fields (-f/-F) or a
+			request body (--input) are supplied; override it with -X/--method.
+
+			Fields given with -f are sent as strings. Fields given with -F are parsed:
+			"true"/"false" become booleans, integers become numbers, "null" becomes null,
+			and "@path" reads the value from a file ("@-" reads stdin). For GET, fields are
+			added to the query string; otherwise they form a JSON request body.
+
+			The response body is streamed to stdout exactly as received. On an HTTP status
+			of 400 or above the body is still printed, a short "HTTP <status>" line is
+			written to stderr, and the command exits non-zero.`),
+		Example: heredoc(`
+			# List organizations
+			$ amctl api /orgs
+
+			# List agents, filling {org}/{project} from the current context
+			$ amctl api /orgs/{org}/projects/{project}/agents
+
+			# Get one agent (org/project spelled out explicitly)
+			$ amctl api /orgs/default/projects/default/agents/it-helpdesk-agent
+
+			# Filter with query parameters (explicit GET keeps fields in the query)
+			$ amctl api -X GET /orgs/{org}/projects/{project}/agents -f limit=10
+
+			# Create a project from typed fields (inferred POST + JSON body)
+			$ amctl api /orgs/{org}/projects -f name=triage -F retain=true
+
+			# Send a raw JSON body from a file or stdin
+			$ amctl api -X POST /orgs/{org}/projects --input ./project.json
+			$ cat project.json | amctl api -X POST /orgs/{org}/projects --input -
+
+			# Inspect response headers
+			$ amctl api -i /orgs/{org}/projects/{project}/agents`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.RequestPath = args[0]
+			opts.RequestMethodPassed = cmd.Flags().Changed("method")
+			opts.Scope = func() (string, string, error) {
+				return f.ResolveOrgProject(cmd, false, false)
+			}
+			return runAPI(cmd.Context(), opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.RequestMethod, "method", "X", "GET", "The HTTP method for the request")
+	cmd.Flags().StringArrayVarP(&opts.RawFields, "raw-field", "f", nil, "Add a string parameter in `key=value` format")
+	cmd.Flags().StringArrayVarP(&opts.MagicFields, "field", "F", nil, "Add a typed parameter in `key=value` format (bool/int/null, or @file/@- to read a value)")
+	cmd.Flags().StringArrayVarP(&opts.RequestHeaders, "header", "H", nil, "Add a request header in `key:value` format")
+	cmd.Flags().StringVar(&opts.RequestInputFile, "input", "", "`file` to send as the request body (use \"-\" for stdin)")
+	cmd.Flags().BoolVarP(&opts.ShowResponseHeaders, "include", "i", false, "Include the response status line and headers in the output")
+	cmd.Flags().String("project", "", "Override the project used to fill the {project} placeholder")
+
+	return cmd
+}
+
+// heredoc trims a leading newline and the leading tab indentation shared by the
+// block, so command help can be written as an indented raw string literal.
+func heredoc(s string) string {
+	s = strings.TrimPrefix(s, "\n")
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimPrefix(ln, "\t\t\t")
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n")
+}
+
+// APIOptions carries everything runAPI needs: its dependencies (resolved off
+// the Factory) and the parsed request flags.
+type APIOptions struct {
+	IO         *iostreams.IOStreams
+	HTTPClient func() *http.Client
+	Token      func(context.Context) (string, error)
+	BaseURL    func() (string, error)
+	// Scope resolves the (org, project) used to fill {org}/{project} path
+	// placeholders. It is only invoked when the endpoint contains placeholders.
+	Scope func() (org, project string, err error)
+
+	RequestPath         string
+	RequestMethod       string
+	RequestMethodPassed bool
+	RawFields           []string
+	MagicFields         []string
+	RequestHeaders      []string
+	RequestInputFile    string
+	ShowResponseHeaders bool
+}
+
+// runAPI builds and sends the request, then streams the response verbatim.
+// Output and error bodies are passed through unchanged; on an HTTP status of
+// 400+ it prints a short status line to stderr and returns a rendered error so
+// the process exits non-zero without re-printing.
+func runAPI(ctx context.Context, o *APIOptions) error {
+	bail := func(code, format string, args ...any) error {
+		return render.Error(o.IO, render.Scope{}, clierr.Newf(code, format, args...))
+	}
+
+	params, err := parseFields(o.RawFields, o.MagicFields, o.IO.In)
+	if err != nil {
+		return bail(clierr.InvalidFlag, "%v", err)
+	}
+
+	method := inferMethod(o.RequestMethod, o.RequestMethodPassed, len(params) > 0, o.RequestInputFile)
+
+	endpoint := o.RequestPath
+	if hasPlaceholders(endpoint) {
+		org, project, serr := o.Scope()
+		if serr != nil {
+			return bail(clierr.NoOrg, "%v", serr)
+		}
+		endpoint, err = substituteContext(endpoint, map[string]string{"org": org, "project": project})
+		if err != nil {
+			return bail(clierr.InvalidFlag, "%v", err)
+		}
+	}
+
+	baseURL, err := o.BaseURL()
+	if err != nil {
+		return bail(clierr.NoInstance, "%v", err)
+	}
+	requestURL, err := resolveURL(baseURL, endpoint)
+	if err != nil {
+		return bail(clierr.InvalidFlag, "%v", err)
+	}
+
+	var body io.Reader
+	bodyIsJSON := false
+	switch {
+	case o.RequestInputFile != "":
+		b, err := readInput(o.RequestInputFile, o.IO.In)
+		if err != nil {
+			return bail(clierr.InvalidFlag, "%v", err)
+		}
+		requestURL = addQuery(requestURL, params)
+		body = bytes.NewReader(b)
+	case method == http.MethodGet:
+		requestURL = addQuery(requestURL, params)
+	case len(params) > 0:
+		b, err := json.Marshal(params)
+		if err != nil {
+			return bail(clierr.Internal, "serialize fields: %v", err)
+		}
+		body = bytes.NewReader(b)
+		bodyIsJSON = true
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, body)
+	if err != nil {
+		return bail(clierr.Transport, "build request: %v", err)
+	}
+
+	token, err := o.Token(ctx)
+	if err != nil {
+		return render.Error(o.IO, render.Scope{}, err)
+	}
+
+	if err := applyHeaders(req, o.RequestHeaders); err != nil {
+		return bail(clierr.InvalidFlag, "%v", err)
+	}
+	if req.Header.Get("Authorization") == "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if bodyIsJSON && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	}
+	if req.Header.Get("Accept") == "" {
+		req.Header.Set("Accept", "*/*")
+	}
+
+	resp, err := o.HTTPClient().Do(req)
+	if err != nil {
+		return bail(clierr.Transport, "%v", err)
+	}
+	defer resp.Body.Close()
+
+	if o.ShowResponseHeaders {
+		printResponseHeaders(o.IO.Out, resp)
+	}
+	if _, err := io.Copy(o.IO.Out, resp.Body); err != nil {
+		return bail(clierr.Transport, "read response: %v", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		fmt.Fprintf(o.IO.ErrOut, "amctl: HTTP %d\n", resp.StatusCode)
+		return render.Rendered(clierr.Newf(clierr.ServerError, "HTTP %d", resp.StatusCode))
+	}
+	return nil
+}
+
+// readInput returns the raw request body referenced by --input. "-" reads
+// stdin; anything else is a file path.
+func readInput(name string, stdin io.Reader) ([]byte, error) {
+	if name == "-" {
+		if stdin == nil {
+			return nil, fmt.Errorf("no stdin available for --input -")
+		}
+		b, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return b, nil
+	}
+	b, err := os.ReadFile(name)
+	if err != nil {
+		return nil, fmt.Errorf("read input file %q: %w", name, err)
+	}
+	return b, nil
+}
+
+// applyHeaders parses "Name: value" header flags onto the request.
+func applyHeaders(req *http.Request, headers []string) error {
+	for _, h := range headers {
+		name, value, found := strings.Cut(h, ":")
+		if !found {
+			return fmt.Errorf("header %q requires a value separated by ':'", h)
+		}
+		req.Header.Set(name, strings.TrimSpace(value))
+	}
+	return nil
+}
+
+// printResponseHeaders writes the status line and headers (sorted) followed by
+// a blank line, mirroring `gh api -i`.
+func printResponseHeaders(w io.Writer, resp *http.Response) {
+	fmt.Fprintf(w, "%s %s\n", resp.Proto, resp.Status)
+	keys := make([]string, 0, len(resp.Header))
+	for k := range resp.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, v := range resp.Header[k] {
+			fmt.Fprintf(w, "%s: %s\n", k, v)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// placeholderRe matches {name} context placeholders in an endpoint path.
+var placeholderRe = regexp.MustCompile(`\{(\w+)\}`)
+
+// hasPlaceholders reports whether the endpoint contains any {name} placeholder.
+func hasPlaceholders(endpoint string) bool {
+	return placeholderRe.MatchString(endpoint)
+}
+
+// substituteContext replaces {name} placeholders in the endpoint with values
+// from vals (e.g. {org}/{project} resolved from the current context). It errors
+// on an unknown placeholder name or one whose resolved value is empty, so a
+// typo or missing context fails loudly instead of producing a 404.
+func substituteContext(endpoint string, vals map[string]string) (string, error) {
+	var bad error
+	out := placeholderRe.ReplaceAllStringFunc(endpoint, func(match string) string {
+		name := match[1 : len(match)-1]
+		v, ok := vals[name]
+		if !ok {
+			bad = fmt.Errorf("unknown placeholder %s (supported: %s)", match, supportedPlaceholders(vals))
+			return match
+		}
+		if v == "" {
+			bad = fmt.Errorf("cannot resolve placeholder %s: no %s in context (set --%s, run `amctl link`, or `amctl login`)", match, name, name)
+			return match
+		}
+		return v
+	})
+	if bad != nil {
+		return "", bad
+	}
+	return out, nil
+}
+
+// supportedPlaceholders renders the known placeholder names for error messages.
+func supportedPlaceholders(vals map[string]string) string {
+	names := make([]string, 0, len(vals))
+	for k := range vals {
+		names = append(names, "{"+k+"}")
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// resolveURL joins the instance base URL with a user-supplied endpoint,
+// prefixing /api/v1 unless the endpoint already carries it.
+func resolveURL(baseURL, endpoint string) (string, error) {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if base == "" {
+		return "", fmt.Errorf("no instance URL configured; run `amctl login`")
+	}
+	path := strings.TrimLeft(strings.TrimSpace(endpoint), "/")
+	if path == "" {
+		return "", fmt.Errorf("an endpoint path is required")
+	}
+	if path != apiBasePath && !strings.HasPrefix(path, apiBasePath+"/") {
+		path = apiBasePath + "/" + path
+	}
+	return base + "/" + path, nil
+}
+
+// inferMethod returns the HTTP method to use. When the user did not pass an
+// explicit method, the presence of fields or a request body implies POST.
+func inferMethod(method string, methodPassed, hasParams bool, inputFile string) string {
+	if !methodPassed && (hasParams || inputFile != "") {
+		return "POST"
+	}
+	return strings.ToUpper(method)
+}
+
+// magicFieldValue converts a -F value into its typed form (bool, int, null,
+// @file contents) or returns it unchanged as a string.
+func magicFieldValue(v string, stdin io.Reader) (any, error) {
+	if strings.HasPrefix(v, "@") {
+		return readFileArg(v[1:], stdin)
+	}
+	if n, err := strconv.Atoi(v); err == nil {
+		return n, nil
+	}
+	switch v {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	case "null":
+		return nil, nil
+	default:
+		return v, nil
+	}
+}
+
+// readFileArg reads the contents referenced by an @-prefixed field value. "-"
+// reads from stdin; anything else is a file path.
+func readFileArg(name string, stdin io.Reader) (string, error) {
+	if name == "-" {
+		if stdin == nil {
+			return "", fmt.Errorf("no stdin available for @- field")
+		}
+		b, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		return string(b), nil
+	}
+	b, err := os.ReadFile(name)
+	if err != nil {
+		return "", fmt.Errorf("read field file %q: %w", name, err)
+	}
+	return string(b), nil
+}
+
+// parseField splits "key=value" into its parts. When magic is true the value
+// is type-converted via magicFieldValue.
+func parseField(raw string, magic bool, stdin io.Reader) (string, any, error) {
+	key, val, found := strings.Cut(raw, "=")
+	if !found {
+		return "", nil, fmt.Errorf("field %q requires a value separated by '='", raw)
+	}
+	if magic {
+		v, err := magicFieldValue(val, stdin)
+		if err != nil {
+			return "", nil, err
+		}
+		return key, v, nil
+	}
+	return key, val, nil
+}
+
+// parseFields collects raw (-f) and magic (-F) fields into a single map.
+func parseFields(rawFields, magicFields []string, stdin io.Reader) (map[string]any, error) {
+	params := make(map[string]any, len(rawFields)+len(magicFields))
+	for _, f := range rawFields {
+		k, v, err := parseField(f, false, stdin)
+		if err != nil {
+			return nil, err
+		}
+		params[k] = v
+	}
+	for _, f := range magicFields {
+		k, v, err := parseField(f, true, stdin)
+		if err != nil {
+			return nil, err
+		}
+		params[k] = v
+	}
+	return params, nil
+}
+
+// addQuery appends params to path as a URL query string, preserving any query
+// already present on path.
+func addQuery(path string, params map[string]any) string {
+	if len(params) == 0 {
+		return path
+	}
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	q := url.Values{}
+	for _, k := range keys {
+		q.Set(k, fmt.Sprintf("%v", params[k]))
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + q.Encode()
+}

--- a/cli/pkg/cmd/api/api_test.go
+++ b/cli/pkg/cmd/api/api_test.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+func TestResolveURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		endpoint string
+		want     string
+		wantErr  bool
+	}{
+		{"prefixes api/v1 for leading-slash path", "https://x.com", "/agents", "https://x.com/api/v1/agents", false},
+		{"prefixes api/v1 for bare path", "https://x.com", "agents", "https://x.com/api/v1/agents", false},
+		{"trims trailing slash on base", "https://x.com/", "agents", "https://x.com/api/v1/agents", false},
+		{"does not double-prefix api/v1", "https://x.com", "api/v1/agents", "https://x.com/api/v1/agents", false},
+		{"does not double-prefix leading-slash api/v1", "https://x.com", "/api/v1/orgs/1", "https://x.com/api/v1/orgs/1", false},
+		{"preserves existing query string", "https://x.com", "/agents?limit=2", "https://x.com/api/v1/agents?limit=2", false},
+		{"errors on empty base", "", "agents", "", true},
+		{"errors on empty endpoint", "https://x.com", "  ", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveURL(tc.baseURL, tc.endpoint)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveURL(%q,%q) = %q, want %q", tc.baseURL, tc.endpoint, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInferMethod(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		methodPass bool
+		hasParams  bool
+		inputFile  string
+		want       string
+	}{
+		{"defaults to GET", "GET", false, false, "", "GET"},
+		{"uppercases method", "get", false, false, "", "GET"},
+		{"infers POST when params present", "GET", false, true, "", "POST"},
+		{"infers POST when input present", "GET", false, false, "body.json", "POST"},
+		{"honors explicit method despite params", "DELETE", true, true, "", "DELETE"},
+		{"honors explicit GET despite params", "GET", true, true, "", "GET"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inferMethod(tc.method, tc.methodPass, tc.hasParams, tc.inputFile)
+			if got != tc.want {
+				t.Errorf("inferMethod(%q,%v,%v,%q) = %q, want %q",
+					tc.method, tc.methodPass, tc.hasParams, tc.inputFile, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMagicFieldValue(t *testing.T) {
+	if v, _ := magicFieldValue("true", nil); v != true {
+		t.Errorf(`"true" = %#v, want true`, v)
+	}
+	if v, _ := magicFieldValue("false", nil); v != false {
+		t.Errorf(`"false" = %#v, want false`, v)
+	}
+	if v, _ := magicFieldValue("null", nil); v != nil {
+		t.Errorf(`"null" = %#v, want nil`, v)
+	}
+	if v, _ := magicFieldValue("42", nil); v != 42 {
+		t.Errorf(`"42" = %#v, want 42`, v)
+	}
+	if v, _ := magicFieldValue("hello", nil); v != "hello" {
+		t.Errorf(`"hello" = %#v, want "hello"`, v)
+	}
+}
+
+func TestMagicFieldValue_FileAndStdin(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "payload.txt")
+	if err := os.WriteFile(fp, []byte("file-contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if v, err := magicFieldValue("@"+fp, nil); err != nil || v != "file-contents" {
+		t.Errorf(`"@file" = %#v, err %v; want "file-contents"`, v, err)
+	}
+
+	v, err := magicFieldValue("@-", strings.NewReader("stdin-contents"))
+	if err != nil || v != "stdin-contents" {
+		t.Errorf(`"@-" = %#v, err %v; want "stdin-contents"`, v, err)
+	}
+}
+
+func TestParseFields(t *testing.T) {
+	got, err := parseFields(
+		[]string{"name=order-triage", "num=123"},
+		[]string{"count=3", "active=true"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Raw fields stay strings even when numeric-looking.
+	if got["name"] != "order-triage" {
+		t.Errorf("name = %#v, want string order-triage", got["name"])
+	}
+	if got["num"] != "123" {
+		t.Errorf("num = %#v, want string \"123\" (raw fields are not typed)", got["num"])
+	}
+	// Magic fields are typed.
+	if got["count"] != 3 {
+		t.Errorf("count = %#v, want int 3", got["count"])
+	}
+	if got["active"] != true {
+		t.Errorf("active = %#v, want bool true", got["active"])
+	}
+}
+
+func TestParseFields_ValueWithEquals(t *testing.T) {
+	got, err := parseFields([]string{"filter=a=b=c"}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["filter"] != "a=b=c" {
+		t.Errorf("filter = %#v, want \"a=b=c\" (split on first =)", got["filter"])
+	}
+}
+
+func TestParseFields_MissingEquals(t *testing.T) {
+	if _, err := parseFields([]string{"oops"}, nil, nil); err == nil {
+		t.Error("expected error for field without '='")
+	}
+}
+
+func TestHasPlaceholders(t *testing.T) {
+	if !hasPlaceholders("/orgs/{org}/projects/{project}/agents") {
+		t.Error("expected placeholders to be detected")
+	}
+	if hasPlaceholders("/orgs/default/projects/default/agents") {
+		t.Error("literal path should report no placeholders")
+	}
+	if hasPlaceholders("/orgs") {
+		t.Error("plain path should report no placeholders")
+	}
+}
+
+func TestSubstituteContext(t *testing.T) {
+	vals := map[string]string{"org": "acme", "project": "bot"}
+
+	got, err := substituteContext("/orgs/{org}/projects/{project}/agents", vals)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "/orgs/acme/projects/bot/agents" {
+		t.Errorf("got %q, want /orgs/acme/projects/bot/agents", got)
+	}
+
+	// Literal paths pass through untouched.
+	if got, err := substituteContext("/orgs/default/projects/default", vals); err != nil || got != "/orgs/default/projects/default" {
+		t.Errorf("literal path = %q, err %v; want unchanged", got, err)
+	}
+}
+
+func TestSubstituteContext_UnknownPlaceholderErrors(t *testing.T) {
+	_, err := substituteContext("/orgs/{org}/projects/{proj}/agents", map[string]string{"org": "acme", "project": "bot"})
+	if err == nil {
+		t.Fatal("expected an error for unknown placeholder {proj}")
+	}
+	if !strings.Contains(err.Error(), "{proj}") {
+		t.Errorf("error %q should name the offending placeholder", err)
+	}
+}
+
+func TestSubstituteContext_EmptyValueErrors(t *testing.T) {
+	_, err := substituteContext("/orgs/{org}/projects/{project}/agents", map[string]string{"org": "acme", "project": ""})
+	if err == nil {
+		t.Fatal("expected an error when {project} resolves to empty")
+	}
+	if !strings.Contains(err.Error(), "{project}") {
+		t.Errorf("error %q should name the unresolved placeholder", err)
+	}
+}
+
+// TestAPIExamplesUseRealEndpoints guards against documenting endpoints that do
+// not exist: every "amctl api <endpoint>" example must address an /orgs path,
+// since this API has no flat top-level resources.
+func TestAPIExamplesUseRealEndpoints(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	cmd := NewAPICmd(&cmdutil.Factory{IOStreams: ios})
+
+	var endpoints []string
+	for _, line := range strings.Split(cmd.Example, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "$ amctl api") {
+			continue
+		}
+		for _, tok := range strings.Fields(line) {
+			if strings.HasPrefix(tok, "/") {
+				endpoints = append(endpoints, tok)
+			}
+		}
+	}
+	if len(endpoints) == 0 {
+		t.Fatal("found no example endpoints to check")
+	}
+	for _, ep := range endpoints {
+		if !strings.HasPrefix(ep, "/orgs") {
+			t.Errorf("example endpoint %q must begin with /orgs (this API has no flat resources)", ep)
+		}
+	}
+}
+
+func TestAddQuery(t *testing.T) {
+	if got := addQuery("https://x/api/v1/agents", nil); got != "https://x/api/v1/agents" {
+		t.Errorf("empty params should be unchanged, got %q", got)
+	}
+	if got := addQuery("https://x/api/v1/agents", map[string]any{"limit": "2"}); got != "https://x/api/v1/agents?limit=2" {
+		t.Errorf("got %q", got)
+	}
+	// Sorted, typed values.
+	if got := addQuery("https://x/api/v1/agents", map[string]any{"n": 5, "active": true}); got != "https://x/api/v1/agents?active=true&n=5" {
+		t.Errorf("got %q, want sorted typed query", got)
+	}
+	// Appends to an existing query with '&'.
+	if got := addQuery("https://x/api/v1/agents?x=1", map[string]any{"limit": "2"}); got != "https://x/api/v1/agents?x=1&limit=2" {
+		t.Errorf("got %q, want '&' join", got)
+	}
+}

--- a/cli/pkg/cmd/api/api_test.go
+++ b/cli/pkg/cmd/api/api_test.go
@@ -164,6 +164,15 @@ func TestParseFields_MissingEquals(t *testing.T) {
 	}
 }
 
+func TestParseFields_EmptyKey(t *testing.T) {
+	if _, err := parseFields([]string{"=value"}, nil, nil); err == nil {
+		t.Error("expected error for field with an empty key")
+	}
+	if _, err := parseFields(nil, []string{"  =true"}, nil); err == nil {
+		t.Error("expected error for field with a whitespace-only key")
+	}
+}
+
 func TestHasPlaceholders(t *testing.T) {
 	if !hasPlaceholders("/orgs/{org}/projects/{project}/agents") {
 		t.Error("expected placeholders to be detected")

--- a/cli/pkg/cmd/api/run_test.go
+++ b/cli/pkg/cmd/api/run_test.go
@@ -261,6 +261,47 @@ func TestApplyHeaders_Malformed(t *testing.T) {
 	}
 }
 
+// A user-supplied Authorization header is preserved and token resolution is
+// skipped entirely (so it works even when not logged in).
+func TestRunAPI_AuthHeaderSkipsTokenResolution(t *testing.T) {
+	_, captured, o, _ := newTestServer(t, http.StatusOK, nil, `{}`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "GET"
+	o.RequestHeaders = []string{"Authorization: Bearer mine"}
+	o.Token = func(context.Context) (string, error) {
+		t.Fatal("Token must not be called when an Authorization header is supplied")
+		return "", nil
+	}
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := captured.headers.Get("Authorization"); got != "Bearer mine" {
+		t.Errorf("Authorization = %q, want Bearer mine", got)
+	}
+}
+
+// --input - and an @- field both read stdin; requesting both must error before
+// any HTTP request rather than silently sending malformed data.
+func TestRunAPI_RejectsDoubleStdin(t *testing.T) {
+	srv, captured, o, ios := newTestServer(t, http.StatusOK, nil, `{}`)
+	_ = srv
+	ios.In = strings.NewReader(`payload`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "POST"
+	o.RequestMethodPassed = true
+	o.RequestInputFile = "-"
+	o.MagicFields = []string{"data=@-"}
+
+	err := runAPI(context.Background(), o)
+	if err == nil {
+		t.Fatal("expected an error when --input - and an @- field both consume stdin")
+	}
+	if captured.method != "" {
+		t.Errorf("no HTTP request should be made; got method %q", captured.method)
+	}
+}
+
 func TestRunAPI_InputFromStdin(t *testing.T) {
 	srv, captured, o, ios := newTestServer(t, http.StatusOK, nil, `{}`)
 	_ = srv

--- a/cli/pkg/cmd/api/run_test.go
+++ b/cli/pkg/cmd/api/run_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+type capturedReq struct {
+	method   string
+	path     string
+	rawQuery string
+	headers  http.Header
+	body     []byte
+}
+
+// newTestServer returns a server that records the inbound request and replies
+// with the given status and body, plus the capture and the constructed options
+// pointed at the server.
+func newTestServer(t *testing.T, status int, respHeaders map[string]string, respBody string) (*httptest.Server, *capturedReq, *APIOptions, *iostreams.IOStreams) {
+	t.Helper()
+	captured := &capturedReq{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.rawQuery = r.URL.RawQuery
+		captured.headers = r.Header.Clone()
+		captured.body, _ = io.ReadAll(r.Body)
+		for k, v := range respHeaders {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+
+	ios, _, _, _ := iostreams.Test()
+	o := &APIOptions{
+		IO:         ios,
+		HTTPClient: func() *http.Client { return srv.Client() },
+		Token:      func(context.Context) (string, error) { return "test-token", nil },
+		BaseURL:    func() (string, error) { return srv.URL, nil },
+	}
+	return srv, captured, o, ios
+}
+
+func bufOut(ios *iostreams.IOStreams) string { return ios.Out.(interface{ String() string }).String() }
+func bufErr(ios *iostreams.IOStreams) string {
+	return ios.ErrOut.(interface{ String() string }).String()
+}
+
+func TestRunAPI_GETPassthrough(t *testing.T) {
+	_, captured, o, ios := newTestServer(t, http.StatusOK, nil, `{"ok":true}`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "GET"
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := bufOut(ios); got != `{"ok":true}` {
+		t.Errorf("stdout = %q, want raw body", got)
+	}
+	if captured.method != "GET" {
+		t.Errorf("method = %q, want GET", captured.method)
+	}
+	if captured.path != "/api/v1/agents" {
+		t.Errorf("path = %q, want /api/v1/agents", captured.path)
+	}
+	if got := captured.headers.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("Authorization = %q, want Bearer test-token", got)
+	}
+}
+
+// With an explicit -X GET, fields become query parameters rather than a body.
+// (Without -X, fields imply POST — see TestRunAPI_POSTJSONBodyFromFields.)
+func TestRunAPI_GETQueryFromFields(t *testing.T) {
+	_, captured, o, _ := newTestServer(t, http.StatusOK, nil, `[]`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "GET"
+	o.RequestMethodPassed = true
+	o.RawFields = []string{"limit=2"}
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != "GET" {
+		t.Errorf("method = %q, want GET (explicit -X GET)", captured.method)
+	}
+	if captured.rawQuery != "limit=2" {
+		t.Errorf("query = %q, want limit=2", captured.rawQuery)
+	}
+	if len(captured.body) != 0 {
+		t.Errorf("GET should have no body, got %q", captured.body)
+	}
+}
+
+func TestRunAPI_POSTJSONBodyFromFields(t *testing.T) {
+	_, captured, o, ios := newTestServer(t, http.StatusCreated, nil, `{"id":"a1"}`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "GET" // default; not passed -> inferred POST because fields present
+	o.RequestMethodPassed = false
+	o.RawFields = []string{"name=order"}
+	o.MagicFields = []string{"count=2", "active=true"}
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != "POST" {
+		t.Errorf("method = %q, want POST (inferred)", captured.method)
+	}
+	if ct := captured.headers.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(captured.body, &body); err != nil {
+		t.Fatalf("body not JSON: %v (%q)", err, captured.body)
+	}
+	if body["name"] != "order" || body["count"] != float64(2) || body["active"] != true {
+		t.Errorf("body = %#v, want typed fields", body)
+	}
+	if got := bufOut(ios); got != `{"id":"a1"}` {
+		t.Errorf("stdout = %q, want raw body", got)
+	}
+}
+
+func TestRunAPI_ErrorStatusRawBodyAndExit(t *testing.T) {
+	_, _, o, ios := newTestServer(t, http.StatusNotFound, nil, `{"message":"nope"}`)
+	o.RequestPath = "/missing"
+	o.RequestMethod = "GET"
+
+	err := runAPI(context.Background(), o)
+	if err == nil {
+		t.Fatal("expected non-nil error for HTTP 404")
+	}
+	if !render.IsRendered(err) {
+		t.Error("expected the error to be Rendered (no re-print / usage)")
+	}
+	if got := bufOut(ios); got != `{"message":"nope"}` {
+		t.Errorf("stdout = %q, want raw error body", got)
+	}
+	if got := bufErr(ios); !strings.Contains(got, "HTTP 404") {
+		t.Errorf("stderr = %q, want it to mention HTTP 404", got)
+	}
+}
+
+func TestRunAPI_IncludeHeaders(t *testing.T) {
+	_, _, o, ios := newTestServer(t, http.StatusOK, map[string]string{"X-Test": "yes"}, `{"ok":true}`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "GET"
+	o.ShowResponseHeaders = true
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := bufOut(ios)
+	if !strings.Contains(got, "HTTP") || !strings.Contains(got, "200") {
+		t.Errorf("stdout = %q, want a status line", got)
+	}
+	if !strings.Contains(got, "X-Test: yes") {
+		t.Errorf("stdout = %q, want the X-Test header", got)
+	}
+	if !strings.Contains(got, `{"ok":true}`) {
+		t.Errorf("stdout = %q, want the body after headers", got)
+	}
+}
+
+func TestRunAPI_CustomHeaderAndAuthOverride(t *testing.T) {
+	_, captured, o, _ := newTestServer(t, http.StatusOK, nil, `{}`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "GET"
+	o.RequestHeaders = []string{"X-Custom: hi", "Authorization: Bearer override"}
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := captured.headers.Get("X-Custom"); got != "hi" {
+		t.Errorf("X-Custom = %q, want hi", got)
+	}
+	if got := captured.headers.Get("Authorization"); got != "Bearer override" {
+		t.Errorf("Authorization = %q, want the user-supplied override (not the token)", got)
+	}
+}
+
+func TestRunAPI_SubstitutesPlaceholders(t *testing.T) {
+	_, captured, o, _ := newTestServer(t, http.StatusOK, nil, `{"agents":[]}`)
+	o.RequestPath = "/orgs/{org}/projects/{project}/agents"
+	o.RequestMethod = "GET"
+	o.Scope = func() (string, string, error) { return "acme", "bot", nil }
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.path != "/api/v1/orgs/acme/projects/bot/agents" {
+		t.Errorf("path = %q, want /api/v1/orgs/acme/projects/bot/agents", captured.path)
+	}
+}
+
+// A literal path must never trigger context resolution.
+func TestRunAPI_LiteralPathSkipsScope(t *testing.T) {
+	_, captured, o, _ := newTestServer(t, http.StatusOK, nil, `{}`)
+	o.RequestPath = "/orgs"
+	o.RequestMethod = "GET"
+	o.Scope = func() (string, string, error) {
+		t.Fatal("Scope must not be called for a literal path")
+		return "", "", nil
+	}
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.path != "/api/v1/orgs" {
+		t.Errorf("path = %q, want /api/v1/orgs", captured.path)
+	}
+}
+
+// When a placeholder cannot be resolved, the command errors before making any
+// HTTP request.
+func TestRunAPI_PlaceholderMissingValueErrors(t *testing.T) {
+	srv, captured, o, _ := newTestServer(t, http.StatusOK, nil, `{}`)
+	_ = srv
+	o.RequestPath = "/orgs/{org}/projects/{project}/agents"
+	o.RequestMethod = "GET"
+	o.Scope = func() (string, string, error) { return "acme", "", nil }
+
+	err := runAPI(context.Background(), o)
+	if err == nil {
+		t.Fatal("expected an error when {project} is unresolved")
+	}
+	if captured.method != "" {
+		t.Errorf("no HTTP request should be made; got method %q", captured.method)
+	}
+}
+
+func TestApplyHeaders_Malformed(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "https://x", nil)
+	if err := applyHeaders(req, []string{"NoColonHere"}); err == nil {
+		t.Error("expected error for header without ':'")
+	}
+}
+
+func TestRunAPI_InputFromStdin(t *testing.T) {
+	srv, captured, o, ios := newTestServer(t, http.StatusOK, nil, `{}`)
+	_ = srv
+	ios.In = strings.NewReader(`{"raw":1}`)
+	o.RequestPath = "/agents"
+	o.RequestMethod = "GET" // not passed -> inferred POST because input present
+	o.RequestInputFile = "-"
+
+	if err := runAPI(context.Background(), o); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != "POST" {
+		t.Errorf("method = %q, want POST (inferred from --input)", captured.method)
+	}
+	if string(captured.body) != `{"raw":1}` {
+		t.Errorf("body = %q, want raw stdin passthrough", captured.body)
+	}
+}

--- a/cli/pkg/cmd/root.go
+++ b/cli/pkg/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/wso2/agent-manager/cli/pkg/cmd/agent"
+	"github.com/wso2/agent-manager/cli/pkg/cmd/api"
 	amcontext "github.com/wso2/agent-manager/cli/pkg/cmd/context"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/llmprovider"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/project"
@@ -45,6 +46,7 @@ func NewRootCmd(f *cmdutil.Factory) (*cobra.Command, error) {
 
 	cmd.AddCommand(NewLoginCmd(f))
 	cmd.AddCommand(agent.NewAgentCmd(f))
+	cmd.AddCommand(api.NewAPICmd(f))
 	cmd.AddCommand(amcontext.NewContextCmd(f))
 	cmd.AddCommand(llmprovider.NewLLMProviderCmd(f))
 	cmd.AddCommand(project.NewProjectCmd(f))

--- a/cli/pkg/render/render.go
+++ b/cli/pkg/render/render.go
@@ -91,6 +91,14 @@ func textError(ios *iostreams.IOStreams, err error) error {
 	return &renderedError{err: err}
 }
 
+// Rendered marks err as already presented to the user without writing
+// anything itself. Commands that emit their own raw output (e.g. `amctl api`)
+// return Rendered(err) so the top-level runner exits non-zero but does not
+// re-print the error or append usage.
+func Rendered(err error) error {
+	return &renderedError{err: err}
+}
+
 // IsRendered reports whether err is (or wraps) a value returned by Error.
 func IsRendered(err error) bool {
 	var r *renderedError

--- a/cli/pkg/render/render.go
+++ b/cli/pkg/render/render.go
@@ -96,6 +96,9 @@ func textError(ios *iostreams.IOStreams, err error) error {
 // return Rendered(err) so the top-level runner exits non-zero but does not
 // re-print the error or append usage.
 func Rendered(err error) error {
+	if err == nil {
+		return nil
+	}
 	return &renderedError{err: err}
 }
 

--- a/cli/pkg/render/render_test.go
+++ b/cli/pkg/render/render_test.go
@@ -74,6 +74,12 @@ func TestRendered_MarksWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestRendered_NilReturnsNil(t *testing.T) {
+	if err := Rendered(nil); err != nil {
+		t.Errorf("Rendered(nil) = %v, want nil", err)
+	}
+}
+
 func TestError_DispatchesJSON(t *testing.T) {
 	ios, _, out, _ := iostreams.Test()
 	ios.JSON = true

--- a/cli/pkg/render/render_test.go
+++ b/cli/pkg/render/render_test.go
@@ -56,6 +56,24 @@ func TestJSONError_WritesEnvelope(t *testing.T) {
 	}
 }
 
+func TestRendered_MarksWithoutWriting(t *testing.T) {
+	inner := clierr.New(clierr.Transport, "boom")
+	err := Rendered(inner)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !IsRendered(err) {
+		t.Fatal("expected IsRendered to be true for Rendered(err)")
+	}
+	if err.Error() != inner.Error() {
+		t.Errorf("Error() = %q, want %q", err.Error(), inner.Error())
+	}
+	var cliErr clierr.CLIError
+	if !errors.As(err, &cliErr) {
+		t.Fatal("expected errors.As to reach the wrapped clierr through Rendered")
+	}
+}
+
 func TestError_DispatchesJSON(t *testing.T) {
 	ios, _, out, _ := iostreams.Test()
 	ios.JSON = true

--- a/documentation/docs/reference/cli/api.mdx
+++ b/documentation/docs/reference/cli/api.mdx
@@ -1,0 +1,121 @@
+---
+sidebar_position: 8
+sidebar_label: API
+---
+
+# amctl api
+
+Make an authenticated HTTP request to the Agent Manager API and print the response verbatim. `amctl api` is the low-level escape hatch for endpoints that do not yet have a dedicated command, modeled on GitHub CLI's `gh api`.
+
+```
+amctl api <endpoint> [flags]
+```
+
+The current instance's access token is attached automatically, and the response body is streamed to stdout exactly as received.
+
+## Arguments
+
+| Name | Description |
+|------|-------------|
+| `<endpoint>` | API path to request. Resolved relative to the current instance's API base, so the `/api/v1` prefix may be omitted — `amctl api /orgs` and `amctl api /api/v1/orgs` are equivalent. May contain `{org}` and `{project}` placeholders. |
+
+## Options inherited from parent commands
+
+| Name | Description |
+|------|-------------|
+| `--org` | Override the active organization. Used to fill the `{org}` placeholder. |
+
+## Options
+
+| Name | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--method` | `-X` | string | `GET` | HTTP method for the request. Switches to `POST` automatically when fields or a body are supplied. |
+| `--raw-field` | `-f` | strings | (none) | Add a string parameter as `key=value`. The value is sent as a raw string. Repeatable. |
+| `--field` | `-F` | strings | (none) | Add a typed parameter as `key=value`. Repeatable. See [Typed fields](#typed-fields). |
+| `--header` | `-H` | strings | (none) | Add a request header as `Name: value`. Repeatable. |
+| `--input` | | file | (none) | File to send as the raw request body. Use `-` to read stdin. |
+| `--include` | `-i` | bool | `false` | Print the response status line and headers before the body. |
+| `--project` | | string | (linked project) | Project used to fill the `{project}` placeholder. |
+
+## Org and project placeholders
+
+The Agent Manager API has no flat top-level resources — everything lives under `/orgs/{org}/projects/{project}/...`. The literal tokens `{org}` and `{project}` in the endpoint are substituted from the current context, using the same precedence as other commands:
+
+1. The `--org` / `--project` flags.
+2. The linked project for the working directory.
+3. The active org (`current_org`).
+
+From a [linked directory](./overview.mdx#linked-context), `amctl api /orgs/{org}/projects/{project}/agents` works without spelling out names.
+
+:::note
+An unknown placeholder (for example, a typo like `{proj}`) fails immediately with `unknown placeholder {proj} (supported: {org}, {project})` and makes no HTTP request. A known placeholder that resolves to empty also errors before any request is sent.
+:::
+
+## HTTP method
+
+The method defaults to `GET`. It switches to `POST` automatically when you supply fields (`-f` / `-F`) or a request body (`--input`). Override the method explicitly with `-X` / `--method`.
+
+## Fields
+
+Fields become query-string parameters on a `GET` request, and a JSON request body otherwise.
+
+- `-f key=value` sends the value as a raw string.
+- `-F key=value` is typed — see below.
+
+### Typed fields
+
+`-F` parses the value before sending it:
+
+| Value | Sent as |
+|-------|---------|
+| `true` / `false` | boolean |
+| an integer | number |
+| `null` | null |
+| `@path` | the contents of a file (`@-` reads stdin) |
+| anything else | string |
+
+## Headers
+
+`-H "Name: value"` adds a request header. The current instance's access token is attached as a bearer token automatically when no `Authorization` header is given; supplying your own `Authorization` header overrides it.
+
+## Request body
+
+`--input <file>` sends a raw request body. Use `--input -` to read the body from stdin.
+
+## Response
+
+The response body is streamed to stdout exactly as received. With `-i` / `--include`, the status line and response headers are printed before the body.
+
+On an HTTP status of 400 or above, the body is still printed, a short `amctl: HTTP <status>` line is written to stderr, and the command exits non-zero.
+
+## Examples
+
+```bash
+# List organizations
+amctl api /orgs
+
+# List agents, filling {org}/{project} from the current context
+amctl api /orgs/{org}/projects/{project}/agents
+
+# Get one agent (org/project spelled out explicitly)
+amctl api /orgs/default/projects/default/agents/it-helpdesk-agent
+
+# Filter with query parameters (explicit GET keeps fields in the query)
+amctl api -X GET /orgs/{org}/projects/{project}/agents -f limit=10
+
+# Create a project from typed fields (inferred POST + JSON body)
+amctl api /orgs/{org}/projects -f name=triage -F retain=true
+
+# Send a raw JSON body from a file or stdin
+amctl api -X POST /orgs/{org}/projects --input ./project.json
+cat project.json | amctl api -X POST /orgs/{org}/projects --input -
+
+# Inspect response headers
+amctl api -i /orgs/{org}/projects/{project}/agents
+```
+
+## See Also
+
+- [`amctl agent`](./agent.mdx) — high-level commands for managing agents
+- [`amctl project`](./project.mdx) — high-level commands for managing projects
+- [`amctl context link`](./context.mdx#amctl-context-link) — link the current directory to a project

--- a/documentation/docs/reference/cli/api.mdx
+++ b/documentation/docs/reference/cli/api.mdx
@@ -39,7 +39,7 @@ The current instance's access token is attached automatically, and the response 
 
 ## Org and project placeholders
 
-The Agent Manager API has no flat top-level resources — everything lives under `/orgs/{org}/projects/{project}/...`. The literal tokens `{org}` and `{project}` in the endpoint are substituted from the current context, using the same precedence as other commands:
+Most Agent Manager resources are scoped to an organization and project, under paths like `/orgs/{org}/projects/{project}/...`. For endpoints that include the literal `{org}` and `{project}` tokens, those placeholders are substituted from the current context, using the same precedence as other commands:
 
 1. The `--org` / `--project` flags.
 2. The linked project for the working directory.

--- a/documentation/docs/reference/cli/overview.mdx
+++ b/documentation/docs/reference/cli/overview.mdx
@@ -35,6 +35,7 @@ amctl <command> --help
 | [`amctl agent`](./agent.mdx) | Create, build, deploy, and observe agents |
 | [`amctl skills`](./skills.mdx) | Install AI assistant skills locally |
 | [`amctl version`](./version.mdx) | Print the CLI version |
+| [`amctl api`](./api.mdx) | Make an authenticated request to the Agent Manager API |
 
 ## Global Flags
 

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -85,6 +85,7 @@ const sidebars: SidebarsConfig = {
             'reference/cli/agent',
             'reference/cli/skills',
             'reference/cli/version',
+            'reference/cli/api',
           ],
         },
       ],


### PR DESCRIPTION
## What

Adds `amctl api <endpoint>` — a low-level authenticated passthrough to the Agent Manager HTTP API, modeled on GitHub CLI's `gh api`. It's the escape hatch for endpoints that don't yet have a dedicated command.

## Why

There was no way to hit an arbitrary Agent Manager endpoint from the CLI without hand-crafting a `curl` with a bearer token and the right base URL. `amctl api` reuses the existing auth/token-refresh and instance resolution so any endpoint is one command away.

## Highlights

- **Base path is implicit** — endpoints resolve relative to the current instance's API base, so `/api/v1` may be omitted. `amctl api /orgs` and `amctl api /api/v1/orgs` are equivalent.
- **`{org}` / `{project}` placeholders** — this API has no flat resources; everything is under `/orgs/{org}/projects/{project}/...`. The placeholders are filled from the current context using the same precedence as every other command (`--org`/`--project` → linked project → active org). An **unknown placeholder** (typo) or one that **resolves to empty** errors *before* any request is made, instead of silently 404ing.
- **Method inference** — defaults to `GET`, switches to `POST` automatically when fields (`-f`/`-F`) or a body (`--input`) are supplied; override with `-X`.
- **Typed fields** — `-f` sends raw strings; `-F` parses `true`/`false`→bool, ints→number, `null`→null, and `@file`/`@-`→file/stdin contents. On `GET` fields go to the query string, otherwise into a JSON body.
- **Raw passthrough** — the response body is streamed verbatim; `-i` prepends the status line and headers. On HTTP ≥ 400 the body is still printed, a short `amctl: HTTP <status>` line goes to stderr, and the command exits non-zero.

## Examples

```bash
# List organizations
amctl api /orgs

# List agents, filling {org}/{project} from the current (linked) context
amctl api /orgs/{org}/projects/{project}/agents

# Get one agent (org/project spelled out explicitly)
amctl api /orgs/default/projects/default/agents/it-helpdesk-agent

# Filter with query parameters (explicit GET keeps fields in the query)
amctl api -X GET /orgs/{org}/projects/{project}/agents -f limit=10

# Create a project from typed fields (inferred POST + JSON body)
amctl api /orgs/{org}/projects -f name=triage -F retain=true

# Send a raw JSON body from a file or stdin
amctl api -X POST /orgs/{org}/projects --input ./project.json
cat project.json | amctl api -X POST /orgs/{org}/projects --input -

# Inspect response headers
amctl api -i /orgs/{org}/projects/{project}/agents
```

A typo in a placeholder fails fast, before any network call:

```
$ amctl api '/orgs/{org}/projects/{proj}/agents'
X unknown placeholder {proj} (supported: {org}, {project})
```

## Testing

- Unit tests for URL resolution, placeholder substitution (incl. unknown/empty errors), method inference, typed-field parsing, and query building.
- `httptest` integration tests through `runAPI` covering GET passthrough, query-from-fields, JSON body from fields, placeholder substitution end-to-end, raw error body + non-zero exit, response-header inclusion, header override, and stdin input.
- A guard test asserts every documented example endpoint begins with `/orgs`, so the docs can't regress to non-existent flat paths.
- Verified manually against a live backend: `/orgs`, placeholder substitution, query fields, and the fail-fast typo path all behave as documented.

## Docs

New reference page `documentation/docs/reference/cli/api.mdx`, linked from the CLI overview table and the docs sidebar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `amctl api` command for making authenticated HTTP requests to the Agent Manager API
  * Automatic HTTP method inference (GET by default, POST when fields or input provided)
  * Support for custom headers, request fields, and file/stdin input
  * Automatic placeholder substitution for `{org}` and `{project}` in API endpoints
  * Detailed error reporting with HTTP status codes

* **Documentation**
  * Added comprehensive documentation for the `amctl api` command with usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->