### PR TITLE
Register Dataplane Thunder instances as gateway identity providers

### DIFF
--- a/agent-manager-service/models/agent.go
+++ b/agent-manager-service/models/agent.go
@@ -17,6 +17,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -81,10 +82,16 @@ var SystemIdentityProviderNames = map[string]bool{
 	"ThunderKeyManager": true,
 }
 
+// EnvThunderIdentityProviderPrefix matches the env-Thunder release names
+// (amp-thunder-<org>-<env>) that the gateway bootstrap job seeds as identity
+// providers. Must stay in sync with thundersvc.ThunderReleaseName and
+// deployments/scripts/thunder-naming.sh.
+const EnvThunderIdentityProviderPrefix = "amp-thunder-"
+
 // IsSystemIdentityProvider reports whether the given identity provider name is a
 // platform-seeded system provider.
 func IsSystemIdentityProvider(name string) bool {
-	return SystemIdentityProviderNames[name]
+	return SystemIdentityProviderNames[name] || strings.HasPrefix(name, EnvThunderIdentityProviderPrefix)
 }
 
 type OAuthConfig struct {

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -351,7 +351,35 @@ install_gateway_extension() {
     local chart_version="${VERSION}"
     local release_name="api-platform-default-default"
     local gateway_vhost="http://default-default.gateway.localhost:19080"
+    local idp_skip_tls_verify="${IDP_SKIP_TLS_VERIFY:-true}"
 
+    # Wire the gateway's ThunderKeyManager to the default environment's own Thunder
+    # instance when it exists, mirroring the THUNDER_PROVISIONED logic in
+    # add-environment.sh. keymanagers[0] is re-asserted alongside keymanagers[1]
+    # because this install uses no -f values file, so --set on keymanagers[1]
+    # alone would otherwise drop keymanagers[0] (verified via `helm template`).
+    local thunder_args=()
+    local thunder_release
+    thunder_release="$(thunder_release_name default default)"
+    if helm status "${thunder_release}" --namespace "${thunder_release}" &>/dev/null; then
+        local thunder_issuer_url thunder_jwks
+        thunder_issuer_url="$(thunder_issuer default default)"
+        thunder_jwks="http://${thunder_release}-service.${thunder_release}.svc.cluster.local:8090/oauth2/jwks"
+        thunder_args=(
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].name=agent-manager-service"
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].issuer=agent-manager-service"
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].jwks.remote.uri=http://amp-api.wso2-amp.svc.cluster.local:9000/auth/external/jwks.json"
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].jwks.remote.skipTlsVerify=true"
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].name=ThunderKeyManager"
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].issuer=${thunder_issuer_url}"
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.uri=${thunder_jwks}"
+            --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.skipTlsVerify=${idp_skip_tls_verify}"
+            --set "bootstrap.identityProviders[0].name=${thunder_release}"
+            --set "bootstrap.identityProviders[0].issuer=${thunder_issuer_url}"
+            --set "bootstrap.identityProviders[0].jwksUri=${thunder_jwks}"
+            --set "bootstrap.identityProviders[0].skipTlsVerify=${idp_skip_tls_verify}"
+        )
+    fi
 
     # Install Helm chart
     if ! install_amp_helm_chart "${release_name}" "${chart_ref}" "${DATA_PLANE_NS}" "${TIMEOUT_AMP_INSTALL}" \
@@ -359,6 +387,7 @@ install_gateway_extension() {
         --set agentManager.orgName=default \
         --set gateway.environment=default \
         --set gateway.vhost="${gateway_vhost}" \
+        "${thunder_args[@]}" \
         "${GATEWAY_HELM_ARGS[@]}"; then
         return 1
     fi

--- a/deployments/scripts/add-environment.sh
+++ b/deployments/scripts/add-environment.sh
@@ -39,6 +39,7 @@ set -euo pipefail
 #     https listener variant. Set ENV_INGRESS_HTTPS_HOST=$ENV_INGRESS_HOST for
 #     the TLS toggle alone; without it the deployed-agent invoke URL is empty.
 #   - ENV_INGRESS_HTTPS_PORT (default: 443): port for the https listener variant.
+#   - IDP_SKIP_TLS_VERIFY (default: true): skipTlsVerify for the seeded env-Thunder identity provider.
 
 # --- Required inputs ---
 : "${ENV_NAME:?ENV_NAME is required (e.g. ENV_NAME=staging)}"
@@ -92,6 +93,14 @@ DATAPLANE_REF="${DATAPLANE_REF:-default}"
 AGENT_MANAGER_URL="${AGENT_MANAGER_URL:-http://localhost:9000}"
 AGENT_MANAGER_API_URL="${AGENT_MANAGER_API_URL:-${AGENT_MANAGER_URL}/api/v1}"
 GATEWAY_NAMESPACE="${GATEWAY_NAMESPACE:-openchoreo-data-plane}"
+IDP_SKIP_TLS_VERIFY="${IDP_SKIP_TLS_VERIFY:-true}"
+case "$IDP_SKIP_TLS_VERIFY" in
+    true|false) ;;
+    *)
+        echo "❌ IDP_SKIP_TLS_VERIFY must be 'true' or 'false' (got '${IDP_SKIP_TLS_VERIFY}')"
+        exit 1
+        ;;
+esac
 
 CHART_REF="oci://ghcr.io/wso2/wso2-amp-api-platform-gateway-extension"
 
