### PR TITLE
Implement CLI for agent mcp proxy configs.

### DIFF
--- a/cli/pkg/cmd/agent/agent.go
+++ b/cli/pkg/cmd/agent/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/cmd/agent/build"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/agent/create"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/agent/llm"
+	"github.com/wso2/agent-manager/cli/pkg/cmd/agent/mcp"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/agent/traces"
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 )
@@ -40,6 +41,7 @@ func NewAgentCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(build.NewBuildCmd(f))
 	cmd.AddCommand(create.NewCreateCmd(f))
 	cmd.AddCommand(llm.NewLLMCmd(f))
+	cmd.AddCommand(mcp.NewMCPCmd(f))
 	cmd.AddCommand(NewLogsCmd(f))
 	cmd.AddCommand(NewMetricsCmd(f))
 	cmd.AddCommand(traces.NewTracesCmd(f))

--- a/cli/pkg/cmd/agent/mcp/get.go
+++ b/cli/pkg/cmd/agent/mcp/get.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+	"github.com/wso2/agent-manager/cli/pkg/tableprinter"
+)
+
+type GetOptions struct {
+	IO           *iostreams.IOStreams
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
+
+	Org       string
+	Proj      string
+	Scope     render.Scope
+	AgentName string
+	Name      string
+}
+
+func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &GetOptions{
+		IO:           f.IOStreams,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get [agent] --name <config>",
+		Short: "Show an agent's MCP proxy configuration",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, proj, err := opts.ResolveScope(cmd, true, true)
+			if err != nil {
+				return render.Error(opts.IO, opts.MakeScope(org, proj, ""), err)
+			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
+			opts.Org, opts.Proj, opts.Scope = org, proj, scope
+			opts.AgentName = agent
+			return runGet(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the MCP configuration (required)")
+	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func runGet(ctx context.Context, o *GetOptions) error {
+	if err := cmdutil.ValidatePathParam("agent name", o.AgentName); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	id, found, err := findMCPConfigByName(ctx, client, o.Org, o.Proj, o.AgentName, o.Name)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	if !found {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.NotFound, "no MCP configuration named %q for agent %q", o.Name, o.AgentName))
+	}
+
+	resp, err := client.GetAgentMCPConfigWithResponse(ctx, o.Org, o.Proj, o.AgentName, id)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON404, resp.JSON500)))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, resp.JSON200)
+	}
+
+	return printConfig(o.IO, resp.JSON200)
+}
+
+func printConfig(io *iostreams.IOStreams, c *amsvc.AgentModelConfigResponse) error {
+	cs := io.ColorScheme()
+	desc := "-"
+	if c.Description != nil && *c.Description != "" {
+		desc = *c.Description
+	}
+	fmt.Fprintf(io.Out, "name:         %s\n", cs.Bold(c.Name))
+	fmt.Fprintf(io.Out, "type:         %s\n", c.Type)
+	fmt.Fprintf(io.Out, "description:  %s\n", desc)
+
+	if len(c.EnvMappings) > 0 {
+		envs := make([]string, 0, len(c.EnvMappings))
+		for env := range c.EnvMappings {
+			envs = append(envs, env)
+		}
+		sort.Strings(envs)
+
+		fmt.Fprintf(io.Out, "\nenvironments:\n")
+		tp := tableprinter.New(io, "env", "proxy", "url", "status")
+		for _, env := range envs {
+			m := c.EnvMappings[env]
+			proxy, url, status := "-", "-", "-"
+			if m.Configuration != nil {
+				if p := proxyNameFromConfig(m.Configuration); p != "" {
+					proxy = p
+				}
+				if m.Configuration.Url != "" {
+					url = m.Configuration.Url
+				}
+				if m.Configuration.Status != nil && *m.Configuration.Status != "" {
+					status = *m.Configuration.Status
+				}
+			}
+			tp.AddField(env, tableprinter.WithColor(cs.Bold))
+			tp.AddField(proxy)
+			tp.AddField(url, tableprinter.WithColor(cs.Gray))
+			tp.AddField(status)
+			tp.EndRow()
+		}
+		if err := tp.Render(); err != nil {
+			return err
+		}
+	}
+
+	if len(c.EnvironmentVariables) > 0 {
+		fmt.Fprintf(io.Out, "\nenvironment variables:\n")
+		for _, ev := range c.EnvironmentVariables {
+			fmt.Fprintf(io.Out, "  %-8s %s\n", ev.Key, ev.Name)
+		}
+	}
+
+	return nil
+}

--- a/cli/pkg/cmd/agent/mcp/get_test.go
+++ b/cli/pkg/cmd/agent/mcp/get_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+const getUUID = "11111111-1111-1111-1111-111111111111"
+
+func getResponseFixture() amsvc.AgentModelConfigResponse {
+	active := "active"
+	desc := "primary github binding"
+	return amsvc.AgentModelConfigResponse{
+		Name:        "primary",
+		Type:        "mcp",
+		Description: &desc,
+		Uuid:        mustUUID(getUUID),
+		EnvMappings: map[string]amsvc.EnvProviderConfigMappings{
+			"dev":  {EnvironmentName: "dev", Configuration: &amsvc.ProviderConfig{ProviderName: "github", ProxyName: stringPtr("github"), Url: "https://dev.mcp", Status: &active}},
+			"prod": {EnvironmentName: "prod", Configuration: &amsvc.ProviderConfig{ProviderName: "gitlab", ProxyName: stringPtr("gitlab"), Url: "https://prod.mcp"}},
+		},
+		EnvironmentVariables: []amsvc.EnvironmentVariableConfig{
+			{Key: "url", Name: "MCP_URL"},
+			{Key: "apikey", Name: "MCP_KEY"},
+		},
+	}
+}
+
+func newGetOpts(io *iostreams.IOStreams, client clientFn) *GetOptions {
+	return &GetOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot", Name: "primary"}
+}
+
+func Test_runGet_humanOutput(t *testing.T) {
+	io, out, _ := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(getResponseFixture()),
+	})
+	defer cleanup()
+
+	if err := runGet(context.Background(), newGetOpts(io, client)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"primary", "mcp", "primary github binding",
+		"ENV", "PROXY", "URL", "STATUS",
+		"dev", "github", "https://dev.mcp", "active",
+		"prod", "gitlab",
+		"MCP_URL", "MCP_KEY",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func Test_runGet_json(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(getResponseFixture()),
+	})
+	defer cleanup()
+
+	if err := runGet(context.Background(), newGetOpts(io, client)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeEnvelope(t, out.String())["data"].(map[string]any)
+	if data["name"] != "primary" {
+		t.Errorf("name = %v, want primary", data["name"])
+	}
+	envs := data["envMappings"].(map[string]any)
+	if _, ok := envs["dev"]; !ok {
+		t.Errorf("envMappings missing dev: %v", envs)
+	}
+}
+
+func Test_runGet_nameNotFound(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	// Only list is stubbed; if get() were called the mock returns NOT_STUBBED.
+	client, cleanup := newClient(t, map[string]route{
+		listPath: okJSON(listResponse(mcpItem("other", getUUID))),
+	})
+	defer cleanup()
+
+	opts := newGetOpts(io, client)
+	opts.Name = "primary"
+	if err := runGet(context.Background(), opts); err == nil {
+		t.Fatal("expected error")
+	}
+	errBody := decodeEnvelope(t, out.String())["error"].(map[string]any)
+	if errBody["code"] != clierr.NotFound {
+		t.Fatalf("code = %v, want %s", errBody["code"], clierr.NotFound)
+	}
+}
+
+func Test_runGet_detailServerError(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): {status: http.StatusNotFound, body: map[string]any{"code": "MODEL_CONFIG_NOT_FOUND", "message": "gone"}},
+	})
+	defer cleanup()
+
+	if err := runGet(context.Background(), newGetOpts(io, client)); err == nil {
+		t.Fatal("expected error")
+	}
+	if status := decodeEnvelope(t, out.String())["error"].(map[string]any)["status"]; status.(float64) != 404 {
+		t.Fatalf("status = %v, want 404", status)
+	}
+}

