### PR TITLE
Add inline LLM provider creation to monitor flow

### DIFF
--- a/console/common/config/rush/pnpm-lock.yaml
+++ b/console/common/config/rush/pnpm-lock.yaml
@@ -2089,6 +2089,9 @@ importers:
       '@agent-management-platform/api-client':
         specifier: workspace:*
         version: link:../../libs/api-client
+      '@agent-management-platform/llm-providers':
+        specifier: workspace:*
+        version: link:../llm-providers
       '@agent-management-platform/shared-component':
         specifier: workspace:*
         version: link:../../libs/shared-component

--- a/console/workspaces/libs/api-client/src/hooks/llm-providers.ts
+++ b/console/workspaces/libs/api-client/src/hooks/llm-providers.ts
@@ -217,6 +217,7 @@ export function useCreateLLMProvider() {
     mutationFn: ({ params, body }) => createLLMProvider(params, body, getToken),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+      queryClient.invalidateQueries({ queryKey: ["catalog", "llm-providers"] });
     },
   });
 }

--- a/console/workspaces/pages/eval/package.json
+++ b/console/workspaces/pages/eval/package.json
@@ -55,6 +55,7 @@
     "@agent-management-platform/api-client": "workspace:*",
     "@agent-management-platform/types": "workspace:*",
     "@agent-management-platform/shared-component": "workspace:*",
+    "@agent-management-platform/llm-providers": "workspace:*",
     "zod": "4.3.6",
     "lodash": "4.17.21",
     "@monaco-editor/react": "4.7.0"

--- a/console/workspaces/pages/eval/src/subComponents/MonitorLLMProviderDrawer.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/MonitorLLMProviderDrawer.tsx
@@ -16,22 +16,29 @@
  * under the License.
  */
 
+import { type CatalogLLMProviderEntry } from "@agent-management-platform/types";
 import {
-  absoluteRouteMap,
-  type CatalogLLMProviderEntry,
-} from "@agent-management-platform/types";
-import {
+  useCreateLLMProvider,
   useListCatalogLLMProviders,
   useListLLMProviderTemplates,
 } from "@agent-management-platform/api-client";
+import {
+  AddLLMProviderForm,
+  buildCreateLLMProviderRequest,
+  mapLLMProviderTemplatesToCards,
+  type AddLLMProviderFormValues,
+  type GuardrailSelection,
+} from "@agent-management-platform/llm-providers";
 import {
   DrawerContent,
   DrawerHeader,
   DrawerWrapper,
 } from "@agent-management-platform/views";
