### PR TITLE
Refactor PromoteAgentDrawer state management

### DIFF
--- a/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
@@ -95,11 +95,6 @@ export function PromoteAgentDrawer({
     [environments],
   );
 
-  const { data: sourceConfigs } = useGetAgentConfigurations(
-    { orgName: orgId, projName: projectId, agentName: agentId },
-    { environment: sourceEnvironment.name },
-  );
-
   const { mutateAsync: promoteAgent, isPending, error, reset: resetMutation } = usePromoteAgent();
 
   const targetEnvOptions = useMemo(() => {
@@ -110,32 +105,65 @@ export function PromoteAgentDrawer({
     return path?.targetEnvironmentRefs ?? [];
   }, [pipeline, sourceEnvironment.name]);
 
-  // Initialize form state once per drawer-open cycle so background refetches of
-  // sourceConfigs/targetEnvOptions don't wipe in-progress user edits.
-  const [didInitOnOpen, setDidInitOnOpen] = useState(false);
+  // Existing configuration of the selected destination environment. Keyed on the
+  // target env, so selecting a different target refetches that env's config.
+  const { data: targetConfigs, isSuccess: isTargetConfigLoaded } =
+    useGetAgentConfigurations(
+      { orgName: orgId, projName: projectId, agentName: agentId },
+      { environment: formState.targetEnvironment },
+    );
 
+  // Tracks which target env we've already pre-filled the editor for, so we fill
+  // once per target rather than on every background refetch.
+  const [filledForTarget, setFilledForTarget] = useState<string | null>(null);
+
+  // Pick a default target environment when the drawer opens, and clear state on close.
   useEffect(() => {
     if (!open) {
-      setDidInitOnOpen(false);
+      setFilledForTarget(null);
+      setFormState(DEFAULT_STATE);
+      resetMutation();
       return;
     }
-    if (didInitOnOpen) return;
-    // Pre-fill the editor with the source env's user-managed keys (isSystem=false),
-    // values blank. System-managed entries are platform-injected and not editable.
-    // Sensitivity is carried over so the row's "sensitive" badge matches the source,
-    // but secretRef is dropped — the user is providing a new value for this env.
-    const userEditableEnv =
-      (sourceConfigs?.configurations?.env ?? [])
-        .filter((e) => !e.isSystem)
-        .map((e) => ({ key: e.key, value: "", isSensitive: e.isSensitive }));
-    setFormState({
-      ...DEFAULT_STATE,
-      targetEnvironment: targetEnvOptions[0]?.name ?? "",
+    setFormState((prev) =>
+      prev.targetEnvironment
+        ? prev
+        : { ...prev, targetEnvironment: targetEnvOptions[0]?.name ?? "" },
+    );
+  }, [open, targetEnvOptions, resetMutation]);
+
+  // Pre-fill the editor with the destination environment's existing config so the
+  // user edits from its previous values rather than starting blank. Only the
+  // user-managed keys (isSystem=false) are editable; system entries are
+  // platform-injected. We fill once per target (tracked by filledForTarget) so a
+  // background refetch of the same target doesn't clobber in-progress edits, but
+  // switching to a different target re-fills from that env's config.
+  useEffect(() => {
+    if (!open) return;
+    const target = formState.targetEnvironment;
+    if (!target || filledForTarget === target || !isTargetConfigLoaded) return;
+    const cfg = targetConfigs?.configurations;
+    const userEditableEnv = (cfg?.env ?? [])
+      .filter((e) => !e.isSystem)
+      .map((e) => ({
+        key: e.key,
+        value: e.value ?? "",
+        isSensitive: e.isSensitive,
+        secretRef: e.secretRef,
+      }));
+    setFormState((prev) => ({
+      ...prev,
       env: userEditableEnv,
-    });
-    resetMutation();
-    setDidInitOnOpen(true);
-  }, [open, didInitOnOpen, resetMutation, targetEnvOptions, sourceConfigs]);
+      files: cfg?.files ?? [],
+    }));
+    setFilledForTarget(target);
+  }, [
+    open,
+    formState.targetEnvironment,
+    isTargetConfigLoaded,
+    targetConfigs,
+    filledForTarget,
+  ]);
 
   const handleToggleUseSourceConfig = useCallback(
     (checked: boolean) => {


### PR DESCRIPTION
## Purpose
This pull request refactors how the Promote Agent drawer initializes and manages environment configuration state, improving the user experience by ensuring that in-progress edits are preserved and that the editor is pre-filled with the correct environment's configuration. The main changes are focused on state management and data fetching logic.

**Improvements to configuration pre-filling and state management:**

* The drawer now fetches and pre-fills the editor with the existing configuration of the selected target environment, rather than always starting with a blank or source environment configuration. This ensures users edit from the current state of the target environment.
* The logic tracks which target environment has been pre-filled to avoid overwriting user edits during background refetches, only re-filling when the user switches to a different target environment.
* The previous logic that fetched the source environment configuration and initialized form state on drawer open has been removed, simplifying state handling and reducing unnecessary data fetching. [[1]](diffhunk://#diff-e9da2b26349364adfc6691a6b5e1e27597976c1c8f417763611b1e327899eba9L98-L102) [[2]](diffhunk://#diff-e9da2b26349364adfc6691a6b5e1e27597976c1c8f417763611b1e327899eba9L113-R166)
* On drawer close, all relevant state (including the pre-fill tracker and form state) is reset to ensure a clean slate for the next open cycle.


Issue: https://github.com/wso2/agent-manager/issues/1130
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Agent promotion drawer now pre-fills configuration values from the target environment instead of the source environment.
* Editor state resets when closing the promotion drawer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->