### PR TITLE
Route VM gateway host through kgateway

### DIFF
--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -82,6 +82,12 @@ build_amp_helm_args() {
 # in full; only the ThunderKeyManager issuer differs from the chart default. This is
 # chart-version-coupled: re-verify both keymanagers (names + jwks URIs) on chart bumps.
 # gateway_helm_args — hostname-driven core. Reads AMP_HOST_GATEWAY, AMP_HOST_THUNDER.
+#
+# gateway.hostname MUST match the host in gateway.vhost. vhost is the public URL the
+# controller mints into LLM-proxy endpoints; hostname is the host the kgateway
+# catch-all HTTPRoute matches to forward traffic to the gateway runtime. Left unset,
+# hostname defaults to "<env>-<org>.gateway.localhost", which never matches the public
+# vhost the LLM judge calls, so the proxy request 404s at kgateway. Keep them aligned.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 gateway_helm_args() {
   local thunder keymanagers
@@ -89,6 +95,7 @@ gateway_helm_args() {
   keymanagers=$(printf '[{"name":"agent-manager-service","issuer":"agent-manager-service","jwks":{"remote":{"uri":"http://amp-api.wso2-amp.svc.cluster.local:9000/auth/external/jwks.json","skipTlsVerify":true}}},{"name":"ThunderKeyManager","issuer":"%s","jwks":{"remote":{"uri":"http://amp-thunder-extension-service.amp-thunder:8090/oauth2/jwks","skipTlsVerify":true}}}]' "$thunder")
   printf '%s\n' \
     "--set" "gateway.vhost=https://${AMP_HOST_GATEWAY}" \
+    "--set" "gateway.hostname=${AMP_HOST_GATEWAY}" \
     "--set-json" "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers=${keymanagers}"
 }
 
@@ -359,7 +366,14 @@ caddyfile() {
   _site "$AMP_HOST_API"      9000   # agent-manager REST API
   _site "$AMP_HOST_THUNDER"  8080   # Thunder OAuth (OC kgateway, host-routed)
   _site "$AMP_HOST_OBSERVER" 9098   # traces observer
-  _site "$AMP_HOST_GATEWAY"  22893  # api-platform gateway: OTel ingest
+  # The api-platform gateway runtime is a ClusterIP service (ports 22893/22894 are
+  # not node-published), so it is reached through the kgateway data plane on 19080 —
+  # which has a catch-all HTTPRoute for AMP_HOST_GATEWAY that forwards to the runtime
+  # (see gateway_helm_args setting gateway.hostname). Pointing here at 22893 dead-ends
+  # (Caddy gets an empty reply -> 502), breaking the publicly-minted LLM-judge proxy
+  # URL. (Agent OTel ingestion is unaffected: it goes in-cluster to the runtime
+  # ClusterIP, not through this host.)
+  _site "$AMP_HOST_GATEWAY"  19080  # api-platform gateway via kgateway (LLM proxy)
 
   if [[ -n "$AMP_HOST_CP" ]]; then
     # 9243 is HTTPS with a self-signed cert -> proxy over TLS, skip verification.

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -89,6 +89,9 @@ gw="$(build_gateway_helm_args 203.0.113.10)"
 assert_eq "gateway vhost" \
   "gateway.vhost=https://gateway.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'gateway.vhost' <<<"$gw")"
+assert_eq "gateway hostname matches vhost host" \
+  "gateway.hostname=gateway.amp.203.0.113.10.sslip.io" \
+  "$(grep -F 'gateway.hostname' <<<"$gw")"
 # keymanagers supplied as a full list via --set-json (a list-index --set wipes the
 # other entry); ThunderKeyManager gets the public issuer, agent-manager-service kept.
 assert_eq "gateway keymanagers via --set-json" "yes" "$(has "$gw" '--set-json')"
@@ -194,7 +197,12 @@ assert_eq "caddy email block" "	email ops@example.com" "$(grep -F 'email ops@exa
 assert_eq "caddy console site" "console.amp.203.0.113.10.sslip.io {" "$(grep -F 'console.amp' <<<"$cf" | head -1)"
 assert_eq "caddy console upstream" "	reverse_proxy 127.0.0.1:3000" "$(grep -F '127.0.0.1:3000' <<<"$cf")"
 assert_eq "caddy thunder upstream" "	reverse_proxy 127.0.0.1:8080" "$(grep -F '127.0.0.1:8080' <<<"$cf")"
-assert_eq "caddy gateway upstream" "	reverse_proxy 127.0.0.1:22893" "$(grep -F '127.0.0.1:22893' <<<"$cf")"
+# gateway host routes through the kgateway data plane (19080), not the ClusterIP
+# runtime (22893) which is not node-published; scope the grep to the gateway block
+# since 19080 is shared with the agents site.
+assert_eq "caddy gateway upstream (via kgateway)" "	reverse_proxy 127.0.0.1:19080" \
+  "$(grep -F -A8 'gateway.amp.203.0.113.10.sslip.io {' <<<"$cf" | grep -F 'reverse_proxy' | head -1)"
+assert_eq "caddy no 22893 dead-end" "" "$(grep -F '127.0.0.1:22893' <<<"$cf")"
 assert_eq "caddy no cp when disabled" "" "$(grep -F 'cp.amp' <<<"$cf")"
 assert_eq "caddy api upstream" "	reverse_proxy 127.0.0.1:9000" "$(grep -F '127.0.0.1:9000' <<<"$cf")"
 assert_eq "caddy observer upstream" "	reverse_proxy 127.0.0.1:9098" "$(grep -F '127.0.0.1:9098' <<<"$cf")"
@@ -308,6 +316,9 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core gateway vhost" \
     "gateway.vhost=https://gateway.amp.example.com" \
     "$(grep -F 'gateway.vhost' <<<"$core_gw")"
+  assert_eq "core gateway hostname matches vhost host" \
+    "gateway.hostname=gateway.amp.example.com" \
+    "$(grep -F 'gateway.hostname' <<<"$core_gw")"
 
   core_cp="$(cp_helm_args)"
   assert_eq "core cp oidc issuer" \


### PR DESCRIPTION
## Purpose
On VM installs (both the simple `install-vm.sh` and advanced `install-advanced.sh` paths, which share `lib-vm.sh`), the LLM-as-judge in monitor evaluations fails with `LLM judge failed after 3 attempts: Error code: 502 [model=openai/gpt-4o-mini]`, so evaluators like Coherence skip. The judge calls the publicly-minted LLM-proxy URL `https://<gateway-host>/<id>/chat/completions`, which resolves to the VM and hairpins through Caddy. Two installer faults broke that path:

1. Caddy proxied the gateway host to `127.0.0.1:22893`, the api-platform gateway runtime's port. That runtime is a **ClusterIP** service, so its ports are not published on the k3d node; the host port dead-ends and Caddy returns `502` (empty reply from upstream). The runtime is only reachable via the **kgateway** data plane on `19080`, which carries a catch-all HTTPRoute for the gateway host that forwards to the runtime (the same tier the agents wildcard already uses).
2. `gateway.hostname` was never set, so the kgateway catch-all route matched only the default `<env>-<org>.gateway.localhost`, never the public host the judge actually calls. `gateway.vhost` (which mints the proxy URL) was set to the public host, but the route hostname was not — so even via `19080` the request `404`s at kgateway.

This is independent of #1168 (the deployed-agent invoke URL) and affects every VM install, so it should land before the next tag.

## Goals
On any VM install, the LLM-judge proxy URL minted from the public gateway host should route through to the gateway runtime and reach the upstream model, so evaluators score instead of 502-skipping.

## Approach
In `lib-vm.sh`: point the Caddy `gateway.*` block at `127.0.0.1:19080` (the kgateway data plane) instead of the ClusterIP runtime port `22893`, and set `gateway.hostname=${AMP_HOST_GATEWAY}` in `gateway_helm_args` so the kgateway catch-all route matches the same public host that `gateway.vhost` mints into proxy URLs. No chart change is required — the catch-all route and `gateway.hostname` value already exist in the gateway-extension chart.

## User stories
As an operator running the platform on a VM, monitor evaluations that use an LLM-as-judge (e.g. Coherence) complete and produce scores instead of skipping with a 502.

## Release note
Fix LLM-as-judge 502 in monitor evaluations on VM installs by routing the gateway host through the kgateway data plane and aligning the gateway route hostname with the minted proxy vhost.

## Documentation
N/A. No doc impact; install-time configuration fix.

## Training
N/A.

## Certification
N/A.

## Marketing
N/A.

## Automation tests
 - Unit tests
   > Updated `deployments/vm/tests/run.sh`: the Caddy gateway upstream now asserts `127.0.0.1:19080` (scoped to the gateway block, since 19080 is shared with the agents site), with a guard that `22893` no longer appears; and `gateway_helm_args` asserts `gateway.hostname` equals the `gateway.vhost` host. Full suite plus `preflight.sh` pass under bash 3.2; `shellcheck` clean.
 - Integration tests
   > Verified end to end on a VM: a direct POST to the live proxy path via `19080` returns `200` with a real `gpt-4o-mini` completion; via Caddy the path flips from `502` to a routed response (with `x-envoy-upstream-service-time`); after applying the fix the judge's `…/chat/completions` calls stop 502-ing and Coherence evaluates. Confirmed agent OTel ingestion is unaffected (it goes in-cluster to the runtime ClusterIP, not through the public gateway host).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (shell-only change, no Java).
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
 - #1168 (deployed-agent invoke URL on the default environment) — separate VM-install fix.

## Migrations (if applicable)
N/A. Affects only install-time gateway routing/host values.

## Test environment
GCP and office VMs, Ubuntu, k3d, AMP 0.17.0-rc4; verified via `sudo kubectl`, the Caddy admin API, and direct/Caddy `curl` probes.

## Learning
Traced the 502 backward from the judge: the proxy URL hairpins through Caddy to the gateway runtime, which is ClusterIP (node-unpublished) and only reachable via the kgateway catch-all route — and that route keys on `gateway.hostname`, which must equal the minted `gateway.vhost` host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gateway routing so traffic uses the correct internal port, helping avoid broken proxy requests and unexpected 404s.
  * Ensured the gateway hostname and virtual host stay aligned for more reliable request handling.
* **Tests**
  * Added and updated checks to verify gateway hostname settings and routing expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->