### PR TITLE
Derive agent-level eval input/output from LLM spans

### DIFF
--- a/libs/amp-evaluation/src/amp_evaluation/trace/models.py
+++ b/libs/amp-evaluation/src/amp_evaluation/trace/models.py
@@ -1274,6 +1274,33 @@ class Trace:
                 if system_prompt:
                     break
 
+        # Fall back to the agent's LLM spans when the agent span records no
+        # input/output (e.g. a LangGraph invoke_agent wrapper carries neither):
+        # first user message as the goal, last LLM response as the final output.
+        # Mirrors the system_prompt fallback above so agent-level judges still
+        # receive real content instead of an empty response.
+        agent_input = agent_span.input
+        agent_output = agent_span.output
+        if not (agent_input or "").strip() or not (agent_output or "").strip():
+            # Sort on the narrowed (non-None) start times, then append any
+            # timestamp-less spans so ordering stays deterministic.
+            timed = sorted(
+                ((s.start_time, s) for s in llm_spans if s.start_time is not None),
+                key=lambda pair: pair[0],
+            )
+            ordered_llms = [s for _, s in timed] + [s for s in llm_spans if s.start_time is None]
+            if not (agent_input or "").strip():
+                for llm in ordered_llms:
+                    user_msg = next((m.content for m in llm.get_user_messages() if m.content.strip()), "")
+                    if user_msg:
+                        agent_input = user_msg
+                        break
+            if not (agent_output or "").strip():
+                for llm in reversed(ordered_llms):
+                    if llm.output and llm.output.strip():
+                        agent_output = llm.output
+                        break
+
         return AgentTrace(
             agent_id=agent_span.span_id,
             agent_name=agent_span.name,
@@ -1281,8 +1308,8 @@ class Trace:
             model=agent_span.model,
             system_prompt=system_prompt,
             available_tools=list(agent_span.available_tools),
-            input=agent_span.input,
-            output=agent_span.output,
+            input=agent_input,
+            output=agent_output,
             steps=agent_steps,
             metrics=agent_metrics,
         )

--- a/libs/amp-evaluation/tests/test_trace_models.py
+++ b/libs/amp-evaluation/tests/test_trace_models.py
@@ -457,6 +457,101 @@ class TestTrajectoryGetAgents:
         agents = trajectory.get_agents()
         assert len(agents) == 2
 
+    def test_io_falls_back_to_llm_spans_when_agent_span_empty(self):
+        """Agent-rooted traces (e.g. a LangGraph invoke_agent wrapper) record no
+        input/output on the agent span itself. _create_agent_trace must derive
+        them from the agent's LLM spans — first user message as the goal, last
+        LLM response as the final output — so agent-level judges receive real
+        content instead of an empty response."""
+        agent = AgentSpan(
+            span_id="a1",
+            parent_span_id=None,
+            start_time=datetime(2026, 1, 1, 12, 0, 0),
+            name="LangGraph",
+            input="",  # invoke_agent wrapper carries neither
+            output="",
+        )
+        llm1 = LLMSpan(
+            span_id="llm-1",
+            parent_span_id="a1",
+            start_time=datetime(2026, 1, 1, 12, 0, 1),
+            input=[UserMessage(content="find accommodations in Spain")],
+            output="Let me look that up.",
+        )
+        llm2 = LLMSpan(
+            span_id="llm-2",
+            parent_span_id="a1",
+            start_time=datetime(2026, 1, 1, 12, 0, 2),
+            input=[UserMessage(content="continue")],
+            output="Here are five hotels in Spain.",
+        )
+        # Spans intentionally out of order to prove the fallback sorts by start_time.
+        trajectory = Trace(trace_id="t1", spans=[agent, llm2, llm1])
+        agent_trace = trajectory._create_agent_trace("a1")
+        assert agent_trace.input == "find accommodations in Spain"  # first user msg, earliest span
+        assert agent_trace.output == "Here are five hotels in Spain."  # last LLM response
+
+    def test_io_preserved_when_agent_span_has_them(self, agent_span):
+        """When the agent span already carries input/output, they are used as-is
+        (the LLM-span fallback must not override real agent I/O)."""
+        llm = LLMSpan(
+            span_id="llm-x",
+            parent_span_id="agent-1",
+            start_time=datetime(2026, 1, 1, 12, 0, 1),
+            input=[UserMessage(content="unrelated turn")],
+            output="unrelated response",
+        )
+        trajectory = Trace(trace_id="t1", spans=[agent_span, llm])
+        agent_trace = trajectory._create_agent_trace("agent-1")
+        assert agent_trace.input == "I want to check my order status"
+        assert agent_trace.output == "Your order #123 is being shipped."
+
+    def test_only_empty_input_falls_back_output_preserved(self):
+        """Per-field fallback: an empty input is derived from the LLM spans while
+        a pre-populated output is left untouched."""
+        agent = AgentSpan(
+            span_id="a1",
+            parent_span_id=None,
+            start_time=datetime(2026, 1, 1, 12, 0, 0),
+            name="LangGraph",
+            input="",  # only the input is missing
+            output="Agent's own final answer.",
+        )
+        llm = LLMSpan(
+            span_id="llm-1",
+            parent_span_id="a1",
+            start_time=datetime(2026, 1, 1, 12, 0, 1),
+            input=[UserMessage(content="the real goal")],
+            output="an intermediate llm response",
+        )
+        trajectory = Trace(trace_id="t1", spans=[agent, llm])
+        agent_trace = trajectory._create_agent_trace("a1")
+        assert agent_trace.input == "the real goal"  # derived from the LLM span
+        assert agent_trace.output == "Agent's own final answer."  # preserved
+
+    def test_only_empty_output_falls_back_input_preserved(self):
+        """Per-field fallback: an empty output is derived from the LLM spans while
+        a pre-populated input is left untouched."""
+        agent = AgentSpan(
+            span_id="a1",
+            parent_span_id=None,
+            start_time=datetime(2026, 1, 1, 12, 0, 0),
+            name="LangGraph",
+            input="Agent's own goal.",
+            output="",  # only the output is missing
+        )
+        llm = LLMSpan(
+            span_id="llm-1",
+            parent_span_id="a1",
+            start_time=datetime(2026, 1, 1, 12, 0, 1),
+            input=[UserMessage(content="an intermediate turn")],
+            output="the real final answer",
+        )
+        trajectory = Trace(trace_id="t1", spans=[agent, llm])
+        agent_trace = trajectory._create_agent_trace("a1")
+        assert agent_trace.input == "Agent's own goal."  # preserved
+        assert agent_trace.output == "the real final answer"  # derived from the LLM span
+
 
 # ============================================================================
 # TESTS: Trace - _get_agent_steps() Reconstruction


