### PR TITLE
Add default namespace for traces-observer organziation queries

### DIFF
--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: "{{ .Values.tracesObserver.observer.baseUrl }}"
             - name: IDP_TOKEN_URL
               value: "{{ .Values.tracesObserver.observer.idpTokenUrl }}"
+            - name: OBSERVER_DEFAULT_NAMESPACE
+              value: "{{ .Values.tracesObserver.observer.defaultNamespace }}"
             - name: IDP_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
@@ -23,6 +23,7 @@ tracesObserver:
     idpTokenUrl: "http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token"
     idpClientId: "amp-api-client"
     idpClientSecret: "amp-api-client-secret"
+    defaultNamespace: "default"
   # JWT authentication — must match the agent-manager keyManager config so the
   # same user token issued by Thunder is accepted by both services. Thunder
   # (v0.45+) stamps the resource-server identifier "amp" as the token audience,

--- a/traces-observer-service/.env.example
+++ b/traces-observer-service/.env.example
@@ -11,6 +11,9 @@ IDP_TOKEN_URL=http://localhost:8090/oauth2/token
 IDP_CLIENT_ID=amp-api-client
 IDP_CLIENT_SECRET=amp-api-client-secret
 
+# Namespace all trace queries are scoped to (single-namespace deployment).
+OBSERVER_DEFAULT_NAMESPACE=default
+
 # -----------------------------------------------------------------------------
 # Development Environment
 # Set IS_LOCAL_DEV_ENV=true to skip JWT validation (local dev only).

--- a/traces-observer-service/AGENTS.md
+++ b/traces-observer-service/AGENTS.md
@@ -63,6 +63,7 @@ make mock-traces  # generate OTLP traces via telemetrygen (for local testing)
 | `IDP_TOKEN_URL` | `cfg.Observer.TokenURL` | Observer OAuth2 token endpoint |
 | `IDP_CLIENT_ID` | `cfg.Observer.ClientID` | Observer OAuth2 client id |
 | `IDP_CLIENT_SECRET` | `cfg.Observer.ClientSecret` | Observer OAuth2 client secret |
+| `OBSERVER_DEFAULT_NAMESPACE` | `cfg.Observer.DefaultNamespace` | namespace all trace queries are scoped to (default `default`) |
 | `KEY_MANAGER_JWKS_URL` | `cfg.Auth.JWKSUrl` | JWKS endpoint for JWT validation |
 | `KEY_MANAGER_ISSUER` | `cfg.Auth.Issuer` (list) | accepted token issuers (comma-separated) |
 | `KEY_MANAGER_AUDIENCE` | `cfg.Auth.Audience` (list) | accepted audiences (comma-separated) |

--- a/traces-observer-service/config/config.go
+++ b/traces-observer-service/config/config.go
@@ -37,6 +37,8 @@ type ObserverConfig struct {
 	TokenURL     string
 	ClientID     string
 	ClientSecret string
+	// DefaultNamespace scopes all trace queries to a single namespace.
+	DefaultNamespace string
 }
 
 // AuthConfig holds JWT authentication configuration