@@ -130,9 +139,7 @@ AGENT_MANAGER_INTERNAL_CP="${AGENT_MANAGER_INTERNAL_CP:-host.docker.internal:924
 AGENT_MANAGER_INTERNAL_API="${AGENT_MANAGER_INTERNAL_BASE_URL}/api/v1"
 AGENT_MANAGER_INTERNAL_JWKS="${AGENT_MANAGER_INTERNAL_BASE_URL}/auth/external/jwks.json"
 
-# Platform Thunder (shared) identity — matches the chart's built-in defaults.
-# Must always be re-asserted alongside keymanagers[0] because helm --set on
-# an indexed array replaces the entire list, not just the specified element.
+# Platform Thunder (shared) fallback identity — matches the chart's built-in defaults.
 PLATFORM_THUNDER_ISSUER="${PLATFORM_THUNDER_ISSUER:-http://thunder.amp.localhost:8080}"
 PLATFORM_THUNDER_JWKS="${PLATFORM_THUNDER_JWKS:-http://amp-thunder-extension-service.amp-thunder:8090/oauth2/jwks}"
 
@@ -343,7 +350,14 @@ if [ "$THUNDER_PROVISIONED" = "true" ]; then
         --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].name=ThunderKeyManager"
         --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].issuer=${THUNDER_ISSUER}"
         --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.uri=${THUNDER_INTERNAL_JWKS}"
-        --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.skipTlsVerify=true"
+        --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.skipTlsVerify=${IDP_SKIP_TLS_VERIFY}"
+    )
+    # Mirror the env-Thunder into Agent Manager as this gateway's identity provider.
+    HELM_ARGS+=(
+        --set "bootstrap.identityProviders[0].name=${THUNDER_RELEASE}"
+        --set "bootstrap.identityProviders[0].issuer=${THUNDER_ISSUER}"
+        --set "bootstrap.identityProviders[0].jwksUri=${THUNDER_INTERNAL_JWKS}"
+        --set "bootstrap.identityProviders[0].skipTlsVerify=${IDP_SKIP_TLS_VERIFY}"
     )
 else
     # Re-assert the platform Thunder keymanager explicitly. Helm --set on an indexed array

--- a/deployments/setup/setup-gateway.sh
+++ b/deployments/setup/setup-gateway.sh
@@ -18,6 +18,17 @@ ORG_NAME="${ORG_NAME:-default}"
 ENV_NAME="${ENV_NAME:-default}"
 GATEWAY_VHOST_PORT="${GATEWAY_VHOST_PORT:-19080}"
 GATEWAY_VHOST="${GATEWAY_VHOST:-http://${ENV_NAME}-${ORG_NAME}.gateway.localhost:${GATEWAY_VHOST_PORT}}"
+IDP_SKIP_TLS_VERIFY="${IDP_SKIP_TLS_VERIFY:-true}"
+case "$IDP_SKIP_TLS_VERIFY" in
+    true|false) ;;
+    *)
+        echo "❌ IDP_SKIP_TLS_VERIFY must be 'true' or 'false' (got '${IDP_SKIP_TLS_VERIFY}')"
+        exit 1
+        ;;
+esac
+
+# shellcheck source=../scripts/thunder-naming.sh
+source "${SCRIPT_DIR}/../scripts/thunder-naming.sh"
 
 echo "=== Installing API Platform Gateway ==="
 
@@ -37,17 +48,41 @@ until curl -sf "$AGENT_MANAGER_HEALTH_URL" > /dev/null 2>&1; do
 done
 echo "✅ Agent Manager is healthy"
 
