### PR TITLE
Clarify and restructure VM TLS example configs

### DIFF
--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -164,13 +164,15 @@ Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `h
 
 The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you need a real domain or operator-managed certificates. It supports a VM reachable from the public internet **and** a VM reachable only from your private network.
 
-The setup is the same for both: do the shared steps below ([Prerequisites](#adv-prerequisites), [Configure](#adv-configure)), then open the **Public network** or **Private network** tab, which is self-contained: it carries its own TLS modes, the exact config keys to set, an example config, and the DNS records for that case.
+The setup is the same for both networks: do the shared steps below ([Prerequisites](#adv-prerequisites), [Configure](#adv-configure)), then open the **Public network** or **Private network** tab, which is self-contained: it carries its own TLS modes, the exact config keys to set, an example config, and the DNS records for that case.
+
+Across every TLS mode, the installer fronts the stack with [Caddy](https://caddyserver.com), an open-source web server that listens on `:443`, terminates TLS, and reverse-proxies each hostname to the right service. It runs as a single `amp-caddy` Docker container and is the only process on the internet-facing port; the TLS mode you pick just selects how Caddy obtains its certificate.
 
 If you just want a quick IP-based demo with automatic TLS, prefer the **Simple** tab.
 
 ## Prerequisites {#adv-prerequisites}
 
-The compute, disk, and tooling prerequisites are the same as the Simple tab:
+The compute, disk, and tooling prerequisites are:
 
 - **Git** to clone this repository and fetch the installer. This is the one tool you need *before* running the script (the script can't install what you use to download it); on a minimal image install it with `sudo apt-get update && sudo apt-get install -y git` (Debian/Ubuntu).
 - **Docker.** The whole stack runs on it. If it isn't already installed, the script installs it for you, along with k3d, kubectl, helm, lsof, and openssl.
@@ -179,7 +181,7 @@ The compute, disk, and tooling prerequisites are the same as the Simple tab:
 In addition, the advanced installer needs:
 
 - **Control of your own DNS** for the chosen domain. The installer derives all service hostnames from a single base domain (`DOMAIN_BASE`), so you create DNS records under that domain (see the **Public network** or **Private network** tab below for the exact records).
-- **The right inbound port open**, depending on the TLS mode (see the TLS modes table in your network's tab below): `443` for `letsencrypt`, `letsencrypt-dns`, `byoc`, and `selfsigned`, or your chosen forward port for `upstream`. For a private deployment this `443` only needs to be reachable from your private network; the VM never needs inbound access from the public internet.
+- **The right inbound port open**, depending on the TLS mode (see your network's tab below): `443` for `letsencrypt`, `letsencrypt-dns`, `byoc`, and `selfsigned`, or your chosen forward port for `upstream`. For a private deployment this `443` only needs to be reachable from your private network; the VM never needs inbound access from the public internet.
 
 ## Configure {#adv-configure}
 
@@ -204,17 +206,9 @@ The config file is plain shell (sourced by the installer). Generate the template
 
 Use this when the VM is reachable from the public internet. Point DNS at the VM's public IP and either let Caddy obtain certificates automatically, bring your own public certificate, or terminate TLS at a load balancer in front.
 
-### TLS modes (public) {#adv-public-tls}
-
 In every mode the URLs published to browsers and clients are `https://`; that is what the user sees. Only how TLS is terminated differs.
 
-| Mode | How TLS is handled | Inbound port to open | When to use |
-|---|---|---|---|
-| `letsencrypt` | Caddy obtains and renews trusted Let's Encrypt certificates automatically (TLS-ALPN-01, inside the `:443` handshake) | `443` (raw TCP, no proxy in front), reachable from the **public internet** | You control DNS for the domain and the VM is publicly reachable |
-| `byoc` | Caddy serves your supplied certificate and key on `:443`; no ACME | `443` | You have a certificate from a public or internal CA, or a secrets store |
-| `upstream` | A cloud load balancer / proxy in front terminates TLS; Caddy listens plain-HTTP on `UPSTREAM_LISTEN_PORT` and only routes by Host | the LB's forward port (the LB owns `443` publicly) | You already run an edge load balancer that holds the certificate |
-
-### Config keys (public) {#adv-public-config}
+### Config keys {#adv-public-config}
 
 The config file is plain shell (sourced by the installer). The keys for a public deployment are:
 
