### PR TITLE
Fix gateway registration 403 for client-credentials tokens

### DIFF
--- a/agent-manager-service/api/gateway_routes.go
+++ b/agent-manager-service/api/gateway_routes.go
@@ -23,7 +23,7 @@ import (
 )
 
 func RegisterGatewayRoutes(rr *middleware.RouteRegistrar, ctrl controllers.GatewayController) {
-	rr.HandleFuncWithValidationAndAuthz("POST /orgs/{orgName}/gateways", rbac.GatewayCreate, ctrl.RegisterGateway)
+	rr.HandleFuncWithValidationAndAuthzAllowRootOU("POST /orgs/{orgName}/gateways", rbac.GatewayCreate, ctrl.RegisterGateway)
 	rr.HandleFuncWithValidationAndAuthz("GET /orgs/{orgName}/gateways", rbac.GatewayRead, ctrl.ListGateways)
 	rr.HandleFuncWithValidationAndAuthz("GET /orgs/{orgName}/gateways/{gatewayID}", rbac.GatewayRead, ctrl.GetGateway)
 	rr.HandleFuncWithValidationAndAuthz("PUT /orgs/{orgName}/gateways/{gatewayID}", rbac.GatewayUpdate, ctrl.UpdateGateway)

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -108,6 +108,13 @@ type Config struct {
 	// Flip to true after roles are assigned to users in Thunder.
 	RBACEnabled bool
 
+	// RootOUHandle identifies the root/admin Organization Unit in Thunder.
+	// Client-credentials tokens issued to this OU are allowed to access any
+	// org's gateway-registration route (see RequireOrgMatchAllowRootOU /
+	// RequirePermissionAllowRootOU in middleware/authorization.go), since
+	// system clients always carry the root OU rather than a specific tenant's OU.
+	RootOUHandle string
+
 	// TLS Configurations
 	TLSConfig TLSConfig
 

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -229,6 +229,7 @@ func loadEnvs() {
 	}
 
 	config.RBACEnabled = r.readOptionalBool("RBAC_ENABLED", false)
+	config.RootOUHandle = r.readOptionalString("ROOT_OU_HANDLE", "admin")
 
 	// Resource limits for agent resource configurations (operator-controlled ceilings)
 	config.PerAgentResourceLimits = ResourceLimitsConfig{

--- a/agent-manager-service/middleware/authorization.go
+++ b/agent-manager-service/middleware/authorization.go
@@ -58,11 +58,13 @@ func RequireOrgMatch(resolver OrgResolver) func(http.HandlerFunc) http.HandlerFu
 
 // RequireOrgMatchAllowRootOU behaves like RequireOrgMatch but additionally allows
 // a client-credentials token issued to the configured root/admin OU
-// (config.RootOUHandle) to access any org's route. ResolvedOrg is set to the
-// PATH org (resolved via OrgResolver), not the token's admin OU, so downstream
-// handlers operate on the correct tenant. Use only for system-client
-// endpoints (currently: gateway registration during org bootstrap) — do not
-// apply broadly to user-facing routes.
+// (config.RootOUHandle) to access any org's route, for any path org — this is a
+// system client, not scoped to a specific tenant, so its OUID is not resolved.
+// ResolvedOrg.OuHandle is set to the PATH org (not the token's admin OU) so
+// downstream handlers operate on the correct tenant; ResolvedOrg.OUID is left
+// empty since gateway registration does not consume it. Use only for
+// system-client endpoints (currently: gateway registration during org
+// bootstrap) — do not apply broadly to user-facing routes.
 func RequireOrgMatchAllowRootOU(resolver OrgResolver) func(http.HandlerFunc) http.HandlerFunc {
 	return requireOrgMatch(resolver, true)
 }
@@ -86,20 +88,9 @@ func requireOrgMatch(resolver OrgResolver, allowRootOU bool) func(http.HandlerFu
 			pathOrg := r.PathValue(utils.PathParamOrgName)
 			if pathOrg != claims.OuHandle {
 				if allowRootOU && claims.OuHandle == config.GetConfig().RootOUHandle {
-					ouid, err := resolver.ResolveOUID(r.Context(), pathOrg)
-					if err != nil {
-						var re *ResolverError
-						if errors.As(err, &re) {
-							utils.WriteErrorResponse(w, re.StatusCode, re.Message)
-						} else {
-							utils.WriteErrorResponse(w, http.StatusInternalServerError, "internal error resolving organization")
-						}
-						return
-					}
 					slog.Info("RequireOrgMatch: root OU token granted cross-org access", "sub", claims.Sub, "pathOrg", pathOrg)
 					ctx := WithResolvedOrg(r.Context(), ResolvedOrg{
 						OuHandle: pathOrg,
-						OUID:     ouid,
 					})
 					next(w, r.WithContext(ctx))
 					return

--- a/agent-manager-service/middleware/authorization.go
+++ b/agent-manager-service/middleware/authorization.go
@@ -18,6 +18,7 @@ package middleware
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
@@ -52,14 +53,31 @@ func NewResolverForbiddenError(msg string) *ResolverError {
 //  2. Validates path {orgName} parameter matches token's OuHandle.
 //  3. Injects ResolvedOrg into the request context for handlers to use.
 func RequireOrgMatch(resolver OrgResolver) func(http.HandlerFunc) http.HandlerFunc {
+	return requireOrgMatch(resolver, false)
+}
+
+// RequireOrgMatchAllowRootOU behaves like RequireOrgMatch but additionally allows
+// a client-credentials token issued to the configured root/admin OU
+// (config.RootOUHandle) to access any org's route. ResolvedOrg is set to the
+// PATH org (resolved via OrgResolver), not the token's admin OU, so downstream
+// handlers operate on the correct tenant. Use only for system-client
+// endpoints (currently: gateway registration during org bootstrap) — do not
+// apply broadly to user-facing routes.
+func RequireOrgMatchAllowRootOU(resolver OrgResolver) func(http.HandlerFunc) http.HandlerFunc {
+	return requireOrgMatch(resolver, true)
+}
+
+func requireOrgMatch(resolver OrgResolver, allowRootOU bool) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			claims := jwtassertion.GetTokenClaims(r.Context())
 			if claims == nil {
+				slog.Warn("RequireOrgMatch rejected", "reason", "missing token claims", "path", r.URL.Path)
 				utils.WriteErrorResponse(w, http.StatusForbidden, "missing token claims")
 				return
 			}
 			if claims.OuId == "" || claims.OuHandle == "" {
+				slog.Warn("RequireOrgMatch rejected", "reason", "missing ou identity in token", "sub", claims.Sub, "path", r.URL.Path)
 				utils.WriteErrorResponse(w, http.StatusForbidden, "missing ou identity in token")
 				return
 			}
@@ -67,6 +85,26 @@ func RequireOrgMatch(resolver OrgResolver) func(http.HandlerFunc) http.HandlerFu
 			// Validate path orgName matches token's OuHandle
 			pathOrg := r.PathValue(utils.PathParamOrgName)
 			if pathOrg != claims.OuHandle {
+				if allowRootOU && claims.OuHandle == config.GetConfig().RootOUHandle {
+					ouid, err := resolver.ResolveOUID(r.Context(), pathOrg)
+					if err != nil {
+						var re *ResolverError
+						if errors.As(err, &re) {
+							utils.WriteErrorResponse(w, re.StatusCode, re.Message)
+						} else {
+							utils.WriteErrorResponse(w, http.StatusInternalServerError, "internal error resolving organization")
+						}
+						return
+					}
+					slog.Info("RequireOrgMatch: root OU token granted cross-org access", "sub", claims.Sub, "pathOrg", pathOrg)
+					ctx := WithResolvedOrg(r.Context(), ResolvedOrg{
+						OuHandle: pathOrg,
+						OUID:     ouid,
+					})
+					next(w, r.WithContext(ctx))
+					return
+				}
+				slog.Warn("RequireOrgMatch rejected", "reason", "invalid organization access", "sub", claims.Sub, "tokenOu", claims.OuHandle, "pathOrg", pathOrg)
 				utils.WriteErrorResponse(w, http.StatusForbidden, "invalid organization access")
 				return
 			}
@@ -84,11 +122,30 @@ func RequireOrgMatch(resolver OrgResolver) func(http.HandlerFunc) http.HandlerFu
 // required amp: scope. When RBAC_ENABLED=false the check is skipped entirely,
 // allowing zero-downtime rollout.
 func RequirePermission(perm rbac.Permission) func(http.HandlerFunc) http.HandlerFunc {
+	return requirePermission(perm, false)
+}
+
+// RequirePermissionAllowRootOU behaves like RequirePermission but additionally
+// allows a client-credentials token issued to the configured root/admin OU
+// (config.RootOUHandle) through regardless of scope. Use only for system-client
+// endpoints (currently: gateway registration during org bootstrap) — do not
+// apply broadly to user-facing routes.
+func RequirePermissionAllowRootOU(perm rbac.Permission) func(http.HandlerFunc) http.HandlerFunc {
+	return requirePermission(perm, true)
+}
+
+func requirePermission(perm rbac.Permission, allowRootOU bool) func(http.HandlerFunc) http.HandlerFunc {
 	return func(next http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			if !config.GetConfig().RBACEnabled {
 				next(w, r)
 				return
+			}
+			if allowRootOU {
+				if claims := jwtassertion.GetTokenClaims(r.Context()); claims != nil && claims.OuHandle == config.GetConfig().RootOUHandle {
+					next(w, r)
+					return
+				}
 			}
 			if !jwtassertion.HasAllScopes(r.Context(), []string{perm.Scope()}) {
 				utils.WriteErrorResponse(w, http.StatusForbidden, "insufficient permissions")

--- a/agent-manager-service/middleware/path_params.go
+++ b/agent-manager-service/middleware/path_params.go
@@ -65,6 +65,23 @@ func (rr *RouteRegistrar) HandleFuncWithValidationAndAuthz(pattern string, perm 
 	rr.mux.HandleFunc(pattern, handler)
 }
 
+// HandleFuncWithValidationAndAuthzAllowRootOU is identical to
+// HandleFuncWithValidationAndAuthz except it also permits the configured
+// root OU (system clients) to access the route for any org, and bypasses
+// scope checks for that same root-OU token. Use only for system-client
+// bootstrap endpoints — see RequireOrgMatchAllowRootOU / RequirePermissionAllowRootOU.
+func (rr *RouteRegistrar) HandleFuncWithValidationAndAuthzAllowRootOU(pattern string, perm rbac.Permission, handler http.HandlerFunc) {
+	params := extractPathParams(pattern)
+	if len(params) > 0 {
+		handler = WithPathParamValidation(handler, params...)
+	}
+	handler = RequirePermissionAllowRootOU(perm)(handler)
+	if strings.Contains(pattern, orgNamePlaceholder) {
+		handler = RequireOrgMatchAllowRootOU(rr.orgResolver)(handler)
+	}
+	rr.mux.HandleFunc(pattern, handler)
+}
+
 func (rr *RouteRegistrar) HandleFuncWithValidationAndAnyAuthz(pattern string, handler http.HandlerFunc, perms ...rbac.Permission) {
 	params := extractPathParams(pattern)
 	if len(params) > 0 {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Client-credentials (system) tokens issued to the root/admin OU always carry that OU's handle, never the target tenant's. This made `RequireOrgMatch` reject every cross-org system call with a silent 403, breaking the gateway bootstrap job's `POST /orgs/{orgName}/gateways` call during org provisioning — no default gateways were being created for new orgs. This PR adds a narrowly-scoped, opt-in bypass (keyed on a configurable root OU handle) for that one route only, so system clients can register gateways for any org while resolving the correct target org via the existing `OrgResolver`.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway registration can now be allowed for a designated root/admin OU, enabling cross-org gateway setup when permitted.
  * Added support for configuring the root OU handle through environment settings, with a default value of `admin`.

* **Bug Fixes**
  * Improved access checks and error handling for org-based and permission-based requests, with clearer responses when org resolution fails.
  * Added more consistent logging for authorization decisions and mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->