### PR TITLE
Tear down CLI-owned e2e agent when its suite ends

### DIFF
--- a/test/e2e/framework/amctl/suite.go
+++ b/test/e2e/framework/amctl/suite.go
@@ -37,6 +37,9 @@ type suiteConfig struct {
 	// sharedEveryProc runs on every process during the second phase, after
 	// login, receiving the bytes sharedProc1 returned. nil when unused.
 	sharedEveryProc func([]byte)
+	// sharedTeardownProc1 runs on process 1 in SynchronizedAfterSuite, after all
+	// specs finish, to tear down whatever sharedProc1 provisioned. nil when unused.
+	sharedTeardownProc1 func()
 }
 
 // SuiteOption configures optional behavior on RegisterSuite.
@@ -54,6 +57,16 @@ func WithSharedSetup(proc1 func() []byte, everyProc func([]byte)) SuiteOption {
 	return func(c *suiteConfig) {
 		c.sharedProc1 = proc1
 		c.sharedEveryProc = everyProc
+	}
+}
+
+// WithSharedTeardown registers teardown that runs once on process 1 after all
+// specs finish — the counterpart to WithSharedSetup's proc1 provisioning, for
+// deleting a once-provisioned fixture. Should be best-effort. Ginkgo allows only
+// one SynchronizedAfterSuite per suite, so teardown must route through here.
+func WithSharedTeardown(proc1 func()) SuiteOption {
+	return func(c *suiteConfig) {
+		c.sharedTeardownProc1 = proc1
 	}
 }
 
