### PR TITLE
Stop llm-provider and mcp-proxy status from being updated after creation.

### DIFF
--- a/agent-manager-service/repositories/llm_provider_repository.go
+++ b/agent-manager-service/repositories/llm_provider_repository.go
@@ -86,7 +86,7 @@ func (r *LLMProviderRepo) Create(tx *gorm.DB, p *models.LLMProvider, handle, nam
 
 	// Insert into llm_providers table
 	slog.Info("LLMProviderRepo.Create: inserting into llm_providers table", "handle", handle, "uuid", p.UUID)
-	if err := tx.Create(p).Error; err != nil {
+	if err := tx.Omit("status").Create(p).Error; err != nil {
 		slog.Error("LLMProviderRepo.Create: failed to insert provider", "handle", handle, "uuid", p.UUID, "error", err)
 		return err
 	}
@@ -205,7 +205,6 @@ func (r *LLMProviderRepo) Update(p *models.LLMProvider, providerID string, orgUU
 				"template_handle": p.TemplateHandle,
 				"openapi_spec":    p.OpenAPISpec,
 				"model_list":      p.ModelList,
-				"status":          p.Status,
 				"configuration":   p.Configuration,
 			})
 

--- a/agent-manager-service/repositories/mcp_proxy_repository.go
+++ b/agent-manager-service/repositories/mcp_proxy_repository.go
@@ -79,7 +79,7 @@ func (r *MCPProxyRepo) Create(ctx context.Context, tx *gorm.DB, p *models.MCPPro
 		return fmt.Errorf("failed to create artifact: %w", err)
 	}
 
-	if err := tx.WithContext(ctx).Create(p).Error; err != nil {
+	if err := tx.WithContext(ctx).Omit("status").Create(p).Error; err != nil {
 		return err
 	}
 	return nil
@@ -95,7 +95,6 @@ func (r *MCPProxyRepo) Update(ctx context.Context, tx *gorm.DB, p *models.MCPPro
 		Where("uuid = ?", p.UUID).
 		Updates(map[string]interface{}{
 			"description":   p.Description,
-			"status":        p.Status,
 			"configuration": p.Configuration,
 		})
 	if result.Error != nil {

--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -139,13 +139,12 @@ func (s *LLMProviderService) Create(ctx context.Context, orgName, createdBy stri
 
 	// Set default values
 	provider.CreatedBy = createdBy
-	provider.Status = llmStatusPending
 	if provider.Configuration.Context == nil {
 		defaultContext := "/"
 		provider.Configuration.Context = &defaultContext
 	}
 
-	slog.Info("LLMProviderService.Create: set default values", "orgName", orgName, "handle", handle, "status", provider.Status, "context", *provider.Configuration.Context)
+	slog.Info("LLMProviderService.Create: set default values", "orgName", orgName, "handle", handle, "context", *provider.Configuration.Context)
 
 	// Serialize model providers to ModelList
 	if len(provider.ModelProviders) > 0 {

--- a/agent-manager-service/services/mcp_proxy_service.go
+++ b/agent-manager-service/services/mcp_proxy_service.go
@@ -175,7 +175,6 @@ func (s *MCPProxyService) Create(ctx context.Context, orgUUID, createdBy string,
 	proxy := &models.MCPProxy{
 		Description: valueOrEmpty(req.Description),
 		CreatedBy:   createdBy,
-		Status:      "pending",
 		Configuration: models.MCPProxyConfig{
 			Name:         name,
 			Version:      version,

--- a/agent-manager-service/utils/spec_converter.go
+++ b/agent-manager-service/utils/spec_converter.go
@@ -205,7 +205,6 @@ func ConvertSpecToModelLLMProvider(req *spec.CreateLLMProviderRequest, orgName s
 		TemplateHandle: req.Template,
 		Description:    ptrToString(req.Description),
 		OpenAPISpec:    ptrToString(req.Openapi),
-		Status:         "ACTIVE",
 		Configuration:  ConvertSpecToModelLLMProviderConfigFromRequest(req),
 	}
 


### PR DESCRIPTION
Currently the `status` column of the `llm-providers` and `mcp-proxies` tables are not used properly and there isn't a specific enum set defined.

This PR will stop changing the status after creation so it's always in the `CREATED` state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status management for LLM Providers has been updated to prevent automatic status assignment during creation and configuration updates.
  * Status management for MCP Proxies has been refined to exclude status from routine update operations.
  * Configuration changes can now be applied independently without affecting entity status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->