### PR TITLE
Add traceloop 0.62.1 as instr 0.4.0 default

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -31,6 +31,11 @@
       "instrumentation_version": "0.3.0",
       "traceloop_version": "0.61.0",
       "python_versions": ["3.10", "3.11", "3.12", "3.13"]
+    },
+    {
+      "instrumentation_version": "0.4.0",
+      "traceloop_version": "0.62.1",
+      "python_versions": ["3.10", "3.11", "3.12", "3.13"]
     }
   ],
 

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -114,7 +114,7 @@ func loadEnvs() {
 		SDKVolumeName: r.readOptionalString("OTEL_SDK_VOLUME_NAME", "otel-tracing-sdk-volume"),
 		SDKMountPath:  r.readOptionalString("OTEL_SDK_MOUNT_PATH", "/otel-tracing-sdk"),
 
-		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.3.0"),
+		DefaultInstrumentationVersion: r.readOptionalString("OTEL_DEFAULT_INSTRUMENTATION_VERSION", "0.4.0"),
 
 		InstrumentationExtensionPath: r.readOptionalString("INSTRUMENTATION_EXTENSION_PATH", "/etc/amp/instrumentation-extension.yaml"),
 

--- a/agent-manager-service/instrumentation/baseline.json
+++ b/agent-manager-service/instrumentation/baseline.json
@@ -9,5 +9,16 @@
       "3.13"
     ],
     "imageRepository": "ghcr.io/wso2/amp-python-instrumentation-provider"
+  },
+  {
+    "version": "0.4.0",
+    "traceloopSdk": "0.62.1",
+    "pythonVersions": [
+      "3.10",
+      "3.11",
+      "3.12",
+      "3.13"
+    ],
+    "imageRepository": "ghcr.io/wso2/amp-python-instrumentation-provider"
   }
 ]

