### PR TITLE
Add amctl agent mcp lifecycle CLI e2e specs

### DIFF
--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -188,9 +188,11 @@ picked up automatically with no CI change.
 
 - **HTTP operations** go in `operations/<resource>/`; **CLI operations** go in
   `operations/cli/<resource>/`. The `agentplatform` suite owns a dedicated
-  running platform agent and hosts its mutating/observability/llm commands; the
-  keyless `agent` suite covers build-free agent CRUD. Every e2e run executes all
-  suites together.
+  running platform agent and hosts its mutating/observability/llm/mcp commands;
+  the keyless `agent` suite covers build-free agent CRUD. Every e2e run executes
+  all suites together. The `agent mcp` specs additionally require a running AI
+  gateway in `DefaultEnv` and reachability of `framework.TestMCPServerURL`, since
+  an mcp config can only bind a gateway-deployed catalog proxy.
 - Keep `framework/amctl` resource-agnostic. Never add project/agent/etc.
   knowledge to the harness.
 - CLI specs assert exit codes and JSON envelopes, not human-readable text.

--- a/test/e2e/framework/shared_agent.go
+++ b/test/e2e/framework/shared_agent.go
@@ -30,11 +30,19 @@ import (
 const E2EProjectPrefix = "e2e-test-"
 const E2EAgentPrefix = "e2e-test-agent-"
 const E2ELLMProviderPrefix = "e2e-test-llm-provider-"
+const E2EMCPProxyPrefix = "e2e-test-mcp-proxy-"
 const E2EMonitorPrefix = "e2e-test-mon-monitor-"
 
 // E2EEnvPrefix is the naming prefix for all e2e test environments. It is kept
 // short because environment names are length-constrained:
 const E2EEnvPrefix = "e2e-"
+
+// TestMCPServerURL is a public, always-on upstream MCP "everything" server used
+// as the proxy upstream by the MCP e2e tests (proxy lifecycle, invocation, and
+// the CLI agent-mcp suite). Proxy creation validates this URL via SSRF checks
+// but does not require a live MCP handshake, so it is safe to reuse for
+// config-only coverage.
+const TestMCPServerURL = "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0/mcp"
 
 // Shared Projects and Agent
 const E2ESharedProjectName = "e2e-test-shared"

--- a/test/e2e/operations/cli/agent/mcp_operations.go
+++ b/test/e2e/operations/cli/agent/mcp_operations.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// amctl agent mcp commands as thin, assertion-backed operations over the amctl
+// harness. Lives in package cliagent alongside llm_operations.go and reuses its
+// DeleteResult. Decode structs mirror amsvc.AgentModelConfigResponse /
+// AgentModelConfigListItem (only the fields specs assert on). Unlike an llm
+// config, an mcp config references a catalog MCP proxy by handle; the server
+// mirrors that handle into proxyName/mcpProxyName/providerName, so
+// AgentMCPProxyRef.Handle reads them in that order. Note that `agent mcp unset`
+// requires --yes for a whole-config delete (the llm equivalent does not).
+package cliagent
+
+import (
+	. "github.com/onsi/gomega"
+
+	"github.com/wso2/agent-manager/test/e2e/framework/amctl"
+)
+
+// AgentMCPConfig is the data shape of `agent mcp set`/`get` (AgentModelConfigResponse).
+type AgentMCPConfig struct {
+	Name        string                        `json:"name"`
+	Type        string                        `json:"type"`
+	Description string                        `json:"description"`
+	EnvMappings map[string]AgentMCPEnvMapping `json:"envMappings"`
+}
+
+// AgentMCPEnvMapping is one entry of AgentModelConfigResponse.EnvMappings.
+// Configuration is server-managed and may be nil for an undeployed proxy.
+type AgentMCPEnvMapping struct {
+	Configuration *AgentMCPProxyRef `json:"configuration,omitempty"`
+}
+
+// AgentMCPProxyRef is the subset of ProviderConfig we assert on. The server
+// mirrors the bound MCP proxy handle into all three fields; Handle prefers the
+// proxy-specific names and falls back to providerName.
+type AgentMCPProxyRef struct {
+	ProxyName    string `json:"proxyName,omitempty"`
+	McpProxyName string `json:"mcpProxyName,omitempty"`
+	ProviderName string `json:"providerName,omitempty"`
+}
+
+// Handle returns the bound MCP proxy handle (proxyName → mcpProxyName → providerName).
+func (r AgentMCPProxyRef) Handle() string {
+	if r.ProxyName != "" {
+		return r.ProxyName
+	}
+	if r.McpProxyName != "" {
+		return r.McpProxyName
+	}
+	return r.ProviderName
+}
+
+// AgentMCPConfigList is the data shape of `agent mcp list --json` (CLI's ListResult).
+type AgentMCPConfigList struct {
+	Configs []AgentMCPConfig `json:"configs"`
+}
+
+// Names returns the config names in the list, for membership assertions.
+func (l AgentMCPConfigList) Names() []string {
+	names := make([]string, 0, len(l.Configs))
+	for _, c := range l.Configs {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+// SetAgentMCPParams are the inputs to `agent mcp set`.
+type SetAgentMCPParams struct {
+	Name        string
+	Env         string
+	Proxy       string
+	URLEnv      string
+	APIKeyEnv   string
+	Description string
+}
+
+// SetAgentMCP runs `agent mcp set <agent>` (create or update) and returns the config.
+func SetAgentMCP(g Gomega, h *amctl.Harness, org, project, agent string, p SetAgentMCPParams) AgentMCPConfig {
+	args := []string{"agent", "mcp", "set", agent, "--name", p.Name, "--env", p.Env, "--proxy", p.Proxy}
+	if p.URLEnv != "" {
+		args = append(args, "--url-env", p.URLEnv)
+	}
+	if p.APIKeyEnv != "" {
+		args = append(args, "--apikey-env", p.APIKeyEnv)
+	}
+	if p.Description != "" {
+		args = append(args, "--description", p.Description)
+	}
+	args = append(args, "--org", org, "--project", project, "--json")
+	return amctl.DecodeData[AgentMCPConfig](g, h.Run(args...))
+}
+
+// GetAgentMCP runs `agent mcp get <agent> --name` and returns the config.
+func GetAgentMCP(g Gomega, h *amctl.Harness, org, project, agent, name string) AgentMCPConfig {
+	return amctl.DecodeData[AgentMCPConfig](g, h.Run(
+		"agent", "mcp", "get", agent, "--name", name,
+		"--org", org, "--project", project, "--json"))
+}
+
+// GetAgentMCPExpectError runs `agent mcp get` expecting a non-zero exit (e.g. the
+// config no longer exists) and returns the error envelope — the deletion check.
+func GetAgentMCPExpectError(g Gomega, h *amctl.Harness, org, project, agent, name string) amctl.EnvelopeError {
+	return h.Run("agent", "mcp", "get", agent, "--name", name,
+		"--org", org, "--project", project, "--json").ExpectError(g)
+}
+
+// ListAgentMCP runs `agent mcp list <agent>` and returns the (type=mcp) configs.
+func ListAgentMCP(g Gomega, h *amctl.Harness, org, project, agent string) AgentMCPConfigList {
+	return amctl.DecodeData[AgentMCPConfigList](g, h.Run(
+		"agent", "mcp", "list", agent,
+		"--org", org, "--project", project, "--json"))
+}
+
+// UnsetAgentMCP runs `agent mcp unset <agent> --name --yes` (whole-config delete)
+// and returns the delete result. --yes is required because the harness runs with
+// a non-terminal stdin and the command refuses an unconfirmed whole-config delete.
+func UnsetAgentMCP(g Gomega, h *amctl.Harness, org, project, agent, name string) DeleteResult {
+	return amctl.DecodeData[DeleteResult](g, h.Run(
+		"agent", "mcp", "unset", agent, "--name", name, "--yes",
+		"--org", org, "--project", project, "--json"))
+}

--- a/test/e2e/tests/cli/agentplatform/agent_mcp_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_mcp_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Validates the amctl agent mcp lifecycle end to end against the CLI-owned
+// platform agent: set (create→POST), get, list, set (update→GET+PUT), unset
+// (whole-config DELETE), and the post-unset not-found envelope. Asserts JSON
+// envelopes and exit codes only.
+//
+// Unlike agent llm — which binds a config-only provider — an mcp config can only
+// reference a catalog MCP proxy, and a proxy becomes catalog-eligible only after
+// it is deployed to a gateway. The CLI cannot provision proxies, so BeforeAll
+// creates a gateway-deployed proxy through the HTTP API first. This makes the
+// suite depend on a running AI gateway in DefaultEnv and the reachability of
+// framework.TestMCPServerURL.
+
+package cliagentplatformtests
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/wso2/agent-manager/test/e2e/framework"
+	cliagent "github.com/wso2/agent-manager/test/e2e/operations/cli/agent"
+	"github.com/wso2/agent-manager/test/e2e/operations/gateway"
+	mcpproxyop "github.com/wso2/agent-manager/test/e2e/operations/mcpproxy"
+)
+
+var _ = Describe("amctl agent mcp (CLI-owned agent)", Label("cli", "agent", "mcp"), Ordered, func() {
+	const (
+		configName = "primary"
+		urlEnv     = "E2E_MCP_URL"
+		apiKeyEnv  = "E2E_MCP_KEY"
+	)
+	var proxyID string
+
+	BeforeAll(func() {
+		ensurePlatformAgent()
+
+		// The agent's mcp config can only bind a catalog proxy, which requires a
+		// gateway deployment — provision one over HTTP (the CLI can't).
+		gatewayUUID := gateway.WaitForActiveGatewayForEnv(apiClient, H.Org(), cfg.DefaultEnv, 3*time.Minute)
+		Expect(gatewayUUID).NotTo(BeEmpty())
+
+		proxyID = framework.E2EMCPProxyPrefix + uuid.New().String()[:8]
+		upstreamURL := framework.TestMCPServerURL
+		ctx := "/" + proxyID
+		proxy := mcpproxyop.CreateMCPProxy(Default, apiClient, H.Org(),
+			framework.CreateMCPProxyRequest{
+				ID:      proxyID,
+				Name:    "CLI E2E MCP Proxy " + proxyID[len(proxyID)-8:],
+				Version: "v1.0",
+				Context: &ctx,
+				Upstream: framework.UpstreamConfig{
+					Main: &framework.UpstreamEndpoint{URL: &upstreamURL},
+				},
+				Security: &framework.SecurityConfig{
+					Enabled: true,
+					APIKey: &framework.SecurityAPIKey{
+						Enabled: true,
+						Key:     "X-API-Key",
+						In:      "header",
+					},
+				},
+				Gateways: []string{gatewayUUID},
+			})
+		Expect(proxy.ID).To(Equal(proxyID))
+
+		// LIFO cleanup: unset the agent config first, then delete the proxy.
+		DeferCleanup(func() {
+			mcpproxyop.DeleteMCPProxy(Default, apiClient, H.Org(), proxyID)
+		})
+		DeferCleanup(func() {
+			_ = H.Run("agent", "mcp", "unset", owned.AgentName, "--name", configName, "--yes",
+				"--org", H.Org(), "--project", owned.ProjectName, "--json")
+		})
+		GinkgoWriter.Printf("CLI agent mcp: agent=%s proxy=%s\n", owned.AgentName, proxyID)
+	})
+
+	It("sets a new mcp config (create → POST)", func() {
+		c := cliagent.SetAgentMCP(Default, H, H.Org(), owned.ProjectName, owned.AgentName, cliagent.SetAgentMCPParams{
+			Name:        configName,
+			Env:         cfg.DefaultEnv,
+			Proxy:       proxyID,
+			URLEnv:      urlEnv,
+			APIKeyEnv:   apiKeyEnv,
+			Description: "created by agent mcp e2e",
+		})
+		Expect(c.Name).To(Equal(configName))
+		Expect(c.Type).To(Equal("mcp"))
+		Expect(c.EnvMappings).To(HaveKey(cfg.DefaultEnv))
+		Expect(c.EnvMappings[cfg.DefaultEnv].Configuration).NotTo(BeNil())
+		Expect(c.EnvMappings[cfg.DefaultEnv].Configuration.Handle()).To(Equal(proxyID))
+	})
+
+	It("gets the mcp config", func() {
+		c := cliagent.GetAgentMCP(Default, H, H.Org(), owned.ProjectName, owned.AgentName, configName)
+		Expect(c.Name).To(Equal(configName))
+		Expect(c.Description).To(Equal("created by agent mcp e2e"))
+		Expect(c.EnvMappings).To(HaveKey(cfg.DefaultEnv))
+	})
+
+	It("lists mcp configs (type=mcp only)", func() {
+		list := cliagent.ListAgentMCP(Default, H, H.Org(), owned.ProjectName, owned.AgentName)
+		Expect(list.Names()).To(ContainElement(configName))
+		for _, c := range list.Configs {
+			Expect(c.Type).To(Equal("mcp"))
+		}
+	})
+
+	It("updates the mcp config (existing → GET+PUT)", func() {
+		c := cliagent.SetAgentMCP(Default, H, H.Org(), owned.ProjectName, owned.AgentName, cliagent.SetAgentMCPParams{
+			Name:        configName,
+			Env:         cfg.DefaultEnv,
+			Proxy:       proxyID,
+			Description: "updated by agent mcp e2e",
+		})
+		Expect(c.Name).To(Equal(configName))
+		Expect(c.Description).To(Equal("updated by agent mcp e2e"))
+	})
+
+	It("unsets the whole mcp config (DELETE)", func() {
+		res := cliagent.UnsetAgentMCP(Default, H, H.Org(), owned.ProjectName, owned.AgentName, configName)
+		Expect(res.Name).To(Equal(configName))
+		Expect(res.Deleted).To(BeTrue())
+	})
+
+	It("reports the mcp config gone after unset", func() {
+		Eventually(func(g Gomega) {
+			cliagent.GetAgentMCPExpectError(g, H, H.Org(), owned.ProjectName, owned.AgentName, configName)
+		}).WithTimeout(30 * time.Second).WithPolling(3 * time.Second).Should(Succeed())
+	})
+})

--- a/test/e2e/tests/mcpproxy/mcp_proxy_invocation_test.go
+++ b/test/e2e/tests/mcpproxy/mcp_proxy_invocation_test.go
@@ -83,7 +83,7 @@ var _ = Describe("MCP Proxy with External Agent and Policy Enforcement", Label("
 	})
 
 	It("should create an MCP proxy with api-key security deployed to the gateway", func() {
-		upstreamURL := testMCPServerURL
+		upstreamURL := framework.TestMCPServerURL
 		ctx := "/" + proxyID
 
 		proxy := mcpproxyop.CreateMCPProxy(Default, Client, Cfg.DefaultOrg,

--- a/test/e2e/tests/mcpproxy/mcp_proxy_test.go
+++ b/test/e2e/tests/mcpproxy/mcp_proxy_test.go
@@ -52,7 +52,7 @@ var _ = Describe("MCP Proxy Lifecycle", Label("mcp-proxy"), Ordered, func() {
 	It("should discover the upstream MCP server", func() {
 		info := mcpproxyop.FetchServerInfo(Default, Client, Cfg.DefaultOrg,
 			framework.MCPServerInfoFetchRequest{
-				URL: testMCPServerURL,
+				URL: framework.TestMCPServerURL,
 			})
 		Expect(len(info.Tools)).To(BeNumerically(">", 0), "expected the everything server to report tools")
 		GinkgoWriter.Printf("Discovered MCP server: %d tools, %d prompts, %d resources\n",
@@ -60,7 +60,7 @@ var _ = Describe("MCP Proxy Lifecycle", Label("mcp-proxy"), Ordered, func() {
 	})
 
 	It("should create an MCP proxy deployed to the gateway", func() {
-		upstreamURL := testMCPServerURL
+		upstreamURL := framework.TestMCPServerURL
 		ctx := "/" + proxyID
 
 		proxy := mcpproxyop.CreateMCPProxy(Default, Client, Cfg.DefaultOrg,

--- a/test/e2e/tests/mcpproxy/suite_test.go
+++ b/test/e2e/tests/mcpproxy/suite_test.go
@@ -31,8 +31,6 @@ var Client *framework.AMPClient
 // Cfg is the shared test configuration.
 var Cfg *framework.Config
 
-const testMCPServerURL = "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/godzilla/mcp-everything-server/v1.0/mcp"
-
 func TestMCPProxy(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "MCP Proxy Suite")

--- a/test/e2e/testsetup/cleanup.go
+++ b/test/e2e/testsetup/cleanup.go
@@ -110,6 +110,7 @@ func CleanupStaleE2EResources(client *framework.AMPClient, orgName string) {
 	// deletion while a pipeline references it).
 	cleanupStaleDeploymentPipelines(client, orgName)
 	cleanupStaleLLMProviders(client, orgName)
+	cleanupStaleMCPProxies(client, orgName)
 	cleanupStaleCustomEvaluators(client, orgName)
 	cleanupStaleEnvironments(client, orgName)
 }
@@ -275,6 +276,84 @@ func cleanupStaleLLMProviders(client *framework.AMPClient, orgName string) {
 		delResp.Body.Close()
 		logDeleteResult("LLM provider", p.ID, delResp.StatusCode)
 	}
+}
+
+// cleanupStaleMCPProxies deletes e2e-created MCP proxies (handle prefixed with
+// E2EMCPProxyPrefix) created more than the cutoff ago. These are org-scoped and
+// are not cascaded by project or environment deletion. The list payload omits
+// createdAt, so each candidate is fetched by handle to read its age.
+func cleanupStaleMCPProxies(client *framework.AMPClient, orgName string) {
+
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies", orgName)
+	resp, err := client.Get(path)
+	if err != nil {
+		ginkgo.GinkgoWriter.Printf("stale cleanup: failed to list MCP proxies: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		ginkgo.GinkgoWriter.Printf("stale cleanup: list MCP proxies returned %d, skipping\n", resp.StatusCode)
+		return
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		ginkgo.GinkgoWriter.Printf("stale cleanup: failed to read MCP proxies response: %v\n", err)
+		return
+	}
+
+	var proxies framework.MCPProxyListResponse
+	if err := json.Unmarshal(body, &proxies); err != nil {
+		ginkgo.GinkgoWriter.Printf("stale cleanup: failed to decode MCP proxies: %v\n", err)
+		return
+	}
+
+	for _, p := range proxies.List {
+		if p.ID == nil || !strings.HasPrefix(*p.ID, framework.E2EMCPProxyPrefix) {
+			continue
+		}
+		if !mcpProxyOlderThanCutoff(client, orgName, *p.ID) {
+			continue
+		}
+
+		proxyPath := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies/%s", orgName, *p.ID)
+		delResp, err := client.Delete(proxyPath)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("stale cleanup: failed to delete MCP proxy %s: %v\n", *p.ID, err)
+			continue
+		}
+		delResp.Body.Close()
+		logDeleteResult("MCP proxy", *p.ID, delResp.StatusCode)
+	}
+}
+
+// mcpProxyOlderThanCutoff fetches a proxy by handle and reports whether it was
+// created more than the cutoff ago. On any fetch/decode error (or missing
+// createdAt) it returns false, leaving an unreadable proxy alone rather than
+// deleting one out from under a concurrent run.
+func mcpProxyOlderThanCutoff(client *framework.AMPClient, orgName, handle string) bool {
+	path := fmt.Sprintf("/api/v1/orgs/%s/mcp-proxies/%s", orgName, handle)
+	resp, err := client.Get(path)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+	var proxy framework.MCPProxyResponse
+	if err := json.Unmarshal(body, &proxy); err != nil {
+		return false
+	}
+	if proxy.CreatedAt == nil {
+		return false
+	}
+	return time.Since(*proxy.CreatedAt) >= cutoff
 }
 
 // cleanupStaleEnvironments finds environments with the E2EEnvPrefix that were


### PR DESCRIPTION
## Purpose
We had no CLI e2e coverage for the `amctl agent mcp` command group, even though the sibling `amctl agent llm` lifecycle is covered. This adds the missing black-box coverage, exercising the real `amctl` binary against a running platform agent.

For:
- https://github.com/wso2/agent-manager/issues/1128

## Goals
Validate the full `agent mcp` lifecycle through the CLI's `--json` envelopes and exit codes: `set` (create → POST), `get`, `list` (filtered to `type=mcp`), `set` (update → GET+PUT), `unset` (whole-config DELETE), and the post-unset not-found envelope.

## Approach
The spec lives in the existing `tests/cli/agentplatform` suite and reuses its CLI-owned running agent, config, and authenticated API client.

The key difference from `agent llm`: an `llm` config can bind a config-only provider, but an `mcp` config can only reference a **catalog** MCP proxy, and a proxy becomes catalog-eligible only after it is deployed to a gateway (server-side `ValidateMCPProxiesInCatalog`). The CLI cannot provision proxies, so `BeforeAll` provisions a gateway-deployed proxy through the HTTP stack — reusing the existing `operations/mcpproxy` + `operations/gateway` helpers and the proven recipe from `tests/mcpproxy/mcp_proxy_invocation_test.go` — before driving the CLI.

Changes:
- `operations/cli/agent/mcp_operations.go` — thin, assertion-backed `agent mcp` wrappers (mirrors `llm_operations.go`). Note: `agent mcp unset` requires `--yes` for a whole-config delete (the `llm` equivalent does not), since the harness runs with a non-terminal stdin.
- `tests/cli/agentplatform/agent_mcp_test.go` — the 6-spec lifecycle; LIFO cleanup unsets the config then deletes the proxy.
- `testsetup/cleanup.go` — new `cleanupStaleMCPProxies` backstop (MCP proxies were not previously swept); fetches each prefixed proxy by handle to respect the 1-hour age cutoff.
- `framework/shared_agent.go` — adds `E2EMCPProxyPrefix` and promotes the upstream MCP server URL to a shared `framework.TestMCPServerURL` (the `mcpproxy` suite now references it too, single source of truth).

## User stories
N/A — internal test coverage, no user-facing behavior change.

## Release note
N/A — test-only change.

## Documentation
N/A — test-only. Updated `test/e2e/AGENTS.md` to note the suite's gateway + upstream dependency.

## Training
N/A — no training impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > N/A — this change *is* test code.
 - Integration tests
   > Adds 6 ordered e2e specs covering the `amctl agent mcp` lifecycle against a live platform agent, including HTTP provisioning of a gateway-deployed catalog proxy and best-effort + stale-sweep cleanup. Verified locally at compile/vet level (`go build ./...`, `go vet ./...`, and `go test -c ./tests/cli/agentplatform/` all green). The behavioral run requires a quick-start environment with an active AI gateway in `DefaultEnv`, `OPENAI_API_KEY`, and reachability of `TestMCPServerURL`; it runs as part of the standard e2e suite in CI.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs is a Java/SpotBugs tool; this is Go test code.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the only literal is a public MCP "everything" server URL already used by the existing `mcpproxy` suite; credentials come from env/`.env` at runtime.

## Samples
N/A.

## Related PRs
Follows the recent `amctl agent llm` / `llm-provider` CLI e2e work in the `agentplatform` suite.

## Migrations (if applicable)
N/A — no schema or data migrations.

## Test environment
Go (`test/e2e` module). Compile + vet verified on darwin/arm64. Behavioral run targets a quick-start install (default `AMP_API_BASE_URL=http://localhost:9000`) with an active gateway in `DefaultEnv`.

## Learning
Reused the existing HTTP operation helpers (`operations/mcpproxy`, `operations/gateway`) and the catalog/gateway provisioning recipe already proven by `mcp_proxy_invocation_test.go`, rather than building new provisioning paths.

---
https://claude.ai/code/session_01LrbsbZjTd8Wm9Kb7a8rp6h
