### PR TITLE
Document amp-instrument env and tracing caveats

### DIFF
--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -40,6 +40,27 @@ export AMP_OTEL_ENDPOINT="https://amp-otel-endpoint.com" # AMP OTEL endpoint
 export AMP_AGENT_API_KEY="your-agent-api-key" # Agent-specific key generated after registration
 ```
 
+:::note These must be shell variables, not a `.env` file
+`amp-instrument` reads `AMP_OTEL_ENDPOINT` and `AMP_AGENT_API_KEY` from the process environment at launch and it does not load a `.env` file. If you keep these values in a `.env` file, export them into the shell before running `amp-instrument`:
+
+```bash
+set -a && source .env && set +a
+amp-instrument python my_script.py
+```
+:::
+
+:::note Using Pydantic Settings
+AMP puts extra variables in the environment at runtime (`AMP_OTEL_ENDPOINT`, `AMP_AGENT_API_KEY`). Pydantic Settings reads the whole process environment, so with its default `extra="forbid"` these undeclared variables raise an `extra_forbidden` validation error. Set `extra="ignore"` on your settings model (or scope it to your own variables with an `env_prefix`) so it leaves variables it doesn't own alone:
+
+```python
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(extra="ignore")
+    # your fields...
+```
+:::
+
 ### 3. Run Your Application
 
 Use the `amp-instrument` command to wrap your application run command:
@@ -57,6 +78,10 @@ amp-instrument uv run python script.py
 ```
 
 That's it! Your application is now instrumented and sending traces to the WSO2 Agent Manager.
+
+:::note What auto-instrumentation captures
+The Traceloop SDK generates GenAI spans by patching recognized LLM and framework SDKs (OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, and more). It does **not** trace raw HTTP calls. If your agent calls an LLM by hand with `httpx`, `requests`, or `urllib`, either call the model through a supported SDK - for example, the OpenAI SDK pointed at an OpenAI-compatible endpoint with `base_url` - or emit the spans yourself with [manual instrumentation](#manual-instrumentation).
+:::
 
 ## Manual instrumentation
 

--- a/documentation/versioned_docs/version-v0.17.x/components/amp-instrumentation.mdx
+++ b/documentation/versioned_docs/version-v0.17.x/components/amp-instrumentation.mdx
@@ -40,6 +40,27 @@ export AMP_OTEL_ENDPOINT="https://amp-otel-endpoint.com" # AMP OTEL endpoint
 export AMP_AGENT_API_KEY="your-agent-api-key" # Agent-specific key generated after registration
 ```
 
+:::note These must be shell variables, not a `.env` file
+`amp-instrument` reads `AMP_OTEL_ENDPOINT` and `AMP_AGENT_API_KEY` from the process environment at launch and it does not load a `.env` file. If you keep these values in a `.env` file, export them into the shell before running `amp-instrument`:
+
+```bash
+set -a && source .env && set +a
+amp-instrument python my_script.py
+```
+:::
+
+:::note Using Pydantic Settings
+AMP puts extra variables in the environment at runtime (`AMP_OTEL_ENDPOINT`, `AMP_AGENT_API_KEY`). Pydantic Settings reads the whole process environment, so with its default `extra="forbid"` these undeclared variables raise an `extra_forbidden` validation error. Set `extra="ignore"` on your settings model (or scope it to your own variables with an `env_prefix`) so it leaves variables it doesn't own alone:
+
+```python
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(extra="ignore")
+    # your fields...
+```
+:::
+
 ### 3. Run Your Application
 
 Use the `amp-instrument` command to wrap your application run command:
@@ -57,6 +78,10 @@ amp-instrument uv run python script.py
 ```
 
 That's it! Your application is now instrumented and sending traces to the WSO2 Agent Manager.
+
+:::note What auto-instrumentation captures
+The Traceloop SDK generates GenAI spans by patching recognized LLM and framework SDKs (OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, and more). It does **not** trace raw HTTP calls. If your agent calls an LLM by hand with `httpx`, `requests`, or `urllib`, either call the model through a supported SDK - for example, the OpenAI SDK pointed at an OpenAI-compatible endpoint with `base_url` - or emit the spans yourself with [manual instrumentation](#manual-instrumentation).
+:::
 
 ## Manual instrumentation
 


### PR DESCRIPTION
## Purpose
The `amp-instrumentation` guide didn't cover three things Python developers commonly hit when instrumenting an externally-hosted agent. This PR documents each so they're self-serviceable.

## Goals
Add three notes to `components/amp-instrumentation.mdx` covering these gaps:

- **Environment variables are read from the shell, not a `.env` file.** `amp-instrument` reads `AMP_OTEL_ENDPOINT` / `AMP_AGENT_API_KEY` from the process environment at launch; if they live in a `.env` file they must be exported first (`set -a && source .env && set +a`).
- **Pydantic Settings rejects the injected AMP vars.** With the default `extra="forbid"`, the runtime `AMP_*` variables raise `extra_forbidden`; the fix is `extra="ignore"` (or an `env_prefix`).
- **Auto-instrumentation only patches recognized SDKs.** The Traceloop SDK instruments known LLM/framework SDKs, not raw `httpx`/`requests` calls, so hand-rolled HTTP calls produce no GenAI spans — use a supported SDK (e.g. the OpenAI SDK with `base_url`) or the manual-instrumentation path.

## Approach
Added three `:::note` admonitions matching the existing doc style: two in the "Set Required Environment Variables" step (env-not-`.env`, Pydantic Settings) and one after Quick Start clarifying what auto-instrumentation captures. Applied the same changes to the `version-v0.17.x` snapshot as well. Docs-only change — no code, UI, or behavior changes.

## User stories
As a Python developer instrumenting an externally-hosted agent with `amp-instrument`, I can find documented guidance on loading env vars, coexisting with Pydantic Settings, and why raw-HTTP LLM calls don't produce traces.

## Release note
Documentation: clarified `amp-instrument` environment-variable loading (shell vs `.env`), Pydantic Settings coexistence (`extra="ignore"`), and that auto-instrumentation covers recognized LLM SDKs (not raw HTTP calls).

## Documentation
This PR *is* the documentation change: `documentation/docs/components/amp-instrumentation.mdx` and `documentation/versioned_docs/version-v0.17.x/components/amp-instrumentation.mdx`.

## Training
N/A — no training-content impact.

## Certification
N/A — documentation clarification only; no impact on certification exams.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > N/A — docs-only change, no code paths to cover.
 - Integration tests
   > N/A — docs-only change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes.

## Related PRs
N/A.

## Migrations (if applicable)
N/A — no migration impact.

## Test environment
Rendered/reviewed as GitHub-flavored Markdown/MDX; no runtime environment involved.

## Learning
Grounded the notes in the `amp-instrumentation` package source (Traceloop SDK auto-instrumentation scope, `os.getenv`-based config with no `.env` loading) and the AMP OTLP ingest path to confirm the described behavior before documenting it.
