### PR TITLE
Advertise public agents host on the default environment

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/environment.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/environment.yaml
@@ -27,3 +27,13 @@ spec:
           host: {{ .Values.environment.gateway.http.host | quote }}
           listenerName: http
           port: {{ .Values.environment.gateway.http.port }}
+        {{- with .Values.environment.gateway.https }}
+        # The external gateway wholly replaces the dataplane's, so when the console
+        # reads the https endpoint variant (tlsEnabled=true) this block must exist or
+        # the binding carries only an http externalURL and the invoke URL is empty.
+        # Bind listenerName http (TLS terminates upstream, e.g. at Caddy on the VM).
+        https:
+          host: {{ .host | quote }}
+          listenerName: http
+          port: {{ .port }}
+        {{- end }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -117,6 +117,13 @@ environment:
     http:
       host: am-gateway.localhost
       port: 19080
+    # https: optional TLS-fronted variant. Unset by default (local/compose serves
+    # agents over plain http, tlsEnabled=false). Set host/port on TLS deployments
+    # (e.g. the VM installer) so the binding carries an https externalURL; otherwise
+    # the tlsEnabled console reads a missing variant and the invoke URL is empty.
+    # https:
+    #   host: am-gateway.localhost
+    #   port: 443
 
 # Deployment Pipeline configuration
 deploymentPipeline:

--- a/deployments/scripts/add-environment.sh
+++ b/deployments/scripts/add-environment.sh
@@ -32,6 +32,14 @@ set -euo pipefail
 #   - IS_PRODUCTION (default: false)
 #   - ORG_NAME (default: default), DATAPLANE_REF (default: default)
 #   - AGENT_MANAGER_URL (default: http://localhost:9000)
+#   - ENV_INGRESS_HOST (default: am-gateway.localhost): agent-facing gateway host.
+#   - ENV_INGRESS_HTTPS_HOST (default: unset): set on TLS deployments to advertise
+#     an https listener variant. The console reads the https endpoint variant when
+#     the platform runs with tlsEnabled=true, and an Environment's external gateway
+#     wholly replaces the dataplane's, so without this the deployed-agent invoke URL
+#     is empty and try-out 405s. Defaults to ENV_INGRESS_HOST on :443 when only the
+#     TLS toggle is wanted (set ENV_INGRESS_HTTPS_HOST=$ENV_INGRESS_HOST).
+#   - ENV_INGRESS_HTTPS_PORT (default: 443): port for the https listener variant.
 
 # --- Required inputs ---
 : "${ENV_NAME:?ENV_NAME is required (e.g. ENV_NAME=staging)}"
@@ -150,6 +158,19 @@ echo ""
 echo "🌍 Creating environment '${ENV_NAME}'..."
 
 ENV_INGRESS_HOST="${ENV_INGRESS_HOST:-am-gateway.localhost}"
+ENV_INGRESS_HTTPS_HOST="${ENV_INGRESS_HTTPS_HOST:-}"
+ENV_INGRESS_HTTPS_PORT="${ENV_INGRESS_HTTPS_PORT:-443}"
+
+# Build the external listener set. Always advertise http; add an https variant when
+# ENV_INGRESS_HTTPS_HOST is set (TLS deployments). The console reads the https
+# endpoint variant when tlsEnabled=true, and an Environment's external gateway
+# wholly replaces the dataplane's, so an http-only override on a TLS platform leaves
+# the deployed-agent invoke URL empty (try-out then 405s against the console host).
+EXTERNAL_LISTENERS="\"http\": {\"host\": \"${ENV_INGRESS_HOST}\", \"port\": ${GATEWAY_VHOST_PORT}}"
+if [ -n "${ENV_INGRESS_HTTPS_HOST}" ]; then
+    EXTERNAL_LISTENERS="${EXTERNAL_LISTENERS}, \"https\": {\"host\": \"${ENV_INGRESS_HTTPS_HOST}\", \"port\": ${ENV_INGRESS_HTTPS_PORT}}"
+fi
+
 ENV_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${AGENT_MANAGER_API_URL}/orgs/${ORG_NAME}/environments" \
     -H "${AUTH_HEADER}" \
     -H "Content-Type: application/json" \
@@ -162,10 +183,7 @@ ENV_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${AGENT_MANAGER_API_URL}/org
         \"gateway\": {
             \"ingress\": {
                 \"external\": {
-                    \"http\": {
-                        \"host\": \"${ENV_INGRESS_HOST}\",
-                        \"port\": ${GATEWAY_VHOST_PORT}
-                    }
+                    ${EXTERNAL_LISTENERS}
                 }
             }
         }

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -81,6 +81,11 @@ run_install() {
   mapfile -t GATEWAY_HELM_ARGS < <(build_gateway_helm_args "$VM_IP")
   # shellcheck disable=SC2034
   mapfile -t CP_HELM_ARGS < <(build_cp_helm_args "$VM_IP")
+  # Public agents base for the default Environment's gateway host (read by
+  # build_platform_resources_helm_args via dynamic scope); mirrors
+  # render_dataplane_external_ingress.
+  # shellcheck disable=SC2034
+  local AMP_AGENTS_BASE="agents.${VM_IP}.sslip.io"
   # shellcheck disable=SC2034
   mapfile -t PLATFORM_RESOURCES_HELM_ARGS < <(build_platform_resources_helm_args)
   # shellcheck disable=SC2034

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -164,12 +164,22 @@ build_cp_helm_args() {
 #    agents base (AMP_AGENTS_BASE, e.g. agents.<domain> or agents.<ip>.sslip.io) on
 #    :443 so routes resolve to <org>-<project>.<AMP_AGENTS_BASE>, served by Caddy's
 #    wildcard *.agents site.
+#
+#    Set BOTH the http and https variants. Because the override wholly replaces the
+#    dataplane's external endpoint, an http-only override drops the https variant
+#    dataplane_external_ingress emits. The console reads the https variant when
+#    tlsEnabled=true, so an http-only override leaves the binding with only an http
+#    externalURL: the invoke URL is empty and try-out falls back to a relative /chat
+#    (405) — the very symptom this override exists to fix. Both bind listenerName
+#    http (TLS terminates at Caddy) and differ only in advertised scheme.
 # shellcheck disable=SC2154  # AMP_AGENTS_BASE comes from the caller's scope by design.
 build_platform_resources_helm_args() {
   printf '%s\n' \
     "--set" "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
     "--set" "environment.gateway.http.host=${AMP_AGENTS_BASE}" \
-    "--set" "environment.gateway.http.port=443"
+    "--set" "environment.gateway.http.port=443" \
+    "--set" "environment.gateway.https.host=${AMP_AGENTS_BASE}" \
+    "--set" "environment.gateway.https.port=443"
 }
 
 # build_thunder_helm_args <ip>

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -144,17 +144,32 @@ build_cp_helm_args() {
 }
 
 # build_platform_resources_helm_args
-# Prints PLATFORM_RESOURCES_HELM_ARGS tokens. The platform-resources chart's
-# workload-publisher defaults its OAuth token endpoint to the kgateway path
-# (`host.k3d.internal:8080/oauth2/token` + Host `thunder.amp.localhost`). On the
-# VM that route no longer matches: build_cp_helm_args / build_thunder_helm_args
-# move Thunder's vhost to the public sslip.io host, so the localhost Host header
-# 404s and `generate-workload-cr` fails with "Failed to get access token". Point
-# it at the Thunder service directly (no gateway, no Host header, no issuer
-# coupling) — the same in-cluster endpoint every other extension already uses.
+# Prints PLATFORM_RESOURCES_HELM_ARGS tokens. Two overrides:
+#
+# 1. OAuth token endpoint. The platform-resources chart's workload-publisher
+#    defaults its OAuth token endpoint to the kgateway path
+#    (`host.k3d.internal:8080/oauth2/token` + Host `thunder.amp.localhost`). On the
+#    VM that route no longer matches: build_cp_helm_args / build_thunder_helm_args
+#    move Thunder's vhost to the public sslip.io host, so the localhost Host header
+#    404s and `generate-workload-cr` fails with "Failed to get access token". Point
+#    it at the Thunder service directly (no gateway, no Host header, no issuer
+#    coupling) — the same in-cluster endpoint every other extension already uses.
+#
+# 2. Default-Environment agent-facing gateway host. The chart seeds the default
+#    Environment CR with environment.gateway.http (default am-gateway.localhost:19080).
+#    OpenChoreo builds deployed-agent route hostnames as "<env>-<org>.<that host>",
+#    and the Environment's external WHOLLY REPLACES the dataplane's, so without this
+#    override agent routes land on *.am-gateway.localhost: the console then shows an
+#    empty invoke URL and try-out 405s against its own host. Point it at the public
+#    agents base (AMP_AGENTS_BASE, e.g. agents.<domain> or agents.<ip>.sslip.io) on
+#    :443 so routes resolve to <org>-<project>.<AMP_AGENTS_BASE>, served by Caddy's
+#    wildcard *.agents site.
+# shellcheck disable=SC2154  # AMP_AGENTS_BASE comes from the caller's scope by design.
 build_platform_resources_helm_args() {
   printf '%s\n' \
-    "--set" "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token"
+    "--set" "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
+    "--set" "environment.gateway.http.host=${AMP_AGENTS_BASE}" \
+    "--set" "environment.gateway.http.port=443"
 }
 
 # build_thunder_helm_args <ip>

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -218,14 +218,26 @@ assert_eq "caddy cp on by default" "cp.amp.203.0.113.10.sslip.io {" "$(grep -F '
 cf_cp="$(render_caddyfile 203.0.113.10 "" true)"
 assert_eq "caddy cp tls skip verify" "			tls_insecure_skip_verify" "$(grep -F 'tls_insecure_skip_verify' <<<"$cf_cp")"
 
-# --- build_platform_resources_helm_args points the workload publisher at the
-#     Thunder service directly (the gateway path 404s once Thunder's vhost moves
-#     to the public sslip.io host) ---
-pr="$(build_platform_resources_helm_args)"
-assert_eq "platform-resources oauth tokenUrl (direct svc)" \
-  "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
-  "$(grep -F 'global.oauth.tokenUrl' <<<"$pr")"
-assert_eq "platform-resources oauth not via host.k3d.internal" "no" "$(has "$pr" 'host.k3d.internal')"
+# --- build_platform_resources_helm_args: point the workload publisher at the
+#     Thunder service directly (the gateway path 404s once Thunder's vhost moves to
+#     the public sslip.io host), AND advertise the public agents host on the default
+#     Environment so deployed-agent routes resolve to <org>-<project>.<agents-base>
+#     (else OpenChoreo uses am-gateway.localhost and the console invoke URL is empty,
+#     with try-out 405ing against its own host). Reads AMP_AGENTS_BASE from scope. ---
+(
+  AMP_AGENTS_BASE=agents.amp.example.com
+  pr="$(build_platform_resources_helm_args)"
+  assert_eq "platform-resources oauth tokenUrl (direct svc)" \
+    "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
+    "$(grep -F 'global.oauth.tokenUrl' <<<"$pr")"
+  assert_eq "platform-resources oauth not via host.k3d.internal" "no" "$(has "$pr" 'host.k3d.internal')"
+  assert_eq "platform-resources env gateway host (public agents base)" \
+    "environment.gateway.http.host=agents.amp.example.com" \
+    "$(grep -F 'environment.gateway.http.host' <<<"$pr")"
+  assert_eq "platform-resources env gateway port 443" \
+    "environment.gateway.http.port=443" \
+    "$(grep -F 'environment.gateway.http.port' <<<"$pr")"
+)
 
 # --- render_coredns_vm_config rewrites the in-cluster names to the server node ---
 cd_cfg="$(render_coredns_vm_config k3d-amp-local-server-0)"

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -237,6 +237,16 @@ assert_eq "caddy cp tls skip verify" "			tls_insecure_skip_verify" "$(grep -F 't
   assert_eq "platform-resources env gateway port 443" \
     "environment.gateway.http.port=443" \
     "$(grep -F 'environment.gateway.http.port' <<<"$pr")"
+  # The console reads the https endpoint variant when tlsEnabled=true, so the
+  # Environment override MUST carry an https variant too. Without it the binding
+  # status has only an http externalURL, the console invoke URL is empty, and
+  # try-out falls back to a relative /chat (405). Mirror dataplane_external_ingress.
+  assert_eq "platform-resources env gateway https host (public agents base)" \
+    "environment.gateway.https.host=agents.amp.example.com" \
+    "$(grep -F 'environment.gateway.https.host' <<<"$pr")"
+  assert_eq "platform-resources env gateway https port 443" \
+    "environment.gateway.https.port=443" \
+    "$(grep -F 'environment.gateway.https.port' <<<"$pr")"
 )
 
 # --- render_coredns_vm_config rewrites the in-cluster names to the server node ---


### PR DESCRIPTION
## Purpose
On VM installs the deployed-agent invoke URL was empty in the console, and try-out POSTed to a relative `/chat` which 405'd against the console's own host. The platform-resources chart seeds the default Environment CR with `environment.gateway.http.host` defaulting to `am-gateway.localhost:19080`, and the VM installer never overrode it. OpenChoreo builds agent route hostnames as `<env>-<org>.<that host>`, and an Environment's external gateway WHOLLY REPLACES the dataplane's (no per-field fallback), so agent routes landed on `*.am-gateway.localhost` even though the ClusterDataPlane and Caddy were correctly set to the public agents host.

Pointing the host at the public agents base was necessary but not sufficient. The console reads the `https` endpoint variant when `tlsEnabled=true`, and because the override wholly replaces the dataplane's external endpoint, an http-only override dropped the `https` variant that `dataplane_external_ingress` emits. The release binding's `externalURLs` then carried only an `http` entry, so the resolved invoke URL stayed empty even once the host was correct. The same http-only gap existed in `add-environment.sh` (used to add further environments), so it is fixed here too.

Related to #1106.

## Goals
On a TLS deployment, both the default environment and any environment added via `add-environment.sh` should resolve deployed agents to `<org>-<project>.<agents-base>`, and the console should show a working `https://` invoke URL that try-out can call directly.

## Approach
Override the default Environment's agent gateway in `build_platform_resources_helm_args` with BOTH variants: `environment.gateway.http.{host,port}` and `environment.gateway.https.{host,port}`, both pointed at `AMP_AGENTS_BASE` on `:443`. Render an optional `https` block on the Environment CR template (`environment.yaml`) that mirrors `dataplane_external_ingress`: both variants bind `listenerName: http` since TLS terminates upstream at Caddy, and they differ only in advertised scheme. The `https` block is gated on the value being set, so local/compose installs (`tlsEnabled=false`, http only) render exactly as before. `install-vm.sh` already sets `AMP_AGENTS_BASE` in scope before the call.

Apply the same shape to `add-environment.sh`: add optional `ENV_INGRESS_HTTPS_HOST` / `ENV_INGRESS_HTTPS_PORT` (default 443) so the environment-create POST advertises an `https` listener alongside `http` on TLS deployments. When `ENV_INGRESS_HTTPS_HOST` is unset (the local default) the request body is unchanged. The API request model already supports the `https` listener and applies it as an override.

## User stories
As an operator installing the platform on a VM with TLS, when I deploy an agent (in the default environment or one I added with `add-environment.sh`) I can see its public invoke URL in the console and exercise it from try-out without a 405.

## Release note
Fix empty deployed-agent invoke URL (and try-out 405) on TLS deployments by advertising the public agents host, with both http and https variants, on the default environment and on environments created via add-environment.sh.

## Documentation
N/A. No doc changes here; the VM TLS install docs are handled separately in #1165.

## Training
N/A. No training content impact.

## Certification
N/A. No certification exam impact; this is an install-time gateway configuration fix.

## Marketing
N/A. No marketing impact.

## Automation tests
 - Unit tests
   > Extended the VM lib unit tests (`deployments/vm/tests/run.sh`) to assert both `environment.gateway.https.host` and `environment.gateway.https.port` are emitted by `build_platform_resources_helm_args`. Full suite plus `preflight.sh` pass under bash 3.2; `shellcheck` clean across the touched shell scripts. `helm template` verified both renderings of the chart (no https value: unchanged; with value: correct https block). `add-environment.sh` request body validated as JSON both with and without the https variant.
 - Integration tests
   > Verified manually on a TLS VM (AMP 0.17.0-rc1, k3d): with both variants the release binding gains an `externalURLs.https` entry (scheme https, public host) and the console invoke URL populates and is callable. Note: the platform-resources chart is pulled from the published OCI registry by version, so the template half of the fix takes effect once the chart is republished at the next tag; until then the equivalent override was applied directly and confirmed end to end.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (shell and Helm chart changes only, no Java).
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
 - #1106 (private-network VM install)
 - #1165 (VM install TLS docs)

## Migrations (if applicable)
N/A. No migration required; the change only affects gateway host values rendered at install time.

## Test environment
GCP/office VM, Ubuntu, k3d, AMP 0.17.0-rc1; verified via `sudo kubectl` inspection of the Environment CR and ReleaseBinding status, and through the console UI in a browser.

## Learning
Traced the invoke URL backward from the console: it is derived from the rendered HTTPRoute and surfaced via the release binding's `Status.Endpoints[].ExternalURLs` (selected by `tlsEnabled`), not computed independently. That made clear an http-only override could not populate a tls-enabled console.
