### PR TITLE
Harden flaky monitor and CLI redeploy e2e specs

### DIFF
--- a/test/e2e/operations/cli/agent/agent_operations.go
+++ b/test/e2e/operations/cli/agent/agent_operations.go
@@ -19,6 +19,10 @@
 package cliagent
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/wso2/agent-manager/test/e2e/framework/amctl"
@@ -152,4 +156,30 @@ type DeployResult struct {
 // to the pipeline's lowest environment) and returns the deploy result.
 func DeployAgent(g Gomega, h *amctl.Harness, org, project, name string) DeployResult {
 	return amctl.DecodeData[DeployResult](g, h.Run("agent", "deploy", name, "--org", org, "--project", project, "--yes", "--json"))
+}
+
+// DeployAgentEventually redeploys the agent, tolerating a transient 409
+// conflict. The server rejects a redeploy while the target environment's
+// release binding still reports its Ready condition as Progressing, which can
+// briefly happen right after a fresh deployment settles (see the
+// IsDeploymentInProgress guard in agent_manager.go). That surfaces as a 409;
+// this retries on it and fails fast on any other error.
+func DeployAgentEventually(h *amctl.Harness, org, project, name string, timeout time.Duration) DeployResult {
+	var result DeployResult
+	Eventually(func(g Gomega) {
+		res := h.Run("agent", "deploy", name, "--org", org, "--project", project, "--yes", "--json")
+		if res.ExitCode != 0 {
+			env := res.Envelope(g)
+			g.Expect(env.Error).NotTo(BeNil(), "expected error envelope on failed deploy: %s", res.Combined())
+			if env.Error.Status != 409 {
+				StopTrying(fmt.Sprintf("agent deploy failed (non-retryable): %s", res.Combined())).Now()
+			}
+			ginkgo.GinkgoWriter.Printf("agent deploy: 409 deployment still in progress, retrying (%s)\n", name)
+			// Fail this attempt so Eventually retries the redeploy.
+			g.Expect(res.ExitCode).To(Equal(0), "deployment still in progress (409): %s", res.Combined())
+			return
+		}
+		result = amctl.DecodeData[DeployResult](g, res)
+	}).WithTimeout(timeout).WithPolling(10 * time.Second).Should(Succeed())
+	return result
 }

--- a/test/e2e/operations/monitor/monitor_runs.go
+++ b/test/e2e/operations/monitor/monitor_runs.go
@@ -148,8 +148,10 @@ type WaitForMonitorRunParams struct {
 	Timeout     time.Duration // default: 10 minutes
 }
 
-// WaitForMonitorRun polls until a monitor run reaches "completed" status.
-// Returns the first completed run.
+// WaitForMonitorRun polls until a monitor run reaches "success" status with at
+// least one evaluator score, and returns that run. A scoreless success is
+// treated as still in progress, because a run can report success before its
+// scores are persisted (see the success case below).
 func WaitForMonitorRun(client *framework.AMPClient, params *WaitForMonitorRunParams) framework.MonitorRunResponse {
 	timeout := params.Timeout
 	if timeout == 0 {
@@ -180,11 +182,26 @@ func WaitForMonitorRun(client *framework.AMPClient, params *WaitForMonitorRunPar
 		statuses := make([]string, 0, len(runs.Runs))
 		for i := range runs.Runs {
 			run := runs.Runs[i]
-			statuses = append(statuses, run.Status)
+			status := run.Status
+			if run.Status == "success" {
+				status = fmt.Sprintf("success(scores=%d)", len(run.Scores))
+			}
+			statuses = append(statuses, status)
 			switch run.Status {
 			case "success":
-				completedRun = run
-				found = true
+				// A run can briefly report "success" before its evaluator
+				// scores are persisted. This is most visible for future
+				// monitors, whose scheduled run may fire and complete before
+				// freshly generated traces have been ingested and evaluated,
+				// yielding a scoreless success. Treat that as still in
+				// progress so we keep polling for a scored run (the next
+				// scheduled run picks up the ingested traces).
+				if len(run.Scores) > 0 {
+					completedRun = run
+					found = true
+				} else {
+					pending = true
+				}
 			case "failed":
 				if failedRun == nil {
 					failedRun = &runs.Runs[i]
@@ -211,11 +228,11 @@ func WaitForMonitorRun(client *framework.AMPClient, params *WaitForMonitorRunPar
 			StopTrying(fmt.Sprintf("monitor run %s failed (%s): %s", failedRun.ID, scope, errMsg)).Now()
 		}
 
-		lastDiag = fmt.Sprintf("%s | attempt %d | %d run(s) statuses=%v, no success yet", scope, attempt, len(runs.Runs), statuses)
+		lastDiag = fmt.Sprintf("%s | attempt %d | %d run(s) statuses=%v, no scored success yet", scope, attempt, len(runs.Runs), statuses)
 		if !found && len(runs.Runs) > 0 {
 			ginkgo.GinkgoWriter.Printf("Monitor runs: %d, statuses=%v\n", len(runs.Runs), statuses)
 		}
-		g.Expect(found).To(BeTrue(), "no successful monitor run found yet for %s (%d run(s), statuses=%v)", scope, len(runs.Runs), statuses)
+		g.Expect(found).To(BeTrue(), "no scored successful monitor run found yet for %s (%d run(s), statuses=%v)", scope, len(runs.Runs), statuses)
 	}).WithTimeout(timeout).WithPolling(15 * time.Second).Should(Succeed())
 
 	return completedRun

--- a/test/e2e/tests/cli/agentplatform/agent_observability_test.go
+++ b/test/e2e/tests/cli/agentplatform/agent_observability_test.go
@@ -36,7 +36,7 @@ var _ = Describe("amctl agent (CLI-owned lifecycle)", Label("cli", "agent"), Ord
 	// specs below assert against a freshly redeployed, ready instance.
 	Context("deploy", func() {
 		It("redeploys the agent via amctl agent deploy", func() {
-			res := cliagent.DeployAgent(Default, H, H.Org(), owned.ProjectName, owned.AgentName)
+			res := cliagent.DeployAgentEventually(H, H.Org(), owned.ProjectName, owned.AgentName, 3*time.Minute)
 			Expect(res.Agent).To(Equal(owned.AgentName))
 			Expect(res.Build).NotTo(BeEmpty())
 			Expect(res.ImageId).NotTo(BeEmpty())


### PR DESCRIPTION
## Purpose
Two independent intermittent failures in the E2E suite, both cases of a spec asserting on a single immediate call that races an asynchronous backend state. They surfaced on consecutive runs of the release workflow (the `monitors` suite failed on one run; re-running it passed `monitors` but failed the CLI `agentplatform` suite instead — classic flakes, not regressions).

1. **`monitors` suite** — `Future monitor: completes the scheduled future monitor run` failed at the score assertion (`future_monitor_test.go:104`, `expected scores from future monitor run`). `WaitForMonitorRun` returned the first run reporting `success`, but that run sometimes carried zero evaluator scores, so the immediately-following `Scores`-not-empty check blew up. A future monitor's scheduled run can fire and complete before the traces generated moments earlier are ingested and evaluated, yielding a legitimate but scoreless success.

2. **`agentplatform` (CLI) suite** — `amctl agent (CLI-owned lifecycle) deploy — redeploys the agent via amctl agent deploy` (`agent_observability_test.go:38`) failed: the redeploy returned HTTP 409 and the CLI exited non-zero, failing the single-shot deploy assertion. The redeploy path guards against concurrent deploys by reading the target environment's release-binding `Ready` condition (`IsDeploymentInProgress`); right after a fresh deployment settles, that condition can transiently report `Progressing`, so an immediate redeploy is misread as a concurrent deploy and rejected with 409 "a deployment is already in progress" — a race the guard's own comment already acknowledges.

## Goals
Make both specs resolve on the state they actually assert against, instead of racing the backend's asynchronous settling.

## Approach
**Monitors** (`test/e2e/operations/monitor/monitor_runs.go`): treat a `success` run with zero scores as still in progress and keep polling, so the wait resolves on a run that has scores. The next scheduled run (5m interval) picks up the ingested traces, well within the spec's 8m timeout. This also stops the fail-fast path from aborting on an unrelated historical failed run while a newer run is still progressing. Success entries in the poll diagnostic are annotated with their score count (`success(scores=N)`) so a scoreless success is legible instead of the previous contradictory `statuses=[success] ... no success yet`.

**CLI redeploy** (`test/e2e/operations/cli/agent/agent_operations.go`, `test/e2e/tests/cli/agentplatform/agent_observability_test.go`): add `DeployAgentEventually`, which retries the redeploy while the error is a 409 and fails fast on any other error, and use it in the spec. The 3m budget covers the brief settling window without masking real deploy failures.

Both are test-harness-only changes; no product code is touched. All `WaitForMonitorRun` callers ultimately expect a scored run, so requiring a scored success matches every caller's intent; past/custom monitors evaluate an already-populated window and are unaffected in practice.

Not included here: the CLI reported the 409 as `server returned 409 with no JSON body` (`clierr.SERVER_RESPONSE_INVALID`) because the deploy operation's generated OpenAPI client has no `JSON409` field to decode the error body into. Fixing that (modelling 409 on the deploy operation) touches the OpenAPI spec + codegen and is out of scope for this flake-hardening change.

## User stories
N/A — internal test reliability fix.

## Release note
N/A — no user-facing change; stabilizes two flaky e2e specs (future-monitor scores, CLI redeploy conflict).

## Documentation
N/A — no product behavior or API change.

## Training
N/A — no training impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > N/A — changes are confined to the e2e test harness.
 - Integration tests
   > Affects the existing `monitors` and CLI `agentplatform` e2e suites. `test/e2e` builds, vets, and formats clean (`go build ./...`, `go vet`, `gofmt`). Full-suite execution requires the provisioned platform stack and runs in the E2E CI job; re-running that job validates the fix end-to-end.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — test-only change, no product code.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
GitHub Actions E2E CI job (k3d-provisioned platform stack); local `go build`/`go vet`/`gofmt` on Go toolchain.

## Learning
N/A
