### PR TITLE
Prompt before whole-config llm unset to match mcp unset

### DIFF
--- a/cli/pkg/cmd/agent/llm/helpers_test.go
+++ b/cli/pkg/cmd/agent/llm/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +35,24 @@ import (
 
 // clientFn is the lazy client accessor shape every command's Options expects.
 type clientFn = func(context.Context) (*amsvc.ClientWithResponses, error)
+
+func unreachableClient(context.Context) (*amsvc.ClientWithResponses, error) {
+	return nil, errors.New("client should not be constructed")
+}
+
+type fakePrompter struct {
+	confirmDeletionErr error
+	confirmDeletionArg string
+	calls              int
+}
+
+func (p *fakePrompter) ConfirmDeletion(required string) error {
+	p.calls++
+	p.confirmDeletionArg = required
+	return p.confirmDeletionErr
+}
+
+func (p *fakePrompter) Confirm(prompt string) (bool, error) { return false, nil }
 
 // route describes one stubbed HTTP response keyed by "METHOD /path".
 type route struct {

--- a/cli/pkg/cmd/agent/llm/unset.go
+++ b/cli/pkg/cmd/agent/llm/unset.go
@@ -29,11 +29,13 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/clierr"
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/prompter"
 	"github.com/wso2/agent-manager/cli/pkg/render"
 )
 
 type UnsetOptions struct {
 	IO           *iostreams.IOStreams
+	Prompter     prompter.Prompter
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
 	MakeScope    func(org, proj, agent string) render.Scope
@@ -46,6 +48,7 @@ type UnsetOptions struct {
 
 	Name string
 	Env  string
+	Yes  bool
 }
 
 // UnsetResult is the JSON envelope payload for a full-config delete.
@@ -57,6 +60,7 @@ type UnsetResult struct {
 func NewUnsetCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &UnsetOptions{
 		IO:           f.IOStreams,
+		Prompter:     f.Prompter,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
 		MakeScope:    f.AgentScope,
@@ -86,6 +90,7 @@ func NewUnsetCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.Name, "name", "", "Name of the LLM configuration (required)")
 	cmd.Flags().StringVar(&opts.Env, "env", "", "Environment binding to remove (default: remove the whole configuration)")
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip confirmation prompt")
 	_ = cmd.MarkFlagRequired("name")
 	return cmd
 }
@@ -94,6 +99,15 @@ func runUnset(ctx context.Context, o *UnsetOptions) error {
 	if err := cmdutil.ValidatePathParam("agent name", o.AgentName); err != nil {
 		return render.Error(o.IO, o.Scope, err)
 	}
+	if o.Env == "" && !o.Yes {
+		if !o.IO.CanPrompt() {
+			return render.Error(o.IO, o.Scope, clierr.New(clierr.ConfirmationRequired, "deletion requires --yes when stdin is not a terminal"))
+		}
+		if err := o.Prompter.ConfirmDeletion(o.Name); err != nil {
+			return render.Error(o.IO, o.Scope, clierr.Newf(clierr.ConfirmationRequired, "%v", err))
+		}
+	}
+
 	client, err := o.Client(ctx)
 	if err != nil {
 		return render.Error(o.IO, o.Scope, err)

--- a/cli/pkg/cmd/agent/llm/unset_test.go
+++ b/cli/pkg/cmd/agent/llm/unset_test.go
@@ -18,6 +18,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -28,20 +29,32 @@ import (
 )
 
 func newUnsetOpts(io *iostreams.IOStreams, client clientFn) *UnsetOptions {
-	return &UnsetOptions{IO: io, Client: client, Scope: baseScope(), Org: "acme", Proj: "triage", AgentName: "order-bot", Name: "primary"}
+	return &UnsetOptions{
+		IO: io, Prompter: &fakePrompter{}, Client: client, Scope: baseScope(),
+		Org: "acme", Proj: "triage", AgentName: "order-bot", Name: "primary",
+	}
 }
 
 func Test_runUnset_deletesWholeConfig(t *testing.T) {
 	io, _, errOut := newTestIO(false)
 	io.SetTerminal(true, true, true)
+	prompter := &fakePrompter{}
 	client, cleanup := newClient(t, map[string]route{
 		listPath:                      okJSON(listResponse(llmItem("primary", getUUID))),
 		configPath("DELETE", getUUID): {status: http.StatusNoContent},
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err != nil {
+	opts := newUnsetOpts(io, client)
+	opts.Prompter = prompter
+	if err := runUnset(context.Background(), opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if prompter.calls != 1 {
+		t.Errorf("prompter calls = %d, want 1", prompter.calls)
+	}
+	if prompter.confirmDeletionArg != "primary" {
+		t.Errorf("confirmation arg = %q, want primary", prompter.confirmDeletionArg)
 	}
 	if !strings.Contains(errOut.String(), "deleted") {
 		t.Errorf("expected 'deleted' confirmation, got %q", errOut.String())
@@ -56,12 +69,70 @@ func Test_runUnset_deleteJSON(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err != nil {
+	opts := newUnsetOpts(io, client)
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	data := decodeEnvelope(t, out.String())["data"].(map[string]any)
 	if data["deleted"] != true {
 		t.Errorf("data.deleted = %v, want true", data["deleted"])
+	}
+}
+
+func Test_runUnset_deleteYesSkipsPrompt(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	prompter := &fakePrompter{}
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                      okJSON(listResponse(llmItem("primary", getUUID))),
+		configPath("DELETE", getUUID): {status: http.StatusNoContent},
+	})
+	defer cleanup()
+
+	opts := newUnsetOpts(io, client)
+	opts.Prompter = prompter
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prompter.calls != 0 {
+		t.Errorf("prompter calls = %d, want 0 with --yes", prompter.calls)
+	}
+}
+
+func Test_runUnset_deleteNonTTYWithoutYes(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	called := false
+	client := func(context.Context) (*amsvc.ClientWithResponses, error) {
+		called = true
+		return nil, errors.New("client should not be constructed")
+	}
+
+	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+		t.Fatal("expected error for non-TTY without --yes")
+	}
+	if called {
+		t.Fatal("client should not be constructed before confirmation")
+	}
+	errBody := decodeEnvelope(t, out.String())["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Fatalf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
+	}
+}
+
+func Test_runUnset_deleteConfirmationMismatch(t *testing.T) {
+	io, out, _ := newTestIO(true)
+	io.SetTerminal(true, true, true)
+	prompter := &fakePrompter{confirmDeletionErr: errors.New("confirmation mismatch")}
+	opts := newUnsetOpts(io, unreachableClient)
+	opts.Prompter = prompter
+
+	if err := runUnset(context.Background(), opts); err == nil {
+		t.Fatal("expected error from confirmation mismatch")
+	}
+	errBody := decodeEnvelope(t, out.String())["error"].(map[string]any)
+	if errBody["code"] != clierr.ConfirmationRequired {
+		t.Fatalf("code = %v, want %s", errBody["code"], clierr.ConfirmationRequired)
 	}
 }
 
@@ -87,6 +158,30 @@ func Test_runUnset_envRemovesOnePreservesOthers(t *testing.T) {
 	}
 	if _, ok := em["dev"]; !ok {
 		t.Errorf("dev should be preserved in envMappings: %v", em)
+	}
+}
+
+// With --env, a targeted binding removal must never prompt: it is a
+// non-destructive edit, mirroring the mcp unset behavior.
+func Test_runUnset_envDoesNotPrompt(t *testing.T) {
+	io, _, _ := newTestIO(false)
+	io.SetTerminal(true, true, true)
+	prompter := &fakePrompter{}
+	client, cleanup := newClient(t, map[string]route{
+		listPath:                   okJSON(listResponse(llmItem("primary", getUUID))),
+		configPath("GET", getUUID): okJSON(getResponseFixture()), // dev + prod
+		configPath("PUT", getUUID): {status: http.StatusOK, body: getResponseFixture()},
+	})
+	defer cleanup()
+
+	opts := newUnsetOpts(io, client)
+	opts.Prompter = prompter
+	opts.Env = "prod"
+	if err := runUnset(context.Background(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if prompter.calls != 0 {
+		t.Errorf("prompter calls = %d, want 0 for --env removal", prompter.calls)
 	}
 }
 
@@ -142,7 +237,9 @@ func Test_runUnset_nameNotFound(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+	opts := newUnsetOpts(io, client)
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err == nil {
 		t.Fatal("expected error")
 	}
 	if code := decodeEnvelope(t, out.String())["error"].(map[string]any)["code"]; code != clierr.NotFound {
@@ -158,7 +255,9 @@ func Test_runUnset_deleteServerError(t *testing.T) {
 	})
 	defer cleanup()
 
-	if err := runUnset(context.Background(), newUnsetOpts(io, client)); err == nil {
+	opts := newUnsetOpts(io, client)
+	opts.Yes = true
+	if err := runUnset(context.Background(), opts); err == nil {
 		t.Fatal("expected error")
 	}
 	if status := decodeEnvelope(t, out.String())["error"].(map[string]any)["status"]; status.(float64) != 404 {

--- a/test/e2e/operations/cli/agent/llm_operations.go
+++ b/test/e2e/operations/cli/agent/llm_operations.go
@@ -97,12 +97,14 @@ func ListAgentLLM(g Gomega, h *amctl.Harness, org, project, agent string) AgentL
 		"--org", org, "--project", project, "--json"))
 }
 
-// UnsetAgentLLM runs `agent llm unset <agent> --name` (whole-config delete) and
-// returns the delete result (reusing the package's DeleteResult).
+// UnsetAgentLLM runs `agent llm unset <agent> --name --yes` (whole-config
+// delete) and returns the delete result (reusing the package's DeleteResult).
+// A whole-config unset (no --env) prompts for confirmation, so --yes is
+// required under the non-terminal harness.
 func UnsetAgentLLM(g Gomega, h *amctl.Harness, org, project, agent, name string) DeleteResult {
 	return amctl.DecodeData[DeleteResult](g, h.Run(
 		"agent", "llm", "unset", agent, "--name", name,
-		"--org", org, "--project", project, "--json"))
+		"--org", org, "--project", project, "--yes", "--json"))
 }
 
 // Names returns the config names in the list, for membership assertions.

--- a/test/e2e/tests/cli/agentplatform/agent_llm_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_llm_test.go
@@ -55,7 +55,7 @@ var _ = Describe("amctl agent llm (CLI-owned agent)", Label("cli", "agent", "llm
 		})
 		DeferCleanup(func() {
 			_ = H.Run("agent", "llm", "unset", owned.AgentName, "--name", configName,
-				"--org", H.Org(), "--project", owned.ProjectName, "--json")
+				"--org", H.Org(), "--project", owned.ProjectName, "--yes", "--json")
 		})
 		GinkgoWriter.Printf("CLI agent llm: agent=%s provider=%s\n", owned.AgentName, providerID)
 	})


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

`amctl agent mcp unset` and `amctl agent llm unset` behaved inconsistently. When unsetting a whole configuration (no `--env`), `mcp unset` prompts for confirmation before deleting the config across all environments, but `llm unset` deleted it silently with no prompt. This makes the destructive LLM operation surprisingly easy to trigger by accident.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Make `llm unset` match `mcp unset`:
- Prompt for confirmation before deleting the whole LLM provider config (all environments).
- Allow targeted, non-destructive removals via `--env` **without** a prompt.
- Support `--yes/-y` to skip the confirmation (required in non-terminal contexts such as CI/e2e).

## Approach
> Describe how you are implementing the solutions.

Mirrored the existing `mcp unset` implementation in `cli/pkg/cmd/agent/llm/unset.go`:
- Added a `Prompter` field and a `Yes` flag to `UnsetOptions`, wired `Prompter: f.Prompter` in `NewUnsetCmd`, and registered `--yes/-y`.
- Added a confirmation gate in `runUnset` keyed on `Env == "" && !Yes`, so it fires only for whole-config deletes and never for `--env` binding removals. Non-terminal + no `--yes` returns `ConfirmationRequired` before any client is constructed; a terminal prompts via `Prompter.ConfirmDeletion(name)`.

Developed test-first: added the failing prompt-behavior tests, watched them fail, then implemented the gate.

## User stories
> Summary of user stories addressed by this change

As an operator, when I run `amctl agent llm unset` without `--env`, I'm asked to confirm before the config is deleted from all environments — consistent with `mcp unset`.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

`amctl agent llm unset` now prompts for confirmation before removing an LLM provider config from all environments (matching `mcp unset`). Targeted `--env` removals are unaffected; use `--yes` to skip the prompt.

## Documentation
N/A — CLI-internal behavior change; command help text already describes the whole-config vs `--env` distinction.

## Training
N/A — no training content impact.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > Added `cli/pkg/cmd/agent/llm/unset_test.go` cases mirroring the mcp suite: prompts on whole-config delete, `--yes` skips the prompt, non-TTY without `--yes` errors with `ConfirmationRequired`, confirmation mismatch propagates, and `--env` removal never prompts. Added `fakePrompter`/`unreachableClient` doubles to the llm test helpers.
 - Integration tests
   > Amended the agent-llm e2e (`test/e2e`): `UnsetAgentLLM` and the `DeferCleanup` whole-config unset now pass `--yes`, since the e2e harness runs the CLI non-interactively.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable to this Go CLI change (no Java/FindSecurityBugs pipeline); change is a confirmation-prompt gate with no new attack surface.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples affected.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no schema or data migrations.

## Test environment
Go (CLI module and `test/e2e` module); macOS (darwin). Verified with `go build ./...`, `go vet`, and `go test ./...` on the CLI module (all pass), and `go build`/`go vet` on the e2e module.

## Learning
Followed the existing `mcp unset` command as the reference implementation to keep the two commands behaviorally identical.