@@ -233,29 +227,7 @@ The config file is plain shell (sourced by the installer). The keys for a public
 
 With `DOMAIN_BASE=amp.mycompany.com`, the derived hosts are `console.amp.mycompany.com`, `api.amp.mycompany.com`, `thunder.amp.mycompany.com`, `observer.amp.mycompany.com`, `gateway.amp.mycompany.com`, `cp.amp.mycompany.com`, and deployed agents at `<org>-<project>.agents.amp.mycompany.com`.
 
-### BYOC certificate requirements {#adv-public-byoc}
-
-Deployed-agent endpoints live one DNS level deeper than the service hosts, at `<org>-<project>.<AGENTS_BASE>`. A standard `*.<DOMAIN_BASE>` wildcard does **not** cover that tier, and there is no ACME in `byoc` mode to issue per-host certificates on demand. So your single certificate must carry SANs covering **both** `*.<DOMAIN_BASE>` and `*.<AGENTS_BASE>`. The installer's pre-flight checks this and fails fast (naming the missing SAN) if it is absent, along with verifying the cert and key match and the cert is not expired.
-
-For example, a cert request covering both tiers:
-
-```bash
-openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
-  -keyout privkey.pem -out fullchain.pem -subj "/CN=amp.mycompany.com" \
-  -addext "subjectAltName=DNS:*.amp.mycompany.com,DNS:*.agents.amp.mycompany.com"
-```
-
-### Upstream (load-balancer) topology {#adv-upstream}
-
-In `upstream` mode the load balancer owns `:443` and the public certificate. Configure it to forward each derived hostname to the VM's `UPSTREAM_LISTEN_PORT` over plain HTTP, and to set the `X-Forwarded-Proto: https` header, which Caddy trusts so the backends still see the original `https` scheme. Because the LB fronts DNS, the installer's DNS check is advisory (not a hard failure) in this mode.
-
-Because the listen port carries plain HTTP and Caddy trusts the forwarded scheme, lock down who can reach it: **restrict `UPSTREAM_LISTEN_PORT` to the load balancer at the firewall**, and set `UPSTREAM_TRUSTED_PROXIES` to the LB's source CIDRs so only the LB can set `X-Forwarded-*`. The default (`0.0.0.0/0`) trusts any source and relies solely on the firewall, which is fine if the port is firewalled to the LB, but scoping both is safer. For a GCP Application Load Balancer the source ranges are `130.211.0.0/22` and `35.191.0.0/16`, so:
-
-```sh
-UPSTREAM_TRUSTED_PROXIES="130.211.0.0/22 35.191.0.0/16"
-```
-
-### DNS (public) {#adv-public-dns}
+### DNS {#adv-public-dns}
 
 Point A records for every service host at the VM's public IP, plus a wildcard for the deployed-agent tier. Two wildcard records are the simplest:
 
