### PR TITLE
Make AgentID provisioning a deployment-injected dependency

### DIFF
--- a/agent-manager-service/app/app.go
+++ b/agent-manager-service/app/app.go
@@ -43,6 +43,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/wiring"
 
 	"go.uber.org/automaxprocs/maxprocs"
+	"gorm.io/gorm"
 )
 
 // Options holds the configuration options for running the application.
@@ -60,6 +61,11 @@ type Options struct {
 	// default) preserves the script-driven behavior; cloud deployments inject an
 	// implementation. See services.GatewayConfigApplier.
 	GatewayConfigApplier services.GatewayConfigApplier
+	// AgentThunderProvisioning is the deployment-specific AgentID provisioning
+	// implementation. A factory because the open-source impl is DB-backed and the
+	// DB is initialized inside Run. nil disables provisioning (identity endpoints
+	// report it unavailable, reconciler not started, no OpenBao required).
+	AgentThunderProvisioning func(db *gorm.DB) services.AgentThunderProvisioningService
 }
 
 // Run starts the application with the provided providers and options.
@@ -96,7 +102,14 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 
 	// Get the raw DB instance without context - repositories will add context per-operation
 	database := db.GetDB()
-	dependencies, err := wiring.InitializeAppParams(cfg, database, authProvider, secretProvider, opts.GatewayConfigApplier)
+
+	// Deployment-specific AgentID provisioning; nil disables it.
+	var agentThunderProvisioning services.AgentThunderProvisioningService
+	if opts.AgentThunderProvisioning != nil {
+		agentThunderProvisioning = opts.AgentThunderProvisioning(database)
+	}
+
+	dependencies, err := wiring.InitializeAppParams(cfg, database, authProvider, secretProvider, opts.GatewayConfigApplier, agentThunderProvisioning)
 	if err != nil {
 		slog.Error("failed to initialize app dependencies", "error", err)
 		os.Exit(1)
@@ -109,11 +122,14 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 		os.Exit(1)
 	}
 
-	// Start the AgentID provisioning retry reconciler with its own background context
+	// Start the AgentID provisioning retry reconciler, but only when provisioning
+	// is enabled — otherwise there is nothing to reconcile.
 	agentThunderReconcilerCtx, agentThunderReconcilerCancel := context.WithCancel(context.Background())
-	if err := dependencies.AgentThunderReconciler.Start(agentThunderReconcilerCtx); err != nil {
-		slog.Error("failed to start agent thunder provisioning reconciler", "error", err)
-		os.Exit(1)
+	if agentThunderProvisioning != nil {
+		if err := dependencies.AgentThunderReconciler.Start(agentThunderReconcilerCtx); err != nil {
+			slog.Error("failed to start agent thunder provisioning reconciler", "error", err)
+			os.Exit(1)
+		}
 	}
 
 	// Load built-in LLM provider templates into memory
@@ -157,8 +173,10 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 		}
 
 		agentThunderReconcilerCancel()
