### PR TITLE
Block deleting a source agent that has published kinds

### DIFF
--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -135,6 +135,9 @@ func handleCommonErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 	case errors.Is(err, utils.ErrAgentKindHasInstances):
 		utils.WriteErrorResponseWithReason(w, http.StatusConflict,
 			"Agent kind has active instances", err.Error(), utils.ErrCodeConflict)
+	case errors.Is(err, utils.ErrAgentIsKindSource):
+		utils.WriteErrorResponseWithReason(w, http.StatusConflict,
+			"Agent is the source of an agent kind", err.Error(), utils.ErrCodeConflict)
 	// Generic conflict catch-all: any unclassified conflict (e.g. a raw "already exists"
 	// from OpenChoreo) is a 409, never a 500. Keep this after the specific conflict cases
 	// above so they win; err.Error() carries the detail in the response reason.

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -103,6 +103,9 @@ func handleCommonErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 	case errors.Is(err, utils.ErrKindVersionNotFound):
 		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
 			"Agent kind version not found", err.Error(), utils.ErrCodeNotFound)
+	case errors.Is(err, utils.ErrSourceAgentNotFound):
+		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
+			"Source agent not found", err.Error(), utils.ErrCodeNotFound)
 
 	// Conflict errors
 	case errors.Is(err, utils.ErrAgentAlreadyExists):

