### PR TITLE
Support instrumentation version on deploy/promote

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -2393,6 +2393,14 @@ func (c *openChoreoClient) buildBallerinaConfigFileTraitParameters(opts ...Trait
 	return params
 }
 
+// BuildInstrumentationImage is the exported wrapper around getInstrumentationImage
+// so callers outside this package (e.g. the service layer) can compute the
+// init-container image reference for a per-environment instrumentationImage
+// override without re-deriving the registry/name/tag convention.
+func BuildInstrumentationImage(languageVersion, instrumentationVersion string) (string, error) {
+	return getInstrumentationImage(languageVersion, instrumentationVersion)
+}
+
 // getInstrumentationImage builds the pre-built init-container image reference for
 // the given AMP instrumentation version and the agent's Python runtime version,
 // e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python3.11.

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -2405,11 +2405,15 @@ func BuildInstrumentationImage(languageVersion, instrumentationVersion string) (
 // the given AMP instrumentation version and the agent's Python runtime version,
 // e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python3.11.
 func getInstrumentationImage(languageVersion, instrumentationVersion string) (string, error) {
-	parts := strings.Split(languageVersion, ".")
+	// Trim before splitting so the built tag matches the trimmed major.minor the
+	// service validates against the catalog (normalizePythonMinor also trims);
+	// otherwise a value like "  3.11  " would validate yet produce a malformed
+	// image tag with embedded whitespace.
+	parts := strings.Split(strings.TrimSpace(languageVersion), ".")
 	if len(parts) < 2 {
 		return "", fmt.Errorf("invalid languageVersion format: expected 'major.minor' but got '%s'", languageVersion)
 	}
-	pythonMajorMinor := parts[0] + "." + parts[1]
+	pythonMajorMinor := strings.TrimSpace(parts[0]) + "." + strings.TrimSpace(parts[1])
 	return fmt.Sprintf("%s/%s:%s-python%s", InstrumentationImageRegistry, InstrumentationImageName, instrumentationVersion, pythonMajorMinor), nil
 }
 

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -12878,6 +12878,17 @@ components:
         enableAutoInstrumentation:
           type: boolean
           description: Enable auto instrumentation for observability in this environment. Omit to keep the current value.
+        instrumentationVersion:
+          type: string
+          nullable: true
+          description: |
+            AMP instrumentation version to pin for this agent. Selects the
+            pre-built init-container image
+            (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the
+            `traceloop-sdk` it bundles. Applies only to Python buildpack agents
+            with auto-instrumentation enabled. Omit (or send null) to keep the
+            currently-pinned version. Must be one of the versions supported by
+            the deployment; unknown or python-incompatible values are rejected.
         enableApiKeySecurity:
           type: boolean
           description: Enable API key security for the agent endpoint in this environment. Omit to keep the current value.
@@ -12926,6 +12937,17 @@ components:
         enableAutoInstrumentation:
           type: boolean
           description: Enable auto instrumentation for observability in the target environment
+        instrumentationVersion:
+          type: string
+          nullable: true
+          description: |
+            AMP instrumentation version to pin for the agent in the target
+            environment. Selects the pre-built init-container image
+            (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the
+            `traceloop-sdk` it bundles. Applies only to Python buildpack agents
+            with auto-instrumentation enabled. Omit (or send null) to inherit the
+            currently-pinned version. Must be one of the versions supported by
+            the deployment; unknown or python-incompatible values are rejected.
         enableApiKeySecurity:
           type: boolean
           description: Enable API key security for the agent endpoint in the target environment

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -567,19 +567,8 @@ func buildpackPythonVersion(b *spec.Build) string {
 	if bp.LanguageVersion == nil {
 		return ""
 	}
-	raw := strings.TrimSpace(*bp.LanguageVersion)
-	if raw == "" {
-		return ""
-	}
-	parts := strings.SplitN(raw, ".", 3)
-	if len(parts) < 2 {
-		return ""
-	}
-	major, minor := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
-	if major == "" || minor == "" {
-		return ""
-	}
-	return major + "." + minor
+	// Single source of the major.minor normalisation rule.
+	return normalizePythonMinor(*bp.LanguageVersion)
 }
 
 // validateEffectivePythonInstrumentationPair resolves the instrumentation
@@ -617,6 +606,90 @@ func (s *agentManagerService) validatePythonInstrumentationPair(pythonVersion, i
 	}
 	return fmt.Errorf("%w: instrumentation %q does not support python %q (supports: %v)",
 		utils.ErrInvalidInput, instrumentationVersion, pythonVersion, entry.PythonVersions)
+}
+
+// normalizePythonMinor collapses a Python runtime version to its bare
+// major.minor form ("3.11.4" -> "3.11"), matching the shape stored in the
+// instrumentation catalog. Returns "" when the value has fewer than two
+// dot-separated components.
+func normalizePythonMinor(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parts := strings.SplitN(raw, ".", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	major, minor := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	if major == "" || minor == "" {
+		return ""
+	}
+	return major + "." + minor
+}
+
+// resolveInstrumentationImageOverride resolves the per-environment
+// instrumentationImage override for a Python buildpack agent. Precedence for the
+// effective version is: request override -> existing pin. When a version is
+// requested it is validated against the deployment catalog and the agent's Python
+// version; the existing pin is trusted (it validated at creation) so a redeploy
+// never fails on a catalog that has since changed.
+//
+// It returns the version to persist (nil when nothing is pinned) and the image to
+// write into the OTEL trait's per-environment config ("" when no version is
+// pinned, meaning the Component's create-time default stands). For non-Python
+// agents it is a no-op that echoes the existing pin.
+func (s *agentManagerService) resolveInstrumentationImageOverride(isPythonBuildpack bool, languageVersion string, requested, existing *string) (*string, string, error) {
+	if !isPythonBuildpack {
+		return existing, "", nil
+	}
+	pyMinor := normalizePythonMinor(languageVersion)
+	version := existing
+	if requested != nil {
+		if err := s.validateInstrumentationVersion(*requested); err != nil {
+			return nil, "", err
+		}
+		if err := s.validateEffectivePythonInstrumentationPair(pyMinor, requested); err != nil {
+			return nil, "", err
+		}
+		version = requested
+	}
+	if version == nil || *version == "" {
+		return version, "", nil
+	}
+	// For an existing (not freshly-requested) pin, guard against a Python
+	// version that changed since the pin was set — build-parameters only
+	// re-validates the lowest environment's pin, so a non-lowest env's pin can
+	// silently become Python-incompatible. Building the image from an
+	// incompatible pair (or an unparseable Python version) would yield an
+	// init-container tag that doesn't exist (ImagePullBackOff). Keep the
+	// persisted pin but skip the per-env image override so the deployment falls
+	// back to the Component's image instead of a broken tag. A freshly-requested
+	// version is already strictly validated above.
+	if requested == nil {
+		if pyMinor == "" {
+			s.logger.Warn("Cannot determine Python version for instrumentation image; keeping component default",
+				"languageVersion", languageVersion, "instrumentationVersion", *version)
+			return version, "", nil
+		}
+		if err := s.validatePythonInstrumentationPair(pyMinor, *version); err != nil {
+			s.logger.Warn("Pinned instrumentation version is not compatible with the current Python version; keeping component default",
+				"languageVersion", languageVersion, "instrumentationVersion", *version, "error", err)
+			return version, "", nil
+		}
+	}
+	image, err := client.BuildInstrumentationImage(languageVersion, *version)
+	if err != nil {
+		if requested != nil {
+			return nil, "", fmt.Errorf("%w: %s", utils.ErrInvalidInput, err.Error())
+		}
+		// Defensive: the compatibility guard above should already have caught
+		// this; keep the Component default rather than failing a valid redeploy.
+		s.logger.Warn("Failed to build instrumentation image from existing pin; keeping component default",
+			"languageVersion", languageVersion, "instrumentationVersion", *version, "error", err)
+		return version, "", nil
+	}
+	return version, image, nil
 }
 
 // persistInstrumentationConfig saves the instrumentation config to the database.
@@ -2407,7 +2480,18 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, orgName string, p
 	policies := buildPolicies(apiCfg)
 	isPythonBuildpack := agent.Build != nil && agent.Build.Buildpack != nil && agent.Build.Buildpack.Language == string(utils.LanguagePython)
 	isBallerinaBuildpack := agent.Build != nil && agent.Build.Buildpack != nil && agent.Build.Buildpack.Language == string(utils.LanguageBallerina)
-	deployTraitEnvConfigs := buildTraitEnvConfigs(agentName, policies, "", isPythonBuildpack, isBallerinaBuildpack, enableAutoInstrumentation)
+	// Re-apply the agent's pinned instrumentation version as a per-env image
+	// override so a redeploy doesn't drop a version set via deploy-settings/promote
+	// back to the Component default. Deploy carries no version override of its own.
+	deployLanguageVersion := ""
+	if agent.Build != nil && agent.Build.Buildpack != nil {
+		deployLanguageVersion = agent.Build.Buildpack.LanguageVersion
+	}
+	_, deployInstrumentationImage, err := s.resolveInstrumentationImageOverride(isPythonBuildpack, deployLanguageVersion, nil, existingInstrumentationVersion)
+	if err != nil {
+		return "", err
+	}
+	deployTraitEnvConfigs := buildTraitEnvConfigs(agentName, policies, "", isPythonBuildpack, isBallerinaBuildpack, enableAutoInstrumentation, deployInstrumentationImage)
 
 	// Replace Component CR workflow parameters with env vars and file mounts from deploy request
 	// This replaces all existing env vars to ensure the component CR matches the deploy request
@@ -2761,7 +2845,10 @@ func buildPolicies(cfg resolvedCORSConfig) []map[string]interface{} {
 // For Python buildpack agents, instrumentationEnabled is set per-environment on the OTEL trait;
 // for Ballerina buildpack agents it is set on the ballerina-config-file trait. In both cases the
 // 'where' clause on patches enables/disables instrumentation independently per environment.
-func buildTraitEnvConfigs(agentName string, policies []map[string]interface{}, artifactID string, isPythonBuildpack, isBallerinaBuildpack bool, autoInstrumentation bool) map[string]interface{} {
+// instrumentationImage, when non-empty, pins the OTEL init-container image for this environment
+// (overriding the Component's create-time default) so the AMP instrumentation version can be
+// changed per-environment on deploy/promote without re-attaching the Component trait.
+func buildTraitEnvConfigs(agentName string, policies []map[string]interface{}, artifactID string, isPythonBuildpack, isBallerinaBuildpack bool, autoInstrumentation bool, instrumentationImage string) map[string]interface{} {
 	instanceName := func(traitType client.TraitType) string {
 		return agentName + "-" + string(traitType)
 	}
@@ -2775,9 +2862,13 @@ func buildTraitEnvConfigs(agentName string, policies []map[string]interface{}, a
 		instanceName(client.TraitAPIManagement): apiTraitCfg,
 	}
 	if isPythonBuildpack {
-		traitEnvConfigs[instanceName(client.TraitOTELInstrumentation)] = map[string]interface{}{
+		otelCfg := map[string]interface{}{
 			"instrumentationEnabled": autoInstrumentation,
 		}
+		if instrumentationImage != "" {
+			otelCfg["instrumentationImage"] = instrumentationImage
+		}
+		traitEnvConfigs[instanceName(client.TraitOTELInstrumentation)] = otelCfg
 	}
 	if isBallerinaBuildpack {
 		traitEnvConfigs[instanceName(client.TraitBallerinaOTELInstrumentation)] = map[string]interface{}{
@@ -2989,7 +3080,24 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, orgName string, 
 		targetArtifactID := artifact.UUID.String()
 		promotePythonBuildpack := agent.Build != nil && agent.Build.Buildpack != nil && agent.Build.Buildpack.Language == string(utils.LanguagePython)
 		promoteBallerinaBuildpack := agent.Build != nil && agent.Build.Buildpack != nil && agent.Build.Buildpack.Language == string(utils.LanguageBallerina)
-		traitEnvConfigs = buildTraitEnvConfigs(agentName, policies, targetArtifactID, promotePythonBuildpack, promoteBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation)
+		// Resolve the instrumentation version for the target env: request override
+		// (validated) -> source env's pinned version. The resolved version is
+		// persisted below and its image is written as a per-env override.
+		promoteLanguageVersion := ""
+		if agent.Build != nil && agent.Build.Buildpack != nil {
+			promoteLanguageVersion = agent.Build.Buildpack.LanguageVersion
+		}
+		var existingInstrumentationVersion *string
+		if existingConfig != nil {
+			existingInstrumentationVersion = existingConfig.InstrumentationVersion
+		}
+		resolvedInstrumentationVersion, promoteInstrumentationImage, resolveErr := s.resolveInstrumentationImageOverride(
+			promotePythonBuildpack, promoteLanguageVersion, req.InstrumentationVersion.Get(), existingInstrumentationVersion,
+		)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		traitEnvConfigs = buildTraitEnvConfigs(agentName, policies, targetArtifactID, promotePythonBuildpack, promoteBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation, promoteInstrumentationImage)
 
 		apiKey, apiKeyErr := s.generateAgentAPIKey(ctx, orgName, projectName, agentName, req.TargetEnvironment)
 		if apiKeyErr != nil {
@@ -3018,6 +3126,7 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, orgName string, 
 			AgentName:                 agentName,
 			EnvironmentName:           req.TargetEnvironment,
 			EnableAutoInstrumentation: tracingCfg.EnableAutoInstrumentation,
+			InstrumentationVersion:    resolvedInstrumentationVersion,
 			EnableApiKeySecurity:      apiCfg.EnableApiKeySecurity,
 			CORSEnabled:               apiCfg.CORSEnabled,
 			CORSAllowOrigins:          apiCfg.CORSAllowOrigins,
@@ -3103,7 +3212,24 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, org
 	}
 	isPythonBuildpack := agent.Build != nil && agent.Build.Buildpack != nil && agent.Build.Buildpack.Language == string(utils.LanguagePython)
 	isBallerinaBuildpack := agent.Build != nil && agent.Build.Buildpack != nil && agent.Build.Buildpack.Language == string(utils.LanguageBallerina)
-	traitEnvConfigs := buildTraitEnvConfigs(agentName, policies, artifact.UUID.String(), isPythonBuildpack, isBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation)
+	// Resolve the instrumentation version: request override (validated) -> the
+	// env's currently-pinned version. The resolved version is persisted below and
+	// its image is written as a per-env override on the OTEL trait.
+	languageVersion := ""
+	if agent.Build != nil && agent.Build.Buildpack != nil {
+		languageVersion = agent.Build.Buildpack.LanguageVersion
+	}
+	var existingInstrumentationVersion *string
+	if existingConfig != nil {
+		existingInstrumentationVersion = existingConfig.InstrumentationVersion
+	}
+	resolvedInstrumentationVersion, instrumentationImage, resolveErr := s.resolveInstrumentationImageOverride(
+		isPythonBuildpack, languageVersion, req.InstrumentationVersion.Get(), existingInstrumentationVersion,
+	)
+	if resolveErr != nil {
+		return resolveErr
+	}
+	traitEnvConfigs := buildTraitEnvConfigs(agentName, policies, artifact.UUID.String(), isPythonBuildpack, isBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation, instrumentationImage)
 
 	// Apply to the release binding (atomic: trait configs + restartedAt in a single update).
 	if updateErr := s.ocClient.UpdateReleaseBindingTraitConfigs(ctx, orgName, agentName, req.EnvironmentName, traitEnvConfigs); updateErr != nil {
@@ -3118,6 +3244,7 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, org
 		AgentName:                 agentName,
 		EnvironmentName:           req.EnvironmentName,
 		EnableAutoInstrumentation: tracingCfg.EnableAutoInstrumentation,
+		InstrumentationVersion:    resolvedInstrumentationVersion,
 		EnableApiKeySecurity:      apiCfg.EnableApiKeySecurity,
 		CORSEnabled:               apiCfg.CORSEnabled,
 		CORSAllowOrigins:          apiCfg.CORSAllowOrigins,
@@ -3130,10 +3257,6 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, org
 		OAuthHeaderName:           apiCfg.OAuthHeaderName,
 		OAuthAuthHeaderPrefix:     apiCfg.OAuthAuthHeaderPrefix,
 		OAuthForwardToken:         apiCfg.OAuthForwardToken,
-	}
-	if existingConfig != nil {
-		// Preserve any pinned instrumentation_version that wasn't part of this request.
-		agentConfig.InstrumentationVersion = existingConfig.InstrumentationVersion
 	}
 	if upsertErr := s.agentConfigRepo.Upsert(agentConfig); upsertErr != nil {
 		s.logger.Error("Failed to persist agent deploy settings", "agentName", agentName, "environment", req.EnvironmentName, "error", upsertErr)

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -17,11 +17,13 @@
 package services
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/wso2/agent-manager/agent-manager-service/instrumentation"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func TestValidateInstrumentationVersion_UsesCatalog(t *testing.T) {
@@ -141,4 +143,131 @@ func TestValidateEffectivePair_NoPythonIsNoOp(t *testing.T) {
 	if err := s.validateEffectivePythonInstrumentationPair("", nil); err != nil {
 		t.Errorf("empty python should be a no-op: %v", err)
 	}
+}
+
+func TestNormalizePythonMinor(t *testing.T) {
+	cases := map[string]string{
+		"3.11":     "3.11",
+		"3.11.4":   "3.11",
+		"3.11.x":   "3.11",
+		"  3.11  ": "3.11",
+		"3":        "",
+		"":         "",
+		"   ":      "",
+	}
+	for in, want := range cases {
+		if got := normalizePythonMinor(in); got != want {
+			t.Errorf("normalizePythonMinor(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveInstrumentationImageOverride(t *testing.T) {
+	instrumentation.SetCatalog(instrumentation.NewForTest(
+		[]instrumentation.Version{
+			{Version: "0.2.1", PythonVersions: []string{"3.10", "3.11"}, ImageRepository: "x"},
+			{Version: "0.4.0", PythonVersions: []string{"3.12", "3.13"}, ImageRepository: "x"},
+		},
+		"0.2.1",
+	))
+	strPtr := func(s string) *string { return &s }
+	s := &agentManagerService{logger: discardLogger()}
+
+	t.Run("non-python echoes existing pin, no image", func(t *testing.T) {
+		version, image, err := s.resolveInstrumentationImageOverride(false, "3.11", strPtr("0.4.0"), strPtr("0.2.1"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version == nil || *version != "0.2.1" {
+			t.Errorf("version = %v, want existing 0.2.1", version)
+		}
+		if image != "" {
+			t.Errorf("image = %q, want empty for non-python", image)
+		}
+	})
+
+	t.Run("request override validates and wins", func(t *testing.T) {
+		version, image, err := s.resolveInstrumentationImageOverride(true, "3.11", strPtr("0.2.1"), strPtr("0.4.0"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version == nil || *version != "0.2.1" {
+			t.Errorf("version = %v, want requested 0.2.1", version)
+		}
+		if !strings.HasSuffix(image, "0.2.1-python3.11") {
+			t.Errorf("image = %q, want suffix 0.2.1-python3.11", image)
+		}
+	})
+
+	t.Run("unknown request version is rejected", func(t *testing.T) {
+		_, _, err := s.resolveInstrumentationImageOverride(true, "3.11", strPtr("9.9.9"), nil)
+		if !errors.Is(err, utils.ErrInvalidInput) {
+			t.Fatalf("err = %v, want ErrInvalidInput", err)
+		}
+	})
+
+	t.Run("python-incompatible request version is rejected", func(t *testing.T) {
+		// 0.4.0 supports 3.12/3.13, not 3.11.
+		_, _, err := s.resolveInstrumentationImageOverride(true, "3.11", strPtr("0.4.0"), nil)
+		if !errors.Is(err, utils.ErrInvalidInput) {
+			t.Fatalf("err = %v, want ErrInvalidInput", err)
+		}
+	})
+
+	t.Run("no request preserves existing pin as image", func(t *testing.T) {
+		version, image, err := s.resolveInstrumentationImageOverride(true, "3.11", nil, strPtr("0.2.1"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version == nil || *version != "0.2.1" {
+			t.Errorf("version = %v, want preserved 0.2.1", version)
+		}
+		if !strings.HasSuffix(image, "0.2.1-python3.11") {
+			t.Errorf("image = %q, want suffix 0.2.1-python3.11", image)
+		}
+	})
+
+	t.Run("no request and no existing pin yields no override", func(t *testing.T) {
+		version, image, err := s.resolveInstrumentationImageOverride(true, "3.11", nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version != nil {
+			t.Errorf("version = %v, want nil", version)
+		}
+		if image != "" {
+			t.Errorf("image = %q, want empty", image)
+		}
+	})
+
+	t.Run("existing pin incompatible with current python keeps version but skips image", func(t *testing.T) {
+		// Pin 0.2.1 supports 3.10/3.11; the agent's Python is now 3.13. Building
+		// the image would yield a nonexistent 0.2.1-python3.13 tag, so the
+		// override is skipped (empty image) while the DB version is preserved.
+		version, image, err := s.resolveInstrumentationImageOverride(true, "3.13", nil, strPtr("0.2.1"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version == nil || *version != "0.2.1" {
+			t.Errorf("version = %v, want preserved 0.2.1", version)
+		}
+		if image != "" {
+			t.Errorf("image = %q, want empty (incompatible pin, component default kept)", image)
+		}
+	})
+
+	t.Run("existing pin with unparseable python keeps component default", func(t *testing.T) {
+		// No request override + bad language version: don't fail the redeploy,
+		// just skip the per-env image override.
+		version, image, err := s.resolveInstrumentationImageOverride(true, "notaversion", nil, strPtr("0.2.1"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version == nil || *version != "0.2.1" {
+			t.Errorf("version = %v, want preserved 0.2.1", version)
+		}
+		if image != "" {
+			t.Errorf("image = %q, want empty (component default kept)", image)
+		}
+	})
 }

--- a/agent-manager-service/spec/model_promote_agent_request.go
+++ b/agent-manager-service/spec/model_promote_agent_request.go
@@ -31,6 +31,8 @@ type PromoteAgentRequest struct {
 	Files []FileMount `json:"files,omitempty"`
 	// Enable auto instrumentation for observability in the target environment
 	EnableAutoInstrumentation *bool `json:"enableAutoInstrumentation,omitempty"`
+	// AMP instrumentation version to pin for the agent in the target environment. Selects the pre-built init-container image (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the `traceloop-sdk` it bundles. Applies only to Python buildpack agents with auto-instrumentation enabled. Omit (or send null) to inherit the currently-pinned version. Must be one of the versions supported by the deployment; unknown or python-incompatible values are rejected.
+	InstrumentationVersion NullableString `json:"instrumentationVersion,omitempty"`
 	// Enable API key security for the agent endpoint in the target environment
 	EnableApiKeySecurity *bool       `json:"enableApiKeySecurity,omitempty"`
 	CorsConfig           *CORSConfig `json:"corsConfig,omitempty"`
@@ -234,6 +236,49 @@ func (o *PromoteAgentRequest) SetEnableAutoInstrumentation(v bool) {
 	o.EnableAutoInstrumentation = &v
 }
 
+// GetInstrumentationVersion returns the InstrumentationVersion field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *PromoteAgentRequest) GetInstrumentationVersion() string {
+	if o == nil || IsNil(o.InstrumentationVersion.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.InstrumentationVersion.Get()
+}
+
+// GetInstrumentationVersionOk returns a tuple with the InstrumentationVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *PromoteAgentRequest) GetInstrumentationVersionOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.InstrumentationVersion.Get(), o.InstrumentationVersion.IsSet()
+}
+
+// HasInstrumentationVersion returns a boolean if a field has been set.
+func (o *PromoteAgentRequest) HasInstrumentationVersion() bool {
+	if o != nil && o.InstrumentationVersion.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetInstrumentationVersion gets a reference to the given NullableString and assigns it to the InstrumentationVersion field.
+func (o *PromoteAgentRequest) SetInstrumentationVersion(v string) {
+	o.InstrumentationVersion.Set(&v)
+}
+
+// SetInstrumentationVersionNil sets the value for InstrumentationVersion to be an explicit nil
+func (o *PromoteAgentRequest) SetInstrumentationVersionNil() {
+	o.InstrumentationVersion.Set(nil)
+}
+
+// UnsetInstrumentationVersion ensures that no value is present for InstrumentationVersion, not even an explicit nil
+func (o *PromoteAgentRequest) UnsetInstrumentationVersion() {
+	o.InstrumentationVersion.Unset()
+}
+
 // GetEnableApiKeySecurity returns the EnableApiKeySecurity field value if set, zero value otherwise.
 func (o *PromoteAgentRequest) GetEnableApiKeySecurity() bool {
 	if o == nil || IsNil(o.EnableApiKeySecurity) {
@@ -385,6 +430,9 @@ func (o PromoteAgentRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.EnableAutoInstrumentation) {
 		toSerialize["enableAutoInstrumentation"] = o.EnableAutoInstrumentation
+	}
+	if o.InstrumentationVersion.IsSet() {
+		toSerialize["instrumentationVersion"] = o.InstrumentationVersion.Get()
 	}
 	if !IsNil(o.EnableApiKeySecurity) {
 		toSerialize["enableApiKeySecurity"] = o.EnableApiKeySecurity

--- a/agent-manager-service/spec/model_update_agent_deploy_settings_request.go
+++ b/agent-manager-service/spec/model_update_agent_deploy_settings_request.go
@@ -23,6 +23,8 @@ type UpdateAgentDeploySettingsRequest struct {
 	EnvironmentName string `json:"environmentName"`
 	// Enable auto instrumentation for observability in this environment. Omit to keep the current value.
 	EnableAutoInstrumentation *bool `json:"enableAutoInstrumentation,omitempty"`
+	// AMP instrumentation version to pin for this agent. Selects the pre-built init-container image (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the `traceloop-sdk` it bundles. Applies only to Python buildpack agents with auto-instrumentation enabled. Omit (or send null) to keep the currently-pinned version. Must be one of the versions supported by the deployment; unknown or python-incompatible values are rejected.
+	InstrumentationVersion NullableString `json:"instrumentationVersion,omitempty"`
 	// Enable API key security for the agent endpoint in this environment. Omit to keep the current value.
 	EnableApiKeySecurity *bool       `json:"enableApiKeySecurity,omitempty"`
 	CorsConfig           *CORSConfig `json:"corsConfig,omitempty"`
@@ -103,6 +105,49 @@ func (o *UpdateAgentDeploySettingsRequest) HasEnableAutoInstrumentation() bool {
 // SetEnableAutoInstrumentation gets a reference to the given bool and assigns it to the EnableAutoInstrumentation field.
 func (o *UpdateAgentDeploySettingsRequest) SetEnableAutoInstrumentation(v bool) {
 	o.EnableAutoInstrumentation = &v
+}
+
+// GetInstrumentationVersion returns the InstrumentationVersion field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *UpdateAgentDeploySettingsRequest) GetInstrumentationVersion() string {
+	if o == nil || IsNil(o.InstrumentationVersion.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.InstrumentationVersion.Get()
+}
+
+// GetInstrumentationVersionOk returns a tuple with the InstrumentationVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *UpdateAgentDeploySettingsRequest) GetInstrumentationVersionOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.InstrumentationVersion.Get(), o.InstrumentationVersion.IsSet()
+}
+
+// HasInstrumentationVersion returns a boolean if a field has been set.
+func (o *UpdateAgentDeploySettingsRequest) HasInstrumentationVersion() bool {
+	if o != nil && o.InstrumentationVersion.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetInstrumentationVersion gets a reference to the given NullableString and assigns it to the InstrumentationVersion field.
+func (o *UpdateAgentDeploySettingsRequest) SetInstrumentationVersion(v string) {
+	o.InstrumentationVersion.Set(&v)
+}
+
+// SetInstrumentationVersionNil sets the value for InstrumentationVersion to be an explicit nil
+func (o *UpdateAgentDeploySettingsRequest) SetInstrumentationVersionNil() {
+	o.InstrumentationVersion.Set(nil)
+}
+
+// UnsetInstrumentationVersion ensures that no value is present for InstrumentationVersion, not even an explicit nil
+func (o *UpdateAgentDeploySettingsRequest) UnsetInstrumentationVersion() {
+	o.InstrumentationVersion.Unset()
 }
 
 // GetEnableApiKeySecurity returns the EnableApiKeySecurity field value if set, zero value otherwise.
@@ -246,6 +291,9 @@ func (o UpdateAgentDeploySettingsRequest) ToMap() (map[string]interface{}, error
 	toSerialize["environmentName"] = o.EnvironmentName
 	if !IsNil(o.EnableAutoInstrumentation) {
 		toSerialize["enableAutoInstrumentation"] = o.EnableAutoInstrumentation
+	}
+	if o.InstrumentationVersion.IsSet() {
+		toSerialize["instrumentationVersion"] = o.InstrumentationVersion.Get()
 	}
 	if !IsNil(o.EnableApiKeySecurity) {
 		toSerialize["enableApiKeySecurity"] = o.EnableApiKeySecurity

--- a/agent-manager-service/tests/promote_agent_test.go
+++ b/agent-manager-service/tests/promote_agent_test.go
@@ -238,7 +238,7 @@ func TestPromoteAgent(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
 		require.Equal(t, utils.ErrCodeValidation, errResp.Code)
 		require.Equal(t,
-			"useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, enableApiKeySecurity, corsConfig, enableOAuthSecurity, and oauthConfig",
+			"useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, instrumentationVersion, enableApiKeySecurity, corsConfig, enableOAuthSecurity, and oauthConfig",
 			errResp.Message)
 
 		// The agent must not have been promoted.

--- a/agent-manager-service/utils/utils.go
+++ b/agent-manager-service/utils/utils.go
@@ -748,11 +748,12 @@ func ValidatePromoteAgentRequest(payload *spec.PromoteAgentRequest) error {
 	if useSource {
 		if len(payload.Env) > 0 || len(payload.Files) > 0 ||
 			payload.EnableAutoInstrumentation != nil ||
+			payload.InstrumentationVersion.IsSet() ||
 			payload.EnableApiKeySecurity != nil ||
 			payload.CorsConfig != nil ||
 			payload.EnableOAuthSecurity != nil ||
 			payload.OauthConfig != nil {
-			return fmt.Errorf("useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, enableApiKeySecurity, corsConfig, enableOAuthSecurity, and oauthConfig")
+			return fmt.Errorf("useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, instrumentationVersion, enableApiKeySecurity, corsConfig, enableOAuthSecurity, and oauthConfig")
 		}
 	}
 

--- a/agent-manager-service/utils/validation_test.go
+++ b/agent-manager-service/utils/validation_test.go
@@ -19,7 +19,41 @@ package utils
 import (
 	"strings"
 	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
+
+func TestValidatePromoteAgentRequest_UseSourceExcludesInstrumentationVersion(t *testing.T) {
+	useSource := true
+	req := &spec.PromoteAgentRequest{
+		SourceEnvironment:      "dev",
+		TargetEnvironment:      "staging",
+		UseConfigFromSourceEnv: &useSource,
+	}
+	req.InstrumentationVersion.Set(strPtrForTest("0.4.0"))
+
+	err := ValidatePromoteAgentRequest(req)
+	if err == nil {
+		t.Fatal("expected error: instrumentationVersion is mutually exclusive with useConfigFromSourceEnv=true")
+	}
+	if !strings.Contains(err.Error(), "instrumentationVersion") {
+		t.Errorf("error %q should mention instrumentationVersion", err)
+	}
+}
+
+func TestValidatePromoteAgentRequest_InstrumentationVersionAllowedWithoutUseSource(t *testing.T) {
+	req := &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	}
+	req.InstrumentationVersion.Set(strPtrForTest("0.4.0"))
+
+	if err := ValidatePromoteAgentRequest(req); err != nil {
+		t.Errorf("instrumentationVersion should be allowed when useConfigFromSourceEnv is unset: %v", err)
+	}
+}
+
+func strPtrForTest(s string) *string { return &s }
 
 func TestValidateTemplateHandle(t *testing.T) {
 	tests := []struct {

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -4029,6 +4029,15 @@ type PromoteAgentRequest struct {
 	// Files Environment-specific file mounts for the target environment.
 	Files *[]FileMount `json:"files,omitempty"`
 
+	// InstrumentationVersion AMP instrumentation version to pin for the agent in the target
+	// environment. Selects the pre-built init-container image
+	// (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the
+	// `traceloop-sdk` it bundles. Applies only to Python buildpack agents
+	// with auto-instrumentation enabled. Omit (or send null) to inherit the
+	// currently-pinned version. Must be one of the versions supported by
+	// the deployment; unknown or python-incompatible values are rejected.
+	InstrumentationVersion *string `json:"instrumentationVersion,omitempty"`
+
 	// OauthConfig OAuth security configuration for the agent endpoint. Callers authenticate with a standard Authorization Bearer token validated by the gateway.
 	OauthConfig *OAuthConfig `json:"oauthConfig,omitempty"`
 
@@ -4597,6 +4606,15 @@ type UpdateAgentDeploySettingsRequest struct {
 
 	// EnvironmentName Name of the environment whose deploy settings to update.
 	EnvironmentName string `json:"environmentName"`
+
+	// InstrumentationVersion AMP instrumentation version to pin for this agent. Selects the
+	// pre-built init-container image
+	// (`amp-python-instrumentation-provider:<version>-python<X.Y>`) and the
+	// `traceloop-sdk` it bundles. Applies only to Python buildpack agents
+	// with auto-instrumentation enabled. Omit (or send null) to keep the
+	// currently-pinned version. Must be one of the versions supported by
+	// the deployment; unknown or python-incompatible values are rejected.
+	InstrumentationVersion *string `json:"instrumentationVersion,omitempty"`
 
 	// OauthConfig OAuth security configuration for the agent endpoint. Callers authenticate with a standard Authorization Bearer token validated by the gateway.
 	OauthConfig *OAuthConfig `json:"oauthConfig,omitempty"`

--- a/console/workspaces/libs/types/src/api/deployments.ts
+++ b/console/workspaces/libs/types/src/api/deployments.ts
@@ -34,6 +34,11 @@ export interface DeployAgentRequest {
 export interface UpdateAgentDeploySettingsRequest {
   environmentName: string;
   enableAutoInstrumentation?: boolean;
+  /**
+   * AMP instrumentation version to pin for this Python buildpack agent in this
+   * environment. Omit to keep the currently-pinned version.
+   */
+  instrumentationVersion?: string;
   enableApiKeySecurity?: boolean;
   enableOAuthSecurity?: boolean;
   corsConfig?: CorsConfig;
@@ -201,6 +206,11 @@ export interface PromoteAgentRequest {
   env?: EnvironmentVariable[];
   files?: FileMount[];
   enableAutoInstrumentation?: boolean;
+  /**
+   * AMP instrumentation version to pin for this Python buildpack agent in the
+   * target environment. Omit to inherit the currently-pinned version.
+   */
+  instrumentationVersion?: string;
   enableApiKeySecurity?: boolean;
   enableOAuthSecurity?: boolean;
   corsConfig?: CorsConfig;

--- a/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
@@ -17,6 +17,7 @@
  */
 
 import {
+  useAgentBuildOptions,
   useDeployAgent,
   useUpdateAgentDeploySettings,
   useGetAgent,
@@ -63,6 +64,7 @@ import {
   IconButton,
   Menu,
   MenuItem,
+  Select,
   Skeleton,
   Stack,
   Switch,
@@ -88,6 +90,11 @@ import {
   TraceListTimeRange,
 } from "@agent-management-platform/types";
 import { extractBuildIdFromImageId } from "../utils/extractBuildIdFromImageId";
+import {
+  compatibleInstrumentationVersions,
+  normalizePythonMinor,
+  pickInstrumentationVersion,
+} from "../utils/instrumentation";
 import { formatDistanceToNow } from "date-fns";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { EditResourceConfigsDrawer } from "./EditResourceConfigsDrawer";
@@ -397,6 +404,10 @@ export function DeployCard(props: DeployCardProps) {
     agent?.build?.type === "buildpack" &&
     "buildpack" in (agent.build ?? {}) &&
     (agent.build as { buildpack?: { language?: string } }).buildpack?.language === "python";
+  const agentPythonVersion = normalizePythonMinor(
+    (agent?.build as { buildpack?: { languageVersion?: string } } | undefined)
+      ?.buildpack?.languageVersion,
+  );
 
   // Inline toggle: tracing. Endpoint authentication (none/api-key/oauth) is
   // managed in the security drawer since it spans three mutually-exclusive
@@ -404,12 +415,59 @@ export function DeployCard(props: DeployCardProps) {
   const [tracingEnabled, setTracingEnabled] = useState(false);
   const [isSavingConfig, setIsSavingConfig] = useState(false);
   const [actionsMenuAnchor, setActionsMenuAnchor] = useState<null | HTMLElement>(null);
+  // AMP instrumentation version shown for this environment. Seeded for display
+  // from the agent's current config; it is only PERSISTED when the user
+  // explicitly changes it (versionDirty), so merely toggling tracing never
+  // converts an unpinned agent into an explicit pin.
+  const [instrumentationVersion, setInstrumentationVersion] = useState<string>("");
+  const [versionDirty, setVersionDirty] = useState(false);
+
+  // Server instrumentation catalog (Python runtimes + version→SDK mapping),
+  // shared with the create wizard.
+  const { data: buildOptions } = useAgentBuildOptions({ orgName: orgId ?? "" });
+  // Instrumentation versions compatible with this agent's Python runtime.
+  const compatibleInstrumentation = useMemo(
+    () => compatibleInstrumentationVersions(buildOptions, agentPythonVersion),
+    [buildOptions, agentPythonVersion],
+  );
 
   useEffect(() => {
     if (agent?.configurations?.enableAutoInstrumentation !== undefined) {
       setTracingEnabled(agent.configurations.enableAutoInstrumentation);
     }
   }, [agent?.configurations?.enableAutoInstrumentation]);
+
+  // Reset per-agent selector state when the viewed agent changes, so a version
+  // from a previously-viewed agent never leaks onto (or gets persisted for) a
+  // different agent when this card instance is reused across navigation.
+  useEffect(() => {
+    setInstrumentationVersion("");
+    setVersionDirty(false);
+  }, [agentId, currentEnvironment.name]);
+
+  // Seed the selector for DISPLAY once BOTH the agent (for its Python version)
+  // and the catalog have loaded — waiting avoids seeding from the all-versions
+  // set while agentPythonVersion is still undefined. Re-seed whenever the
+  // current value is not in the compatible set (self-corrects a stale seed);
+  // a valid user selection is always in the set, so this never clobbers it.
+  useEffect(() => {
+    if (!buildOptions || !agent) return;
+    const inSet = compatibleInstrumentation.some(
+      (v) => v.version === instrumentationVersion,
+    );
+    if (inSet) return;
+    const seed = pickInstrumentationVersion(
+      compatibleInstrumentation,
+      agent?.configurations?.instrumentationVersion,
+      buildOptions.instrumentation.defaultVersion,
+    );
+    setInstrumentationVersion(seed);
+  }, [
+    buildOptions,
+    agent,
+    compatibleInstrumentation,
+    instrumentationVersion,
+  ]);
 
   const authMode: "none" | "apikey" | "oauth" = agent?.configurations
     ?.enableOAuthSecurity
@@ -434,9 +492,25 @@ export function DeployCard(props: DeployCardProps) {
   const { mutate: deployAgentMutate } = useDeployAgent();
   const { mutate: updateDeploySettingsMutate } = useUpdateAgentDeploySettings();
 
-  // Stable debounced redeploy — reads latest values via ref at fire time
-  const latestToggleRef = useRef({ tracing: tracingEnabled });
-  latestToggleRef.current = { tracing: tracingEnabled };
+  // Stable debounced redeploy — reads latest values via ref at fire time.
+  // `versionInSet` gates whether the selected version is safe to send (it must
+  // be compatible with the agent's Python), and `versionDirty` whether the user
+  // actually changed it (vs. a display-only seed).
+  const versionInCompatibleSet = compatibleInstrumentation.some(
+    (v) => v.version === instrumentationVersion,
+  );
+  const latestToggleRef = useRef({
+    tracing: tracingEnabled,
+    instrumentationVersion,
+    versionDirty,
+    versionInCompatibleSet,
+  });
+  latestToggleRef.current = {
+    tracing: tracingEnabled,
+    instrumentationVersion,
+    versionDirty,
+    versionInCompatibleSet,
+  };
 
   const redeployContextRef = useRef({
     orgId, projectId, agentId, currentEnvironment, isApiAgent, isPythonBuildpack,
@@ -469,16 +543,28 @@ export function DeployCard(props: DeployCardProps) {
         isPythonBuildpack: isPy,
       } = redeployContextRef.current;
       if (!o || !p || !a || !env?.name) return;
-      const { tracing } = latestToggleRef.current;
+      const {
+        tracing,
+        instrumentationVersion: version,
+        versionDirty: dirty,
+        versionInCompatibleSet: inSet,
+      } = latestToggleRef.current;
       setIsSavingConfig(true);
       // Auth + CORS are omitted so resolveAPIConfig preserves them from the
-      // existing DB config; only the tracing toggle is changed here.
+      // existing DB config; only the tracing toggle and instrumentation version
+      // are changed here. The version is sent only when the user actually
+      // changed it to a compatible value while tracing is on — otherwise it is
+      // omitted so the backend preserves the existing pin (and an unpinned agent
+      // keeps floating with the platform default rather than being frozen).
       updateDeploySettingsRef.current(
         {
           params: { orgName: o, projName: p, agentName: a },
           body: {
             environmentName: env.name,
             ...(isPy && { enableAutoInstrumentation: tracing }),
+            ...(isPy && tracing && dirty && inSet && version
+              ? { instrumentationVersion: version }
+              : {}),
           },
         },
         { onSuccess: () => setIsSavingConfig(false), onError: () => setIsSavingConfig(false) },
@@ -787,6 +873,42 @@ export function DeployCard(props: DeployCardProps) {
                           debouncedRedeploy();
                         }}
                       />
+                    </Box>
+                  )}
+
+                  {/* AMP Instrumentation Version — pins the init-container image
+                      + bundled OpenLLMetry SDK for this environment. */}
+                  {isPythonBuildpack && tracingEnabled && (
+                    <Box display="flex" alignItems="center" justifyContent="space-between">
+                      <Box display="flex" alignItems="center" gap={1}>
+                        <Info size={14} style={{ opacity: 0.6 }} />
+                        <Typography variant="body2">Instrumentation Version</Typography>
+                      </Box>
+                      {compatibleInstrumentation.length === 0 && buildOptions ? (
+                        <Typography variant="caption" color="text.secondary">
+                          None available for Python {agentPythonVersion ?? "runtime"}
+                        </Typography>
+                      ) : (
+                        <Select
+                          size="small"
+                          value={versionInCompatibleSet ? instrumentationVersion : ""}
+                          disabled={isSavingConfig || !buildOptions}
+                          onChange={(e) => {
+                            setInstrumentationVersion(e.target.value as string);
+                            setVersionDirty(true);
+                            debouncedRedeploy();
+                          }}
+                          sx={{ minWidth: 200 }}
+                        >
+                          {compatibleInstrumentation.map((v) => (
+                            <MenuItem key={v.version} value={v.version}>
+                              {v.traceloopSdk
+                                ? `${v.version} (OpenLLMetry v${v.traceloopSdk})`
+                                : v.version}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      )}
                     </Box>
                   )}
                 </Stack>

--- a/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
@@ -42,7 +42,9 @@ import {
   FileMountEditor,
 } from "@agent-management-platform/views";
 import {
+  useAgentBuildOptions,
   usePromoteAgent,
+  useGetAgent,
   useGetAgentConfigurations,
   useGetDeploymentPipeline,
   useListAgentDeployments,
@@ -53,6 +55,11 @@ import type {
   EnvironmentVariable,
   FileMount,
 } from "@agent-management-platform/types";
+import {
+  compatibleInstrumentationVersions,
+  normalizePythonMinor,
+  pickInstrumentationVersion,
+} from "../utils/instrumentation";
 
 interface PromoteAgentDrawerProps {
   open: boolean;
@@ -68,6 +75,11 @@ interface PromoteFormState {
   useConfigFromSourceEnv: boolean;
   env: EnvironmentVariable[];
   files: FileMount[];
+  instrumentationVersion: string;
+  // True once the user explicitly picks a version. When false, the version is
+  // omitted from the promote request so the backend inherits the source env's
+  // pin rather than overwriting the target with a display-only seed.
+  instrumentationVersionDirty: boolean;
 }
 
 const DEFAULT_STATE: PromoteFormState = {
@@ -75,6 +87,8 @@ const DEFAULT_STATE: PromoteFormState = {
   useConfigFromSourceEnv: false,
   env: [],
   files: [],
+  instrumentationVersion: "",
+  instrumentationVersionDirty: false,
 };
 
 export function PromoteAgentDrawer({
@@ -92,6 +106,29 @@ export function PromoteAgentDrawer({
     projName: projectId,
   });
   const { data: environments } = useListEnvironments({ orgName: orgId });
+  const { data: agent } = useGetAgent({
+    orgName: orgId,
+    projName: projectId,
+    agentName: agentId,
+  });
+
+  // Instrumentation version selection is only relevant for Python buildpack agents.
+  const isPythonBuildpack =
+    agent?.build?.type === "buildpack" &&
+    "buildpack" in (agent.build ?? {}) &&
+    (agent.build as { buildpack?: { language?: string } }).buildpack?.language ===
+      "python";
+  const agentPythonVersion = normalizePythonMinor(
+    (agent?.build as { buildpack?: { languageVersion?: string } } | undefined)
+      ?.buildpack?.languageVersion,
+  );
+
+  // Server instrumentation catalog, shared with the create wizard.
+  const { data: buildOptions } = useAgentBuildOptions({ orgName: orgId });
+  const compatibleInstrumentation = useMemo(
+    () => compatibleInstrumentationVersions(buildOptions, agentPythonVersion),
+    [buildOptions, agentPythonVersion],
+  );
 
   const envDisplayName = useCallback(
     (name: string) =>
@@ -191,6 +228,31 @@ export function PromoteAgentDrawer({
     filledForTarget,
   ]);
 
+  // Seed the version selector for DISPLAY once both the agent (for its Python
+  // version) and the catalog have loaded. Re-seed whenever the current value is
+  // not in the compatible set (self-corrects a stale seed / a target-env change);
+  // a valid user selection is always in the set, so this never clobbers it.
+  useEffect(() => {
+    if (!open || !buildOptions || !agent) return;
+    setFormState((prev) => {
+      const inSet = compatibleInstrumentation.some(
+        (v) => v.version === prev.instrumentationVersion,
+      );
+      if (inSet) return prev;
+      const seed = pickInstrumentationVersion(
+        compatibleInstrumentation,
+        agent?.configurations?.instrumentationVersion,
+        buildOptions.instrumentation.defaultVersion,
+      );
+      return { ...prev, instrumentationVersion: seed };
+    });
+  }, [
+    open,
+    buildOptions,
+    agent,
+    compatibleInstrumentation,
+  ]);
+
   const handleToggleUseSourceConfig = useCallback((checked: boolean) => {
     setFormState((prev) => ({ ...prev, useConfigFromSourceEnv: checked }));
   }, []);
@@ -282,6 +344,18 @@ export function PromoteAgentDrawer({
                         : { key, value, isSensitive },
                     ),
                   files: formState.files,
+                  // Only send the version when the user explicitly picked a
+                  // compatible one; otherwise omit it so the backend inherits
+                  // the source env's pin rather than overwriting the target with
+                  // a display-only seed.
+                  ...(isPythonBuildpack &&
+                  formState.instrumentationVersionDirty &&
+                  formState.instrumentationVersion &&
+                  compatibleInstrumentation.some(
+                    (v) => v.version === formState.instrumentationVersion,
+                  )
+                    ? { instrumentationVersion: formState.instrumentationVersion }
+                    : {}),
                 }),
           },
         });
@@ -292,6 +366,8 @@ export function PromoteAgentDrawer({
     },
     [
       formState,
+      isPythonBuildpack,
+      compatibleInstrumentation,
       promoteAgent,
       orgId,
       projectId,
@@ -508,6 +584,65 @@ export function PromoteAgentDrawer({
                         </Stack>
                       </CardContent>
                     </Card>
+
+                    {isPythonBuildpack && (
+                      <Card variant="outlined">
+                        <CardContent>
+                          <Stack spacing={1.5}>
+                            <Typography variant="h6">
+                              AMP Instrumentation Version
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary">
+                              Pins the init-container image and the bundled
+                              OpenLLMetry SDK version for{" "}
+                              {envDisplayName(formState.targetEnvironment)}.
+                            </Typography>
+                            {compatibleInstrumentation.length === 0 &&
+                            buildOptions ? (
+                              <Alert severity="info">
+                                <Typography variant="body2">
+                                  No AMP-provided instrumentation is available for
+                                  Python {agentPythonVersion ?? "the selected version"}.
+                                  You can still promote and instrument manually.
+                                </Typography>
+                              </Alert>
+                            ) : (
+                              <FormControl sx={{ minWidth: 240 }}>
+                                <Select
+                                  size="small"
+                                  value={
+                                    compatibleInstrumentation.some(
+                                      (v) =>
+                                        v.version ===
+                                        formState.instrumentationVersion,
+                                    )
+                                      ? formState.instrumentationVersion
+                                      : ""
+                                  }
+                                  disabled={isPending || !buildOptions}
+                                  onChange={(e) =>
+                                    setFormState((prev) => ({
+                                      ...prev,
+                                      instrumentationVersion: e.target
+                                        .value as string,
+                                      instrumentationVersionDirty: true,
+                                    }))
+                                  }
+                                >
+                                  {compatibleInstrumentation.map((v) => (
+                                    <MenuItem key={v.version} value={v.version}>
+                                      {v.traceloopSdk
+                                        ? `${v.version} (OpenLLMetry v${v.traceloopSdk})`
+                                        : v.version}
+                                    </MenuItem>
+                                  ))}
+                                </Select>
+                              </FormControl>
+                            )}
+                          </Stack>
+                        </CardContent>
+                      </Card>
+                    )}
                   </Stack>
                 </Collapse>
               </Form.Stack>

--- a/console/workspaces/pages/deploy/src/utils/instrumentation.ts
+++ b/console/workspaces/pages/deploy/src/utils/instrumentation.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { AgentBuildOptions } from "@agent-management-platform/types";
+
+type InstrumentationVersionEntry =
+  AgentBuildOptions["instrumentation"]["versions"][number];
+
+/**
+ * Collapse a Python runtime version to its bare `major.minor` form
+ * ("3.11.4" -> "3.11"), matching the shape the instrumentation catalog uses.
+ * Mirrors the backend's `normalizePythonMinor` so client-side compatibility
+ * filtering agrees with server-side validation. Returns undefined when the
+ * value has fewer than two dot-separated components.
+ */
+export function normalizePythonMinor(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  const parts = trimmed.split(".");
+  if (parts.length < 2) return undefined;
+  const [major, minor] = parts;
+  if (!major || !minor) return undefined;
+  return `${major}.${minor}`;
+}
+
+/**
+ * Instrumentation catalog entries compatible with the given (normalized) Python
+ * version. When the Python version is unknown (undefined/unnormalizable), returns
+ * an empty list rather than every entry — we must not offer or seed a version we
+ * cannot verify covers the agent's runtime (the version is baked into an
+ * init-container image and a mismatch fails the deploy).
+ */
+export function compatibleInstrumentationVersions(
+  buildOptions: AgentBuildOptions | undefined,
+  pythonMinor: string | undefined,
+): InstrumentationVersionEntry[] {
+  if (!buildOptions || !pythonMinor) return [];
+  return buildOptions.instrumentation.versions.filter((v) =>
+    v.pythonVersions.includes(pythonMinor),
+  );
+}
+
+/**
+ * Pick the version to seed the selector with: the agent's pinned version if it
+ * is still compatible, otherwise the platform default if compatible, otherwise
+ * the first compatible entry, otherwise "" (no compatible version — the manual
+ * instrumentation fallback). Never returns a version outside `compatible`, so
+ * the selector and the redeploy payload never carry a python-incompatible pin.
+ */
+export function pickInstrumentationVersion(
+  compatible: InstrumentationVersionEntry[],
+  pinned: string | undefined,
+  defaultVersion: string | undefined,
+): string {
+  const has = (v: string | undefined): v is string =>
+    !!v && compatible.some((c) => c.version === v);
+  if (has(pinned)) return pinned;
+  if (has(defaultVersion)) return defaultVersion;
+  return compatible[0]?.version ?? "";
+}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/python-otel-instrumentation-trait.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/python-otel-instrumentation-trait.yaml
@@ -43,6 +43,9 @@ spec:
           type: string
           default: "true"
           description: "Flag to enable or disable tracing of content for this environment"
+        instrumentationImage:
+          type: string
+          description: "Per-environment override for the OTEL instrumentation init-container image (pins the AMP instrumentation version). Falls back to the component-level parameters.instrumentationImage when unset."
 
   # Patches to modify the Deployment resource.
   # AMP_OTEL_ENDPOINT and AMP_AGENT_API_KEY are always injected by
@@ -61,7 +64,7 @@ spec:
           path: /spec/template/spec/initContainers/-
           value:
             name: setup-instrumentation
-            image: ${parameters.instrumentationImage}
+            image: "${has(environmentConfigs.instrumentationImage) ? environmentConfigs.instrumentationImage : parameters.instrumentationImage}"
             imagePullPolicy: IfNotPresent
             volumeMounts:
               - name: ${parameters.sdkVolumeName}


### PR DESCRIPTION
## Purpose

The AMP instrumentation version (which pins the OTEL init-container image and the bundled OpenLLMetry SDK) could only be chosen in the create-agent wizard. After creation it was fixed, with the deploy page offering only an on/off auto-instrumentation toggle. This adds the same version selector to the deploy and promote flows so an already-created Python buildpack agent can be re-pinned per environment.

Resolves https://github.com/wso2/agent-manager/issues/1234

## Goals

- Let users select the AMP instrumentation version when deploying or promoting an existing Python buildpack agent, mirroring the create wizard.
- Make the pinned version a genuine per-environment setting so different environments can run different versions.

## Approach

The version is applied as a **per-environment override** on the OTEL trait rather than by re-attaching the component trait: the resolved init-container image is written into the release binding's `traitEnvironmentConfigs`, overriding the component-level default. This required extending the `python-otel-instrumentation-trait` definition to expose `instrumentationImage` as an environment-overridable parameter with a `has()`-fallback patch — without both the schema entry and the fallback the override is silently ignored.

Resolution precedence is **request override → existing pin → platform default**. A requested version is validated against the deployment catalog and the agent's Python version. An existing pin that is no longer compatible with the current Python (build-parameters only re-validates the lowest environment, so a non-lowest pin can drift) is skipped rather than built into a nonexistent image tag.

On the console side the version is sent only when the user explicitly changes it, so merely toggling tracing never converts an unpinned agent into an explicit pin, and the selector never offers or sends a version incompatible with the agent's Python runtime.

Backend: `agent-manager-service` (OpenAPI spec + regenerated models, `resolveInstrumentationImageOverride`, `buildTraitEnvConfigs`, deploy/promote/deploy-settings handlers, exported image builder). Frontend: `console` deploy page (`DeployCard`, `PromoteAgentDrawer`, shared `instrumentation.ts` helpers, request types). Chart: the OTEL trait template.

## Goals / User stories

As a user, I want to change an agent's AMP instrumentation version after creation, per environment, from the deploy and promote screens.

## Release note

Added the ability to select the AMP instrumentation version when deploying or promoting an existing Python agent, applied as a per-environment override.

## Documentation

N/A — no user-facing docs exist yet for the instrumentation version selector; the control mirrors the existing create-wizard field.

## Training

N/A — no training content impact.

## Certification

N/A — no certification impact.

## Marketing

N/A

## Automation tests

- Unit tests
  - `resolveInstrumentationImageOverride`: precedence, catalog/Python validation of a requested version, preservation of an existing pin, the Python-incompatible-existing-pin skip, and the unparseable-Python fallback.
  - `normalizePythonMinor` normalization cases.
  - `ValidatePromoteAgentRequest`: `instrumentationVersion` is rejected under `useConfigFromSourceEnv=true` and allowed otherwise.
- Integration tests
  - N/A — no new DB-backed paths; existing deploy/promote integration coverage exercises the touched handlers.

## Security checks

- Followed secure coding standards? yes
- Ran FindSecurityBugs plugin and verified report? no — not part of this repo's standard workflow; change adds no new external input handling beyond validated version strings.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

The `python-otel-instrumentation-trait` chart template changed. Existing deployments need the `wso2-amp-platform-resources-extension` chart re-applied for the per-environment override to take effect; agents created before the upgrade continue to use their component-level default until re-pinned.

## Test environment

Verified end-to-end on a local k3d + Docker Compose stack (OpenChoreo control plane). Confirmed the release binding's per-environment `instrumentationImage` override is rendered into the workload Deployment's init-container image (overriding the component default) and that the resolved version is persisted.

## Learning

Per-environment trait overrides in OpenChoreo require both an `environmentConfigs` schema entry and a `has(environmentConfigs.x) ? … : parameters.x` fallback in the patch; a key written to `traitEnvironmentConfigs` without both is silently pruned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing an instrumentation version during deploy and promote flows.
  * Python buildpack agents can now display a compatible version selector and pin a version per environment.
  * The deploy experience now preserves or applies the selected instrumentation version when redeploying.

* **Bug Fixes**
  * Improved handling of Python version compatibility so invalid instrumentation selections are prevented.
  * Fixed promotion validation so source-environment reuse cannot be combined with an explicit instrumentation version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->