+import { getErrorMessage } from "@agent-management-platform/shared-component";
 import {
   Avatar,
   Box,
+  Button,
   Chip,
   CircularProgress,
   Divider,
@@ -43,11 +50,11 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import {
+  ArrowLeft,
   Check,
   Circle,
   Coins,
   DoorClosedLocked,
-  ExternalLink,
   Hash,
   Info,
   Plus,
@@ -55,7 +62,7 @@ import {
 } from "@wso2/oxygen-ui-icons-react";
 import { formatDistanceToNow } from "date-fns";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { generatePath, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import debounce from "lodash/debounce";
 
 interface MonitorLLMProviderDrawerProps {
@@ -285,9 +292,11 @@ export function MonitorLLMProviderDrawer({
     { orgName: orgId },
     { limit: PAGE_SIZE, offset: fetchOffset },
   );
-  const { data: templatesData } = useListLLMProviderTemplates({
-    orgName: orgId,
-  });
+  const { data: templatesData, isLoading: isLoadingTemplates } =
+    useListLLMProviderTemplates(
+      { orgName: orgId },
+      { limit: 50, offset: 0 },
+    );
 
   const templateMap = useMemo(() => {
     const map = new Map<string, { displayName: string; logoUrl?: string }>();
@@ -297,6 +306,22 @@ export function MonitorLLMProviderDrawer({
     }
     return map;
   }, [templatesData]);
+
+  const templateCards = useMemo(
+    () => mapLLMProviderTemplatesToCards(templatesData?.templates),
+    [templatesData],
+  );
+
+  const [mode, setMode] = useState<"list" | "create">("list");
+  // Guards the "auto-open create view when the org has no providers" behavior
+  // so it fires at most once per drawer-open and never overrides a user who
+  // deliberately navigated back to the list.
+  const autoSwitchDone = useRef(false);
+  const {
+    mutate: createLLMProvider,
+    isPending: isCreatingProvider,
+    error: createProviderError,
+  } = useCreateLLMProvider();
 
   const debouncedSetSearch = useMemo(
     () => debounce((value: string) => setDebouncedSearch(value), 250),
@@ -314,8 +339,21 @@ export function MonitorLLMProviderDrawer({
       setAllProviders([]);
       setFetchOffset(0);
       setRefreshKey((k) => k + 1);
+      setMode("list");
+      autoSwitchDone.current = false;
     }
   }, [open]);
+
+  // When the org has no LLM providers yet, open straight into the create view
+  // so the user isn't shown an empty list they have to click through. Fires
+  // once per open; if the user goes back to the (empty) list, we respect it.
+  useEffect(() => {
+    if (!open || autoSwitchDone.current || isFetching || !catalogData) return;
+    autoSwitchDone.current = true;
+    if ((catalogData.total ?? 0) === 0) {
+      setMode("create");
+    }
+  }, [open, isFetching, catalogData]);
 
   // Accumulate each page as it arrives and trigger the next fetch if needed.
   useEffect(() => {
@@ -349,13 +387,6 @@ export function MonitorLLMProviderDrawer({
     );
   }, [allProviders, debouncedSearch, templateMap]);
 
-  const addProviderPath = orgId
-    ? generatePath(
-        absoluteRouteMap.children.org.children.llmProviders.children.add.path,
-        { orgId },
-      )
-    : null;
-
   const handleSearchChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setSearch(event.target.value);
@@ -372,95 +403,136 @@ export function MonitorLLMProviderDrawer({
     [onProviderChange, onClose],
   );
 
+  const handleCreateProvider = useCallback(
+    (values: AddLLMProviderFormValues, guardrails: GuardrailSelection[]) => {
+      if (!orgId) return;
+      const body = buildCreateLLMProviderRequest(
+        values,
+        guardrails,
+        templateCards,
+      );
+      createLLMProvider(
+        { params: { orgName: orgId }, body },
+        {
+          onSuccess: (data) => {
+            onProviderChange(data.id);
+            onClose();
+          },
+        },
+      );
+    },
+    [orgId, templateCards, createLLMProvider, onProviderChange, onClose],
+  );
+
   return (
     <DrawerWrapper open={open} onClose={onClose} maxWidth={520}>
       <DrawerHeader
         icon={<DoorClosedLocked size={24} />}
-        title="Select LLM Provider"
+        title={mode === "create" ? "Create LLM Provider" : "Select LLM Provider"}
         onClose={onClose}
       />
       <DrawerContent>
-        <Stack spacing={2}>
-          <Typography variant="body2" color="text.secondary">
-            Select the LLM provider for all LLM-judge evaluators in this
-            monitor.
-          </Typography>
-          <SearchBar
-            placeholder="Search providers"
-            size="small"
-            fullWidth
-            value={search}
-            onChange={handleSearchChange}
-          />
-          {isFetching && filteredProviders.length === 0 && (
-            <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-              <CircularProgress size={32} />
-            </Box>
-          )}
-          {filteredProviders.length === 0 && !isFetching && (
-            <ListingTable.EmptyState
-              title={
-                search.trim()
-                  ? "No providers match your search"
-                  : "No LLM providers configured"
-              }
-              description={
-                search.trim()
-                  ? "Try a different keyword."
-                  : "Add an LLM service provider to get started."
-              }
+        {mode === "list" ? (
+          <Stack spacing={2}>
+            <Typography variant="body2" color="text.secondary">
+              Select the LLM provider for all LLM-judge evaluators in this
+              monitor.
+            </Typography>
+            <SearchBar
+              placeholder="Search providers"
+              size="small"
+              fullWidth
+              value={search}
+              onChange={handleSearchChange}
             />
-          )}
-          {filteredProviders.length > 0 && (
-            <Stack spacing={1}>
-              {filteredProviders.map((entry) => {
-                const isSelected = entry.handle === selectedProviderName;
-                const templateInfo = templateMap.get(entry.template ?? "");
-                return (
-                  <Form.CardButton
-                    key={entry.uuid}
-                    onClick={() => handleSelect(entry.handle)}
-                    selected={isSelected}
-                  >
-                    <Form.CardContent>
-                      <ProviderCardContent
-                        entry={entry}
-                        isSelected={isSelected}
-                        templateInfo={templateInfo}
-                      />
-                    </Form.CardContent>
-                  </Form.CardButton>
-                );
-              })}
-            </Stack>
-          )}
-          {addProviderPath && (
-            <>
-              <Divider />
-              <Box
-                component="a"
-                href={addProviderPath}
-                target="_blank"
-                rel="noopener noreferrer"
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1,
-                  color: "primary.main",
-                  textDecoration: "none",
-                  cursor: "pointer",
-                  "&:hover": { textDecoration: "underline" },
-                }}
-              >
-                <Plus size={16} />
-                <Typography variant="body2" color="primary">
-                  Add LLM Provider
-                </Typography>
-                <ExternalLink size={14} />
+            {isFetching && filteredProviders.length === 0 && (
+              <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+                <CircularProgress size={32} />
               </Box>
-            </>
-          )}
-        </Stack>
+            )}
+            {filteredProviders.length === 0 && !isFetching && (
+              <ListingTable.EmptyState
+                title={
+                  search.trim()
+                    ? "No providers match your search"
+                    : "No LLM providers configured"
+                }
+                description={
+                  search.trim()
+                    ? "Try a different keyword."
+                    : "Add an LLM service provider to get started."
+                }
+              />
+            )}
+            {filteredProviders.length > 0 && (
+              <Stack spacing={1}>
+                {filteredProviders.map((entry) => {
+                  const isSelected = entry.handle === selectedProviderName;
+                  const templateInfo = templateMap.get(entry.template ?? "");
+                  return (
+                    <Form.CardButton
+                      key={entry.uuid}
+                      onClick={() => handleSelect(entry.handle)}
+                      selected={isSelected}
+                    >
+                      <Form.CardContent>
+                        <ProviderCardContent
+                          entry={entry}
+                          isSelected={isSelected}
+                          templateInfo={templateInfo}
+                        />
+                      </Form.CardContent>
+                    </Form.CardButton>
+                  );
+                })}
+              </Stack>
+            )}
+            <Divider />
+            <Button
+              variant="text"
+              size="small"
+              startIcon={<Plus size={16} />}
+              onClick={() => setMode("create")}
+              sx={{ alignSelf: "flex-start" }}
+            >
+              Add LLM Provider
+            </Button>
+          </Stack>
+        ) : (
+          <Stack spacing={2}>
+            <Button
+              variant="text"
+              size="small"
+              startIcon={<ArrowLeft size={16} />}
+              onClick={() => setMode("list")}
+              sx={{ alignSelf: "flex-start" }}
+            >
+              Back to providers
+            </Button>
+            <Typography variant="body2" color="text.secondary">
+              Create an LLM provider for this monitor&apos;s LLM-judge
+              evaluators. It will be added to your organization&apos;s
+              provider catalog.
+            </Typography>
+            <AddLLMProviderForm
+              orgId={orgId ?? ""}
+              templates={templateCards}
+              isLoadingTemplates={isLoadingTemplates}
+              isSubmitting={isCreatingProvider}
+              errorMessage={
+                createProviderError
+                  ? getErrorMessage(createProviderError)
+                  : null
+              }
+              submitLabel="Create & use provider"
+              showAdvancedBasicDetails={false}
+              showGuardrails={false}
+              showGatewaySelector={false}
+              onCancel={() => setMode("list")}
+              onSubmit={handleCreateProvider}
+            />
+          </Stack>
+        )}
       </DrawerContent>
     </DrawerWrapper>
   );

--- a/console/workspaces/pages/llm-providers/src/AddLLMProviders.Organization.tsx
+++ b/console/workspaces/pages/llm-providers/src/AddLLMProviders.Organization.tsx
@@ -20,11 +20,7 @@ import React, { useCallback, useMemo } from "react";
 import { PageLayout } from "@agent-management-platform/views";
 import { generatePath, useNavigate, useParams } from "react-router-dom";
 import { getErrorMessage } from "@agent-management-platform/shared-component";
-import {
-  absoluteRouteMap,
-  type CreateLLMProviderRequest,
-  type UpstreamAuthType,
-} from "@agent-management-platform/types";
+import { absoluteRouteMap } from "@agent-management-platform/types";
 import {
   useCreateLLMProvider,
   useListGateways,
@@ -34,15 +30,11 @@ import {
   AddLLMProviderForm,
   type AddLLMProviderFormValues,
   type GuardrailSelection,
-  type TemplateCard,
 } from "./subComponents/AddLLMProviderForm";
-
-const toProviderId = (name: string): string =>
-  name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+import {
+  buildCreateLLMProviderRequest,
+  mapLLMProviderTemplatesToCards,
+} from "./utils/llmProviderPayload";
 
 export const AddLLMProvidersOrganization: React.FC = () => {
   const { orgId } = useParams<{ orgId: string }>();
@@ -76,22 +68,8 @@ export const AddLLMProvidersOrganization: React.FC = () => {
     error: createError,
   } = useCreateLLMProvider();
 
-  const templates: TemplateCard[] = useMemo(
-    () =>
-      templatesData?.templates?.map((t) => ({
-        id: t.id,
-        handle: t.id,
-        name: t.name,
-        description: t.description,
-        image: t.metadata?.logoUrl,
-        hasTemplateUrl: Boolean(t.metadata?.endpointUrl),
-        endpointUrl: t.metadata?.endpointUrl,
-        hasTemplateAuthType: Boolean(t.metadata?.auth?.type),
-        hasTemplateAuthHeader: Boolean(t.metadata?.auth?.header),
-        authType: t.metadata?.auth?.type,
-        authHeader: t.metadata?.auth?.header,
-        authValuePrefix: t.metadata?.auth?.valuePrefix,
-      })) ?? [],
+  const templates = useMemo(
+    () => mapLLMProviderTemplatesToCards(templatesData?.templates),
     [templatesData],
   );
 
@@ -121,85 +99,7 @@ export const AddLLMProvidersOrganization: React.FC = () => {
         return;
       }
 
-      const normalizedDisplayName = values.displayName?.trim() || "";
-      const providerId =
-        toProviderId(normalizedDisplayName) || "llm-provider";
-      const selectedTemplate = templates.find(
-        (tpl) => tpl.id === values.templateId,
-      );
-      const templateHandle =
-        selectedTemplate?.handle || selectedTemplate?.name || values.templateId;
-
-      const policies =
-        guardrails.length > 0
-          ? guardrails.map((g) => ({
-              name: g.name,
-              version: g.version,
-              paths: [
-                {
-                  path: "/*",
-                  methods: ["*"],
-                  params: g.settings ?? {},
-                },
-              ],
-            }))
-          : undefined;
-
-      const contextPath =
-        values.context?.trim() || ``;
-
-      const authType: UpstreamAuthType =
-        (selectedTemplate?.authType as UpstreamAuthType) ?? "bearer";
-      const authHeader =
-        selectedTemplate?.authHeader ?? "Authorization";
-      const apiKey = values.apiKey?.trim() ?? "";
-      const authValue = apiKey
-        ? (selectedTemplate?.authValuePrefix
-            ? `${selectedTemplate.authValuePrefix}${apiKey}`
-            : authType === "bearer"
-              ? `Bearer ${apiKey}`
-              : apiKey)
-        : "";
-
-      const payload: CreateLLMProviderRequest = {
-        id: providerId,
-        name: normalizedDisplayName || providerId,
-        version: values.version.trim(),
-        context: contextPath,
-        template: templateHandle,
-        upstream: {
-          main: {
-            url: values.upstreamUrl?.trim(),
-            auth: values.apiKey
-              ? {
-                  type: authType,
-                  header: authHeader,
-                  value: authValue,
-                }
-              : undefined,
-          },
-        },
-        description: values.description?.trim() || undefined,
-        security: values.apiKey
-          ? {
-              enabled: true,
-              apiKey: {
-                enabled: true,
-                key: "X-API-Key",
-                in: "header",
-              },
-            }
-          : undefined,
-        policies,
-        gateways:
-          values.gatewayIds && values.gatewayIds.length > 0
-            ? values.gatewayIds
-            : undefined,
-        accessControl: {
-          exceptions: [],
-          mode: "allow_all",
-        },
-      };
+      const payload = buildCreateLLMProviderRequest(values, guardrails, templates);
 
       createLLMProvider(
         {
@@ -229,6 +129,7 @@ export const AddLLMProvidersOrganization: React.FC = () => {
       backLabel="Back to Providers List"
     >
       <AddLLMProviderForm
+        orgId={orgId ?? ""}
         templates={templates}
         isLoadingTemplates={isLoadingTemplates}
         missingParamsMessage={missingParamsMessage}

--- a/console/workspaces/pages/llm-providers/src/index.ts
+++ b/console/workspaces/pages/llm-providers/src/index.ts
@@ -40,3 +40,15 @@ export {
   LLMProvidersOrganization,
   AddLLMProvidersOrganization,
 };
+
+export { AddLLMProviderForm } from './subComponents/AddLLMProviderForm';
+export type {
+  AddLLMProviderFormValues,
+  GuardrailSelection,
+  TemplateCard,
+} from './subComponents/AddLLMProviderForm';
+export {
+  buildCreateLLMProviderRequest,
+  mapLLMProviderTemplatesToCards,
+  toProviderId,
+} from './utils/llmProviderPayload';

--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -43,7 +43,6 @@ import {
   type PolicySelection as GuardrailSelection,
 } from "@agent-management-platform/shared-component";
 import { useListGateways } from "@agent-management-platform/api-client";
-import { useParams } from "react-router-dom";
 
 export type TemplateCard = {
   id: string;
@@ -78,11 +77,32 @@ export type TemplateCard = {
 export type { AddLLMProviderFormValues, GuardrailSelection };
 
 interface AddLLMProviderFormProps {
+  orgId: string;
   templates: TemplateCard[];
   isLoadingTemplates: boolean;
   missingParamsMessage?: string | null;
   errorMessage?: string | null;
   isSubmitting?: boolean;
+  submitLabel?: string;
+  /**
+   * Set to false to collapse the Basic Details section to just the Name
+   * field, hiding Version / Description / Context path. Their defaults
+   * (version `v1.0`, auto-derived context, empty description) are still
+   * submitted, so the provider is created with no extra input.
+   */
+  showAdvancedBasicDetails?: boolean;
+  /**
+   * Set to false to hide the Guardrails section, e.g. when the form is
+   * embedded in a flow that only needs a minimal provider (name, template,
+   * connection config).
+   */
+  showGuardrails?: boolean;
+  /**
+   * Set to false to hide the multi-gateway Deployment Configuration section.
+   * A gateway is still required and auto-selected under the hood; only the
+   * UI is simplified based on how many active gateways the org has.
+   */
+  showGatewaySelector?: boolean;
   onCancel: () => void;
   onSubmit: (
     values: AddLLMProviderFormValues,
@@ -115,11 +135,16 @@ const INITIAL_FORM_VALUES: AddLLMProviderFormValues = {
 const TEMPLATE_GRID_COLUMNS = "repeat(auto-fill, minmax(min(100%, 240px), 1fr))";
 
 export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
+  orgId,
   templates,
   isLoadingTemplates,
   missingParamsMessage,
   errorMessage,
   isSubmitting,
+  submitLabel = "Add provider",
+  showAdvancedBasicDetails = true,
+  showGuardrails = true,
+  showGatewaySelector = true,
   onCancel,
   onSubmit,
 }) => {
@@ -144,7 +169,6 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
     [formData.templateId, templates],
   );
 
-  const { orgId } = useParams<{ orgId: string }>();
   const { data: gatewaysData, isLoading: isLoadingGateways } = useListGateways({
     orgName: orgId,
   });
@@ -340,49 +364,65 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
               </Form.ElementWrapper>
             </Box>
 
-            <Box sx={{ flex: 1 }}>
-              <Form.ElementWrapper label="Version" name="version">
-                <TextField
-                  id="version"
-                  fullWidth
-                  value={formData.version}
-                  onChange={(e) => handleFieldChange("version", e.target.value)}
-                  placeholder="v1.0"
-                  error={Boolean(errors.version)}
-                  helperText={errors.version}
-                />
-              </Form.ElementWrapper>
-            </Box>
+            {showAdvancedBasicDetails && (
+              <Box sx={{ flex: 1 }}>
+                <Form.ElementWrapper label="Version" name="version">
+                  <TextField
+                    id="version"
+                    fullWidth
+                    value={formData.version}
+                    onChange={(e) =>
+                      handleFieldChange("version", e.target.value)
+                    }
+                    placeholder="v1.0"
+                    error={Boolean(errors.version)}
+                    helperText={errors.version}
+                  />
+                </Form.ElementWrapper>
+              </Box>
+            )}
           </Form.Stack>
 
-          <Form.ElementWrapper label="Description (optional)" name="description">
-            <TextField
-              id="description"
-              fullWidth
-              multiline
-              rows={2}
-              value={formData.description ?? ""}
-              onChange={(e) => handleFieldChange("description", e.target.value)}
-              placeholder="Primary LLM provider for production"
-              error={Boolean(errors.description)}
-              helperText={errors.description}
-            />
-          </Form.ElementWrapper>
+          {showAdvancedBasicDetails && (
+            <>
+              <Form.ElementWrapper
+                label="Description (optional)"
+                name="description"
+              >
+                <TextField
+                  id="description"
+                  fullWidth
+                  multiline
+                  rows={2}
+                  value={formData.description ?? ""}
+                  onChange={(e) =>
+                    handleFieldChange("description", e.target.value)
+                  }
+                  placeholder="Primary LLM provider for production"
+                  error={Boolean(errors.description)}
+                  helperText={errors.description}
+                />
+              </Form.ElementWrapper>
 
-          <Form.ElementWrapper label="Context path (optional)" name="context">
-            <TextField
-              id="context"
-              fullWidth
-              value={formData.context ?? ""}
-              onChange={(e) => handleFieldChange("context", e.target.value)}
-              placeholder="/my-provider"
-              error={Boolean(errors.context)}
-              helperText={
-                errors.context ??
-                "API context path (must start with /, no trailing slash)"
-              }
-            />
-          </Form.ElementWrapper>
+              <Form.ElementWrapper
+                label="Context path (optional)"
+                name="context"
+              >
+                <TextField
+                  id="context"
+                  fullWidth
+                  value={formData.context ?? ""}
+                  onChange={(e) => handleFieldChange("context", e.target.value)}
+                  placeholder="/my-provider"
+                  error={Boolean(errors.context)}
+                  helperText={
+                    errors.context ??
+                    "API context path (must start with /, no trailing slash)"
+                  }
+                />
+              </Form.ElementWrapper>
+            </>
+          )}
         </Form.Stack>
       </Form.Section>
 
@@ -558,46 +598,89 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
         </Form.Section>
       </Collapse>
       {/* Guardrails */}
-      <Collapse in={!!formData.templateId}>
-        <PolicyListSection
-          title="Guardrails"
-          description="Add safety policies to enforce consistent protections."
-          addButtonLabel="Add Guardrail"
-          drawerAddTitle="Add Guardrail"
-          drawerEditTitle="Edit Guardrail"
-          drawerAddSubtitle="Choose a guardrail to configure advanced options."
-          drawerEditSubtitle="Update the guardrail configuration."
-          policyNoun="guardrail"
-          loadingLabel="Loading guardrails..."
-          searchPlaceholder="Search guardrails..."
-          catalogErrorLabel="Failed to load guardrails."
-          emptySearchTitle="No guardrails match your search"
-          emptyCatalogTitle="No guardrails available"
-          emptyCatalogDescription="No guardrail policies are available in the catalog."
-          policies={guardrails}
-          onAdd={handleAddGuardrail}
-          onEdit={handleEditGuardrail}
-          onRemove={handleRemoveGuardrail}
-        />
-      </Collapse>
-      <Collapse in={!!formData.templateId}>
-        <Form.Section>
-          <Form.Subheader>Deployment Configuration</Form.Subheader>
-          <Form.ElementWrapper label="Gateway" name="gatewayIds">
-            {isLoadingGateways ? (
-              <Skeleton variant="rounded" height={40} />
-            ) : (
+      {showGuardrails && (
+        <Collapse in={!!formData.templateId}>
+          <PolicyListSection
+            title="Guardrails"
+            description="Add safety policies to enforce consistent protections."
+            addButtonLabel="Add Guardrail"
+            drawerAddTitle="Add Guardrail"
+            drawerEditTitle="Edit Guardrail"
+            drawerAddSubtitle="Choose a guardrail to configure advanced options."
+            drawerEditSubtitle="Update the guardrail configuration."
+            policyNoun="guardrail"
+            loadingLabel="Loading guardrails..."
+            searchPlaceholder="Search guardrails..."
+            catalogErrorLabel="Failed to load guardrails."
+            emptySearchTitle="No guardrails match your search"
+            emptyCatalogTitle="No guardrails available"
+            emptyCatalogDescription="No guardrail policies are available in the catalog."
+            policies={guardrails}
+            onAdd={handleAddGuardrail}
+            onEdit={handleEditGuardrail}
+            onRemove={handleRemoveGuardrail}
+          />
+        </Collapse>
+      )}
+      {showGatewaySelector ? (
+        <Collapse in={!!formData.templateId}>
+          <Form.Section>
+            <Form.Subheader>Deployment Configuration</Form.Subheader>
+            <Form.ElementWrapper label="Gateway" name="gatewayIds">
+              {isLoadingGateways ? (
+                <Skeleton variant="rounded" height={40} />
+              ) : (
+                <Autocomplete
+                  multiple
+                  options={gateways}
+                  size="small"
+                  value={gateways.filter((g) =>
+                    (formData.gatewayIds ?? []).includes(g.uuid),
+                  )}
+                  onChange={(_, newValue) => {
+                    handleFieldChange(
+                      "gatewayIds",
+                      newValue.map((g) => g.uuid),
+                    );
+                  }}
+                  getOptionLabel={(option) =>
+                    option.displayName || option.name || option.uuid
+                  }
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      placeholder="Select gateway(s)"
+                      error={Boolean(errors.gatewayIds)}
+                      helperText={errors.gatewayIds}
+                    />
+                  )}
+                />
+              )}
+            </Form.ElementWrapper>
+          </Form.Section>
+        </Collapse>
+      ) : (
+        <Collapse in={!!formData.templateId}>
+          {!isLoadingGateways && gateways.length === 0 && (
+            <Alert severity="warning">
+              No active gateway is configured for this organization. Ask an
+              admin to configure one before creating an LLM provider.
+            </Alert>
+          )}
+          {!isLoadingGateways && gateways.length > 1 && (
+            <Form.ElementWrapper label="Gateway" name="gatewayIds">
               <Autocomplete
-                multiple
                 options={gateways}
                 size="small"
-                value={gateways.filter((g) =>
-                  (formData.gatewayIds ?? []).includes(g.uuid),
-                )}
+                value={
+                  gateways.find((g) =>
+                    (formData.gatewayIds ?? []).includes(g.uuid),
+                  ) ?? null
+                }
                 onChange={(_, newValue) => {
                   handleFieldChange(
                     "gatewayIds",
-                    newValue.map((g) => g.uuid),
+                    newValue ? [newValue.uuid] : [],
                   );
                 }}
                 getOptionLabel={(option) =>
@@ -606,16 +689,16 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
                 renderInput={(params) => (
                   <TextField
                     {...params}
-                    placeholder="Select gateway(s)"
+                    placeholder="Select gateway"
                     error={Boolean(errors.gatewayIds)}
                     helperText={errors.gatewayIds}
                   />
                 )}
               />
-            )}
-          </Form.ElementWrapper>
-        </Form.Section>
-      </Collapse>
+            </Form.ElementWrapper>
+          )}
+        </Collapse>
+      )}
       {errorMessage && (
         <Alert severity="error">
           <Typography variant="body2">{errorMessage}</Typography>
@@ -651,7 +734,7 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
             formData.gatewayIds?.length === 0
           }
         >
-          {isSubmitting ? "Creating..." : "Add provider"}
+          {isSubmitting ? "Creating..." : submitLabel}
         </Button>
       </Box>
     </Form.Stack>

--- a/console/workspaces/pages/llm-providers/src/utils/llmProviderPayload.ts
+++ b/console/workspaces/pages/llm-providers/src/utils/llmProviderPayload.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type {
+  CreateLLMProviderRequest,
+  LLMProviderTemplateResponse,
+  UpstreamAuthType,
+} from "@agent-management-platform/types";
+import type {
+  AddLLMProviderFormValues,
+  GuardrailSelection,
+  TemplateCard,
+} from "../subComponents/AddLLMProviderForm";
+
+export const toProviderId = (name: string): string =>
+  name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export function mapLLMProviderTemplatesToCards(
+  templates: LLMProviderTemplateResponse[] | undefined,
+): TemplateCard[] {
+  return (
+    templates?.map((t) => ({
+      id: t.id,
+      handle: t.id,
+      name: t.name,
+      description: t.description,
+      image: t.metadata?.logoUrl,
+      hasTemplateUrl: Boolean(t.metadata?.endpointUrl),
+      endpointUrl: t.metadata?.endpointUrl,
+      hasTemplateAuthType: Boolean(t.metadata?.auth?.type),
+      hasTemplateAuthHeader: Boolean(t.metadata?.auth?.header),
+      authType: t.metadata?.auth?.type,
+      authHeader: t.metadata?.auth?.header,
+      authValuePrefix: t.metadata?.auth?.valuePrefix,
+    })) ?? []
+  );
+}
+
+export function buildCreateLLMProviderRequest(
+  values: AddLLMProviderFormValues,
+  guardrails: GuardrailSelection[],
+  templates: TemplateCard[],
+): CreateLLMProviderRequest {
+  const normalizedDisplayName = values.displayName?.trim() || "";
+  const providerId = toProviderId(normalizedDisplayName) || "llm-provider";
+  const selectedTemplate = templates.find((tpl) => tpl.id === values.templateId);
+  const templateHandle =
+    selectedTemplate?.handle || selectedTemplate?.name || values.templateId;
+
+  const policies =
+    guardrails.length > 0
+      ? guardrails.map((g) => ({
+          name: g.name,
+          version: g.version,
+          paths: [
+            {
+              path: "/*",
+              methods: ["*"],
+              params: g.settings ?? {},
+            },
+          ],
+        }))
+      : undefined;
+
+  const contextPath = values.context?.trim() || ``;
+
+  const authType: UpstreamAuthType =
+    (selectedTemplate?.authType as UpstreamAuthType) ?? "bearer";
+  const authHeader = selectedTemplate?.authHeader ?? "Authorization";
+  const apiKey = values.apiKey?.trim() ?? "";
+  const authValue = apiKey
+    ? selectedTemplate?.authValuePrefix
+      ? `${selectedTemplate.authValuePrefix}${apiKey}`
+      : authType === "bearer"
+        ? `Bearer ${apiKey}`
+        : apiKey
+    : "";
+
+  return {
+    id: providerId,
+    name: normalizedDisplayName || providerId,
+    version: values.version.trim(),
+    context: contextPath,
+    template: templateHandle,
+    upstream: {
+      main: {
+        url: values.upstreamUrl?.trim(),
+        auth: values.apiKey
+          ? {
+              type: authType,
+              header: authHeader,
+              value: authValue,
+            }
+          : undefined,
+      },
+    },
+    description: values.description?.trim() || undefined,
+    security: values.apiKey
+      ? {
+          enabled: true,
+          apiKey: {
+            enabled: true,
+            key: "X-API-Key",
+            in: "header",
+          },
+        }
+      : undefined,
+    policies,
+    gateways:
+      values.gatewayIds && values.gatewayIds.length > 0
+        ? values.gatewayIds
+        : undefined,
+    accessControl: {
+      exceptions: [],
+      mode: "allow_all",
+    },
+  };
+}


### PR DESCRIPTION
## Purpose

Closes #1236

Creating an evaluation monitor with an LLM-judge evaluator requires an org-level LLM provider to exist. If none does, the UI sent the user out of the monitor wizard (opened the org-level "Add LLM Provider" page in a new tab), forcing them to complete a separate wizard, come back, and pick the new provider from the list.

This is unnecessary friction — especially for users who already have a gateway/LLM connection ready, or who just want to run a monitor by supplying credentials without treating "providers" as a separate governed resource they must manage first.

## What changed

Users can now create an LLM provider **inline**, directly from the monitor's LLM-provider drawer, entering only the essentials (name, provider template, connection config). No backend changes — monitor creation only references a provider by handle, and provider creation is already an independent endpoint.

- **Inline create mode** in `MonitorLLMProviderDrawer` — replaces the open-in-new-tab link with an in-drawer create form; on success the new provider is auto-selected and the drawer closes.
- **Auto-opens the create view** when the org has no providers yet (once per open; respects the user navigating back).
- **Shared payload utils** (`buildCreateLLMProviderRequest`, `mapLLMProviderTemplatesToCards`, `toProviderId`) extracted from the org-level page so both entry points build the request identically — no duplicated logic.
- **Compact form props** on `AddLLMProviderForm` (`showAdvancedBasicDetails`, `showGuardrails`, `showGatewaySelector`, `submitLabel`, explicit `orgId`) so the embedded form collects only Name + template + connection config. Gateway is auto-selected under the hood (blocking warning when the org has zero active gateways; single-select when it has more than one). Defaults keep the standalone org page unchanged.
- **Cache fix**: `useCreateLLMProvider` now also invalidates the `["catalog", "llm-providers"]` query, so a freshly created provider appears in the picker without a manual refresh.

## Testing

- `rush build` passes for all affected packages (`views`, `api-client`, `llm-providers`, `eval`).
- Lint: no new errors/warnings introduced.
- Manual: create-from-empty-org auto-opens the create view; name-only form creates and immediately selects the provider; standalone org-level "Add LLM Provider" page still works unchanged (full form + guardrails + multi-gateway).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now add a new LLM provider directly from the provider drawer without leaving the page.
  * The add-provider form now supports a more flexible setup flow, including optional advanced details, guardrails, and gateway selection.

* **Bug Fixes**
  * Provider lists now refresh correctly after creating a new provider.
  * The create flow now opens automatically when no providers are configured, making first-time setup smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->