### PR TITLE
Return instrumentation version in agent read path

### DIFF
--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -127,6 +127,12 @@ func convertToConfigurations(configs *models.Configurations) *spec.Configuration
 		EnableApiKeySecurity:      configs.EnableApiKeySecurity,
 		EnableOAuthSecurity:       configs.EnableOAuthSecurity,
 	}
+	// Surface the pinned AMP instrumentation version on reads so the deploy/promote
+	// UI shows the currently-applied version instead of falling back to the platform
+	// default. Left unset (omitted) when the agent has no pin.
+	if configs.InstrumentationVersion != nil {
+		result.InstrumentationVersion.Set(configs.InstrumentationVersion)
+	}
 	if configs.CorsConfig != nil {
 		corsConfig := spec.CORSConfig{
 			Enabled:          configs.CorsConfig.Enabled,

--- a/agent-manager-service/utils/makeresults_test.go
+++ b/agent-manager-service/utils/makeresults_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+)
+
+func TestConvertToConfigurations_SurfacesInstrumentationVersion(t *testing.T) {
+	version := "0.3.0"
+	got := convertToConfigurations(&models.Configurations{
+		InstrumentationVersion: &version,
+	})
+	if got == nil {
+		t.Fatal("expected non-nil configurations")
+	}
+	// The read path must surface the pinned version, otherwise the deploy/promote
+	// UI falls back to the platform default and shows a version different from
+	// what is actually deployed.
+	if !got.InstrumentationVersion.IsSet() {
+		t.Fatal("InstrumentationVersion should be set on the response")
+	}
+	if v := got.InstrumentationVersion.Get(); v == nil || *v != "0.3.0" {
+		t.Errorf("InstrumentationVersion = %v, want 0.3.0", v)
+	}
+}
+
+func TestConvertToConfigurations_UnpinnedIsOmitted(t *testing.T) {
+	got := convertToConfigurations(&models.Configurations{})
+	if got == nil {
+		t.Fatal("expected non-nil configurations")
+	}
+	if got.InstrumentationVersion.IsSet() {
+		t.Errorf("InstrumentationVersion should be unset when the agent has no pin")
+	}
+}


### PR DESCRIPTION
## Purpose

Follow-up to #1259 (merged). After selecting an AMP instrumentation version on the Deploy/Promote screen, the version was persisted and applied correctly (the running pod's init-container image and `traceloop-sdk` did change), but the UI kept showing the previously-selected / platform-default version (e.g. `0.4.0` for an agent actually pinned to `0.3.0`). The value read back wrong.

## Goals

Make the GET-agent response return the pinned instrumentation version so the Deploy/Promote UI reflects what is actually deployed.

## Approach

Root cause: `convertToConfigurations` (`agent-manager-service/utils/makeresults.go`) — the mapper that builds the `GetAgent` API response from the internal model — copied `enableAutoInstrumentation`, CORS and OAuth, but never copied `instrumentationVersion`. So `GetAgent` read the pinned version from `agent_configs` into the internal model and then dropped it during serialization; the console received `instrumentationVersion: null` and its selector seeded to the platform default.

Fix: copy `InstrumentationVersion` into the response `Configurations` (left unset/omitted when the agent has no pin, preserving the "floats with the platform default" semantics). Added `makeresults_test.go` covering both the pinned and unpinned cases so the read path can't silently regress again.

No API-shape change (the field already exists in the `Configurations` schema and the TS types from #1259); this only populates it.

## User stories

As a user, when I change an agent's AMP instrumentation version on Deploy/Promote, the screen should show the version that is actually applied.

## Release note

Fixed the Deploy/Promote UI showing the platform-default AMP instrumentation version instead of the version actually pinned to the agent.

## Documentation

N/A — no doc impact; behavior now matches what the existing UI already implied.

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

- Unit tests
  - `TestConvertToConfigurations_SurfacesInstrumentationVersion` — a pinned version appears on the response.
  - `TestConvertToConfigurations_UnpinnedIsOmitted` — no pin ⇒ field omitted.
- Integration tests
  - N/A — no new DB-backed path; the existing GetAgent coverage exercises the mapper.

## Security checks

- Followed secure coding standards? yes
- Ran FindSecurityBugs plugin and verified report? no — not part of this repo's standard workflow; change only copies an existing internal field onto the response.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

Follow-up to #1259.

## Migrations (if applicable)

None.

## Test environment

Verified on a local k3d + Docker Compose stack: an agent pinned to `0.3.0` (persisted in `agent_configs`, applied to the running init-container image) previously read back as the platform default in the UI; after the fix, `GetAgent` returns `0.3.0`.

## Learning

Adding a field to a request/DB path is only half the loop — the read/serialization mapper (`convertToConfigurations`) has to surface it too, or the UI silently falls back to defaults. Worth a test at the mapper boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration results now correctly show the currently pinned instrumentation version when one is set.
  * Unpinned instrumentation versions are now omitted instead of being included as empty values.

* **Tests**
  * Added unit coverage for both pinned and unpinned instrumentation version behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->