--- a/cli/pkg/cmd/agent/mcp/group_test.go
+++ b/cli/pkg/cmd/agent/mcp/group_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+func Test_NewMCPCmd_registersSubcommands(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+	cmd := NewMCPCmd(&cmdutil.Factory{IOStreams: ios})
+
+	if cmd.Use != "mcp" {
+		t.Errorf("Use = %q, want mcp", cmd.Use)
+	}
+	want := map[string]bool{"list": false, "get": false, "set": false, "unset": false}
+	for _, c := range cmd.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("subcommand %q not registered under mcp", name)
+		}
+	}
+}

--- a/cli/pkg/cmd/agent/mcp/helpers_test.go
+++ b/cli/pkg/cmd/agent/mcp/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +35,24 @@ import (
 
 // clientFn is the lazy client accessor shape every command's Options expects.
 type clientFn = func(context.Context) (*amsvc.ClientWithResponses, error)
+
+func unreachableClient(context.Context) (*amsvc.ClientWithResponses, error) {
+	return nil, errors.New("client should not be constructed")
+}
+
+type fakePrompter struct {
+	confirmDeletionErr error
+	confirmDeletionArg string
+	calls              int
+}
+
+func (p *fakePrompter) ConfirmDeletion(required string) error {
+	p.calls++
+	p.confirmDeletionArg = required
+	return p.confirmDeletionErr
+}
+
+func (p *fakePrompter) Confirm(prompt string) (bool, error) { return false, nil }
 
 // route describes one stubbed HTTP response keyed by "METHOD /path".
 type route struct {

--- a/cli/pkg/cmd/agent/mcp/helpers_test.go
+++ b/cli/pkg/cmd/agent/mcp/helpers_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+// clientFn is the lazy client accessor shape every command's Options expects.
+type clientFn = func(context.Context) (*amsvc.ClientWithResponses, error)
+
+// route describes one stubbed HTTP response keyed by "METHOD /path".
+type route struct {
+	status       int
+	body         any
+	transportErr error
+	// capture, when non-nil, receives the decoded request body the handler saw.
+	capture *map[string]any
+}
+
+func okJSON(body any) route { return route{status: http.StatusOK, body: body} }
+
+// newClient spins up an httptest server whose responses are keyed by
+// "METHOD /path", mirroring the agent package's status_test harness.
+func newClient(t *testing.T, routes map[string]route) (func(context.Context) (*amsvc.ClientWithResponses, error), func()) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		rt, ok := routes[key]
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]any{"code": "NOT_STUBBED", "message": key})
+			return
+		}
+		if rt.transportErr != nil {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatalf("response writer does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			_ = conn.Close()
+			return
+		}
+		if rt.capture != nil {
+			raw, _ := io.ReadAll(r.Body)
+			m := map[string]any{}
+			_ = json.Unmarshal(raw, &m)
+			*rt.capture = m
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(rt.status)
+		if rt.body != nil {
+			_ = json.NewEncoder(w).Encode(rt.body)
+		}
+	}))
+	client, err := amsvc.NewClientWithResponses(srv.URL)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("new client: %v", err)
+	}
+	return func(context.Context) (*amsvc.ClientWithResponses, error) { return client, nil }, srv.Close
+}
+
+func baseScope() render.Scope {
+	return render.Scope{Instance: "default", Org: "acme", Project: "triage", Agent: "order-bot"}
+}
+
+func newTestIO(jsonMode bool) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	ios, _, out, errOut := iostreams.Test()
+	ios.SetTerminal(!jsonMode, !jsonMode, !jsonMode)
+	ios.JSON = jsonMode
+	return ios, out, errOut
+}
+
+func decodeEnvelope(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("decode envelope: %v\nbody=%q", err, raw)
+	}
+	return m
+}
+
+// Path constants for the mcp-configs endpoints under the test agent.
+const (
+	listPath = "GET /orgs/acme/projects/triage/agents/order-bot/mcp-configs"
+	postPath = "POST /orgs/acme/projects/triage/agents/order-bot/mcp-configs"
+)
+
+func configPath(method, uuid string) string {
+	return method + " /orgs/acme/projects/triage/agents/order-bot/mcp-configs/" + uuid
+}
+
+func mustUUID(s string) openapi_types.UUID {
+	u, err := uuid.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/cli/pkg/cmd/agent/mcp/list.go
+++ b/cli/pkg/cmd/agent/mcp/list.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+	"github.com/wso2/agent-manager/cli/pkg/tableprinter"
+)
+
+type ListOptions struct {
+	IO           *iostreams.IOStreams
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
+
+	Org       string
+	Proj      string
+	Scope     render.Scope
+	AgentName string
+}
+
+// ListResult is the JSON envelope payload for `mcp list`.
+type ListResult struct {
+	Configs []amsvc.AgentModelConfigListItem `json:"configs"`
+}
+
+func NewListCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &ListOptions{
+		IO:           f.IOStreams,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list [agent]",
+		Short: "List MCP proxy configurations for an agent",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, proj, err := opts.ResolveScope(cmd, true, true)
+			if err != nil {
+				return render.Error(opts.IO, opts.MakeScope(org, proj, ""), err)
+			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
+			opts.Org, opts.Proj, opts.Scope = org, proj, scope
+			opts.AgentName = agent
+			return runList(cmd.Context(), opts)
+		},
+	}
+	return cmd
+}
+
+func runList(ctx context.Context, o *ListOptions) error {
+	if err := cmdutil.ValidatePathParam("agent name", o.AgentName); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	resp, err := client.ListAgentMCPConfigsWithResponse(ctx, o.Org, o.Proj, o.AgentName, &amsvc.ListAgentMCPConfigsParams{})
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, resp.JSON500))
+	}
+
+	configs := make([]amsvc.AgentModelConfigListItem, 0, len(resp.JSON200.Configs))
+	for _, c := range resp.JSON200.Configs {
+		if c.Type == configType {
+			configs = append(configs, c)
+		}
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, ListResult{Configs: configs})
+	}
+
+	tp := tableprinter.New(o.IO, "name", "description")
+	cs := o.IO.ColorScheme()
+	for _, c := range configs {
+		tp.AddField(c.Name, tableprinter.WithColor(cs.Bold))
+		desc := "-"
+		if c.Description != nil && *c.Description != "" {
+			desc = *c.Description
+		}
+		tp.AddField(desc)
+		tp.EndRow()
+	}
+	return tp.Render()
+}

