### PR TITLE
Use X-API-Key header for org-level provider invocation in docs

### DIFF
--- a/documentation/docs/tutorials/configure-agent-llm-configuration.mdx
+++ b/documentation/docs/tutorials/configure-agent-llm-configuration.mdx
@@ -78,7 +78,7 @@ apikey = os.environ.get('OPENAI_API_KEY')
 client = OpenAI(
     base_url=url,
     api_key="",
-    default_headers={"API-Key": apikey, "Authorization": ""}
+    default_headers={"X-API-Key": apikey, "Authorization": ""}
 )
 ```
 
@@ -181,7 +181,7 @@ Immediately after saving, the **Connect to LLM Provider** panel opens automatica
 | Field | Description |
 |---|---|
 | **Endpoint URL** | The gateway URL for this provider — use this as the base URL in your LLM client |
-| **Header Name** | The HTTP header to pass the API key (`API-Key`) |
+| **Header Name** | The HTTP header to pass the API key (`X-API-Key`) |
 | **API Key** | The generated client key — **copy it now**, it will not be shown again |
 | **Example cURL** | A ready-to-use cURL command showing the Endpoint URL, Header Name, and API Key together |
 
@@ -189,11 +189,11 @@ Example cURL:
 
 ```bash
 curl -X POST <endpoint-url> \
-  --header "API-Key: <your-api-key>" \
+  --header "X-API-Key: <your-api-key>" \
   -d '{"model": "", "messages": [{"role": "user", "content": "Hi..."}]}'
 ```
 
-Configure your agent's LLM client using the Endpoint URL as the base URL and pass the API Key in the `API-Key` header on every request.
+Configure your agent's LLM client using the Endpoint URL as the base URL and pass the API Key in the `X-API-Key` header on every request.
 
 You can reopen the connection details panel at any time from the LLM configuration detail page by clicking **Connect to LLM Provider** in the top-right corner. However, the API Key is only displayed once at creation time — if lost, delete the configuration and re-add it to generate a new key.
 

--- a/documentation/docs/tutorials/configure-agent-mcp-proxies.mdx
+++ b/documentation/docs/tutorials/configure-agent-mcp-proxies.mdx
@@ -74,7 +74,7 @@ server_configs: dict[str, dict[str, Any]] = {
         "url": url,
         "transport": "streamable_http",
         "headers": {
-            "API-Key": mcp_api_key,
+            "X-API-Key": mcp_api_key,
             "Authorization": "",
         },
     }


### PR DESCRIPTION
## Purpose

Correct the documentation for **organization-level LLM Service Providers** (and the MCP proxy code snippet) so the API key is passed in the `X-API-Key` header. The "Next" docs previously instructed callers to use an `API-Key` header for org-level provider invocation, which does not match the gateway, which expects `X-API-Key`.

## Goals

- Make the docs consistent with the gateway's actual inbound auth header (`X-API-Key`) for org-level provider invocation.
- Align all header references across the tutorials docs.

## Approach

Updated the `Next` (current) docs only — versioned docs were left untouched:

- `documentation/docs/tutorials/configure-agent-llm-configuration.mdx` — Python snippet, Header Name table row, example cURL, and prose (4 occurrences) `API-Key` → `X-API-Key`.
- `documentation/docs/tutorials/configure-agent-mcp-proxies.mdx` — Python snippet (1 occurrence) `API-Key` → `X-API-Key`.

The registration, secure-endpoints, MCP-proxy cURL, and CORS docs already used `X-API-Key`, so the tutorial set is now fully consistent.

## User stories

N/A — documentation-only correction.

## Release note

Docs: org-level LLM/MCP provider invocation examples now use the correct `X-API-Key` header.

## Documentation

This PR is the documentation change.

## Training

N/A — no training impact.

## Certification

N/A — no certification impact.

## Marketing

N/A — internal docs correction.

## Automation tests

**Unit tests:** N/A — docs-only change.
**Integration tests:** N/A — docs-only change.

## Security checks

- Did you add or modify any encrypted secrets? **No**
- Did you add or modify any code that handles authentication/authorization? **No** — docs only; describes an existing header.
- Did you add or modify any dependencies? **No**

## Samples

N/A — no samples affected.

## Related PRs

N/A

## Migrations

N/A — no DB migrations.

## Test environment

N/A — docs-only.

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent setup examples to use the `X-API-Key` header consistently when connecting to LLM providers and MCP proxies.
  * Clarified the sample request headers and command-line examples so they match the expected authentication format.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->