### PR DESCRIPTION
## Purpose
Follow-up to #1050 (which fixed trace-level and LLM-span empty-output handling). Colleagues reported that **agent-level** LLM judges still fail/skip. The agent-level evaluators (`reasoning_quality`, `path_efficiency`, `error_recovery`, `instruction_following`) run against the `AgentTrace` built by `Trace._create_agent_trace`, whose `input`/`output` were copied verbatim from the agent span. A LangGraph `invoke_agent` wrapper span carries no `traceloop.entity.input`/`traceloop.entity.output` (only the inner `LangGraph.workflow` chain span and the leaf `*.chat` spans do), so `agent_trace.output` was empty and the empty-output guard skipped every agent-level evaluation (e.g. "Reasoning Quality: 4 skip(s) — No output found to evaluate").

Related to #1050.
Resolves https://github.com/wso2/agent-manager/issues/1153

## Goals
Agent-level judges receive the real goal and final response (derived from the agent's own LLM spans) and therefore evaluate the trajectory instead of being skipped for an empty response.

## Approach
In `Trace._create_agent_trace`, mirror the existing `system_prompt` fallback: when the agent span itself records no `input`/`output`, derive them from the agent's descendant LLM spans — the first user message as the goal, the last LLM response as the final output (LLM spans ordered by `start_time`). When the agent span already carries `input`/`output`, they are used unchanged. No UI changes.

## User stories
N/A — internal correctness bugfix; no new user-facing story.

## Release note
Fix agent-level evaluators (reasoning quality, path efficiency, error recovery, instruction following) being skipped for agent-rooted traces (e.g. LangGraph) whose wrapper span has no input/output; the agent's input/output are now derived from its LLM spans.

## Documentation
N/A — no public API or behavioral contract change.

## Training
N/A — no training-content impact.

## Certification
N/A — no certification-exam impact.

## Marketing
N/A — internal bugfix.

## Automation tests
 - Unit tests
   > `tests/test_trace_models.py::TestTrajectoryGetAgents` adds: agent I/O derived from LLM spans when the agent span is empty (first user message / last LLM response, verified order-independent), and agent I/O preserved unchanged when the agent span already carries them. Full amp-evaluation suite green: 718 passed, 25 skipped.
 - Integration tests
   > Verified on a local k3d cluster: rebuilt/loaded the `amp-evaluation-monitor` image; a monitor re-run now scores agent-level evaluators instead of skipping them.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable; change is Python parsing logic with no new security-sensitive surface.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples affected.

## Related PRs
#1050 — fixed the trace-level and LLM-span empty-output handling; this PR extends the same fix to agent-level evaluators.

## Migrations (if applicable)
N/A — no schema or data migration.

## Test environment
> macOS (Apple Silicon); local k3d cluster `openchoreo-local-setup`. Python 3.13 for amp-evaluation tests.

## Learning
> Traced the agent-level evaluation path: `base.py` builds the `AgentTrace` via `Trace._create_agent_trace`, which sourced `input`/`output` only from the agent span. Confirmed against the raw OpenSearch spans that the `invoke_agent` wrapper span carries no `traceloop.entity` I/O while the descendant `LangGraph.workflow` / `*.chat` spans do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced agent trace construction: When agent-level inputs or outputs are missing, the system now intelligently derives them from descendant LLM traces by selecting the earliest user message as input and the final LLM response as output, ensuring comprehensive trace data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->