--- a/cli/pkg/cmd/agent/mcp/list_test.go
+++ b/cli/pkg/cmd/agent/mcp/list_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+)
+
+func mixedListResponse() amsvc.AgentModelConfigListResponse {
+	desc := "primary github binding"
+	return amsvc.AgentModelConfigListResponse{Configs: []amsvc.AgentModelConfigListItem{
+		{Name: "primary", Type: "mcp", Description: &desc, Uuid: mustUUID("11111111-1111-1111-1111-111111111111")},
+		{Name: "secondary", Type: "mcp", Uuid: mustUUID("22222222-2222-2222-2222-222222222222")},
+		{Name: "model-binding", Type: "llm", Uuid: mustUUID("33333333-3333-3333-3333-333333333333")},
+	}}
+}
+
+func Test_runList_humanTable_mcpOnly(t *testing.T) {
+	io, out, _ := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	client, cleanup := newClient(t, map[string]route{listPath: okJSON(mixedListResponse())})
+	defer cleanup()
+
+	opts := &ListOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot"}
+	if err := runList(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"NAME", "DESCRIPTION", "primary", "secondary", "primary github binding"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "model-binding") {
+		t.Errorf("llm config must be filtered out of mcp list, got:\n%s", got)
+	}
+}
+
+func Test_runList_json_onlyMCP(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{listPath: okJSON(mixedListResponse())})
+	defer cleanup()
+
+	opts := &ListOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot"}
+	if err := runList(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeEnvelope(t, out.String())["data"].(map[string]any)
+	configs, ok := data["configs"].([]any)
+	if !ok {
+		t.Fatalf("data.configs not an array: %v", data["configs"])
+	}
+	if len(configs) != 2 {
+		t.Fatalf("len(configs) = %d, want 2 (mcp only)", len(configs))
+	}
+	for _, c := range configs {
+		if c.(map[string]any)["type"] != "mcp" {
+			t.Errorf("non-mcp config leaked into list: %v", c)
+		}
+	}
+}
+
+func Test_runList_serverError(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath: {status: http.StatusInternalServerError, body: map[string]any{"code": "INTERNAL", "message": "boom"}},
+	})
+	defer cleanup()
+
+	opts := &ListOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot"}
+	if err := runList(context.Background(), opts); err == nil {
+		t.Fatal("expected error")
+	}
+	if code := decodeEnvelope(t, out.String())["error"].(map[string]any)["status"]; code.(float64) != 500 {
+		t.Fatalf("status = %v, want 500", code)
+	}
+}
+
+func Test_runList_transportError(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{listPath: {transportErr: errors.New("refused")}})
+	defer cleanup()
+
+	opts := &ListOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot"}
+	if err := runList(context.Background(), opts); err == nil {
+		t.Fatal("expected error")
+	}
+	if code := decodeEnvelope(t, out.String())["error"].(map[string]any)["code"]; code != clierr.Transport {
+		t.Fatalf("code = %v, want %s", code, clierr.Transport)
+	}
+}

--- a/cli/pkg/cmd/agent/mcp/mcp.go
+++ b/cli/pkg/cmd/agent/mcp/mcp.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+)
+
+// NewMCPCmd is the `agent mcp` command group for managing an agent's MCP
+// proxy configurations per environment, after the agent is created.
+func NewMCPCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Manage an agent's MCP proxy configurations",
+	}
+	cmd.AddCommand(NewListCmd(f))
+	cmd.AddCommand(NewGetCmd(f))
+	cmd.AddCommand(NewSetCmd(f))
+	cmd.AddCommand(NewUnsetCmd(f))
+	return cmd
+}
+
+// configType is the model-config Type value this command group manages. The
+// mcp-configs endpoint shares its response shape with model-configs across
+// config types (llm/mcp/other), so every read filters to this value.
+const configType = "mcp"
+
+// proxyNameFromConfig extracts the MCP proxy handle from a GET-response env
+// mapping. The server mirrors the proxy handle into providerName and the
+// proxy*-named fields for MCP configs; this prefers the proxy-specific fields
+// and falls back to providerName.
+func proxyNameFromConfig(c *amsvc.ProviderConfig) string {
+	if c == nil {
+		return ""
+	}
+	if c.ProxyName != nil && *c.ProxyName != "" {
+		return *c.ProxyName
+	}
+	if c.McpProxyName != nil && *c.McpProxyName != "" {
+		return *c.McpProxyName
+	}
+	return c.ProviderName
+}
+
+// toEnvModelConfigRequest translates a GET-response env mapping into the shape
+// the PUT/POST request body expects. Server-managed fields (URL, status, auth
+// info, proxy UUID) are dropped; only the proxy handle and policies survive.
+func toEnvModelConfigRequest(m amsvc.EnvProviderConfigMappings) amsvc.EnvModelConfigRequest {
+	req := amsvc.EnvModelConfigRequest{}
+	if m.Configuration != nil {
+		req.ProxyName = stringPtr(proxyNameFromConfig(m.Configuration))
+		req.Configuration = amsvc.EnvProviderConfiguration{Policies: m.Configuration.Policies}
+	}
+	return req
+}
+
+func stringPtr(v string) *string {
+	return &v
+}
+
+// mergeExistingEnvMappings translates the full env-mapping set of an existing
+// config into request shape — the read half of read-merge-write.
+func mergeExistingEnvMappings(resp *amsvc.AgentModelConfigResponse) map[string]amsvc.EnvModelConfigRequest {
+	out := make(map[string]amsvc.EnvModelConfigRequest, len(resp.EnvMappings))
+	for env, m := range resp.EnvMappings {
+		out[env] = toEnvModelConfigRequest(m)
+	}
+	return out
+}
+
+// findMCPConfigByName resolves a config name to its UUID via List, considering
+// only mcp-typed configs. found is false when no mcp config matches the name.
+func findMCPConfigByName(ctx context.Context, client *amsvc.ClientWithResponses, org, proj, agent, name string) (openapi_types.UUID, bool, error) {
+	resp, err := client.ListAgentMCPConfigsWithResponse(ctx, org, proj, agent, &amsvc.ListAgentMCPConfigsParams{})
+	if err != nil {
+		return openapi_types.UUID{}, false, clierr.Newf(clierr.Transport, "%v", err)
+	}
+	if resp.JSON200 == nil {
+		return openapi_types.UUID{}, false, cmdutil.ErrorFromServer(resp.HTTPResponse, resp.JSON500)
+	}
+	for _, c := range resp.JSON200.Configs {
+		if c.Type == configType && c.Name == name {
+			return c.Uuid, true, nil
+		}
+	}
+	return openapi_types.UUID{}, false, nil
+}

