### PR TITLE
[amp-pre-release] Resolve namespace for ou id

### DIFF
--- a/agent-manager-service/api/app.go
+++ b/agent-manager-service/api/app.go
@@ -51,6 +51,7 @@ func MakeHTTPHandler(params *wiring.AppParams, extraAPIRoutes func(*http.ServeMu
 		AgentManagerService:      params.AgentManagerService,
 		AgentTokenManagerService: params.AgentTokenManagerService,
 		TraceObserverSvcClient:   params.TraceObserverSvcClient,
+		OpenChoreoClient:         params.OpenChoreoClient,
 	}, params.AuthMiddleware)
 
 	// Create a sub-mux for API v1 routes (JWT-authenticated)

--- a/agent-manager-service/mcp/handlers/observability_handler.go
+++ b/agent-manager-service/mcp/handlers/observability_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
@@ -30,10 +31,18 @@ import (
 type ObservabilityHandler struct {
 	agentSvc    services.AgentManagerService
 	traceClient traceobserversvc.TraceObserverSvcClient
+	ocClient    occlient.OpenChoreoClient
 }
 
-func NewObservabilityHandler(agentSvc services.AgentManagerService, traceClient traceobserversvc.TraceObserverSvcClient) *ObservabilityHandler {
-	return &ObservabilityHandler{agentSvc: agentSvc, traceClient: traceClient}
+func NewObservabilityHandler(agentSvc services.AgentManagerService, traceClient traceobserversvc.TraceObserverSvcClient, ocClient occlient.OpenChoreoClient) *ObservabilityHandler {
+	return &ObservabilityHandler{agentSvc: agentSvc, traceClient: traceClient, ocClient: ocClient}
+}
+
+// resolveNamespace resolves the OpenChoreo namespace for an OU. The trace
+// observer scopes queries by the OpenChoreo namespace the workloads run in,
+// not the OU ID.
+func (h *ObservabilityHandler) resolveNamespace(ctx context.Context, _ string) (string, error) {
+	return services.ResolveNamespace(ctx, h.ocClient)
 }
 
 func (h *ObservabilityHandler) GetRuntimeLogs(ctx context.Context, ouID string, projectName string, agentName string, payload spec.LogFilterRequest) (*models.LogsResponse, error) {
@@ -49,8 +58,13 @@ func (h *ObservabilityHandler) ListTraces(ctx context.Context, ouID string, proj
 		return nil, fmt.Errorf("trace observer client is not configured")
 	}
 
+	namespace, err := h.resolveNamespace(ctx, ouID)
+	if err != nil {
+		return nil, err
+	}
+
 	params := traceobserversvc.TraceListParams{
-		Organization: ouID,
+		Organization: namespace,
 		Project:      projectName,
 		Component:    agentName,
 		Environment:  environment,
@@ -68,8 +82,13 @@ func (h *ObservabilityHandler) ExportTraces(ctx context.Context, ouID string, pr
 		return nil, fmt.Errorf("trace observer client is not configured")
 	}
 
+	namespace, err := h.resolveNamespace(ctx, ouID)
+	if err != nil {
+		return nil, err
+	}
+
 	params := traceobserversvc.TraceListParams{
-		Organization: ouID,
+		Organization: namespace,
 		Project:      projectName,
 		Component:    agentName,
 		Environment:  environment,
@@ -87,9 +106,14 @@ func (h *ObservabilityHandler) GetTraceDetails(ctx context.Context, ouID string,
 		return nil, fmt.Errorf("trace observer client is not configured")
 	}
 
+	namespace, err := h.resolveNamespace(ctx, ouID)
+	if err != nil {
+		return nil, err
+	}
+
 	params := traceobserversvc.TraceDetailsParams{
 		TraceID:      traceID,
-		Organization: ouID,
+		Organization: namespace,
 		Project:      projectName,
 		Component:    agentName,
 		Environment:  environment,
@@ -106,10 +130,15 @@ func (h *ObservabilityHandler) GetSpanDetails(ctx context.Context, ouID string, 
 		return nil, fmt.Errorf("trace observer client is not configured")
 	}
 
+	namespace, err := h.resolveNamespace(ctx, ouID)
+	if err != nil {
+		return nil, err
+	}
+
 	params := traceobserversvc.SpanDetailsParams{
 		TraceID:      traceID,
 		SpanID:       spanID,
-		Organization: ouID,
+		Organization: namespace,
 		Project:      projectName,
 		Component:    agentName,
 		Environment:  environment,

--- a/agent-manager-service/mcp/setup.go
+++ b/agent-manager-service/mcp/setup.go
@@ -19,6 +19,7 @@ package mcp
 import (
 	"net/http"
 
+	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	traceobserversvc "github.com/wso2/agent-manager/agent-manager-service/clients/traceobserversvc"
 
 	"github.com/wso2/agent-manager/agent-manager-service/mcp/handlers"
@@ -33,6 +34,7 @@ type Dependencies struct {
 	AgentManagerService      services.AgentManagerService
 	AgentTokenManagerService services.AgentTokenManagerService
 	TraceObserverSvcClient   traceobserversvc.TraceObserverSvcClient
+	OpenChoreoClient         occlient.OpenChoreoClient
 }
 
 // RegisterRoute builds the MCP HTTP handler, wraps it with the standard middleware chain,
@@ -44,7 +46,7 @@ func RegisterRoute(mux *http.ServeMux, deps Dependencies, authMiddleware func(ht
 		AgentToolset:         handlers.NewAgentHandler(deps.AgentManagerService, deps.AgentTokenManagerService),
 		BuildToolset:         handlers.NewBuildHandler(deps.AgentManagerService),
 		DeploymentToolset:    handlers.NewDeploymentHandler(deps.AgentManagerService),
-		ObservabilityToolset: handlers.NewObservabilityHandler(deps.AgentManagerService, deps.TraceObserverSvcClient),
+		ObservabilityToolset: handlers.NewObservabilityHandler(deps.AgentManagerService, deps.TraceObserverSvcClient, deps.OpenChoreoClient),
 	}
 
 	handler := NewHTTPServer(toolsets)

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -139,6 +139,12 @@ type agentThunderProvisioningService struct {
 	bindingLocks keyedMutex
 }
 
+// resolveNamespace resolves the OpenChoreo namespace (organization) name for
+// an OU
+func (s *agentThunderProvisioningService) resolveNamespace(_ string) string {
+	return config.GetConfig().OpenChoreo.DefaultNamespace
+}
+
 // NewOpenBaoAgentThunderProvisioning returns the deployment factory that builds
 // the OpenBao-backed provisioning service once the DB is available (see
 // app.Options.AgentThunderProvisioning). Used by the open-source deployment,
@@ -314,7 +320,7 @@ func (s *agentThunderProvisioningService) AttemptProvision(ctx context.Context, 
 		return
 	}
 
-	thunderClient, err := s.envResolver.Resolve(ctx, binding.OUID, binding.EnvironmentName)
+	thunderClient, err := s.envResolver.Resolve(ctx, s.resolveNamespace(binding.OUID), binding.EnvironmentName)
 	if err != nil {
 		s.recordFailure(ctx, binding, "", "", err)
 		return
@@ -439,7 +445,7 @@ func (s *agentThunderProvisioningService) RegenerateSecret(ctx context.Context, 
 		return "", "", "", fmt.Errorf("%w: %s in %s", utils.ErrAgentIdentityNotProvisioned, agentName, envName)
 	}
 
-	thunderClient, err := s.envResolver.Resolve(ctx, ouID, envName)
+	thunderClient, err := s.envResolver.Resolve(ctx, s.resolveNamespace(ouID), envName)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -506,7 +512,7 @@ func (s *agentThunderProvisioningService) RevokeSecret(ctx context.Context, ouID
 		return "", fmt.Errorf("%w: %s in %s", utils.ErrAgentIdentityNotProvisioned, agentName, envName)
 	}
 
-	thunderClient, err := s.envResolver.Resolve(ctx, ouID, envName)
+	thunderClient, err := s.envResolver.Resolve(ctx, s.resolveNamespace(ouID), envName)
 	if err != nil {
 		return "", err
 	}
@@ -633,7 +639,7 @@ func (s *agentThunderProvisioningService) DeleteAllBindings(ctx context.Context,
 		if b.ThunderAgentID == "" {
 			continue // never made it to Thunder — nothing to delete there
 		}
-		thunderClient, err := s.envResolver.Resolve(ctx, ouID, b.EnvironmentName)
+		thunderClient, err := s.envResolver.Resolve(ctx, s.resolveNamespace(ouID), b.EnvironmentName)
 		if err != nil {
 			s.logger.Warn("Env-thunder resolver error during agent binding cleanup", "agentName", agentName, "env", b.EnvironmentName, "error", err)
 			continue

--- a/agent-manager-service/services/agent_token_manager.go
+++ b/agent-manager-service/services/agent_token_manager.go
@@ -281,6 +281,16 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 		return nil, fmt.Errorf("failed to get project: %w", err)
 	}
 
+	// Resolve the OpenChoreo namespace for the org. Traces are stamped with this
+	// namespace at ingest (via the gateway -> collector), so the token's namespace
+	// claim must carry the OpenChoreo namespace rather than the raw OU id for the
+	// observability read path (which scopes queries by organization) to match.
+	namespace, err := ResolveNamespace(ctx, s.ocClient)
+	if err != nil {
+		s.logger.Error("Failed to resolve namespace", "ouID", req.OrgName, "error", err)
+		return nil, err
+	}
+
 	// Determine expiry duration
 	expiryDuration, err := s.parseExpiryDuration(req.ExpiresIn)
 	if err != nil {
@@ -303,7 +313,7 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 		EnvironmentUid: environment.UUID,
 		ProjectUid:     project.UUID,
 		OrgId:          req.OrgId,
-		Namespace:      req.OrgName,
+		Namespace:      namespace,
 	}
 
 	// Get the active signing key

--- a/agent-manager-service/services/agent_token_manager_unit_test.go
+++ b/agent-manager-service/services/agent_token_manager_unit_test.go
@@ -242,6 +242,9 @@ func fullClientMock(compUID, envUID, projUID string) *clientmocks.OpenChoreoClie
 		GetProjectFunc: func(_ context.Context, _, _ string) (*models.ProjectResponse, error) {
 			return &models.ProjectResponse{UUID: projUID}, nil
 		},
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "acme-namespace"}}, nil
+		},
 	}
 }
 
@@ -317,7 +320,7 @@ func TestAgentTokenManager_GenerateToken_HappyPath(t *testing.T) {
 	assert.Equal(t, "env-uuid", claims.EnvironmentUid)
 	assert.Equal(t, "proj-uuid", claims.ProjectUid)
 	assert.Equal(t, "org-123", claims.OrgId)
-	assert.Equal(t, "acme", claims.Namespace)
+	assert.Equal(t, "acme-namespace", claims.Namespace, "namespace claim must come from GetOrganization, not the raw OU id")
 	assert.Equal(t, "my-agent", claims.Subject)
 	assert.Equal(t, "agent-manager-test", claims.Issuer)
 	assert.Equal(t, "key-1", parsed.Header["kid"])

--- a/agent-manager-service/services/environment_service.go
+++ b/agent-manager-service/services/environment_service.go
@@ -444,6 +444,16 @@ func (s *environmentService) ListThunderInstances(ctx context.Context, ouID stri
 		return nil, fmt.Errorf("list environments for org %s: %w", ouID, err)
 	}
 
+	// Thunder naming (release name, namespace, host, issuer URL) is keyed by the
+	// org NAME the provisioning scripts deployed with (ORG_NAME, e.g. "default"),
+	// which is the OpenChoreo namespace — not the OU id from the JWT. Probing or
+	// advertising URLs derived from the OU id would point at instances that don't
+	// exist.
+	orgNamespace, err := ResolveNamespace(ctx, s.ocClient)
+	if err != nil {
+		return nil, err
+	}
+
 	// Probe every environment's env-Thunder JWKS endpoint concurrently. Each probe can take
 	// up to ~8s in the worst case (ThunderProbe's 4-step fallback chain, 2s timeout each), so
 	// probing sequentially would scale request latency linearly with environment count.
@@ -456,7 +466,7 @@ func (s *environmentService) ListThunderInstances(ctx context.Context, ouID stri
 		wg.Add(1)
 		go func(idx int, envName string) {
 			defer wg.Done()
-			reachable[idx] = s.thunderProber.Probe(ctx, ouID, envName)
+			reachable[idx] = s.thunderProber.Probe(ctx, orgNamespace, envName)
 		}(i, env.Name)
 	}
 	wg.Wait()
@@ -484,10 +494,10 @@ func (s *environmentService) ListThunderInstances(ctx context.Context, ouID stri
 			EnvName:      env.Name,
 			DisplayName:  env.DisplayName,
 			IsProduction: env.IsProduction,
-			IssuerURL:    thundersvc.ThunderIssuerURL(ouID, env.Name),
-			TokenURL:     thundersvc.ThunderExternalTokenURL(ouID, env.Name),
-			JWKSURL:      thundersvc.ThunderExternalJWKSURL(ouID, env.Name),
-			Namespace:    thundersvc.ThunderNamespace(ouID, env.Name),
+			IssuerURL:    thundersvc.ThunderIssuerURL(orgNamespace, env.Name),
+			TokenURL:     thundersvc.ThunderExternalTokenURL(orgNamespace, env.Name),
+			JWKSURL:      thundersvc.ThunderExternalJWKSURL(orgNamespace, env.Name),
+			Namespace:    thundersvc.ThunderNamespace(orgNamespace, env.Name),
 		})
 	}
 	return &models.ThunderInstanceListResponse{ThunderInstances: instances}, nil

--- a/agent-manager-service/services/environment_service_unit_test.go
+++ b/agent-manager-service/services/environment_service_unit_test.go
@@ -758,6 +758,9 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 					{UUID: "u2", Name: "staging", DisplayName: "Staging", IsProduction: false},
 				}, nil
 			},
+			ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+				return []*models.OrganizationResponse{{Namespace: org}}, nil
+			},
 		}
 		prober := &clientmocks.ThunderProberMock{
 			ProbeFunc: func(_ context.Context, _, _ string) bool { return false },
@@ -781,6 +784,9 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 					{UUID: "u1", Name: ""},
 				}, nil
 			},
