### PR TITLE
Improve Test API Keys fetching and retry logic to address intermittent 401 issues during testing

### DIFF
--- a/agent-manager-service/controllers/agent_apikey_controller.go
+++ b/agent-manager-service/controllers/agent_apikey_controller.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 
 	"github.com/wso2/agent-manager/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
@@ -261,9 +262,9 @@ func (c *agentAPIKeyController) RotateAPIKey(w http.ResponseWriter, r *http.Requ
 
 // IssueTestAPIKey handles POST /api/v1/orgs/{ouID}/projects/{projName}/agents/{agentName}/environments/{envID}/api-keys/test
 //
-// Issues (or rotates) the single short-lived test API key for the agent.
-// Used by the console Try-It flow. The key is test-scoped, scoped to the
-// fixed name "console-test", and never appears in the user-facing list.
+// Issues (or rotates) a short-lived test API key scoped to the calling user
+// (derived from the JWT subject). Used by the console Try-It flow; test keys
+// never appear in the user-facing list.
 func (c *agentAPIKeyController) IssueTestAPIKey(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := logger.GetLogger(ctx)
@@ -275,7 +276,14 @@ func (c *agentAPIKeyController) IssueTestAPIKey(w http.ResponseWriter, r *http.R
 
 	log.Info("IssueTestAPIKey: starting", "ouID", ouID, "projName", projName, "agentName", agentName, "envID", envID)
 
-	response, err := c.apiKeyService.IssueTestAPIKey(ctx, ouID, projName, agentName, envID)
+	claims := jwtassertion.GetTokenClaims(ctx)
+	if claims == nil || claims.Sub == "" {
+		log.Warn("IssueTestAPIKey: missing token claims")
+		utils.WriteErrorResponse(w, http.StatusUnauthorized, "Missing token claims")
+		return
+	}
+
+	response, err := c.apiKeyService.IssueTestAPIKey(ctx, ouID, projName, agentName, envID, claims.Sub)
 	if err != nil {
 		switch {
 		case errors.Is(err, utils.ErrArtifactNotFound):

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -9440,6 +9440,13 @@ components:
         apiKey:
           type: string
           description: Generated API key value. Returned only once; store it securely.
+        gatewayConnected:
+          type: boolean
+          description: |
+            Whether every target gateway had a live websocket connection to the
+            control plane when the key was created. When false, the key has
+            been stored but will only become usable once the gateway
+            reconnects and syncs.
 
     ListAPIKeysResponse:
       type: object
@@ -9553,6 +9560,13 @@ components:
           type: string
           format: date-time
           description: Expiry timestamp (RFC3339); the console rotates the key before this elapses.
+        gatewayConnected:
+          type: boolean
+          description: |
+            Whether every gateway serving the agent's environment had a live
+            websocket connection to the control plane when the key was issued.
+            When false, the key has been stored but will only become usable
+            once the gateway reconnects and syncs.
 
     RotateLLMAPIKeyRequest:
       type: object
@@ -9582,6 +9596,13 @@ components:
         apiKey:
           type: string
           description: New API key value. Returned only once; store it securely.
+        gatewayConnected:
+          type: boolean
+          description: |
+            Whether every target gateway had a live websocket connection to the
+            control plane when the key was rotated. When false, the new key has
+            been stored but will only become usable once the gateway
+            reconnects and syncs.
 
     CreateOrganizationRequest:
       type: object

--- a/agent-manager-service/models/apikey.go
+++ b/agent-manager-service/models/apikey.go
@@ -34,9 +34,10 @@ const (
 	APIKeyPurposeUserManaged    = 1
 	APIKeyPurposeTest           = 2
 	APIKeyPurposeConsoleManaged = 3
-	// APIKeyTestKeyName is the fixed name used for the single test
-	// key per agent. Subsequent IssueTestAPIKey calls rotate this row.
-	APIKeyTestKeyName = "console-test"
+	// APIKeyTestKeyPrefix is the name prefix for per-user console test keys.
+	// Each user gets their own row (prefix + truncated SHA-256 of their JWT sub),
+	// so concurrent sessions across users don't invalidate each other's keys.
+	APIKeyTestKeyPrefix = "console-test-"
 )
 
 // StoredAPIKey represents an API key persisted in the database for gateway bulk-sync

--- a/agent-manager-service/models/apikey.go
+++ b/agent-manager-service/models/apikey.go
@@ -95,6 +95,12 @@ type IssueTestAPIKeyResponse struct {
 	KeyID     string `json:"keyId,omitempty"`
 	APIKey    string `json:"apiKey,omitempty"`
 	ExpiresAt string `json:"expiresAt"`
+
+	// GatewayConnected reports whether every gateway serving the agent's
+	// environment had a live websocket connection when the key was issued.
+	// When false, the key is stored but only becomes usable after the gateway
+	// reconnects and syncs.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
 }
 
 // APIKeyInfo is a masked, read-only view of a stored API key for listing.
@@ -163,6 +169,12 @@ type CreateAPIKeyResponse struct {
 
 	// APIKey is the generated API key value (returned only once)
 	APIKey string `json:"apiKey,omitempty"`
+
+	// GatewayConnected reports whether every target gateway had a live
+	// websocket connection to the control plane when the key was written.
+	// When false, the key is stored but only becomes usable after the gateway
+	// reconnects and syncs. Nil when the issuing path does not check.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
 }
 
 // APIKeyCreatedEvent represents the event payload for "apikey.created" event type

--- a/agent-manager-service/services/agent_apikey_service.go
+++ b/agent-manager-service/services/agent_apikey_service.go
@@ -30,8 +30,15 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 	"gorm.io/gorm"
 )
+
+// GatewayConnectionChecker reports live websocket connections for a gateway.
+// *websocket.Manager satisfies this interface.
+type GatewayConnectionChecker interface {
+	GetConnections(gatewayID string) []*websocket.Connection
+}
 
 // testKeyTTL is the validity window for a console-issued test API key.
 // The console refreshes the key at staleTime well before this elapses.
@@ -65,6 +72,7 @@ type AgentAPIKeyService struct {
 	apiKeyRepo   repositories.APIKeyRepository
 	gatewayRepo  repositories.GatewayRepository
 	broadcaster  apiKeyBroadcaster
+	connChecker  GatewayConnectionChecker
 }
 
 // NewAgentAPIKeyService creates a new agent API key service instance
@@ -74,6 +82,7 @@ func NewAgentAPIKeyService(
 	gatewayRepo repositories.GatewayRepository,
 	gatewayService *GatewayEventsService,
 	apiKeyRepo repositories.APIKeyRepository,
+	connChecker GatewayConnectionChecker,
 ) *AgentAPIKeyService {
 	return &AgentAPIKeyService{
 		artifactRepo: artifactRepo,
@@ -85,7 +94,23 @@ func NewAgentAPIKeyService(
 			gatewayService: gatewayService,
 			apiKeyRepo:     apiKeyRepo,
 		},
+		connChecker: connChecker,
 	}
+}
+
+// gatewaysConnected reports whether every given gateway currently has at
+// least one live websocket connection to this control plane. Key events for
+// a disconnected gateway are queued and only apply after it reconnects, so
+// callers surface this to warn that a fresh key is not yet usable.
+func (s *AgentAPIKeyService) gatewaysConnected(gateways []*models.Gateway) *bool {
+	connected := true
+	for _, gw := range gateways {
+		if len(s.connChecker.GetConnections(gw.UUID.String())) == 0 {
+			connected = false
+			break
+		}
+	}
+	return &connected
 }
 
 func (s *AgentAPIKeyService) resolveAgentAPIArtifact(ctx context.Context, ouID, projectName, agentName, envID string) (*models.Artifact, string, error) {
@@ -142,7 +167,11 @@ func (s *AgentAPIKeyService) CreateAPIKey(
 		return nil, err
 	}
 	artifactUUID := artifact.UUID.String()
-	return s.broadcaster.broadcastCreateToGateways(gateways, ouID, artifactUUID, artifactUUID, req)
+	resp, err := s.broadcaster.broadcastCreateToGateways(gateways, ouID, artifactUUID, artifactUUID, req)
+	if resp != nil {
+		resp.GatewayConnected = s.gatewaysConnected(gateways)
+	}
+	return resp, err
 }
 
 // RevokeAPIKey broadcasts an API key revocation event to the environment's gateways.
@@ -178,7 +207,11 @@ func (s *AgentAPIKeyService) RotateAPIKey(
 		return nil, err
 	}
 	artifactUUID := artifact.UUID.String()
-	return s.broadcaster.broadcastRotateToGateways(gateways, ouID, artifactUUID, artifactUUID, keyName, req)
+	resp, err := s.broadcaster.broadcastRotateToGateways(gateways, ouID, artifactUUID, artifactUUID, keyName, req)
+	if resp != nil {
+		resp.GatewayConnected = s.gatewaysConnected(gateways)
+	}
+	return resp, err
 }
 
 // ListAPIKeys returns API keys for the given agent (masked values only).
@@ -258,10 +291,11 @@ func (s *AgentAPIKeyService) IssueTestAPIKey(
 	}
 
 	return &models.IssueTestAPIKeyResponse{
-		Status:    resp.Status,
-		Message:   resp.Message,
-		KeyID:     resp.KeyID,
-		APIKey:    resp.APIKey,
-		ExpiresAt: expiresAt,
+		Status:           resp.Status,
+		Message:          resp.Message,
+		KeyID:            resp.KeyID,
+		APIKey:           resp.APIKey,
+		ExpiresAt:        expiresAt,
+		GatewayConnected: s.gatewaysConnected(gateways),
 	}, nil
 }

--- a/agent-manager-service/services/agent_apikey_service.go
+++ b/agent-manager-service/services/agent_apikey_service.go
@@ -18,11 +18,15 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -33,13 +37,25 @@ import (
 // The console refreshes the key at staleTime well before this elapses.
 const testKeyTTL = 10 * time.Minute
 
+// legacyTestKeyName is the pre-per-user shared test key name; still reserved
+// so user-created keys can't collide with lingering legacy rows.
+const legacyTestKeyName = "console-test"
+
+// testKeyName returns a stable, per-user key name derived from the JWT subject.
+// Hashing keeps the name within the gateway's alphanumeric-hyphen constraint
+// and avoids storing raw user identifiers as key names.
+func testKeyName(userSub string) string {
+	h := sha256.Sum256([]byte(userSub))
+	return models.APIKeyTestKeyPrefix + hex.EncodeToString(h[:])[:12]
+}
+
 // AgentAPIKeyServiceInterface defines the contract for agent API key operations
 type AgentAPIKeyServiceInterface interface {
 	CreateAPIKey(ctx context.Context, ouID, projectName, agentName, envID string, req *models.CreateAPIKeyRequest) (*models.CreateAPIKeyResponse, error)
 	RevokeAPIKey(ctx context.Context, ouID, projectName, agentName, envID, keyName string) error
 	RotateAPIKey(ctx context.Context, ouID, projectName, agentName, envID, keyName string, req *models.RotateAPIKeyRequest) (*models.CreateAPIKeyResponse, error)
 	ListAPIKeys(ctx context.Context, ouID, projectName, agentName, envID string) ([]models.StoredAPIKey, error)
-	IssueTestAPIKey(ctx context.Context, ouID, projectName, agentName, envID string) (*models.IssueTestAPIKeyResponse, error)
+	IssueTestAPIKey(ctx context.Context, ouID, projectName, agentName, envID, userSub string) (*models.IssueTestAPIKeyResponse, error)
 }
 
 // AgentAPIKeyService handles API key management for agents
@@ -114,8 +130,8 @@ func (s *AgentAPIKeyService) CreateAPIKey(
 	ouID, projectName, agentName, envID string,
 	req *models.CreateAPIKeyRequest,
 ) (*models.CreateAPIKeyResponse, error) {
-	if req != nil && req.Name == models.APIKeyTestKeyName {
-		return nil, fmt.Errorf("%w: %q is reserved for console test keys", utils.ErrBadRequest, models.APIKeyTestKeyName)
+	if req != nil && (strings.HasPrefix(req.Name, models.APIKeyTestKeyPrefix) || req.Name == legacyTestKeyName) {
+		return nil, fmt.Errorf("%w: names starting with %q are reserved for console test keys", utils.ErrBadRequest, models.APIKeyTestKeyPrefix)
 	}
 	artifact, envUUID, err := s.resolveAgentAPIArtifact(ctx, ouID, projectName, agentName, envID)
 	if err != nil {
@@ -187,12 +203,13 @@ func (s *AgentAPIKeyService) ListAPIKeys(
 	return result, nil
 }
 
-// IssueTestAPIKey issues (or rotates) the single short-lived test API key
-// associated with an agent. Used by the console Try-It flow. The key is
-// scoped by APIKeyTestKeyName and never appears in the user-facing list.
+// IssueTestAPIKey issues (or rotates) a short-lived test API key scoped to the
+// calling user (userSub). Each user gets their own DB row, so concurrent sessions
+// across different users don't invalidate each other's keys. Used by the console
+// Try-It flow; test keys never appear in the user-facing list.
 func (s *AgentAPIKeyService) IssueTestAPIKey(
 	ctx context.Context,
-	ouID, projectName, agentName, envID string,
+	ouID, projectName, agentName, envID, userSub string,
 ) (*models.IssueTestAPIKeyResponse, error) {
 	artifact, envUUID, err := s.resolveAgentAPIArtifact(ctx, ouID, projectName, agentName, envID)
 	if err != nil {
@@ -204,29 +221,37 @@ func (s *AgentAPIKeyService) IssueTestAPIKey(
 	}
 	artifactUUID := artifact.UUID.String()
 
+	keyName := testKeyName(userSub)
 	expiresAt := time.Now().UTC().Add(testKeyTTL).Format(time.RFC3339)
 
-	existing, err := s.apiKeyRepo.GetByArtifactAndName(artifactUUID, models.APIKeyTestKeyName)
+	existing, err := s.apiKeyRepo.GetByArtifactAndName(artifactUUID, keyName)
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("failed to look up existing test key: %w", err)
 	}
 
+	log := logger.GetLogger(ctx)
 	var resp *models.CreateAPIKeyResponse
 	if existing != nil {
 		if existing.Purpose != models.APIKeyPurposeTest {
-			return nil, fmt.Errorf("%w: %q is reserved for console test keys", utils.ErrBadRequest, models.APIKeyTestKeyName)
+			return nil, fmt.Errorf("%w: %q is reserved for console test keys", utils.ErrBadRequest, keyName)
 		}
 		// Same DB row, new hash + expiry; purpose is preserved (Upsert.DoUpdates excludes it).
-		resp, err = s.broadcaster.broadcastRotateToGateways(gateways, ouID, artifactUUID, artifactUUID, models.APIKeyTestKeyName,
+		resp, err = s.broadcaster.broadcastRotateToGateways(gateways, ouID, artifactUUID, artifactUUID, keyName,
 			&models.RotateAPIKeyRequest{ExpiresAt: &expiresAt})
+		if err == nil {
+			log.Info("IssueTestAPIKey: rotated", "keyName", keyName, "org", ouID, "agent", agentName, "env", envID, "expiresAt", expiresAt)
+		}
 	} else {
 		resp, err = s.broadcaster.broadcastCreateToGateways(gateways, ouID, artifactUUID, artifactUUID,
 			&models.CreateAPIKeyRequest{
-				Name:        models.APIKeyTestKeyName,
+				Name:        keyName,
 				DisplayName: "Console Try-It",
 				Purpose:     models.APIKeyPurposeTest,
 				ExpiresAt:   &expiresAt,
 			})
+		if err == nil {
+			log.Info("IssueTestAPIKey: created", "keyName", keyName, "org", ouID, "agent", agentName, "env", envID, "expiresAt", expiresAt)
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/agent-manager-service/services/agent_apikey_service_unit_test.go
+++ b/agent-manager-service/services/agent_apikey_service_unit_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 )
 
 // stubEventHub is a hand-written EventHub stub (no generated mock exists for
@@ -60,12 +61,25 @@ func (s *stubEventHub) UnsubscribeAll(string) error                     { return
 func (s *stubEventHub) CleanUpEvents() error                            { return nil }
 func (s *stubEventHub) Close() error                                    { return nil }
 
+// stubConnChecker reports a fixed websocket-connectivity state for any gateway.
+type stubConnChecker struct {
+	connected bool
+}
+
+func (s *stubConnChecker) GetConnections(string) []*websocket.Connection {
+	if !s.connected {
+		return nil
+	}
+	return []*websocket.Connection{{}}
+}
+
 // apiKeyServiceFixture bundles the mocked collaborators for AgentAPIKeyService.
 type apiKeyServiceFixture struct {
 	svc          *AgentAPIKeyService
 	apiKeyRepo   *repomocks.APIKeyRepositoryMock
 	upsertedKeys *[]*models.StoredAPIKey
 	lookedUpName *string
+	connChecker  *stubConnChecker
 }
 
 // newAPIKeyServiceFixture wires an AgentAPIKeyService whose artifact/env/gateway
@@ -113,8 +127,15 @@ func newAPIKeyServiceFixture(t *testing.T, existing *models.StoredAPIKey) *apiKe
 		},
 	}
 
-	svc := NewAgentAPIKeyService(artifactRepo, oc, gatewayRepo, NewGatewayEventsService(&stubEventHub{}), apiKeyRepo)
-	return &apiKeyServiceFixture{svc: svc, apiKeyRepo: apiKeyRepo, upsertedKeys: upserted, lookedUpName: lookedUp}
+	connChecker := &stubConnChecker{connected: true}
+	svc := NewAgentAPIKeyService(artifactRepo, oc, gatewayRepo, NewGatewayEventsService(&stubEventHub{}), apiKeyRepo, connChecker)
+	return &apiKeyServiceFixture{
+		svc:          svc,
+		apiKeyRepo:   apiKeyRepo,
+		upsertedKeys: upserted,
+		lookedUpName: lookedUp,
+		connChecker:  connChecker,
+	}
 }
 
 // expectedTestKeyName mirrors the documented naming scheme: the test-key prefix
@@ -175,6 +196,21 @@ func TestAgentAPIKeyService_IssueTestAPIKey_PerUser(t *testing.T) {
 		assert.Equal(t, keyName, (*fx.upsertedKeys)[0].Name)
 	})
 
+	t.Run("reports gateway websocket connectivity in the response", func(t *testing.T) {
+		fx := newAPIKeyServiceFixture(t, nil)
+
+		resp, err := fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
+		require.NoError(t, err)
+		require.NotNil(t, resp.GatewayConnected)
+		assert.True(t, *resp.GatewayConnected)
+
+		fx.connChecker.connected = false
+		resp, err = fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
+		require.NoError(t, err)
+		require.NotNil(t, resp.GatewayConnected)
+		assert.False(t, *resp.GatewayConnected)
+	})
+
 	t.Run("rejects reissue when the existing row is not a test key", func(t *testing.T) {
 		existing := &models.StoredAPIKey{
 			UUID:    uuid.Must(uuid.NewV7()),
@@ -199,5 +235,17 @@ func TestAgentAPIKeyService_CreateAPIKey_ReservedTestKeyPrefix(t *testing.T) {
 			&models.CreateAPIKeyRequest{Name: models.APIKeyTestKeyPrefix + "deadbeef0123"})
 
 		assert.ErrorIs(t, err, utils.ErrBadRequest)
+	})
+
+	t.Run("reports gateway websocket connectivity in the response", func(t *testing.T) {
+		fx := newAPIKeyServiceFixture(t, nil)
+		fx.connChecker.connected = false
+
+		resp, err := fx.svc.CreateAPIKey(context.Background(), org, proj, agent, env,
+			&models.CreateAPIKeyRequest{Name: "my-key"})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp.GatewayConnected)
+		assert.False(t, *resp.GatewayConnected)
 	})
 }

--- a/agent-manager-service/services/agent_apikey_service_unit_test.go
+++ b/agent-manager-service/services/agent_apikey_service_unit_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/eventhub"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// stubEventHub is a hand-written EventHub stub (no generated mock exists for
+// this in-package interface); it records published events and no-ops the rest.
+type stubEventHub struct {
+	published []eventhub.Event
+}
+
+func (s *stubEventHub) Initialize() error            { return nil }
+func (s *stubEventHub) RegisterGateway(string) error { return nil }
+
+func (s *stubEventHub) PublishEvent(_ string, e eventhub.Event) error {
+	s.published = append(s.published, e)
+	return nil
+}
+
+func (s *stubEventHub) Subscribe(string) (<-chan eventhub.Event, error) {
+	ch := make(chan eventhub.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (s *stubEventHub) Unsubscribe(string, <-chan eventhub.Event) error { return nil }
+func (s *stubEventHub) UnsubscribeAll(string) error                     { return nil }
+func (s *stubEventHub) CleanUpEvents() error                            { return nil }
+func (s *stubEventHub) Close() error                                    { return nil }
+
+// apiKeyServiceFixture bundles the mocked collaborators for AgentAPIKeyService.
+type apiKeyServiceFixture struct {
+	svc          *AgentAPIKeyService
+	apiKeyRepo   *repomocks.APIKeyRepositoryMock
+	upsertedKeys *[]*models.StoredAPIKey
+	lookedUpName *string
+}
+
+// newAPIKeyServiceFixture wires an AgentAPIKeyService whose artifact/env/gateway
+// resolution succeeds, with GetByArtifactAndName returning the provided existing
+// key (or record-not-found when nil) and Upsert recording stored keys.
+func newAPIKeyServiceFixture(t *testing.T, existing *models.StoredAPIKey) *apiKeyServiceFixture {
+	t.Helper()
+
+	artifactUUID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	envUUID := "dada1090-0ddb-457a-a116-7f03d3cd0c4c"
+	gatewayUUID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	oc := &clientmocks.OpenChoreoClientMock{
+		GetEnvironmentFunc: func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
+			return &models.EnvironmentResponse{UUID: envUUID, Name: "dev"}, nil
+		},
+	}
+	artifactRepo := &repomocks.ArtifactRepositoryMock{
+		GetByHandleFunc: func(_ string, _ string) (*models.Artifact, error) {
+			return &models.Artifact{UUID: artifactUUID, Kind: models.KindAgent}, nil
+		},
+	}
+	gatewayRepo := &repomocks.GatewayRepositoryMock{
+		GetEnvironmentMappingsByEnvironmentIDFunc: func(_ string) ([]models.GatewayEnvironmentMapping, error) {
+			return []models.GatewayEnvironmentMapping{{GatewayUUID: gatewayUUID}}, nil
+		},
+		GetByUUIDFunc: func(_ string) (*models.Gateway, error) {
+			return &models.Gateway{UUID: gatewayUUID}, nil
+		},
+	}
+
+	upserted := &[]*models.StoredAPIKey{}
+	lookedUp := new(string)
+	apiKeyRepo := &repomocks.APIKeyRepositoryMock{
+		GetByArtifactAndNameFunc: func(_ string, name string) (*models.StoredAPIKey, error) {
+			*lookedUp = name
+			if existing == nil {
+				return nil, gorm.ErrRecordNotFound
+			}
+			return existing, nil
+		},
+		UpsertFunc: func(key *models.StoredAPIKey) error {
+			*upserted = append(*upserted, key)
+			return nil
+		},
+	}
+
+	svc := NewAgentAPIKeyService(artifactRepo, oc, gatewayRepo, NewGatewayEventsService(&stubEventHub{}), apiKeyRepo)
+	return &apiKeyServiceFixture{svc: svc, apiKeyRepo: apiKeyRepo, upsertedKeys: upserted, lookedUpName: lookedUp}
+}
+
+// expectedTestKeyName mirrors the documented naming scheme: the test-key prefix
+// plus the first 12 hex chars of the SHA-256 of the JWT subject.
+func expectedTestKeyName(userSub string) string {
+	h := sha256.Sum256([]byte(userSub))
+	return models.APIKeyTestKeyPrefix + hex.EncodeToString(h[:])[:12]
+}
+
+func TestAgentAPIKeyService_IssueTestAPIKey_PerUser(t *testing.T) {
+	const org, proj, agent, env = "default", "default", "customeragent", "dev"
+
+	t.Run("creates a per-user key named from the JWT subject", func(t *testing.T) {
+		fx := newAPIKeyServiceFixture(t, nil)
+
+		resp, err := fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.NotEmpty(t, resp.APIKey)
+		assert.NotEmpty(t, resp.ExpiresAt)
+
+		want := expectedTestKeyName("user-a-sub")
+		assert.Equal(t, want, *fx.lookedUpName)
+		require.Len(t, *fx.upsertedKeys, 1)
+		stored := (*fx.upsertedKeys)[0]
+		assert.Equal(t, want, stored.Name)
+		assert.Equal(t, models.APIKeyPurposeTest, stored.Purpose)
+		assert.True(t, strings.HasPrefix(stored.Name, models.APIKeyTestKeyPrefix))
+	})
+
+	t.Run("different users get distinct key rows", func(t *testing.T) {
+		fx := newAPIKeyServiceFixture(t, nil)
+
+		_, err := fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
+		require.NoError(t, err)
+		_, err = fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-b-sub")
+		require.NoError(t, err)
+
+		require.Len(t, *fx.upsertedKeys, 2)
+		assert.NotEqual(t, (*fx.upsertedKeys)[0].Name, (*fx.upsertedKeys)[1].Name)
+	})
+
+	t.Run("reissue for the same user rotates the same row", func(t *testing.T) {
+		keyName := expectedTestKeyName("user-a-sub")
+		existing := &models.StoredAPIKey{
+			UUID:    uuid.Must(uuid.NewV7()),
+			Name:    keyName,
+			Purpose: models.APIKeyPurposeTest,
+		}
+		fx := newAPIKeyServiceFixture(t, existing)
+
+		resp, err := fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.APIKey)
+		require.Len(t, *fx.upsertedKeys, 1)
+		assert.Equal(t, keyName, (*fx.upsertedKeys)[0].Name)
+	})
+
+	t.Run("rejects reissue when the existing row is not a test key", func(t *testing.T) {
+		existing := &models.StoredAPIKey{
+			UUID:    uuid.Must(uuid.NewV7()),
+			Name:    expectedTestKeyName("user-a-sub"),
+			Purpose: models.APIKeyPurposeUserManaged,
+		}
+		fx := newAPIKeyServiceFixture(t, existing)
+
+		_, err := fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
+
+		assert.ErrorIs(t, err, utils.ErrBadRequest)
+	})
+}
+
+func TestAgentAPIKeyService_CreateAPIKey_ReservedTestKeyPrefix(t *testing.T) {
+	const org, proj, agent, env = "default", "default", "customeragent", "dev"
+
+	t.Run("rejects names with the console test-key prefix", func(t *testing.T) {
+		fx := newAPIKeyServiceFixture(t, nil)
+
+		_, err := fx.svc.CreateAPIKey(context.Background(), org, proj, agent, env,
+			&models.CreateAPIKeyRequest{Name: models.APIKeyTestKeyPrefix + "deadbeef0123"})
+
+		assert.ErrorIs(t, err, utils.ErrBadRequest)
+	})
+}

--- a/agent-manager-service/spec/model_create_llmapi_key_response.go
+++ b/agent-manager-service/spec/model_create_llmapi_key_response.go
@@ -27,6 +27,8 @@ type CreateLLMAPIKeyResponse struct {
 	KeyId *string `json:"keyId,omitempty"`
 	// Generated API key value. Returned only once; store it securely.
 	ApiKey *string `json:"apiKey,omitempty"`
+	// Whether every target gateway had a live websocket connection to the control plane when the key was created. When false, the key has been stored but will only become usable once the gateway reconnects and syncs.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
 }
 
 // NewCreateLLMAPIKeyResponse instantiates a new CreateLLMAPIKeyResponse object
@@ -160,6 +162,38 @@ func (o *CreateLLMAPIKeyResponse) SetApiKey(v string) {
 	o.ApiKey = &v
 }
 
+// GetGatewayConnected returns the GatewayConnected field value if set, zero value otherwise.
+func (o *CreateLLMAPIKeyResponse) GetGatewayConnected() bool {
+	if o == nil || IsNil(o.GatewayConnected) {
+		var ret bool
+		return ret
+	}
+	return *o.GatewayConnected
+}
+
+// GetGatewayConnectedOk returns a tuple with the GatewayConnected field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CreateLLMAPIKeyResponse) GetGatewayConnectedOk() (*bool, bool) {
+	if o == nil || IsNil(o.GatewayConnected) {
+		return nil, false
+	}
+	return o.GatewayConnected, true
+}
+
+// HasGatewayConnected returns a boolean if a field has been set.
+func (o *CreateLLMAPIKeyResponse) HasGatewayConnected() bool {
+	if o != nil && !IsNil(o.GatewayConnected) {
+		return true
+	}
+
+	return false
+}
+
+// SetGatewayConnected gets a reference to the given bool and assigns it to the GatewayConnected field.
+func (o *CreateLLMAPIKeyResponse) SetGatewayConnected(v bool) {
+	o.GatewayConnected = &v
+}
+
 func (o CreateLLMAPIKeyResponse) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -177,6 +211,9 @@ func (o CreateLLMAPIKeyResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ApiKey) {
 		toSerialize["apiKey"] = o.ApiKey
+	}
+	if !IsNil(o.GatewayConnected) {
+		toSerialize["gatewayConnected"] = o.GatewayConnected
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/spec/model_issue_test_api_key_response.go
+++ b/agent-manager-service/spec/model_issue_test_api_key_response.go
@@ -28,6 +28,8 @@ type IssueTestAPIKeyResponse struct {
 	ApiKey *string `json:"apiKey,omitempty"`
 	// Expiry timestamp (RFC3339); the console rotates the key before this elapses.
 	ExpiresAt time.Time `json:"expiresAt"`
+	// Whether every gateway serving the agent's environment had a live websocket connection to the control plane when the key was issued. When false, the key has been stored but will only become usable once the gateway reconnects and syncs.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
 }
 
 // NewIssueTestAPIKeyResponse instantiates a new IssueTestAPIKeyResponse object
@@ -193,6 +195,38 @@ func (o *IssueTestAPIKeyResponse) SetExpiresAt(v time.Time) {
 	o.ExpiresAt = v
 }
 
+// GetGatewayConnected returns the GatewayConnected field value if set, zero value otherwise.
+func (o *IssueTestAPIKeyResponse) GetGatewayConnected() bool {
+	if o == nil || IsNil(o.GatewayConnected) {
+		var ret bool
+		return ret
+	}
+	return *o.GatewayConnected
+}
+
+// GetGatewayConnectedOk returns a tuple with the GatewayConnected field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *IssueTestAPIKeyResponse) GetGatewayConnectedOk() (*bool, bool) {
+	if o == nil || IsNil(o.GatewayConnected) {
+		return nil, false
+	}
+	return o.GatewayConnected, true
+}
+
+// HasGatewayConnected returns a boolean if a field has been set.
+func (o *IssueTestAPIKeyResponse) HasGatewayConnected() bool {
+	if o != nil && !IsNil(o.GatewayConnected) {
+		return true
+	}
+
+	return false
+}
+
+// SetGatewayConnected gets a reference to the given bool and assigns it to the GatewayConnected field.
+func (o *IssueTestAPIKeyResponse) SetGatewayConnected(v bool) {
+	o.GatewayConnected = &v
+}
+
 func (o IssueTestAPIKeyResponse) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -214,6 +248,9 @@ func (o IssueTestAPIKeyResponse) ToMap() (map[string]interface{}, error) {
 		toSerialize["apiKey"] = o.ApiKey
 	}
 	toSerialize["expiresAt"] = o.ExpiresAt
+	if !IsNil(o.GatewayConnected) {
+		toSerialize["gatewayConnected"] = o.GatewayConnected
+	}
 	return toSerialize, nil
 }
 

--- a/agent-manager-service/spec/model_rotate_llmapi_key_response.go
+++ b/agent-manager-service/spec/model_rotate_llmapi_key_response.go
@@ -27,6 +27,8 @@ type RotateLLMAPIKeyResponse struct {
 	KeyId *string `json:"keyId,omitempty"`
 	// New API key value. Returned only once; store it securely.
 	ApiKey *string `json:"apiKey,omitempty"`
+	// Whether every target gateway had a live websocket connection to the control plane when the key was rotated. When false, the new key has been stored but will only become usable once the gateway reconnects and syncs.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
 }
 
 // NewRotateLLMAPIKeyResponse instantiates a new RotateLLMAPIKeyResponse object
@@ -160,6 +162,38 @@ func (o *RotateLLMAPIKeyResponse) SetApiKey(v string) {
 	o.ApiKey = &v
 }
 
+// GetGatewayConnected returns the GatewayConnected field value if set, zero value otherwise.
+func (o *RotateLLMAPIKeyResponse) GetGatewayConnected() bool {
+	if o == nil || IsNil(o.GatewayConnected) {
+		var ret bool
+		return ret
+	}
+	return *o.GatewayConnected
+}
+
+// GetGatewayConnectedOk returns a tuple with the GatewayConnected field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RotateLLMAPIKeyResponse) GetGatewayConnectedOk() (*bool, bool) {
+	if o == nil || IsNil(o.GatewayConnected) {
+		return nil, false
+	}
+	return o.GatewayConnected, true
+}
+
+// HasGatewayConnected returns a boolean if a field has been set.
+func (o *RotateLLMAPIKeyResponse) HasGatewayConnected() bool {
+	if o != nil && !IsNil(o.GatewayConnected) {
+		return true
+	}
+
+	return false
+}
+
+// SetGatewayConnected gets a reference to the given bool and assigns it to the GatewayConnected field.
+func (o *RotateLLMAPIKeyResponse) SetGatewayConnected(v bool) {
+	o.GatewayConnected = &v
+}
+
 func (o RotateLLMAPIKeyResponse) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -177,6 +211,9 @@ func (o RotateLLMAPIKeyResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.ApiKey) {
 		toSerialize["apiKey"] = o.ApiKey
+	}
+	if !IsNil(o.GatewayConnected) {
+		toSerialize["gatewayConnected"] = o.GatewayConnected
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -341,9 +341,16 @@ var repositoryProviderSet = wire.NewSet(
 var websocketProviderSet = wire.NewSet(
 	ProvideEventHub,
 	ProvideWebSocketManager,
+	ProvideGatewayConnectionChecker,
 	services.NewGatewayEventsService,
 	ProvideDeploymentAckHandler,
 )
+
+// ProvideGatewayConnectionChecker exposes the websocket manager through the
+// narrow connectivity interface consumed by services.
+func ProvideGatewayConnectionChecker(m *websocket.Manager) services.GatewayConnectionChecker {
+	return m
+}
 
 // Test client providers
 func ProvideTestOpenChoreoClient(testClients TestClients) occlient.OpenChoreoClient {

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -125,11 +125,12 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	llmDeploymentController := controllers.NewLLMDeploymentController(llmProviderDeploymentService)
 	llmProviderAPIKeyController := controllers.NewLLMProviderAPIKeyController(llmProviderAPIKeyService)
 	llmProxyAPIKeyController := controllers.NewLLMProxyAPIKeyController(llmProxyAPIKeyService)
-	agentAPIKeyService := services.NewAgentAPIKeyService(artifactRepository, openChoreoClient, gatewayRepository, gatewayEventsService, apiKeyRepository)
+	manager := ProvideWebSocketManager(configConfig, eventHub)
+	gatewayConnectionChecker := ProvideGatewayConnectionChecker(manager)
+	agentAPIKeyService := services.NewAgentAPIKeyService(artifactRepository, openChoreoClient, gatewayRepository, gatewayEventsService, apiKeyRepository, gatewayConnectionChecker)
 	agentAPIKeyController := controllers.NewAgentAPIKeyController(agentAPIKeyService)
 	llmProxyDeploymentController := controllers.NewLLMProxyDeploymentController(llmProxyDeploymentService)
 	mcpProxyController := controllers.NewMCPProxyController(mcpProxyService)
-	manager := ProvideWebSocketManager(configConfig, eventHub)
 	deploymentAckHandler := ProvideDeploymentAckHandler(deploymentRepository)
 	webSocketController := ProvideWebSocketController(manager, eventHub, platformGatewayService, deploymentAckHandler, configConfig)
 	gatewayInternalAPIService := services.NewGatewayInternalAPIService(llmProviderRepository, llmProxyRepository, deploymentRepository, gatewayRepository, infraResourceManager, v)
@@ -298,11 +299,12 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	llmDeploymentController := controllers.NewLLMDeploymentController(llmProviderDeploymentService)
 	llmProviderAPIKeyController := controllers.NewLLMProviderAPIKeyController(llmProviderAPIKeyService)
 	llmProxyAPIKeyController := controllers.NewLLMProxyAPIKeyController(llmProxyAPIKeyService)
-	agentAPIKeyService := services.NewAgentAPIKeyService(artifactRepository, openChoreoClient, gatewayRepository, gatewayEventsService, apiKeyRepository)
+	manager := ProvideWebSocketManager(configConfig, eventHub)
+	gatewayConnectionChecker := ProvideGatewayConnectionChecker(manager)
+	agentAPIKeyService := services.NewAgentAPIKeyService(artifactRepository, openChoreoClient, gatewayRepository, gatewayEventsService, apiKeyRepository, gatewayConnectionChecker)
 	agentAPIKeyController := controllers.NewAgentAPIKeyController(agentAPIKeyService)
 	llmProxyDeploymentController := controllers.NewLLMProxyDeploymentController(llmProxyDeploymentService)
 	mcpProxyController := controllers.NewMCPProxyController(mcpProxyService)
-	manager := ProvideWebSocketManager(configConfig, eventHub)
 	deploymentAckHandler := ProvideDeploymentAckHandler(deploymentRepository)
 	webSocketController := ProvideWebSocketController(manager, eventHub, platformGatewayService, deploymentAckHandler, configConfig)
 	gatewayInternalAPIService := services.NewGatewayInternalAPIService(llmProviderRepository, llmProxyRepository, deploymentRepository, gatewayRepository, infraResourceManager, v)
@@ -614,8 +616,15 @@ var repositoryProviderSet = wire.NewSet(
 
 var websocketProviderSet = wire.NewSet(
 	ProvideEventHub,
-	ProvideWebSocketManager, services.NewGatewayEventsService, ProvideDeploymentAckHandler,
+	ProvideWebSocketManager,
+	ProvideGatewayConnectionChecker, services.NewGatewayEventsService, ProvideDeploymentAckHandler,
 )
+
+// ProvideGatewayConnectionChecker exposes the websocket manager through the
+// narrow connectivity interface consumed by services.
+func ProvideGatewayConnectionChecker(m *websocket.Manager) services.GatewayConnectionChecker {
+	return m
+}
 
 // Test client providers
 func ProvideTestOpenChoreoClient(testClients TestClients) client.OpenChoreoClient {

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -2025,6 +2025,12 @@ type CreateLLMAPIKeyResponse struct {
 	// ApiKey Generated API key value. Returned only once; store it securely.
 	ApiKey *string `json:"apiKey,omitempty"`
 
+	// GatewayConnected Whether every target gateway had a live websocket connection to the
+	// control plane when the key was created. When false, the key has
+	// been stored but will only become usable once the gateway
+	// reconnects and syncs.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
+
 	// KeyId Unique identifier of the created key.
 	KeyId *string `json:"keyId,omitempty"`
 
@@ -2963,6 +2969,12 @@ type IssueTestAPIKeyResponse struct {
 
 	// ExpiresAt Expiry timestamp (RFC3339); the console rotates the key before this elapses.
 	ExpiresAt time.Time `json:"expiresAt"`
+
+	// GatewayConnected Whether every gateway serving the agent's environment had a live
+	// websocket connection to the control plane when the key was issued.
+	// When false, the key has been stored but will only become usable
+	// once the gateway reconnects and syncs.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
 
 	// KeyId The fixed name "console-test".
 	KeyId   *string `json:"keyId,omitempty"`
@@ -4330,6 +4342,12 @@ type RotateLLMAPIKeyRequest struct {
 type RotateLLMAPIKeyResponse struct {
 	// ApiKey New API key value. Returned only once; store it securely.
 	ApiKey *string `json:"apiKey,omitempty"`
+
+	// GatewayConnected Whether every target gateway had a live websocket connection to the
+	// control plane when the key was rotated. When false, the new key has
+	// been stored but will only become usable once the gateway
+	// reconnects and syncs.
+	GatewayConnected *bool `json:"gatewayConnected,omitempty"`
 
 	// KeyId Unique identifier of the rotated key.
 	KeyId *string `json:"keyId,omitempty"`

--- a/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agent-api-keys.ts
@@ -100,9 +100,11 @@ export function useRevokeAgentAPIKey() {
 }
 
 // useTestAgentAPIKey issues (or rotates) a 10-minute test API key for the
-// agent's Try-It flow. Each refetch rotates the same logical row on the
-// backend (same name, new hash + expiry), so callers can rely on the cached
-// value being valid until staleTime elapses.
+// agent's Try-It flow. Keys are per-user on the backend (name derived from
+// the JWT subject), so a refetch only rotates the calling user's own row and
+// never invalidates other users' keys. refetchOnWindowFocus respects
+// staleTime, so returning to a long-idle tab picks up a fresh key without
+// rotating on every focus.
 export function useTestAgentAPIKey(
   params: IssueTestAgentAPIKeyPathParams,
   options: { enabled: boolean },
@@ -122,6 +124,6 @@ export function useTestAgentAPIKey(
       && !!(params.orgName && params.projName && params.agentName && params.envId),
     staleTime: 9 * 60 * 1000,
     refetchInterval: 9 * 60 * 1000,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 }

--- a/console/workspaces/libs/types/src/api/agent-api-keys.ts
+++ b/console/workspaces/libs/types/src/api/agent-api-keys.ts
@@ -29,6 +29,9 @@ export interface CreateAgentAPIKeyResponse {
   message: string;
   keyId?: string;
   apiKey?: string;
+  /** False when the environment's gateway had no live websocket connection
+   * at creation time; the key only activates once the gateway reconnects. */
+  gatewayConnected?: boolean;
 }
 
 export interface RotateAgentAPIKeyRequest {
@@ -41,6 +44,9 @@ export interface RotateAgentAPIKeyResponse {
   message: string;
   keyId?: string;
   apiKey?: string;
+  /** False when the environment's gateway had no live websocket connection
+   * at rotation time; the new key only activates once the gateway reconnects. */
+  gatewayConnected?: boolean;
 }
 
 export interface AgentAPIKeyListItem {
@@ -76,4 +82,7 @@ export interface IssueTestAgentAPIKeyResponse {
   keyId?: string;
   apiKey?: string;
   expiresAt: string;
+  /** False when the environment's gateway had no live websocket connection
+   * at issuance time; the key only activates once the gateway reconnects. */
+  gatewayConnected?: boolean;
 }

--- a/console/workspaces/pages/agent-security/src/Security.Component.tsx
+++ b/console/workspaces/pages/agent-security/src/Security.Component.tsx
@@ -74,6 +74,7 @@ export const SecurityComponent: React.FC = () => {
   const { mutateAsync: createKey, isPending: isCreating } =
     useCreateAgentAPIKey();
   const { mutate: revokeKey, isPending: isRevoking } = useRevokeAgentAPIKey();
+  const [gatewayOffline, setGatewayOffline] = React.useState(false);
 
   const handleCreate = async ({ displayName, expiresAt }: CreateAPIKeyInput) => {
     const data = await createKey({
@@ -85,6 +86,7 @@ export const SecurityComponent: React.FC = () => {
       },
       body: { displayName, expiresAt },
     });
+    setGatewayOffline(data.gatewayConnected === false);
     return data.apiKey;
   };
 
@@ -128,6 +130,18 @@ export const SecurityComponent: React.FC = () => {
           it from the <strong>Deployment</strong> settings and redeploy.
         </Alert>
       ) : (
+        <>
+        {gatewayOffline && (
+          <Alert
+            severity="warning"
+            onClose={() => setGatewayOffline(false)}
+            sx={{ mb: 2 }}
+          >
+            The gateway is not connected to the control plane right now. The
+            API key has been stored but will only work once the gateway
+            reconnects.
+          </Alert>
+        )}
         <APIKeysManager
           keys={keys}
           isLoading={false}
@@ -138,6 +152,7 @@ export const SecurityComponent: React.FC = () => {
           onCreate={handleCreate}
           onRevoke={handleRevoke}
         />
+        </>
       )}
     </PageLayout>
   );

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
@@ -154,27 +154,44 @@ export function AgentChat() {
           referrerPolicy: "",
         });
       };
-      let apiResponse = await sendChatRequest(testKey?.apiKey);
+      // The gateway strips CORS headers from auth-rejected responses, so a
+      // cross-origin 401 surfaces as a thrown TypeError ("Failed to fetch")
+      // rather than a readable status. While security is enabled, treat both
+      // shapes as a possible auth failure (null = auth-like failure).
+      const attemptSend = async (): Promise<Response | null> => {
+        try {
+          const res = await sendChatRequest(testKey?.apiKey);
+          return securityEnabled && res.status === 401 ? null : res;
+        } catch (err) {
+          if (securityEnabled && err instanceof TypeError) {
+            return null;
+          }
+          throw err;
+        }
+      };
 
-      // Retry once with the same key: a 401 right after key issuance usually
-      // just means the gateway has not finished loading the key. Refetching
-      // here would rotate the key and restart that propagation window.
-      if (securityEnabled && apiResponse.status === 401) {
+      let apiResponse = await attemptSend();
+
+      // Retry once with the same key: an auth failure right after key
+      // issuance usually just means the gateway has not finished loading the
+      // key. Refetching here would rotate the key and restart that
+      // propagation window.
+      if (apiResponse === null) {
         setIsRetryingAuth(true);
         try {
           await new Promise((resolve) =>
             setTimeout(resolve, TEST_KEY_PROPAGATION_RETRY_DELAY_MS),
           );
-          apiResponse = await sendChatRequest(testKey?.apiKey);
+          apiResponse = await attemptSend();
         } finally {
           setIsRetryingAuth(false);
         }
       }
 
-      // Persistent 401: hand control back to the user instead of retrying
-      // blindly — restore the message so it can be resent with one click
-      // after the key is refreshed.
-      if (securityEnabled && apiResponse.status === 401) {
+      // Persistent auth failure: hand control back to the user instead of
+      // retrying blindly — restore the message so it can be resent with one
+      // click after the key is refreshed.
+      if (apiResponse === null) {
         setMessages((prev) => prev.filter((m) => m.id !== userMessage.id));
         setMessage(userMessage.content);
         setKeyAlert("unauthorized");
@@ -255,33 +272,45 @@ export function AgentChat() {
     }
   };
 
-  const keyAlertBanner =
-    keyAlert === "unauthorized" ? (
-      <Alert
-        severity="error"
-        action={
-          <Button
-            color="inherit"
-            size="small"
-            onClick={handleRefreshTestKey}
-            disabled={isRefreshingKey}
-          >
-            {isRefreshingKey ? "Refreshing..." : "Refresh test key"}
-          </Button>
-        }
-        sx={{ borderRadius: 1 }}
-      >
-        The test API key is not authorized on the gateway yet.
-      </Alert>
-    ) : keyAlert === "refreshed" ? (
-      <Alert
-        severity="info"
-        onClose={() => setKeyAlert(null)}
-        sx={{ borderRadius: 1 }}
-      >
-        Test key refreshed. Send your message again.
-      </Alert>
-    ) : null;
+  const keyAlertBanner = (
+    <>
+      {securityEnabled && testKey?.gatewayConnected === false && (
+        <Alert severity="warning" sx={{ borderRadius: 1 }}>
+          The gateway is not connected to the control plane right now. The
+          test API key has been stored but will only work once the gateway
+          reconnects.
+        </Alert>
+      )}
+      {keyAlert === "unauthorized" && (
+        <Alert
+          severity="error"
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={handleRefreshTestKey}
+              disabled={isRefreshingKey}
+            >
+              {isRefreshingKey ? "Refreshing..." : "Refresh test key"}
+            </Button>
+          }
+          sx={{ borderRadius: 1 }}
+        >
+          The request was not authorized. The test API key may not be active
+          on the gateway yet.
+        </Alert>
+      )}
+      {keyAlert === "refreshed" && (
+        <Alert
+          severity="info"
+          onClose={() => setKeyAlert(null)}
+          sx={{ borderRadius: 1 }}
+        >
+          Test key refreshed. Send your message again.
+        </Alert>
+      )}
+    </>
+  );
 
   const inputDisabled =
     oauthOnly ||

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
@@ -190,11 +190,15 @@ export function AgentChat() {
 
       // Persistent auth failure: hand control back to the user instead of
       // retrying blindly — restore the message so it can be resent with one
-      // click after the key is refreshed.
+      // click after the key is refreshed. When the gateway is offline the
+      // standing warning banner already explains the failure and refreshing
+      // the key cannot help, so no additional alert is shown.
       if (apiResponse === null) {
         setMessages((prev) => prev.filter((m) => m.id !== userMessage.id));
         setMessage(userMessage.content);
-        setKeyAlert("unauthorized");
+        if (testKey?.gatewayConnected !== false) {
+          setKeyAlert("unauthorized");
+        }
         return;
       }
 

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
@@ -42,6 +42,11 @@ interface ChatMessage {
   timestamp: Date;
 }
 
+// A freshly issued test key takes a couple of seconds to reach the gateway's
+// policy engine (control plane -> event hub -> websocket -> policy snapshot),
+// so a single delayed retry with the same key rides out that window.
+const TEST_KEY_PROPAGATION_RETRY_DELAY_MS = 2000;
+
 export function AgentChat() {
   const [endpoint, setEndpoint] = useState("");
   const [message, setMessage] = useState("");
@@ -56,6 +61,10 @@ export function AgentChat() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isRetryingAuth, setIsRetryingAuth] = useState(false);
+  const [keyAlert, setKeyAlert] = useState<"unauthorized" | "refreshed" | null>(
+    null,
+  );
+  const [isRefreshingKey, setIsRefreshingKey] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const { agentId, orgId, projectId, envId } = useParams();
   const { data: endpoints, isLoading: isEndpointsLoading } =
@@ -122,6 +131,7 @@ export function AgentChat() {
     setMessages((prev) => [...prev, userMessage]);
     setMessage("");
     setError(null);
+    setKeyAlert(null);
     setIsLoading(true);
 
     try {
@@ -144,33 +154,31 @@ export function AgentChat() {
           referrerPolicy: "",
         });
       };
-      const sleep = (ms: number) =>
-        new Promise((resolve) => setTimeout(resolve, ms));
-
       let apiResponse = await sendChatRequest(testKey?.apiKey);
 
-      // A 401 usually means the gateway has not finished loading a freshly
-      // issued test key (propagation takes a few seconds) or our cached key
-      // was superseded. Retry with the same key first, then once more with a
-      // newly issued key, instead of surfacing the error to the user.
+      // Retry once with the same key: a 401 right after key issuance usually
+      // just means the gateway has not finished loading the key. Refetching
+      // here would rotate the key and restart that propagation window.
       if (securityEnabled && apiResponse.status === 401) {
         setIsRetryingAuth(true);
         try {
-          for (const delayMs of [1000, 2500]) {
-            await sleep(delayMs);
-            apiResponse = await sendChatRequest(testKey?.apiKey);
-            if (apiResponse.status !== 401) break;
-          }
-          if (apiResponse.status === 401) {
-            const freshKey = (await refetchTestKey()).data?.apiKey;
-            if (freshKey) {
-              await sleep(4000);
-              apiResponse = await sendChatRequest(freshKey);
-            }
-          }
+          await new Promise((resolve) =>
+            setTimeout(resolve, TEST_KEY_PROPAGATION_RETRY_DELAY_MS),
+          );
+          apiResponse = await sendChatRequest(testKey?.apiKey);
         } finally {
           setIsRetryingAuth(false);
         }
+      }
+
+      // Persistent 401: hand control back to the user instead of retrying
+      // blindly — restore the message so it can be resent with one click
+      // after the key is refreshed.
+      if (securityEnabled && apiResponse.status === 401) {
+        setMessages((prev) => prev.filter((m) => m.id !== userMessage.id));
+        setMessage(userMessage.content);
+        setKeyAlert("unauthorized");
+        return;
       }
 
       let responseData: any;
@@ -237,6 +245,44 @@ export function AgentChat() {
     }
   };
 
+  const handleRefreshTestKey = async () => {
+    setIsRefreshingKey(true);
+    try {
+      await refetchTestKey();
+      setKeyAlert("refreshed");
+    } finally {
+      setIsRefreshingKey(false);
+    }
+  };
+
+  const keyAlertBanner =
+    keyAlert === "unauthorized" ? (
+      <Alert
+        severity="error"
+        action={
+          <Button
+            color="inherit"
+            size="small"
+            onClick={handleRefreshTestKey}
+            disabled={isRefreshingKey}
+          >
+            {isRefreshingKey ? "Refreshing..." : "Refresh test key"}
+          </Button>
+        }
+        sx={{ borderRadius: 1 }}
+      >
+        The test API key is not authorized on the gateway yet.
+      </Alert>
+    ) : keyAlert === "refreshed" ? (
+      <Alert
+        severity="info"
+        onClose={() => setKeyAlert(null)}
+        sx={{ borderRadius: 1 }}
+      >
+        Test key refreshed. Send your message again.
+      </Alert>
+    ) : null;
+
   const inputDisabled =
     oauthOnly ||
     isLoading ||
@@ -280,7 +326,8 @@ export function AgentChat() {
               Send a message to begin chatting with the agent
             </Typography>
           </Box>
-          <Box width="100%" maxWidth={600}>
+          <Box width="100%" maxWidth={600} display="flex" flexDirection="column" gap={1}>
+            {keyAlertBanner}
             <Box
               width="100%"
               display="flex"
@@ -366,6 +413,7 @@ export function AgentChat() {
         </Box>
 
         {/* Error Display */}
+        {keyAlertBanner}
         {error && (
           <Alert
             severity="error"

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
@@ -55,6 +55,7 @@ export function AgentChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isRetryingAuth, setIsRetryingAuth] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const { agentId, orgId, projectId, envId } = useParams();
   const { data: endpoints, isLoading: isEndpointsLoading } =
@@ -82,6 +83,7 @@ export function AgentChat() {
     data: testKey,
     isLoading: isLoadingTestKey,
     error: testKeyError,
+    refetch: refetchTestKey,
   } = useTestAgentAPIKey(
     { orgName: orgId, projName: projectId, agentName: agentId, envId },
     { enabled: securityEnabled && !oauthOnly },
@@ -128,19 +130,48 @@ export function AgentChat() {
         message: userMessage.content,
       };
 
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
+      const sendChatRequest = (apiKey?: string) => {
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+        };
+        if (securityEnabled && apiKey) {
+          headers["X-API-Key"] = apiKey;
+        }
+        return fetch(endpoint, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(requestBody),
+          referrerPolicy: "",
+        });
       };
-      if (securityEnabled && testKey?.apiKey) {
-        headers["X-API-Key"] = testKey.apiKey;
-      }
+      const sleep = (ms: number) =>
+        new Promise((resolve) => setTimeout(resolve, ms));
 
-      const apiResponse = await fetch(endpoint, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(requestBody),
-        referrerPolicy: "",
-      });
+      let apiResponse = await sendChatRequest(testKey?.apiKey);
+
+      // A 401 usually means the gateway has not finished loading a freshly
+      // issued test key (propagation takes a few seconds) or our cached key
+      // was superseded. Retry with the same key first, then once more with a
+      // newly issued key, instead of surfacing the error to the user.
+      if (securityEnabled && apiResponse.status === 401) {
+        setIsRetryingAuth(true);
+        try {
+          for (const delayMs of [1000, 2500]) {
+            await sleep(delayMs);
+            apiResponse = await sendChatRequest(testKey?.apiKey);
+            if (apiResponse.status !== 401) break;
+          }
+          if (apiResponse.status === 401) {
+            const freshKey = (await refetchTestKey()).data?.apiKey;
+            if (freshKey) {
+              await sleep(4000);
+              apiResponse = await sendChatRequest(freshKey);
+            }
+          }
+        } finally {
+          setIsRetryingAuth(false);
+        }
+      }
 
       let responseData: any;
       const contentType = apiResponse.headers.get("content-type");
@@ -324,7 +355,9 @@ export function AgentChat() {
                   color="text.secondary"
                   sx={{ fontSize: "0.875rem" }}
                 >
-                  Loading...
+                  {isRetryingAuth
+                    ? "Waiting for the test API key to become active..."
+                    : "Loading..."}
                 </Typography>
               </Box>
             </Box>

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -24,7 +24,7 @@ import {
 import { getErrorMessage } from "@agent-management-platform/shared-component";
 import { Alert, Box, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { useParams } from "react-router-dom";
-import { useMemo, lazy, Suspense } from "react";
+import { useMemo, useState, lazy, Suspense } from "react";
 
 const SwaggerUI = lazy(() => import("swagger-ui-react"));
 
@@ -70,11 +70,13 @@ export function Swagger() {
     isLoading: isLoadingTestKey,
     isError: isTestKeyError,
     error: testKeyError,
+    refetch: refetchTestKey,
   } = useTestAgentAPIKey(
     { orgName: orgId, projName: projectId, agentName: agentId, envId },
     { enabled: securityEnabled && !oauthOnly },
   );
   const testApiKey = testKey?.apiKey;
+  const [keyRefreshed, setKeyRefreshed] = useState(false);
 
   const endpoint = useMemo(() => Object.keys(data ?? {})?.[0] ?? "", [data]);
   const requestInterceptor = useMemo(
@@ -103,6 +105,20 @@ export function Swagger() {
       return req;
     },
     [data, endpoint, securityEnabled, testApiKey]
+  );
+
+  // swagger-ui cannot replay a request, so on a 401 (usually a test key the
+  // gateway hasn't loaded yet, or one superseded by another session) refresh
+  // the key and ask the user to execute the request again.
+  const responseInterceptor = useMemo(
+    () => (res: any) => {
+      if (securityEnabled && res?.status === 401) {
+        refetchTestKey();
+        setKeyRefreshed(true);
+      }
+      return res;
+    },
+    [securityEnabled, refetchTestKey]
   );
 
   if (isLoading || (securityEnabled && isLoadingTestKey)) {
@@ -139,6 +155,16 @@ export function Swagger() {
           </Typography>
         </Alert>
       )}
+      {keyRefreshed && (
+        <Alert
+          severity="info"
+          onClose={() => setKeyRefreshed(false)}
+          sx={{ mb: 2 }}
+        >
+          The test API key was refreshed after an authorization failure.
+          Execute the request again.
+        </Alert>
+      )}
       <Box sx={{ "& .swagger-ui .wrapper": { padding: 0 } }}>
         <SwaggerUI
           spec={data?.[endpoint].schema.content}
@@ -146,6 +172,7 @@ export function Swagger() {
           plugins={[disableAuthorizeAndInfoPluginCustomSecuritySchema]}
           docExpansion="list"
           requestInterceptor={requestInterceptor}
+          responseInterceptor={responseInterceptor}
           supportedSubmitMethods={oauthOnly ? [] : undefined}
         />
       </Box>

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -168,6 +168,13 @@ export function Swagger() {
           </Typography>
         </Alert>
       )}
+      {securityEnabled && testKey?.gatewayConnected === false && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          The gateway is not connected to the control plane right now. The
+          test API key has been stored but will only work once the gateway
+          reconnects.
+        </Alert>
+      )}
       {keyAlert === "unauthorized" && (
         <Alert
           severity="error"

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -28,6 +28,10 @@ import { useMemo, useState, lazy, Suspense } from "react";
 
 const SwaggerUI = lazy(() => import("swagger-ui-react"));
 
+// A freshly issued test key takes a couple of seconds to reach the gateway's
+// policy engine, so one delayed retry with the same key rides out that window.
+const TEST_KEY_PROPAGATION_RETRY_DELAY_MS = 2000;
+
 const disableAuthorizeAndInfoPluginCustomSecuritySchema = {
   statePlugins: {
     spec: {
@@ -81,7 +85,14 @@ export function Swagger() {
   );
   const [isRefreshingKey, setIsRefreshingKey] = useState(false);
 
+  const gatewayOffline = testKey?.gatewayConnected === false;
+
   const endpoint = useMemo(() => Object.keys(data ?? {})?.[0] ?? "", [data]);
+
+  // The gateway drops CORS headers on 401s, so a cross-origin 401 rejects
+  // fetch with a TypeError before swagger-ui's responseInterceptor runs.
+  // Inject a custom fetch (req.userFetch) instead: retry once to ride out key
+  // propagation, then surface the refresh alert on a persistent 401/TypeError.
   const requestInterceptor = useMemo(
     () => (req: any) => {
       const targetUrl = data?.[endpoint]?.url;
@@ -105,26 +116,41 @@ export function Swagger() {
         req.headers = req.headers ?? {};
         req.headers["X-API-Key"] = testApiKey;
       }
+
+      if (securityEnabled && !gatewayOffline) {
+        req.userFetch = async (url: string, options: RequestInit) => {
+          const sleep = () =>
+            new Promise((resolve) =>
+              setTimeout(resolve, TEST_KEY_PROPAGATION_RETRY_DELAY_MS),
+            );
+          try {
+            const res = await fetch(url, options);
+            if (res.status !== 401) {
+              return res;
+            }
+            await sleep();
+            const retry = await fetch(url, options);
+            if (retry.status === 401) {
+              setKeyAlert("unauthorized");
+            }
+            return retry;
+          } catch (err) {
+            if (!(err instanceof TypeError)) {
+              throw err;
+            }
+            await sleep();
+            try {
+              return await fetch(url, options);
+            } catch (retryErr) {
+              setKeyAlert("unauthorized");
+              throw retryErr;
+            }
+          }
+        };
+      }
       return req;
     },
-    [data, endpoint, securityEnabled, testApiKey]
-  );
-
-  // swagger-ui cannot replay a request, so on a 401 (usually a test key the
-  // gateway hasn't loaded yet, or one superseded by another session) surface
-  // an alert with a manual refresh action. Refetching automatically would
-  // rotate the key and restart the gateway propagation window. When the
-  // gateway is offline the standing warning banner already explains the
-  // failure and refreshing cannot help, so no additional alert is shown.
-  const gatewayOffline = testKey?.gatewayConnected === false;
-  const responseInterceptor = useMemo(
-    () => (res: any) => {
-      if (securityEnabled && res?.status === 401 && !gatewayOffline) {
-        setKeyAlert("unauthorized");
-      }
-      return res;
-    },
-    [securityEnabled, gatewayOffline]
+    [data, endpoint, securityEnabled, testApiKey, gatewayOffline]
   );
 
   const handleRefreshTestKey = async () => {
@@ -213,7 +239,6 @@ export function Swagger() {
           plugins={[disableAuthorizeAndInfoPluginCustomSecuritySchema]}
           docExpansion="list"
           requestInterceptor={requestInterceptor}
-          responseInterceptor={responseInterceptor}
           supportedSubmitMethods={oauthOnly ? [] : undefined}
         />
       </Box>

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -113,15 +113,18 @@ export function Swagger() {
   // swagger-ui cannot replay a request, so on a 401 (usually a test key the
   // gateway hasn't loaded yet, or one superseded by another session) surface
   // an alert with a manual refresh action. Refetching automatically would
-  // rotate the key and restart the gateway propagation window.
+  // rotate the key and restart the gateway propagation window. When the
+  // gateway is offline the standing warning banner already explains the
+  // failure and refreshing cannot help, so no additional alert is shown.
+  const gatewayOffline = testKey?.gatewayConnected === false;
   const responseInterceptor = useMemo(
     () => (res: any) => {
-      if (securityEnabled && res?.status === 401) {
+      if (securityEnabled && res?.status === 401 && !gatewayOffline) {
         setKeyAlert("unauthorized");
       }
       return res;
     },
-    [securityEnabled]
+    [securityEnabled, gatewayOffline]
   );
 
   const handleRefreshTestKey = async () => {
@@ -168,7 +171,7 @@ export function Swagger() {
           </Typography>
         </Alert>
       )}
-      {securityEnabled && testKey?.gatewayConnected === false && (
+      {securityEnabled && gatewayOffline && (
         <Alert severity="warning" sx={{ mb: 2 }}>
           The gateway is not connected to the control plane right now. The
           test API key has been stored but will only work once the gateway

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -22,7 +22,7 @@ import {
   useTestAgentAPIKey,
 } from "@agent-management-platform/api-client";
 import { getErrorMessage } from "@agent-management-platform/shared-component";
-import { Alert, Box, Skeleton, Typography } from "@wso2/oxygen-ui";
+import { Alert, Box, Button, Skeleton, Typography } from "@wso2/oxygen-ui";
 import { useParams } from "react-router-dom";
 import { useMemo, useState, lazy, Suspense } from "react";
 
@@ -76,7 +76,10 @@ export function Swagger() {
     { enabled: securityEnabled && !oauthOnly },
   );
   const testApiKey = testKey?.apiKey;
-  const [keyRefreshed, setKeyRefreshed] = useState(false);
+  const [keyAlert, setKeyAlert] = useState<"unauthorized" | "refreshed" | null>(
+    null,
+  );
+  const [isRefreshingKey, setIsRefreshingKey] = useState(false);
 
   const endpoint = useMemo(() => Object.keys(data ?? {})?.[0] ?? "", [data]);
   const requestInterceptor = useMemo(
@@ -108,18 +111,28 @@ export function Swagger() {
   );
 
   // swagger-ui cannot replay a request, so on a 401 (usually a test key the
-  // gateway hasn't loaded yet, or one superseded by another session) refresh
-  // the key and ask the user to execute the request again.
+  // gateway hasn't loaded yet, or one superseded by another session) surface
+  // an alert with a manual refresh action. Refetching automatically would
+  // rotate the key and restart the gateway propagation window.
   const responseInterceptor = useMemo(
     () => (res: any) => {
       if (securityEnabled && res?.status === 401) {
-        refetchTestKey();
-        setKeyRefreshed(true);
+        setKeyAlert("unauthorized");
       }
       return res;
     },
-    [securityEnabled, refetchTestKey]
+    [securityEnabled]
   );
+
+  const handleRefreshTestKey = async () => {
+    setIsRefreshingKey(true);
+    try {
+      await refetchTestKey();
+      setKeyAlert("refreshed");
+    } finally {
+      setIsRefreshingKey(false);
+    }
+  };
 
   if (isLoading || (securityEnabled && isLoadingTestKey)) {
     return <Skeleton variant="rounded" height={500} />;
@@ -155,14 +168,32 @@ export function Swagger() {
           </Typography>
         </Alert>
       )}
-      {keyRefreshed && (
+      {keyAlert === "unauthorized" && (
         <Alert
-          severity="info"
-          onClose={() => setKeyRefreshed(false)}
+          severity="error"
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={handleRefreshTestKey}
+              disabled={isRefreshingKey}
+            >
+              {isRefreshingKey ? "Refreshing..." : "Refresh test key"}
+            </Button>
+          }
           sx={{ mb: 2 }}
         >
-          The test API key was refreshed after an authorization failure.
-          Execute the request again.
+          The test API key is not authorized on the gateway yet. Execute the
+          request again, or refresh the test key.
+        </Alert>
+      )}
+      {keyAlert === "refreshed" && (
+        <Alert
+          severity="info"
+          onClose={() => setKeyAlert(null)}
+          sx={{ mb: 2 }}
+        >
+          Test key refreshed. Execute the request again.
         </Alert>
       )}
       <Box sx={{ "& .swagger-ui .wrapper": { padding: 0 } }}>

--- a/console/workspaces/pages/test/src/Test.Component.tsx
+++ b/console/workspaces/pages/test/src/Test.Component.tsx
@@ -101,7 +101,7 @@ export const TestComponent: React.FC = () => {
       {isLoading ? (
         <SkeletonTestPageLayout />
       ) : (
-        <>{isChatAgent ? <AgentChat /> : <Swagger />}</>
+        <>{isChatAgent ? <AgentChat key={agentId} /> : <Swagger key={agentId} />}</>
       )}
     </PageLayout>
   );

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -374,7 +374,8 @@ install_gateway_extension() {
             --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].issuer=${thunder_issuer_url}"
             --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.uri=${thunder_jwks}"
             --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.skipTlsVerify=${idp_skip_tls_verify}"
-            --set "bootstrap.identityProviders[0].name=${thunder_release}"
+            # Name must match keymanagers[].name, which is always "ThunderKeyManager" (set above).
+            --set "bootstrap.identityProviders[0].name=ThunderKeyManager"
             --set "bootstrap.identityProviders[0].issuer=${thunder_issuer_url}"
             --set "bootstrap.identityProviders[0].jwksUri=${thunder_jwks}"
             --set "bootstrap.identityProviders[0].skipTlsVerify=${idp_skip_tls_verify}"


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Agent chat would intermittently return a 401 right after an agent was set up, and users had to refresh the page a few times before it worked. Investigation traced this to three causes:

1. **Shared test key.** Every user session shared a single `console-test` API key per agent and environment, and each visit to the test page rotated it — so a page reload, a second tab, or another user silently invalidated everyone else's key.
2. **Propagation window.** A newly issued key takes a few seconds (measured 2–4 s) to propagate from the control plane to the gateway's policy engine, and during that window the gateway rejects it.
3. **Gateway offline / significant propagation delay.** The gateway learns about keys over a websocket to the control plane. If that connection is down — most commonly right after the control plane restarts, but also on any gateway disconnect — the control plane still issues keys and reports success, queuing the events. Until the gateway reconnects and syncs, the delay is effectively unbounded, so every invocation with the "successfully issued" key fails with a 401 and there was no signal to the user explaining why.

This PR addresses all three:

- **Per-user test keys** (key name derived from the JWT subject) so sessions no longer invalidate each other.
- **Automatic recovery in the console.** In the chat flow a 401 triggers a single automatic retry with the same key after a short delay to ride out the propagation window; if it still fails, the message is restored to the input and an alert offers a "Refresh test key" action so the user recovers with one click instead of reloading the page. The Swagger view surfaces the same alert and refresh action.
- **Gateway-connectivity signal.** The test/create/rotate key responses now include a `gatewayConnected` flag, set from the live websocket connection state at issue time. When the gateway is disconnected the Try-It and Credentials pages show a clear warning that the key was stored but will only work once the gateway reconnects — and, because refreshing the key cannot help in that state, the retry/refresh alert is suppressed so only the offline warning is shown. This turns the previously silent restart-window failure into an explicit, understandable message.

Resolves #931

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Console “Try-It” test API keys are now issued per user, so refreshing rotates only your own key.
  - API key responses now include whether gateways were connected when the key was created/rotated.

- **Bug Fixes**
  - Improved retry handling in the test chat and Swagger UI after authorization failures.
  - Added clearer guidance when an API key is saved while gateways are offline.

- **UI Improvements**
  - Test API keys now refresh on window focus and on refresh actions, improving recovery from expired auth.
  - Agent test UI remounts correctly when switching agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