@@ -59,10 +61,11 @@ func Load() (*Config, error) {
 			Port: getEnvAsInt("TRACES_OBSERVER_PORT", 9098),
 		},
 		Observer: ObserverConfig{
-			BaseURL:      getEnv("OBSERVER_BASE_URL", ""),
-			TokenURL:     getEnv("IDP_TOKEN_URL", ""),
-			ClientID:     getEnv("IDP_CLIENT_ID", ""),
-			ClientSecret: getEnv("IDP_CLIENT_SECRET", ""),
+			BaseURL:          getEnv("OBSERVER_BASE_URL", ""),
+			TokenURL:         getEnv("IDP_TOKEN_URL", ""),
+			ClientID:         getEnv("IDP_CLIENT_ID", ""),
+			ClientSecret:     getEnv("IDP_CLIENT_SECRET", ""),
+			DefaultNamespace: getEnv("OBSERVER_DEFAULT_NAMESPACE", "default"),
 		},
 		LogLevel: getEnv("LOG_LEVEL", "INFO"),
 		Auth: AuthConfig{

--- a/traces-observer-service/controllers/controller.go
+++ b/traces-observer-service/controllers/controller.go
@@ -99,7 +99,7 @@ func (c *TracingController) GetTraceOverviews(ctx context.Context, params TraceQ
 		Limit:     &params.Limit,
 		SortOrder: &sortOrder,
 		SearchScope: observer.ComponentSearchScope{
-			Namespace:   params.Organization,
+			Namespace:   c.observerClient.NamespaceFor(params.Organization),
 			Project:     params.Project,
 			Component:   params.Agent,
 			Environment: params.Environment,
@@ -318,7 +318,7 @@ func (c *TracingController) fetchTraceSpanSummaries(
 		EndTime:   params.EndTime,
 		Limit:     &spanLimit,
 		SearchScope: observer.ComponentSearchScope{
-			Namespace:   params.Organization,
+			Namespace:   c.observerClient.NamespaceFor(params.Organization),
 			Project:     params.Project,
 			Component:   params.Agent,
 			Environment: params.Environment,
@@ -481,7 +481,7 @@ func (c *TracingController) GetTraceSpans(ctx context.Context, traceID string, p
 		Limit:     &params.Limit,
 		SortOrder: &sortOrder,
 		SearchScope: observer.ComponentSearchScope{
-			Namespace:   params.Organization,
+			Namespace:   c.observerClient.NamespaceFor(params.Organization),
 			Project:     params.Project,
 			Component:   params.Agent,
 			Environment: params.Environment,
@@ -543,7 +543,7 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 		Limit:     &params.Limit,
 		SortOrder: &sortOrder,
 		SearchScope: observer.ComponentSearchScope{
-			Namespace:   params.Organization,
+			Namespace:   c.observerClient.NamespaceFor(params.Organization),
 			Project:     params.Project,
 			Component:   params.Agent,
 			Environment: params.Environment,
@@ -602,7 +602,7 @@ func (c *TracingController) ExportTraces(ctx context.Context, params TraceQueryP
 				Limit:             &spanLimit,
 				IncludeAttributes: true,
 				SearchScope: observer.ComponentSearchScope{
-					Namespace:   params.Organization,
+					Namespace:   c.observerClient.NamespaceFor(params.Organization),
 					Project:     params.Project,
 					Component:   params.Agent,
 					Environment: params.Environment,

--- a/traces-observer-service/controllers/controller_test.go
+++ b/traces-observer-service/controllers/controller_test.go
@@ -60,6 +60,10 @@ func (f *fakeObserverClient) QueryTraceSpans(_ context.Context, _ string, req ob
 	return &observer.TraceSpansQueryResponse{Spans: f.spans, Total: len(f.spans)}, nil
 }
 
+func (f *fakeObserverClient) NamespaceFor(organization string) string {
+	return organization
+}
+
 func (f *fakeObserverClient) GetSpanDetails(_ context.Context, _, spanID string) (*observer.SpanDetailsResponse, error) {
 	atomic.AddInt32(&f.getSpanDetailsCalls, 1)
 	if f.rootSpan != nil && spanID == f.rootSpan.SpanID {

--- a/traces-observer-service/controllers/controller_test.go
+++ b/traces-observer-service/controllers/controller_test.go
@@ -48,6 +48,9 @@ type fakeObserverClient struct {
 
 	getSpanDetailsCalls  int32
 	queryTraceSpansCalls int32
+
+	// defaultNamespace is returned by NamespaceFor, mirroring the real client.
+	defaultNamespace string
 }
 
 func (f *fakeObserverClient) QueryTraces(_ context.Context, _ observer.TracesQueryRequest) (*observer.TracesQueryResponse, error) {
@@ -60,8 +63,8 @@ func (f *fakeObserverClient) QueryTraceSpans(_ context.Context, _ string, req ob
 	return &observer.TraceSpansQueryResponse{Spans: f.spans, Total: len(f.spans)}, nil
 }
 
-func (f *fakeObserverClient) NamespaceFor(organization string) string {
-	return organization
+func (f *fakeObserverClient) NamespaceFor(_ string) string {
+	return f.defaultNamespace
 }
 
 func (f *fakeObserverClient) GetSpanDetails(_ context.Context, _, spanID string) (*observer.SpanDetailsResponse, error) {

--- a/traces-observer-service/main.go
+++ b/traces-observer-service/main.go
@@ -94,7 +94,7 @@ func main() {
 		cfg.Observer.ClientID,
 		cfg.Observer.ClientSecret,
 	)
-	observerClient := observer.NewClient(cfg.Observer.BaseURL, authProvider)
+	observerClient := observer.NewClient(cfg.Observer.BaseURL, authProvider, cfg.Observer.DefaultNamespace)
 	controller := controllers.NewTracingController(observerClient)
 	handler := handlers.NewHandler(controller)
 

--- a/traces-observer-service/observer/client.go
+++ b/traces-observer-service/observer/client.go
@@ -37,21 +37,30 @@ type Client interface {
 
 	// GetSpanDetails fetches the full details (including OTEL attributes) for a single span.
 	GetSpanDetails(ctx context.Context, traceID, spanID string) (*SpanDetailsResponse, error)
+
+	// NamespaceFor resolves the namespace a trace query is scoped to.
+	NamespaceFor(organization string) string
 }
 
 type clientImpl struct {
-	baseURL      string
-	authProvider *AuthProvider
-	httpClient   *http.Client
+	baseURL          string
+	authProvider     *AuthProvider
+	httpClient       *http.Client
+	defaultNamespace string
 }
 
 // NewClient creates a new observer service client.
-func NewClient(baseURL string, auth *AuthProvider) Client {
+func NewClient(baseURL string, auth *AuthProvider, defaultNamespace string) Client {
 	return &clientImpl{
-		baseURL:      baseURL,
-		authProvider: auth,
-		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		baseURL:          baseURL,
+		authProvider:     auth,
+		httpClient:       &http.Client{Timeout: 30 * time.Second},
+		defaultNamespace: defaultNamespace,
 	}
+}
+
+func (c *clientImpl) NamespaceFor(_ string) string {
+	return c.defaultNamespace
 }
 
 func (c *clientImpl) QueryTraces(ctx context.Context, req TracesQueryRequest) (*TracesQueryResponse, error) {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

traces-observer previously used the incoming organization param as the OpenChoreo searchScope.namespace. This adds an OBSERVER_DEFAULT_NAMESPACE config (default "default") and resolves every trace query through observer.Client.NamespaceFor, so all queries scope to a single configured namespace - this behaviour is intended for onPrem as it is single tenanted.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable default namespace for trace queries and exports.
  * Trace requests now use a namespace derived from the organization instead of a direct value.

* **Bug Fixes**
  * Improved trace retrieval behavior in deployments where queries must be scoped to a specific namespace.

* **Documentation**
  * Updated environment and configuration references with the new namespace setting.

* **Tests**
  * Extended test doubles to cover namespace resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->