--- a/agent-manager-service/repositories/agent_kind_repository.go
+++ b/agent-manager-service/repositories/agent_kind_repository.go
@@ -32,6 +32,7 @@ type AgentKindRepository interface {
 	ListKinds(ctx context.Context, orgName string, limit, offset int) ([]models.AgentKind, int64, error)
 	UpdateKind(ctx context.Context, kind *models.AgentKind) error
 	DeleteKind(ctx context.Context, orgName, kindName string) error
+	ExistsBySourceAgent(ctx context.Context, orgName, projectName, agentName string) (bool, error)
 
 	CreateVersion(ctx context.Context, version *models.AgentKindVersion) error
 	GetVersion(ctx context.Context, kindID uuid.UUID, versionTag string) (*models.AgentKindVersion, error)
@@ -184,6 +185,14 @@ func (r *agentKindRepo) ListVersions(ctx context.Context, kindID uuid.UUID) ([]m
 		Order("created_at DESC").
 		Find(&versions)
 	return versions, result.Error
+}
+
+func (r *agentKindRepo) ExistsBySourceAgent(ctx context.Context, orgName, projectName, agentName string) (bool, error) {
+	var count int64
+	result := r.db.WithContext(ctx).Model(&models.AgentKind{}).
+		Where("org_name = ? AND project_name = ? AND agent_name = ?", orgName, projectName, agentName).
+		Count(&count)
+	return count > 0, result.Error
 }
 
 func (r *agentKindRepo) DeleteVersion(ctx context.Context, kindID uuid.UUID, versionTag string) error {

--- a/agent-manager-service/repositories/agent_kind_repository.go
+++ b/agent-manager-service/repositories/agent_kind_repository.go
@@ -209,7 +209,6 @@ func (r *agentKindRepo) ListVersions(ctx context.Context, kindID uuid.UUID) ([]m
 	return versions, result.Error
 }
 
-
 func (r *agentKindRepo) DeleteVersion(ctx context.Context, kindID uuid.UUID, versionTag string) error {
 	result := r.db.WithContext(ctx).
 		Where("agent_kind_id = ? AND version = ?", kindID, versionTag).

--- a/agent-manager-service/repositories/agent_kind_repository.go
+++ b/agent-manager-service/repositories/agent_kind_repository.go
@@ -32,6 +32,20 @@ type AgentKindRepository interface {
 	ListKinds(ctx context.Context, orgName string, limit, offset int) ([]models.AgentKind, int64, error)
 	UpdateKind(ctx context.Context, kind *models.AgentKind) error
 	DeleteKind(ctx context.Context, orgName, kindName string) error
+
+	// ExistsBySourceAgent reports whether any agent kind is published from the
+	// given source agent.
+	//
+	// NOTE: this is intentionally a plain existence check, not lock-protected.
+	// There's a check-then-act gap between this and whatever the caller does next
+	// (e.g. deleting the agent in OpenChoreo), but closing it fully would mean
+	// holding a DB transaction open across OpenChoreo/secret-manager network
+	// calls — a worse trade than the risk it prevents. That risk also requires
+	// two admins racing the exact same agent within milliseconds, and is
+	// independently mitigated by publishVersion verifying the source agent still
+	// exists before it ever creates a kind (see agent_kind_service.go). Treat a
+	// false negative here as acceptable; do not "fix" this with a lock without
+	// re-reading that reasoning.
 	ExistsBySourceAgent(ctx context.Context, orgName, projectName, agentName string) (bool, error)
 
 	CreateVersion(ctx context.Context, version *models.AgentKindVersion) error
@@ -56,6 +70,14 @@ func (r *agentKindRepo) CreateKind(ctx context.Context, kind *models.AgentKind) 
 	}
 	result := r.db.WithContext(ctx).Create(kind)
 	return result.Error
+}
+
+func (r *agentKindRepo) ExistsBySourceAgent(ctx context.Context, orgName, projectName, agentName string) (bool, error) {
+	var count int64
+	result := r.db.WithContext(ctx).Model(&models.AgentKind{}).
+		Where("org_name = ? AND project_name = ? AND agent_name = ?", orgName, projectName, agentName).
+		Count(&count)
+	return count > 0, result.Error
 }
 
 func (r *agentKindRepo) GetKind(ctx context.Context, orgName, kindName string) (*models.AgentKind, error) {
@@ -187,13 +209,6 @@ func (r *agentKindRepo) ListVersions(ctx context.Context, kindID uuid.UUID) ([]m
 	return versions, result.Error
 }
 
-func (r *agentKindRepo) ExistsBySourceAgent(ctx context.Context, orgName, projectName, agentName string) (bool, error) {
-	var count int64
-	result := r.db.WithContext(ctx).Model(&models.AgentKind{}).
-		Where("org_name = ? AND project_name = ? AND agent_name = ?", orgName, projectName, agentName).
-		Count(&count)
-	return count > 0, result.Error
-}
 
 func (r *agentKindRepo) DeleteVersion(ctx context.Context, kindID uuid.UUID, versionTag string) error {
 	result := r.db.WithContext(ctx).

--- a/agent-manager-service/services/agent_kind_service.go
+++ b/agent-manager-service/services/agent_kind_service.go
@@ -55,7 +55,9 @@ type AgentKindService interface {
 	// ListKindAgents returns all agents deployed from a given kind across all projects in the org.
 	ListKindAgents(ctx context.Context, orgName, kindName string) ([]*models.AgentResponse, error)
 
-	// HasKindsSourcedFrom reports whether any agent kind is sourced from the given agent.
+	// HasKindsSourcedFrom reports whether any agent kind is published from the
+	// given source agent. See ExistsBySourceAgent in agent_kind_repository.go for
+	// why this is a plain (not lock-protected) check, by design.
 	HasKindsSourcedFrom(ctx context.Context, orgName, projectName, agentName string) (bool, error)
 }
 
@@ -143,7 +145,11 @@ func (s *agentKindService) DeleteKind(ctx context.Context, orgName, kindName str
 	return err
 }
 
-// HasKindsSourcedFrom reports whether any agent kind is sourced from the given agent.
+// HasKindsSourcedFrom reports whether any agent kind is published from the
+// given source agent. This is a plain existence check, not lock-protected —
+// see the NOTE on AgentKindRepository.ExistsBySourceAgent for why a small
+// check-then-act window here is an accepted, intentional trade-off rather than
+// an oversight.
 func (s *agentKindService) HasKindsSourcedFrom(ctx context.Context, orgName, projectName, agentName string) (bool, error) {
 	exists, err := s.kindRepo.ExistsBySourceAgent(ctx, orgName, projectName, agentName)
 	if err != nil {
@@ -357,6 +363,17 @@ func (s *agentKindService) publishVersion(
 	}
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("failed to check existing version: %w", err)
+	}
+
+	// Explicitly verify the source agent component still exists, rather than
+	// relying on GetBuild to fail if it doesn't. Build CRs aren't guaranteed to be
+	// cascade-deleted with their owning component, so without this check a kind
+	// could be published from (or have a version added from) an agent that was
+	// already deleted — with no concurrency/timing involved at all. This is what
+	// actually closes the "kind published from a deleted agent" gap; the
+	// recheck in DeleteAgent only narrows the much rarer concurrent-race variant.
+	if _, err := s.ocClient.GetComponent(ctx, orgName, sourceProjectName, sourceAgentName); err != nil {
+		return nil, fmt.Errorf("%w: %s/%s", utils.ErrSourceAgentNotFound, sourceProjectName, sourceAgentName)
 	}
 
 	build, err := s.ocClient.GetBuild(ctx, orgName, sourceProjectName, sourceAgentName, buildName)

--- a/agent-manager-service/services/agent_kind_service.go
+++ b/agent-manager-service/services/agent_kind_service.go
@@ -54,6 +54,9 @@ type AgentKindService interface {
 
 	// ListKindAgents returns all agents deployed from a given kind across all projects in the org.
 	ListKindAgents(ctx context.Context, orgName, kindName string) ([]*models.AgentResponse, error)
+
+	// HasKindsSourcedFrom reports whether any agent kind is sourced from the given agent.
+	HasKindsSourcedFrom(ctx context.Context, orgName, projectName, agentName string) (bool, error)
 }
 
 type agentKindService struct {
@@ -138,6 +141,15 @@ func (s *agentKindService) DeleteKind(ctx context.Context, orgName, kindName str
 		return utils.ErrAgentKindNotFound
 	}
 	return err
+}
+
+// HasKindsSourcedFrom reports whether any agent kind is sourced from the given agent.
+func (s *agentKindService) HasKindsSourcedFrom(ctx context.Context, orgName, projectName, agentName string) (bool, error) {
+	exists, err := s.kindRepo.ExistsBySourceAgent(ctx, orgName, projectName, agentName)
+	if err != nil {
+		return false, fmt.Errorf("failed to check agent kinds sourced from agent: %w", err)
+	}
+	return exists, nil
 }
 
 // AddVersion publishes a new version to an existing Agent Kind.

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1974,6 +1974,25 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, orgName string, p
 		isExternalAgent = agentComp.Provisioning.Type == string(utils.ExternalAgent)
 	}
 
+	// Recheck immediately before the actual delete call (the commit point) rather
+	// than relying solely on the check above. This is a deliberate, narrow
+	// mitigation for the gap between that check and this call — not a full fix:
+	// a kind could in theory still be published in the moment between this
+	// recheck and DeleteComponent below. Closing that completely would mean
+	// holding a DB transaction open across the OpenChoreo/secret-manager calls
+	// above, which is a worse trade than the (now millisecond-scale, two-admins-
+	// racing-the-same-agent) risk it would prevent. publishVersion independently
+	// verifies the source agent still exists before ever creating a kind, which
+	// is what actually closes the common (non-racing) case of this gap.
+	isKindSource, err = s.agentKindService.HasKindsSourcedFrom(ctx, orgName, projectName, agentName)
+	if err != nil {
+		s.logger.Error("Failed to recheck agent kinds sourced from agent", "agentName", agentName, "error", err)
+		return err
+	}
+	if isKindSource {
+		return utils.ErrAgentIsKindSource
+	}
+
 	// Step 5: Delete agent component in OpenChoreo — this is the commit point.
 	// LLM config cleanup happens after a confirmed DeleteComponent so a transient OC
 	// failure leaves the system fully intact and the delete can be retried cleanly.

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1940,6 +1940,17 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, orgName string, p
 		return translateProjectError(err)
 	}
 
+	// Refuse to delete an agent that is still the source of an agent kind —
+	// deleting it would leave the kind unable to create new instances.
+	isKindSource, err := s.agentKindService.HasKindsSourcedFrom(ctx, orgName, projectName, agentName)
+	if err != nil {
+		s.logger.Error("Failed to check agent kinds sourced from agent", "agentName", agentName, "error", err)
+		return err
+	}
+	if isKindSource {
+		return utils.ErrAgentIsKindSource
+	}
+
 	// Step 1: Fetch workload and check for secret references in env vars
 	secretRefNames, err := s.ocClient.GetWorkloadSecretRefNames(ctx, orgName, projectName, agentName)
 	if err != nil {

--- a/agent-manager-service/tests/delete_agent_test.go
+++ b/agent-manager-service/tests/delete_agent_test.go
@@ -22,12 +22,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/db"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/wiring"
@@ -190,6 +193,51 @@ func TestDeleteAgent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteAgentBlockedWhenKindSource(t *testing.T) {
+	authMiddleware := jwtassertion.NewMockMiddleware(t)
+
+	t.Run("Deleting an agent that is the source of an agent kind should return 409", func(t *testing.T) {
+		orgName := fmt.Sprintf("test-org-%s", uuid.New().String()[:5])
+		projName := fmt.Sprintf("test-project-%s", uuid.New().String()[:5])
+		agentName := fmt.Sprintf("test-agent-%s", uuid.New().String()[:5])
+
+		gdb := db.DB(context.Background())
+		kind := &models.AgentKind{
+			ID:          uuid.New(),
+			Name:        fmt.Sprintf("test-kind-%s", uuid.New().String()[:5]),
+			DisplayName: "Test Kind",
+			OrgName:     orgName,
+			ProjectName: projName,
+			AgentName:   agentName,
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		}
+		require.NoError(t, gdb.Create(kind).Error)
+		t.Cleanup(func() {
+			gdb.Delete(kind)
+		})
+
+		openChoreoClient := apitestutils.CreateMockOpenChoreoClient()
+		secretMgmtClient := apitestutils.CreateMockSecretManagementClient()
+		testClients := wiring.TestClients{
+			OpenChoreoClient: openChoreoClient,
+			SecretMgmtClient: secretMgmtClient,
+		}
+
+		app := apitestutils.MakeAppClientWithDeps(t, testClients, authMiddleware)
+
+		url := fmt.Sprintf("/api/v1/orgs/%s/projects/%s/agents/%s", orgName, projName, agentName)
+		req := httptest.NewRequest(http.MethodDelete, url, nil)
+
+		rr := httptest.NewRecorder()
+		app.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusConflict, rr.Code)
+		require.Contains(t, rr.Body.String(), "Agent is the source of an agent kind")
+		require.Empty(t, openChoreoClient.DeleteComponentCalls())
+	})
 }
 
 func TestDeleteAgentIdempotency(t *testing.T) {

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -186,4 +186,5 @@ var (
 	ErrBuildNotComplete          = errors.New("build must be completed before publishing as a kind")
 	ErrMissingKindConfigValue    = errors.New("missing required configuration value for agent kind")
 	ErrKindImageAlreadyPublished = errors.New("this build image is already published as a kind version")
+	ErrSourceAgentNotFound       = errors.New("source agent not found; cannot publish a kind from a deleted agent")
 )

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -180,6 +180,7 @@ var (
 	ErrAgentKindNotFound         = errors.New("agent kind not found")
 	ErrAgentKindAlreadyExists    = errors.New("agent kind already exists")
 	ErrAgentKindHasInstances     = errors.New("agent kind cannot be deleted while agents are instantiated from it")
+	ErrAgentIsKindSource         = errors.New("agent cannot be deleted while it is the source of an agent kind")
 	ErrKindVersionNotFound       = errors.New("agent kind version not found")
 	ErrKindVersionAlreadyExists  = errors.New("agent kind version already exists")
 	ErrBuildNotComplete          = errors.New("build must be completed before publishing as a kind")


### PR DESCRIPTION
## Summary
- Deleting a source agent left published kinds unable to create new instances, since the kind's image and the source component share OpenChoreo's registry lifecycle — duplicating the image per kind isn't viable because OpenChoreo controls all registry interactions.
- `DeleteAgent` now refuses deletion (409) while any agent kind is still published from the agent, mirroring the existing `ErrAgentKindHasInstances` guard on `DeleteKind`.

Fixes #907

## Test plan
- [x] `make dev-test` passes, including a new test seeding an `AgentKind` row and asserting `DeleteAgent` returns 409 without calling `DeleteComponent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent deletion of agents that are used as sources for one or more agent kinds. Deletion is now blocked with **409 Conflict** and a clear message.
* **Bug Fixes**
  * Improved “source agent” error handling: missing sources now return **404 Not Found**, and kind-source conflicts return **409 Conflict**.
  * Publishing now checks that the source component exists before fetching build details.
* **Tests**
  * Added coverage to ensure delete requests are rejected when the agent is an agent-kind source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->