### PR TITLE
Fix ThunderID v0.45 service-account 403s causing E2E suite failures

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -901,6 +901,48 @@ fi
 
 wait_for_pods "openchoreo-control-plane" "${TIMEOUT_CONTROL_PLANE}"
 
+# ----------------------------------------------------------------------------
+# ThunderID v0.45 identity migration (sub -> client_id) for the control plane.
+# v0.45 client_credentials tokens carry the client identity in 'client_id'
+# (sub is now a random UUID). OpenChoreo still resolves service accounts by
+# 'claim: sub', so without these patches every service-account call returns 403
+# (project/agent create) and environment creation fails. The chart schema does
+# not expose the claim, so patch the configmap via server-side apply (Apply op,
+# helm field manager) and migrate OpenChoreo's built-in ClusterAuthzRoleBindings.
+# ----------------------------------------------------------------------------
+log_info "Patching openchoreo-api-config: service_account entitlement claim -> client_id..."
+if kubectl get configmap openchoreo-api-config -n openchoreo-control-plane &>/dev/null; then
+    patched_yaml=$(kubectl get configmap openchoreo-api-config -n openchoreo-control-plane -o yaml \
+        | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
+    if echo "$patched_yaml" | grep -q "claim: client_id"; then
+        echo "$patched_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
+        kubectl rollout restart deployment/openchoreo-api -n openchoreo-control-plane
+        kubectl rollout status deployment/openchoreo-api -n openchoreo-control-plane --timeout=120s
+        log_success "openchoreo-api-config patched (client_id claim)"
+    else
+        log_error "Failed to patch openchoreo-api-config entitlement claim to client_id"
+        exit 1
+    fi
+else
+    log_warning "openchoreo-api-config not found - skipping claim patch"
+fi
+
+log_info "Migrating service-account ClusterAuthzRoleBindings: claim sub -> client_id..."
+for binding in $(kubectl get clusterauthzrolebindings.openchoreo.dev \
+    -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true); do
+    claim=$(kubectl get clusterauthzrolebinding.openchoreo.dev "$binding" \
+        -o jsonpath='{.spec.entitlement.claim}' 2>/dev/null || true)
+    if [ "$claim" = "sub" ]; then
+        if kubectl patch clusterauthzrolebinding.openchoreo.dev "$binding" \
+            --type=merge -p '{"spec":{"entitlement":{"claim":"client_id"}}}' >/dev/null 2>&1; then
+            log_info "  migrated ${binding}"
+        else
+            log_warning "  failed to migrate ClusterAuthzRoleBinding '${binding}'"
+        fi
+    fi
+done
+log_success "Service-account bindings migrated to client_id"
+
 # ============================================================================
 # Step 8: Install OpenChoreo Data Plane
 # ============================================================================
@@ -1269,6 +1311,25 @@ if helm upgrade --install observability-traces-opensearch \
     log_success "OpenSearch based tracing module installed"
 else
     log_error "Failed to install opensearch based tracing module (non-fatal)"
+fi
+
+# ThunderID v0.45: the observer resolves service accounts from its own config
+# (observer-auth-config), still keyed on 'claim: sub'. Patch to client_id, else
+# agent build-log / observability queries return 403.
+log_info "Patching observer-auth-config: service_account entitlement claim -> client_id..."
+if kubectl get configmap observer-auth-config -n openchoreo-observability-plane &>/dev/null; then
+    patched_obs_yaml=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml \
+        | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
+    if echo "$patched_obs_yaml" | grep -q "claim: client_id"; then
+        echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
+        kubectl rollout restart deployment/observer -n openchoreo-observability-plane
+        kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s
+        log_success "observer-auth-config patched (client_id claim)"
+    else
+        log_warning "observer-auth-config has no 'sub' claim to patch - skipping"
+    fi
+else
+    log_warning "observer-auth-config not found - skipping observer claim patch"
 fi
 
 # Register Observability Plane with Control Plane

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -77,7 +77,7 @@ install_control_plane() {
             echo "❌ Failed to patch openchoreo-api-config entitlement claim to client_id"
             return 1
         fi
-        echo "$patched_yaml" | kubectl apply --server-side --field-manager=helm -f -
+        echo "$patched_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
         kubectl rollout restart deployment/openchoreo-api -n openchoreo-control-plane
         kubectl rollout status deployment/openchoreo-api -n openchoreo-control-plane --timeout=120s
         echo "✅ openchoreo-api-config patched (client_id claim)"
@@ -264,7 +264,7 @@ install_observability_plane() {
             echo "❌ Failed to patch observer-auth-config entitlement claim to client_id"
             return 1
         fi
-        echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm -f -
+        echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
         kubectl rollout restart deployment/observer -n openchoreo-observability-plane
         kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s
         echo "✅ observer-auth-config patched (client_id claim)"


### PR DESCRIPTION
## Purpose
> Upgraded ThunderID from v0.34.0 to v0.45.0 changed how service-account tokens identify themselves - the client identity moved from the sub claim to *client_id*. OpenChoreo's authz layer wasn't updated to match, so all service-account API calls returned 403 and 6 E2E test suites failed at startup.

## Goals
> - Apply the `sub` → `client_id` entitlement claim migration to both the control plane (`openchoreo-api-config`) and the observability plane (`observer-auth-config`) at install time
> - Fix the server-side apply conflict with Helm's field-manager ownership by adding `--force-conflicts`
> - Ensure the Nightly (which deploys via `quick-start/install.sh`) applies the same migrations that previously only existed in `setup-openchoreo.sh`

## Approach
> **`deployments/quick-start/install.sh`** — two new migration blocks added:
> - After the control plane is ready: patches `openchoreo-api-config` ConfigMap (`claim: sub` → `claim: client_id`), migrates all `ClusterAuthzRoleBinding` resources with `claim: sub`, and restarts `openchoreo-api`
> - After the tracing module install: patches `observer-auth-config` ConfigMap and restarts the `observer` deployment

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > -Full E2E suite re-run after this fix

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> - **OS:** macOS (Colima), Ubuntu (GitHub Actions Nightly)
> - **Kubernetes:** k3d
> - **ThunderID:** v0.45.0
 
## Learning
> N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated setup and install flows to consistently use the new authentication claim value for service accounts.
  * Ensured repeated setup runs can safely apply configuration changes without field-conflict errors.
  * Improved post-install handling by restarting affected services after configuration updates and waiting for them to be ready.
  * Added safeguards to detect missing or unexpected configuration during installation and stop with a clear error when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->