@@ -266,9 +238,9 @@ Point A records for every service host at the VM's public IP, plus a wildcard fo
 
 The second record is separate because deployed-agent hostnames sit one level below the service hosts, and a `*.amp.mycompany.com` wildcard does not match `x.agents.amp.mycompany.com`. If you use a proxying DNS provider (for example Cloudflare's orange-cloud), set these records to **DNS-only**, since a proxy that terminates TLS in front of the VM breaks the TLS-ALPN-01 challenge. In `letsencrypt` mode these records must resolve to the VM **before** you install; the DNS pre-flight hard-fails otherwise, naming the exact records to create. In `upstream` mode, point DNS at the load balancer instead; the VM-side check is advisory.
 
-### Example configs (public) {#adv-public-examples}
+### Automatic Let's Encrypt (`letsencrypt`) {#adv-public-letsencrypt}
 
-Automatic Let's Encrypt (recommended):
+Caddy obtains and renews trusted Let's Encrypt certificates automatically via TLS-ALPN-01 (inside the `:443` handshake). Use this when you control DNS for the domain and the VM is publicly reachable on `:443` as raw TCP, with no TLS-terminating proxy in front. This is the recommended public mode.
 
 ```sh
 AMP_VERSION=0.0.0-dev
@@ -277,7 +249,11 @@ TLS_MODE=letsencrypt
 ACME_EMAIL=ops@mycompany.com
 ```
 
-Behind a load balancer that terminates TLS (`upstream`):
+### Load balancer in front (`upstream`) {#adv-upstream}
+
+Use this when you already run an edge load balancer or proxy that holds the certificate. The LB owns `:443` and the public certificate; Caddy listens plain-HTTP on `UPSTREAM_LISTEN_PORT` and only routes by Host. Configure the LB to forward each derived hostname to that port over plain HTTP and to set the `X-Forwarded-Proto: https` header, which Caddy trusts so the backends still see the original `https` scheme. Because the LB fronts DNS, the installer's DNS check is advisory (not a hard failure) in this mode.
+
+Because the listen port carries plain HTTP and Caddy trusts the forwarded scheme, lock down who can reach it: **restrict `UPSTREAM_LISTEN_PORT` to the load balancer at the firewall**, and set `UPSTREAM_TRUSTED_PROXIES` to the LB's source CIDRs so only the LB can set `X-Forwarded-*`. The default (`0.0.0.0/0`) trusts any source and relies solely on the firewall, which is fine if the port is firewalled to the LB, but scoping both is safer. For a GCP Application Load Balancer the source ranges are `130.211.0.0/22` and `35.191.0.0/16`:
 
 ```sh
 AMP_VERSION=0.0.0-dev
@@ -287,7 +263,19 @@ UPSTREAM_LISTEN_PORT=80
 UPSTREAM_TRUSTED_PROXIES="130.211.0.0/22 35.191.0.0/16"   # example: GCP load balancer ranges
 ```
 
-For a publicly trusted certificate you supply yourself, use `byoc` (see [BYOC certificate requirements](#adv-public-byoc) for the SAN rules):
+### Bring your own certificate (`byoc`) {#adv-public-byoc}
+
+Caddy serves a certificate and key you supply on `:443`, with no ACME. Use this when you have a certificate from a public or internal CA, or a secrets store. Deployed-agent endpoints live one DNS level deeper than the service hosts, at `<org>-<project>.<AGENTS_BASE>`. A standard `*.<DOMAIN_BASE>` wildcard does **not** cover that tier, and there is no ACME in `byoc` mode to issue per-host certificates on demand. So your single certificate must carry SANs covering **both** `*.<DOMAIN_BASE>` and `*.<AGENTS_BASE>`. The installer's pre-flight checks this and fails fast (naming the missing SAN) if it is absent, along with verifying the cert and key match and the cert is not expired.
+
+For example, a cert request covering both tiers:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -keyout privkey.pem -out fullchain.pem -subj "/CN=amp.mycompany.com" \
+  -addext "subjectAltName=DNS:*.amp.mycompany.com,DNS:*.agents.amp.mycompany.com"
+```
+
+Then point the installer at the cert and key:
 
 ```sh
 AMP_VERSION=0.0.0-dev
@@ -300,9 +288,38 @@ TLS_KEY_FILE=/opt/amp/certs/privkey.pem
 </TabItem>
 <TabItem value="private" label="Private network">
 
-Use this when the VM is reachable only from your private network (private subnet, VPN, or security-group rules). The VM still needs **outbound** internet access (to pull images and charts and, for `letsencrypt-dns`, to reach the ACME and DNS-provider APIs), but it never needs inbound access from the public internet. Reachability is governed by your cloud network configuration, not the installer; the installer only opens inbound `443/tcp` on the host firewall for clients on your network.
+Use this when the VM is reachable only from your private network (private subnet, VPN, or security-group rules). The VM still needs **outbound** internet access (to pull images and charts and, for `letsencrypt-dns` mode, to reach the ACME and DNS-provider APIs), but it never needs inbound access from the public internet. Reachability is governed by your cloud network configuration, not the installer; the installer only opens inbound `443/tcp` on the host firewall for clients on your network.
 
-The diagram shows the recommended `letsencrypt-dns` flow. The key idea: Let's Encrypt proves you own the domain by reading a DNS `TXT` record, so it **never connects to the VM**; that is what lets a firewalled, private-only VM still obtain public-trusted certificates.
+In every mode the URLs published to browsers and clients are `https://`; that is what the user sees. Only how TLS is terminated differs.
+
+### Config keys {#adv-private-config}
+
+The config file is plain shell (sourced by the installer). The keys for a private deployment are:
+
+| Key | Required | Purpose |
+|---|---|---|
+| `AMP_VERSION` | yes | Agent Manager release to install; use the same `amp/v*` [tag](https://github.com/wso2/agent-manager/tags) you checked out above (`0.0.0-dev`) |
+| `DOMAIN_BASE` | yes | Base domain; service hosts are derived as `<svc>.<DOMAIN_BASE>` |
+| `TLS_MODE` | yes | `letsencrypt-dns`, `selfsigned`, or `byoc` |
+| `ACME_EMAIL` | letsencrypt-dns | ACME contact; **required** for `letsencrypt-dns` (the ACME account is registered with it) |
+| `DNS_PROVIDER` | letsencrypt-dns | [lego](https://go-acme.github.io/lego/dns/) DNS provider that writes the DNS-01 TXT record, e.g. `route53`, `cloudflare`, `gcloud`, `azuredns`. Supply that provider's credential env vars in the same file |
+| `ACME_SERVER` | no | Override the ACME directory URL (e.g. Let's Encrypt staging) while testing `letsencrypt-dns` to avoid rate limits |
+| `TLS_CERT_FILE` / `TLS_KEY_FILE` | byoc | Paths to the operator certificate and private key. For `letsencrypt-dns` and `selfsigned` these default to `/opt/amp/certs/fullchain.pem` and `/opt/amp/certs/privkey.pem` |
+| `EXTERNAL_GATEWAYS` | no | `true` (default) exposes the `cp` endpoint for external data-plane gateways |
+| `HOST_CONSOLE`, `HOST_API`, `HOST_THUNDER`, `HOST_OBSERVER`, `HOST_GATEWAY`, `HOST_CP` | no | Override an individual service hostname (default `<svc>.<DOMAIN_BASE>`) |
+| `AGENTS_BASE` | no | Base for deployed-agent hostnames (default `agents.<DOMAIN_BASE>`) |
+
+With `DOMAIN_BASE=amp.internal.mycompany.com`, the derived hosts are `console.amp.internal.mycompany.com`, `api.amp.internal.mycompany.com`, `thunder.amp.internal.mycompany.com`, `observer.amp.internal.mycompany.com`, `gateway.amp.internal.mycompany.com`, `cp.amp.internal.mycompany.com`, and deployed agents at `<org>-<project>.agents.amp.internal.mycompany.com`.
+
+### DNS {#adv-private-dns}
+
+For `letsencrypt-dns`, the `A` records may point at the VM's **private** IP, because Let's Encrypt only reads the `_acme-challenge` TXT records during validation, not the `A` records, so split-horizon DNS works. The zone must still be a public zone your `DNS_PROVIDER` credentials can write TXT records in. The VM-side DNS pre-flight is advisory in this mode (it will not hard-fail on a private IP). For `selfsigned`, no public DNS is involved at all; resolve the hostnames however your private network does (internal DNS, or `/etc/hosts` on clients).
+
+### Public-trusted certificates via DNS-01 (`letsencrypt-dns`) {#adv-private-letsencrypt-dns}
+
+The installer obtains the certificates with [lego](https://go-acme.github.io/lego/), an open-source ACME (Let's Encrypt) client that it runs as a Docker container. lego solves the **DNS-01** challenge by writing a DNS TXT record, so the ACME CA never connects to the VM, and a daily timer renews the certificates. Use this when the VM has no public ingress but you control a public DNS zone; it is the recommended private mode.
+
+That is what lets a firewalled, private-only VM still obtain public-trusted certificates. The full flow:
 
 ```mermaid
 flowchart TB
@@ -330,69 +347,47 @@ flowchart TB
     caddy --> svc
 ```
 
-### TLS modes (private) {#adv-private-tls}
-
-In every mode the URLs published to browsers and clients are `https://`; that is what the user sees. Only how TLS is terminated differs.
-
-| Mode | How TLS is handled | Inbound port to open | When to use |
-|---|---|---|---|
-| `letsencrypt-dns` | `lego` obtains trusted Let's Encrypt certificates via the **DNS-01** challenge (a DNS TXT record); the ACME CA never connects to the VM. A daily timer renews them | `443` reachable from your **private network** only (egress to ACME + DNS APIs required) | A private VM with no public ingress, where you control a public DNS zone (the recommended private mode) |
-| `selfsigned` | The installer generates a local CA + leaf and serves it on `:443`; the CA is written to `/opt/amp/certs/ca.crt` for distribution | `443` (private network) | Self-contained TLS: no public DNS zone and no external CA (the host still needs outbound internet to pull images) |
-| `byoc` | Caddy serves your supplied certificate and key on `:443`; no ACME | `443` | You have a certificate from a public or internal CA, or a secrets store |
-
-### Config keys (private) {#adv-private-config}
-
-The config file is plain shell (sourced by the installer). The keys for a private deployment are:
-
-| Key | Required | Purpose |
-|---|---|---|
-| `AMP_VERSION` | yes | Agent Manager release to install; use the same `amp/v*` [tag](https://github.com/wso2/agent-manager/tags) you checked out above (`0.0.0-dev`) |
-| `DOMAIN_BASE` | yes | Base domain; service hosts are derived as `<svc>.<DOMAIN_BASE>` |
-| `TLS_MODE` | yes | `letsencrypt-dns`, `selfsigned`, or `byoc` |
-| `ACME_EMAIL` | letsencrypt-dns | ACME contact; **required** for `letsencrypt-dns` (the ACME account is registered with it) |
-| `DNS_PROVIDER` | letsencrypt-dns | [lego](https://go-acme.github.io/lego/dns/) DNS provider that writes the DNS-01 TXT record, e.g. `route53`, `cloudflare`, `gcloud`, `azuredns`. Supply that provider's credential env vars in the same file |
-| `ACME_SERVER` | no | Override the ACME directory URL (e.g. Let's Encrypt staging) while testing `letsencrypt-dns` to avoid rate limits |
-| `TLS_CERT_FILE` / `TLS_KEY_FILE` | byoc | Paths to the operator certificate and private key. For `letsencrypt-dns` and `selfsigned` these default to `/opt/amp/certs/fullchain.pem` and `/opt/amp/certs/privkey.pem` |
-| `EXTERNAL_GATEWAYS` | no | `true` (default) exposes the `cp` endpoint for external data-plane gateways |
-| `HOST_CONSOLE`, `HOST_API`, `HOST_THUNDER`, `HOST_OBSERVER`, `HOST_GATEWAY`, `HOST_CP` | no | Override an individual service hostname (default `<svc>.<DOMAIN_BASE>`) |
-| `AGENTS_BASE` | no | Base for deployed-agent hostnames (default `agents.<DOMAIN_BASE>`) |
-
-With `DOMAIN_BASE=amp.internal.mycompany.com`, the derived hosts are `console.amp.internal.mycompany.com`, `api.amp.internal.mycompany.com`, `thunder.amp.internal.mycompany.com`, `observer.amp.internal.mycompany.com`, `gateway.amp.internal.mycompany.com`, `cp.amp.internal.mycompany.com`, and deployed agents at `<org>-<project>.agents.amp.internal.mycompany.com`.
-
-### BYOC certificate requirements {#adv-private-byoc}
-
-In `byoc` mode the installer serves a certificate you supply, typically issued by your internal CA. Deployed-agent endpoints live one DNS level deeper than the service hosts, at `<org>-<project>.<AGENTS_BASE>`. A standard `*.<DOMAIN_BASE>` wildcard does **not** cover that tier, and there is no ACME in `byoc` mode to issue per-host certificates on demand. So your single certificate must carry SANs covering **both** `*.<DOMAIN_BASE>` and `*.<AGENTS_BASE>`. The installer's pre-flight checks this and fails fast (naming the missing SAN) if it is absent, along with verifying the cert and key match and the cert is not expired.
-
-For example, a cert request covering both tiers:
-
-```bash
-openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
-  -keyout privkey.pem -out fullchain.pem -subj "/CN=amp.internal.mycompany.com" \
-  -addext "subjectAltName=DNS:*.amp.internal.mycompany.com,DNS:*.agents.amp.internal.mycompany.com"
-```
-
-### DNS (private) {#adv-private-dns}
-
-For `letsencrypt-dns`, the `A` records may point at the VM's **private** IP, because Let's Encrypt only reads the `_acme-challenge` TXT records during validation, not the `A` records, so split-horizon DNS works. The zone must still be a public zone your `DNS_PROVIDER` credentials can write TXT records in. The VM-side DNS pre-flight is advisory in this mode (it will not hard-fail on a private IP). For `selfsigned`, no public DNS is involved at all; resolve the hostnames however your private network does (internal DNS, or `/etc/hosts` on clients).
-
-### Example configs (private) {#adv-private-examples}
-
-Public-trusted certificates via DNS-01, using Google Cloud DNS (recommended):
+DNS-01 works with any [DNS provider lego supports](https://go-acme.github.io/lego/dns/); pick whichever hosts your domain's public zone. The base config is the same across providers; only the `DNS_PROVIDER` line and that provider's credential variables change:
 
 ```sh
 AMP_VERSION=0.0.0-dev
 DOMAIN_BASE=amp.internal.mycompany.com
 TLS_MODE=letsencrypt-dns
 ACME_EMAIL=ops@mycompany.com
-DNS_PROVIDER=gcloud
-GCE_PROJECT=my-gcp-project
-GCE_SERVICE_ACCOUNT_FILE=/opt/amp/certs/gcp-dns-sa.json
 # ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory   # LE staging while testing
 ```
 
-`lego` runs as a container that mounts `/opt/amp/certs`, so a credential **file** (such as the Google service-account key) must live under that directory to be readable from the container. Place the key at `/opt/amp/certs/gcp-dns-sa.json` as shown. Token-based providers (`route53`, `cloudflare`, `azuredns`) instead set credential env vars in the same config file and need no mounted file. See the [`lego` provider list](https://go-acme.github.io/lego/dns/) for any other provider and its variables.
+Then add the credential block for your provider.
 
-Self-contained TLS with a generated local CA (`selfsigned`):
+Cloudflare (scoped API token):
+
+```sh
+DNS_PROVIDER=cloudflare
+CF_DNS_API_TOKEN=<Zone:DNS:Edit token>
+```
+
+AWS Route 53 (IAM access key):
+
+```sh
+DNS_PROVIDER=route53
+AWS_ACCESS_KEY_ID=<access-key-id>
+AWS_SECRET_ACCESS_KEY=<secret-access-key>
+AWS_REGION=us-east-1
+```
+
+Google Cloud DNS (service-account key file):
+
+```sh
+DNS_PROVIDER=gcloud
+GCE_PROJECT=my-gcp-project
+GCE_SERVICE_ACCOUNT_FILE=/opt/amp/certs/gcp-dns-sa.json
+```
+
+`lego` runs as a container that mounts `/opt/amp/certs`, so a credential **file** (such as the Google service-account key) must live under that directory to be readable from the container. Place the key at `/opt/amp/certs/gcp-dns-sa.json` as shown. Token-based providers (`cloudflare`, `route53`, `azuredns`) instead set credential env vars in the same config file and need no mounted file. See the [`lego` provider list](https://go-acme.github.io/lego/dns/) for any other provider and its variables.
+
+### Self-contained local CA (`selfsigned`) {#adv-private-selfsigned}
+
+The installer generates a local CA and leaf certificate and serves it on `:443`, writing the CA to `/opt/amp/certs/ca.crt` for distribution. Use this for self-contained TLS with no public DNS zone and no external CA (the host still needs outbound internet to pull images).
 
 ```sh
 AMP_VERSION=0.0.0-dev
@@ -402,7 +397,19 @@ TLS_MODE=selfsigned
 
 After install, import `/opt/amp/certs/ca.crt` into your clients' trust stores (via MDM/GPO) so browsers trust the console and API without warnings.
 
-For a certificate from your internal CA, use `byoc` (see [BYOC certificate requirements](#adv-private-byoc) for the SAN rules):
+### Bring your own certificate (`byoc`) {#adv-private-byoc}
+
+Caddy serves a certificate and key you supply on `:443`, with no ACME, typically issued by your internal CA. Deployed-agent endpoints live one DNS level deeper than the service hosts, at `<org>-<project>.<AGENTS_BASE>`. A standard `*.<DOMAIN_BASE>` wildcard does **not** cover that tier, and there is no ACME in `byoc` mode to issue per-host certificates on demand. So your single certificate must carry SANs covering **both** `*.<DOMAIN_BASE>` and `*.<AGENTS_BASE>`. The installer's pre-flight checks this and fails fast (naming the missing SAN) if it is absent, along with verifying the cert and key match and the cert is not expired.
+
+For example, a cert request covering both tiers:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -keyout privkey.pem -out fullchain.pem -subj "/CN=amp.internal.mycompany.com" \
+  -addext "subjectAltName=DNS:*.amp.internal.mycompany.com,DNS:*.agents.amp.internal.mycompany.com"
+```
+
+Then point the installer at the cert and key:
 
 ```sh
 AMP_VERSION=0.0.0-dev
@@ -448,7 +455,7 @@ Use `sudo` (Docker and k3d run as root). Plain `./uninstall.sh` without `--delet
 
 ## Connect an external gateway {#adv-external-gw}
 
-This works the same as in the Simple tab: the control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Generate a registration token from **Infrastructure → Gateways** and follow the generated commands. Set `EXTERNAL_GATEWAYS=false` to drop the endpoint if you do not connect external gateways. The registration token grants a gateway your LLM-provider API keys, so treat it as a secret and revoke it when a gateway is decommissioned.
+The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Generate a registration token from **Infrastructure → Gateways** and follow the generated commands. Set `EXTERNAL_GATEWAYS=false` to drop the endpoint if you do not connect external gateways. The registration token grants a gateway your LLM-provider API keys, so treat it as a secret and revoke it when a gateway is decommissioned.
 
 ## Troubleshooting {#adv-troubleshooting}
 


### PR DESCRIPTION
## Purpose
Readability improvements to the VM install docs (`documentation/docs/getting-started/on-a-vm.mdx`), specifically the advanced installer's TLS sections. Issues addressed:
- The private DNS-01 example presented Google Cloud DNS as the recommended provider, conflating the recommended *mode* (DNS-01) with one specific provider (and Google Cloud DNS is often the highest-friction option: downloadable key file, blocked by common org policies).
- TLS info was organized by *concern* (a "TLS modes" table, a "Config keys" table, scattered detail sections, a catch-all "Example configs" block at the bottom), so configuring one mode meant jumping between several places.
- An Advanced-only reader met `Caddy` and `lego` with no introduction, and saw text deferring to the Simple tab.
- After the restructure, the DNS-01-only flow diagram sat in the general private intro, before the reader picks a mode.

Follow-up to #1106 (which introduced the `letsencrypt-dns` mode and these example configs).

## Goals
Make DNS-01 provider-agnostic and make each TLS mode a single self-contained, digestible section, with the supporting tools (Caddy, lego) introduced in place.

## Approach
Docs-only, applied symmetrically to the public and private network tabs:
- **Provider-agnostic DNS-01**: one shared base config block plus three per-provider credential blocks (Cloudflare scoped token, AWS Route 53 IAM key, Google Cloud DNS key file), leading with the lower-friction token providers; the credential-file note (key under the bind-mounted `/opt/amp/certs`) is retained.
- **Mode-centric restructure**: drop both "TLS modes" comparison tables (absorbing each row's "how TLS works / when to use" into the mode's lead-in) and both "Example configs" wrappers; each TLS mode is now its own `###` section holding its description and example, with the byoc SAN requirements + `openssl` folded into the byoc section. The shared "Config keys" and "DNS" sections stay.
- **Heading titles** drop the `(public)` / `(private)` suffix, keeping it only in the anchor keys (the two tabs share heading text but need distinct anchors). The `#adv-public-byoc` / `#adv-private-byoc` anchors are preserved so the Troubleshooting cross-links still resolve.
- **Introduce Caddy and lego**: a shared sentence in the Advanced intro introduces Caddy (with a link to caddyserver.com); the `letsencrypt-dns` section opens by introducing lego (with a link), so an Advanced-only reader is not left guessing.
- **Self-contained Advanced tab**: drop the "same as the Simple tab" / "works the same as in the Simple tab" deferrals (the legitimate "prefer the Simple tab for a quick demo" pointer is kept).
- **Diagram placement**: move the DNS-01 flow diagram out of the private intro into the `letsencrypt-dns` section it depicts, so `selfsigned`/`byoc` readers no longer see a diagram that does not apply to them.

No code changes; the installer already supports every lego provider and the `DNS_PROVIDER` reference row already lists them.

## User stories
As an operator installing on a VM, I can read one self-contained section for my chosen TLS mode (its description, requirements, and a copy-pasteable example), use my own DNS provider for DNS-01, and understand what Caddy and lego are without leaving the Advanced tab.

## Release note
VM install docs reorganized so each TLS mode is a self-contained section (description + example); private DNS-01 examples now cover Cloudflare, AWS Route 53, and Google Cloud DNS and frame DNS-01 (not a provider) as the recommended private mode; Caddy and lego are now introduced in the Advanced section.

## Documentation
This PR *is* the documentation change. Page: Getting started → On a VM → Advanced → (public/private network tabs).

## Training
N/A — no training content impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — internal docs clarification.

## Automation tests
 - Unit tests
   > N/A — documentation-only change, no code paths affected.
 - Integration tests
   > N/A. The DNS-01 path itself was verified end-to-end on real VMs under #1106 (Google Cloud DNS via both metadata ADC and key file).

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — examples use placeholders only.

## Samples
N/A.

## Related PRs
- wso2/agent-manager#1106 (introduced the `letsencrypt-dns` mode and the example configs this PR revises)

## Migrations (if applicable)
N/A.

## Test environment
N/A — documentation-only. The underlying DNS-01 flow was exercised on real GCP and office-network private VMs.

## Learning
N/A.