--- a/cli/pkg/cmd/agent/mcp/mcp_test.go
+++ b/cli/pkg/cmd/agent/mcp/mcp_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+func Test_mergeExistingEnvMappings_translatesEveryEnv(t *testing.T) {
+	policies := []amsvc.LLMPolicy{{Name: "rate-limit", Version: "v1"}}
+	resp := &amsvc.AgentModelConfigResponse{
+		EnvMappings: map[string]amsvc.EnvProviderConfigMappings{
+			"dev": {
+				EnvironmentName: "dev",
+				Configuration: &amsvc.ProviderConfig{
+					ProviderName: "github",
+					ProxyName:    stringPtr("github"),
+					Url:          "https://server-managed.example.com",
+					Policies:     &policies,
+				},
+			},
+			"prod": {
+				EnvironmentName: "prod",
+				Configuration:   &amsvc.ProviderConfig{ProviderName: "gitlab", ProxyName: stringPtr("gitlab")},
+			},
+		},
+	}
+
+	got := mergeExistingEnvMappings(resp)
+
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got["dev"].ProxyName == nil || *got["dev"].ProxyName != "github" {
+		t.Errorf("dev proxy = %v, want github", got["dev"].ProxyName)
+	}
+	if got["prod"].ProxyName == nil || *got["prod"].ProxyName != "gitlab" {
+		t.Errorf("prod proxy = %v, want gitlab", got["prod"].ProxyName)
+	}
+	// Policies must survive the round-trip translation.
+	dp := got["dev"].Configuration.Policies
+	if dp == nil || len(*dp) != 1 || (*dp)[0].Name != "rate-limit" {
+		t.Errorf("dev policies not carried over: %#v", got["dev"].Configuration.Policies)
+	}
+}
+
+func Test_toEnvModelConfigRequest_nilConfiguration(t *testing.T) {
+	got := toEnvModelConfigRequest(amsvc.EnvProviderConfigMappings{EnvironmentName: "dev"})
+	if got.ProxyName != nil {
+		t.Errorf("ProxyName = %q, want nil", *got.ProxyName)
+	}
+	if got.Configuration.Policies != nil {
+		t.Errorf("Policies = %#v, want nil", got.Configuration.Policies)
+	}
+}
+
+// proxyNameFromConfig must prefer the proxy-specific fields, then fall back to
+// providerName (which the server mirrors the proxy handle into).
+func Test_proxyNameFromConfig(t *testing.T) {
+	t.Run("prefers proxyName", func(t *testing.T) {
+		c := &amsvc.ProviderConfig{ProviderName: "github", ProxyName: stringPtr("github-proxy")}
+		if got := proxyNameFromConfig(c); got != "github-proxy" {
+			t.Errorf("got %q, want github-proxy", got)
+		}
+	})
+	t.Run("falls back to providerName", func(t *testing.T) {
+		c := &amsvc.ProviderConfig{ProviderName: "github"}
+		if got := proxyNameFromConfig(c); got != "github" {
+			t.Errorf("got %q, want github", got)
+		}
+	})
+	t.Run("nil configuration", func(t *testing.T) {
+		if got := proxyNameFromConfig(nil); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func listResponse(items ...amsvc.AgentModelConfigListItem) amsvc.AgentModelConfigListResponse {
+	return amsvc.AgentModelConfigListResponse{Configs: items}
+}
+
+func mcpItem(name, uuid string) amsvc.AgentModelConfigListItem {
+	return amsvc.AgentModelConfigListItem{Name: name, Type: "mcp", Uuid: mustUUID(uuid)}
+}
+
+func Test_findMCPConfigByName(t *testing.T) {
+	const uuidA = "11111111-1111-1111-1111-111111111111"
+	t.Run("found", func(t *testing.T) {
+		client, cleanup := newClient(t, map[string]route{
+			listPath: okJSON(listResponse(
+				amsvc.AgentModelConfigListItem{Name: "shared", Type: "llm", Uuid: mustUUID("22222222-2222-2222-2222-222222222222")},
+				mcpItem("primary", uuidA),
+			)),
+		})
+		defer cleanup()
+		c, _ := client(context.Background())
+		id, found, err := findMCPConfigByName(context.Background(), c, "acme", "triage", "order-bot", "primary")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !found {
+			t.Fatal("found = false, want true")
+		}
+		if id != mustUUID(uuidA) {
+			t.Errorf("uuid = %v, want %s", id, uuidA)
+		}
+	})
+
+	t.Run("ignores same name with non-mcp type", func(t *testing.T) {
+		client, cleanup := newClient(t, map[string]route{
+			listPath: okJSON(listResponse(
+				amsvc.AgentModelConfigListItem{Name: "primary", Type: "llm", Uuid: mustUUID(uuidA)},
+			)),
+		})
+		defer cleanup()
+		c, _ := client(context.Background())
+		_, found, err := findMCPConfigByName(context.Background(), c, "acme", "triage", "order-bot", "primary")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Fatal("found = true, want false (llm type must be ignored)")
+		}
+	})
+
+	t.Run("not found returns no error", func(t *testing.T) {
+		client, cleanup := newClient(t, map[string]route{
+			listPath: okJSON(listResponse(mcpItem("other", uuidA))),
+		})
+		defer cleanup()
+		c, _ := client(context.Background())
+		_, found, err := findMCPConfigByName(context.Background(), c, "acme", "triage", "order-bot", "primary")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Fatal("found = true, want false")
+		}
+	})
+}

--- a/cli/pkg/cmd/agent/mcp/set.go
+++ b/cli/pkg/cmd/agent/mcp/set.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+type SetOptions struct {
+	IO           *iostreams.IOStreams
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
+
+	Org       string
+	Proj      string
+	Scope     render.Scope
+	AgentName string
+
+	Name        string
+	Env         string
+	Proxy       string
+	URLEnv      string
+	APIKeyEnv   string
+	Description string
+}
+
+func NewSetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &SetOptions{
+		IO:           f.IOStreams,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "set [agent] --name <config> --env <env> --proxy <handle>",
+		Short: "Bind an MCP proxy to an agent's environment",
+		Long: "Create or update an agent's MCP proxy configuration for a single " +
+			"environment. Other environments on the same configuration are preserved.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, proj, err := opts.ResolveScope(cmd, true, true)
+			if err != nil {
+				return render.Error(opts.IO, opts.MakeScope(org, proj, ""), err)
+			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
+			opts.Org, opts.Proj, opts.Scope = org, proj, scope
+			opts.AgentName = agent
+			return runSet(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the MCP configuration (required)")
+	cmd.Flags().StringVar(&opts.Env, "env", "", "Environment to bind the proxy in (required)")
+	cmd.Flags().StringVar(&opts.Proxy, "proxy", "", "Handle of a configured MCP proxy (required)")
+	cmd.Flags().StringVar(&opts.URLEnv, "url-env", "", "Env var name for the proxy URL (default: auto-generated)")
+	cmd.Flags().StringVar(&opts.APIKeyEnv, "apikey-env", "", "Env var name for the proxy API key (default: auto-generated)")
+	cmd.Flags().StringVar(&opts.Description, "description", "", "Optional description for the configuration")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("env")
+	_ = cmd.MarkFlagRequired("proxy")
+	return cmd
+}
+
+func runSet(ctx context.Context, o *SetOptions) error {
+	if err := cmdutil.ValidatePathParam("agent name", o.AgentName); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	if o.URLEnv != "" {
+		if err := cmdutil.ValidateEnvVarName("--url-env", o.URLEnv); err != nil {
+			return render.Error(o.IO, o.Scope, err)
+		}
+	}
+	if o.APIKeyEnv != "" {
+		if err := cmdutil.ValidateEnvVarName("--apikey-env", o.APIKeyEnv); err != nil {
+			return render.Error(o.IO, o.Scope, err)
+		}
+	}
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	id, found, err := findMCPConfigByName(ctx, client, o.Org, o.Proj, o.AgentName, o.Name)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	mapping := amsvc.EnvModelConfigRequest{ProxyName: stringPtr(o.Proxy)}
+	envVars := buildEnvVars(o)
+
+	var result *amsvc.AgentModelConfigResponse
+	var verb string
+	if !found {
+		body := amsvc.CreateAgentModelConfigRequest{
+			Name:                 o.Name,
+			Type:                 amsvc.CreateAgentModelConfigRequestTypeMcp,
+			EnvMappings:          map[string]amsvc.EnvModelConfigRequest{o.Env: mapping},
+			EnvironmentVariables: envVars,
+			Description:          descriptionPtr(o.Description),
+		}
+		resp, err := client.CreateAgentMCPConfigWithResponse(ctx, o.Org, o.Proj, o.AgentName, body)
+		if err != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+		}
+		if resp.JSON201 == nil {
+			return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse,
+				cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON404, resp.JSON409, resp.JSON500)))
+		}
+		result, verb = resp.JSON201, "created"
+	} else {
+		// Read-merge-write: PUT replaces the entire envMappings set, so we must
+		// re-send every existing environment alongside the one we are changing.
+		current, err := client.GetAgentMCPConfigWithResponse(ctx, o.Org, o.Proj, o.AgentName, id)
+		if err != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+		}
+		if current.JSON200 == nil {
+			return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(current.HTTPResponse,
+				cmdutil.FirstNonNil(current.JSON400, current.JSON404, current.JSON500)))
+		}
+		merged := mergeExistingEnvMappings(current.JSON200)
+		merged[o.Env] = mapping
+
+		body := amsvc.UpdateAgentModelConfigRequest{EnvMappings: &merged}
+		if envVars != nil {
+			body.EnvironmentVariables = envVars
+		}
+		if d := descriptionPtr(o.Description); d != nil {
+			body.Description = d
+		}
+		resp, err := client.UpdateAgentMCPConfigWithResponse(ctx, o.Org, o.Proj, o.AgentName, id, body)
+		if err != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+		}
+		if resp.JSON200 == nil {
+			return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse,
+				cmdutil.FirstNonNil(resp.JSON400, resp.JSON404, resp.JSON500)))
+		}
+		result, verb = resp.JSON200, "updated"
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, result)
+	}
+	cs := o.IO.StderrColorScheme()
+	fmt.Fprintf(o.IO.ErrOut, "%s %s MCP config %q: bound proxy %q to environment %q\n",
+		cs.SuccessIcon(), verb, o.Name, o.Proxy, o.Env)
+	return nil
+}
+
+func buildEnvVars(o *SetOptions) *[]amsvc.EnvironmentVariableConfig {
+	var evs []amsvc.EnvironmentVariableConfig
+	if o.URLEnv != "" {
+		evs = append(evs, amsvc.EnvironmentVariableConfig{Key: "url", Name: o.URLEnv})
+	}
+	if o.APIKeyEnv != "" {
+		evs = append(evs, amsvc.EnvironmentVariableConfig{Key: "apikey", Name: o.APIKeyEnv})
+	}
+	if len(evs) == 0 {
+		return nil
+	}
+	return &evs
+}
+
+func descriptionPtr(d string) *string {
+	if d == "" {
+		return nil
+	}
+	return &d
+}

