### PR TITLE
Pin instrumentation heavy tier to GitHub-hosted

### DIFF
--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -162,8 +162,13 @@ jobs:
             investigating, not a rubber-stamp refresh.
 
   heavy:
-    runs-on:
-      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    # Pinned to GitHub-hosted, unlike the emission jobs above: this is the only
+    # job that stands up k3d (via amp-dev-stack), and k3d's API server never
+    # becomes reachable on the CodeBuild runners' Docker-in-Docker daemon — the
+    # published host port (kubeAPI 6550) lands on the Docker host, not the
+    # runner, so `kubectl` hangs and `make setup-k3d` times out. ubuntu-latest
+    # is its own Docker host, where k3d's port publishing works.
+    runs-on: ubuntu-latest
     needs: run-cells
     # Normal run: gate behind a green emission matrix. heavy_only: run
     # regardless (run-cells is skipped), so always() is needed to evaluate at all.

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -42,8 +42,13 @@ jobs:
           path: test/instrumentation-matrix/reports/cells/
 
   heavy-tier:
-    runs-on:
-      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    # Pinned to GitHub-hosted, unlike the emission jobs: this is the only job
+    # that stands up k3d (via amp-dev-stack), and k3d's API server never becomes
+    # reachable on the CodeBuild runners' Docker-in-Docker daemon — the published
+    # host port (kubeAPI 6550) lands on the Docker host, not the runner, so
+    # `kubectl` hangs and `make setup-k3d` times out. ubuntu-latest is its own
+    # Docker host, where k3d's port publishing works.
+    runs-on: ubuntu-latest
     needs: full-emission-matrix
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
## Purpose

The instrumentation-matrix **heavy tier** has failed on every run since #1232 merged. #1232 moved all instrumentation-matrix jobs from GitHub-hosted `ubuntu-latest` to the org's AWS CodeBuild self-hosted runners to escape GitHub-hosted Actions quota starvation. That fix was correct for the emission jobs, but it broke the heavy tier — the only matrix job that stands up a k3d cluster (via the `amp-dev-stack` composite action). On the CodeBuild runners k3d's API server never becomes reachable, so `make setup-k3d` fails its readiness wait ("Cluster failed to become ready after 30 attempts") before any AMP component deploys. Two consecutive manual runs failed identically at that step ([run 1](https://github.com/wso2/agent-manager/actions/runs/28566880804/job/84697166282), [run 2](https://github.com/wso2/agent-manager/actions/runs/28567572194/job/84697964603)).

Root cause: on the CodeBuild runners' Docker-in-Docker daemon, k3d publishes the API host port (`kubeAPI.hostPort: "6550"`) onto the *Docker host's* network namespace, not the runner's, so `kubectl` against `0.0.0.0:6550` gets connection-refused (`dial tcp 0.0.0.0:6550: connect: connection refused` in the diagnostics dump). On `ubuntu-latest` the runner *is* the Docker host, so k3d's port publishing works — which is why the last run before #1232 was green. The instrumentation-matrix manual + nightly workflows are the only two in the repo that use k3d, so #1232 was the first time k3d ran on CodeBuild.

Related to #1232

## Goals

Restore a green heavy tier while keeping #1232's quota fix where it actually helps (the emission and reporting jobs, which don't touch k3d).

## Approach

Revert **only** the two k3d-dependent jobs — `heavy` (manual) and `heavy-tier` (nightly) — back to `runs-on: ubuntu-latest`, and leave every emission/reporting job on the CodeBuild runners. Each reverted job carries a comment explaining why it's pinned to GitHub-hosted, so a future reader doesn't "consolidate" it back onto CodeBuild and reintroduce the break.

The longer-term alternative — making k3d work under CodeBuild's Docker-in-Docker (rewriting the kubeconfig server to the Docker-host address and re-pointing the port-forward/exposure logic) — is more involved and runner-topology-dependent; this PR is the surgical fix.

## User stories

N/A — CI infrastructure fix.

## Release note

N/A — CI-only change, no user-facing impact.

## Documentation

N/A — no product behavior change.

## Training

N/A — no training impact.

## Certification

N/A — no certification impact.

## Marketing

N/A — no marketing impact.

## Automation tests

 - Unit tests
   > N/A — the change is to CI workflow runner selection; there is no unit-testable code.
 - Integration tests
   > The heavy tier itself *is* the integration test; validated by dispatching the manual workflow with `heavy_only` after merge (see Test environment).

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no application code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- #1232 — the CodeBuild migration this partially reverts.

## Migrations (if applicable)

N/A

## Test environment

GitHub Actions `ubuntu-latest` (heavy jobs) and CodeBuild self-hosted runners (emission jobs). To verify: dispatch the manual workflow with `heavy_only=true` and confirm the k3d bring-up in `amp-dev-stack` reaches a ready cluster.

## Learning

The tell was that k3d reported "Cluster created successfully" yet `0.0.0.0:6550` stayed connection-refused for the entire wait — the classic signature of k3d against a sibling/remote Docker daemon, where published host ports land on the daemon's host rather than the client's `localhost`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of instrumentation matrix runs by switching certain heavy jobs to a different runner environment.
  * Reduced hangs and timeouts during cluster setup, helping automation complete more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->