### PR TITLE
Fix CLI e2e config name collision on shared agent

### DIFF
--- a/test/e2e/tests/cli/agentplatform/agent_llm_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_llm_test.go
@@ -35,7 +35,8 @@ import (
 
 var _ = Describe("amctl agent llm (CLI-owned agent)", Label("cli", "agent", "llm"), Ordered, func() {
 	const (
-		configName = "primary"
+		// Distinct from the mcp spec: config names are unique per agent across types and both specs share this agent.
+		configName = "llm-primary"
 		urlEnv     = "E2E_LLM_URL"
 		apiKeyEnv  = "E2E_LLM_KEY"
 	)

--- a/test/e2e/tests/cli/agentplatform/agent_mcp_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_mcp_test.go
@@ -43,7 +43,8 @@ import (
 
 var _ = Describe("amctl agent mcp (CLI-owned agent)", Label("cli", "agent", "mcp"), Ordered, func() {
 	const (
-		configName = "primary"
+		// Distinct from the llm spec: config names are unique per agent across types and both specs share this agent.
+		configName = "mcp-primary"
 		urlEnv     = "E2E_MCP_URL"
 		apiKeyEnv  = "E2E_MCP_KEY"
 	)


### PR DESCRIPTION
## Purpose
A follow-up to #1191. That PR made the amctl CLI platform-agent suite provision its CLI-owned agent **once across all parallel processes** (eliminating the agent-create 409 race). With the agent now shared cleanly, **both** Ordered specs that mutate it — `agent llm` and `agent mcp` — run on separate `ginkgo -p` processes and ran concurrently for the first time, surfacing a latent collision:

```
agent llm set e2e-cli-it-helpdesk --name primary ... → exit 1
{ "error": { "status": 409, "code": "CONFLICT", "message": "Agent configuration already exists" } }
```

Both specs created a config named **`primary`** on the same shared agent. The DB constraint that enforces config-name uniqueness is type-agnostic:

```
db_migrations/008_create_agent_configurations.go:40
CONSTRAINT uq_agent_config_name UNIQUE(agent_id, name, organization_name, project_name)
```

`type_id` is not part of the key, so an `llm` config and an `mcp` config cannot share the name `primary` on one agent. The two specs raced to insert the same row; the loser hit Postgres `23505` → `ErrAgentConfigAlreadyExists` → the controller's LLM branch (`agent_configuration_controller.go:105`) → the 409 above. Before #1191 the agent-create race meant only one of the two specs ever ran its `It`s, which masked the collision.

## Goals
- Let the `agent llm` and `agent mcp` specs run concurrently against the shared CLI-owned agent without colliding on a config name.

## Approach
The two specs are independent and nothing requires the literal name `primary`, so give each a distinct name so their parallel writes land on different rows:
- `agent_llm_test.go` — `configName = "llm-primary"`
- `agent_mcp_test.go` — `configName = "mcp-primary"`

Added a comment in each file explaining the per-agent (type-agnostic) uniqueness rule, so the two are not later "simplified" back to a shared `primary` and reintroduce the race. The shared-agent design and the DB constraint are intentional and left untouched; sharing the agent stays valid because the writes now target different rows.

## User stories
N/A — internal e2e test-harness reliability change; no end-user-facing behavior.

## Release note
N/A — test infrastructure only; no product change.

## Documentation
N/A — no product behavior or API change.

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — internal test reliability fix.

## Automation tests
 - Unit tests
   > N/A — the change is to the e2e test specs themselves. Verified it builds and type-checks: `go build ./...`, `go vet ./tests/cli/agentplatform/...`, and `go test -c` (test-compile) all pass in the `test/e2e` module.
 - Integration tests
   > This change targets the CLI Platform Agent e2e suite. The full suite runs against a live k3d cluster via the nightly/e2e GitHub Actions workflow; CI starts from a fresh DB each run, so the only trigger for this 409 was the cross-spec name collision the fix removes.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** — Go test-spec change; FindSecurityBugs is a Java SpotBugs plugin and does not apply.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A.

## Related PRs
Follow-up to #1191 (provisioned the CLI-owned agent once across parallel processes), which exposed this collision.

## Migrations (if applicable)
N/A — no schema or data migrations.

## Test environment
Local: macOS (darwin), Go 1.25.7 — build/vet/test-compile only. Full suite execution: GitHub Actions e2e/nightly workflow on a k3d cluster.

## Learning
Once #1191 stopped the agent-create race, the two config-mutating specs ran concurrently for the first time and collided on a shared config name. Root-caused by tracing the 409 to the type-agnostic `uq_agent_config_name` constraint rather than re-patching the harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CLI-owned agent end-to-end tests to use distinct configuration names for different agent workflows.
  * Prevented intermittent “configuration already exists” conflicts when test suites run in parallel.
  * Kept create, get, list, update, unset, and not-found checks unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->