-		if err := dependencies.AgentThunderReconciler.Stop(); err != nil {
-			slog.Error("error stopping agent thunder provisioning reconciler", "error", err)
+		if agentThunderProvisioning != nil {
+			if err := dependencies.AgentThunderReconciler.Stop(); err != nil {
+				slog.Error("error stopping agent thunder provisioning reconciler", "error", err)
+			}
 		}
 
 		// Shutdown WebSocket manager in a goroutine since it blocks

--- a/agent-manager-service/main.go
+++ b/agent-manager-service/main.go
@@ -24,6 +24,7 @@ import (
 	ocauth "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/auth"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc/providers/openbao"
 	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
 )
 
 func main() {
@@ -45,8 +46,12 @@ func main() {
 	// Open-source: OpenBao secret management
 	secretProvider := openbao.NewProvider()
 
+	// Open-source: OpenBao-backed AgentID provisioning
+	agentThunderProvisioning := services.NewOpenBaoAgentThunderProvisioning(*cfg)
+
 	app.Run(authProvider, secretProvider, app.Options{
-		Server:  *serverFlag,
-		Migrate: *migrateFlag,
+		Server:                   *serverFlag,
+		Migrate:                  *migrateFlag,
+		AgentThunderProvisioning: agentThunderProvisioning,
 	})
 }

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1291,26 +1291,29 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 	// environments when displaying bindings). Runs after every step above has
 	// succeeded, so a Thunder hiccup never rolls back an otherwise-successful
 	// agent creation; the write-ahead + retry reconciler make it durable
-	// without needing a place in the rollback chain above.
-	if envs, envErr := s.ocClient.ListEnvironments(ctx, ouID); envErr != nil {
-		s.logger.Warn("Failed to list org environments for agent thunder provisioning", "agentName", req.Name, "error", envErr)
-	} else if len(envs) > 0 {
-		envNames := make([]string, 0, len(envs))
-		for _, e := range envs {
-			envNames = append(envNames, e.Name)
+	// without needing a place in the rollback chain above. Skipped when this
+	// deployment injects no provisioning implementation.
+	if s.agentThunderProvisioning != nil {
+		if envs, envErr := s.ocClient.ListEnvironments(ctx, ouID); envErr != nil {
+			s.logger.Warn("Failed to list org environments for agent thunder provisioning", "agentName", req.Name, "error", envErr)
+		} else if len(envs) > 0 {
+			envNames := make([]string, 0, len(envs))
+			for _, e := range envs {
+				envNames = append(envNames, e.Name)
+			}
+			ownership := models.AgentProvisioningType(req.Provisioning.Type)
+			// requestedBy is captured now, synchronously, because the retry reconciler
+			// may not attempt some of these bindings until minutes or hours later, long
+			// after this request's own caller identity would otherwise be gone. It is
+			// AMS's own audit record only — never sent to Thunder (see
+			// models.AgentThunderClient.RequestedBy for why Thunder's own "owner" field
+			// cannot carry this).
+			var requestedBy string
+			if callerClaims := jwtassertion.GetTokenClaims(ctx); callerClaims != nil {
+				requestedBy = callerClaims.Sub
+			}
+			s.agentThunderProvisioning.ProvisionForAgent(ctx, ouID, projectName, req.Name, ownership, envNames, requestedBy)
 		}
-		ownership := models.AgentProvisioningType(req.Provisioning.Type)
-		// requestedBy is captured now, synchronously, because the retry reconciler
-		// may not attempt some of these bindings until minutes or hours later, long
-		// after this request's own caller identity would otherwise be gone. It is
-		// AMS's own audit record only — never sent to Thunder (see
-		// models.AgentThunderClient.RequestedBy for why Thunder's own "owner" field
-		// cannot carry this).
-		var requestedBy string
-		if callerClaims := jwtassertion.GetTokenClaims(ctx); callerClaims != nil {
-			requestedBy = callerClaims.Sub
-		}
-		s.agentThunderProvisioning.ProvisionForAgent(ctx, ouID, projectName, req.Name, ownership, envNames, requestedBy)
 	}
 
 	s.logger.Info("Agent created successfully", "agentName", req.Name, "ouID", ouID, "projectName", projectName, "provisioningType", req.Provisioning.Type)
@@ -2177,7 +2180,9 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 				s.logger.Warn("Failed to delete agent configs from database", "agentName", agentName, "error", configErr)
 			}
 			s.deleteAgentAPIArtifact(ctx, ouID, projectName, agentName)
-			go s.agentThunderProvisioning.DeleteAllBindings(context.WithoutCancel(ctx), ouID, projectName, agentName)
+			if s.agentThunderProvisioning != nil {
+				go s.agentThunderProvisioning.DeleteAllBindings(context.WithoutCancel(ctx), ouID, projectName, agentName)
+			}
 			return nil
 		}
 		s.logger.Error("Failed to delete oc agent", "agentName", agentName, "error", err)
@@ -2189,7 +2194,9 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 	// is not cancelled when the HTTP handler returns, while still inheriting any values
 	// (trace IDs, logger) from the request context.
 	go s.deleteAgentLLMConfigurations(context.WithoutCancel(ctx), ouID, projectName, agentName, isExternalAgent)
-	go s.agentThunderProvisioning.DeleteAllBindings(context.WithoutCancel(ctx), ouID, projectName, agentName)
+	if s.agentThunderProvisioning != nil {
+		go s.agentThunderProvisioning.DeleteAllBindings(context.WithoutCancel(ctx), ouID, projectName, agentName)
+	}
 
 	// Cleanup agent configs from database
 	if configErr := s.agentConfigRepo.DeleteAllByAgent(ouID, projectName, agentName); configErr != nil {
@@ -2998,6 +3005,10 @@ func allPipelineEnvironmentNames(promotionPaths []models.PromotionPath) map[stri
 // it never returns or destroys a secret. Use ClaimAgentIdentitySecret to
 // actually retrieve an unclaimed External agent's secret.
 func (s *agentManagerService) GetAgentIdentity(ctx context.Context, ouID string, projectName string, agentName string) ([]models.AgentIdentityEnvironmentView, error) {
+	// No provisioning implementation: no identities to report.
+	if s.agentThunderProvisioning == nil {
+		return []models.AgentIdentityEnvironmentView{}, nil
+	}
 	views, err := s.agentThunderProvisioning.GetIdentityViews(ctx, ouID, projectName, agentName)
 	if err != nil {
 		return nil, err
@@ -3025,6 +3036,9 @@ func (s *agentManagerService) GetAgentIdentity(ctx context.Context, ouID string,
 // destroys the stored secret. Internal agents are rejected; use
 // GetAgentCredentials instead.
 func (s *agentManagerService) ClaimAgentIdentitySecret(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (*models.AgentClaimSecretResponse, error) {
+	if s.agentThunderProvisioning == nil {
+		return nil, utils.ErrAgentIdentityNotProvisioned
+	}
 	agent, err := s.ocClient.GetComponent(ctx, ouID, projectName, agentName)
 	if err != nil {
 		s.logger.Error("Failed to fetch agent for identity secret claim", "agentName", agentName, "error", err)
@@ -3058,6 +3072,9 @@ func (s *agentManagerService) ClaimAgentIdentitySecret(ctx context.Context, ouID
 // included so the caller can tell which kind of agent this is without a
 // separate lookup.
 func (s *agentManagerService) RegenerateAgentIdentitySecret(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (*models.AgentRegenerateSecretResponse, error) {
+	if s.agentThunderProvisioning == nil {
+		return nil, utils.ErrAgentIdentityNotProvisioned
+	}
 	ownership, clientID, newSecret, err := s.agentThunderProvisioning.RegenerateSecret(ctx, ouID, projectName, agentName, environmentName)
 	if err != nil {
 		return nil, err
@@ -3076,6 +3093,9 @@ func (s *agentManagerService) RegenerateAgentIdentitySecret(ctx context.Context,
 // It never returns a usable secret — an explicit regenerate is required
 // afterward to restore access.
 func (s *agentManagerService) RevokeAgentIdentitySecret(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (models.AgentRevokeSecretResponse, error) {
+	if s.agentThunderProvisioning == nil {
+		return models.AgentRevokeSecretResponse{}, utils.ErrAgentIdentityNotProvisioned
+	}
 	clientID, err := s.agentThunderProvisioning.RevokeSecret(ctx, ouID, projectName, agentName, environmentName)
 	if err != nil {
 		return models.AgentRevokeSecretResponse{}, err
@@ -3100,6 +3120,9 @@ func (s *agentManagerService) RevokeAgentIdentitySecret(ctx context.Context, ouI
 // new happened, here's the current state) and 202 (provisioning was just
 // kicked off in the background).
 func (s *agentManagerService) ProvisionAgentIdentity(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (models.AgentIdentityEnvironmentView, bool, error) {
+	if s.agentThunderProvisioning == nil {
+		return models.AgentIdentityEnvironmentView{}, false, utils.ErrAgentIdentityNotProvisioned
+	}
 	agent, err := s.ocClient.GetComponent(ctx, ouID, projectName, agentName)
 	if err != nil {
 		s.logger.Error("Failed to fetch agent for identity provisioning", "agentName", agentName, "error", err)
@@ -3152,6 +3175,9 @@ func (s *agentManagerService) ProvisionAgentIdentity(ctx context.Context, ouID s
 // one-time claim, or RegenerateAgentIdentitySecret), and letting them use this
 // endpoint too would defeat the point of that one-time claim design.
 func (s *agentManagerService) GetAgentCredentials(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (models.AgentCredentialsResponse, error) {
+	if s.agentThunderProvisioning == nil {
+		return models.AgentCredentialsResponse{}, utils.ErrAgentIdentityNotProvisioned
+	}
 	agent, err := s.ocClient.GetComponent(ctx, ouID, projectName, agentName)
 	if err != nil {
 		s.logger.Error("Failed to fetch agent for credential retrieval", "agentName", agentName, "error", err)
@@ -3426,14 +3452,16 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 	// created, so its binding could be missing entirely — best-effort and
 	// non-blocking, exactly like provisioning at agent-creation time, so a
 	// Thunder hiccup never rolls back an otherwise-successful promotion.
-	var requestedBy string
-	if callerClaims := jwtassertion.GetTokenClaims(ctx); callerClaims != nil {
-		requestedBy = callerClaims.Sub
-	}
-	if _, err := s.agentThunderProvisioning.ProvisionForEnvironmentIfMissing(
-		ctx, ouID, projectName, agentName, req.TargetEnvironment, models.AgentProvisioningTypeInternal, requestedBy,
-	); err != nil {
-		s.logger.Warn("Failed to ensure AgentID for promoted agent's target environment", "agentName", agentName, "environment", req.TargetEnvironment, "error", err)
+	if s.agentThunderProvisioning != nil {
+		var requestedBy string
+		if callerClaims := jwtassertion.GetTokenClaims(ctx); callerClaims != nil {
+			requestedBy = callerClaims.Sub
+		}
+		if _, err := s.agentThunderProvisioning.ProvisionForEnvironmentIfMissing(
+			ctx, ouID, projectName, agentName, req.TargetEnvironment, models.AgentProvisioningTypeInternal, requestedBy,
+		); err != nil {
+			s.logger.Warn("Failed to ensure AgentID for promoted agent's target environment", "agentName", agentName, "environment", req.TargetEnvironment, "error", err)
+		}
 	}
 
 	s.logger.Info("Agent promoted successfully", "agentName", agentName, "sourceEnvironment", req.SourceEnvironment, "targetEnvironment", req.TargetEnvironment)

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -135,6 +137,30 @@ type agentThunderProvisioningService struct {
 	secretStore  thundersvc.AgentSecretStore
 	logger       *slog.Logger
 	bindingLocks keyedMutex
+}
+
+// NewOpenBaoAgentThunderProvisioning returns the deployment factory that builds
+// the OpenBao-backed provisioning service once the DB is available (see
+// app.Options.AgentThunderProvisioning). Used by the open-source deployment,
+// which provisions AgentIDs against per-environment Thunder via OpenBao; panics
+// on a missing/invalid OPENBAO_* config so startup fails fast.
+func NewOpenBaoAgentThunderProvisioning(cfg config.Config) func(db *gorm.DB) AgentThunderProvisioningService {
+	return func(db *gorm.DB) AgentThunderProvisioningService {
+		envResolver, err := thundersvc.NewEnvThunderResolver(cfg.OpenBao.URL, cfg.OpenBao.Token, cfg.OpenBao.Path)
+		if err != nil {
+			panic(fmt.Errorf("create env thunder resolver: %w", err))
+		}
+		secretStore, err := thundersvc.NewAgentSecretStore(cfg.OpenBao.URL, cfg.OpenBao.Token, cfg.OpenBao.Path)
+		if err != nil {
+			panic(fmt.Errorf("create agent secret store: %w", err))
+		}
+		return NewAgentThunderProvisioningService(
+			repositories.NewAgentThunderClientRepo(db),
+			envResolver,
+			secretStore,
+			slog.Default(),
+		)
+	}
 }
 
 // NewAgentThunderProvisioningService creates a new AgentThunderProvisioningService.

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -59,8 +59,8 @@ var clientProviderSet = wire.NewSet(
 	ProvideIdentityClient,
 	ProvideOrgResolver,
 	thundersvc.NewProber,
-	ProvideEnvThunderResolver,
-	ProvideAgentSecretStore,
+	// OpenBao-backed EnvThunderResolver/AgentSecretStore are not wired here;
+	// AgentID provisioning is injected via app.Options.AgentThunderProvisioning.
 )
 
 var serviceProviderSet = wire.NewSet(
@@ -74,7 +74,8 @@ var serviceProviderSet = wire.NewSet(
 	services.NewMonitorManagerService,
 	ProvideThunderConfig,
 	services.NewMonitorSchedulerService,
-	services.NewAgentThunderProvisioningService,
+	// Provisioning service is injected (see InitializeAppParams); only the
+	// reconciler that consumes it is wired here.
 	services.NewAgentThunderReconcilerService,
 	services.NewEvaluatorManagerService,
 	services.NewEnvironmentService,
@@ -143,6 +144,12 @@ var testClientProviderSet = wire.NewSet(
 	thundersvc.NewProber,
 	ProvideEnvThunderResolver,
 	ProvideAgentSecretStore,
+)
+
+// thunderProvisioningTestSet builds the OpenBao-backed provisioning service for
+// the test wiring only; production injects it via InitializeAppParams.
+var thunderProvisioningTestSet = wire.NewSet(
+	services.NewAgentThunderProvisioningService,
 )
 
 // ProvideLogger provides the configured slog.Logger instance
@@ -499,8 +506,9 @@ func ProvideOrgResolver(client thundersvc.IdentityClient) middleware.OrgResolver
 	return middleware.NewOrgResolver(client)
 }
 
-// InitializeAppParams wires up all application dependencies
-func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier) (*AppParams, error) {
+// InitializeAppParams wires up all application dependencies. agentThunderProvisioning
+// is the deployment-injected AgentID provisioning implementation (nil to disable).
+func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier, agentThunderProvisioning services.AgentThunderProvisioningService) (*AppParams, error) {
 	wire.Build(
 		configProviderSet,
 		clientProviderSet,
@@ -527,6 +535,7 @@ func InitializeTestAppParamsWithClientMocks(
 ) (*AppParams, error) {
 	wire.Build(
 		testClientProviderSet,
+		thunderProvisioningTestSet,
 		loggerProviderSet,
 		repositoryProviderSet,
 		websocketProviderSet,

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -32,8 +32,9 @@ import (
 
 // Injectors from wire.go:
 
-// InitializeAppParams wires up all application dependencies
-func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier) (*AppParams, error) {
+// InitializeAppParams wires up all application dependencies. agentThunderProvisioning
+// is the deployment-injected AgentID provisioning implementation (nil to disable).
+func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier, agentThunderProvisioning services.AgentThunderProvisioningService) (*AppParams, error) {
 	configConfig := ProvideConfigFromPtr(cfg)
 	middleware := ProvideAuthMiddleware(configConfig)
 	logger := ProvideLogger()
@@ -94,17 +95,7 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	agentKindRepository := ProvideAgentKindRepository(db)
 	agentKindService := services.NewAgentKindService(agentKindRepository, openChoreoClient)
 	artifactRepository := ProvideArtifactRepository(db)
-	agentThunderClientRepository := ProvideAgentThunderClientRepository(db)
-	envThunderResolver, err := ProvideEnvThunderResolver(configConfig)
-	if err != nil {
-		return nil, err
-	}
-	agentSecretStore, err := ProvideAgentSecretStore(configConfig)
-	if err != nil {
-		return nil, err
-	}
-	agentThunderProvisioningService := services.NewAgentThunderProvisioningService(agentThunderClientRepository, envThunderResolver, agentSecretStore, logger)
-	agentManagerService := services.NewAgentManagerService(db, openChoreoClient, observabilitySvcClient, secretManagementClient, repositoryService, agentTokenManagerService, agentConfigRepository, agentConfigurationService, agentKindService, artifactRepository, aiApplicationService, gatewayRepository, agentThunderProvisioningService, logger)
+	agentManagerService := services.NewAgentManagerService(db, openChoreoClient, observabilitySvcClient, secretManagementClient, repositoryService, agentTokenManagerService, agentConfigRepository, agentConfigurationService, agentKindService, artifactRepository, aiApplicationService, gatewayRepository, agentThunderProvisioning, logger)
 	agentController := controllers.NewAgentController(agentManagerService, agentKindService)
 	agentKindController := controllers.NewAgentKindController(agentKindService)
 	infraResourceController := controllers.NewInfraResourceController(infraResourceManager)
@@ -166,7 +157,8 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	gitSecretController := controllers.NewGitSecretController(gitSecretService)
 	identityController := controllers.NewIdentityController(identityClient)
 	monitorSchedulerService := services.NewMonitorSchedulerService(openChoreoClient, publisherCredentialProvisioner, logger, monitorExecutor, monitorRepository)
-	agentThunderReconcilerService := services.NewAgentThunderReconcilerService(agentThunderProvisioningService, agentThunderClientRepository, logger)
+	agentThunderClientRepository := ProvideAgentThunderClientRepository(db)
+	agentThunderReconcilerService := services.NewAgentThunderReconcilerService(agentThunderProvisioning, agentThunderClientRepository, logger)
 	traceObserverSvcClient, err := ProvideTraceObserverClient(configConfig, authProvider)
 	if err != nil {
 		return nil, err
@@ -400,11 +392,10 @@ var clientProviderSet = wire.NewSet(
 	ProvideSecretManagementClient,
 	ProvidePublisherProvisioner,
 	ProvideIdentityClient,
-	ProvideOrgResolver, thundersvc.NewProber, ProvideEnvThunderResolver,
-	ProvideAgentSecretStore,
+	ProvideOrgResolver, thundersvc.NewProber,
 )
 
-var serviceProviderSet = wire.NewSet(services.NewAgentManagerService, services.NewAgentKindService, services.NewInfraResourceManager, services.NewAgentTokenManagerService, ProvideGitCredentialsService, services.NewRepositoryService, services.NewMonitorExecutor, services.NewMonitorManagerService, ProvideThunderConfig, services.NewMonitorSchedulerService, services.NewAgentThunderProvisioningService, services.NewAgentThunderReconcilerService, services.NewEvaluatorManagerService, services.NewEnvironmentService, services.NewPlatformGatewayService, services.NewLLMProviderTemplateService, services.NewLLMProviderService, services.NewLLMProxyService, services.NewLLMProviderDeploymentService, services.NewLLMProviderAPIKeyService, services.NewLLMProxyAPIKeyService, services.NewAgentAPIKeyService, services.NewLLMProxyDeploymentService, services.NewMCPProxyService, services.NewGatewayInternalAPIService, services.NewMonitorScoresService, services.NewCatalogService, services.NewLLMProxyProvisioner, services.NewAgentConfigurationService, services.NewLLMTemplateStore, services.NewGitSecretService, services.NewAIApplicationService)
+var serviceProviderSet = wire.NewSet(services.NewAgentManagerService, services.NewAgentKindService, services.NewInfraResourceManager, services.NewAgentTokenManagerService, ProvideGitCredentialsService, services.NewRepositoryService, services.NewMonitorExecutor, services.NewMonitorManagerService, ProvideThunderConfig, services.NewMonitorSchedulerService, services.NewAgentThunderReconcilerService, services.NewEvaluatorManagerService, services.NewEnvironmentService, services.NewPlatformGatewayService, services.NewLLMProviderTemplateService, services.NewLLMProviderService, services.NewLLMProxyService, services.NewLLMProviderDeploymentService, services.NewLLMProviderAPIKeyService, services.NewLLMProxyAPIKeyService, services.NewAgentAPIKeyService, services.NewLLMProxyDeploymentService, services.NewMCPProxyService, services.NewGatewayInternalAPIService, services.NewMonitorScoresService, services.NewCatalogService, services.NewLLMProxyProvisioner, services.NewAgentConfigurationService, services.NewLLMTemplateStore, services.NewGitSecretService, services.NewAIApplicationService)
 
 var instrumentationProviderSet = wire.NewSet(
 	ProvideInstrumentationCatalog,
@@ -424,6 +415,10 @@ var testClientProviderSet = wire.NewSet(
 	ProvideOrgResolver, thundersvc.NewProber, ProvideEnvThunderResolver,
 	ProvideAgentSecretStore,
 )
+
+// thunderProvisioningTestSet builds the OpenBao-backed provisioning service for
+// the test wiring only; production injects it via InitializeAppParams.
+var thunderProvisioningTestSet = wire.NewSet(services.NewAgentThunderProvisioningService)
 
 // ProvideLogger provides the configured slog.Logger instance
 func ProvideLogger() *slog.Logger {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The shared app/wiring path was unconditionally creating the OpenBao-backed `EnvThunderResolver` and `AgentSecretStore`, both of which fail fast when `OPENBAO_TOKEN` is missing. This broke cloud startup, where per-environment Thunder AgentID provisioning is not used and OpenBao is not configured.

Provisioning is now gated behind `app.Options.AgentThunderProvisioning` and injected per deployment. The open-source `main.go` injects `services.NewOpenBaoAgentThunderProvisioning`, preserving fail-fast behavior when `OPENBAO_*` is misconfigured. Cloud passes `nil`, disabling provisioning entirely: OpenBao is not constructed, the retry reconciler is not started, and identity endpoints return `ErrAgentIdentityNotProvisioned`.

`InitializeAppParams` now accepts the provisioning service as a parameter and no longer wires OpenBao clients in production. Test wiring still builds them because the integration suite runs with `OPENBAO_TOKEN` set. All `AgentManagerService` call sites now guard against nil provisioning, so create, promote, and delete flows skip provisioning without error.



## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Agent ID provisioning support for deployments that use it.
  * Startup and shutdown now handle provisioning only when enabled.

* **Bug Fixes**
  * Improved Agent identity flows to avoid errors when provisioning is not configured.
  * Agent creation, deletion, promotion, and identity endpoints now behave safely when Agent ID provisioning is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->