--- a/cli/pkg/cmd/agent/mcp/set_test.go
+++ b/cli/pkg/cmd/agent/mcp/set_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+func newSetOpts(io *iostreams.IOStreams, client clientFn) *SetOptions {
+	return &SetOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot", Name: "primary"}
+}
+
+// envMapKeys returns the env names present in a captured request body's envMappings.
+func envMapKeys(body map[string]any) map[string]any {
+	em, _ := body["envMappings"].(map[string]any)
+	return em
+}
+
+func Test_runSet_createsWhenAbsent(t *testing.T) {
+	io, _, errOut := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	var posted map[string]any
+	client, cleanup := newClient(t, map[string]route{
+		listPath: okJSON(listResponse(mcpItem("other", getUUID))), // name not present
+		postPath: {status: http.StatusCreated, body: getResponseFixture(), capture: &posted},
+	})
+	defer cleanup()
+
+	opts := newSetOpts(io, client)
+	opts.Env, opts.Proxy = "dev", "github"
+	if err := runSet(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if posted["name"] != "primary" {
+		t.Errorf("posted name = %v, want primary", posted["name"])
+	}
+	if posted["type"] != "mcp" {
+		t.Errorf("posted type = %v, want mcp", posted["type"])
+	}
+	em := envMapKeys(posted)
+	dev, ok := em["dev"].(map[string]any)
+	if !ok {
+		t.Fatalf("envMappings.dev missing: %v", em)
+	}
+	if dev["proxyName"] != "github" {
+		t.Errorf("dev proxyName = %v, want github", dev["proxyName"])
+	}
+	if !strings.Contains(errOut.String(), "created") {
+		t.Errorf("expected 'created' confirmation, got %q", errOut.String())
+	}
+}
+
+// The critical read-merge-write guarantee: updating one env must NOT drop the
+// others, since PUT replaces the entire envMappings set.
+func Test_runSet_updatePreservesSiblingEnvs(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	var put map[string]any
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(getResponseFixture()), // has dev + prod
+		configPath("PUT", getUUID): {status: http.StatusOK, body: getResponseFixture(), capture: &put},
+	})
+	defer cleanup()
+
+	opts := newSetOpts(io, client)
+	opts.Env, opts.Proxy = "staging", "bitbucket"
+	if err := runSet(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	em := envMapKeys(put)
+	for _, env := range []string{"dev", "prod", "staging"} {
+		if _, ok := em[env]; !ok {
+			t.Errorf("PUT envMappings missing %q (read-merge-write dropped a sibling): %v", env, em)
+		}
+	}
+	if staging := em["staging"].(map[string]any); staging["proxyName"] != "bitbucket" {
+		t.Errorf("staging proxyName = %v, want bitbucket", staging["proxyName"])
+	}
+	// Sibling proxy must be carried over from the GET response untouched.
+	if dev := em["dev"].(map[string]any); dev["proxyName"] != "github" {
+		t.Errorf("dev proxyName = %v, want github (preserved)", dev["proxyName"])
+	}
+}
+
+func Test_runSet_updateOverwritesExistingEnv(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	var put map[string]any
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(getResponseFixture()),
+		configPath("PUT", getUUID): {status: http.StatusOK, body: getResponseFixture(), capture: &put},
+	})
+	defer cleanup()
+
+	opts := newSetOpts(io, client)
+	opts.Env, opts.Proxy = "dev", "github-enterprise"
+	if err := runSet(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dev := envMapKeys(put)["dev"].(map[string]any)
+	if dev["proxyName"] != "github-enterprise" {
+		t.Errorf("dev proxyName = %v, want github-enterprise", dev["proxyName"])
+	}
+}
+
+func Test_runSet_createCarriesEnvVars(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	var posted map[string]any
+	client, cleanup := newClient(t, map[string]route{
+		listPath: okJSON(listResponse()),
+		postPath: {status: http.StatusCreated, body: getResponseFixture(), capture: &posted},
+	})
+	defer cleanup()
+
+	opts := newSetOpts(io, client)
+	opts.Env, opts.Proxy = "dev", "github"
+	opts.URLEnv, opts.APIKeyEnv = "MCP_URL", "MCP_KEY"
+	if err := runSet(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	evs, ok := posted["environmentVariables"].([]any)
+	if !ok || len(evs) != 2 {
+		t.Fatalf("environmentVariables = %v, want 2 entries", posted["environmentVariables"])
+	}
+	byKey := map[string]string{}
+	for _, e := range evs {
+		m := e.(map[string]any)
+		byKey[m["key"].(string)] = m["name"].(string)
+	}
+	if byKey["url"] != "MCP_URL" || byKey["apikey"] != "MCP_KEY" {
+		t.Errorf("env vars = %v, want url=MCP_URL apikey=MCP_KEY", byKey)
+	}
+}
+
+// Invalid env-var names must be rejected client-side, before any API call, so
+// the user gets early feedback instead of a server rejection. Empty routes mean
+// any HTTP request would 500 with NOT_STUBBED — reaching one is a test failure.
+func Test_runSet_rejectsInvalidEnvVarName(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		set     func(*SetOptions)
+		wantArg string
+	}{
+		{name: "url-env", set: func(o *SetOptions) { o.URLEnv = "1BAD" }, wantArg: "--url-env"},
+		{name: "apikey-env", set: func(o *SetOptions) { o.APIKeyEnv = "BAD-KEY" }, wantArg: "--apikey-env"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			io, out, _ := newTestIO(true)
+			client, cleanup := newClient(t, map[string]route{})
+			defer cleanup()
+
+			opts := newSetOpts(io, client)
+			opts.Env, opts.Proxy = "dev", "github"
+			tc.set(opts)
+			if err := runSet(context.Background(), opts); err == nil {
+				t.Fatalf("expected error for invalid %s", tc.wantArg)
+			}
+			if !strings.Contains(out.String(), tc.wantArg) {
+				t.Errorf("error output %q does not mention %s", out.String(), tc.wantArg)
+			}
+		})
+	}
+}
+
+func Test_runSet_createServerError(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath: okJSON(listResponse()),
+		postPath: {status: http.StatusConflict, body: map[string]any{"code": "CONFLICT", "message": "exists"}},
+	})
+	defer cleanup()
+
+	opts := newSetOpts(io, client)
+	opts.Env, opts.Proxy = "dev", "github"
+	if err := runSet(context.Background(), opts); err == nil {
+		t.Fatal("expected error")
+	}
+	if status := decodeEnvelope(t, out.String())["error"].(map[string]any)["status"]; status.(float64) != 409 {
+		t.Fatalf("status = %v, want 409", status)
+	}
+}