+			ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+				return []*models.OrganizationResponse{{Namespace: org}}, nil
+			},
 		}
 		svc := newEnvService(&repomocks.GatewayRepositoryMock{}, oc)
 
@@ -798,6 +804,9 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 					{UUID: "u1", Name: "dev", DisplayName: "Dev", IsProduction: false},
 					{UUID: "u2", Name: "staging", DisplayName: "Staging", IsProduction: true},
 				}, nil
+			},
+			ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+				return []*models.OrganizationResponse{{Namespace: org}}, nil
 			},
 		}
 		prober := &clientmocks.ThunderProberMock{

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -132,6 +132,12 @@ func (e *monitorExecutor) ExecuteMonitorRun(ctx context.Context, params ExecuteM
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve LLM proxy config: %w", err)
 	}
+	ocClient := ocClientFromContext(ctx, e.ocClient)
+	// Resolve the OpenChoreo namespace name for this org.
+	namespace, err := ResolveNamespace(ctx, ocClient)
+	if err != nil {
+		return nil, err
+	}
 
 	// Build WorkflowRun request (this also resolves custom evaluator types from DB).
 	workflowRunReq, err := e.buildWorkflowRunRequest(
@@ -143,15 +149,13 @@ func (e *monitorExecutor) ExecuteMonitorRun(ctx context.Context, params ExecuteM
 		llmProxySecretPath,
 		llmApiBase,
 		templateHandle,
+		namespace,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build WorkflowRun request: %w", err)
 	}
 
 	// Create WorkflowRun via OpenChoreo API.
-	// The scheduler injects an org-scoped OC client into context before calling here;
-	// user-request paths leave the context as-is and fall back to the system client.
-	ocClient := ocClientFromContext(ctx, e.ocClient)
 	workflowRunResp, err := ocClient.CreateWorkflowRun(ctx, params.OUID, *workflowRunReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create WorkflowRun: %w", err)
@@ -283,6 +287,7 @@ func (e *monitorExecutor) buildWorkflowRunRequest(
 	llmProxySecretPath string,
 	llmApiBase string,
 	templateHandle string,
+	namespace string,
 ) (*client.CreateWorkflowRunRequest, error) {
 	evaluatorsJSON, hasLLMJudge, err := e.serializeEvaluators(monitor.OUID, evaluators, templateHandle)
 	if err != nil {
@@ -312,7 +317,7 @@ func (e *monitorExecutor) buildWorkflowRunRequest(
 				"name":        monitor.Name,
 				"displayName": monitor.DisplayName,
 			},
-			"organization": monitor.OUID,
+			"organization": namespace,
 			"project":      monitor.ProjectName,
 			"agent": map[string]interface{}{
 				"id":   monitor.AgentID,

--- a/agent-manager-service/services/namespace_resolver.go
+++ b/agent-manager-service/services/namespace_resolver.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"context"
+	"fmt"
+
+	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+)
+
+// ResolveNamespace resolves the OpenChoreo namespace (organization) name.
+// Trace ingestion, the observer's search-scope resolution, and env-Thunder
+// naming are all keyed by this name (e.g. "default"), NOT by the OU id from
+// the JWT — passing the raw OU id where a namespace is expected targets
+// resources that don't exist. Single-namespace deployment: the first (only)
+// organization is the one every OU maps to.
+func ResolveNamespace(ctx context.Context, ocClient occlient.OpenChoreoClient) (string, error) {
+	orgs, err := ocClient.ListOrganizations(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to list organizations for namespace resolution: %w", err)
+	}
+	if len(orgs) == 0 {
+		return "", fmt.Errorf("no organization found for namespace resolution")
+	}
+	return orgs[0].Namespace, nil
+}

--- a/agent-manager-service/tests/agent_token_test.go
+++ b/agent-manager-service/tests/agent_token_test.go
@@ -72,6 +72,9 @@ func createMockOpenChoreoClientForToken(agentName string, componentUid string, e
 				Name: orgName,
 			}, nil
 		},
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 	}
 }
 

--- a/agent-manager-service/tests/apitestutils/mock_clients.go
+++ b/agent-manager-service/tests/apitestutils/mock_clients.go
@@ -41,6 +41,11 @@ func CreateMockOpenChoreoClient() *clientmocks.OpenChoreoClientMock {
 		NamespaceForFunc: func(ouID string) string {
 			return config.GetConfig().OpenChoreo.DefaultNamespace
 		},
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{
+				{Namespace: config.GetConfig().OpenChoreo.DefaultNamespace},
+			}, nil
+		},
 		GetOrganizationFunc: func(ctx context.Context, orgName string) (*models.OrganizationResponse, error) {
 			if orgName == "nonexistent-org" {
 				return nil, utils.ErrOrganizationNotFound

--- a/agent-manager-service/tests/monitor_executor_test.go
+++ b/agent-manager-service/tests/monitor_executor_test.go
@@ -99,6 +99,9 @@ func TestExecuteMonitorRun_CRStructure(t *testing.T) {
 	var capturedReq client.CreateWorkflowRunRequest
 	var capturedNamespace string
 	mockClient := &clientmocks.OpenChoreoClientMock{
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, namespaceName string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			capturedNamespace = namespaceName
 			capturedReq = req
@@ -171,6 +174,9 @@ func TestExecuteMonitorRun_EvaluatorsJSON(t *testing.T) {
 
 	var capturedReq client.CreateWorkflowRunRequest
 	mockClient := &clientmocks.OpenChoreoClientMock{
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, namespaceName string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			capturedReq = req
 			return &client.WorkflowRunResponse{
@@ -264,6 +270,9 @@ func TestExecuteMonitorRun_DBRecordCreated(t *testing.T) {
 	monitor := seedMonitor(t)
 
 	mockClient := &clientmocks.OpenChoreoClientMock{
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, namespaceName string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			return &client.WorkflowRunResponse{
 				Name:         "test-workflow-run-123",
@@ -376,6 +385,9 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 
 	var capturedReq client.CreateWorkflowRunRequest
 	mockClient := &clientmocks.OpenChoreoClientMock{
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, _ string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			capturedReq = req
 			return &client.WorkflowRunResponse{Name: "run-1", WorkflowName: req.WorkflowName, Status: "Running", OrgName: monitor.OUID}, nil
@@ -412,6 +424,9 @@ func TestExecuteMonitorRun_NilEvaluatorsReturnsError(t *testing.T) {
 	monitor := seedMonitor(t)
 
 	mockClient := &clientmocks.OpenChoreoClientMock{
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, namespaceName string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			t.Fatal("CreateWorkflowRun should not be called with nil evaluators")
 			return nil, errors.New("unexpected call")
@@ -452,6 +467,9 @@ func TestExecuteMonitorRun_PerOrgPublisherCredentials(t *testing.T) {
 
 	var capturedReq client.CreateWorkflowRunRequest
 	mockClient := &clientmocks.OpenChoreoClientMock{
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, namespaceName string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			capturedReq = req
 			return &client.WorkflowRunResponse{
@@ -488,6 +506,9 @@ func TestExecuteMonitorRun_FallbackPublisherCredentials(t *testing.T) {
 
 	var capturedReq client.CreateWorkflowRunRequest
 	mockClient := &clientmocks.OpenChoreoClientMock{
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{{Namespace: "default"}}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, namespaceName string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			capturedReq = req
 			return &client.WorkflowRunResponse{

--- a/agent-manager-service/tests/monitor_test.go
+++ b/agent-manager-service/tests/monitor_test.go
@@ -74,6 +74,11 @@ func createBaseMockChoreoClient() *clientmocks.OpenChoreoClientMock {
 		NamespaceForFunc: func(ouID string) string {
 			return config.GetConfig().OpenChoreo.DefaultNamespace
 		},
+		ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+			return []*models.OrganizationResponse{
+				{Namespace: config.GetConfig().OpenChoreo.DefaultNamespace},
+			}, nil
+		},
 		CreateWorkflowRunFunc: func(ctx context.Context, namespaceName string, req client.CreateWorkflowRunRequest) (*client.WorkflowRunResponse, error) {
 			return &client.WorkflowRunResponse{
 				Name:         "test-workflow-run-123",


### PR DESCRIPTION
## Purpose
Port of #1292 to `amp-pre-release`.

Trace ingestion, the observer's search-scope resolution, and env-Thunder naming are all keyed by the OpenChoreo namespace name (e.g. `default`), not the OU id from the JWT. Several code paths were passing the raw OU id where the namespace name is expected, breaking trace queries (monitor evaluation 500s, empty trace lists) and env-Thunder resolution.

## Changes
- Add shared `services.ResolveNamespace` util (resolves the OpenChoreo namespace via `ListOrganizations`)
- Agent token: stamp the `namespace` claim with the resolved namespace instead of the OU id
- Monitor executor: pass the resolved namespace as the evaluation workflow `organization` parameter
- MCP observability handler: resolve the namespace for trace observer queries
- `ListThunderInstances` / agent Thunder provisioning: resolve the org name env-Thunder instances are deployed under
- Test fixes: stub `ListOrganizationsFunc` in affected `OpenChoreoClientMock` setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)