### PR TITLE
MCP Proxy feature bug fixes

### DIFF
--- a/agent-manager-service/models/constants.go
+++ b/agent-manager-service/models/constants.go
@@ -74,6 +74,7 @@ const (
 
 // Status values
 const (
+	StatusCreated = "CREATED"
 	StatusActive  = "active"
 	StatusPending = "pending"
 	StatusFailed  = "failed"

--- a/agent-manager-service/repositories/env_agent_mcp_mapping_repository.go
+++ b/agent-manager-service/repositories/env_agent_mcp_mapping_repository.go
@@ -71,6 +71,9 @@ func (r *envAgentMCPMappingRepository) Create(ctx context.Context, tx *gorm.DB, 
 	if proxyMapping.SourceMCPProxyUUID == uuid.Nil {
 		proxyMapping.SourceMCPProxyUUID = mapping.MCPProxyUUID
 	}
+	if proxyMapping.Status == "" {
+		proxyMapping.Status = models.StatusCreated
+	}
 	now := time.Now()
 	if err := r.artifactRepo.Create(tx, &models.Artifact{
 		UUID:             mapping.ArtifactUUID,

--- a/agent-manager-service/repositories/llm_proxy_repository.go
+++ b/agent-manager-service/repositories/llm_proxy_repository.go
@@ -129,7 +129,7 @@ func (r *LLMProxyRepo) Create(p *models.LLMProxy, handle, name, version string, 
 		}
 
 		// Insert into llm_proxies table
-		return tx.Create(p).Error
+		return tx.Omit("Status").Create(p).Error
 	})
 }
 
@@ -255,7 +255,6 @@ func (r *LLMProxyRepo) Update(p *models.LLMProxy, handle string, orgName string)
 				"description":   p.Description,
 				"provider_uuid": p.ProviderUUID,
 				"openapi_spec":  p.OpenAPISpec,
-				"status":        p.Status,
 				"configuration": p.Configuration,
 			})
 

--- a/agent-manager-service/repositories/mcp_proxy_repository.go
+++ b/agent-manager-service/repositories/mcp_proxy_repository.go
@@ -65,6 +65,9 @@ func (r *MCPProxyRepo) Create(ctx context.Context, tx *gorm.DB, p *models.MCPPro
 	if p.UUID == uuid.Nil {
 		p.UUID = uuid.New()
 	}
+	if p.Status == "" {
+		p.Status = models.StatusCreated
+	}
 	now := time.Now()
 
 	if err := r.artifactRepo.Create(tx.WithContext(ctx), &models.Artifact{
@@ -81,7 +84,7 @@ func (r *MCPProxyRepo) Create(ctx context.Context, tx *gorm.DB, p *models.MCPPro
 		return fmt.Errorf("failed to create artifact: %w", err)
 	}
 
-	if err := tx.WithContext(ctx).Omit("status").Create(p).Error; err != nil {
+	if err := tx.WithContext(ctx).Create(p).Error; err != nil {
 		return err
 	}
 	return nil

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -2130,7 +2130,6 @@ func (s *agentConfigurationService) updateExistingMCPMapping(ctx context.Context
 			Updates(map[string]interface{}{
 				"source_mcp_proxy_uuid": proxyMapping.SourceMCPProxyUUID,
 				"description":           proxyMapping.Description,
-				"status":                proxyMapping.Status,
 				"configuration":         proxyMapping.Configuration,
 			}).Error; err != nil {
 			return err
@@ -3812,7 +3811,7 @@ func buildMCPProxyMapping(sourceProxyUUID uuid.UUID, deployedProxy *models.MCPPr
 		UUID:               deployedProxy.UUID,
 		SourceMCPProxyUUID: sourceProxyUUID,
 		Description:        deployedProxy.Description,
-		Status:             deployedProxy.Status,
+		Status:             models.StatusCreated,
 		Configuration:      deployedProxy.Configuration,
 	}
 }

--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -33,10 +33,6 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
-const (
-	llmStatusPending = "pending"
-)
-
 // DeploymentResult captures the outcome of deploying to a single gateway
 type DeploymentResult struct {
 	GatewayID string `json:"gateway_id"`

--- a/agent-manager-service/services/llm_proxy_service.go
+++ b/agent-manager-service/services/llm_proxy_service.go
@@ -98,7 +98,6 @@ func (s *LLMProxyService) Create(orgName, createdBy string, proxy *models.LLMPro
 	// Set default values
 	proxy.CreatedBy = createdBy
 	proxy.ProviderUUID = providerModel.UUID
-	proxy.Status = llmStatusPending
 	if proxy.Configuration.Context == nil {
 		defaultContext := "/"
 		proxy.Configuration.Context = &defaultContext

--- a/agent-manager-service/services/mcp_proxy_service.go
+++ b/agent-manager-service/services/mcp_proxy_service.go
@@ -54,13 +54,6 @@ const (
 	maxMCPResponseBody     = 10 << 20
 )
 
-var excludedMCPProxyPolicyListNames = map[string]struct{}{
-	"mcp-acl-list": {},
-	"mcp-auth":     {},
-	"mcp-authz":    {},
-	"mcp-rewrite":  {},
-}
-
 // MCPProxyService handles MCP proxy operations.
 type MCPProxyService struct {
 	db                   *gorm.DB
@@ -486,9 +479,6 @@ func extractGatewayPolicyManifestItems(value interface{}) []models.MCPPolicyAvai
 		name = strings.TrimSpace(name)
 		version = strings.TrimSpace(version)
 		if name == "" || version == "" {
-			return
-		}
-		if _, ok := excludedMCPProxyPolicyListNames[strings.ToLower(name)]; ok {
 			return
 		}
 		key := name + "\x00" + version

--- a/agent-manager-service/services/mcp_proxy_service.go
+++ b/agent-manager-service/services/mcp_proxy_service.go
@@ -137,6 +137,7 @@ func (s *MCPProxyService) Create(ctx context.Context, orgUUID, createdBy string,
 	proxy := &models.MCPProxy{
 		Description: valueOrEmpty(req.Description),
 		CreatedBy:   createdBy,
+		Status:      models.StatusCreated,
 		Configuration: models.MCPProxyConfig{
 			Name:         name,
 			Version:      version,

--- a/agent-manager-service/utils/spec_converter.go
+++ b/agent-manager-service/utils/spec_converter.go
@@ -346,7 +346,6 @@ func ConvertSpecToModelLLMProxy(req *spec.CreateLLMProxyRequest, projectID strin
 		ProviderUUID:  providerUUID,
 		Description:   ptrToString(req.Description),
 		OpenAPISpec:   ptrToString(req.Openapi),
-		Status:        "ACTIVE",
 		Configuration: ConvertSpecToModelLLMProxyConfig(req.Configuration),
 	}
 


### PR DESCRIPTION
1. Remove the backend filtering of policies so access control and rewrite policies work properly.
2. Always keep the status of LLM Proxies, MCP Proxies and MCP Proxy Mappings as `CREATED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New records now start with a clear “Created” status by default across proxy and mapping workflows.

* **Bug Fixes**
  * Updated proxy updates so existing status values are preserved instead of being overwritten.
  * Improved policy handling so gateway-reported policy items are included more consistently and validated for duplicates.
  * Removed an unintended default active status during LLM proxy creation, keeping initial state more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->