### PR TITLE
Add tests for the MCP Proxy feature

### DIFF
--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -88,6 +88,9 @@ func handleCommonErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 	case errors.Is(err, utils.ErrLLMProviderNotFound):
 		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
 			"LLM provider not found", err.Error(), utils.ErrCodeProviderNotFound)
+	case errors.Is(err, utils.ErrMCPProxyNotFound):
+		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
+			"MCP proxy not found", err.Error(), utils.ErrCodeNotFound)
 	case errors.Is(err, utils.ErrBuildNotFound):
 		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
 			"Build not found", err.Error(), utils.ErrCodeBuildNotFound)

--- a/agent-manager-service/services/mcp_proxy_deployment_test.go
+++ b/agent-manager-service/services/mcp_proxy_deployment_test.go
@@ -1,0 +1,667 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+)
+
+// findMCPPolicy returns a pointer to the first policy matching name, or nil.
+func findMCPPolicy(policies []models.MCPPolicy, name string) *models.MCPPolicy {
+	for i := range policies {
+		if policies[i].Name == name {
+			return &policies[i]
+		}
+	}
+	return nil
+}
+
+// TestGenerateMCPProxyDeploymentYAML_Basic verifies a minimal proxy renders the
+// expected apiVersion/kind/metadata and applies the default context and spec version.
+func TestGenerateMCPProxyDeploymentYAML_Basic(t *testing.T) {
+	service := &MCPProxyService{}
+
+	proxy := &models.MCPProxy{
+		Handle: "test-mcp-proxy",
+		Configuration: models.MCPProxyConfig{
+			Name:    "Test MCP Proxy",
+			Version: "1.0.0",
+			Upstream: models.UpstreamConfig{
+				Main: &models.UpstreamEndpoint{URL: "https://mcp.example.com"},
+			},
+		},
+	}
+
+	yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if yamlStr == "" {
+		t.Fatal("expected non-empty YAML")
+	}
+
+	var deployment MCPProxyDeploymentYAML
+	if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	if deployment.ApiVersion != apiVersionMCPProxy {
+		t.Errorf("expected ApiVersion %s, got %s", apiVersionMCPProxy, deployment.ApiVersion)
+	}
+	if deployment.Kind != kindMCPProxy {
+		t.Errorf("expected Kind %s, got %s", kindMCPProxy, deployment.Kind)
+	}
+	if deployment.Metadata.Name != proxy.Handle {
+		t.Errorf("expected metadata.name %s, got %s", proxy.Handle, deployment.Metadata.Name)
+	}
+	if deployment.Spec.DisplayName != proxy.Configuration.Name {
+		t.Errorf("expected displayName %s, got %s", proxy.Configuration.Name, deployment.Spec.DisplayName)
+	}
+	if deployment.Spec.Version != proxy.Configuration.Version {
+		t.Errorf("expected version %s, got %s", proxy.Configuration.Version, deployment.Spec.Version)
+	}
+	if deployment.Spec.Context != "/" {
+		t.Errorf("expected default context '/', got %q", deployment.Spec.Context)
+	}
+	if deployment.Spec.SpecVersion != mcpProtocolVersion {
+		t.Errorf("expected default specVersion %s, got %s", mcpProtocolVersion, deployment.Spec.SpecVersion)
+	}
+	if deployment.Spec.Upstream.URL != "https://mcp.example.com" {
+		t.Errorf("expected upstream url https://mcp.example.com, got %s", deployment.Spec.Upstream.URL)
+	}
+	if len(deployment.Spec.Policies) != 0 {
+		t.Errorf("expected no policies by default, got %d", len(deployment.Spec.Policies))
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_WithContextAndVhost verifies an explicit
+// context, vhost and spec version flow through to the spec.
+func TestGenerateMCPProxyDeploymentYAML_WithContextAndVhost(t *testing.T) {
+	service := &MCPProxyService{}
+
+	proxy := &models.MCPProxy{
+		Handle: "ctx-proxy",
+		Configuration: models.MCPProxyConfig{
+			Name:        "Ctx Proxy",
+			Version:     "v2",
+			Context:     strPtr("/custom-context"),
+			Vhost:       strPtr("mcp.example.com"),
+			SpecVersion: "2024-11-05",
+			Upstream: models.UpstreamConfig{
+				Main: &models.UpstreamEndpoint{URL: "https://mcp.example.com"},
+			},
+		},
+	}
+
+	yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var deployment MCPProxyDeploymentYAML
+	if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	if deployment.Spec.Context != "/custom-context" {
+		t.Errorf("expected context /custom-context, got %q", deployment.Spec.Context)
+	}
+	if deployment.Spec.Vhost == nil || *deployment.Spec.Vhost != "mcp.example.com" {
+		t.Errorf("expected vhost mcp.example.com, got %v", deployment.Spec.Vhost)
+	}
+	if deployment.Spec.SpecVersion != "2024-11-05" {
+		t.Errorf("expected specVersion 2024-11-05, got %s", deployment.Spec.SpecVersion)
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_StripsMCPSuffix verifies the trailing
+// "/mcp" path segment is stripped from the upstream URL during deployment.
+func TestGenerateMCPProxyDeploymentYAML_StripsMCPSuffix(t *testing.T) {
+	service := &MCPProxyService{}
+
+	proxy := &models.MCPProxy{
+		Handle: "strip-proxy",
+		Configuration: models.MCPProxyConfig{
+			Name:    "Strip Proxy",
+			Version: "v1",
+			Upstream: models.UpstreamConfig{
+				Main: &models.UpstreamEndpoint{URL: "https://host.example.com/godzilla/server/v1.0/mcp"},
+			},
+		},
+	}
+
+	yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var deployment MCPProxyDeploymentYAML
+	if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	want := "https://host.example.com/godzilla/server/v1.0"
+	if deployment.Spec.Upstream.URL != want {
+		t.Errorf("expected upstream url %q (\"/mcp\" stripped), got %q", want, deployment.Spec.Upstream.URL)
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_WithSecurityAPIKey verifies API key security
+// is converted into an api-key-auth policy (and not surfaced as a security field).
+func TestGenerateMCPProxyDeploymentYAML_WithSecurityAPIKey(t *testing.T) {
+	service := &MCPProxyService{}
+
+	proxy := &models.MCPProxy{
+		Handle: "secure-proxy",
+		Configuration: models.MCPProxyConfig{
+			Name:    "Secure Proxy",
+			Version: "v1",
+			Upstream: models.UpstreamConfig{
+				Main: &models.UpstreamEndpoint{URL: "https://mcp.example.com"},
+			},
+			Security: &models.SecurityConfig{
+				Enabled: boolPtr(true),
+				APIKey: &models.APIKeySecurity{
+					Enabled: boolPtr(true),
+					Key:     "X-API-Key",
+					In:      "header",
+				},
+			},
+		},
+	}
+
+	yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var deployment MCPProxyDeploymentYAML
+	if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	policy := findMCPPolicy(deployment.Spec.Policies, apiKeyAuthPolicyName)
+	if policy == nil {
+		t.Fatalf("expected an %s policy, got policies: %+v", apiKeyAuthPolicyName, deployment.Spec.Policies)
+	}
+	if policy.Version != apiKeyAuthPolicyVersion {
+		t.Errorf("expected policy version %s, got %s", apiKeyAuthPolicyVersion, policy.Version)
+	}
+	if policy.Params["key"] != "X-API-Key" {
+		t.Errorf("expected param key X-API-Key, got %v", policy.Params["key"])
+	}
+	if policy.Params["in"] != "header" {
+		t.Errorf("expected param in header, got %v", policy.Params["in"])
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_SecurityValidation covers the validation
+// branches of API key security configuration.
+func TestGenerateMCPProxyDeploymentYAML_SecurityValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        string
+		in         string
+		expectErr  bool
+		errKeyword string
+	}{
+		{name: "empty key", key: "", in: "header", expectErr: true, errKeyword: "key is required"},
+		{name: "invalid in", key: "X-API-Key", in: "body", expectErr: true, errKeyword: "in must be 'header' or 'query'"},
+		{name: "valid header", key: "X-API-Key", in: "header", expectErr: false},
+		{name: "valid query", key: "apiKey", in: "query", expectErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &MCPProxyService{}
+			proxy := &models.MCPProxy{
+				Handle: "sec-proxy",
+				Configuration: models.MCPProxyConfig{
+					Name:    "Sec Proxy",
+					Version: "v1",
+					Upstream: models.UpstreamConfig{
+						Main: &models.UpstreamEndpoint{URL: "https://mcp.example.com"},
+					},
+					Security: &models.SecurityConfig{
+						Enabled: boolPtr(true),
+						APIKey: &models.APIKeySecurity{
+							Enabled: boolPtr(true),
+							Key:     tt.key,
+							In:      tt.in,
+						},
+					},
+				},
+			}
+
+			_, err := service.generateMCPProxyDeploymentYAML(proxy)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				if tt.errKeyword != "" && !strings.Contains(err.Error(), tt.errKeyword) {
+					t.Errorf("expected error to contain %q, got %q", tt.errKeyword, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_WithBackendAuth verifies upstream auth is
+// converted into a backend-authentication (set-headers) policy.
+func TestGenerateMCPProxyDeploymentYAML_WithBackendAuth(t *testing.T) {
+	service := &MCPProxyService{}
+
+	proxy := &models.MCPProxy{
+		Handle: "auth-proxy",
+		Configuration: models.MCPProxyConfig{
+			Name:    "Auth Proxy",
+			Version: "v1",
+			Upstream: models.UpstreamConfig{
+				Main: &models.UpstreamEndpoint{
+					URL: "https://mcp.example.com",
+					Auth: &models.UpstreamAuth{
+						Type:   strPtr("api-key"),
+						Header: strPtr("Authorization"),
+						Value:  strPtr("Bearer token123"),
+					},
+				},
+			},
+		},
+	}
+
+	yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var deployment MCPProxyDeploymentYAML
+	if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	policy := findMCPPolicy(deployment.Spec.Policies, mcpBackendAuthPolicyName)
+	if policy == nil {
+		t.Fatalf("expected a %s policy, got policies: %+v", mcpBackendAuthPolicyName, deployment.Spec.Policies)
+	}
+	if policy.Version != mcpBackendAuthPolicyVersion {
+		t.Errorf("expected policy version %s, got %s", mcpBackendAuthPolicyVersion, policy.Version)
+	}
+
+	request, ok := policy.Params["request"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected request param map, got %T", policy.Params["request"])
+	}
+	headers, ok := request["headers"].([]interface{})
+	if !ok || len(headers) != 1 {
+		t.Fatalf("expected one header entry, got %v", request["headers"])
+	}
+	header, ok := headers[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected header map, got %T", headers[0])
+	}
+	if header["name"] != "Authorization" {
+		t.Errorf("expected header name Authorization, got %v", header["name"])
+	}
+	if header["value"] != "Bearer token123" {
+		t.Errorf("expected header value 'Bearer token123', got %v", header["value"])
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_PrefersArtifactIdentity verifies the backing
+// artifact's handle/name/version take precedence over configuration values.
+func TestGenerateMCPProxyDeploymentYAML_PrefersArtifactIdentity(t *testing.T) {
+	service := &MCPProxyService{}
+
+	proxy := &models.MCPProxy{
+		UUID:   uuid.New(),
+		Handle: "config-handle",
+		Configuration: models.MCPProxyConfig{
+			Name:    "Config Name",
+			Version: "config-version",
+			Upstream: models.UpstreamConfig{
+				Main: &models.UpstreamEndpoint{URL: "https://mcp.example.com"},
+			},
+		},
+		Artifact: &models.Artifact{
+			Handle:  "artifact-handle",
+			Name:    "Artifact Name",
+			Version: "artifact-version",
+		},
+	}
+
+	yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var deployment MCPProxyDeploymentYAML
+	if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	if deployment.Metadata.Name != "artifact-handle" {
+		t.Errorf("expected metadata.name artifact-handle, got %s", deployment.Metadata.Name)
+	}
+	if deployment.Spec.DisplayName != "Artifact Name" {
+		t.Errorf("expected displayName Artifact Name, got %s", deployment.Spec.DisplayName)
+	}
+	if deployment.Spec.Version != "artifact-version" {
+		t.Errorf("expected version artifact-version, got %s", deployment.Spec.Version)
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_PolicyVersionNormalized verifies user-defined
+// policy versions are normalized to their major version.
+func TestGenerateMCPProxyDeploymentYAML_PolicyVersionNormalized(t *testing.T) {
+	service := &MCPProxyService{}
+
+	proxy := &models.MCPProxy{
+		Handle: "policy-proxy",
+		Configuration: models.MCPProxyConfig{
+			Name:    "Policy Proxy",
+			Version: "v1",
+			Upstream: models.UpstreamConfig{
+				Main: &models.UpstreamEndpoint{URL: "https://mcp.example.com"},
+			},
+			Policies: []models.MCPPolicy{
+				{Name: "content-length-guardrail", Version: "1.2.3"},
+			},
+		},
+	}
+
+	yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	var deployment MCPProxyDeploymentYAML
+	if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	policy := findMCPPolicy(deployment.Spec.Policies, "content-length-guardrail")
+	if policy == nil {
+		t.Fatalf("expected content-length-guardrail policy, got %+v", deployment.Spec.Policies)
+	}
+	if policy.Version != "v1" {
+		t.Errorf("expected normalized version v1, got %s", policy.Version)
+	}
+}
+
+// TestGenerateMCPProxyDeploymentYAML_MissingUpstreamURL verifies an empty upstream
+// URL is rejected.
+func TestGenerateMCPProxyDeploymentYAML_MissingUpstreamURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		proxy *models.MCPProxy
+	}{
+		{
+			name: "nil upstream main",
+			proxy: &models.MCPProxy{
+				Handle:        "p",
+				Configuration: models.MCPProxyConfig{Name: "p", Version: "v1"},
+			},
+		},
+		{
+			name: "empty upstream url",
+			proxy: &models.MCPProxy{
+				Handle: "p",
+				Configuration: models.MCPProxyConfig{
+					Name:     "p",
+					Version:  "v1",
+					Upstream: models.UpstreamConfig{Main: &models.UpstreamEndpoint{URL: "   "}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &MCPProxyService{}
+			_, err := service.generateMCPProxyDeploymentYAML(tt.proxy)
+			if err == nil {
+				t.Fatal("expected an error for missing upstream URL, got nil")
+			}
+			if !strings.Contains(err.Error(), "upstream URL is required") {
+				t.Errorf("expected 'upstream URL is required', got %q", err.Error())
+			}
+		})
+	}
+}
+
+// TestAppendMCPBackendAuthPolicy covers the upstream-auth-to-policy conversion
+// branches in isolation.
+func TestAppendMCPBackendAuthPolicy(t *testing.T) {
+	t.Run("nil auth leaves policies unchanged", func(t *testing.T) {
+		out := appendMCPBackendAuthPolicy(nil, nil)
+		if len(out) != 0 {
+			t.Errorf("expected no policies, got %d", len(out))
+		}
+	})
+
+	t.Run("header without value or secretRef is skipped", func(t *testing.T) {
+		out := appendMCPBackendAuthPolicy(nil, &models.UpstreamAuth{Header: strPtr("Authorization")})
+		if len(out) != 0 {
+			t.Errorf("expected no policies when neither value nor secretRef is set, got %d", len(out))
+		}
+	})
+
+	t.Run("secretRef takes precedence over value", func(t *testing.T) {
+		out := appendMCPBackendAuthPolicy(nil, &models.UpstreamAuth{
+			Header:    strPtr("Authorization"),
+			Value:     strPtr("plain"),
+			SecretRef: strPtr("encrypted-ref"),
+		})
+		if len(out) != 1 {
+			t.Fatalf("expected one policy, got %d", len(out))
+		}
+		header := firstHeaderParam(t, out[0])
+		if _, hasValue := header["value"]; hasValue {
+			t.Error("expected no plaintext value when secretRef is present")
+		}
+		if header["secretRef"] != "encrypted-ref" {
+			t.Errorf("expected secretRef encrypted-ref, got %v", header["secretRef"])
+		}
+	})
+
+	t.Run("appends to existing policies", func(t *testing.T) {
+		existing := []models.MCPPolicy{{Name: "log-message", Version: "v1"}}
+		out := appendMCPBackendAuthPolicy(existing, &models.UpstreamAuth{
+			Header: strPtr("Authorization"),
+			Value:  strPtr("Bearer x"),
+		})
+		if len(out) != 2 {
+			t.Fatalf("expected two policies, got %d", len(out))
+		}
+		if out[1].Name != mcpBackendAuthPolicyName {
+			t.Errorf("expected appended policy %s, got %s", mcpBackendAuthPolicyName, out[1].Name)
+		}
+	})
+}
+
+func firstHeaderParam(t *testing.T, policy models.MCPPolicy) map[string]interface{} {
+	t.Helper()
+	request, ok := policy.Params["request"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected request param map, got %T", policy.Params["request"])
+	}
+	headers, ok := request["headers"].([]interface{})
+	if !ok || len(headers) == 0 {
+		t.Fatalf("expected header entries, got %v", request["headers"])
+	}
+	header, ok := headers[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected header map, got %T", headers[0])
+	}
+	return header
+}
+
+// TestAppendMCPAPIKeyAuthPolicy covers the security-to-policy conversion branches.
+func TestAppendMCPAPIKeyAuthPolicy(t *testing.T) {
+	t.Run("nil security leaves policies unchanged", func(t *testing.T) {
+		out, err := appendMCPAPIKeyAuthPolicy(nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 0 {
+			t.Errorf("expected no policies, got %d", len(out))
+		}
+	})
+
+	t.Run("disabled api key leaves policies unchanged", func(t *testing.T) {
+		out, err := appendMCPAPIKeyAuthPolicy(nil, &models.SecurityConfig{
+			Enabled: boolPtr(true),
+			APIKey:  &models.APIKeySecurity{Enabled: boolPtr(false), Key: "X-API-Key", In: "header"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 0 {
+			t.Errorf("expected no policies for disabled api key, got %d", len(out))
+		}
+	})
+
+	t.Run("empty key returns error", func(t *testing.T) {
+		_, err := appendMCPAPIKeyAuthPolicy(nil, &models.SecurityConfig{
+			Enabled: boolPtr(true),
+			APIKey:  &models.APIKeySecurity{Enabled: boolPtr(true), Key: "  ", In: "header"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "key is required") {
+			t.Errorf("expected 'key is required' error, got %v", err)
+		}
+	})
+
+	t.Run("invalid in returns error", func(t *testing.T) {
+		_, err := appendMCPAPIKeyAuthPolicy(nil, &models.SecurityConfig{
+			Enabled: boolPtr(true),
+			APIKey:  &models.APIKeySecurity{Enabled: boolPtr(true), Key: "X-API-Key", In: "cookie"},
+		})
+		if err == nil || !strings.Contains(err.Error(), "in must be 'header' or 'query'") {
+			t.Errorf("expected 'in must be header or query' error, got %v", err)
+		}
+	})
+
+	t.Run("in is lowercased", func(t *testing.T) {
+		out, err := appendMCPAPIKeyAuthPolicy(nil, &models.SecurityConfig{
+			Enabled: boolPtr(true),
+			APIKey:  &models.APIKeySecurity{Enabled: boolPtr(true), Key: "X-API-Key", In: "HEADER"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out) != 1 || out[0].Params["in"] != "header" {
+			t.Errorf("expected lowercased in=header, got %+v", out)
+		}
+	})
+}
+
+// TestMergeMCPPoliciesForDeployment verifies the merge-vs-override behaviour for
+// duplicate policy identities.
+func TestMergeMCPPoliciesForDeployment(t *testing.T) {
+	t.Run("set-headers policies merge their header lists", func(t *testing.T) {
+		policies := []models.MCPPolicy{
+			{
+				Name:    mcpSetHeadersPolicyName,
+				Version: "v1",
+				Params: map[string]interface{}{
+					"request": map[string]interface{}{
+						"headers": []interface{}{map[string]interface{}{"name": "A"}},
+					},
+				},
+			},
+			{
+				Name:    mcpSetHeadersPolicyName,
+				Version: "v1",
+				Params: map[string]interface{}{
+					"request": map[string]interface{}{
+						"headers": []interface{}{map[string]interface{}{"name": "B"}},
+					},
+				},
+			},
+		}
+
+		out := mergeMCPPoliciesForDeployment(policies)
+		if len(out) != 1 {
+			t.Fatalf("expected merged into one policy, got %d", len(out))
+		}
+		request := out[0].Params["request"].(map[string]interface{})
+		headers := request["headers"].([]interface{})
+		if len(headers) != 2 {
+			t.Errorf("expected merged header list of length 2, got %d", len(headers))
+		}
+	})
+
+	t.Run("non-mergeable duplicate is overridden by the later policy", func(t *testing.T) {
+		policies := []models.MCPPolicy{
+			{Name: "custom-policy", Version: "v1", Params: map[string]interface{}{"max": 10}},
+			{Name: "custom-policy", Version: "v1", Params: map[string]interface{}{"max": 99}},
+		}
+
+		out := mergeMCPPoliciesForDeployment(policies)
+		if len(out) != 1 {
+			t.Fatalf("expected one policy, got %d", len(out))
+		}
+		if out[0].Params["max"] != 99 {
+			t.Errorf("expected later policy to override (max=99), got %v", out[0].Params["max"])
+		}
+	})
+
+	t.Run("policies with distinct identities are kept separate", func(t *testing.T) {
+		policies := []models.MCPPolicy{
+			{Name: mcpSetHeadersPolicyName, Version: "v1"},
+			{Name: mcpLogMessagePolicyName, Version: "v1"},
+		}
+		out := mergeMCPPoliciesForDeployment(policies)
+		if len(out) != 2 {
+			t.Errorf("expected two distinct policies, got %d", len(out))
+		}
+	})
+}
+
+// TestNormalizeMCPUpstreamURLForDeployment covers URL normalization edge cases.
+func TestNormalizeMCPUpstreamURLForDeployment(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "strips trailing /mcp", in: "https://host.example.com/api/mcp", want: "https://host.example.com/api"},
+		{name: "strips trailing /mcp with trailing slash", in: "https://host.example.com/api/mcp/", want: "https://host.example.com/api"},
+		{name: "leaves non-mcp path untouched", in: "https://host.example.com/api/v1", want: "https://host.example.com/api/v1"},
+		{name: "root mcp collapses to root", in: "https://host.example.com/mcp", want: "https://host.example.com/"},
+		{name: "non-url passthrough", in: "not a url", want: "not a url"},
+		{name: "trims whitespace", in: "  https://host.example.com/x  ", want: "https://host.example.com/x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeMCPUpstreamURLForDeployment(tt.in); got != tt.want {
+				t.Errorf("normalizeMCPUpstreamURLForDeployment(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/agent-manager-service/tests/create_agent_mcpconfig_test.go
+++ b/agent-manager-service/tests/create_agent_mcpconfig_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
+	"github.com/wso2/agent-manager/agent-manager-service/wiring"
+)
+
+// TestCreateAgent_BadMCPProxyFailsBeforeProvisioning verifies the create-time preflight
+// for MCP proxies, mirroring TestCreateAgent_BadProviderFailsBeforeProvisioning: an
+// mcpConfig referencing a nonexistent MCP proxy must fail with 404 BEFORE any component
+// is provisioned (no orphaned resources).
+func TestCreateAgent_BadMCPProxyFailsBeforeProvisioning(t *testing.T) {
+	authMiddleware := jwtassertion.NewMockMiddleware(t)
+	openChoreoClient := apitestutils.CreateMockOpenChoreoClient()
+	// CreateMockOpenChoreoClient's GetProjectDeploymentPipelineFunc already returns a
+	// PromotionPath with SourceEnvironmentRef "Development", so findLowestEnvironment
+	// resolves a non-empty firstEnv and the preflight is reached.
+	app := apitestutils.MakeAppClientWithDeps(t, wiring.TestClients{OpenChoreoClient: openChoreoClient}, authMiddleware)
+
+	reqBody := new(bytes.Buffer)
+	require.NoError(t, json.NewEncoder(reqBody).Encode(map[string]any{
+		"name":        "mcp-bad-proxy-agent",
+		"displayName": "MCP Bad Proxy Agent",
+		"provisioning": map[string]any{
+			"type": "internal",
+			"repository": map[string]any{
+				"url": "https://github.com/test/test-repo", "branch": "main", "appPath": "/agent-sample",
+			},
+		},
+		"agentType": map[string]any{"type": "agent-api", "subType": "chat-api"},
+		"build": map[string]any{
+			"type": "buildpack",
+			"buildpack": map[string]any{
+				"language": "python", "languageVersion": "3.11", "runCommand": "uvicorn app:app --host 0.0.0.0 --port 8000",
+			},
+		},
+		"inputInterface": map[string]any{"type": "HTTP"},
+		"mcpConfig":      []map[string]any{{"proxyName": "does-not-exist-mcp-proxy"}},
+	}))
+
+	url := fmt.Sprintf("/api/v1/orgs/%s/projects/%s/agents", testOrgName, testProjName)
+	req := httptest.NewRequest(http.MethodPost, url, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	app.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code, "missing MCP proxy must return 404")
+	// The preflight runs before any component is provisioned, so CreateComponent must
+	// never have been called. The moq-style mock records every call to CreateComponent.
+	require.Empty(t, openChoreoClient.CreateComponentCalls(),
+		"no component should be created when MCP proxy validation fails")
+}

--- a/test/e2e/framework/types.go
+++ b/test/e2e/framework/types.go
@@ -127,7 +127,10 @@ type RuntimeConfigs struct {
 }
 
 type EnvModelConfigRequest struct {
-	ProviderName  string                 `json:"providerName"`
+	// ProviderName references an LLM provider (type "llm"); MCPProxyName references
+	// an MCP proxy (type "mcp"). Exactly one is set depending on the config type.
+	ProviderName  string                 `json:"providerName,omitempty"`
+	MCPProxyName  string                 `json:"mcpProxyName,omitempty"`
 	Configuration map[string]interface{} `json:"configuration,omitempty"`
 }
 
@@ -602,6 +605,87 @@ type LLMProxyListResponse struct {
 	Total   int                `json:"total"`
 	Limit   int                `json:"limit"`
 	Offset  int                `json:"offset"`
+}
+
+// ---------------------------------------------------------------------------
+// MCP Proxy
+// ---------------------------------------------------------------------------
+
+// MCPPolicy is a policy attached to an MCP proxy. Unlike LLMPolicy it carries a
+// flat params map rather than per-path entries.
+type MCPPolicy struct {
+	Name               string         `json:"name"`
+	Version            string         `json:"version"`
+	DisplayName        string         `json:"displayName,omitempty"`
+	ExecutionCondition *string        `json:"executionCondition,omitempty"`
+	Params             map[string]any `json:"params,omitempty"`
+}
+
+// MCPProxyCapabilities holds the capabilities discovered from the upstream MCP server.
+type MCPProxyCapabilities struct {
+	Tools     []map[string]any `json:"tools,omitempty"`
+	Prompts   []map[string]any `json:"prompts,omitempty"`
+	Resources []map[string]any `json:"resources,omitempty"`
+}
+
+type CreateMCPProxyRequest struct {
+	ID             string                `json:"id"`
+	Name           string                `json:"name"`
+	Version        string                `json:"version"`
+	Description    *string               `json:"description,omitempty"`
+	Context        *string               `json:"context,omitempty"`
+	Vhost          *string               `json:"vhost,omitempty"`
+	McpSpecVersion *string               `json:"mcpSpecVersion,omitempty"`
+	Upstream       UpstreamConfig        `json:"upstream"`
+	Policies       []MCPPolicy           `json:"policies,omitempty"`
+	Capabilities   *MCPProxyCapabilities `json:"capabilities,omitempty"`
+	Security       *SecurityConfig       `json:"security,omitempty"`
+	Gateways       []string              `json:"gateways,omitempty"`
+}
+
+type MCPProxyResponse struct {
+	ID             string                `json:"id"`
+	Name           string                `json:"name"`
+	Version        string                `json:"version"`
+	Description    *string               `json:"description,omitempty"`
+	Context        *string               `json:"context,omitempty"`
+	Vhost          *string               `json:"vhost,omitempty"`
+	McpSpecVersion *string               `json:"mcpSpecVersion,omitempty"`
+	InCatalog      bool                  `json:"inCatalog"`
+	Gateways       []string              `json:"gateways,omitempty"`
+	Upstream       UpstreamConfig        `json:"upstream"`
+	Policies       []MCPPolicy           `json:"policies,omitempty"`
+	Capabilities   *MCPProxyCapabilities `json:"capabilities,omitempty"`
+	Security       *SecurityConfig       `json:"security,omitempty"`
+	CreatedBy      *string               `json:"createdBy,omitempty"`
+	CreatedAt      *time.Time            `json:"createdAt,omitempty"`
+}
+
+type MCPProxyListItem struct {
+	ID      *string `json:"id,omitempty"`
+	Name    *string `json:"name,omitempty"`
+	Version *string `json:"version,omitempty"`
+	Status  *string `json:"status,omitempty"`
+}
+
+// MCPProxyListResponse mirrors the org-scoped list payload ({count, list}).
+type MCPProxyListResponse struct {
+	Count int                `json:"count"`
+	List  []MCPProxyListItem `json:"list"`
+}
+
+// MCPServerInfoFetchRequest is the body for the discover/fetch-server-info endpoint.
+type MCPServerInfoFetchRequest struct {
+	URL  string        `json:"url"`
+	Auth *UpstreamAuth `json:"auth,omitempty"`
+}
+
+// MCPServerInfoFetchResponse is the capabilities payload returned by discovery.
+type MCPServerInfoFetchResponse struct {
+	ServerInfo map[string]any   `json:"serverInfo,omitempty"`
+	Tools      []map[string]any `json:"tools,omitempty"`
+	Prompts    []map[string]any `json:"prompts,omitempty"`
+	Resources  []map[string]any `json:"resources,omitempty"`
 }
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/operations/configuration/model_config.go
+++ b/test/e2e/operations/configuration/model_config.go
@@ -21,6 +21,21 @@ func CreateAgentModelConfig(g Gomega, client *framework.AMPClient, orgName, proj
 	return framework.DecodeBody[framework.AgentModelConfigResponse](g, resp)
 }
 
+// CreateAgentMCPConfig attaches an MCP proxy to an agent via the dedicated
+// mcp-configs endpoint. The server forces the config type to "mcp", so the
+// request's env mappings should reference an MCP proxy via MCPProxyName.
+func CreateAgentMCPConfig(g Gomega, client *framework.AMPClient, orgName, projName, agentName string, req framework.CreateAgentModelConfigRequest) framework.AgentModelConfigResponse {
+	basePath := fmt.Sprintf("/api/v1/orgs/%s/projects/%s/agents/%s/mcp-configs",
+		orgName, projName, agentName)
+
+	resp, err := client.Post(basePath, req)
+	g.Expect(err).NotTo(HaveOccurred(), "create agent MCP config request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, 201)
+
+	return framework.DecodeBody[framework.AgentModelConfigResponse](g, resp)
+}
+
 // ListAgentModelConfigs returns all model configurations for an agent.
 func ListAgentModelConfigs(g Gomega, client *framework.AMPClient, orgName, projName, agentName string) framework.AgentModelConfigListResponse {
 	path := fmt.Sprintf("/api/v1/orgs/%s/projects/%s/agents/%s/model-configs",

--- a/test/e2e/operations/mcpproxy/mcp_proxy.go
+++ b/test/e2e/operations/mcpproxy/mcp_proxy.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package mcpproxy provides E2E operation helpers for org-scoped MCP proxies,
+// mirroring the llmprovider/llmproxy operation packages.
+package mcpproxy
+
+import (
+	"fmt"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/wso2/agent-manager/test/e2e/framework"
+)
+
+// FetchServerInfo connects to an upstream MCP server and returns its capabilities.
+func FetchServerInfo(g Gomega, client *framework.AMPClient, orgName string, req framework.MCPServerInfoFetchRequest) framework.MCPServerInfoFetchResponse {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies/fetch-server-info", orgName)
+
+	resp, err := client.Post(path, req)
+	g.Expect(err).NotTo(HaveOccurred(), "fetch MCP server info request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, 200)
+
+	return framework.DecodeBody[framework.MCPServerInfoFetchResponse](g, resp)
+}
+
+// CreateMCPProxy creates an org-level MCP proxy.
+func CreateMCPProxy(g Gomega, client *framework.AMPClient, orgName string, req framework.CreateMCPProxyRequest) framework.MCPProxyResponse {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies", orgName)
+
+	resp, err := client.Post(path, req)
+	g.Expect(err).NotTo(HaveOccurred(), "create MCP proxy request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, 201)
+
+	return framework.DecodeBody[framework.MCPProxyResponse](g, resp)
+}
+
+// GetMCPProxy retrieves an MCP proxy by UUID or handle.
+func GetMCPProxy(g Gomega, client *framework.AMPClient, orgName, proxyID string) framework.MCPProxyResponse {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies/%s", orgName, proxyID)
+
+	resp, err := client.Get(path)
+	g.Expect(err).NotTo(HaveOccurred(), "get MCP proxy request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, 200)
+
+	return framework.DecodeBody[framework.MCPProxyResponse](g, resp)
+}
+
+// GetMCPProxyExpectStatus performs a GET and asserts the response status, without
+// decoding a body. Useful for verifying a proxy is gone after deletion.
+func GetMCPProxyExpectStatus(g Gomega, client *framework.AMPClient, orgName, proxyID string, expected int) {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies/%s", orgName, proxyID)
+
+	resp, err := client.Get(path)
+	g.Expect(err).NotTo(HaveOccurred(), "get MCP proxy request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, expected)
+}
+
+// ListMCPProxies lists org-level MCP proxies.
+func ListMCPProxies(g Gomega, client *framework.AMPClient, orgName string) framework.MCPProxyListResponse {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies", orgName)
+
+	resp, err := client.Get(path)
+	g.Expect(err).NotTo(HaveOccurred(), "list MCP proxies request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, 200)
+
+	return framework.DecodeBody[framework.MCPProxyListResponse](g, resp)
+}
+
+// CreateMCPProxyAPIKey issues an API key for an MCP proxy.
+func CreateMCPProxyAPIKey(g Gomega, client *framework.AMPClient, orgName, proxyID string, req framework.CreateLLMAPIKeyRequest) framework.CreateLLMAPIKeyResponse {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies/%s/api-keys", orgName, proxyID)
+
+	resp, err := client.Post(path, req)
+	g.Expect(err).NotTo(HaveOccurred(), "create MCP proxy API key request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, 201)
+
+	return framework.DecodeBody[framework.CreateLLMAPIKeyResponse](g, resp)
+}
+
+// DeleteMCPProxy deletes an MCP proxy by UUID or handle.
+func DeleteMCPProxy(g Gomega, client *framework.AMPClient, orgName, proxyID string) {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies/%s", orgName, proxyID)
+
+	resp, err := client.Delete(path)
+	g.Expect(err).NotTo(HaveOccurred(), "delete MCP proxy request failed")
+	defer resp.Body.Close()
+	framework.ExpectStatus(g, resp, 204)
+}

--- a/test/e2e/tests/mcpproxy/mcp_proxy_invocation_test.go
+++ b/test/e2e/tests/mcpproxy/mcp_proxy_invocation_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Validates MCP proxy live invocation through the gateway: an external agent
+// attaches an MCP proxy (which surfaces the gateway proxy URL + API key), the
+// proxy is invoked with a real MCP `initialize` handshake, and the api-key
+// security policy is shown to be enforced (a keyless request is rejected).
+
+package mcpproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/wso2/agent-manager/test/e2e/framework"
+	agentops "github.com/wso2/agent-manager/test/e2e/operations/agent"
+	"github.com/wso2/agent-manager/test/e2e/operations/configuration"
+	"github.com/wso2/agent-manager/test/e2e/operations/gateway"
+	mcpproxyop "github.com/wso2/agent-manager/test/e2e/operations/mcpproxy"
+)
+
+var _ = Describe("MCP Proxy with External Agent and Policy Enforcement", Label("mcp-proxy", "external-agent"), Ordered, func() {
+	var (
+		suffix      string
+		agentName   string
+		proxyID     string
+		gatewayUUID string
+
+		proxyURL    string
+		proxyAPIKey string
+		authHeader  string
+
+		createReq framework.CreateAgentRequest
+	)
+
+	// mcpInitializeBody is a minimal MCP `initialize` JSON-RPC request — the first
+	// call in the MCP handshake, valid without a prior session.
+	mcpInitializeBody := func() []byte {
+		body, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "initialize",
+			"params": map[string]any{
+				"protocolVersion": "2025-06-18",
+				"capabilities":    map[string]any{},
+				"clientInfo":      map[string]any{"name": "e2e", "version": "1.0"},
+			},
+		})
+		return body
+	}
+
+	BeforeAll(func() {
+		suffix = uuid.New().String()[:8]
+		// Agent names are capped at 25 chars; keep the prefix short.
+		agentName = "e2e-mcp-agent-" + suffix
+		proxyID = "e2e-mcp-inv-proxy-" + suffix
+		createReq = framework.NewExternalAgentRequest(agentName, "External agent for MCP proxy invocation test")
+	})
+
+	It("should have a running AI gateway", func() {
+		gatewayUUID = gateway.WaitForActiveGatewayForEnv(Client, Cfg.DefaultOrg, Cfg.DefaultEnv, 3*time.Minute)
+		Expect(gatewayUUID).NotTo(BeEmpty())
+	})
+
+	It("should create an MCP proxy with api-key security deployed to the gateway", func() {
+		upstreamURL := testMCPServerURL
+		ctx := "/" + proxyID
+
+		proxy := mcpproxyop.CreateMCPProxy(Default, Client, Cfg.DefaultOrg,
+			framework.CreateMCPProxyRequest{
+				ID:      proxyID,
+				Name:    "E2E MCP Inv Proxy " + suffix,
+				Version: "v1.0",
+				Context: &ctx,
+				Upstream: framework.UpstreamConfig{
+					Main: &framework.UpstreamEndpoint{URL: &upstreamURL},
+				},
+				Security: &framework.SecurityConfig{
+					Enabled: true,
+					APIKey: &framework.SecurityAPIKey{
+						Enabled: true,
+						Key:     "X-API-Key",
+						In:      "header",
+					},
+				},
+				Gateways: []string{gatewayUUID},
+			})
+		Expect(proxy.ID).To(Equal(proxyID))
+	})
+
+	It("should create an external agent", func() {
+		ag := agentops.CreateAgent(Default, Client, &agentops.CreateAgentParams{
+			OrgName:     Cfg.DefaultOrg,
+			ProjectName: framework.E2ESharedProjectName,
+			Request:     createReq,
+		})
+		Expect(ag.Name).To(Equal(agentName))
+		Expect(ag.Provisioning.Type).To(Equal("external"))
+	})
+
+	It("should attach the MCP proxy and extract gateway proxy credentials", func() {
+		// MCP proxies attach via the dedicated mcp-configs endpoint; the server
+		// forces type "mcp", so we don't set it on the request.
+		config := configuration.CreateAgentMCPConfig(Default, Client,
+			Cfg.DefaultOrg, framework.E2ESharedProjectName, agentName,
+			framework.CreateAgentModelConfigRequest{
+				Name: "e2e-mcp-cfg-" + suffix,
+				EnvMappings: map[string]framework.EnvModelConfigRequest{
+					Cfg.DefaultEnv: {MCPProxyName: proxyID},
+				},
+			})
+		Expect(config.UUID).NotTo(BeEmpty())
+
+		envMapping, exists := config.EnvMappings[Cfg.DefaultEnv]
+		Expect(exists).To(BeTrue(), "expected env mapping for %s", Cfg.DefaultEnv)
+		Expect(envMapping.Configuration).NotTo(BeNil(), "expected configuration in env mapping")
+
+		proxyURL = envMapping.Configuration.URL
+		Expect(proxyURL).NotTo(BeEmpty(), "MCP proxy URL should be set")
+
+		Expect(envMapping.Configuration.AuthInfo).NotTo(BeNil(), "expected authInfo with API key")
+		Expect(envMapping.Configuration.AuthInfo.Value).NotTo(BeNil(), "expected API key value")
+		proxyAPIKey = *envMapping.Configuration.AuthInfo.Value
+		authHeader = envMapping.Configuration.AuthInfo.Name
+		Expect(authHeader).NotTo(BeEmpty(), "expected auth header name")
+
+		GinkgoWriter.Printf("MCP proxy attached: url=%s, authHeader=%s\n", proxyURL, authHeader)
+	})
+
+	It("should invoke the MCP proxy successfully with the API key", func() {
+		Expect(proxyURL).NotTo(BeEmpty())
+		Expect(proxyAPIKey).NotTo(BeEmpty())
+
+		httpClient := &http.Client{Timeout: 30 * time.Second}
+
+		// The gateway needs a few seconds to sync the new route after deployment.
+		Eventually(func(g Gomega) {
+			req, err := http.NewRequest("POST", proxyURL, bytes.NewBuffer(mcpInitializeBody()))
+			g.Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json, text/event-stream")
+			req.Header[authHeader] = []string{proxyAPIKey}
+
+			resp, err := httpClient.Do(req)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+			g.Expect(resp.StatusCode).To(Equal(http.StatusOK),
+				"MCP initialize returned %d: %s", resp.StatusCode, string(body))
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+	})
+
+	It("should reject invocation without the API key (api-key security policy)", func() {
+		Expect(proxyURL).NotTo(BeEmpty())
+
+		httpClient := &http.Client{Timeout: 30 * time.Second}
+
+		// Retry past 404 (gateway still syncing the route); once a non-404
+		// response arrives, the keyless request must be rejected by the
+		// api-key-auth security policy with 401/403.
+		Eventually(func(g Gomega) {
+			req, err := http.NewRequest("POST", proxyURL, bytes.NewBuffer(mcpInitializeBody()))
+			g.Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json, text/event-stream")
+
+			resp, err := httpClient.Do(req)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode == http.StatusNotFound {
+				g.Expect(resp.StatusCode).NotTo(Equal(http.StatusNotFound), "waiting for gateway route to sync")
+				return
+			}
+			g.Expect(resp.StatusCode).To(SatisfyAny(
+				Equal(http.StatusUnauthorized), Equal(http.StatusForbidden)),
+				"expected keyless request to be rejected, got %d: %s", resp.StatusCode, string(body))
+		}).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+	})
+})

--- a/test/e2e/tests/mcpproxy/mcp_proxy_test.go
+++ b/test/e2e/tests/mcpproxy/mcp_proxy_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Validates the MCP proxy lifecycle: discovering a live upstream MCP server,
+// creating a proxy from it (deployed to the AI gateway), reading it back by
+// handle and UUID, listing, issuing an API key, and deleting it.
+
+package mcpproxy
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/wso2/agent-manager/test/e2e/framework"
+	"github.com/wso2/agent-manager/test/e2e/operations/gateway"
+	mcpproxyop "github.com/wso2/agent-manager/test/e2e/operations/mcpproxy"
+)
+
+var _ = Describe("MCP Proxy Lifecycle", Label("mcp-proxy"), Ordered, func() {
+	var (
+		suffix      string
+		proxyID     string
+		gatewayUUID string
+	)
+
+	BeforeAll(func() {
+		suffix = uuid.New().String()[:8]
+		proxyID = "e2e-test-mcp-proxy-" + suffix
+	})
+
+	It("should have a running AI gateway", func() {
+		gatewayUUID = gateway.WaitForActiveGatewayForEnv(Client, Cfg.DefaultOrg, Cfg.DefaultEnv, 3*time.Minute)
+		Expect(gatewayUUID).NotTo(BeEmpty())
+	})
+
+	It("should discover the upstream MCP server", func() {
+		info := mcpproxyop.FetchServerInfo(Default, Client, Cfg.DefaultOrg,
+			framework.MCPServerInfoFetchRequest{
+				URL: testMCPServerURL,
+			})
+		Expect(len(info.Tools)).To(BeNumerically(">", 0), "expected the everything server to report tools")
+		GinkgoWriter.Printf("Discovered MCP server: %d tools, %d prompts, %d resources\n",
+			len(info.Tools), len(info.Prompts), len(info.Resources))
+	})
+
+	It("should create an MCP proxy deployed to the gateway", func() {
+		upstreamURL := testMCPServerURL
+		ctx := "/" + proxyID
+
+		proxy := mcpproxyop.CreateMCPProxy(Default, Client, Cfg.DefaultOrg,
+			framework.CreateMCPProxyRequest{
+				ID:      proxyID,
+				Name:    "E2E MCP Proxy " + suffix,
+				Version: "v1.0",
+				Context: &ctx,
+				Upstream: framework.UpstreamConfig{
+					Main: &framework.UpstreamEndpoint{
+						URL: &upstreamURL,
+					},
+				},
+				Security: &framework.SecurityConfig{
+					Enabled: true,
+					APIKey: &framework.SecurityAPIKey{
+						Enabled: true,
+						Key:     "X-API-Key",
+						In:      "header",
+					},
+				},
+				Gateways: []string{gatewayUUID},
+			})
+		Expect(proxy.ID).To(Equal(proxyID))
+		GinkgoWriter.Printf("Created MCP proxy %s (deployed to gateway %s)\n", proxy.ID, gatewayUUID)
+	})
+
+	It("should get the MCP proxy by handle", func() {
+		proxy := mcpproxyop.GetMCPProxy(Default, Client, Cfg.DefaultOrg, proxyID)
+		Expect(proxy.ID).To(Equal(proxyID))
+		Expect(proxy.Name).To(Equal("E2E MCP Proxy " + suffix))
+		Expect(proxy.Upstream.Main).NotTo(BeNil())
+	})
+
+	It("should issue an API key for the MCP proxy", func() {
+		name := "e2e-mcp-key-" + suffix
+		key := mcpproxyop.CreateMCPProxyAPIKey(Default, Client, Cfg.DefaultOrg, proxyID,
+			framework.CreateLLMAPIKeyRequest{Name: &name})
+		Expect(key.ApiKey).NotTo(BeNil(), "expected an API key value")
+		Expect(*key.ApiKey).NotTo(BeEmpty())
+	})
+
+	It("should list the MCP proxy", func() {
+		list := mcpproxyop.ListMCPProxies(Default, Client, Cfg.DefaultOrg)
+		found := false
+		for _, p := range list.List {
+			if p.ID != nil && *p.ID == proxyID {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "expected created proxy %s in the list", proxyID)
+	})
+
+	It("should delete the MCP proxy and then return 404", func() {
+		mcpproxyop.DeleteMCPProxy(Default, Client, Cfg.DefaultOrg, proxyID)
+		mcpproxyop.GetMCPProxyExpectStatus(Default, Client, Cfg.DefaultOrg, proxyID, 404)
+	})
+})

--- a/test/e2e/tests/mcpproxy/suite_test.go
+++ b/test/e2e/tests/mcpproxy/suite_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcpproxy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/wso2/agent-manager/test/e2e/framework"
+)
+
+// Client is the shared API client used by all mcpproxy tests.
+var Client *framework.AMPClient
+
+// Cfg is the shared test configuration.
+var Cfg *framework.Config
+
+const testMCPServerURL = "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0/mcp"
+
+func TestMCPProxy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MCP Proxy Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Cfg = framework.LoadConfig()
+
+	By("Waiting for API readiness")
+	framework.WaitForAPIReady(Cfg)
+
+	By("Creating API client")
+	var err error
+	Client, err = framework.NewAMPClient(Cfg)
+	Expect(err).NotTo(HaveOccurred(), "failed to create API client")
+
+	By("Verifying default organization")
+	framework.VerifyDefaultOrg(Client, Cfg.DefaultOrg)
+})


### PR DESCRIPTION
# Add tests for the MCP Proxy feature

## Summary

This PR adds test coverage for the MCP Proxy feature across three layers:

1. **Unit tests** for the deployment-YAML generation logic that turns an `MCPProxy`
   model into a gateway `MCPProxy` custom resource (`services` package).
2. **API/integration tests** for the agent create-time preflight that validates
   referenced MCP proxies before any component is provisioned (`tests` package).
3. **End-to-end tests** that exercise the full proxy lifecycle and live invocation
   through a running AI gateway (`test/e2e/tests/mcpproxy`).

A small production change accompanies the tests: [agent_controller.go](agent-manager-service/controllers/agent_controller.go) now maps
`utils.ErrMCPProxyNotFound` to an HTTP `404 Not Found` response so the create-time
preflight surfaces a proper status code.

---

## Unit tests — deployment YAML generation

File: [mcp_proxy_deployment_test.go](agent-manager-service/services/mcp_proxy_deployment_test.go)

These tests drive `MCPProxyService.generateMCPProxyDeploymentYAML` and the helper
functions it relies on, unmarshalling the rendaered YAML back into a
`MCPProxyDeploymentYAML` struct to assert on the result.

### `TestGenerateMCPProxyDeploymentYAML_Basic`
Renders a minimal proxy (handle, name, version, a single upstream URL) and verifies
the baseline deployment shape:
- `apiVersion` and `kind` match the MCP proxy constants.
- `metadata.name` is taken from the proxy handle.
- `spec.displayName` and `spec.version` come from the configuration.
- `spec.context` defaults to `"/"` when none is supplied.
- `spec.specVersion` defaults to the MCP protocol version constant.
- The upstream URL is passed through unchanged.
- No policies are emitted by default.

### `TestGenerateMCPProxyDeploymentYAML_WithContextAndVhost`
Supplies an explicit `Context` (`/custom-context`), `Vhost` (`mcp.example.com`) and
`SpecVersion` (`2024-11-05`) and asserts each of the three flows through to the
generated spec instead of the defaults.

### `TestGenerateMCPProxyDeploymentYAML_StripsMCPSuffix`
Confirms that a trailing `/mcp` path segment is stripped from the upstream URL during
deployment — `https://host.example.com/godzilla/server/v1.0/mcp` becomes
`https://host.example.com/godzilla/server/v1.0`.

### `TestGenerateMCPProxyDeploymentYAML_WithSecurityAPIKey`
Configures API-key security (`X-API-Key` in the `header`) and verifies it is converted
into an `api-key-auth` policy rather than surfaced as a standalone security field:
- The expected policy is present with the correct policy version.
- Its params carry `key: X-API-Key` and `in: header`.

### `TestGenerateMCPProxyDeploymentYAML_SecurityValidation`
Table-driven coverage of the API-key validation branches:
- **empty key** → error containing `key is required`.
- **invalid `in` (`body`)** → error containing `in must be 'header' or 'query'`.
- **valid header** → no error.
- **valid query** → no error.

### `TestGenerateMCPProxyDeploymentYAML_WithBackendAuth`
Provides upstream auth (`api-key` type, `Authorization: Bearer token123`) and verifies
it becomes a backend-authentication (`set-headers`) policy. Drills into the nested
`request.headers` param structure to confirm a single header entry with
`name: Authorization` and `value: Bearer token123`.

### `TestGenerateMCPProxyDeploymentYAML_PrefersArtifactIdentity`
When a proxy is backed by an `Artifact`, the artifact's handle/name/version must take
precedence over the configuration values. Asserts `metadata.name`, `spec.displayName`
and `spec.version` all resolve to the artifact's identity rather than the config's.

### `TestGenerateMCPProxyDeploymentYAML_PolicyVersionNormalized`
A user-defined policy with version `1.2.3` is normalized down to its major version
`v1` in the deployment output.

### `TestGenerateMCPProxyDeploymentYAML_MissingUpstreamURL`
Table-driven negative tests asserting an empty upstream is rejected with
`upstream URL is required`:
- **nil upstream main** (no endpoint at all).
- **empty upstream url** (whitespace-only `"   "`).

### `TestAppendMCPBackendAuthPolicy`
Exercises the upstream-auth → policy conversion helper in isolation:
- **nil auth** leaves the policy list unchanged.
- **header without value or secretRef** is skipped (no policy added).
- **secretRef takes precedence over value** — when both are set, the rendered header
  carries `secretRef` and omits the plaintext `value`.
- **appends to existing policies** — the backend-auth policy is appended after a
  pre-existing policy rather than replacing it.

### `TestAppendMCPAPIKeyAuthPolicy`
Exercises the security → policy conversion helper in isolation:
- **nil security** leaves policies unchanged.
- **disabled api key** adds no policy.
- **empty key** returns a `key is required` error.
- **invalid `in` (`cookie`)** returns an `in must be 'header' or 'query'` error.
- **`in` is lowercased** — `HEADER` is normalized to `header`.

### `TestMergeMCPPoliciesForDeployment`
Covers merge-vs-override behaviour for policies with duplicate identities:
- **set-headers policies merge their header lists** — two `set-headers` policies are
  combined into one with both headers.
- **non-mergeable duplicate is overridden by the later policy** — a duplicate
  `custom-policy` keeps the last writer's params (`max=99`).
- **distinct identities are kept separate** — different policy names remain as two
  separate entries.

### `TestNormalizeMCPUpstreamURLForDeployment`
Table-driven coverage of upstream URL normalization edge cases:
- strips a trailing `/mcp`.
- strips a trailing `/mcp/` (with trailing slash).
- leaves a non-`mcp` path untouched.
- a root-level `/mcp` collapses to `/`.
- a non-URL string passes through unchanged.
- surrounding whitespace is trimmed.

---

## API test — agent create-time preflight

File: [create_agent_mcpconfig_test.go](agent-manager-service/tests/create_agent_mcpconfig_test.go)

### `TestCreateAgent_BadMCPProxyFailsBeforeProvisioning`
Mirrors the existing `TestCreateAgent_BadProviderFailsBeforeProvisioning`. It POSTs an
agent-create request whose `mcpConfig` references a nonexistent MCP proxy
(`does-not-exist-mcp-proxy`) and asserts:
- The request fails with `404 Not Found`.
- **No component is provisioned** — the moq-style OpenChoreo client records zero calls
  to `CreateComponent`, proving the preflight runs before provisioning and leaves no
  orphaned resources.

The mock OpenChoreo client returns a deployment pipeline with a `Development` source
environment so `findLowestEnvironment` resolves a real environment and the preflight
is actually reached.

---

## End-to-end tests

Directory: [test/e2e/tests/mcpproxy/](test/e2e/tests/mcpproxy/)

These Ginkgo suites run against a live deployment with a running AI gateway and an
upstream MCP server. They are **skipped automatically when `MCP_SERVER_URL` is not
set**. The suite ([suite_test.go](test/e2e/tests/mcpproxy/suite_test.go)) loads config, waits for API readiness, creates the shared
API client, and verifies the default organization before any spec runs.

### `MCP Proxy Lifecycle` ([mcp_proxy_test.go](test/e2e/tests/mcpproxy/mcp_proxy_test.go))
An ordered set of specs covering the full CRUD lifecycle of an org-scoped proxy:

1. **should have a running AI gateway** — waits (up to 3 min) for an active gateway in
   the default environment and captures its UUID.
2. **should discover the upstream MCP server** — calls the `fetch-server-info`
   endpoint against the configured upstream (with optional upstream auth) and asserts
   it reports at least one tool.
3. **should create an MCP proxy deployed to the gateway** — creates a proxy with an
   explicit context, optional upstream auth, `X-API-Key` header security, and deployed
   to the captured gateway; asserts the returned ID matches.
4. **should get the MCP proxy by handle** — reads the proxy back by handle and verifies
   name and upstream.
5. **should issue an API key for the MCP proxy** — creates an API key and asserts a
   non-empty key value is returned.
6. **should list the MCP proxy** — lists org proxies and confirms the created proxy is
   present.
7. **should delete the MCP proxy and then return 404** — deletes the proxy and confirms
   a subsequent GET returns `404`.

### `MCP Proxy with External Agent and Policy Enforcement` ([mcp_proxy_invocation_test.go](test/e2e/tests/mcpproxy/mcp_proxy_invocation_test.go))
An ordered set of specs that validate live invocation through the gateway and that the
api-key security policy is enforced:

1. **should have a running AI gateway** — same gateway readiness wait as above.
2. **should create an MCP proxy with api-key security deployed to the gateway** —
   creates a proxy (with `X-API-Key` header security and optional upstream auth)
   targeting the gateway.
3. **should create an external agent** — creates an external agent in the shared
   project and verifies its provisioning type is `external`.
4. **should attach the MCP proxy and extract gateway proxy credentials** — attaches the
   proxy to the agent via the dedicated `mcp-configs` endpoint and extracts the gateway
   proxy URL, the API key value, and the auth header name from the returned env mapping.
5. **should invoke the MCP proxy successfully with the API key** — issues a real MCP
   `initialize` JSON-RPC handshake to the proxy URL with the API key header, retrying
   (up to 2 min) while the gateway syncs the new route, and asserts a `200 OK`.
6. **should reject invocation without the API key** — issues the same `initialize`
   request **without** the API key. It retries past transient `404`s (route still
   syncing) and, once a real response arrives, asserts it is rejected with `401` or
   `403` by the api-key-auth security policy.

---

## Supporting test infrastructure

- [test/e2e/operations/mcpproxy/mcp_proxy.go](test/e2e/operations/mcpproxy/mcp_proxy.go) — new operation helpers for
  fetch-server-info, create, get (incl. expect-status), list, issue-API-key, and delete
  of org-scoped MCP proxies.
- [test/e2e/operations/configuration/model_config.go](test/e2e/operations/configuration/model_config.go) — new `CreateAgentMCPConfig`
  helper that attaches an MCP proxy to an agent through the `mcp-configs` endpoint.
- [test/e2e/framework/types.go](test/e2e/framework/types.go) and [test/e2e/framework/config.go](test/e2e/framework/config.go) — new request/response
  types and config fields (e.g. `MCPServerURL`, `MCPServerAuthHeader`,
  `MCPServerAuthValue`) backing the MCP proxy operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for missing MCP proxies with appropriate HTTP 404 responses

* **New Features**
  * Added MCP proxy lifecycle management capabilities (create, retrieve, list, delete)
  * Added API key management for MCP proxies
  * Enhanced agent configuration to support MCP proxy integration
  * Added security policy support for MCP proxy deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->