### PR TITLE
Add amctl agent build read e2e specs on the CLI-owned agent

### DIFF
--- a/test/e2e/operations/cli/agent/build_operations.go
+++ b/test/e2e/operations/cli/agent/build_operations.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// amctl agent build read commands (list/get/logs) as thin, assertion-backed
+// operations over the amctl harness. Lives in package cliagent alongside
+// agent_operations.go. Decode structs mirror the CLI's BuildsListResponse /
+// BuildDetailsResponse / LogsResponse (only the fields specs assert on).
+//
+// The mutating `build create` command is intentionally not wrapped here: it
+// triggers a new build that becomes the agent's latest, which the sibling
+// `agent deploy` specs would then pick up (they deploy the latest build and
+// reject in-progress ones). These read helpers run against the CLI-owned
+// agent's existing build without disturbing those specs.
+package cliagent
+
+import (
+	"strconv"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/wso2/agent-manager/test/e2e/framework/amctl"
+)
+
+// BuildSummary is the subset of a `agent build list` entry (the CLI's
+// BuildResponse) we assert on.
+type BuildSummary struct {
+	AgentName   string    `json:"agentName"`
+	ProjectName string    `json:"projectName"`
+	BuildName   string    `json:"buildName"`
+	ImageId     string    `json:"imageId"`
+	Status      string    `json:"status"`
+	StartedAt   time.Time `json:"startedAt"`
+}
+
+// BuildList is the data shape of `agent build list --json` (BuildsListResponse).
+type BuildList struct {
+	Builds []BuildSummary `json:"builds"`
+	Limit  int            `json:"limit"`
+	Offset int            `json:"offset"`
+	Total  int            `json:"total"`
+}
+
+// Names returns the build names in the list, for membership assertions.
+func (l BuildList) Names() []string {
+	names := make([]string, 0, len(l.Builds))
+	for _, b := range l.Builds {
+		names = append(names, b.BuildName)
+	}
+	return names
+}
+
+// BuildStep is one entry of BuildDetailsResponse.Steps.
+type BuildStep struct {
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// BuildDetails is the subset of `agent build get` (the CLI's
+// BuildDetailsResponse) we assert on.
+type BuildDetails struct {
+	AgentName   string      `json:"agentName"`
+	ProjectName string      `json:"projectName"`
+	BuildName   string      `json:"buildName"`
+	ImageId     string      `json:"imageId"`
+	Status      string      `json:"status"`
+	StartedAt   time.Time   `json:"startedAt"`
+	Steps       []BuildStep `json:"steps"`
+}
+
+// BuildLogEntry is one entry of the CLI's LogsResponse.
+type BuildLogEntry struct {
+	Log       string    `json:"log"`
+	LogLevel  string    `json:"logLevel"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// BuildLogs is the data shape of `agent build logs --json` (LogsResponse).
+type BuildLogs struct {
+	Logs       []BuildLogEntry `json:"logs"`
+	TookMs     float32         `json:"tookMs"`
+	TotalCount int             `json:"totalCount"`
+}
+
+// ListAgentBuilds runs `agent build list <agent>`.
+func ListAgentBuilds(g Gomega, h *amctl.Harness, org, project, agent string) BuildList {
+	return amctl.DecodeData[BuildList](g, h.Run(
+		"agent", "build", "list", agent,
+		"--org", org, "--project", project, "--json"))
+}
+
+// ListAgentBuildsPaged runs `agent build list <agent> --limit --offset`.
+func ListAgentBuildsPaged(g Gomega, h *amctl.Harness, org, project, agent string, limit, offset int) BuildList {
+	return amctl.DecodeData[BuildList](g, h.Run(
+		"agent", "build", "list", agent,
+		"--limit", strconv.Itoa(limit), "--offset", strconv.Itoa(offset),
+		"--org", org, "--project", project, "--json"))
+}
+
+// GetAgentBuild runs `agent build get <agent> <build>`.
+func GetAgentBuild(g Gomega, h *amctl.Harness, org, project, agent, build string) BuildDetails {
+	return amctl.DecodeData[BuildDetails](g, h.Run(
+		"agent", "build", "get", agent, build,
+		"--org", org, "--project", project, "--json"))
+}
+
+// GetAgentBuildExpectError runs `agent build get` expecting a non-zero exit
+// (e.g. an unknown build name) and returns the error envelope.
+func GetAgentBuildExpectError(g Gomega, h *amctl.Harness, org, project, agent, build string) amctl.EnvelopeError {
+	return h.Run("agent", "build", "get", agent, build,
+		"--org", org, "--project", project, "--json").ExpectError(g)
+}
+
+// GetAgentBuildLogs runs `agent build logs <agent> <build>` for a named build.
+func GetAgentBuildLogs(g Gomega, h *amctl.Harness, org, project, agent, build string) BuildLogs {
+	return amctl.DecodeData[BuildLogs](g, h.Run(
+		"agent", "build", "logs", agent, build,
+		"--org", org, "--project", project, "--json"))
+}
+
+// GetAgentLatestBuildLogs runs `agent build logs <agent>` with no build name,
+// which the CLI resolves to the agent's latest build.
+func GetAgentLatestBuildLogs(g Gomega, h *amctl.Harness, org, project, agent string) BuildLogs {
+	return amctl.DecodeData[BuildLogs](g, h.Run(
+		"agent", "build", "logs", agent,
+		"--org", org, "--project", project, "--json"))
+}
+
+// GetAgentBuildLogsExpectError runs `agent build logs` expecting a non-zero exit
+// (e.g. an unknown build name) and returns the error envelope.
+func GetAgentBuildLogsExpectError(g Gomega, h *amctl.Harness, org, project, agent, build string) amctl.EnvelopeError {
+	return h.Run("agent", "build", "logs", agent, build,
+		"--org", org, "--project", project, "--json").ExpectError(g)
+}

--- a/test/e2e/tests/cli/agentplatform/agent_build_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_build_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Validates the amctl agent build read commands end to end against the
+// CLI-owned platform agent: list, get (by name), and logs (by name and
+// latest), plus the not-found error envelopes. These are read-only: they
+// assert against the build produced when the CLI-owned agent was provisioned
+// and never trigger a new build, so they don't disturb the deploy specs (which
+// deploy the agent's latest build). Asserts JSON envelopes and exit codes only.
+
+package cliagentplatformtests
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	cliagent "github.com/wso2/agent-manager/test/e2e/operations/cli/agent"
+)
+
+var _ = Describe("amctl agent build (CLI-owned agent, read-only)", Label("cli", "agent", "build"), Ordered, func() {
+	// buildName is the CLI-owned agent's existing build, captured once and
+	// reused to drive the get/logs specs. The CLI-owned agent is provisioned
+	// once by the suite's SynchronizedBeforeSuite (see suite_test.go), so
+	// owned/cfg are ready before these specs run — no per-suite setup needed.
+	var buildName string
+
+	BeforeAll(func() {
+		list := cliagent.ListAgentBuilds(Default, H, H.Org(), owned.ProjectName, owned.AgentName)
+		Expect(list.Builds).NotTo(BeEmpty(), "CLI-owned agent should have at least one build from provisioning")
+		buildName = list.Builds[0].BuildName
+		Expect(buildName).NotTo(BeEmpty())
+		GinkgoWriter.Printf("CLI agent build: agent=%s build=%s\n", owned.AgentName, buildName)
+	})
+
+	It("lists builds for the agent", func() {
+		list := cliagent.ListAgentBuilds(Default, H, H.Org(), owned.ProjectName, owned.AgentName)
+		Expect(list.Total).To(BeNumerically(">=", 1))
+		Expect(list.Builds).NotTo(BeEmpty())
+		for _, b := range list.Builds {
+			Expect(b.BuildName).NotTo(BeEmpty())
+			Expect(b.AgentName).To(Equal(owned.AgentName))
+			Expect(b.ProjectName).To(Equal(owned.ProjectName))
+		}
+	})
+
+	It("respects --limit when listing builds", func() {
+		list := cliagent.ListAgentBuildsPaged(Default, H, H.Org(), owned.ProjectName, owned.AgentName, 1, 0)
+		Expect(len(list.Builds)).To(BeNumerically("<=", 1))
+		Expect(list.Total).To(BeNumerically(">=", 1))
+	})
+
+	It("gets a build by name", func() {
+		b := cliagent.GetAgentBuild(Default, H, H.Org(), owned.ProjectName, owned.AgentName, buildName)
+		Expect(b.BuildName).To(Equal(buildName))
+		Expect(b.AgentName).To(Equal(owned.AgentName))
+		Expect(b.ProjectName).To(Equal(owned.ProjectName))
+		Expect(b.Status).NotTo(BeEmpty())
+		Expect(b.StartedAt).NotTo(BeZero())
+		Expect(b.ImageId).NotTo(BeEmpty(), "a deployed agent's build should carry an image id")
+	})
+
+	It("returns build logs for a named build", func() {
+		logs := cliagent.GetAgentBuildLogs(Default, H, H.Org(), owned.ProjectName, owned.AgentName, buildName)
+		Expect(logs.Logs).NotTo(BeEmpty(), "expected build logs for a completed build")
+		Expect(logs.TotalCount).To(BeNumerically(">=", 1))
+		for _, entry := range logs.Logs {
+			Expect(entry.Log).NotTo(BeEmpty())
+		}
+	})
+
+	It("returns logs for the latest build when no build name is given", func() {
+		logs := cliagent.GetAgentLatestBuildLogs(Default, H, H.Org(), owned.ProjectName, owned.AgentName)
+		Expect(logs.Logs).NotTo(BeEmpty())
+	})
+
+	It("reports not-found for an unknown build (get)", func() {
+		e := cliagent.GetAgentBuildExpectError(Default, H, H.Org(), owned.ProjectName, owned.AgentName, "build-nonexistent-00000000")
+		Expect(e.Status).To(Equal(404))
+	})
+
+	It("reports not-found for an unknown build (logs)", func() {
+		e := cliagent.GetAgentBuildLogsExpectError(Default, H, H.Org(), owned.ProjectName, owned.AgentName, "build-nonexistent-00000000")
+		Expect(e.Status).To(Equal(404))
+	})
+})


### PR DESCRIPTION
## Purpose
The `amctl agent build` read commands (`list`, `get`, `logs`) had no end-to-end coverage. This adds e2e specs that exercise them against a live agent through the CLI's `--json` envelopes.

For:
- https://github.com/wso2/agent-manager/issues/1128

## Goals
Cover the build read surface end-to-end without disturbing the existing CLI suite:
- `agent build list` (including `--limit`)
- `agent build get <build>`
- `agent build logs <build>` and latest-build logs (no build name)
- the not-found error envelope for `get`/`logs`

## Approach
Reuse the CLI-owned platform agent that the `agentplatform` suite already provisions once via `SynchronizedBeforeSuite`. The new specs are **read-only**: they assert against the build produced when that agent was provisioned and never trigger a new one.

This is deliberate. `agent build create` would trigger a build that becomes the agent's *latest*, and the sibling `agent deploy` specs deploy the latest build and reject in-progress ones (`resolveDeployableBuild` in `deploy.go`) — so exercising `create` on the shared agent would race and break those specs under `ginkgo -p`. Keeping to reads lets the build specs share the one agent with zero interference and no extra (slow) provisioning.

Two files, mirroring the existing `agent_llm`/`agent_observability` structure:
- `test/e2e/operations/cli/agent/build_operations.go` — thin, assertion-backed harness wrappers + decode structs mirroring `BuildsListResponse` / `BuildDetailsResponse` / `LogsResponse`.
- `test/e2e/tests/cli/agentplatform/agent_build_test.go` — the Ginkgo specs.

## User stories
As an amctl user, I can list an agent's builds and inspect a build's details and logs, and I get a clear not-found error for an unknown build.

## Release note
N/A — test-only change, no user-facing behavior change.

## Documentation
N/A — no behavior change; the e2e guide's existing CLI-suite instructions already cover running these specs.

## Training
N/A — no training-content impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — internal test coverage.

## Automation tests
 - Unit tests
   > N/A — this PR adds e2e (integration) specs only; the build commands retain their existing unit tests under `cli/pkg/cmd/agent/build/`.
 - Integration tests
   > Adds 7 specs under the `CLI Platform Agent Suite` (`Label("cli", "agent", "build")`): list, list-with-`--limit`, get-by-name, logs-by-name, latest-build logs, and get/logs not-found envelopes. Run with `make e2e-test SUITE=cli/agentplatform` (or `FOCUS="agent build"`). Verified offline via `go build`, `go vet`, `gofmt`, and `ginkgo --dry-run` (spec tree compiles and wires up); the assertions themselves require a live cluster.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — FindSecurityBugs targets Java; this is a Go test-only change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A — no schema or data changes.

## Test environment
Go (test/e2e module toolchain); specs run against a local agent-manager cluster via `ginkgo`.

## Learning
Followed the existing `agent_llm`/`agent_observability` e2e patterns and the CLI build command implementations (`cli/pkg/cmd/agent/build/`) to mirror the exact JSON envelope shapes and command invocations.