--- a/cli/pkg/cmd/agent/mcp/unset.go
+++ b/cli/pkg/cmd/agent/mcp/unset.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+type UnsetOptions struct {
+	IO           *iostreams.IOStreams
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj, agent string) render.Scope
+	ResolveAgent func([]string) (string, []string, error)
+
+	Org       string
+	Proj      string
+	Scope     render.Scope
+	AgentName string
+
+	Name string
+	Env  string
+}
+
+// UnsetResult is the JSON envelope payload for a full-config delete.
+type UnsetResult struct {
+	Name    string `json:"name"`
+	Deleted bool   `json:"deleted"`
+}
+
+func NewUnsetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &UnsetOptions{
+		IO:           f.IOStreams,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.AgentScope,
+		ResolveAgent: f.ResolveAgent,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "unset [agent] --name <config> [--env <env>]",
+		Short: "Remove an MCP proxy binding from an agent",
+		Long: "Without --env, deletes the whole MCP configuration. With --env, " +
+			"removes only that environment's binding and preserves the rest.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, proj, err := opts.ResolveScope(cmd, true, true)
+			if err != nil {
+				return render.Error(opts.IO, opts.MakeScope(org, proj, ""), err)
+			}
+			agent, _, agentErr := opts.ResolveAgent(args)
+			scope := opts.MakeScope(org, proj, agent)
+			if agentErr != nil {
+				return render.Error(opts.IO, scope, agentErr)
+			}
+			opts.Org, opts.Proj, opts.Scope = org, proj, scope
+			opts.AgentName = agent
+			return runUnset(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the MCP configuration (required)")
+	cmd.Flags().StringVar(&opts.Env, "env", "", "Environment binding to remove (default: remove the whole configuration)")
+	_ = cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func runUnset(ctx context.Context, o *UnsetOptions) error {
+	if err := cmdutil.ValidatePathParam("agent name", o.AgentName); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	id, found, err := findMCPConfigByName(ctx, client, o.Org, o.Proj, o.AgentName, o.Name)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+	if !found {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.NotFound, "no MCP configuration named %q for agent %q", o.Name, o.AgentName))
+	}
+
+	if o.Env == "" {
+		return runUnsetDelete(ctx, o, client, id)
+	}
+	return runUnsetEnv(ctx, o, client, id)
+}
+
+func runUnsetDelete(ctx context.Context, o *UnsetOptions, client *amsvc.ClientWithResponses, id openapi_types.UUID) error {
+	resp, err := client.DeleteAgentMCPConfigWithResponse(ctx, o.Org, o.Proj, o.AgentName, id)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.HTTPResponse == nil || resp.HTTPResponse.StatusCode != http.StatusNoContent {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse,
+			cmdutil.FirstNonNil(resp.JSON400, resp.JSON404, resp.JSON500)))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, UnsetResult{Name: o.Name, Deleted: true})
+	}
+	cs := o.IO.StderrColorScheme()
+	fmt.Fprintf(o.IO.ErrOut, "%s deleted MCP config %q\n", cs.SuccessIcon(), o.Name)
+	return nil
+}
+
+func runUnsetEnv(ctx context.Context, o *UnsetOptions, client *amsvc.ClientWithResponses, id openapi_types.UUID) error {
+	current, err := client.GetAgentMCPConfigWithResponse(ctx, o.Org, o.Proj, o.AgentName, id)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if current.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(current.HTTPResponse,
+			cmdutil.FirstNonNil(current.JSON400, current.JSON404, current.JSON500)))
+	}
+
+	merged := mergeExistingEnvMappings(current.JSON200)
+	if _, ok := merged[o.Env]; !ok {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.NotFound, "environment %q is not bound on MCP config %q", o.Env, o.Name))
+	}
+	if len(merged) == 1 {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.InvalidFlag,
+			"environment %q is the only binding on MCP config %q; drop --env to delete the whole configuration", o.Env, o.Name))
+	}
+	delete(merged, o.Env)
+
+	resp, err := client.UpdateAgentMCPConfigWithResponse(ctx, o.Org, o.Proj, o.AgentName, id,
+		amsvc.UpdateAgentModelConfigRequest{EnvMappings: &merged})
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse,
+			cmdutil.FirstNonNil(resp.JSON400, resp.JSON404, resp.JSON500)))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, resp.JSON200)
+	}
+	cs := o.IO.StderrColorScheme()
+	fmt.Fprintf(o.IO.ErrOut, "%s removed environment %q from MCP config %q\n", cs.SuccessIcon(), o.Env, o.Name)
+	return nil
+}

