### PR TITLE
Add CLI docs for amctl llm-provider and agent LLM config

### DIFF
--- a/documentation/docs/reference/cli/agent.mdx
+++ b/documentation/docs/reference/cli/agent.mdx
@@ -89,6 +89,18 @@ amctl agent create payments \
   --env LOG_LEVEL=info \
   --env-secret STRIPE_KEY=sk_test_xxx \
   --env-from-secret OPENAI_API_KEY=shared-openai
+
+# Wire the agent to a registered LLM provider, with custom env var names
+amctl agent create chatbot \
+  --display-name "Chatbot" \
+  --subtype chat-api \
+  --repo-url https://github.com/acme/chatbot \
+  --build-type buildpack \
+  --language python \
+  --language-version 3.12 \
+  --llm-provider prod-openai \
+  --llm-url-env OPENAI_BASE_URL \
+  --llm-api-key-env OPENAI_API_KEY
 ```
 
 ### Options
@@ -118,6 +130,21 @@ amctl agent create payments \
 | `--llm-provider` | string | (none) | Handle of a configured LLM provider to attach (internal only). |
 | `--llm-url-env` | string | (none) | Env var name for the provider URL (default: auto-generated). |
 | `--llm-api-key-env` | string | (none) | Env var name for the provider API key (default: auto-generated). |
+
+### Attaching an LLM provider
+
+`--llm-provider` binds a configured organization-level [LLM provider](./llm-provider.mdx) to the agent at creation time. This is supported only for `internal` (platform-managed) provisioning.
+
+Pass the **handle** of a provider you created with [`amctl llm-provider create`](./llm-provider.mdx#amctl-llm-provider-create) — use [`amctl llm-provider list`](./llm-provider.mdx#amctl-llm-provider-list) to see the handles in your org. The platform routes the agent's LLM calls through the AI Gateway and injects two environment variables into the running agent:
+
+| Variable | Holds | Default name | Override with |
+|----------|-------|--------------|---------------|
+| `url` | Gateway endpoint URL for the provider | auto-generated from the template (e.g. `OPENAI_URL`) | `--llm-url-env` |
+| `apikey` | Client API key for the provider | auto-generated from the template (e.g. `OPENAI_API_KEY`) | `--llm-api-key-env` |
+
+`--llm-url-env` and `--llm-api-key-env` only take effect alongside `--llm-provider`; setting either without it is rejected. The provider credential is never exposed to agent code directly — only these injected variables are available at runtime.
+
+The same binding can be expressed in a YAML manifest (`amctl agent create -f`) via the `modelConfig` block; run `amctl agent create --template` to print the scaffold. For the console-based workflow and the equivalent setup for external agents, see [Configure LLM Providers for an Agent](../../tutorials/configure-agent-llm-configuration.mdx).
 
 ---
 
@@ -502,5 +529,6 @@ amctl agent trace support-bot 7c8f...e1 --span a2b3...c4
 ## See Also
 
 - [`amctl project`](./project.mdx) — manage projects that own agents
+- [`amctl llm-provider`](./llm-provider.mdx) — create and manage the LLM providers attached with `--llm-provider`
 - [`amctl context link`](./context.mdx#amctl-context-link) — link the current directory to an agent
 - [Observe your first agent](../../tutorials/observe-first-agent.mdx)

--- a/documentation/docs/reference/cli/llm-provider.mdx
+++ b/documentation/docs/reference/cli/llm-provider.mdx
@@ -1,0 +1,172 @@
+---
+sidebar_position: 6
+sidebar_label: LLM Provider
+---
+
+# amctl llm-provider
+
+Manage LLM providers in an organization — create, list, and delete connections to upstream LLM APIs.
+
+```
+amctl llm-provider [command]
+```
+
+LLM providers are **organization-level** resources that represent connections to upstream LLM APIs (OpenAI, Anthropic, AWS Bedrock, …). Once created, a provider is exposed through an AI Gateway and can be attached to agents in any project in the organization — see [`amctl agent create`](./agent.mdx#amctl-agent-create). The command group is also available under the `llm-providers` alias.
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| [`create`](#amctl-llm-provider-create) | Create an LLM provider |
+| [`list`](#amctl-llm-provider-list) | List LLM providers in an organization |
+| [`delete`](#amctl-llm-provider-delete) | Delete an LLM provider |
+
+## Options inherited from parent commands
+
+| Name | Description |
+|------|-------------|
+| `--org` | Override the active organization. |
+| `--json` | Output as JSON envelopes. |
+
+---
+
+## amctl llm-provider create
+
+Create an LLM provider in the active organization from a built-in or custom template.
+
+```
+amctl llm-provider create <id> [flags]
+```
+
+The endpoint URL and auth scheme are inherited from the chosen `--template`; override them with `--upstream-url` / `--auth-type` / `--auth-header` only when needed. Supply the provider credential with `--api-key-stdin` (recommended) or `--api-key`.
+
+### Arguments
+
+| Name | Description |
+|------|-------------|
+| `<id>` | Resource handle for the provider. Must be 1–255 characters and contain only letters, digits, `-`, or `_`. Used to reference the provider elsewhere (for example, `amctl agent create --llm-provider <id>`). |
+
+### Examples
+
+```bash
+# OpenAI provider, API key read from stdin (recommended — keeps it out of shell history)
+echo "$OPENAI_API_KEY" | amctl llm-provider create prod-openai \
+  --display-name "Production OpenAI" \
+  --template openai \
+  --api-key-stdin
+
+# Anthropic provider that overrides the template's upstream endpoint
+amctl llm-provider create prod-anthropic \
+  --display-name "Production Anthropic" \
+  --template anthropic \
+  --upstream-url https://api.anthropic.com \
+  --api-key-stdin < anthropic-key.txt
+
+# Deploy the provider to specific AI Gateways at creation time
+echo "$OPENAI_API_KEY" | amctl llm-provider create shared-openai \
+  --display-name "Shared OpenAI" \
+  --template openai \
+  --api-key-stdin \
+  --gateways 550e8400-e29b-41d4-a716-446655440000
+
+# Provider whose template needs no credential
+amctl llm-provider create internal-proxy \
+  --display-name "Internal Proxy" \
+  --template openai \
+  --upstream-url https://llm.internal.acme \
+  --auth-type none
+```
+
+### Options
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `--display-name` | string | _required_ | Human-readable display name. |
+| `--template` | string | _required_ | Provider template handle, e.g. `openai`, `anthropic`, `mistralai`. Tab-completes the live set for your org. |
+| `--version` | string | `v1` | Provider version. |
+| `--context` | string | `/` | API context path. Must start with `/` and must not end with `/` (except the root path). |
+| `--description` | string | (none) | Provider description. |
+| `--upstream-url` | string | (template default) | Override the template's upstream endpoint URL. |
+| `--auth-type` | string | `api-key` | Upstream auth type: `api-key`, `basic`, `bearer`, or `none`. |
+| `--auth-header` | string | (template default) | Override the template's auth header name. |
+| `--api-key` | string | (none) | Provider API key. Leaks into shell history — prefer `--api-key-stdin`. |
+| `--api-key-stdin` | bool | `false` | Read the provider API key from stdin. |
+| `--gateways` | strings | (none) | AI Gateway UUIDs to deploy the provider to. Repeatable, or comma-separated. |
+
+### Built-in templates
+
+`--template` accepts these built-in handles:
+
+`anthropic`, `awsbedrock`, `azure-openai`, `azureai-foundry`, `gemini`, `mistralai`, `openai`
+
+Tab completion on `--template` lists the live set — built-in handles plus any custom templates registered for your organization.
+
+### Template inheritance and credentials
+
+- A provider inherits the template's upstream URL, auth scheme, and auth header. The upstream block is sent only when you supply `--upstream-url`, `--auth-type`, or `--auth-header`, or a credential — otherwise creation defers entirely to the template.
+- `--api-key` and `--api-key-stdin` are mutually exclusive.
+- An API key cannot be combined with `--auth-type none`.
+- A provider must be associated with at least one AI Gateway to be callable by agents. Pass `--gateways` at creation, or associate gateways later from the console (see [Register an LLM Service Provider](../../tutorials/register-llm-service-provider.mdx)).
+
+:::tip
+Reading the key from stdin keeps it out of your shell history and process list. `--api-key-stdin` accepts a piped value (`echo "$KEY" | …`) or a redirected file (`… < key.txt`).
+:::
+
+---
+
+## amctl llm-provider list
+
+List the LLM providers in the active organization.
+
+```
+amctl llm-provider list
+```
+
+Returns up to 50 providers. The default text output is a table with `id`, `name`, `template`, `status`, and `created` columns; `--json` returns the raw response.
+
+### Example
+
+```bash
+amctl llm-provider list
+
+# As JSON for downstream parsing
+amctl llm-provider list --json | jq '.data.providers[].id'
+```
+
+---
+
+## amctl llm-provider delete
+
+Delete an LLM provider. Asks for confirmation unless `--yes` is set; when stdin is not a terminal, `--yes` is required.
+
+```
+amctl llm-provider delete <provider> [flags]
+```
+
+### Arguments
+
+| Name | Description |
+|------|-------------|
+| `<provider>` | Provider handle (`id`) or UUID. Tab-completes existing providers in the org. |
+
+### Options
+
+| Name | Short | Type | Default | Description |
+|------|-------|------|---------|-------------|
+| `--yes` | `-y` | bool | `false` | Skip the confirmation prompt. |
+
+### Examples
+
+```bash
+# Delete by handle, with confirmation
+amctl llm-provider delete prod-openai
+
+# Delete without prompting (also required in non-interactive shells)
+amctl llm-provider delete prod-openai --yes
+```
+
+## See Also
+
+- [`amctl agent create`](./agent.mdx#amctl-agent-create) — attach a provider to an agent with `--llm-provider`
+- [Register an LLM Service Provider](../../tutorials/register-llm-service-provider.mdx) — console walkthrough and per-provider settings
+- [Configure LLM Providers for an Agent](../../tutorials/configure-agent-llm-configuration.mdx) — attaching providers to platform and external agents

--- a/documentation/docs/tutorials/register-llm-service-provider.mdx
+++ b/documentation/docs/tutorials/register-llm-service-provider.mdx
@@ -6,6 +6,10 @@ sidebar_position: 5
 
 LLM Service Providers are organization-level resources that represent connections to upstream LLM APIs (e.g., OpenAI, Anthropic, AWS Bedrock). Once registered, they are exposed through an AI Gateway and can be attached to agents across any project in the organization.
 
+:::tip Prefer the CLI?
+You can also create, list, and delete providers from the command line — see [`amctl llm-provider`](../reference/cli/llm-provider.mdx).
+:::
+
 ## Prerequisites
 
 - Admin access to the WSO2 Agent Manager Console

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -83,6 +83,7 @@ const sidebars: SidebarsConfig = {
             'reference/cli/context',
             'reference/cli/project',
             'reference/cli/agent',
+            'reference/cli/llm-provider',
             'reference/cli/skills',
             'reference/cli/version',
           ],


### PR DESCRIPTION
## Purpose
The `amctl` CLI surface for LLM providers was undocumented. There was no reference page for the `amctl llm-provider` command group (create/list/delete), and the LLM-provider flags on `amctl agent create` (`--llm-provider`, `--llm-url-env`, `--llm-api-key-env`) were listed in a table without explanation or examples. This PR fills those gaps.

## Goals
- Add a complete CLI reference for `amctl llm-provider` (create, list, delete).
- Explain and exemplify attaching a configured LLM provider to an agent at creation time.
- Improve cross-linking between the CLI reference and the existing LLM-provider console tutorials.

## Approach
- New page `documentation/docs/reference/cli/llm-provider.mdx` documenting the `llm-provider` group, following the existing `agent.mdx` conventions (synopsis, subcommands table, per-command options tables with types/defaults/required-ness, examples, behavior notes). Flag details — types, defaults, required flags, valid `--auth-type` values, built-in templates, the `--api-key`/`--api-key-stdin` rules, `--gateways`, and handle/context validation — were taken directly from the command definitions in `cli/pkg/cmd/llmprovider/`.
- Registered the new page in `documentation/sidebars.ts` after `agent`.
- `documentation/docs/reference/cli/agent.mdx`: added an `agent create` example using `--llm-provider`, an "Attaching an LLM provider" subsection (internal-only constraint, the handle/`amctl llm-provider` relationship, the two injected env vars and their auto-naming/overrides, and the manifest `modelConfig` equivalent), and a See-Also link.
- `documentation/docs/tutorials/register-llm-service-provider.mdx`: added a tip pointing to the new CLI reference page.

## User stories
N/A — documentation-only change.

## Release note
Add CLI reference documentation for `amctl llm-provider` and for configuring LLM providers on agents.

## Documentation
This PR is itself the documentation change. Files:
- `documentation/docs/reference/cli/llm-provider.mdx` (new)
- `documentation/docs/reference/cli/agent.mdx`
- `documentation/docs/tutorials/register-llm-service-provider.mdx`
- `documentation/sidebars.ts`

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams (documentation-only).

## Marketing
N/A — no marketing content.

## Automation tests
 - Unit tests
   > N/A — documentation-only change; no code modified.
 - Integration tests
   > N/A. Validated with a successful Docusaurus production build (`npm run build`) with broken-link checking enabled (`onBrokenLinks: throw`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — documentation only, no code.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
N/A.

## Migrations (if applicable)
N/A — no migrations.

## Test environment
Docusaurus production build (`npm run build`) on macOS, using the repo's `documentation` package toolchain.

## Learning
N/A — followed the existing CLI reference doc conventions under `documentation/docs/reference/cli/`.
