### PR TITLE
Run instrumentation-matrix CI on CodeBuild runners

### DIFF
--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -45,7 +45,8 @@ concurrency:
 
 jobs:
   resolve-cells:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     # Skipped for heavy-only iteration — no emission matrix to expand.
     if: ${{ !inputs.heavy_only }}
     outputs:
@@ -73,7 +74,8 @@ jobs:
           exit 1
 
   run-cells:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: resolve-cells
     strategy:
       fail-fast: false
@@ -111,7 +113,8 @@ jobs:
             test/instrumentation-matrix/cassettes/
 
   open-record-pr:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: run-cells
     if: ${{ inputs.include_record_mode }}
     permissions:
@@ -159,7 +162,8 @@ jobs:
             investigating, not a rubber-stamp refresh.
 
   heavy:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: run-cells
     # Normal run: gate behind a green emission matrix. heavy_only: run
     # regardless (run-cells is skipped), so always() is needed to evaluate at all.

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -16,7 +16,8 @@ concurrency:
 
 jobs:
   full-emission-matrix:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -41,7 +42,8 @@ jobs:
           path: test/instrumentation-matrix/reports/cells/
 
   heavy-tier:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: full-emission-matrix
     timeout-minutes: 90
     steps:
@@ -78,7 +80,8 @@ jobs:
           path: test/instrumentation-matrix/reports/heavy/
 
   revalidate-known-broken:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: full-emission-matrix
     permissions:
       contents: read
@@ -159,7 +162,8 @@ jobs:
           path: test/instrumentation-matrix/reports/revalidate/
 
   publish-matrix-summary:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [full-emission-matrix, heavy-tier, revalidate-known-broken]
     # Run on success AND on failures (so the summary + metrics still compute
     # when cells go red), but not during cancellation — `!cancelled()` avoids
@@ -219,7 +223,8 @@ jobs:
           path: test/instrumentation-matrix/reports/summary.md
 
   open-issue-on-failure:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     # All three are listed so the `if:` references below resolve (a
     # needs.<job> reference is only in scope when the job is in `needs`).
     # A heavy-tier failure now opens the tracking issue too — it no longer
@@ -263,7 +268,8 @@ jobs:
           fi
 
   notify-google-chat:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [publish-matrix-summary, open-issue-on-failure, full-emission-matrix, heavy-tier]
     # Quiet on success. Run on any failure signal: per-cell failures the
     # report counted, OR a catastrophic emission/heavy crash before reports

--- a/.github/workflows/instrumentation-matrix-pr.yaml
+++ b/.github/workflows/instrumentation-matrix-pr.yaml
@@ -42,7 +42,8 @@ permissions:
 
 jobs:
   verify-contract-and-manifest:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-go
@@ -54,7 +55,8 @@ jobs:
       - run: make check-matrix-manifest
 
   default-cell-required:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: verify-contract-and-manifest
     steps:
       - uses: actions/checkout@v6
@@ -87,7 +89,8 @@ jobs:
           path: test/instrumentation-matrix/reports/
 
   full-emission-matrix:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: verify-contract-and-manifest
     steps:
       - uses: actions/checkout@v6
@@ -113,7 +116,8 @@ jobs:
           path: test/instrumentation-matrix/reports/
 
   publish-matrix-summary:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [full-emission-matrix, default-cell-required]
     # Run on success AND on advisory cell failures (so the summary still
     # posts when cells go red), but NOT during cancellation — a bare
@@ -144,7 +148,8 @@ jobs:
         run: cat reports/summary.md >> "$GITHUB_STEP_SUMMARY"
 
   scan-cassettes-for-secrets:
-    runs-on: ubuntu-latest
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v6
       - run: ./scripts/check-cassettes.py


### PR DESCRIPTION
## Purpose

The `instrumentation-matrix-*` workflows are the only CI in this repo still pinned to GitHub-hosted `ubuntu-latest` runners; every other workflow runs on the org's AWS CodeBuild self-hosted runners. When the org's GitHub-hosted Actions allowance is exhausted, jobs requesting `ubuntu-latest` sit in `queued` with no runner assigned and never start.

This was observed on PR #1229: `default-cell-required` and `full-emission-matrix` were stuck `queued` for over an hour (the run's first two jobs had grabbed GitHub-hosted runners earlier, then assignment stopped mid-run), while all CodeBuild-based CI kept passing and nothing else was competing for runners.

## Goals

Remove the instrumentation-matrix workflows' dependency on the GitHub-hosted runner quota so they schedule reliably like the rest of the repo's CI.

## Approach

Switch every job in the PR, manual, and nightly matrix workflows from `runs-on: ubuntu-latest` to the same CodeBuild runner label the rest of the repo already uses:

```yaml
runs-on:
  - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
```

15 jobs across three files (`instrumentation-matrix-pr.yaml`, `instrumentation-matrix-manual.yaml`, `instrumentation-matrix-nightly.yaml`). No step logic changed — the actions used (`checkout`, `setup-python`, `setup-go`, `upload/download-artifact`, `nox`) all run identically on the CodeBuild runners.

## User stories

N/A — internal CI infrastructure change.

## Release note

N/A — no user-facing change.

## Documentation

N/A — CI-only change, no product documentation impact.

## Training

N/A — no training impact.

## Certification

N/A — no impact on certification exams.

## Marketing

N/A — no marketing impact.

## Automation tests

- Unit tests
  > N/A — no application code changed.
- Integration tests
  > The change itself is validated by this PR's own matrix workflow running to completion on CodeBuild runners.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — YAML workflow config only, no compiled code.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Related to #1229 (the PR whose run surfaced the stuck-queue behaviour).

## Migrations (if applicable)

N/A

## Test environment

GitHub Actions with AWS CodeBuild self-hosted runners (the org's existing CI runner fleet).

## Learning

The distinguishing signal was the runner labels: completed jobs showed `labels=['codebuild-wso2_agent-manager-…']` (CodeBuild), while the stuck jobs showed `labels=['ubuntu-latest']` with no runner assigned — isolating the cause to the GitHub-hosted quota rather than the workflow or the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a newer instrumentation version and updated the default selection to the latest supported release.
  * Expanded the supported provider/version matrix to include an additional compatible release.

* **Bug Fixes**
  * Updated workflow jobs to run on managed CodeBuild runners for more consistent execution.

* **Documentation**
  * Refreshed the instrumentation docs to reflect the latest default version and compatibility details.

* **Tests**
  * Adjusted coverage and test data to match the expanded version catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->