--- a/cli/pkg/cmd/agent/mcp/unset.go
+++ b/cli/pkg/cmd/agent/mcp/unset.go
@@ -29,11 +29,13 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/prompter"
 	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
 type UnsetOptions struct {
 	IO           *iostreams.IOStreams
+	Prompter     prompter.Prompter
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
 	MakeScope    func(org, proj, agent string) render.Scope
@@ -46,6 +48,7 @@ type UnsetOptions struct {
 
 	Name string
 	Env  string
+	Yes  bool
 }
 
 // UnsetResult is the JSON envelope payload for a full-config delete.
@@ -57,6 +60,7 @@ type UnsetResult struct {
 func NewUnsetCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &UnsetOptions{
 		IO:           f.IOStreams,
+		Prompter:     f.Prompter,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
 		MakeScope:    f.AgentScope,
@@ -86,6 +90,7 @@ func NewUnsetCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the MCP configuration (required)")
 	cmd.Flags().StringVar(&opts.Env, "env", "", "Environment binding to remove (default: remove the whole configuration)")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip confirmation prompt")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }
@@ -94,6 +99,15 @@ func runUnset(ctx context.Context, o *UnsetOptions) error {
 	if err := cmdutil.ValidatePathParam("agent name", o.AgentName); err != nil {
 		return render.Error(o.IO, o.Scope, err)
 	}
+	if o.Env == "" && !o.Yes {
+		if !o.IO.CanPrompt() {
+			return render.Error(o.IO, o.Scope, clierr.New(clierr.ConfirmationRequired, "deletion requires --yes when stdin is not a terminal"))
+		}
+		if err := o.Prompter.ConfirmDeletion(o.Name); err != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.ConfirmationRequired, "%v", err))
+		}
+	}
+
 	client, err := o.Client(ctx)
 	if err != nil {
 		return render.Error(o.IO, o.Scope, err)

--- a/cli/pkg/cmd/agent/mcp/unset_test.go
+++ b/cli/pkg/cmd/agent/mcp/unset_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+)
+
+func newUnsetOpts(io *iostreams.IOStreams, client clientFn) *UnsetOptions {
+	return &UnsetOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot", Name: "primary"}
+}
+
+func Test_runUnset_deletesWholeConfig(t *testing.T) {
+	io, _, errOut := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                      okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("DELETE", getUUID): {status: http.StatusNoContent},
+	})
+	defer cleanup()
+
+	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "deleted") {
+		t.Errorf("expected 'deleted' confirmation, got %q", errOut.String())
+	}
+}
+
+func Test_runUnset_deleteJSON(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                      okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("DELETE", getUUID): {status: http.StatusNoContent},
+	})
+	defer cleanup()
+
+	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeEnvelope(t, out.String())["data"].(map[string]any)
+	if data["deleted"] != true {
+		t.Errorf("data.deleted = %v, want true", data["deleted"])
+	}
+}
+
+func Test_runUnset_envRemovesOnePreservesOthers(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	var put map[string]any
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(getResponseFixture()), // dev + prod
+		configPath("PUT", getUUID): {status: http.StatusOK, body: getResponseFixture(), capture: &put},
+	})
+	defer cleanup()
+
+	opts := newUnsetOpts(io, client)
+	opts.Env = "prod"
+	if err := runUnset(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	em := envMapKeys(put)
+	if _, ok := em["prod"]; ok {
+		t.Errorf("prod should have been removed from envMappings: %v", em)
+	}
+	if _, ok := em["dev"]; !ok {
+		t.Errorf("dev should be preserved in envMappings: %v", em)
+	}
+}
+
+func Test_runUnset_envNotBound(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(getResponseFixture()), // dev + prod only
+	})
+	defer cleanup()
+
+	opts := newUnsetOpts(io, client)
+	opts.Env = "staging"
+	if err := runUnset(context.Background(), opts); err == nil {
+		t.Fatal("expected error")
+	}
+	if code := decodeEnvelope(t, out.String())["error"].(map[string]any)["code"]; code != clierr.NotFound {
+		t.Fatalf("code = %v, want %s", code, clierr.NotFound)
+	}
+}
+
+func Test_runUnset_envLastRemainingRejected(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	single := getResponseFixture()
+	single.EnvMappings = map[string]amsvc.EnvProviderConfigMappings{
+		"dev": {EnvironmentName: "dev", Configuration: &amsvc.ProviderConfig{ProviderName: "github", ProxyName: stringPtr("github")}},
+	}
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(single),
+	})
+	defer cleanup()
+
+	opts := newUnsetOpts(io, client)
+	opts.Env = "dev"
+	if err := runUnset(context.Background(), opts); err == nil {
+		t.Fatal("expected error")
+	}
+	errBody := decodeEnvelope(t, out.String())["error"].(map[string]any)
+	if errBody["code"] != clierr.InvalidFlag {
+		t.Fatalf("code = %v, want %s", errBody["code"], clierr.InvalidFlag)
+	}
+	// Must guide the user to a full unset.
+	if msg := errBody["message"].(string); !strings.Contains(msg, "--env") {
+		t.Errorf("message should mention dropping --env for full delete, got %q", msg)
+	}
+}
+
+func Test_runUnset_nameNotFound(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath: okJSON(listResponse(mcpItem("other", getUUID))),
+	})
+	defer cleanup()
+
+	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+		t.Fatal("expected error")
+	}
+	if code := decodeEnvelope(t, out.String())["error"].(map[string]any)["code"]; code != clierr.NotFound {
+		t.Fatalf("code = %v, want %s", code, clierr.NotFound)
+	}
+}
+
+func Test_runUnset_deleteServerError(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                      okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("DELETE", getUUID): {status: http.StatusNotFound, body: map[string]any{"code": "MODEL_CONFIG_NOT_FOUND", "message": "gone"}},
+	})
+	defer cleanup()
+
+	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+		t.Fatal("expected error")
+	}
+	if status := decodeEnvelope(t, out.String())["error"].(map[string]any)["status"]; status.(float64) != 404 {
+		t.Fatalf("status = %v, want 404", status)
+	}
+}

