### PR TITLE
Provision CLI-owned e2e agent once across parallel processes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -74,7 +74,7 @@ jobs:
           kubectl logs deployment/amp-traces-observer -n openchoreo-observability-plane --tail=500 --all-containers=true > /tmp/pod-logs/amp-traces-observer.txt 2>&1 || true
           kubectl logs deployment/observer -n openchoreo-observability-plane --tail=500 --all-containers=true > /tmp/pod-logs/observer.txt 2>&1 || true
           # openchoreo reconciler (drives data-plane Release/ReleaseBinding rollout)
-          kubectl logs deployment/openchoreo-controller-manager -n openchoreo-control-plane --tail=500 --all-containers=true > /tmp/pod-logs/openchoreo-controller-manager.txt 2>&1 || true
+          kubectl logs deployment/controller-manager -n openchoreo-control-plane --tail=500 --all-containers=true > /tmp/pod-logs/openchoreo-controller-manager.txt 2>&1 || true
           # Cluster-wide pod state, plus Warning events only (surfaces stuck data-plane agent rollouts)
           kubectl get pods -A -o wide > /tmp/pod-logs/all-pods.txt 2>&1 || true
           kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp > /tmp/pod-logs/warning-events.txt 2>&1 || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -309,7 +309,7 @@ jobs:
           kubectl logs deployment/amp-traces-observer -n openchoreo-observability-plane --tail=500 --all-containers=true > /tmp/pod-logs/amp-traces-observer.txt 2>&1 || true
           kubectl logs deployment/observer -n openchoreo-observability-plane --tail=500 --all-containers=true > /tmp/pod-logs/observer.txt 2>&1 || true
           # openchoreo reconciler (drives data-plane Release/ReleaseBinding rollout)
-          kubectl logs deployment/openchoreo-controller-manager -n openchoreo-control-plane --tail=500 --all-containers=true > /tmp/pod-logs/openchoreo-controller-manager.txt 2>&1 || true
+          kubectl logs deployment/controller-manager -n openchoreo-control-plane --tail=500 --all-containers=true > /tmp/pod-logs/openchoreo-controller-manager.txt 2>&1 || true
           # Cluster-wide pod state, plus Warning events only (surfaces stuck data-plane agent rollouts)
           kubectl get pods -A -o wide > /tmp/pod-logs/all-pods.txt 2>&1 || true
           kubectl get events -A --field-selector type=Warning --sort-by=.lastTimestamp > /tmp/pod-logs/warning-events.txt 2>&1 || true

--- a/test/e2e/framework/amctl/suite.go
+++ b/test/e2e/framework/amctl/suite.go
@@ -17,6 +17,7 @@
 package amctl
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,22 +28,73 @@ import (
 	"github.com/wso2/agent-manager/test/e2e/framework"
 )
 
+// suiteConfig holds optional behavior layered onto a suite registration.
+type suiteConfig struct {
+	// sharedProc1 runs on parallel process 1 during SynchronizedBeforeSuite's
+	// first phase, after the binary is built. Its bytes are broadcast to every
+	// process. nil when the suite needs no shared setup.
+	sharedProc1 func() []byte
+	// sharedEveryProc runs on every process during the second phase, after
+	// login, receiving the bytes sharedProc1 returned. nil when unused.
+	sharedEveryProc func([]byte)
+}
+
+// SuiteOption configures optional behavior on RegisterSuite.
+type SuiteOption func(*suiteConfig)
+
+// WithSharedSetup injects suite-specific provisioning into the single
+// SynchronizedBeforeSuite the harness owns. proc1 runs exactly once on parallel
+// process 1 and returns an opaque payload; everyProc runs on every process with
+// that payload. This lets a suite provision a shared fixture (e.g. a CLI-owned
+// agent) once instead of racing to create it from a per-process BeforeAll, while
+// keeping this package free of any resource specifics. Ginkgo permits only one
+// SynchronizedBeforeSuite per suite, so suites that need shared setup must route
+// it through here rather than registering their own.
+func WithSharedSetup(proc1 func() []byte, everyProc func([]byte)) SuiteOption {
+	return func(c *suiteConfig) {
+		c.sharedProc1 = proc1
+		c.sharedEveryProc = everyProc
+	}
+}
+
+// suitePayload is the SynchronizedBeforeSuite wire format: the built binary path
+// plus an opaque shared-setup blob produced on process 1 and broadcast to all.
+type suitePayload struct {
+	Bin    string `json:"bin"`
+	Shared []byte `json:"shared,omitempty"`
+}
+
 // RegisterSuite wires the per-suite CLI setup and returns a Harness that is
 // populated before specs run. Call it from a CLI suite's package scope:
 //
 //	var H = amctl.RegisterSuite()
 //
 // The binary is built once (parallel process 1) and shared; each process then
