### PR TITLE
Prefix heavy-matrix token scopes with amp:

### DIFF
--- a/test/instrumentation-matrix/heavy/amp_client.py
+++ b/test/instrumentation-matrix/heavy/amp_client.py
@@ -52,10 +52,16 @@ _TOKEN_REFRESH_SKEW_S = 30
 # mint API key, and the teardown deletes). Mirrors how the console requests its
 # scope list. Unauthorised/unknown scopes are silently filtered by Thunder, so
 # this stays a tight, intention-revealing set.
+#
+# Thunder v0.45 namespaces every AMP scope with the `amp:` resource-server
+# handle (permissions are built as <resource-server>:<resource>:<action>; see
+# agent-manager-service rbac.Permission.Scope). The service enforces the
+# prefixed names, and Thunder filters the old bare names, so these MUST carry
+# the `amp:` prefix or every call 403s.
 _TOKEN_SCOPES = (
-    "project:create project:read project:delete "
-    "agent:create agent:read agent:delete agent:build "
-    "agent:deploy-non-production agent:api-key-manage"
+    "amp:project:create amp:project:read amp:project:delete "
+    "amp:agent:create amp:agent:read amp:agent:delete amp:agent:build "
+    "amp:agent:deploy-non-production amp:agent:api-key-manage"
 )
 
 # The deployed agent's source is cloned from this repo ref by the in-cluster

--- a/test/instrumentation-matrix/tests/test_heavy_client.py
+++ b/test/instrumentation-matrix/tests/test_heavy_client.py
@@ -62,7 +62,9 @@ def test_access_token_requests_rbac_scopes():
     body = _u.parse_qs([r for r in responses.calls if r.request.url.startswith(TOKEN_URL)][0].request.body)
     assert body["grant_type"] == ["client_credentials"]
     requested = body["scope"][0].split()
-    for required in ("project:create", "agent:create", "agent:api-key-manage", "project:delete"):
+    # Thunder v0.45 namespaces AMP scopes with the `amp:` resource-server handle;
+    # the service enforces the prefixed names (rbac.Permission.Scope).
+    for required in ("amp:project:create", "amp:agent:create", "amp:agent:api-key-manage", "amp:project:delete"):
         assert required in requested
 
 


### PR DESCRIPTION
## Purpose

The nightly **Instrumentation matrix tests** heavy tier has been failing since the 2026-06-29 run: all 8 heavy cells 403 with `POST /api/v1/orgs/default/projects → 403 {"code":"FORBIDDEN","message":"insufficient permissions"}`.

Root cause: the Thunder ID v0.45 upgrade (`2b05a25c`) and the scope-config update (`27b7582a`) namespaced every AMP OAuth scope with the `amp:` resource-server handle. `rbac.Permission.Scope()` now enforces `amp:project:create`, `amp:agent:create`, etc. The e2e framework (`test/e2e/framework/auth.go`) was migrated to the prefixed names in that same change, but the instrumentation-matrix heavy tier was overlooked — `heavy/amp_client.py` still requested the bare `project:create` / `agent:create` names. Thunder v0.45 silently filters unknown scope names, so the `client_credentials` token carried none of the scopes the service requires, and every provisioning call 403d.

Last green nightly was `c27d1b0f` (06-28); first red was `1dfb99dd` (06-29) — the first run after the Thunder upgrade merged.

Related to #1033

## Goals

Restore the heavy-tier nightly by requesting the scope names the service now enforces.

## Approach

Prefix each entry in `heavy/amp_client.py` `_TOKEN_SCOPES` with `amp:`, and update the `test_heavy_client.py` assertions to match. Added a comment documenting the v0.45 namespacing so the next reader understands why the prefix is required.

## User stories

N/A — CI/test-harness fix.

## Release note

N/A — internal test harness only, no product-facing change.

## Documentation

N/A — no product doc impact.

## Training

N/A

## Certification

N/A — no impact on certification exams.

## Marketing

N/A

## Automation tests
 - Unit tests
   > `test/instrumentation-matrix/tests/test_heavy_client.py` updated; all 14 tests pass locally (including `test_access_token_requests_rbac_scopes`, which now asserts the `amp:`-prefixed scopes).
 - Integration tests
   > The full fix is validated by the nightly heavy-tier matrix run itself.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Python test harness, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Follows up #1033 (which first gave the heavy tier explicit RBAC scopes).

## Migrations (if applicable)

N/A

## Test environment

Local: Python 3.14 venv, `pytest` + `responses`. CI: nightly heavy-tier job on `ubuntu-24.04`.

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access-token scope handling to use the correct namespaced AMP scope format, helping prevent authorization failures when requesting tokens.
  * Improved validation to ensure token requests include the expected AMP RBAC scopes with the required prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->