--- a/cli/pkg/cmd/agent/mcp/unset_test.go
+++ b/cli/pkg/cmd/agent/mcp/unset_test.go
@@ -18,6 +18,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -28,20 +29,32 @@ import (
 )
 
 func newUnsetOpts(io *iostreams.IOStreams, client clientFn) *UnsetOptions {
-	return &UnsetOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot", Name: "primary"}
+	return &UnsetOptions{
+		IO: io, Prompter: &fakePrompter{}, Client: client, Scope: baseScope(),
+		Org: "acme", Proj: "triage", AgentName: "order-bot", Name: "primary",
+	}
 }
 
 func Test_runUnset_deletesWholeConfig(t *testing.T) {
 	io, _, errOut := newTestIO(false)
 	io.SetTerminal(true, true, true)
+	prompter := &fakePrompter{}
 	client, cleanup := newClient(t, map[string]route{
 		listPath:                      okJSON(listResponse(mcpItem("primary", getUUID))),
 		configPath("DELETE", getUUID): {status: http.StatusNoContent},
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err != nil {
+	opts := newUnsetOpts(io, client)
+	opts.Prompter = prompter
+	if err := runUnset(context.Background(), opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if prompter.calls != 1 {
+		t.Errorf("prompter calls = %d, want 1", prompter.calls)
+	}
+	if prompter.confirmDeletionArg != "primary" {
+		t.Errorf("confirmation arg = %q, want primary", prompter.confirmDeletionArg)
 	}
 	if !strings.Contains(errOut.String(), "deleted") {
 		t.Errorf("expected 'deleted' confirmation, got %q", errOut.String())
@@ -56,12 +69,70 @@ func Test_runUnset_deleteJSON(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err != nil {
+	opts := newUnsetOpts(io, client)
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data := decodeEnvelope(t, out.String())["data"].(map[string]any)
 	if data["deleted"] != true {
 		t.Errorf("data.deleted = %v, want true", data["deleted"])
+	}
+}
+
+func Test_runUnset_deleteYesSkipsPrompt(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	prompter := &fakePrompter{}
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                      okJSON(listResponse(mcpItem("primary", getUUID))),
+		configPath("DELETE", getUUID): {status: http.StatusNoContent},
+	})
+	defer cleanup()
+
+	opts := newUnsetOpts(io, client)
+	opts.Prompter = prompter
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prompter.calls != 0 {
+		t.Errorf("prompter calls = %d, want 0 with --yes", prompter.calls)
+	}
+}
+
+func Test_runUnset_deleteNonTTYWithoutYes(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	called := false
+	client := func(context.Context) (*amsvc.ClientWithResponses, error) {
+		called = true
+		return nil, errors.New("client should not be constructed")
+	}
+
+	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+		t.Fatal("expected error for non-TTY without --yes")
+	}
+	if called {
+		t.Fatal("client should not be constructed before confirmation")
+	}
+	errBody := decodeEnvelope(t, out.String())["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Fatalf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
+	}
+}
+
+func Test_runUnset_deleteConfirmationMismatch(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	io.SetTerminal(true, true, true)
+	prompter := &fakePrompter{confirmDeletionErr: errors.New("confirmation mismatch")}
+	opts := newUnsetOpts(io, unreachableClient)
+	opts.Prompter = prompter
+
+	if err := runUnset(context.Background(), opts); err == nil {
+		t.Fatal("expected error from confirmation mismatch")
+	}
+	errBody := decodeEnvelope(t, out.String())["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Fatalf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
 	}
 }
 
@@ -142,7 +213,9 @@ func Test_runUnset_nameNotFound(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+	opts := newUnsetOpts(io, client)
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err == nil {
 		t.Fatal("expected error")
 	}
 	if code := decodeEnvelope(t, out.String())["error"].(map[string]any)["code"]; code != clierr.NotFound {
@@ -158,7 +231,9 @@ func Test_runUnset_deleteServerError(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+	opts := newUnsetOpts(io, client)
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err == nil {
 		t.Fatal("expected error")
 	}
 	if status := decodeEnvelope(t, out.String())["error"].(map[string]any)["status"]; status.(float64) != 404 {

--- a/documentation/docs/getting-started/cli-installation.mdx
+++ b/documentation/docs/getting-started/cli-installation.mdx
@@ -72,6 +72,7 @@ If a release archive is not available for your platform, build from source:
 git clone https://github.com/wso2/agent-manager.git
 cd agent-manager
 make amctl-build
+tar -xvzf dist/*.tar.gz -C dist
 sudo mv dist/amctl /usr/local/bin/
 ```
 


### PR DESCRIPTION
# Add CLI commands for agent MCP configs

Adds `amctl agent mcp` commands to list, view, set, and unset per-environment MCP proxy bindings on an agent. This mirrors the existing `agent llm` command group (#1109), applying the LLM→MCP correspondence:

- **LLM provider → MCP proxy** (org-level handle bound per environment)
- **LLM proxy mapping → MCP proxy mapping** (the agent-level, per-environment configuration these commands manage)

## Examples

```bash
amctl agent mcp set order-bot --name primary --env dev --proxy github --url-env MCP_URL --apikey-env MCP_API_KEY
amctl agent mcp list order-bot
amctl agent mcp get order-bot --name primary
amctl agent mcp unset order-bot --name primary --env dev
```

## What's added

A new `cli/pkg/cmd/agent/mcp` package with four subcommands, registered under `agent`:

| Command | Behavior |
|---------|----------|
| `list`  | Lists the agent's configurations, filtered to MCP-typed configs. |
| `get`   | Shows a single MCP config, including its per-environment proxy bindings (env / proxy / url / status). |
| `set`   | Creates or updates an MCP proxy binding for one environment. Optional `--url-env` / `--apikey-env` map the proxy URL and API key to custom env var names; `--description` sets a description. |
| `unset` | Without `--env`, deletes the whole MCP config. With `--env`, removes only that environment's binding and preserves the rest. |

All commands support `--json` output and the global `--org` / `--project` flags, and the agent argument is optional (falls back to the configured default agent).

## Implementation notes

- **Dedicated endpoints**: uses the generated `*AgentMCPConfig*` client methods (the `/agents/{agent}/mcp-configs` path) for list/get/create/update/delete, rather than the LLM `/model-configs` endpoints. Both share the same request/response types.
- **Proxy binding field**: `--proxy` is written to `EnvModelConfigRequest.ProxyName`, the canonical field the server's `resolveEnvConfigProxyName` resolves first. On read-back, `proxyNameFromConfig` extracts the handle from the response (the server mirrors it across `providerName`/`proxyName`/`mcpProxyName`).
- **Type filtering**: configs are created with type `mcp` and every read filters on `type == "mcp"`, so LLM and MCP configs don't leak across the two command groups.
- **Read-merge-write**: `set` (env update) and `unset --env` re-send the full existing env-mapping set, because `PUT` replaces the entire `envMappings` map — updating one environment never drops its siblings.
- **Client-side validation**: `--url-env` / `--apikey-env` names are validated with `cmdutil.ValidateEnvVarName` before any API call, giving early feedback instead of a server rejection. MCP mappings use the same `url` / `apikey` env-var keys as LLM mappings.

## Tests

`go test ./...` (from `cli/`). New table/HTTP-stub tests cover each subcommand: human + JSON output, the MCP-type filter, the read-merge-write sibling-preservation guarantee, last-binding rejection, env-var name validation, and transport/server error paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP proxy configuration management to the agent CLI command with four new subcommands: `list` to view configurations, `get` to display specific settings, `set` to configure proxies per environment, and `unset` to remove configurations.

* **Documentation**
  * Updated build-from-source instructions to include proper archive extraction step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->