+# Wire the gateway's ThunderKeyManager to this environment's own Thunder instance
+# when it exists, mirroring the THUNDER_PROVISIONED logic in add-environment.sh.
+THUNDER_RELEASE="$(thunder_release_name "${ORG_NAME}" "${ENV_NAME}")"
+HELM_ARGS=(
+    upgrade --install "api-platform-${ORG_NAME}-${ENV_NAME}"
+    "${SCRIPT_DIR}/../helm-charts/wso2-amp-api-platform-gateway-extension"
+    --namespace openchoreo-data-plane
+    --set agentManager.orgName="${ORG_NAME}"
+    --set gateway.environment="${ENV_NAME}"
+    --set gateway.vhost="${GATEWAY_VHOST}"
+    --set agentManager.apiUrl="http://host.docker.internal:9000/api/v1"
+    --set apiGateway.controlPlane.host="host.docker.internal:9243"
+    -f "${SCRIPT_DIR}/../helm-charts/wso2-amp-api-platform-gateway-extension/values-dev.yaml"
+)
+if helm status "${THUNDER_RELEASE}" --namespace "${THUNDER_RELEASE}" > /dev/null 2>&1; then
+    echo "✅ Env-Thunder instance found (Helm release: ${THUNDER_RELEASE}) — wiring gateway to it"
+    THUNDER_ISSUER="$(thunder_issuer "${ORG_NAME}" "${ENV_NAME}")"
+    THUNDER_INTERNAL_JWKS="http://${THUNDER_RELEASE}-service.${THUNDER_RELEASE}.svc.cluster.local:8090/oauth2/jwks"
+    HELM_ARGS+=(
+        --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].name=ThunderKeyManager"
+        --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].issuer=${THUNDER_ISSUER}"
+        --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.uri=${THUNDER_INTERNAL_JWKS}"
+        --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.skipTlsVerify=${IDP_SKIP_TLS_VERIFY}"
+        --set "bootstrap.identityProviders[0].name=${THUNDER_RELEASE}"
+        --set "bootstrap.identityProviders[0].issuer=${THUNDER_ISSUER}"
+        --set "bootstrap.identityProviders[0].jwksUri=${THUNDER_INTERNAL_JWKS}"
+        --set "bootstrap.identityProviders[0].skipTlsVerify=${IDP_SKIP_TLS_VERIFY}"
+    )
+else
+    echo "ℹ️  No env-Thunder instance found for '${ENV_NAME}' — gateway will use values-dev.yaml's platform Thunder default"
+fi
+
 echo ""
 echo "🌐 Installing gateway chart..."
-helm upgrade --install "api-platform-${ORG_NAME}-${ENV_NAME}" \
-    "${SCRIPT_DIR}/../helm-charts/wso2-amp-api-platform-gateway-extension" \
-    --namespace openchoreo-data-plane \
-    --set agentManager.orgName="${ORG_NAME}" \
-    --set gateway.environment="${ENV_NAME}" \
-    --set gateway.vhost="${GATEWAY_VHOST}" \
-    --set agentManager.apiUrl="http://host.docker.internal:9000/api/v1" \
-    --set apiGateway.controlPlane.host="host.docker.internal:9243" \
-    -f "${SCRIPT_DIR}/../helm-charts/wso2-amp-api-platform-gateway-extension/values-dev.yaml"
+helm "${HELM_ARGS[@]}"
 
 echo "⏳ Waiting for Gateway to be ready..."
 if kubectl wait --for=condition=Programmed "apigateway/api-platform-${ORG_NAME}-${ENV_NAME}" -n openchoreo-data-plane --timeout=180s; then

--- a/documentation/docs/administration/configure-identity-providers.mdx
+++ b/documentation/docs/administration/configure-identity-providers.mdx
@@ -16,6 +16,20 @@ Agent Manager's records.
 
 An identity provider is any external issuer you add, such as an Auth0 tenant or Microsoft Entra ID.
 
+## Environment-Specific Thunder Identity Providers
+
+When an environment is provisioned with its own Thunder instance (the default in
+`add-environment.sh`), that instance is registered automatically as an identity provider on the
+environment's gateway. The provider is named after the Thunder release (`amp-thunder-<org>-<env>`),
+so each instance is identifiable in the organization-wide identity provider list. Re-running the
+script re-seeds the provider idempotently; the `IDP_SKIP_TLS_VERIFY` variable (default `true`)
+controls its **Skip TLS verification** setting.
+
+Lifecycle: deleting an environment only removes the gateway-to-environment mapping — the gateway
+registration and its identity providers remain. Deleting the gateway itself
+(`DELETE /orgs/{org}/gateways/{id}`) is what removes the gateway record along with all of its
+identity providers.
+
 ## Prerequisites
 
 - A registered gateway in the environment you want to secure.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Environment-specific Thunder instances (introduced in #1214) are already trusted by the gateway because add-environment.sh configures their issuer and JWKS during installation. However, they are not registered in Agent Manager, so they don’t appear in the console Gateway Identity Providers list or as an OAuth issuer for agents.

This PR fixes that by using the identity provider bootstrap support added in #1190. add-environment.sh now includes each environment’s Thunder instance as a bootstrap.identityProviders entry, allowing the gateway bootstrap job to register it automatically in Agent Manager. 

Resolves #1203


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Gateways can automatically register and use an environment-specific Thunder identity provider when its Thunder release exists.
  * Added `IDP_SKIP_TLS_VERIFY` (default `true`) to control TLS verification for the seeded identity provider.

* **Bug Fixes**
  * Improved gateway provisioning to strictly validate `IDP_SKIP_TLS_VERIFY` and reliably fall back to the shared Thunder setup when no environment-specific Thunder is found.
  * Updated system identity provider detection to recognize environment-specific Thunder providers.

* **Documentation**
  * Added documentation for environment-specific Thunder identity providers and clarified provisioning/deletion lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->