### PR TITLE
Add .NET external-agent instrumentation support

### DIFF
--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -211,6 +211,11 @@ Then configure the exporter to AMP. This is the .NET analog of `init_otel()`; th
 ```csharp
 const string SourceName = "my-dotnet-agent";
 
+var endpoint = Environment.GetEnvironmentVariable("AMP_OTEL_ENDPOINT")
+    ?? throw new InvalidOperationException("AMP_OTEL_ENDPOINT is not set");
+var apiKey = Environment.GetEnvironmentVariable("AMP_AGENT_API_KEY")
+    ?? throw new InvalidOperationException("AMP_AGENT_API_KEY is not set");
+
 // Exporter -> AMP. Note: when the OTLP Endpoint is set in code (rather than via
 // OTEL_EXPORTER_OTLP_ENDPOINT), the SDK does not append the signal path, so
 // include /v1/traces yourself.
@@ -219,9 +224,9 @@ Sdk.CreateTracerProviderBuilder()
     .AddSource(SourceName)               // must match the UseOpenTelemetry sourceName
     .AddOtlpExporter(o =>
     {
-        o.Endpoint = new Uri($"{Environment.GetEnvironmentVariable("AMP_OTEL_ENDPOINT")!.TrimEnd('/')}/v1/traces");
+        o.Endpoint = new Uri($"{endpoint.TrimEnd('/')}/v1/traces");
         o.Protocol = OtlpExportProtocol.HttpProtobuf;
-        o.Headers = $"x-amp-api-key={Environment.GetEnvironmentVariable("AMP_AGENT_API_KEY")}";
+        o.Headers = $"x-amp-api-key={Uri.EscapeDataString(apiKey)}";
     })
     .Build();
 

--- a/documentation/docs/components/amp-instrumentation.mdx
+++ b/documentation/docs/components/amp-instrumentation.mdx
@@ -190,6 +190,63 @@ A couple of kinds work as a *kind* but don't have their full data card extracted
 
 Prompt and completion content is captured by default. To suppress it, set `TRACELOOP_TRACE_CONTENT=false` in the agent's environment. The variable is read by the Traceloop SDK on the auto path and is documented here for parity — on a fully hand-rolled manual setup that bypasses Traceloop, you control what you put into `gen_ai.input.messages` / `gen_ai.output.messages` directly.
 
+## Instrumenting .NET agents
+
+AMP's platform-injected auto-instrumentation covers Python (and Ballerina). A .NET agent joins AMP through the **external-agent path**: register it in the Console, then have it push spans to AMP's OTLP endpoint using the same transport and contract as above (`POST ${AMP_OTEL_ENDPOINT}/v1/traces`, header `x-amp-api-key`, `gen_ai.*` attributes). Nothing on the AMP side is .NET-specific — any process that emits contract-shaped spans to that endpoint renders in the Console and feeds evaluators.
+
+The runnable [`dotnet-agent`](https://github.com/wso2/agent-manager/tree/main/samples/dotnet-agent) sample is the worked example of everything below.
+
+### Where the `gen_ai.*` spans come from
+
+Unlike Python's Traceloop SDK, OpenTelemetry's .NET **zero-code** auto-instrumentation (the CoreCLR profiler) ships **no** GenAI instrumentation — it produces infrastructure spans (ASP.NET Core, HttpClient, database) only. In .NET, `gen_ai.*` spans are emitted by the **AI SDK itself** through an `ActivitySource`. So the primary path is SDK-native emission, and the profiler is an optional add-on for infrastructure spans.
+
+The recommended SDK is **Microsoft Agent Framework** (Microsoft's successor to Semantic Kernel and AutoGen, built on Microsoft.Extensions.AI). It emits the GenAI conventions natively — one agent invocation yields `invoke_agent` → `chat` → `execute_tool` spans, the same shape AMP's Python agents produce.
+
+### Enabling it
+
+Instrument the **agent** with `UseOpenTelemetry(sourceName)` and let Agent Framework auto-wire the chat-client and tool spans beneath it. Do not also instrument the chat client yourself — that disables the auto-wiring and flattens the trace.
+
+Then configure the exporter to AMP. This is the .NET analog of `init_otel()`; the sample wraps it in [`AmpTelemetry.cs`](https://github.com/wso2/agent-manager/tree/main/samples/dotnet-agent/AmpTelemetry.cs):
+
+```csharp
+const string SourceName = "my-dotnet-agent";
+
+// Exporter -> AMP. Note: when the OTLP Endpoint is set in code (rather than via
+// OTEL_EXPORTER_OTLP_ENDPOINT), the SDK does not append the signal path, so
+// include /v1/traces yourself.
+Sdk.CreateTracerProviderBuilder()
+    .SetSampler(new AlwaysOnSampler())   // see note below
+    .AddSource(SourceName)               // must match the UseOpenTelemetry sourceName
+    .AddOtlpExporter(o =>
+    {
+        o.Endpoint = new Uri($"{Environment.GetEnvironmentVariable("AMP_OTEL_ENDPOINT")!.TrimEnd('/')}/v1/traces");
+        o.Protocol = OtlpExportProtocol.HttpProtobuf;
+        o.Headers = $"x-amp-api-key={Environment.GetEnvironmentVariable("AMP_AGENT_API_KEY")}";
+    })
+    .Build();
+
+// Agent: one UseOpenTelemetry call, same source name.
+AIAgent agent = new ChatClientAgent(chatClient, name: "WeatherAgent", instructions: "...", tools: [...])
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: cfg => cfg.EnableSensitiveData = true)
+    .Build();
+```
+
+Two things that will otherwise cost you a trace with no visible error:
+
+- **`AddSource(SourceName)` must match** the `sourceName` passed to `UseOpenTelemetry`. If it doesn't, the spans are created but never exported.
+- **Sampling.** When the agent runs inside a web request whose ASP.NET Core activity is not itself sampled (i.e. you have not added ASP.NET Core instrumentation), the default `ParentBased` sampler drops the agent's child spans. Use `AlwaysOnSampler` (as above), or add ASP.NET Core instrumentation so the request span is recorded.
+
+### Content capture and experimental conventions
+
+Message content (prompts, responses, tool arguments) is captured only when `EnableSensitiveData = true`. Wire it to the same `AMP_TRACE_CONTENT` toggle the rest of AMP uses so content can be suppressed without dropping spans.
+
+The .NET GenAI conventions are still experimental, so pin your package versions and set `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` across your fleet to keep the span shape stable.
+
+### Optional: infrastructure spans via zero-code
+
+To also capture ASP.NET Core / HttpClient / DB spans around the `gen_ai.*` spans, install the OpenTelemetry .NET zero-code (CoreCLR) auto-instrumentation and set its env vars (`CORECLR_ENABLE_PROFILING=1`, `CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}`, `CORECLR_PROFILER_PATH`, `DOTNET_STARTUP_HOOKS`, `OTEL_DOTNET_AUTO_HOME`), plus `OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES=<your source name>` so it also exports the agent's spans. On Alpine/musl images, point `CORECLR_PROFILER_PATH` at the `linux-musl-x64` native library rather than `linux-x64`. The profiler adds infrastructure spans only; it does not itself produce `gen_ai.*` spans.
+
 ## AMP instrumentation version mapping
 
 Each AMP-instrumentation version is a single semver shared by the PyPI package (`amp-instrumentation`) and the init-container image (`ghcr.io/wso2/amp-python-instrumentation-provider:<version>-python<X.Y>`) AMP injects into platform-hosted Python agents. The version is independent of the AMP product version. One AMP-instrumentation version pins exactly one Traceloop SDK version.

--- a/samples/dotnet-agent/.env.example
+++ b/samples/dotnet-agent/.env.example
@@ -1,0 +1,24 @@
+# --- AMP telemetry ---------------------------------------------------------
+# Where the agent ships spans, and the key that authenticates them. Generate
+# the API key in the AMP Console when you register the external agent
+# (register the agent -> Generate API Key), which also gives you the OTLP
+# endpoint.
+AMP_OTEL_ENDPOINT=
+AMP_AGENT_API_KEY=
+
+# --- Model -----------------------------------------------------------------
+# Required. The agent makes real chat-completion calls.
+OPENAI_API_KEY=
+# Optional. Defaults to gpt-4o-mini.
+OPENAI_MODEL=gpt-4o-mini
+# Optional. Point at an OpenAI-compatible backend (Azure OpenAI, a gateway, or
+# a local server). Leave unset for api.openai.com.
+OPENAI_BASE_URL=
+
+# --- Optional --------------------------------------------------------------
+# Set to false to suppress prompt/completion content in the emitted spans
+# (span structure and metadata are still recorded). Maps to Agent Framework's
+# EnableSensitiveData option.
+AMP_TRACE_CONTENT=true
+# Set to true to also print spans to the console, for local debugging.
+AMP_OTEL_CONSOLE=false

--- a/samples/dotnet-agent/.gitignore
+++ b/samples/dotnet-agent/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+.env

--- a/samples/dotnet-agent/Agent.cs
+++ b/samples/dotnet-agent/Agent.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.ClientModel;
+using System.ComponentModel;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using OpenAI;
+using OpenAI.Chat;
+
+namespace AmpDotnetAgent;
+
+/// <summary>
+/// Builds the sample agent on Microsoft Agent Framework and turns on its
+/// OpenTelemetry emission. The single <c>UseOpenTelemetry</c> call below is the
+/// only thing needed to produce AMP-compatible <c>gen_ai.*</c> spans — Agent
+/// Framework follows the OpenTelemetry GenAI semantic conventions natively, so
+/// one <c>/chat</c> call yields:
+///
+///   invoke_agent WeatherAgent   (root, from the agent)
+///   └── chat &lt;model&gt;             (the LLM call, auto-wired below)
+///       └── execute_tool GetWeather  (when the model calls the tool)
+///
+/// which is the same span shape AMP's Python agents emit.
+/// </summary>
+public static class AgentFactory
+{
+    private static readonly string Model =
+        Environment.GetEnvironmentVariable("OPENAI_MODEL") ?? "gpt-4o-mini";
+
+    public static AIAgent Create()
+    {
+        var apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY")
+            ?? throw new InvalidOperationException(
+                "OPENAI_API_KEY is required but not set.");
+
+        // Optional endpoint override for OpenAI-compatible backends (Azure OpenAI,
+        // a gateway, or a local server). Leave OPENAI_BASE_URL unset for OpenAI.
+        var baseUrl = Environment.GetEnvironmentVariable("OPENAI_BASE_URL");
+        var clientOptions = string.IsNullOrWhiteSpace(baseUrl)
+            ? null
+            : new OpenAIClientOptions { Endpoint = new Uri(baseUrl) };
+
+        // OpenAI SDK chat client -> Microsoft.Extensions.AI IChatClient, passed to
+        // the agent uninstrumented. UseOpenTelemetry on the *agent* auto-wires the
+        // chat-client instrumentation below the framework's function-invoking layer,
+        // which is what makes the spans nest correctly (invoke_agent -> chat ->
+        // execute_tool), all under AmpTelemetry.SourceName. Instrumenting the chat
+        // client yourself as well would disable that auto-wiring and flatten the
+        // trace.
+        IChatClient chatClient =
+            new ChatClient(Model, new ApiKeyCredential(apiKey), clientOptions)
+                .AsIChatClient();
+
+        return new ChatClientAgent(
+                chatClient,
+                name: "WeatherAgent",
+                instructions:
+                    "You are a helpful weather assistant. Use the tools available "
+                    + "to answer questions about the weather. Keep answers concise.",
+                tools: [AIFunctionFactory.Create(GetWeather)])
+            .AsBuilder()
+            .UseOpenTelemetry(
+                sourceName: AmpTelemetry.SourceName,
+                configure: cfg => cfg.EnableSensitiveData = AmpTelemetry.TraceContentEnabled)
+            .Build();
+    }
+
+    [Description("Get the current weather for a given city.")]
+    private static string GetWeather(
+        [Description("The city to get the weather for.")] string city)
+    {
+        // A real agent would call a weather API here. Kept deterministic so the
+        // sample runs with only an OpenAI key and produces a stable trace.
+        return $"The weather in {city} is sunny with a high of 24°C.";
+    }
+}

--- a/samples/dotnet-agent/AmpTelemetry.cs
+++ b/samples/dotnet-agent/AmpTelemetry.cs
@@ -104,7 +104,9 @@ public static class AmpTelemetry
                 {
                     options.Endpoint = new Uri(TracesEndpoint(endpoint));
                     options.Protocol = OtlpExportProtocol.HttpProtobuf;
-                    options.Headers = $"x-amp-api-key={apiKey}";
+                    // URL-encode: the OTLP exporter parses Headers by splitting
+                    // on ',' and '=', so a key containing either would break it.
+                    options.Headers = $"x-amp-api-key={Uri.EscapeDataString(apiKey)}";
                 });
 
             // Optional: also print spans to the console for local debugging
@@ -118,6 +120,22 @@ public static class AmpTelemetry
             }
 
             _provider = providerBuilder.Build();
+        }
+    }
+
+    /// <summary>
+    /// Flush and shut down the tracer provider so the OTLP batch exporter's
+    /// buffered spans are exported before the process exits. Wire this to the
+    /// application's shutdown event (see <c>Program.cs</c>). A no-op if
+    /// <see cref="Configure"/> was never called.
+    /// </summary>
+    public static void Shutdown()
+    {
+        lock (InitLock)
+        {
+            _provider?.Shutdown();
+            _provider?.Dispose();
+            _provider = null;
         }
     }
 

--- a/samples/dotnet-agent/AmpTelemetry.cs
+++ b/samples/dotnet-agent/AmpTelemetry.cs
@@ -1,0 +1,143 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace AmpDotnetAgent;
+
+/// <summary>
+/// The .NET analog of the <c>amp-instrumentation</c> package's <c>init_otel()</c>
+/// helper. It configures the global OpenTelemetry tracer provider to export spans
+/// over OTLP/HTTP to the AMP gateway, using the <c>AMP_OTEL_ENDPOINT</c> and
+/// <c>AMP_AGENT_API_KEY</c> environment variables — the same two AMP injects into
+/// platform-hosted agents.
+///
+/// It does <i>no</i> instrumentation itself. The agent's
+/// <c>.WithOpenTelemetry(SourceName)</c> / <c>.UseOpenTelemetry(SourceName)</c>
+/// (see <see cref="AgentFactory"/>) is what emits the <c>gen_ai.*</c> spans; this
+/// class only wires the exporter so those spans reach AMP. Idempotent, like
+/// <c>init_otel()</c>.
+/// </summary>
+public static class AmpTelemetry
+{
+    /// <summary>
+    /// The <see cref="System.Diagnostics.ActivitySource"/> name the agent
+    /// instrumentation emits under, and that the tracer provider subscribes to.
+    /// Must match the <c>sourceName</c> passed to
+    /// <c>WithOpenTelemetry</c>/<c>UseOpenTelemetry</c>. If you drop the explicit
+    /// name there, Agent Framework defaults to
+    /// <c>"Experimental.Microsoft.Agents.AI"</c> — subscribe to that instead.
+    /// </summary>
+    public const string SourceName = "amp-dotnet-agent";
+
+    // OTLP/HTTP traces signal path appended to AMP_OTEL_ENDPOINT. When the
+    // exporter Endpoint is set in code (rather than via OTEL_EXPORTER_OTLP_ENDPOINT),
+    // the SDK does NOT append the signal path, so we add it ourselves — matching
+    // amp-instrumentation's otel.py:_traces_endpoint.
+    private const string TracesPath = "/v1/traces";
+
+    private static readonly Lock InitLock = new();
+    private static TracerProvider? _provider;
+
+    /// <summary>
+    /// Whether prompt/response content should be captured in spans. Honors
+    /// <c>AMP_TRACE_CONTENT</c> (the variable AMP's env-injection trait sets);
+    /// content capture is on unless it is explicitly <c>false</c>. Maps to Agent
+    /// Framework's <c>EnableSensitiveData</c> option.
+    /// </summary>
+    public static bool TraceContentEnabled =>
+        !string.Equals(
+            Environment.GetEnvironmentVariable("AMP_TRACE_CONTENT"),
+            "false",
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Configure the global OpenTelemetry tracer provider to export spans to AMP.
+    /// Reads <c>AMP_OTEL_ENDPOINT</c> and <c>AMP_AGENT_API_KEY</c> from the
+    /// environment. A second call is a no-op.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// If <c>AMP_OTEL_ENDPOINT</c> or <c>AMP_AGENT_API_KEY</c> is unset.
+    /// </exception>
+    public static void Configure()
+    {
+        lock (InitLock)
+        {
+            if (_provider is not null)
+            {
+                return;
+            }
+
+            var endpoint = RequireEnv("AMP_OTEL_ENDPOINT");
+            var apiKey = RequireEnv("AMP_AGENT_API_KEY");
+
+            var resource = ResourceBuilder.CreateDefault()
+                .AddService(
+                    serviceName: Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME")
+                        ?? "amp-dotnet-agent");
+
+            var providerBuilder = Sdk.CreateTracerProviderBuilder()
+                .SetResourceBuilder(resource)
+                // Always record agent spans. Without this, the default
+                // ParentBased sampler drops the agent's spans when they are
+                // nested under an unsampled parent (e.g. the ASP.NET Core request
+                // activity, which this sample does not instrument).
+                .SetSampler(new AlwaysOnSampler())
+                .AddSource(SourceName)
+                .AddOtlpExporter(options =>
+                {
+                    options.Endpoint = new Uri(TracesEndpoint(endpoint));
+                    options.Protocol = OtlpExportProtocol.HttpProtobuf;
+                    options.Headers = $"x-amp-api-key={apiKey}";
+                });
+
+            // Optional: also print spans to the console for local debugging
+            // (the .NET analog of amp-instrumentation's console option).
+            if (string.Equals(
+                    Environment.GetEnvironmentVariable("AMP_OTEL_CONSOLE"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                providerBuilder.AddConsoleExporter();
+            }
+
+            _provider = providerBuilder.Build();
+        }
+    }
+
+    private static string TracesEndpoint(string baseEndpoint)
+    {
+        var trimmed = baseEndpoint.TrimEnd('/');
+        return trimmed.EndsWith(TracesPath, StringComparison.Ordinal)
+            ? trimmed
+            : trimmed + TracesPath;
+    }
+
+    private static string RequireEnv(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name)?.Trim();
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable '{name}' is required but not set.");
+        }
+
+        return value;
+    }
+}

--- a/samples/dotnet-agent/Dockerfile
+++ b/samples/dotnet-agent/Dockerfile
@@ -11,6 +11,9 @@ FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 COPY --from=build /app .
 
+# Run as the non-root user the .NET runtime images provide.
+USER $APP_UID
+
 # The agent listens on 8000 (see Program.cs).
 EXPOSE 8000
 

--- a/samples/dotnet-agent/Dockerfile
+++ b/samples/dotnet-agent/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY dotnet-agent.csproj .
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /app .
+
+# The agent listens on 8000 (see Program.cs).
+EXPOSE 8000
+
+# --- Optional: OpenTelemetry .NET zero-code (CoreCLR) overlay --------------
+# The lines below add automatic infrastructure spans (ASP.NET Core, HttpClient,
+# DB) *around* the gen_ai.* spans the app already emits. They are NOT required
+# for AMP telemetry — the app owns its OTLP exporter and gen_ai spans via
+# AmpTelemetry/Agent Framework. Uncomment to enable, and install the auto-
+# instrumentation into the image (see the .NET section of the AMP instrumentation
+# docs). The profiler alone produces no gen_ai.* spans.
+#
+# ENV CORECLR_ENABLE_PROFILING=1 \
+#     CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318} \
+#     CORECLR_PROFILER_PATH=/otel-dotnet-auto/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so \
+#     DOTNET_STARTUP_HOOKS=/otel-dotnet-auto/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll \
+#     OTEL_DOTNET_AUTO_HOME=/otel-dotnet-auto \
+#     OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES=amp-dotnet-agent
+# NOTE: use linux-musl-x64 instead of linux-x64 on Alpine base images.
+
+ENTRYPOINT ["dotnet", "dotnet-agent.dll"]

--- a/samples/dotnet-agent/Program.cs
+++ b/samples/dotnet-agent/Program.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Text.Json.Serialization;
+using AmpDotnetAgent;
+
+// Wire the OpenTelemetry exporter to AMP before creating the agent, exactly like
+// the manual-instrumentation Python sample calls init_otel() in app.py.
+AmpTelemetry.Configure();
+
+var agent = AgentFactory.Create();
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/healthz", () => Results.Ok("ok"));
+
+// One /chat request -> one trace (invoke_agent -> chat -> execute_tool).
+app.MapPost("/chat", async (ChatRequest req) =>
+{
+    var response = await agent.RunAsync(req.Message);
+    return Results.Ok(new ChatResponse(req.SessionId, response.Text));
+});
+
+app.Run("http://0.0.0.0:8000");
+
+public record ChatRequest(
+    [property: JsonPropertyName("session_id")] string? SessionId,
+    [property: JsonPropertyName("message")] string Message);
+
+public record ChatResponse(
+    [property: JsonPropertyName("session_id")] string? SessionId,
+    [property: JsonPropertyName("response")] string Response);

--- a/samples/dotnet-agent/Program.cs
+++ b/samples/dotnet-agent/Program.cs
@@ -26,6 +26,9 @@ var agent = AgentFactory.Create();
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
+// Flush buffered spans to AMP before the process exits.
+app.Lifetime.ApplicationStopping.Register(AmpTelemetry.Shutdown);
+
 app.MapGet("/healthz", () => Results.Ok("ok"));
 
 // One /chat request -> one trace (invoke_agent -> chat -> execute_tool).

--- a/samples/dotnet-agent/README.md
+++ b/samples/dotnet-agent/README.md
@@ -1,0 +1,153 @@
+# .NET External Agent Sample
+
+A small .NET agent that sends OpenTelemetry GenAI traces to WSO2 Agent Manager
+(AMP) as an externally-hosted agent. It's the .NET version of the Python
+[`manual-instrumentation-agent`](../manual-instrumentation-agent) and uses the
+same trace contract, so it shows up in the AMP Console the same way.
+
+## What this shows
+
+AMP auto-instruments Python and Ballerina agents for you. There's no equivalent
+for .NET yet, so a .NET agent connects through the external-agent path instead.
+You host and run the agent yourself, and it pushes traces to AMP's OTLP
+endpoint. AMP doesn't build or run it. It just registers the agent and gives you
+an API key to authenticate the traces you send.
+
+The agent itself is a small weather assistant built with
+[Microsoft Agent Framework](https://learn.microsoft.com/en-us/agent-framework/overview/)
+(Microsoft's newer agent SDK, built on Microsoft.Extensions.AI). Agent Framework
+emits the OpenTelemetry
+[GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+out of the box, so its spans render in the Console and feed evaluators just like
+an auto-instrumented Python agent does.
+
+## How it works
+
+There are two parts, which line up with the Python sample's `init_otel()` plus
+agent split:
+
+- [`AmpTelemetry.cs`](./AmpTelemetry.cs) is the equivalent of `init_otel()`. It
+  reads `AMP_OTEL_ENDPOINT` and `AMP_AGENT_API_KEY`, then sets up the
+  OpenTelemetry tracer provider to export spans over OTLP/HTTP to
+  `<AMP_OTEL_ENDPOINT>/v1/traces` with the `x-amp-api-key` header. It doesn't do
+  any instrumentation on its own.
+- [`Agent.cs`](./Agent.cs) is the agent. One `UseOpenTelemetry(sourceName)` call
+  on the agent is all you need. Agent Framework wires up the chat and tool spans
+  underneath it automatically.
+
+A single `/chat` request produces one trace:
+
+```text
+invoke_agent WeatherAgent   (agent, root)
+├── chat <model>            (the model decides to call a tool)
+│   └── execute_tool GetWeather  (the tool runs)
+└── chat <model>            (the model writes the final answer)
+```
+
+### What's on the spans
+
+The spans carry the OpenTelemetry GenAI attributes AMP's observer reads:
+`gen_ai.operation.name` (`invoke_agent`, `chat`, `execute_tool`),
+`gen_ai.agent.name`, `gen_ai.request.model`, `gen_ai.tool.name`,
+`gen_ai.usage.input_tokens` / `output_tokens`, and the input and output messages
+when content capture is on. The full list is in
+[the contract](https://wso2.github.io/agent-manager/docs/latest/components/amp-instrumentation/#the-contract).
+
+## Prerequisites
+
+- .NET 10 SDK (see below to install)
+- An OpenAI API key (or any OpenAI-compatible endpoint, set via `OPENAI_BASE_URL`)
+- An agent registered in the AMP Console, which gives you the `AMP_AGENT_API_KEY`
+  and the OTLP endpoint
+
+### Installing the .NET SDK
+
+If you don't already have the `dotnet` command, grab the .NET 10 SDK. The
+official installers and instructions for every platform are here:
+<https://dotnet.microsoft.com/download/dotnet/10.0> (Microsoft's per-OS guide:
+<https://learn.microsoft.com/en-us/dotnet/core/install/>).
+
+Quick options:
+
+```bash
+# macOS (Homebrew)
+brew install dotnet
+
+# Linux / macOS (Microsoft's install script, no root needed)
+curl -fsSL https://dot.net/v1/dotnet-install.sh | bash -s -- --channel 10.0
+# then add it to PATH for the current shell:
+export PATH="$HOME/.dotnet:$PATH"
+```
+
+On Windows use the installer from the download page above, or `winget install
+Microsoft.DotNet.SDK.10`. Confirm it worked with `dotnet --version` (you should
+see a `10.x` version).
+
+## Run it
+
+Register the agent in the AMP Console first and generate its API key. See
+[Register an externally-hosted agent](https://wso2.github.io/agent-manager/docs/latest/getting-started/create-your-first-agent/#register-an-externally-hosted-agent).
+That gives you the OTLP endpoint and the `AMP_AGENT_API_KEY`.
+
+Then set the environment variables and run it:
+
+```bash
+cd samples/dotnet-agent
+
+export AMP_OTEL_ENDPOINT="<your-amp-otel-endpoint>"
+export AMP_AGENT_API_KEY="<key-from-the-amp-console>"
+export OPENAI_API_KEY="<your-openai-key>"
+
+dotnet run
+```
+
+The agent listens on `http://localhost:8000`.
+
+## Test it
+
+Send it a request with `curl`:
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"session_id": "demo-1", "message": "What is the weather in Tokyo?"}'
+```
+
+You get back the agent's answer, and one full trace goes to AMP behind it.
+
+If you want to watch the spans locally while you test, set `AMP_OTEL_CONSOLE=true`
+before running. They print to the console as well as getting exported.
+
+## See the traces
+
+Open the agent in the AMP Console and go to **OBSERVABILITY → Traces**. Each
+`/chat` call shows up as one trace, with the per-kind icons, the model and token
+chips, and the input and output. The spans follow the contract, so evaluators
+run against them too.
+
+## Notes
+
+- **Content capture.** Prompt and completion text is captured by default. Set
+  `AMP_TRACE_CONTENT=false` to turn it off. The spans and metadata are still
+  recorded, you just lose the message text.
+- **Experimental conventions.** The .NET GenAI conventions are still
+  experimental, and Agent Framework moves fast, so the package versions in
+  [`dotnet-agent.csproj`](./dotnet-agent.csproj) are pinned on purpose. Bump them
+  deliberately.
+- **Infrastructure spans (optional).** If you also want ASP.NET Core, HttpClient,
+  and DB spans around the gen_ai spans, add the OpenTelemetry .NET zero-code
+  (CoreCLR) auto-instrumentation. There's a commented setup in the
+  [`Dockerfile`](./Dockerfile), and more detail in the .NET section of the AMP
+  instrumentation docs. The profiler only adds infrastructure spans though; it
+  won't produce the gen_ai spans on its own.
+
+## Files
+
+| File | Role |
+|---|---|
+| `AmpTelemetry.cs` | Configures the OpenTelemetry OTLP exporter to AMP. The `init_otel()` equivalent. |
+| `Agent.cs` | The Microsoft Agent Framework agent and its `UseOpenTelemetry` wiring. |
+| `Program.cs` | ASP.NET Core minimal API (`POST /chat`, `GET /healthz`). Calls `AmpTelemetry.Configure()`. |
+| `dotnet-agent.csproj` | Pinned package references. |
+| `Dockerfile` | Container build, with the optional zero-code overlay documented. |
+| `.env.example` | Environment variable template. |

--- a/samples/dotnet-agent/appsettings.json
+++ b/samples/dotnet-agent/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/dotnet-agent/dotnet-agent.csproj
+++ b/samples/dotnet-agent/dotnet-agent.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>AmpDotnetAgent</RootNamespace>
+    <AssemblyName>dotnet-agent</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Microsoft Agent Framework: the agent + its OpenTelemetry emission
+         (.WithOpenTelemetry / .UseOpenTelemetry). Pinned; the framework is
+         evolving, so bump deliberately. -->
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.13.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <!-- OTLP/HTTP exporter that ships the gen_ai.* spans to AMP. -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/instrumentation-matrix/cells/otel_native_agent_sample.py
+++ b/test/instrumentation-matrix/cells/otel_native_agent_sample.py
@@ -1,0 +1,84 @@
+"""OTel-GenAI-native cell sample.
+
+Re-expresses, in Python, the span shape Microsoft Agent Framework (.NET) emits —
+the same shape ``samples/dotnet-agent/`` produces — so the OTel-native contract
+is locked into the emission matrix and re-checked on every PR that touches the
+observer. There is no LLM/network call: the spans are constructed directly from
+a fixed, representative interaction (the weather-agent tool call documented in
+``samples/dotnet-agent/README.md``), which keeps the cell deterministic and
+cassette-free.
+
+Trace shape (matches samples/dotnet-agent):
+
+    invoke_agent WeatherAgent
+    ├── chat {model}                 (model decides to call the tool)
+    │   └── execute_tool GetWeather
+    └── chat {model}                 (final answer)
+
+Distinctive OTel-native traits exercised here (vs the Traceloop shape):
+  * span names "{operation} {model}" (no vendor prefix, no ".chat" suffix)
+  * gen_ai.provider.name instead of gen_ai.system
+  * structured parts[] messages instead of flat content strings
+  * gen_ai.tool.call.arguments / gen_ai.tool.call.result for tool I/O
+"""
+from __future__ import annotations
+
+import json
+
+from opentelemetry import trace
+
+_MODEL = "gpt-4o-mini"
+_PROVIDER = "openai"
+
+# Structured "parts[]" messages — the current OTel GenAI shape (not flat content).
+_USER_MSG = json.dumps(
+    [{"role": "user", "parts": [{"type": "text", "content": "What is the weather in Tokyo?"}]}]
+)
+_FINAL_MSG = json.dumps(
+    [{"role": "assistant", "parts": [{"type": "text", "content": "It is sunny in Tokyo, 24C."}]}]
+)
+
+
+def run_scenario() -> None:
+    tracer = trace.get_tracer("otel-native-agent-sample")
+
+    with tracer.start_as_current_span("invoke_agent WeatherAgent") as agent_span:
+        agent_span.set_attribute("gen_ai.operation.name", "invoke_agent")
+        agent_span.set_attribute("gen_ai.provider.name", _PROVIDER)
+        agent_span.set_attribute("gen_ai.agent.name", "WeatherAgent")
+        agent_span.set_attribute("gen_ai.request.model", _MODEL)
+        agent_span.set_attribute("gen_ai.input.messages", _USER_MSG)
+        agent_span.set_attribute("gen_ai.output.messages", _FINAL_MSG)
+        agent_span.set_attribute("gen_ai.usage.input_tokens", 40)
+        agent_span.set_attribute("gen_ai.usage.output_tokens", 20)
+
+        # First chat: the model requests the tool.
+        with tracer.start_as_current_span(f"chat {_MODEL}") as chat1:
+            _set_chat_attrs(chat1, input_tokens=20, output_tokens=10)
+            chat1.set_attribute("gen_ai.input.messages", _USER_MSG)
+            chat1.set_attribute("gen_ai.response.finish_reasons", json.dumps(["tool_calls"]))
+
+            with tracer.start_as_current_span("execute_tool GetWeather") as tool_span:
+                tool_span.set_attribute("gen_ai.operation.name", "execute_tool")
+                tool_span.set_attribute("gen_ai.tool.name", "GetWeather")
+                tool_span.set_attribute(
+                    "gen_ai.tool.call.arguments", json.dumps({"city": "Tokyo"})
+                )
+                tool_span.set_attribute(
+                    "gen_ai.tool.call.result", "The weather in Tokyo is sunny, 24C."
+                )
+
+        # Second chat: the model produces the final answer.
+        with tracer.start_as_current_span(f"chat {_MODEL}") as chat2:
+            _set_chat_attrs(chat2, input_tokens=20, output_tokens=10)
+            chat2.set_attribute("gen_ai.output.messages", _FINAL_MSG)
+            chat2.set_attribute("gen_ai.response.finish_reasons", json.dumps(["stop"]))
+
+
+def _set_chat_attrs(span, *, input_tokens: int, output_tokens: int) -> None:
+    span.set_attribute("gen_ai.operation.name", "chat")
+    span.set_attribute("gen_ai.provider.name", _PROVIDER)
+    span.set_attribute("gen_ai.request.model", _MODEL)
+    span.set_attribute("gen_ai.response.model", _MODEL)
+    span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
+    span.set_attribute("gen_ai.usage.output_tokens", output_tokens)

--- a/test/instrumentation-matrix/matrix.yaml
+++ b/test/instrumentation-matrix/matrix.yaml
@@ -22,6 +22,15 @@ providers:
     versions: ["0.1.0"]
     contractSchema: "v1"
 
+  otel-genai:
+    # OTel-GenAI-native shape (Microsoft Agent Framework / OpenAI .NET SDK, i.e.
+    # samples/dotnet-agent/). Emission-only, like the manual provider — no
+    # init-container, so no instrumentationVersions. The cell re-expresses the
+    # native span shape in Python; the concrete OTel SDK version is pinned via
+    # the framework package below.
+    versions: ["0.1.0"]
+    contractSchema: "v1"
+
 frameworks:
   # Auto-instrumentation frameworks below all use `provider: traceloop` —
   # otherwise the manual provider would cross-product into each one and
@@ -92,6 +101,15 @@ frameworks:
     versions: ["2.38.0"]
     samplePath: cells/manual_rag_sample.py
     spanKinds: [agent, chain, embedding, retriever, rerank, llm, tool]
+    extras: []
+
+  - name: otel-native
+    provider: otel-genai      # restricts this framework to the otel-genai provider only
+    package: opentelemetry-sdk # the synthetic cell's only runtime dep
+    versions: ["1.43.0"]
+    samplePath: cells/otel_native_agent_sample.py
+    # The .NET/OTel-native trace tree: invoke_agent -> chat -> execute_tool.
+    spanKinds: [agent, llm, tool]
     extras: []
 
   - name: anthropic-direct

--- a/test/instrumentation-matrix/providers/__init__.py
+++ b/test/instrumentation-matrix/providers/__init__.py
@@ -1,8 +1,10 @@
 from harness.provider import InstrumentationProvider
 from providers.manual import ManualProvider
+from providers.otel_genai import OtelGenAIProvider
 from providers.traceloop import TraceloopProvider
 
 PROVIDERS: dict[str, InstrumentationProvider] = {
     "traceloop": TraceloopProvider(),
     "manual": ManualProvider(),
+    "otel-genai": OtelGenAIProvider(),
 }

--- a/test/instrumentation-matrix/providers/bootstrap/otel-genai/sitecustomize.py
+++ b/test/instrumentation-matrix/providers/bootstrap/otel-genai/sitecustomize.py
@@ -1,0 +1,33 @@
+"""Test-only sitecustomize for the otel-genai provider.
+
+Wires a stdlib OpenTelemetry SDK with InMemorySpanExporter so the cell harness
+can read captured spans synchronously — identical to the manual provider's
+bootstrap. The otel-genai cell constructs OTel-GenAI-native spans directly (no
+LLM/network call), so there is no OTLP delivery path to exercise here; the
+matrix validates the emitted span *shape* against AMP's contract.
+"""
+import logging
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+try:
+    import builtins
+
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    _exporter = InMemorySpanExporter()
+    _provider = TracerProvider()
+    _provider.add_span_processor(SimpleSpanProcessor(_exporter))
+    otel_trace.set_tracer_provider(_provider)
+
+    builtins.__amp_matrix_exporter__ = _exporter
+    log.info("matrix-test sitecustomize (otel-genai) initialized")
+
+except Exception as e:  # pragma: no cover
+    log.exception("matrix-test sitecustomize (otel-genai) failed: %s", e)

--- a/test/instrumentation-matrix/providers/otel_genai.py
+++ b/test/instrumentation-matrix/providers/otel_genai.py
@@ -1,0 +1,41 @@
+"""OTel-GenAI-native provider.
+
+Exercises the current OpenTelemetry GenAI semantic conventions as emitted by
+OTel-native SDKs (e.g. Microsoft Agent Framework and the OpenAI .NET SDK):
+span names shaped ``{operation} {model}`` (e.g. ``chat gpt-4o-mini``),
+``gen_ai.provider.name`` rather than the legacy ``gen_ai.system``, structured
+``parts[]`` messages, and ``gen_ai.tool.call.*`` tool I/O.
+
+The .NET external-agent sample (``samples/dotnet-agent/``) emits exactly this
+shape. This provider re-expresses it in Python so the shape is locked into the
+compatibility matrix and validated against the same contract bundle the observer
+reads. It is emission-only (no init-container / instrumentationVersions), like
+the ``manual`` provider. See ``harness/classify.py`` — the classifier already
+recognises this semconv.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+
+
+class OtelGenAIProvider:
+    name = "otel-genai"
+
+    def package_specs(self, version: str) -> list[str]:
+        # Vanilla OpenTelemetry only — no monkey-patching SDK. The SDK itself is
+        # pinned via the framework package in matrix.yaml so the cell venv gets a
+        # concrete version; here we just ensure the API is present.
+        return ["opentelemetry-api"]
+
+    def bootstrap_module(self) -> Path:
+        return _HERE / "bootstrap" / "otel-genai" / "sitecustomize.py"
+
+    def contract_schema_id(self) -> str:
+        # Same schema bundle as every other provider: the observer's contract is
+        # source-agnostic.
+        return "traceloop/v1"
+
+    def normalize_span(self, raw_span):
+        return raw_span

--- a/traces-observer-service/opensearch/process.go
+++ b/traces-observer-service/opensearch/process.go
@@ -259,13 +259,20 @@ func populateRetrieverAttributes(ampAttrs *AmpAttributes, attrs map[string]inter
 
 // populateAgentAttributes extracts and populates agent-specific attributes
 func populateAgentAttributes(ampAttrs *AmpAttributes, attrs map[string]interface{}) {
-	// For Otel agent spans, we could also check gen_ai.input.message and gen_ai.output.message
-	if input, ok := attrs["gen_ai.input.messages"].(string); ok {
-		ampAttrs.Input = input
+	// OTel-native agent spans (e.g. Microsoft Agent Framework "invoke_agent")
+	// carry gen_ai.input.messages / gen_ai.output.messages. Flatten them through
+	// the same parts-aware extractors the LLM path uses, so agent-level
+	// evaluators and the detail view receive structured messages instead of the
+	// raw parts[] JSON string.
+	if _, ok := attrs["gen_ai.input.messages"].(string); ok {
+		if msgs := ExtractPromptMessages(attrs); len(msgs) > 0 {
+			ampAttrs.Input = msgs
+		}
 	}
-
-	if output, ok := attrs["gen_ai.output.messages"].(string); ok {
-		ampAttrs.Output = output
+	if _, ok := attrs["gen_ai.output.messages"].(string); ok {
+		if msgs := ExtractCompletionMessages(attrs); len(msgs) > 0 {
+			ampAttrs.Output = msgs
+		}
 	}
 
 	// For standard agent spans, use traceloop.entity attributes
@@ -620,11 +627,13 @@ func ExtractTokenUsage(spans []Span) *TokenUsage {
 }
 
 // IsLLMLeafSpan reports whether a span name looks like a leaf LLM call.
-// Narrow match on the ".chat" suffix covers ChatOpenAI.chat, openai.chat,
-// anthropic.chat, cohere.chat, etc., while avoiding chain / agent / tool
-// spans whose names share the gen_ai surface.
+// Matches the Traceloop ".chat" suffix (ChatOpenAI.chat, openai.chat,
+// anthropic.chat, cohere.chat, etc.) and the OTel GenAI native "chat {model}"
+// name (e.g. "chat gpt-4o-mini"), while avoiding chain / agent / tool spans
+// whose names share the gen_ai surface.
 func IsLLMLeafSpan(spanName string) bool {
-	return strings.HasSuffix(spanName, ".chat")
+	lower := strings.ToLower(strings.TrimSpace(spanName))
+	return strings.HasSuffix(lower, ".chat") || lower == "chat" || strings.HasPrefix(lower, "chat ")
 }
 
 // ExtractInputPreviewFromLeaf returns a short preview of the user-facing
@@ -1794,6 +1803,8 @@ func ExtractToolExecutionDetails(attrs map[string]interface{}, spanStatus string
 		input = funcArgs
 	} else if genAIArgs, ok := attrs["gen_ai.tool.arguments"].(string); ok { // OTEL-ish
 		input = genAIArgs
+	} else if genAICallArgs, ok := attrs["gen_ai.tool.call.arguments"].(string); ok { // OTel GenAI (Agent Framework)
+		input = genAICallArgs
 	} else if genAIInputMessages, ok := attrs["gen_ai.input.messages"].(string); ok && genAIInputMessages != "" {
 		// OTel GenAI structured messages — last-resort tool-input fallback
 		// (lower priority than the traceloop.entity.* / tool.* / function.* keys above).
@@ -1811,6 +1822,8 @@ func ExtractToolExecutionDetails(attrs map[string]interface{}, spanStatus string
 		output = funcResult
 	} else if genAIOutput, ok := attrs["gen_ai.tool.output"].(string); ok { // OTEL-ish
 		output = genAIOutput
+	} else if genAICallResult, ok := attrs["gen_ai.tool.call.result"].(string); ok { // OTel GenAI (Agent Framework)
+		output = genAICallResult
 	} else if genAIOutputMessages, ok := attrs["gen_ai.output.messages"].(string); ok && genAIOutputMessages != "" {
 		// OTel GenAI structured messages — last-resort tool-output fallback.
 		output = genAIOutputMessages
@@ -2003,12 +2016,27 @@ func DetermineSpanKindFromName(name string) SpanType {
 
 	// Traceloop / LangGraph action prefixes (e.g. "invoke_agent LangGraph").
 	switch {
-	case strings.HasPrefix(lower, "invoke_agent"), strings.HasPrefix(lower, "execute_agent"):
+	case strings.HasPrefix(lower, "invoke_agent"), strings.HasPrefix(lower, "execute_agent"),
+		strings.HasPrefix(lower, "create_agent"):
 		return SpanTypeAgent
 	case strings.HasPrefix(lower, "execute_tool"):
 		return SpanTypeTool
 	case strings.HasPrefix(lower, "execute_task"):
 		return SpanTypeChain
+	}
+
+	// OTel GenAI native names are "{operation} {model}" with no "." separator
+	// (e.g. "chat gpt-4o-mini", "embeddings text-embedding-3-small"). Classify
+	// on the leading operation token. Traceloop instead names spans
+	// "{vendor}.{operation}" (e.g. "openai.chat"), handled by the "."-segment
+	// switch below.
+	if i := strings.IndexByte(lower, ' '); i > 0 {
+		switch lower[:i] {
+		case "chat", "text_completion", "completion", "generate_content":
+			return SpanTypeLLM
+		case "embeddings", "embedding":
+			return SpanTypeEmbedding
+		}
 	}
 
 	// Last "."-segment (e.g. "openai.embeddings" → "embeddings").

--- a/traces-observer-service/opensearch/process_test.go
+++ b/traces-observer-service/opensearch/process_test.go
@@ -1394,6 +1394,76 @@ func TestExtractToolExecutionDetails_OTelMessagesFallback(t *testing.T) {
 			t.Errorf("output = %q, want 'entity result'", output)
 		}
 	})
+
+	t.Run("reads OTel gen_ai.tool.call.arguments/result (Agent Framework)", func(t *testing.T) {
+		attrs := map[string]interface{}{
+			"gen_ai.tool.name":           "GetWeather",
+			"gen_ai.tool.call.arguments": `{"city":"Tokyo"}`,
+			"gen_ai.tool.call.result":    "The weather in Tokyo is sunny.",
+		}
+		name, input, output, _ := ExtractToolExecutionDetails(attrs, "OK")
+		if name != "GetWeather" {
+			t.Errorf("name = %q", name)
+		}
+		if input != `{"city":"Tokyo"}` {
+			t.Errorf("input = %q", input)
+		}
+		if output != "The weather in Tokyo is sunny." {
+			t.Errorf("output = %q", output)
+		}
+	})
+}
+
+func TestPopulateAgentAttributes_OTelMessagesFlattened(t *testing.T) {
+	attrs := map[string]interface{}{
+		"gen_ai.agent.name":      "WeatherAgent",
+		"gen_ai.input.messages":  `[{"role":"user","parts":[{"type":"text","content":"weather in Tokyo?"}]}]`,
+		"gen_ai.output.messages": `[{"role":"assistant","parts":[{"type":"text","content":"It is sunny in Tokyo."}]}]`,
+	}
+	amp := &AmpAttributes{}
+	populateAgentAttributes(amp, attrs)
+
+	inMsgs, ok := amp.Input.([]PromptMessage)
+	if !ok {
+		t.Fatalf("Input type = %T, want []PromptMessage (flattened, not raw JSON string)", amp.Input)
+	}
+	if !containsContent(inMsgs, "weather in Tokyo?") {
+		t.Errorf("input = %+v, want flattened user content", inMsgs)
+	}
+
+	outMsgs, ok := amp.Output.([]PromptMessage)
+	if !ok {
+		t.Fatalf("Output type = %T, want []PromptMessage", amp.Output)
+	}
+	if !containsContent(outMsgs, "It is sunny in Tokyo.") {
+		t.Errorf("output = %+v, want flattened assistant content", outMsgs)
+	}
+}
+
+func TestPopulateAgentAttributes_TraceloopFallback(t *testing.T) {
+	attrs := map[string]interface{}{
+		"gen_ai.agent.name":       "Agent",
+		"traceloop.entity.input":  "some input",
+		"traceloop.entity.output": "some output",
+	}
+	amp := &AmpAttributes{}
+	populateAgentAttributes(amp, attrs)
+
+	if amp.Input != "some input" {
+		t.Errorf("Input = %v, want traceloop.entity.input passthrough", amp.Input)
+	}
+	if amp.Output != "some output" {
+		t.Errorf("Output = %v, want traceloop.entity.output passthrough", amp.Output)
+	}
+}
+
+func containsContent(msgs []PromptMessage, want string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m.Content, want) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestPopulateRetrieverAttributes verifies db.system.name precedence over the
@@ -1560,11 +1630,21 @@ func TestProcessSpan_PureOTelGenAISpans(t *testing.T) {
 		if amp.Kind != string(SpanTypeAgent) {
 			t.Fatalf("kind = %q, want agent", amp.Kind)
 		}
-		if amp.Input != `[{"role":"user","content":"research X"}]` {
-			t.Errorf("input = %#v", amp.Input)
+		// Agent input/output are flattened to structured messages (same as LLM
+		// spans), not passed through as the raw gen_ai.*.messages JSON string.
+		inMsgs, ok := amp.Input.([]PromptMessage)
+		if !ok {
+			t.Fatalf("input type = %T, want []PromptMessage", amp.Input)
 		}
-		if amp.Output != `[{"role":"assistant","content":"here is X"}]` {
-			t.Errorf("output = %#v", amp.Output)
+		if !containsContent(inMsgs, "research X") {
+			t.Errorf("input = %#v, want flattened user content", amp.Input)
+		}
+		outMsgs, ok := amp.Output.([]PromptMessage)
+		if !ok {
+			t.Fatalf("output type = %T, want []PromptMessage", amp.Output)
+		}
+		if !containsContent(outMsgs, "here is X") {
+			t.Errorf("output = %#v, want flattened assistant content", amp.Output)
 		}
 		data, ok := amp.Data.(AgentData)
 		if !ok {
@@ -1639,16 +1719,48 @@ func TestIsLLMLeafSpan(t *testing.T) {
 		{"LangChain ChatOpenAI", "ChatOpenAI.chat", true},
 		{"Anthropic", "anthropic.chat", true},
 		{"Cohere", "cohere.chat", true},
+		{"OTel native chat leaf", "chat gpt-4o-mini", true},
+		{"OTel native chat, bare", "chat", true},
 		{"LangGraph workflow chain — not a leaf", "LangGraph.workflow", false},
 		{"invoke_agent root", "invoke_agent LangGraph", false},
 		{"execute_task chain", "execute_task call_model", false},
 		{"embedding span", "openai.embeddings", false},
+		{"OTel native embeddings — not a leaf", "embeddings text-embedding-3-small", false},
 		{"empty", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := IsLLMLeafSpan(tc.in); got != tc.want {
 				t.Errorf("IsLLMLeafSpan(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetermineSpanKindFromName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want SpanType
+	}{
+		// OTel GenAI native "{operation} {model}" names.
+		{"OTel chat", "chat gpt-4o-mini", SpanTypeLLM},
+		{"OTel text_completion", "text_completion gpt-3.5-turbo-instruct", SpanTypeLLM},
+		{"OTel embeddings", "embeddings text-embedding-3-small", SpanTypeEmbedding},
+		{"OTel invoke_agent", "invoke_agent WeatherAgent(abc123)", SpanTypeAgent},
+		{"OTel create_agent", "create_agent WeatherAgent", SpanTypeAgent},
+		{"OTel execute_tool", "execute_tool GetWeather", SpanTypeTool},
+		// Traceloop "{vendor}.{operation}" names still classify.
+		{"Traceloop openai.chat", "openai.chat", SpanTypeLLM},
+		{"Traceloop openai.embeddings", "openai.embeddings", SpanTypeEmbedding},
+		{"Traceloop LangGraph.workflow", "LangGraph.workflow", SpanTypeChain},
+		{"unknown", "some random span", SpanTypeUnknown},
+		{"empty", "", SpanTypeUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DetermineSpanKindFromName(tc.in); got != tc.want {
+				t.Errorf("DetermineSpanKindFromName(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Purpose

AMP auto-instruments Python and Ballerina agents, but there is no path for .NET agents. This adds the missing .NET story through the external-agent path, and fixes the trace-rendering gaps that any OTel-GenAI-native (non-Traceloop) agent hits along the way.

Fixes https://github.com/wso2/agent-manager/issues/1284

## Goals

- Let a .NET agent report `gen_ai.*` traces to AMP as an externally-hosted agent, so it renders in the Console and feeds evaluators the same way a Python agent does.
- Make the traces observer recognize the current OpenTelemetry GenAI span shapes, not only the older Traceloop convention.
- Lock the OTel-native span shape into the instrumentation-matrix contract so a future regression is caught in CI.

## Approach

Three parts, one commit each:

1. **Sample + docs.** `samples/dotnet-agent/` is a Microsoft Agent Framework weather agent that emits `invoke_agent -> chat -> execute_tool` `gen_ai.*` spans and exports them over OTLP to the AMP gateway `/otel` endpoint with an `x-amp-api-key` token. `AmpTelemetry.cs` is the .NET analog of the Python `init_otel()` helper. The `.NET` section added to `documentation/docs/components/amp-instrumentation.mdx` explains the path, the env vars, the content toggle, and the optional CoreCLR zero-code overlay for infrastructure spans.

2. **Observer.** Real .NET traces showed an unknown-kind icon and blank Input/Output columns because the observer classified spans by name and only recognized the Traceloop naming (`vendor.chat`). Agent Framework names LLM spans `chat {model}`. `traces-observer-service/opensearch/process.go` now recognizes the OTel-native names (`DetermineSpanKindFromName`, `IsLLMLeafSpan`), reads `gen_ai.tool.call.arguments/result` for tool I/O, and flattens the agent span's `parts[]` messages like the LLM path (`populateAgentAttributes`). The `gen_ai.provider.name` fallback and the `parts[]` message format were already handled.

3. **Matrix.** An emission-tier `otel-genai` provider and `otel-native` cell (mirroring the existing `manual` provider) re-express the .NET span shape in Python and validate it against the existing contract bundle, so the OTel-native contract is re-checked on every PR that touches the observer.

The evaluation library needs no change: it consumes the observer's normalized `ampAttributes` and classifies by kind, so the observer fix covers it.

## User stories

As a developer with a .NET agent, I want to register and observe it in AMP so I get the same trace view and evaluation as a platform-hosted Python agent.

## Release note

Add a .NET external-agent instrumentation sample and recognize OpenTelemetry-GenAI-native span shapes in the traces observer.

## Documentation

Added a `.NET` section to `documentation/docs/components/amp-instrumentation.mdx` (in this PR). The sample ships its own `README.md`.

## Training

N/A. No training-content impact.

## Certification

N/A. No impact on certification exams.

## Marketing

N/A. No marketing content associated with this change.

## Automation tests

- Unit tests
  - `traces-observer-service`: added Go unit tests for the OTel-native classification, leaf detection, tool-call keys, and agent-span flattening; full `go test ./...` passes.
  - `test/instrumentation-matrix`: harness unit tests pass; the new `otel-native` emission cell passes (coverage `agent`/`llm`/`tool`, zero schema violations); `check-matrix-manifest` and `check-contract-drift` pass.
- Integration tests
  - Verified the sample end-to-end locally against a mock OpenAI endpoint and a local OTLP sink (full `invoke_agent -> chat -> execute_tool` trace exported to `/otel/v1/traces` with the token; `AMP_TRACE_CONTENT=false` redaction confirmed), and against a local k3d stack with the updated observer (icon, Input/Output columns, and tool I/O render correctly).

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: N/A (no Java code in this change)
- Confirmed this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes (`.env` is gitignored; keys and the OTLP endpoint are supplied at runtime via environment variables)

## Samples

`samples/dotnet-agent/` is a runnable Microsoft Agent Framework agent that publishes `gen_ai.*` traces to AMP as an externally-hosted agent. It includes a README with install and run steps, a `.env.example`, and a Dockerfile (with the optional zero-code overlay documented).

## Related PRs

None.

## Migrations (if applicable)

N/A. No schema or data migration.

## Test environment

- .NET 10 SDK (`net10.0`), macOS
- `traces-observer-service` built and tested with Go
- Instrumentation-matrix emission cell on Python 3.11
- A local k3d cluster for the end-to-end observer check

## Learning

Microsoft Agent Framework observability docs, the OpenTelemetry GenAI semantic conventions, and the OpenTelemetry .NET zero-code instrumentation docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new .NET external agent sample with a runnable chat endpoint, weather tool, and AMP/OpenTelemetry trace export setup.
  * Expanded documentation for instrumenting .NET agents, including setup, trace content capture, and optional local console output.

* **Bug Fixes**
  * Improved trace handling so agent messages and tool data are captured in a more consistent, readable format.
  * Broadened detection of agent and chat span patterns for better trace visibility in AMP.

* **Tests**
  * Added coverage for the new OpenTelemetry GenAI trace shapes and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->