### PR TITLE
Accept aud "amp" on the traces observer

### DIFF
--- a/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
@@ -24,9 +24,13 @@ tracesObserver:
     idpClientId: "amp-api-client"
     idpClientSecret: "amp-api-client-secret"
   # JWT authentication — must match the agent-manager keyManager config so the
-  # same user token issued by Thunder is accepted by both services.
+  # same user token issued by Thunder is accepted by both services. Thunder
+  # (v0.45+) stamps the resource-server identifier "amp" as the token audience,
+  # so query tokens (console/CLI) carry aud=amp. Publisher tokens (aud
+  # amp-publisher-*) are matched by a separate regex in the observer's auth
+  # middleware and do not need to be listed here.
   auth:
     isLocalDevEnv: false
     jwksUrl: "http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/jwks"
     issuer: "http://thunder.amp.localhost:8080"
-    audience: "amp-console-client,amp-api-client,amp-publisher-client"
+    audience: "amp"


### PR DESCRIPTION
## Purpose
The nightly and release E2E pipelines have been failing since the Thunder v0.45 upgrade (`2b05a25c`). Every trace-listing spec fails with `401 {"error":"Unauthorized","message":"invalid or expired token"}`. The traces-observer pod logs give the real reason: `JWT validation failed error="invalid audience: got [amp]"`.

Thunder v0.45 introduced the resource-server model. The bootstrap creates a single resource server with identifier `amp`, and all e2e/console/CLI tokens request `amp:*` scopes — so Thunder now stamps `aud: amp` on those tokens, instead of the per-client-app id (`amp-api-client`, ...) it used before. The `agent-manager-service` keyManager audience list was updated to include `amp`, but the observability extension's list was left as the stale client ids, so the traces observer rejects every query token.

N/A on issue link — no tracking issue; surfaced from the failing nightly/release runs.

## Goals
Make the traces observer accept the token Thunder now issues so trace-listing (console, CLI, and E2E) works again.

## Approach
Set `tracesObserver.auth.audience` to `amp` in the observability extension chart values, matching the resource-server identifier Thunder v0.45 stamps as the audience. The old client-id entries are dead post-v0.45 (single resource server `amp`). Publisher tokens (`aud: amp-publisher-*`), which the evaluation monitor uses to read traces, are matched by a separate hardcoded regex in the observer auth middleware and never relied on this list — so they are unaffected. Added a comment explaining the new audience model.

## User stories
N/A — CI/infra fix.

## Release note
Fix traces observer rejecting valid tokens (`invalid audience`) after the Thunder v0.45 upgrade.

## Documentation
N/A — no user-facing doc impact; internal chart value.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — chart value change; no code.
 - Integration tests
   > Covered by the existing E2E trace-listing specs that were failing (internal-agent, promotion, catalog, basic tracing, `amctl agent traces`). These exercise the fixed path and should pass once the observability chart is repackaged from this branch in the nightly/release run.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #1206 / `2b05a25c` — Upgrade ThunderID v0.34 to v0.45 (introduced the resource-server audience change this fix follows up on)

## Migrations (if applicable)
N/A

## Test environment
Verified against the failing nightly (run 28637309340) and release (run 28644047907) E2E logs; observer pod logs confirm the `invalid audience: got [amp]` root cause. Chart renders `KEY_MANAGER_AUDIENCE: "amp"` via `helm template`.

## Learning
Traced the 401 through the observer JWT middleware (`traces-observer-service/middleware/auth.go`): audience is validated against `KEY_MANAGER_AUDIENCE` OR a hardcoded `amp-publisher-*` regex. Confirmed the evaluation monitor's trace reads keep working via that regex (its client is `amp-publisher-client`), and that the docker-compose and agent-manager-service configs already include `amp` — only the observability chart was missed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token audience handling for trace observation authentication to use a single audience value, improving compatibility with current login and access flows.
  * Clarified the related configuration notes so the expected token behavior is easier to understand, including how publisher tokens are handled separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->