### PR TITLE
Host amctl install script on GitHub Pages

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'documentation/**'
+      - 'scripts/install-amctl.sh'
       - '.github/workflows/docs-deploy.yml'
 
 jobs:
@@ -35,6 +36,11 @@ jobs:
       - name: Build documentation
         working-directory: ./documentation
         run: npm run build
+
+      - name: Include amctl install script
+        run: |
+          sh -n scripts/install-amctl.sh
+          cp scripts/install-amctl.sh documentation/build/install.sh
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3

--- a/documentation/docs/getting-started/cli-installation.mdx
+++ b/documentation/docs/getting-started/cli-installation.mdx
@@ -14,47 +14,29 @@ You need a reachable Agent Manager instance before logging in. Follow the [Quick
 
 ## Step 1: Install amctl
 
-Download the release archive for your platform from the [Agent Manager releases page](https://github.com/wso2/agent-manager/releases), extract the binary, and move it onto your `PATH`.
-
-`amctl` ships with each Agent Manager release and shares its version. The commands below use **`0.0.0-dev`** as an example — replace it with the latest version from the [releases page](https://github.com/wso2/agent-manager/releases).
-
 :::note Pre-release
 `amctl` is currently shipped as a pre-release. Expect breaking changes between versions until the first stable release.
 :::
 
-### macOS (Apple Silicon)
+### macOS / Linux
+
+Install the latest release with the install script. It detects your platform, verifies the checksum, and installs the binary to `/usr/local/bin` (or `~/.local/bin` if that is not writable):
 
 ```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-dev/amctl_v0.0.0-dev_darwin_arm64.tar.gz
-tar -xzf amctl_v0.0.0-dev_darwin_arm64.tar.gz
-sudo mv amctl /usr/local/bin/
+curl -fsSL https://wso2.github.io/agent-manager/install.sh | sh
 ```
 
-### macOS (Intel)
+:::tip
+Set `AMCTL_VERSION` to pin a specific version, and `AMCTL_INSTALL_DIR` to change the install location:
 
 ```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-dev/amctl_v0.0.0-dev_darwin_amd64.tar.gz
-tar -xzf amctl_v0.0.0-dev_darwin_amd64.tar.gz
-sudo mv amctl /usr/local/bin/
+curl -fsSL https://wso2.github.io/agent-manager/install.sh | AMCTL_VERSION=0.0.0-dev AMCTL_INSTALL_DIR="$HOME/bin" sh
 ```
-
-### Linux (x64)
-
-```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-dev/amctl_v0.0.0-dev_linux_amd64.tar.gz
-tar -xzf amctl_v0.0.0-dev_linux_amd64.tar.gz
-sudo mv amctl /usr/local/bin/
-```
-
-### Linux (ARM64)
-
-```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-dev/amctl_v0.0.0-dev_linux_arm64.tar.gz
-tar -xzf amctl_v0.0.0-dev_linux_arm64.tar.gz
-sudo mv amctl /usr/local/bin/
-```
+:::
 
 ### Windows (x64)
+
+Download the release archive from the [Agent Manager releases page](https://github.com/wso2/agent-manager/releases). The commands below use **`0.0.0-dev`** as an example — replace it with the latest version.
 
 ```powershell
 Invoke-WebRequest -Uri https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-dev/amctl_v0.0.0-dev_windows_amd64.zip -OutFile amctl.zip

--- a/documentation/versioned_docs/version-v0.18.x/getting-started/cli-installation.mdx
+++ b/documentation/versioned_docs/version-v0.18.x/getting-started/cli-installation.mdx
@@ -14,29 +14,47 @@ You need a reachable Agent Manager instance before logging in. Follow the [Quick
 
 ## Step 1: Install amctl
 
+Download the release archive for your platform from the [Agent Manager releases page](https://github.com/wso2/agent-manager/releases), extract the binary, and move it onto your `PATH`.
+
+`amctl` ships with each Agent Manager release and shares its version. The commands below use **`0.18.0`** as an example — replace it with the latest version from the [releases page](https://github.com/wso2/agent-manager/releases).
+
 :::note Pre-release
 `amctl` is currently shipped as a pre-release. Expect breaking changes between versions until the first stable release.
 :::
 
-### macOS / Linux
-
-Install the latest release with the install script. It detects your platform, verifies the checksum, and installs the binary to `/usr/local/bin` (or `~/.local/bin` if that is not writable):
+### macOS (Apple Silicon)
 
 ```bash
-curl -fsSL https://wso2.github.io/agent-manager/install.sh | sh
+curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_darwin_arm64.tar.gz
+tar -xzf amctl_v0.18.0_darwin_arm64.tar.gz
+sudo mv amctl /usr/local/bin/
 ```
 
-:::tip
-Set `AMCTL_VERSION` to pin a specific version, and `AMCTL_INSTALL_DIR` to change the install location:
+### macOS (Intel)
 
 ```bash
-curl -fsSL https://wso2.github.io/agent-manager/install.sh | AMCTL_VERSION=0.18.0 AMCTL_INSTALL_DIR="$HOME/bin" sh
+curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_darwin_amd64.tar.gz
+tar -xzf amctl_v0.18.0_darwin_amd64.tar.gz
+sudo mv amctl /usr/local/bin/
 ```
-:::
+
+### Linux (x64)
+
+```bash
+curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_linux_amd64.tar.gz
+tar -xzf amctl_v0.18.0_linux_amd64.tar.gz
+sudo mv amctl /usr/local/bin/
+```
+
+### Linux (ARM64)
+
+```bash
+curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_linux_arm64.tar.gz
+tar -xzf amctl_v0.18.0_linux_arm64.tar.gz
+sudo mv amctl /usr/local/bin/
+```
 
 ### Windows (x64)
-
-Download the release archive from the [Agent Manager releases page](https://github.com/wso2/agent-manager/releases). The commands below use **`0.18.0`** as an example — replace it with the latest version.
 
 ```powershell
 Invoke-WebRequest -Uri https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_windows_amd64.zip -OutFile amctl.zip

--- a/documentation/versioned_docs/version-v0.18.x/getting-started/cli-installation.mdx
+++ b/documentation/versioned_docs/version-v0.18.x/getting-started/cli-installation.mdx
@@ -14,47 +14,29 @@ You need a reachable Agent Manager instance before logging in. Follow the [Quick
 
 ## Step 1: Install amctl
 
-Download the release archive for your platform from the [Agent Manager releases page](https://github.com/wso2/agent-manager/releases), extract the binary, and move it onto your `PATH`.
-
-`amctl` ships with each Agent Manager release and shares its version. The commands below use **`0.18.0`** as an example — replace it with the latest version from the [releases page](https://github.com/wso2/agent-manager/releases).
-
 :::note Pre-release
 `amctl` is currently shipped as a pre-release. Expect breaking changes between versions until the first stable release.
 :::
 
-### macOS (Apple Silicon)
+### macOS / Linux
+
+Install the latest release with the install script. It detects your platform, verifies the checksum, and installs the binary to `/usr/local/bin` (or `~/.local/bin` if that is not writable):
 
 ```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_darwin_arm64.tar.gz
-tar -xzf amctl_v0.18.0_darwin_arm64.tar.gz
-sudo mv amctl /usr/local/bin/
+curl -fsSL https://wso2.github.io/agent-manager/install.sh | sh
 ```
 
-### macOS (Intel)
+:::tip
+Set `AMCTL_VERSION` to pin a specific version, and `AMCTL_INSTALL_DIR` to change the install location:
 
 ```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_darwin_amd64.tar.gz
-tar -xzf amctl_v0.18.0_darwin_amd64.tar.gz
-sudo mv amctl /usr/local/bin/
+curl -fsSL https://wso2.github.io/agent-manager/install.sh | AMCTL_VERSION=0.18.0 AMCTL_INSTALL_DIR="$HOME/bin" sh
 ```
-
-### Linux (x64)
-
-```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_linux_amd64.tar.gz
-tar -xzf amctl_v0.18.0_linux_amd64.tar.gz
-sudo mv amctl /usr/local/bin/
-```
-
-### Linux (ARM64)
-
-```bash
-curl -LO https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_linux_arm64.tar.gz
-tar -xzf amctl_v0.18.0_linux_arm64.tar.gz
-sudo mv amctl /usr/local/bin/
-```
+:::
 
 ### Windows (x64)
+
+Download the release archive from the [Agent Manager releases page](https://github.com/wso2/agent-manager/releases). The commands below use **`0.18.0`** as an example — replace it with the latest version.
 
 ```powershell
 Invoke-WebRequest -Uri https://github.com/wso2/agent-manager/releases/download/amp/v0.18.0/amctl_v0.18.0_windows_amd64.zip -OutFile amctl.zip


### PR DESCRIPTION
## Purpose
Make the `amctl` install script available at a stable URL — https://wso2.github.io/agent-manager/install.sh — so the CLI can be installed with a single command:

```bash
curl -fsSL https://wso2.github.io/agent-manager/install.sh | sh
```

## Changes
- **`.github/workflows/docs-deploy.yml`**: after the Docusaurus build, syntax-check `scripts/install-amctl.sh` (`sh -n`) and copy it into the built site as `install.sh`, so GitHub Pages serves it at `/agent-manager/install.sh`. The script stays in `scripts/` as the single source of truth. Added `scripts/install-amctl.sh` to the workflow's path triggers so script edits redeploy the site.
- **CLI installation docs** (`docs/getting-started/cli-installation.mdx`, the Next version): replaced the four per-platform macOS/Linux download blocks with the one-line install script, plus a tip on `AMCTL_VERSION` (pin a version) and `AMCTL_INSTALL_DIR` (install location). Windows manual download and build-from-source are unchanged, since the script supports macOS/Linux only. The `AMCTL_VERSION` example uses the `0.0.0-dev` placeholder so it is templated with the real version when a docs version is cut. Released version snapshots (v0.18.x and earlier) are untouched — the new instructions apply from the next docs release onward.

## Notes
- The hosted URL goes live when this merges and `docs-deploy.yml` runs.
- Verified locally: workflow YAML parses, script passes `sh -n`, and the docs page renders in the Docusaurus dev server.