@@ -120,7 +133,10 @@ func RegisterSuite(opts ...SuiteOption) *Harness {
 			_ = os.RemoveAll(h.home)
 		}
 	}, func() {
-		// Process 1 only: drop the built binary (skipped when AMCTL_BIN was used).
+		// Process 1 only: tear down the shared fixture, then drop the binary.
+		if sc.sharedTeardownProc1 != nil {
+			sc.sharedTeardownProc1()
+		}
 		if h.builtBinDir != "" {
 			_ = os.RemoveAll(h.builtBinDir)
 		}

--- a/test/e2e/framework/shared_agent.go
+++ b/test/e2e/framework/shared_agent.go
@@ -64,13 +64,15 @@ const E2ESharedKindName = "e2e-it-helpdesk-kind"
 const E2ESharedKindVersion = "1.0.0"
 
 const (
-	// E2ECLIProjectName is the dedicated project owning the amctl CLI e2e
-	// suite's agent. Stable + reused across runs (not swept), so the suite can
-	// mutate (deploy/redeploy) without touching the shared agent the HTTP
-	// observability suites read.
-	E2ECLIProjectName = "e2e-cli-shared"
-	// CLILifecycleAgentName is the dedicated internal agent the amctl CLI
-	// suite builds, redeploys, and observes.
+	// E2ECLIProjectPrefix is the prefix for projects owned solely by the amctl
+	// CLI e2e suite. Distinct from E2EProjectPrefix so the suite can mutate its
+	// own agent freely; the stale sweep reaps it as a teardown backstop.
+	E2ECLIProjectPrefix = "e2e-cli-"
+	// E2ECLIProjectName is the project owning the CLI suite's agent. Torn down on
+	// exit (amctl.WithSharedTeardown) and rebuilt fresh next run.
+	E2ECLIProjectName = E2ECLIProjectPrefix + "shared"
+	// CLILifecycleAgentName is the agent the amctl CLI suite builds, redeploys,
+	// and observes.
 	CLILifecycleAgentName = "e2e-cli-it-helpdesk"
 )
 

--- a/test/e2e/tests/cli/agentplatform/suite_test.go
+++ b/test/e2e/tests/cli/agentplatform/suite_test.go
@@ -48,6 +48,10 @@ var H = amctl.RegisterSuite(
 	amctl.WithSharedSetup(
 		testsetup.SynchronizedCLILifecycleAgent(&cfg, &apiClient, &owned),
 	),
+	// Tear the CLI-owned agent + project down when the suite ends.
+	amctl.WithSharedTeardown(
+		testsetup.CleanupCLILifecycleAgent(&apiClient, &cfg),
+	),
 )
 
 func TestCLIAgentPlatform(t *testing.T) {

--- a/test/e2e/testsetup/cleanup.go
+++ b/test/e2e/testsetup/cleanup.go
@@ -64,7 +64,10 @@ func CleanupStaleE2EResources(client *framework.AMPClient, orgName string) {
 	}
 
 	for _, proj := range projects.Projects {
-		if !strings.HasPrefix(proj.Name, framework.E2EProjectPrefix) {
+		// e2e-cli-* is the CLI suite's own project, swept here as a backstop
+		// when a run dies before its teardown.
+		if !strings.HasPrefix(proj.Name, framework.E2EProjectPrefix) &&
+			!strings.HasPrefix(proj.Name, framework.E2ECLIProjectPrefix) {
 			continue
 		}
 		if time.Since(proj.CreatedAt) < cutoff {

--- a/test/e2e/testsetup/setup_shared_agents.go
+++ b/test/e2e/testsetup/setup_shared_agents.go
@@ -19,6 +19,7 @@ package testsetup
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -189,6 +190,53 @@ func SetupCLILifecycleAgent(client *framework.AMPClient, cfg *framework.Config) 
 	ginkgo.GinkgoWriter.Printf("CLI lifecycle agent ready: project=%s agent=%s endpoint=%s\n",
 		agent.ProjectName, agent.AgentName, agent.EndpointURL)
 	return agent
+}
+
+// CleanupCLILifecycleAgent returns a best-effort teardown that deletes the
+// CLI-owned agent and its project. The agent is owned solely by this suite, so
+// it is safe to drop on exit. It deletes by constant name (not the provisioned
+// handle) so cleanup runs even if provisioning partially failed. Wire it via
+// amctl.WithSharedTeardown to run once on process 1 after all specs finish.
+func CleanupCLILifecycleAgent(client **framework.AMPClient, cfg **framework.Config) func() {
+	return func() {
+		if client == nil || *client == nil || cfg == nil || *cfg == nil {
+			ginkgo.GinkgoWriter.Println("teardown: CLI lifecycle agent cleanup skipped (client/config unset)")
+			return
+		}
+		cl, c := *client, *cfg
+		// Agent before project (LIFO), mirroring the per-test cleanup order.
+		agentops.DeleteAgentBestEffort(cl, c.DefaultOrg, framework.E2ECLIProjectName, framework.CLILifecycleAgentName)
+		deleteProjectBestEffort(cl, c.DefaultOrg, framework.E2ECLIProjectName)
+	}
+}
+
+// deleteProjectBestEffort deletes a project without failing the suite. A 409
+// (agent cascade still in flight) is retried; other non-2xx is logged and left
+// for the stale sweep.
+func deleteProjectBestEffort(client *framework.AMPClient, orgName, projName string) {
+	projPath := fmt.Sprintf("/api/v1/orgs/%s/projects/%s", orgName, projName)
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			time.Sleep(3 * time.Second)
+		}
+		resp, err := client.Delete(projPath)
+		if err != nil {
+			ginkgo.GinkgoWriter.Printf("teardown: delete project %q failed: %v\n", projName, err)
+			return
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+			ginkgo.GinkgoWriter.Printf("teardown: deleted project %q (status %d)\n", projName, resp.StatusCode)
+			return
+		}
+		if resp.StatusCode == http.StatusConflict && attempt < 4 {
+			ginkgo.GinkgoWriter.Printf("teardown: project %q still has resources, retrying...\n", projName)
+			continue
+		}
+		ginkgo.GinkgoWriter.Printf("teardown: delete project %q returned status %d (left for stale sweep)\n",
+			projName, resp.StatusCode)
+		return
+	}
 }
 
 // SetupSharedPromotableITHelpdeskAgent provisions the shared promotable IT


### PR DESCRIPTION
## Purpose

The amctl CLI platform-agent e2e suite provisions a dedicated agent (`e2e-cli-it-helpdesk`) in its own project (`e2e-cli-shared`) once on parallel process 1. Until now nothing ever deleted it: it was intentionally excluded from the stale-resource sweep (which only reaps `e2e-test-*`), so the agent and project leaked indefinitely. This wires up an always-on teardown so the CLI suite cleans up the resources it fully owns when it ends.

For:
- https://github.com/wso2/agent-manager/issues/1128

## Goals

- Always delete the CLI-owned agent + project when the CLI platform-agent suite finishes.
- Add a durable backstop for runs that die before teardown (hard kill / panic).

## Approach

- Add `amctl.WithSharedTeardown(func())` to the CLI harness — the symmetric counterpart to `WithSharedSetup`. It runs exactly once on parallel process 1 inside the harness's existing single `SynchronizedAfterSuite`, after every process has finished, before the built binary is dropped.
- Add `testsetup.CleanupCLILifecycleAgent(...)`, a best-effort teardown that deletes the agent (existing `DeleteAgentBestEffort`) then its project (`deleteProjectBestEffort`, with 409-retry for the async agent cascade). It deletes by the well-known constant names rather than the provisioned handle, so cleanup still runs even if provisioning only partially succeeded. Failures are logged, never fatal.
- Wire the teardown into the CLI platform-agent suite registration.
- Broaden the stale sweep (`CleanupStaleE2EResources`) to also reap `e2e-cli-*` projects older than the 1h cutoff — the backstop for `SynchronizedAfterSuite` being skipped (e.g. `kill -9`). Introduces `E2ECLIProjectPrefix` and derives `E2ECLIProjectName` from it.

Why it's safe to always delete: `e2e-cli-it-helpdesk` / `e2e-cli-shared` are owned solely by this CLI suite. The HTTP observability suites read a *different* shared agent (`e2e-it-helpdesk` in `e2e-test-shared`); a grep confirms nothing else references the CLI-owned names.

Coverage by exit type:
- Normal pass/fail → `SynchronizedAfterSuite` deletes it.
- Single Ctrl-C → Ginkgo runs AfterSuite gracefully.
- `kill -9` / second Ctrl-C / panic → next run's stale sweep reaps it.

The CLI agent now rebuilds on every run; in the ephemeral CI environment the build happens regardless, so there is no added cost.

## User stories

N/A — test-infrastructure change, no user-facing behavior.

## Release note

N/A — internal e2e test harness only.

## Documentation

N/A — no user-facing docs affected (updated in-code doc comments only).

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

- **Unit:** N/A — this is e2e test-harness lifecycle code; not unit-testable in isolation.
- **Integration:** This change *is* e2e harness wiring. Validated locally with `go build ./...`, `go vet`, and `gofmt` over the e2e module (all clean). The teardown path exercises only when the CLI platform-agent suite runs against a live environment.

## Security checks

- Did you add any new external dependencies? **No.**
- Did you implement any cryptographic functions / handle secrets? **No.**
- Did you introduce any new APIs or change authentication/authorization? **No.**

## Samples

N/A

## Related PRs

N/A

## Migrations

N/A — no DB migrations.

## Test environment

Standard e2e environment (ephemeral). No special setup.

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end cleanup so leftover CLI-related resources are removed more reliably after test runs.
  * Added a safer teardown path for shared test environments to reduce stale resources and conflicts.
  * Expanded automatic cleanup to catch additional leftover CLI projects from interrupted runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->