### PR TITLE
Bundle quick-start install resources into image

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -17,7 +17,8 @@
     },
     {
       "name": "amp-quick-start",
-      "dir": "deployments/quick-start"
+      "dir": "deployments/quick-start",
+      "context": "."
     },
     {
       "name": "amp-evaluation-monitor",

--- a/deployments/quick-start/Dockerfile
+++ b/deployments/quick-start/Dockerfile
@@ -35,14 +35,30 @@ RUN adduser -D -h ${USER_HOME} -s /bin/bash wso2-amp && \
     echo "wso2-amp ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/wso2-amp && \
     chmod 0440 /etc/sudoers.d/wso2-amp
 
-COPY --chown=wso2-amp:wso2-amp .bash_profile ${USER_HOME}/.bash_profile
-COPY --chown=wso2-amp:wso2-amp .bashrc ${USER_HOME}/.bashrc
+# Build context is the repo root (see release-config.json: amp-quick-start
+# sets "context": "."), so paths below are repo-relative. This lets the image
+# bundle the deployment resources the installer applies (values/, manifests,
+# helper scripts) instead of fetching them from raw.githubusercontent.com at
+# install time — GitHub rate-limits unauthenticated per-IP requests with HTTP
+# 429, and helm/kubectl do not retry, which aborts the install.
+COPY --chown=wso2-amp:wso2-amp deployments/quick-start/.bash_profile ${USER_HOME}/.bash_profile
+COPY --chown=wso2-amp:wso2-amp deployments/quick-start/.bashrc ${USER_HOME}/.bashrc
 # Copy scripts and configs
-COPY --chown=wso2-amp:wso2-amp install.sh ${USER_HOME}/install.sh
-COPY --chown=wso2-amp:wso2-amp install-helpers.sh ${USER_HOME}/install-helpers.sh
-COPY --chown=wso2-amp:wso2-amp uninstall.sh ${USER_HOME}/uninstall.sh
-COPY --chown=wso2-amp:wso2-amp k3d-config.yaml ${USER_HOME}/k3d-config.yaml
-COPY --chown=root:root entrypoint.sh /entrypoint.sh
+COPY --chown=wso2-amp:wso2-amp deployments/quick-start/install.sh ${USER_HOME}/install.sh
+COPY --chown=wso2-amp:wso2-amp deployments/quick-start/install-helpers.sh ${USER_HOME}/install-helpers.sh
+COPY --chown=wso2-amp:wso2-amp deployments/quick-start/uninstall.sh ${USER_HOME}/uninstall.sh
+COPY --chown=wso2-amp:wso2-amp deployments/quick-start/k3d-config.yaml ${USER_HOME}/k3d-config.yaml
+COPY --chown=root:root deployments/quick-start/entrypoint.sh /entrypoint.sh
+
+# Bundle deployment resources next to the scripts (flat layout). install.sh
+# resolves these under ${SCRIPT_DIR} when the parent-relative repo layout is
+# absent (see DEPLOYMENTS_DIR in install.sh).
+COPY --chown=wso2-amp:wso2-amp deployments/single-cluster/ ${USER_HOME}/single-cluster/
+COPY --chown=wso2-amp:wso2-amp deployments/values/ ${USER_HOME}/values/
+COPY --chown=wso2-amp:wso2-amp deployments/k8s/coredns-amp-custom.yaml ${USER_HOME}/k8s/coredns-amp-custom.yaml
+# Whole scripts/ dir: add-environment-thunder.sh sources its sibling
+# thunder-naming.sh, so both (and the other env helpers) must ship together.
+COPY --chown=wso2-amp:wso2-amp deployments/scripts/ ${USER_HOME}/scripts/
 RUN chmod +x ${USER_HOME}/install.sh && \
     chmod +x /entrypoint.sh && \
     chmod +x ${USER_HOME}/install-helpers.sh && \

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -245,22 +245,32 @@ install_observability_extension() {
 # so the script pins its own validated ThunderID version — the agent-manager
 # release VERSION has no bearing on which ThunderID release env-Thunder runs.
 install_default_env_thunder() {
-    local script_url="https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts/add-environment-thunder.sh"
-    local tmp_script
-    tmp_script="$(mktemp)"
+    # Prefer the copy bundled next to the installer (DEPLOYMENTS_DIR is set by
+    # install.sh). Fetching it from raw.githubusercontent.com is a fallback for
+    # standalone use; GitHub rate-limits unauthenticated per-IP requests (429),
+    # so avoid the network whenever the bundled script is present.
+    local bundled_script="${DEPLOYMENTS_DIR:-}/scripts/add-environment-thunder.sh"
+    local script_path tmp_script=""
 
-    if ! curl -fsSL --connect-timeout 30 "${script_url}" -o "${tmp_script}" 2>/dev/null; then
-        echo "Failed to download add-environment-thunder.sh from ${script_url}"
-        rm -f "${tmp_script}"
-        return 1
+    if [[ -n "${DEPLOYMENTS_DIR:-}" && -f "${bundled_script}" ]]; then
+        script_path="${bundled_script}"
+    else
+        local script_url="https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts/add-environment-thunder.sh"
+        tmp_script="$(mktemp)"
+        if ! curl -fsSL --connect-timeout 30 "${script_url}" -o "${tmp_script}" 2>/dev/null; then
+            echo "Failed to download add-environment-thunder.sh from ${script_url}"
+            rm -f "${tmp_script}"
+            return 1
+        fi
+        script_path="${tmp_script}"
     fi
 
     ENV_NAME=default \
         DISPLAY_NAME="Default" \
         ORG_NAME=default \
-        bash "${tmp_script}"
+        bash "${script_path}"
     local status=$?
-    rm -f "${tmp_script}"
+    [[ -n "${tmp_script}" ]] && rm -f "${tmp_script}"
     return $status
 }
 

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -21,6 +21,21 @@ OPENCHOREO_VERSION="1.1.1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 K3D_CONFIG="${K3D_CONFIG:-${SCRIPT_DIR}/k3d-config.yaml}"
 
+# Directory holding the deployment resources this installer applies
+# (single-cluster/, values/, k8s/, scripts/). These used to be fetched from
+# raw.githubusercontent.com at install time, but GitHub rate-limits
+# unauthenticated requests per client IP and returns HTTP 429 once the
+# per-IP budget is spent (common behind shared/corporate NAT). helm --values
+# <url> and kubectl apply -f <url> do not retry on 429, so a single throttled
+# response aborts the install. Resolve the bundled copies on disk instead:
+# in a repo checkout they live one level up from quick-start/; the dev-container
+# image bundles the same tree flat alongside the scripts.
+if [[ -d "${SCRIPT_DIR}/../single-cluster" ]]; then
+    DEPLOYMENTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+    DEPLOYMENTS_DIR="${SCRIPT_DIR}"
+fi
+
 # WSO2 API Platform / Gateway Operator versions
 GATEWAY_OPERATOR_VERSION="0.7.0"
 GATEWAY_CHART_VERSION="1.1.0"
@@ -673,7 +688,7 @@ log_info "Applying CoreDNS custom configuration for OpenChoreo and AMP..."
 # that rewrites the in-cluster names to the k3d server node instead of
 # host.k3d.internal — required once host ports are loopback-bound. See
 # deployments/vm/lib-vm.sh:render_coredns_vm_config.
-COREDNS_FILE="${COREDNS_FILE:-https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/k8s/coredns-amp-custom.yaml}"
+COREDNS_FILE="${COREDNS_FILE:-${DEPLOYMENTS_DIR}/k8s/coredns-amp-custom.yaml}"
 if kubectl apply -f "${COREDNS_FILE}"; then
     log_success "CoreDNS custom configuration applied successfully"
 else
@@ -809,7 +824,7 @@ if helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
     --namespace openbao \
     --create-namespace \
     --version 0.25.6 \
-    --values "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-openbao.yaml" \
+    --values "${DEPLOYMENTS_DIR}/single-cluster/values-openbao.yaml" \
     --timeout 180s &>/dev/null; then
     log_success "OpenBao installed successfully"
 else
@@ -877,7 +892,7 @@ else
         --create-namespace \
         --timeout "${TIMEOUT_CONTROL_PLANE}s" \
         --version "${OPENCHOREO_VERSION}" \
-        --values "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-cp.yaml" \
+        --values "${DEPLOYMENTS_DIR}/single-cluster/values-cp.yaml" \
         "${CP_HELM_ARGS[@]}" 2>&1); then
         echo "$CP_INSTALL_OUTPUT"
         if echo "$CP_INSTALL_OUTPUT" | grep -q "no endpoints available for service \"controller-manager-webhook-service\""; then
@@ -889,7 +904,7 @@ else
                 --create-namespace \
                 --timeout "${TIMEOUT_CONTROL_PLANE}s" \
                 --version "${OPENCHOREO_VERSION}" \
-                --values "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-cp.yaml" \
+                --values "${DEPLOYMENTS_DIR}/single-cluster/values-cp.yaml" \
                 "${CP_HELM_ARGS[@]}" || { log_error "Failed to install openchoreo-control-plane after retry"; exit 1; }
         else
             log_error "Failed to install openchoreo-control-plane"
@@ -957,7 +972,7 @@ helm_install_idempotent \
     "${DATA_PLANE_NS}" \
     "${TIMEOUT_DATA_PLANE}" \
     --version "${OPENCHOREO_VERSION}" \
-    --values "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-dp.yaml"
+    --values "${DEPLOYMENTS_DIR}/single-cluster/values-dp.yaml"
 
 # Register Data Plane with Control Plane
 log_info "Registering Data Plane with Control Plane..."
@@ -1040,14 +1055,28 @@ log_info "Installing Docker Registry for Workflow Plane..."
 if helm status registry -n openchoreo-workflow-plane &>/dev/null; then
     log_info "Docker Registry already installed, skipping..."
 else
+    # The registry values live in the upstream OpenChoreo repo, not ours, so we
+    # can't bundle them alongside the installer. helm --values <url> does not
+    # retry on GitHub's per-IP 429, so pre-download the file with backoff and
+    # hand helm the local path instead of letting helm fetch it.
+    registry_values="$(mktemp)"
+    registry_values_url="https://raw.githubusercontent.com/openchoreo/openchoreo/v${OPENCHOREO_VERSION}/install/k3d/single-cluster/values-registry.yaml"
+    if ! curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 30 \
+        "${registry_values_url}" -o "${registry_values}"; then
+        rm -f "${registry_values}"
+        log_error "Failed to download registry values from ${registry_values_url}"
+        exit 1
+    fi
     if helm upgrade --install registry docker-registry \
         --repo https://twuni.github.io/docker-registry.helm \
         --namespace openchoreo-workflow-plane \
         --create-namespace \
-        --values https://raw.githubusercontent.com/openchoreo/openchoreo/v${OPENCHOREO_VERSION}/install/k3d/single-cluster/values-registry.yaml \
+        --values "${registry_values}" \
         --timeout 120s; then
+        rm -f "${registry_values}"
         log_success "Docker Registry installed successfully"
     else
+        rm -f "${registry_values}"
         log_error "Failed to install Docker Registry"
         exit 1
     fi
@@ -1159,7 +1188,7 @@ fi
 
 # Apply OpenTelemetry Collector ConfigMap (idempotent)
 log_info "Applying Custom OpenTelemetry Collector configuration..."
-CONFIGMAP_FILE="https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/oc-collector-configmap.yaml"
+CONFIGMAP_FILE="${DEPLOYMENTS_DIR}/values/oc-collector-configmap.yaml"
 
 if kubectl apply -f "${CONFIGMAP_FILE}" -n "${OBSERVABILITY_NS}" &>/dev/null; then
     log_success "OpenTelemetry Collector configuration applied successfully"
@@ -1182,7 +1211,7 @@ helm_install_idempotent \
     "${TIMEOUT_OBSERVABILITY_PLANE}" \
     --version "${OPENCHOREO_VERSION}" \
     --set observer.extraEnv.AUTH_SERVER_BASE_URL=http://thunder-service.openchoreo-control-plane.svc.cluster.local:8090 \
-    --values "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-op.yaml"
+    --values "${DEPLOYMENTS_DIR}/single-cluster/values-op.yaml"
 
 # Install Observability Modules
 log_info "Installing Observability Modules..."
@@ -1517,7 +1546,7 @@ if ! install_default_env_thunder; then
     log_warning "Default environment Thunder provisioning failed (non-fatal)"
     echo "Re-run manually once the platform is ready:"
     echo "  ENV_NAME=default DISPLAY_NAME=Default ORG_NAME=default \\"
-    echo "  bash <(curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts/add-environment-thunder.sh)"
+    echo "  bash ${DEPLOYMENTS_DIR}/scripts/add-environment-thunder.sh"
 else
     log_success "Default environment Thunder identity provider provisioned"
     ENV_THUNDER_PROVISIONED=true
@@ -1572,7 +1601,7 @@ fi
 echo ""
 
 # Apply RestApi for OTEL trace collection
-RESTAPI_FILE="https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/otel-collector-rest-api.yaml"
+RESTAPI_FILE="${DEPLOYMENTS_DIR}/values/otel-collector-rest-api.yaml"
 log_info "Applying OTEL RestApi resource..."
 if kubectl apply -f "${RESTAPI_FILE}" &>/dev/null; then
     log_info "Waiting for RestApi to be programmed..."


### PR DESCRIPTION
## Purpose
While testing the quick-start guide, the installer intermittently failed with `429 Too Many Requests` when fetching Helm values files, e.g.:

```
Error: INSTALLATION FAILED: failed to fetch https://raw.githubusercontent.com/wso2/agent-manager/amp/v<version>/deployments/single-cluster/values-cp.yaml : 429 Too Many Requests
```

The quick-start installer downloaded ~10 Helm values files and Kubernetes manifests from `raw.githubusercontent.com` during a single run. GitHub rate-limits unauthenticated requests per client IP and returns HTTP 429 once the per-IP budget is spent — easy to trigger behind shared or corporate NAT, and likely to affect customer environments. Neither `helm --values <url>` nor `kubectl apply -f <url>` retries on 429, so a single throttled response aborts the install (the control-plane and data-plane steps failed on `values-cp.yaml` / `values-dp.yaml`).

Fixes [wso2/agent-manager#1289](https://github.com/wso2/agent-manager/issues/1289)

## Goals
Remove the install-time dependency on `raw.githubusercontent.com` for the quick-start's own values/manifests so a GitHub rate-limit can no longer abort the install.

## Approach
Resolve the deployment resources from disk instead of over the network:

- `install.sh` computes a `DEPLOYMENTS_DIR` that points at the repo tree one level up from `quick-start/` (git-clone and VM installer paths, where the tree is already present) or at a flat layout bundled beside the scripts (dev container). All nine remote fetches — CoreDNS config, OpenBao/CP/DP/OP/registry values, the OTEL collector ConfigMap, the OTEL RestApi, and the Thunder helper — now use local paths.
- The `amp-quick-start` dev-container build context moves to the repo root (`"context": "."` in `.github/release-config.json`, mirroring the existing `amp-evaluation-monitor` image), so the Dockerfile can `COPY` `single-cluster/`, `values/`, `k8s/`, and `scripts/` into the image.
- `add-environment-thunder.sh` already prefers its local sibling `thunder-naming.sh`, so shipping the whole `scripts/` dir keeps it offline too. The remote download remains only as a fallback for standalone use.
- The Docker Registry values come from the upstream OpenChoreo repo, which we can't bundle with our tree, and that fetch counts against the same per-IP 429 budget regardless of repo. Since `helm --values <url>` won't retry, the installer now pre-downloads that one file with `curl --retry` and hands helm the local path.

This takes effect for the dev-container path once the `amp-quick-start` image is rebuilt/republished; the VM and git-clone paths benefit immediately since the tree is already on disk.

## User stories
N/A — infrastructure/install reliability fix, no user-facing feature.

## Release note
Fix intermittent quick-start install failures caused by GitHub `429 Too Many Requests` when fetching Helm values files; install resources are now bundled into the quick-start dev-container image and applied from disk.

## Documentation
N/A — no documentation changes. The quick-start steps in `documentation/docs/getting-started/quick-start.mdx` are unchanged.

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams; this is an install-script/packaging change.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > N/A — shell/Dockerfile packaging change with no unit-test harness. Validated `bash -n` on both scripts, verified `DEPLOYMENTS_DIR` resolution and file presence in both the repo (`../`) and flat container layouts, and confirmed the Dockerfile `COPY` sources resolve against the repo-root build context.
 - Integration tests
   > Covered by the existing nightly E2E workflow, which exercises a full quick-start-style install.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples affected.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no migration required. Existing installs are unaffected; the change only alters where the installer reads its resources from.

## Test environment
Verified locally on macOS (Darwin) with Docker/Colima: script syntax checks, path-resolution simulation for both layouts, and a `COPY`-only Docker build against the repo-root context.

## Learning
GitHub's `raw.githubusercontent.com` enforces an undocumented per-IP rate limit for unauthenticated requests, and Helm/kubectl do not retry HTTP 429 when fetching remote `--values`/`-f` sources — so any installer that pulls several raw files in a burst is exposed to hard failures. Bundling the files into the artifact that already ships the scripts removes the dependency entirely.