-// gets its own isolated $HOME and logs in.
-func RegisterSuite() *Harness {
+// gets its own isolated $HOME and logs in. Pass WithSharedSetup to provision a
+// suite-wide fixture exactly once alongside the binary build.
+func RegisterSuite(opts ...SuiteOption) *Harness {
 	h := &Harness{}
+	var sc suiteConfig
+	for _, opt := range opts {
+		opt(&sc)
+	}
 
 	ginkgo.SynchronizedBeforeSuite(func() []byte {
-		// Process 1 only: build (or locate) the binary a single time.
-		return []byte(buildAmctl())
-	}, func(binPath []byte) {
+		// Process 1 only: build (or locate) the binary a single time, then run
+		// any shared setup so it happens exactly once across all processes.
+		payload := suitePayload{Bin: buildAmctl()}
+		if sc.sharedProc1 != nil {
+			payload.Shared = sc.sharedProc1()
+		}
+		data, err := json.Marshal(payload)
+		Expect(err).NotTo(HaveOccurred(), "marshal suite payload")
+		return data
+	}, func(data []byte) {
 		// Every process: isolated config home + real login.
-		h.bin = string(binPath)
+		var payload suitePayload
+		Expect(json.Unmarshal(data, &payload)).To(Succeed(), "unmarshal suite payload")
+
+		h.bin = payload.Bin
 		if os.Getenv("AMCTL_BIN") == "" {
 			h.builtBinDir = filepath.Dir(h.bin)
 		}
@@ -56,6 +108,10 @@ func RegisterSuite() *Harness {
 		h.home = home
 
 		h.Login(Default)
+
+		if sc.sharedEveryProc != nil {
+			sc.sharedEveryProc(payload.Shared)
+		}
 	})
 
 	ginkgo.SynchronizedAfterSuite(func() {

--- a/test/e2e/framework/shared_agent.go
+++ b/test/e2e/framework/shared_agent.go
@@ -77,17 +77,16 @@ const (
 // CLILifecycleAgent is a handle to the dedicated CLI-owned IT-helpdesk agent:
 // a built/deployed/ready agent the amctl CLI suite drives mutating and
 // observability commands against. Same shape as SharedITHelpdeskAgent but
-// semantically owned by the CLI suite alone.
-// Unlike SharedITHelpdeskAgent it carries no JSON tags: it is a process-local
-// handle created in the CLI suite's BeforeAll and never serialized across
-// processes.
+// semantically owned by the CLI suite alone. It is provisioned once on parallel
+// process 1 and serialized to every process via the suite's
+// SynchronizedBeforeSuite, so its fields carry JSON tags.
 type CLILifecycleAgent struct {
-	ProjectName string
-	AgentName   string
-	BuildName   string
-	EndpointURL string
-	APIKey      string
-	InvokeReq   json.RawMessage
+	ProjectName string          `json:"projectName"`
+	AgentName   string          `json:"agentName"`
+	BuildName   string          `json:"buildName"`
+	EndpointURL string          `json:"endpointURL"`
+	APIKey      string          `json:"apiKey"`
+	InvokeReq   json.RawMessage `json:"invokeReq"`
 }
 
 // SharedITHelpdeskAgent holds details of the shared internal chat agent that is

--- a/test/e2e/tests/cli/agentplatform/agent_llm_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_llm_test.go
@@ -42,8 +42,6 @@ var _ = Describe("amctl agent llm (CLI-owned agent)", Label("cli", "agent", "llm
 	var providerID string
 
 	BeforeAll(func() {
-		ensurePlatformAgent()
-
 		// A config-only provider (no gateway/upstream/api-key) for the agent's
 		// llm config to reference.
 		providerID = framework.E2ELLMProviderPrefix + uuid.New().String()[:8]

--- a/test/e2e/tests/cli/agentplatform/agent_mcp_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_mcp_test.go
@@ -50,8 +50,6 @@ var _ = Describe("amctl agent mcp (CLI-owned agent)", Label("cli", "agent", "mcp
 	var proxyID string
 
 	BeforeAll(func() {
-		ensurePlatformAgent()
-
 		// The agent's mcp config can only bind a catalog proxy, which requires a
 		// gateway deployment — provision one over HTTP (the CLI can't).
 		gatewayUUID := gateway.WaitForActiveGatewayForEnv(apiClient, H.Org(), cfg.DefaultEnv, 3*time.Minute)

--- a/test/e2e/tests/cli/agentplatform/agent_observability_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_observability_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 var _ = Describe("amctl agent (CLI-owned lifecycle)", Label("cli", "agent"), Ordered, func() {
-	BeforeAll(func() {
-		ensurePlatformAgent()
-	})
+	// The CLI-owned agent is provisioned once by the suite's
+	// SynchronizedBeforeSuite (see suite_test.go), so cfg/apiClient/owned are
+	// ready before these specs run — no per-suite BeforeAll setup needed.
 
 	// Deploy/mutation commands. These run first (Ordered) so the observability
 	// specs below assert against a freshly redeployed, ready instance.

--- a/test/e2e/tests/cli/agentplatform/suite_test.go
+++ b/test/e2e/tests/cli/agentplatform/suite_test.go
@@ -17,7 +17,6 @@
 package cliagentplatformtests
 
 import (
-	"sync"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,30 +27,28 @@ import (
 	"github.com/wso2/agent-manager/test/e2e/testsetup"
 )
 
-// H is the shared CLI harness: binary built once, logged in per parallel process.
-var H = amctl.RegisterSuite()
-
-// Per-process shared fixture for the platform-agent suite: the loaded config, an
-// authenticated API client, and the dedicated CLI-owned agent. The observability
-// and agent-llm specs both need these; ensurePlatformAgent provisions them once
-// instead of each spec re-running login and agent setup in its own BeforeAll.
+// Suite-wide shared fixture for the platform-agent suite: the loaded config, an
+// authenticated API client, and the dedicated CLI-owned agent. The agent is
+// provisioned exactly once on parallel process 1 and its handle is broadcast to
+// every process (see WithSharedSetup below), so the observability, llm, and mcp
+// specs all share one built/deployed instance instead of each parallel process
+// racing to create it.
 var (
-	setupOnce sync.Once
 	cfg       *framework.Config
 	apiClient *framework.AMPClient
 	owned     *framework.CLILifecycleAgent
 )
 
-func ensurePlatformAgent() {
-	setupOnce.Do(func() {
-		var err error
-		cfg = framework.LoadConfig()
-		apiClient, err = framework.NewAMPClient(cfg)
-		Expect(err).NotTo(HaveOccurred())
-		// Idempotent: builds/provisions the CLI-owned agent only on first call.
-		owned = testsetup.SetupCLILifecycleAgent(apiClient, cfg)
-	})
-}
+// H is the shared CLI harness: binary built once, logged in per parallel
+// process. It also carries the once-only provisioning of the CLI-owned agent,
+// folded into the harness's single SynchronizedBeforeSuite (Ginkgo allows only
+// one). Provisioning over the API client racing concurrently across processes is
+// exactly what produced the "already exists" creates and wedged deployments.
+var H = amctl.RegisterSuite(
+	amctl.WithSharedSetup(
+		testsetup.SynchronizedCLILifecycleAgent(&cfg, &apiClient, &owned),
+	),
+)
 
 func TestCLIAgentPlatform(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/test/e2e/testsetup/setup_shared_agents.go
+++ b/test/e2e/testsetup/setup_shared_agents.go
@@ -105,6 +105,37 @@ func SynchronizedITHelpdeskAgent(
 	client **framework.AMPClient,
 	agent **framework.SharedITHelpdeskAgent,
 ) (func() []byte, func([]byte)) {
+	return synchronizedAgentSetup(provision, cfg, client, agent)
+}
+
+// SynchronizedCLILifecycleAgent returns the two SynchronizedBeforeSuite phase
+// functions for the amctl CLI platform-agent suite. Phase 1 provisions the
+// dedicated CLI-owned agent exactly once on parallel process 1; phase 2 runs on
+// every process to build its own API client and decode the shared handle.
+//
+// Wire it into the harness's single SynchronizedBeforeSuite via
+// amctl.WithSharedSetup. Doing so keeps the CLI-owned agent from being created
+// concurrently by each parallel process — the race that otherwise produced
+// "already exists" creates and deployments wedged into a failed state.
+func SynchronizedCLILifecycleAgent(
+	cfg **framework.Config,
+	client **framework.AMPClient,
+	agent **framework.CLILifecycleAgent,
+) (func() []byte, func([]byte)) {
+	return synchronizedAgentSetup(SetupCLILifecycleAgent, cfg, client, agent)
+}
+
+// synchronizedAgentSetup builds the generic two-phase SynchronizedBeforeSuite
+// functions around a provisioner that runs once on process 1. Phase 1 sets up a
+// client, calls provision, and returns the resulting handle as JSON; phase 2
+// runs on every process to build that process's own client and decode the
+// handle into the provided pointers.
+func synchronizedAgentSetup[T any](
+	provision func(*framework.AMPClient, *framework.Config) *T,
+	cfg **framework.Config,
+	client **framework.AMPClient,
+	agent **T,
+) (func() []byte, func([]byte)) {
 	phase1 := func() []byte {
 		c := framework.LoadConfig()
 		ginkgo.By("Waiting for API readiness")
@@ -125,7 +156,7 @@ func SynchronizedITHelpdeskAgent(
 		cl, err := framework.NewAMPClient(*cfg)
 		Expect(err).NotTo(HaveOccurred(), "failed to create API client")
 		*client = cl
-		a := &framework.SharedITHelpdeskAgent{}
+		a := new(T)
 		Expect(json.Unmarshal(data, a)).To(Succeed(), "failed to decode agent")
 		*agent = a
 	}


### PR DESCRIPTION
## Purpose
The nightly e2e run's **CLI Platform Agent Suite** (`test/e2e/tests/cli/agentplatform`, run under `ginkgo -p`) had two failures:

1. **`HTTP 409 CONFLICT` on agent create.** The suite's three `Ordered` Describe blocks (agent/llm/mcp) are distributed across parallel processes. Each process guarded setup with its **own** per-process `sync.Once` (`ensurePlatformAgent`), so two processes concurrently `CreateAgent`'d the same `e2e-cli-it-helpdesk` (~11 ms apart); the loser got a 409 and its `BeforeAll` aborted.
2. **Deployment wedged into terminal `failed`.** The race winner built fine but its deploy reached terminal `failed` and the spec failed fast. This is exactly the failure mode the existing `SynchronizedSharedITHelpdeskAgent` doc comment warns about ("racy 'already exists' creates and the self-heal delete/recreate that wedges the deployment into a failed state").

Separately, the on-failure **pod-log dump** targeted `deployment/openchoreo-controller-manager`, which does not exist (the openchoreo reconciler Deployment is `controller-manager` in `openchoreo-control-plane`), so the one component that explains a wedged data-plane rollout was never captured.

## Goals
- Provision the CLI-owned agent **exactly once across all parallel processes**, eliminating the concurrent-create race (and the deployment contention it caused).
- Capture the correct openchoreo reconciler logs on e2e failure so future deploy failures are diagnosable.

## Approach
The HTTP suites already solve cross-process provisioning with `SynchronizedBeforeSuite` (provision once on process 1, broadcast the handle as JSON to every process). The CLI suite didn't adopt it because the amctl harness already owns the suite's single `SynchronizedBeforeSuite` and Ginkgo permits only one.

- **`framework/amctl/suite.go`** — `RegisterSuite` gains an opt-in `WithSharedSetup(proc1, everyProc)` option that folds suite-specific provisioning into the harness's existing `SynchronizedBeforeSuite` via an opaque payload. The package stays resource-agnostic. No-arg callers (the other CLI suites) are unaffected (variadic).
- **`testsetup/setup_shared_agents.go`** — added `SynchronizedCLILifecycleAgent` plus a generic `synchronizedAgentSetup[T]` helper; refactored the existing `SynchronizedITHelpdeskAgent` to delegate to it (no behavior change).
- **`framework/shared_agent.go`** — `CLILifecycleAgent` is now serialized across processes, so it carries JSON tags (comment corrected).
- **`tests/cli/agentplatform/suite_test.go`** — replaced the per-process `sync.Once`/`ensurePlatformAgent` with `amctl.RegisterSuite(amctl.WithSharedSetup(testsetup.SynchronizedCLILifecycleAgent(&cfg, &apiClient, &owned)))`; removed the now-redundant `ensurePlatformAgent()` calls from the three specs' `BeforeAll`s.
- **`.github/workflows/{e2e,nightly}.yml`** — dump step now targets `deployment/controller-manager -n openchoreo-control-plane`.

## User stories
N/A — internal e2e test-harness and CI reliability change; no end-user-facing behavior.

## Release note
N/A — test infrastructure and CI diagnostics only; no product change.

## Documentation
N/A — no product behavior or API change.

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — internal test reliability fix.

## Automation tests
 - Unit tests
   > N/A — the change *is* to the e2e test harness. Verified it builds and type-checks: `go build ./...` and `go vet ./...` (vet type-checks `_test.go` files) pass in the `test/e2e` module; `go test -c` compiles the agentplatform suite and the sibling CLI suites (agent/project/llmprovider) that share `RegisterSuite`.
 - Integration tests
   > This change targets the CLI Platform Agent e2e suite itself. The full suite runs against a live k3d cluster via the nightly/e2e GitHub Actions workflow; the new wiring uses the same `SynchronizedBeforeSuite` mechanism already proven by the monitors/traces/configuration HTTP suites.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** — Go test-harness/CI change; FindSecurityBugs is a Java SpotBugs plugin and does not apply.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A.

## Related PRs
Builds on #1189 (the amctl CLI agent-mcp e2e specs on the `agent-mcp-cli-e2e-tests` branch).

## Migrations (if applicable)
N/A — no schema or data migrations.

## Test environment
Local: macOS (darwin), Go 1.25.7 — build/vet/test-compile only. Full suite execution: GitHub Actions e2e/nightly workflow on a k3d cluster.

## Learning
Root-caused from the failed nightly run's step logs plus the `pod-logs` artifact (warning-events/all-pods showed CPU-pressure scheduling failures and the absence of a data-plane pod for the CLI agent). The fix mirrors the repo's existing `SynchronizedBeforeSuite` provisioning pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure diagnostics in E2E and nightly workflows by collecting the correct controller-manager logs.
  * Made shared CLI agent setup more reliable across parallel E2E processes, reducing duplicated setup and inconsistent test behavior.
* **Chores**
  * Updated E2E test harness internals to support suite-wide shared setup for parallel runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->