--- a/agent-manager-service/instrumentation/catalog_test.go
+++ b/agent-manager-service/instrumentation/catalog_test.go
@@ -28,18 +28,22 @@ func TestLoad_BaselineOnly(t *testing.T) {
 	if c.Default() != "0.3.0" {
 		t.Errorf("Default = %q, want 0.3.0", c.Default())
 	}
+	// The bundled baseline currently ships two versions. All() ordering is
+	// unspecified (it comes from a map), so assert membership by version key
+	// rather than by slice position.
 	all := c.All()
-	if len(all) != 1 {
-		t.Fatalf("len(All) = %d, want 1", len(all))
+	if len(all) != 2 {
+		t.Fatalf("len(All) = %d, want 2", len(all))
 	}
-	if all[0].Version != "0.3.0" {
-		t.Errorf("All[0].Version = %q, want 0.3.0", all[0].Version)
-	}
-	if all[0].Source != SourceBundled {
-		t.Errorf("All[0].Source = %q, want bundled", all[0].Source)
-	}
-	if !c.Has("0.3.0") {
-		t.Error("Has(0.3.0) = false, want true")
+	for _, want := range []string{"0.3.0", "0.4.0"} {
+		got, ok := c.Get(want)
+		if !ok {
+			t.Errorf("Get(%s) missing from bundled baseline", want)
+			continue
+		}
+		if got.Source != SourceBundled {
+			t.Errorf("Get(%s).Source = %q, want bundled", want, got.Source)
+		}
 	}
 	if c.Has("99.0.0") {
 		t.Error("Has(99.0.0) = true, want false")
@@ -61,15 +65,15 @@ func TestLoad_ExtensionAdds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if !c.Has("0.4.0") {
-		t.Fatal("expected 0.4.0 in effective set")
+	if !c.Has("0.5.0") {
+		t.Fatal("expected 0.5.0 in effective set")
 	}
-	got, _ := c.Get("0.4.0")
+	got, _ := c.Get("0.5.0")
 	if got.Source != SourceExtension {
-		t.Errorf("Get(0.4.0).Source = %q, want extension", got.Source)
+		t.Errorf("Get(0.5.0).Source = %q, want extension", got.Source)
 	}
 	if got.TraceloopSDK != "0.65.0" {
-		t.Errorf("Get(0.4.0).TraceloopSDK = %q, want 0.65.0", got.TraceloopSDK)
+		t.Errorf("Get(0.5.0).TraceloopSDK = %q, want 0.65.0", got.TraceloopSDK)
 	}
 	bundled, _ := c.Get("0.3.0")
 	if bundled.Source != SourceBundled {
@@ -96,8 +100,8 @@ func TestLoad_ExtensionFileAbsent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(c.All()) != 1 {
-		t.Errorf("len(All) = %d, want 1 (baseline only)", len(c.All()))
+	if len(c.All()) != 2 {
+		t.Errorf("len(All) = %d, want 2 (baseline only)", len(c.All()))
 	}
 }
 

--- a/agent-manager-service/instrumentation/testdata/extension_valid.yaml
+++ b/agent-manager-service/instrumentation/testdata/extension_valid.yaml
@@ -1,5 +1,5 @@
 additionalInstrumentationVersions:
-  - version: "0.4.0"
+  - version: "0.5.0"
     traceloopSdk: "0.65.0"
     pythonVersions: ["3.10", "3.11", "3.12", "3.13"]
     imageRepository: "ghcr.io/wso2/amp-python-instrumentation-provider"

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -137,7 +137,7 @@ agentManagerService:
       # Platform default AMP instrumentation version. Must exist in the
       # effective catalog (embedded baseline ∪ additionalInstrumentationVersions);
       # otherwise the server fails to start.
-      defaultInstrumentationVersion: "0.3.0"
+      defaultInstrumentationVersion: "0.4.0"
       # Operator-supplied catalog extension entries, added on top of the
       # bundled baseline. For air-gapped installs, point imageRepository
       # at the internal mirror.

--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -177,6 +177,7 @@ These are the versions that ship with this AMP release:
 
 | AMP instrumentation version | Traceloop SDK (`traceloop-sdk`) | Supported Python versions | Init-container image tag |
 |---|---|---|---|
+| 0.4.0 (default) | 0.62.1 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.4.0-python<X.Y>` |
 | 0.3.0 | 0.61.0 | 3.10, 3.11, 3.12, 3.13 | `ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python<X.Y>` |
 
 The canonical source for this table is [`.github/release-config.json`](https://github.com/wso2/agent-manager/blob/main/.github/release-config.json) under the `python-instrumentation-provider` key. Maintainers cutting a new version: see [`python-instrumentation-provider/RELEASING.md`](https://github.com/wso2/agent-manager/blob/main/python-instrumentation-provider/RELEASING.md) for the release runbook.

--- a/libs/amp-instrumentation/pyproject.toml
+++ b/libs/amp-instrumentation/pyproject.toml
@@ -15,13 +15,14 @@ maintainers = [
 # amp-instrumentation version maps to exactly one OpenLLMetry version. Bumping it
 # is a new amp-instrumentation release. See the AMP instrumentation version mapping.
 dependencies = [
-    "traceloop-sdk==0.61.0",
+    "traceloop-sdk==0.62.1",
      # Pin wrapt below 2.0: wrapt 2.x removed the `module=` kwarg on
-    # wrap_function_wrapper that opentelemetry-instrumentation-* 0.61.0 still calls.
+    # wrap_function_wrapper that the opentelemetry-instrumentation-* packages
+    # bundled with traceloop-sdk 0.62.1 still call.
     "wrapt<2.0.0",
     "httpx>=0.25.0",
     # Imported directly by amp_instrumentation.otel.init_otel. Left unconstrained
-    # on purpose: their version is determined by traceloop-sdk==0.61.0, which
+    # on purpose: their version is determined by traceloop-sdk==0.62.1, which
     # already requires both (kept here only to declare the direct import).
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-http",

--- a/test/instrumentation-matrix/matrix.yaml
+++ b/test/instrumentation-matrix/matrix.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 
 providers:
   traceloop:
-    versions: ["0.61.0"]
+    versions: ["0.61.0", "0.62.1"]
     # Maps traceloop_version → init-container instrumentation_version. The
     # heavy tier resolves the image tag
     # `amp-python-instrumentation-provider:<instr>-python<X.Y>` from this map.
@@ -12,6 +12,7 @@ providers:
     # release-config.json currently lists.
     instrumentationVersions:
       "0.61.0": "0.3.0"
+      "0.62.1": "0.4.0"
     contractSchema: "v1"
 
   manual:
@@ -113,7 +114,7 @@ python:
 
 defaultCell:
   provider: traceloop
-  providerVersion: "0.61.0"
+  providerVersion: "0.62.1"
   framework: langchain
   frameworkVersion: "0.3.27"
   python: "3.11"


### PR DESCRIPTION
## Purpose

OpenLLMetry published `traceloop-sdk` 0.62.1. This adds support for it and makes it the platform default, while keeping the existing 0.61.0 available for agents already pinned to it.

Resolves https://github.com/wso2/agent-manager/issues/1225

## Goals

Ship `traceloop-sdk` 0.62.1 as a new AMP-instrumentation version (`0.4.0`), make it the default version offered in the Console / API / for new agents, retain the existing `0.3.0 → traceloop 0.61.0` entry, wire 0.62.1 into the instrumentation test matrix, and update the customer-facing version-mapping docs.

## Approach

Each AMP-instrumentation version pins exactly one `traceloop-sdk` version, so 0.62.1 is added as a **new** catalog entry (`0.4.0`) rather than a bump of the existing one. Existing agents pinned to `0.3.0` are unaffected and its init-container image stays pullable (per the retention policy in `RELEASING.md`).

| File | Change |
|---|---|
| `.github/release-config.json` | Add `{ instrumentation_version: 0.4.0, traceloop_version: 0.62.1, python_versions: 3.10–3.13 }`; keep the 0.3.0 entry |
| `agent-manager-service/instrumentation/baseline.json` | Regenerated from `release-config.json` via `make gen-instrumentation-baseline` (now two entries) |
| `libs/amp-instrumentation/pyproject.toml` | Pin `traceloop-sdk==0.62.1` for the PyPI package |
| `deployments/helm-charts/wso2-agent-manager/values.yaml` | `defaultInstrumentationVersion: 0.3.0 → 0.4.0` |
| `test/instrumentation-matrix/matrix.yaml` | Add `0.62.1` to the traceloop versions, map `0.62.1 → 0.4.0`, move `defaultCell` onto `0.62.1` |
| `documentation/docs/components/amp-instrumentation.mdx` | Add the `0.4.0 (default) → 0.62.1` row to the Bundled baseline table |
| `agent-manager-service/instrumentation/catalog_test.go` + `testdata/extension_valid.yaml` | Update catalog guards for the now two-entry baseline; move the extension fixture to `0.5.0` so it still exercises adding a genuinely new version, and make `TestLoad_BaselineOnly` order-independent |

The Console version dropdown and the agent-build-options API are server-driven from the runtime catalog, so no frontend change is needed — `0.4.0` appears automatically once the baseline includes it.

## User stories

As a platform user, when I create a Python agent I get the latest OpenLLMetry (traceloop 0.62.1) instrumentation by default, while agents already pinned to the previous version keep working unchanged.

## Release note

Added support for `traceloop-sdk` 0.62.1 as AMP instrumentation version 0.4.0 and made it the platform default. The previous version (0.3.0 / traceloop 0.61.0) remains available.

## Documentation

Updated `documentation/docs/components/amp-instrumentation.mdx` (Bundled baseline mapping table). The maintainer runbook `python-instrumentation-provider/RELEASING.md` already documents this exact scenario.

## Training

N/A — no training-content impact.

## Certification

N/A — no impact on certification exams; this is a dependency/version-catalog change.

## Marketing

N/A — no marketing content associated with this change.

## Automation tests

- Unit tests
  - `go test ./instrumentation/...` passes, including `TestHelmDefaultInstrumentationVersionConsistent` (verifies the chart default `0.4.0` exists in the regenerated baseline), the updated `TestLoad_BaselineOnly` / `TestLoad_ExtensionFileAbsent` (two-entry baseline), and `TestLoad_ExtensionAdds` (now via the `0.5.0` fixture).
- Integration tests
  - `scripts/check-matrix-manifest.py` passes — the matrix now covers both traceloop versions listed in `release-config.json`.
  - The instrumentation matrix will exercise `0.62.1` on its next run (advisory); any framework regressions surface there.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A — no Java code changed
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples

N/A — no sample changes.

## Related PRs

N/A

## Migrations (if applicable)

N/A — no data migration. Existing agents stay pinned to their current version; only new agents get the raised default.

## Test environment

Local: macOS, Go toolchain for `agent-manager-service` unit tests. Publishing of the PyPI package (`amp-instrumentation==0.4.0`) and the init-container images is a manual `workflow_dispatch` step post-merge, per `RELEASING.md` Scenario A.

## Learning

Followed the existing maintainer runbook (`python-instrumentation-provider/RELEASING.md`, Scenario A) and the instrumentation catalog design — the version catalog is code-generated from `release-config.json` and embedded into the server, so a single source-of-truth edit propagates to the API, Console, and default selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new instrumentation release, including updated default version mappings and matrix coverage.
  * Expanded supported provider versions to include the latest release.

* **Bug Fixes**
  * Updated the default instrumentation version used across configuration and deployment settings.
  * Ensured bundled baselines and tests recognize both the existing and newly added versions.

* **Documentation**
  * Refreshed instrumentation documentation to match the latest supported versions and compatibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->