### PR TITLE
Return external trace observer URL to CLI via v1/config

### DIFF
--- a/agent-manager-service/api/config_handler.go
+++ b/agent-manager-service/api/config_handler.go
@@ -30,7 +30,7 @@ func registerConfigRoutes(mux *http.ServeMux) {
 		cfg := config.GetConfig()
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(spec.ConfigResponse{
-			TraceObserverBaseUrl: cfg.TraceObserver.URL,
+			TraceObserverBaseUrl: cfg.TraceObserver.PublicURL,
 		}); err != nil {
 			logger.GetLogger(r.Context()).Error("failed to encode config response", "error", err)
 		}

--- a/agent-manager-service/api/config_handler_test.go
+++ b/agent-manager-service/api/config_handler_test.go
@@ -35,11 +35,11 @@ func setupConfigMux() *http.ServeMux {
 func withTraceObserverURL(t *testing.T, url string) {
 	t.Helper()
 	cfg := config.GetConfig()
-	orig := cfg.TraceObserver.URL
+	orig := cfg.TraceObserver.PublicURL
 	t.Cleanup(func() {
-		cfg.TraceObserver.URL = orig
+		cfg.TraceObserver.PublicURL = orig
 	})
-	cfg.TraceObserver.URL = url
+	cfg.TraceObserver.PublicURL = url
 }
 
 func TestConfigEndpoint_HappyPath(t *testing.T) {

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -221,8 +221,13 @@ type OTELConfig struct {
 }
 
 type TraceObserverConfig struct {
-	// Trace observer service URL
+	// URL is the trace observer service URL the agent-manager-service itself
+	// uses (server-side, in-cluster) to query trace data.
 	URL string
+	// PublicURL is the externally reachable trace observer URL handed to
+	// out-of-cluster clients (e.g. the CLI) via the /v1/config endpoint. It
+	// mirrors the URL the console uses for the trace observer.
+	PublicURL string
 }
 
 type ObserverConfig struct {

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -225,7 +225,7 @@ type TraceObserverConfig struct {
 	// uses (server-side, in-cluster) to query trace data.
 	URL string
 	// PublicURL is the externally reachable trace observer URL handed to
-	// out-of-cluster clients (e.g. the CLI) via the /v1/config endpoint. It
+	// out-of-cluster clients (e.g. the CLI) via the GET /api/v1/config endpoint. It
 	// mirrors the URL the console uses for the trace observer.
 	PublicURL string
 }

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -130,9 +130,15 @@ func loadEnvs() {
 		URL: r.readOptionalString("OBSERVER_URL", "http://localhost:8085"),
 	}
 
-	// Trace Observer service configuration - temporarily use localhost for agent-manager-service to access trace observer service
+	// Trace Observer service configuration.
+	// URL is used server-side (in-cluster) by the agent-manager-service to
+	// query trace data. PublicURL is the externally reachable URL handed to
+	// out-of-cluster clients (e.g. the CLI) via /v1/config; it mirrors the
+	// console's trace observer URL and falls back to URL when unset.
+	traceObserverURL := r.readOptionalString("TRACE_OBSERVER_URL", "http://localhost:9098")
 	config.TraceObserver = TraceObserverConfig{
-		URL: r.readOptionalString("TRACE_OBSERVER_URL", "http://localhost:9098"),
+		URL:       traceObserverURL,
+		PublicURL: r.readOptionalString("TRACE_OBSERVER_PUBLIC_URL", traceObserverURL),
 	}
 
 	config.InstrumentationURL = r.readOptionalString("INSTRUMENTATION_URL", "http://default-default.gateway.localhost:19080/otel")

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -133,7 +133,7 @@ func loadEnvs() {
 	// Trace Observer service configuration.
 	// URL is used server-side (in-cluster) by the agent-manager-service to
 	// query trace data. PublicURL is the externally reachable URL handed to
-	// out-of-cluster clients (e.g. the CLI) via /v1/config; it mirrors the
+	// out-of-cluster clients (e.g. the CLI) via GET /api/v1/config; it mirrors the
 	// console's trace observer URL and falls back to URL when unset.
 	traceObserverURL := r.readOptionalString("TRACE_OBSERVER_URL", "http://localhost:9098")
 	config.TraceObserver = TraceObserverConfig{
@@ -266,6 +266,7 @@ func loadEnvs() {
 	validateOAuthAuthorizationServers(config, r)
 	validateServerPublicURL(config, r)
 	validateInstrumentationURL(config, r)
+	validateTraceObserverURLs(config, r)
 	validateResourceLimitsConfig(config, r)
 	validateAgentWorkloadCORSConfig(agentWorkloadConfig, r)
 
@@ -344,6 +345,27 @@ func validateInstrumentationURL(cfg *Config, r *configReader) {
 	if u.Host == "" {
 		r.errors = append(r.errors, fmt.Errorf("INSTRUMENTATION_URL %q must have a non-empty host", cfg.InstrumentationURL))
 	}
+}
+
+func validateTraceObserverURLs(cfg *Config, r *configReader) {
+	validate := func(envVar, raw string) {
+		if raw == "" {
+			return
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			r.errors = append(r.errors, fmt.Errorf("%s %q is not a valid URL: %w", envVar, raw, err))
+			return
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			r.errors = append(r.errors, fmt.Errorf("%s %q must use http or https scheme", envVar, raw))
+		}
+		if u.Host == "" {
+			r.errors = append(r.errors, fmt.Errorf("%s %q must have a non-empty host", envVar, raw))
+		}
+	}
+	validate("TRACE_OBSERVER_URL", cfg.TraceObserver.URL)
+	validate("TRACE_OBSERVER_PUBLIC_URL", cfg.TraceObserver.PublicURL)
 }
 
 func validateInternalServerConfigs(cfg *Config, r *configReader) {

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -170,3 +170,78 @@ func TestValidateServerPublicURL(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTraceObserverURLs(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		publicURL   string
+		wantErrors  int
+		errContains string
+	}{
+		{
+			name:       "valid in-cluster and public URLs",
+			url:        "http://amp-traces-observer.openchoreo-observability-plane.svc.cluster.local:9098",
+			publicURL:  "https://traces.example.com",
+			wantErrors: 0,
+		},
+		{
+			name:       "valid http URL with port",
+			url:        "http://localhost:9098",
+			publicURL:  "http://localhost:9098",
+			wantErrors: 0,
+		},
+		{
+			name:        "malformed in-cluster URL rejected",
+			url:         "not-a-url",
+			publicURL:   "https://traces.example.com",
+			wantErrors:  2, // missing scheme + missing host
+			errContains: "TRACE_OBSERVER_URL",
+		},
+		{
+			name:        "malformed public URL rejected",
+			url:         "http://localhost:9098",
+			publicURL:   "not-a-url",
+			wantErrors:  2, // missing scheme + missing host
+			errContains: "TRACE_OBSERVER_PUBLIC_URL",
+		},
+		{
+			name:        "non-http(s) scheme rejected",
+			url:         "ftp://traces.example.com",
+			publicURL:   "https://traces.example.com",
+			wantErrors:  1,
+			errContains: "must use http or https",
+		},
+		{
+			name:        "missing host rejected",
+			url:         "http://localhost:9098",
+			publicURL:   "https://",
+			wantErrors:  1,
+			errContains: "must have a non-empty host",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{TraceObserver: TraceObserverConfig{URL: tc.url, PublicURL: tc.publicURL}}
+			r := &configReader{}
+			validateTraceObserverURLs(cfg, r)
+
+			if len(r.errors) != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tc.wantErrors, len(r.errors), r.errors)
+			}
+			if tc.errContains != "" {
+				found := false
+				for _, e := range r.errors {
+					if strings.Contains(e.Error(), tc.errContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected an error containing %q, got %v", tc.errContains, r.errors)
+				}
+			}
+		})
+	}
+}

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -56,6 +56,9 @@ services:
       # - OPENSEARCH_URL=http://host.docker.internal:9200
       - OBSERVER_URL=http://host.docker.internal:8085
       - TRACE_OBSERVER_URL=http://host.docker.internal:9098
+      # Externally reachable trace observer URL returned to the CLI via /v1/config.
+      # Mirrors the console's OBS_API_BASE_URL so the CLI and console agree.
+      - TRACE_OBSERVER_PUBLIC_URL=http://localhost:9098
       - IDP_TOKEN_URL=http://thunder.amp.localhost:8080/oauth2/token
       - IDP_CLIENT_ID=amp-api-client
       - IDP_CLIENT_SECRET=amp-api-client-secret

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -8,6 +8,10 @@ metadata:
 data:
   OBSERVER_URL: {{ .Values.agentManagerService.config.observerURL | quote }}
   TRACE_OBSERVER_URL: {{ .Values.agentManagerService.config.traceObserverURL | quote }}
+  # Externally reachable trace observer URL handed to out-of-cluster clients
+  # (e.g. the CLI) via /v1/config. Mirrors the console's trace observer URL
+  # (console.config.obsApiBaseUrl) so both point at the same endpoint.
+  TRACE_OBSERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.traceObserverPublicURL | default .Values.console.config.obsApiBaseUrl | quote }}
   SERVER_HOST: {{ .Values.agentManagerService.config.serverHost | quote }}
   SERVER_PORT: {{ .Values.agentManagerService.service.targetPort | quote }}
   LOG_LEVEL: {{ .Values.agentManagerService.config.logLevel | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -102,7 +102,12 @@ agentManagerService:
     # Enable RBAC enforcement on all routes
     rbacEnabled: "true"
     observerURL: "http://observer.openchoreo-observability-plane.svc.cluster.local:8080"
+    # In-cluster URL the agent-manager-service uses to query trace data server-side.
     traceObserverURL: "http://amp-traces-observer.openchoreo-observability-plane.svc.cluster.local:9098"
+    # Externally reachable trace observer URL returned to out-of-cluster clients
+    # (e.g. the CLI) via /v1/config. Leave empty to inherit the console's URL
+    # (console.config.obsApiBaseUrl) so the CLI and console use the same endpoint.
+    traceObserverPublicURL: ""
 
 
     # TLS Configuration


### PR DESCRIPTION
## Purpose

Fix the trace observer URL that `am-svc`'s `GET /api/v1/config` endpoint returns to the CLI. It was returning the cluster-internal service DNS name (`http://amp-traces-observer.openchoreo-observability-plane.svc.cluster.local:9098`), which the CLI cannot resolve because it runs outside the cluster (e.g. on the e2e runner / a developer machine). This caused trace-observer access to fail during the nightly e2e tests.

## Goals

- The CLI receives an externally reachable trace observer URL — the same endpoint the console uses (`console.config.obsApiBaseUrl`).
- The agent-manager-service keeps using the in-cluster URL for its own server-side trace queries (MCP observability handler).

## Approach

`TRACE_OBSERVER_URL` was overloaded: it was used both server-side (in-cluster, needs the cluster DNS name) and returned to the CLI via `/v1/config` (needs the external URL). These two consumers need different values, so the config is split:

- Added `TraceObserverConfig.PublicURL`, loaded from a new env var `TRACE_OBSERVER_PUBLIC_URL`, falling back to `TRACE_OBSERVER_URL` when unset (keeps docker-compose behavior unchanged).
- `/api/v1/config` now returns `PublicURL` instead of `URL`.
- Helm: new `TRACE_OBSERVER_PUBLIC_URL` env in the configmap, defaulting to `console.config.obsApiBaseUrl`, so the CLI and console are wired to the same endpoint. New `agentManagerService.config.traceObserverPublicURL` value (empty → inherits the console URL).

Server-side MCP trace queries continue to use the in-cluster `TRACE_OBSERVER_URL`.

## User stories

N/A — internal configuration fix, no user-facing story.

## Release note

Fix trace observer URL returned by `/v1/config` so the CLI uses the same externally reachable endpoint as the console.

## Documentation

N/A — no documented behavior changes.

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

**Unit:** Existing `agent-manager-service/api/config_handler_test.go` updated to exercise the new `PublicURL` field; the endpoint contract (JSON field `traceObserverBaseUrl`) is unchanged.

**Integration:** Covered by the existing nightly e2e pipeline, which is what surfaced the bug.

## Security checks

- Have you used the secure coding practices required by the company? **Yes**
- Have you introduced any new dependencies? **No**
- Does this PR introduce any change to how secrets/credentials are handled? **No**

## Samples

N/A

## Related PRs

N/A

## Migrations

N/A — no database or schema changes.

## Test environment

Local build/vet/gofmt verified. Full e2e validation runs via the nightly pipeline.

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a public, externally reachable trace observer URL for out-of-cluster clients.
  * The configuration endpoint now exposes the public trace observer URL.
* **Bug Fixes**
  * Improved separation between in-cluster and external trace observer endpoints to keep values consistent across environments.
* **Documentation**
  * Updated Helm chart values and configuration comments to explain `TRACE_OBSERVER_PUBLIC_URL` behavior and defaults.
* **Tests**
  * Added coverage for trace observer URL validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->