### PR TITLE
Make the on-your-environment guide production-first

### DIFF
--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -3,6 +3,8 @@ sidebar_position: 3
 ---
 
 import AmpInstallation from './_partials/_amp-installation.mdx';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # On Your Environment
 
@@ -20,10 +22,10 @@ Agent Manager is a two-layer system installed in two phases:
 
 - **Phase 2 — Agent Manager :** The AI agent management platform installed on top of OpenChoreo. It includes the **Console** (web UI), **AMP API** (backend), **AI Gateway**, **PostgreSQL** (database), **Secrets Extension** (OpenBao for runtime secret injection), **Traces Observer** (trace querying), and **Evaluation Engine** (automated agent evaluations).
 
-This guide installs both layers on your existing Kubernetes cluster.
+This guide installs both layers on your existing Kubernetes cluster, production-first: a real domain, trusted TLS certificates issued automatically by cert-manager, and every management surface served through the three OpenChoreo plane gateways — the only LoadBalancers the platform needs.
 
-:::info
-This setup is for **development and exploration**. For production deployments, see the [Production Considerations](#production-considerations) section.
+:::tip No domain yet?
+The main flow assumes you control a DNS zone. If you are evaluating on a cluster without one, follow the [nip.io appendix](#appendix-installing-without-a-domain-nipio) instead — same steps, with hostnames derived from LoadBalancer IPs and self-signed certificates.
 :::
 
 ## Prerequisites
@@ -68,9 +70,25 @@ You need sufficient privileges to:
 
 ---
 
-## Configuration Variables
+## Plan Your Deployment
 
-Set these once before starting the installation. Most subsequent commands reference these variables, though some examples (troubleshooting, uninstall) use literal values — substitute the corresponding variable if you have customised the defaults.
+Three decisions shape the installation. Make them now — everything below is driven by the variables you export here.
+
+### 1. Hostnames
+
+Pick a base domain you control (a delegated subdomain like `amp.yourdomain.com` works well). Every management surface is a hostname on one of the three plane gateway LoadBalancers — you publish exactly four DNS records after the platform installs:
+
+| Hostname | Serves | DNS record → |
+|---|---|---|
+| `console.<base>` | Agent Manager Console | control-plane gateway LB |
+| `api-amp.<base>` | Agent Manager API (browser, `amctl`, MCP) | control-plane gateway LB |
+| `thunder.<base>` | Thunder OAuth login (+ per-environment `<org>-<env>.thunder.<base>`) | control-plane gateway LB |
+| `cp.<base>` | Gateway control plane (external AI gateways, optional) | control-plane gateway LB |
+| `api.<base>` | OpenChoreo API | control-plane gateway LB |
+| `traces.<base>` | Traces Observer | observability-plane gateway LB |
+| `*.agents.<base>` | Deployed-agent invocation endpoints (wildcard) | data-plane gateway LB |
+
+The first five share one record target (the control-plane gateway), so the four records are: `console`/`api-amp`/`thunder`/`cp`/`api` (five names, one LB — or a wildcard `*.<base>`), `traces`, and the `*.agents.<base>` wildcard.
 
 ```bash
 export VERSION="0.0.0-dev"
@@ -81,63 +99,50 @@ export OBSERVABILITY_NS="openchoreo-observability-plane"
 export DEFAULT_NS="default"
 export DATA_PLANE_NS="openchoreo-data-plane"
 export THUNDER_NS="amp-thunder"
-```
 
-**Thunder (Identity Provider) URLs** — Thunder must be reachable from the browser for OAuth login. Set `THUNDER_PUBLIC_URL` to the URL where the browser will access Thunder:
+# Your base domain — everything below derives from it
+export BASE_DOMAIN="amp.yourdomain.com"
 
-```bash
-# Port-forwarding (default for dev):
-export THUNDER_PUBLIC_URL="http://localhost:8090"
+export CONSOLE_PUBLIC_HOST="console.${BASE_DOMAIN}"
+export API_PUBLIC_HOST="api-amp.${BASE_DOMAIN}"
+export THUNDER_PUBLIC_HOST="thunder.${BASE_DOMAIN}"
+export CP_GW_PUBLIC_HOST="cp.${BASE_DOMAIN}"
+export OBS_API_PUBLIC_HOST="traces.${BASE_DOMAIN}"
+export AGENTS_DOMAIN="agents.${BASE_DOMAIN}"
 
-# Public deployment example:
-#   export THUNDER_PUBLIC_URL="https://thunder.yourdomain.com"
+export CONSOLE_PUBLIC_URL="https://${CONSOLE_PUBLIC_HOST}"
+export API_PUBLIC_URL="https://${API_PUBLIC_HOST}"
+export THUNDER_PUBLIC_URL="https://${THUNDER_PUBLIC_HOST}"
+export OBS_API_PUBLIC_URL="https://${OBS_API_PUBLIC_HOST}"
 
-# In-cluster URL (used by backend services for JWKS/token calls):
+# In-cluster URL backend services use for Thunder JWKS/token calls
 export THUNDER_INTERNAL_URL="http://amp-thunder-extension-service.${THUNDER_NS}.svc.cluster.local:8090"
+
+# Trace-export endpoint shown to agent developers (see the OTLP note below)
+export INSTRUMENTATION_URL="http://default-default.gateway.localhost:19080/otel"
 ```
 
-**Console URLs** — Set to how the browser will reach the console, API, and traces observer. These services are ClusterIP and are served through the OpenChoreo plane gateways: the console and API through the control-plane gateway, the traces observer through the observability-plane gateway. The `*_PUBLIC_HOST` values (bare hostname, no scheme or port) become the HTTPRoute hostnames on those gateways, so each hostname's DNS must point at the corresponding gateway LoadBalancer.
-
-With your own domain (recommended — hostnames are known before installation):
-
-```bash
-export CONSOLE_PUBLIC_HOST="console.yourdomain.com"   # DNS → control-plane gateway LB
-export API_PUBLIC_HOST="api-amp.yourdomain.com"       # DNS → control-plane gateway LB
-export OBS_API_PUBLIC_HOST="traces.yourdomain.com"    # DNS → observability-plane gateway LB
-export CONSOLE_PUBLIC_URL="https://${CONSOLE_PUBLIC_HOST}"
-export API_PUBLIC_URL="https://${API_PUBLIC_HOST}"
-export OBS_API_PUBLIC_URL="https://${OBS_API_PUBLIC_HOST}"
-# OTLP trace ingest rides the data-plane gateway (see the instrumentation note below)
-export INSTRUMENTATION_URL="https://gateway.yourdomain.com/otel"
-```
-
-Without your own domain, reuse the nip.io base domains derived from the gateway LoadBalancer IPs in Phase 1 (`CP_BASE_DOMAIN` in Step 5, `OBS_LB_IP` in Step 8) — run these exports after those steps:
-
-```bash
-export CONSOLE_PUBLIC_HOST="console.${CP_BASE_DOMAIN}"
-export API_PUBLIC_HOST="api-amp.${CP_BASE_DOMAIN}"
-export OBS_API_PUBLIC_HOST="traces.${OBS_LB_IP//./-}.nip.io"
-export CONSOLE_PUBLIC_URL="https://${CONSOLE_PUBLIC_HOST}"
-export API_PUBLIC_URL="https://${API_PUBLIC_HOST}"
-export OBS_API_PUBLIC_URL="https://${OBS_API_PUBLIC_HOST}"
-export INSTRUMENTATION_URL="http://default-default.gateway.localhost:19080/otel"  # in-cluster agents; see note
-```
-
-:::warning Console hostname must be known when Thunder installs
-
-Thunder registers the console's OAuth redirect URI at install time (Step 4) and does not update it on `helm upgrade`. `CONSOLE_PUBLIC_URL` must therefore be set before installing Thunder. With the nip.io flow that means provisioning the control-plane gateway first (run the Step 5 placeholder install, derive `CP_BASE_DOMAIN`, then return to Step 4) — or reinstalling the Thunder chart after the domain is known, as described in the warning in Step 4.
-
+:::note Why `api-amp` and not `api`?
+The OpenChoreo API claims `api.<base>` on the same gateway, and the certificates below are single-level wildcards (`*.<base>`), so every hostname must sit directly under the base domain.
 :::
+
+### 2. TLS certificates
+
+The main flow uses **cert-manager with Let's Encrypt (DNS-01)**: publicly trusted certificates, automatic renewal, and wildcard support — you only need API credentials for the DNS provider hosting your zone. Step 3 also shows a corporate-CA alternative. Certificate issuance needs only the DNS zone, so it works before the DNS records for the gateways exist.
+
+### 3. Dependencies
+
+The default install runs PostgreSQL, OpenBao, and OpenSearch in-cluster with development settings. Each install step below carries a **Production** callout with the values to swap in a managed database, a hardened secrets backend, and persistent observability storage. Decide up front which you will use — moving PostgreSQL data or Thunder's identity database later is disruptive.
 
 :::info OTLP trace ingest
 
-`INSTRUMENTATION_URL` is the trace-export endpoint shown to agent developers; the traffic rides the data-plane gateway's `/otel` route. Agents running inside the cluster can use the default route hostname `http://default-default.gateway.localhost:19080/otel` (resolvable in-cluster). For agents running outside the cluster, install the API Platform Gateway extension with a public hostname whose DNS points at the data-plane gateway LoadBalancer — `--set gateway.vhost=https://<host>` and `--set gateway.hostname=<host>` — and use `https://<host>/otel`.
+`INSTRUMENTATION_URL` is the trace-export endpoint shown to agent developers; the traffic rides the data-plane gateway's `/otel` route. Agents running inside the cluster can use the default route hostname `http://default-default.gateway.localhost:19080/otel` (resolvable in-cluster). For agents running outside the cluster, install the API Platform Gateway extension with a public hostname whose DNS points at the data-plane gateway LoadBalancer — `--set gateway.vhost=https://otel.${BASE_DOMAIN}` and `--set gateway.hostname=otel.${BASE_DOMAIN}` — and set `INSTRUMENTATION_URL=https://otel.${BASE_DOMAIN}/otel`.
 
 :::
 
 :::info External AI gateways
 
-AI gateways running outside this cluster also connect through the control-plane gateway. Pick a hostname (for example `cp.yourdomain.com`), point its DNS at the control-plane gateway LoadBalancer, and pass `--set "agentManagerService.ocIngress.gatewayMgmt.hostnames={cp.yourdomain.com}"` and `--set console.config.gatewayControlPlaneUrl=https://cp.yourdomain.com` to the Agent Manager install in Phase 2. See [Register an AI Gateway](../administration/register-ai-gateway.mdx).
+AI gateways running outside this cluster connect through the control-plane gateway at `https://${CP_GW_PUBLIC_HOST}`. Phase 2 passes this hostname to the Agent Manager install; nothing else is needed beyond the DNS record. See [Register an AI Gateway](../administration/register-ai-gateway.mdx).
 
 :::
 
@@ -269,58 +274,86 @@ spec:
 EOF
 ```
 
-:::warning
-OpenBao is installed in **dev mode** (in-memory backend) for this guide. For production, disable dev mode and configure persistent storage.
+:::warning Production
+The values file above runs OpenBao in **dev mode** (in-memory backend, auto-unseal, well-known root token) — secrets are lost on pod restart. For production, install OpenBao without the dev-mode values: set `server.dev.enabled=false`, enable `server.dataStorage` persistence (or an external storage backend), configure [auto-unseal](https://openbao.org/docs/concepts/seal/), and create the Kubernetes auth role (`openchoreo-secret-writer-role`) plus the KV v2 mount at `secret/` that the ClusterSecretStore below expects.
 :::
 
-### Step 3: Setup TLS
+### Step 3: Setup TLS Issuer
 
-Create a self-signed CA chain for cluster-wide certificate issuance:
+Every gateway certificate below references one ClusterIssuer named `openchoreo-ca`. Create it from your chosen certificate authority — the rest of the guide is identical regardless of which tab you pick.
+
+<Tabs>
+  <TabItem value="letsencrypt" label="Let's Encrypt (DNS-01)" default>
+
+DNS-01 validation issues publicly trusted certificates (including the wildcards this guide needs) by writing a TXT record to your DNS zone — the CA never connects to your cluster. Create a credentials Secret for your DNS provider, then the issuer. The example below uses AWS Route 53; cert-manager supports [Cloudflare, Google Cloud DNS, Azure DNS, and others](https://cert-manager.io/docs/configuration/acme/dns01/) with the same structure.
 
 ```bash
-kubectl apply -f - <<'EOF'
+kubectl create secret generic route53-credentials \
+  --namespace cert-manager \
+  --from-literal=secret-access-key='<AWS_SECRET_ACCESS_KEY>'
+
+kubectl apply -f - <<EOF
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: selfsigned-bootstrap
-spec:
-  selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
   name: openchoreo-ca
-  namespace: cert-manager
 spec:
-  isCA: true
-  commonName: openchoreo-ca
-  secretName: openchoreo-ca-secret
-  privateKey:
-    algorithm: ECDSA
-    size: 256
-  issuerRef:
-    name: selfsigned-bootstrap
-    kind: ClusterIssuer
----
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ops@yourdomain.com
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-1
+            accessKeyID: <AWS_ACCESS_KEY_ID>
+            secretAccessKeySecretRef:
+              name: route53-credentials
+              key: secret-access-key
+        selector:
+          dnsZones:
+            - "${BASE_DOMAIN}"
+EOF
+```
+
+:::tip
+Test with the Let's Encrypt staging server (`https://acme-staging-v02.api.letsencrypt.org/directory`) first if you expect to iterate — the production server rate-limits duplicate certificates to 5 per week.
+:::
+
+  </TabItem>
+  <TabItem value="corporate" label="Corporate CA">
+
+If your organization runs an internal PKI, store its intermediate CA certificate and key as a Secret and create a CA issuer. Clients inside your network trust the certificates via your existing root-CA distribution.
+
+```bash
+kubectl create secret tls corporate-ca-secret \
+  --namespace cert-manager \
+  --cert=/path/to/intermediate-ca.crt \
+  --key=/path/to/intermediate-ca.key
+
+kubectl apply -f - <<'EOF'
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: openchoreo-ca
 spec:
   ca:
-    secretName: openchoreo-ca-secret
+    secretName: corporate-ca-secret
 EOF
-
-kubectl wait --for=condition=Ready certificate/openchoreo-ca -n cert-manager --timeout=60s
 ```
 
-:::info
-For production, replace the self-signed CA with a trusted certificate authority (Let's Encrypt, AWS ACM, etc.).
-:::
+  </TabItem>
+  <TabItem value="selfsigned" label="Self-signed (evaluation only)">
+
+For evaluation without a domain, the [nip.io appendix](#appendix-installing-without-a-domain-nipio) creates a self-signed chain under the same `openchoreo-ca` name. Browsers will warn on every hostname and backend components need TLS-verification overrides — do not use this beyond evaluation.
+
+  </TabItem>
+</Tabs>
 
 ### Step 4: Install Thunder Extension (Identity Provider)
 
-Thunder provides authentication and user management for the entire platform — login, API keys, and OAuth token exchange. It must be installed before the Control Plane because the Control Plane, Observability Plane, and Agent Manager all validate JWTs issued by Thunder.
+Thunder provides authentication and user management for the entire platform — login, API keys, and OAuth token exchange. It must be installed before the Control Plane because the Control Plane, Observability Plane, and Agent Manager all validate JWTs issued by Thunder. The browser reaches it at `https://${THUNDER_PUBLIC_HOST}` through the control-plane gateway.
 
 ```bash
 helm install amp-thunder-extension \
@@ -328,10 +361,12 @@ helm install amp-thunder-extension \
   --version ${VERSION} \
   --namespace ${THUNDER_NS} \
   --create-namespace \
+  --set thunder.ocIngress.hostname="${THUNDER_PUBLIC_HOST}" \
   --set thunder.configuration.server.publicUrl="${THUNDER_PUBLIC_URL}" \
   --set thunder.configuration.jwt.issuer="${THUNDER_PUBLIC_URL}" \
-  --set thunder.configuration.gateClient.hostname="localhost" \
-  --set thunder.configuration.gateClient.port=8090 \
+  --set thunder.configuration.gateClient.hostname="${THUNDER_PUBLIC_HOST}" \
+  --set thunder.configuration.gateClient.scheme=https \
+  --set thunder.configuration.gateClient.port=443 \
   --set "thunder.configuration.cors.allowedOrigins={${CONSOLE_PUBLIC_URL}}" \
   --set "thunder.bootstrap.ampConsoleClient.redirectUris={${CONSOLE_PUBLIC_URL}/login}" \
   --timeout 1800s
@@ -342,7 +377,7 @@ kubectl wait --for=condition=Available \
 ```
 
 :::warning
-Thunder persists its configuration (including the issuer URL and the console client's OAuth redirect URIs) in a database on first boot. If you need to change `THUNDER_PUBLIC_URL` or `CONSOLE_PUBLIC_URL` after installation, you must **uninstall the chart, delete its PVC, and reinstall** — a `helm upgrade` alone will not change the issuer in issued tokens or the registered redirect URIs.
+Thunder persists its configuration (including the issuer URL and the console client's OAuth redirect URIs) in a database on first boot. If you need to change `THUNDER_PUBLIC_URL` or `CONSOLE_PUBLIC_URL` after installation, you must **uninstall the chart, delete its PVC, and reinstall** — a `helm upgrade` alone will not change the issuer in issued tokens or the registered redirect URIs. This is why the hostnames are fixed in [Plan Your Deployment](#plan-your-deployment) before anything installs.
 :::
 
 :::tip Verify
@@ -356,70 +391,11 @@ kubectl exec -n ${THUNDER_NS} deploy/amp-thunder-extension-deployment -- \
 
 ### Step 5: Install OpenChoreo Control Plane
 
-Do an initial install with placeholder hostnames to provision the LoadBalancer:
+Because the hostnames are fixed up front, the Control Plane installs once with its final configuration. Create the gateway's wildcard certificate first (issuance needs only the DNS zone, not the DNS records):
 
 ```bash
-helm upgrade --install openchoreo-control-plane \
-  oci://ghcr.io/openchoreo/helm-charts/openchoreo-control-plane \
-  --version 1.1.1 \
-  --namespace openchoreo-control-plane \
-  --create-namespace \
-  --values - <<'EOF'
-openchoreoApi:
-  http:
-    hostnames:
-      - "api.placeholder.tld"
-backstage:
-  enabled: false
-  baseUrl: ""
-  http:
-    hostnames:
-      - ""
-security:
-  oidc:
-    issuer: "https://thunder.placeholder.tld"
-gateway:
-  tls:
-    enabled: false
-EOF
-```
+kubectl create namespace openchoreo-control-plane --dry-run=client -o yaml | kubectl apply -f -
 
-:::note Webhook race condition
-If the install fails with `no endpoints available for service "controller-manager-webhook-service"`, this is a known transient race in OpenChoreo v1.1.1. Wait for the control plane deployments to become ready, then rerun the `helm upgrade --install` command.
-```bash
-kubectl wait --for=condition=Available deployment --all \
-  -n openchoreo-control-plane --timeout=300s
-```
-:::
-
-Wait for the LoadBalancer IP and derive the base domain:
-
-```bash
-echo "Waiting for LoadBalancer IP..."
-kubectl get svc gateway-default -n openchoreo-control-plane -w
-```
-
-Once the IP appears, set the domain:
-
-```bash
-CP_LB_IP=$(kubectl get svc gateway-default -n openchoreo-control-plane \
-  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-if [ -z "$CP_LB_IP" ]; then
-  CP_LB_HOSTNAME=$(kubectl get svc gateway-default -n openchoreo-control-plane \
-    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-  CP_LB_IP=$(dig +short "$CP_LB_HOSTNAME" | head -1)
-fi
-export CP_BASE_DOMAIN="openchoreo.${CP_LB_IP//./-}.nip.io"
-echo "Control Plane domain: ${CP_BASE_DOMAIN}"
-```
-
-:::tip EKS Users
-EKS LoadBalancers return a hostname instead of an IP. Use `dig` to resolve it. For internet-facing access, add annotation: `service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing`
-:::
-
-Create a wildcard TLS certificate:
-
-```bash
 kubectl apply -f - <<EOF
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -432,37 +408,32 @@ spec:
     name: openchoreo-ca
     kind: ClusterIssuer
   dnsNames:
-    - "*.${CP_BASE_DOMAIN}"
-    - "${CP_BASE_DOMAIN}"
+    - "*.${BASE_DOMAIN}"
+    - "${BASE_DOMAIN}"
   privateKey:
     rotationPolicy: Always
 EOF
 
 kubectl wait --for=condition=Ready certificate/cp-gateway-tls \
-  -n openchoreo-control-plane --timeout=60s
+  -n openchoreo-control-plane --timeout=300s
 ```
 
-Reconfigure with real hostnames, TLS, and Thunder OIDC:
+Install the Control Plane with hostnames, TLS, and Thunder OIDC:
 
 ```bash
-helm upgrade openchoreo-control-plane \
+helm upgrade --install openchoreo-control-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-control-plane \
   --version 1.1.1 \
   --namespace openchoreo-control-plane \
-  --reuse-values \
+  --create-namespace \
   --values - <<EOF
 openchoreoApi:
   config:
     server:
-      publicUrl: "https://api.${CP_BASE_DOMAIN}"
-    security:
-      authentication:
-        jwt:
-          jwks:
-            skip_tls_verify: true
+      publicUrl: "https://api.${BASE_DOMAIN}"
   http:
     hostnames:
-      - "api.${CP_BASE_DOMAIN}"
+      - "api.${BASE_DOMAIN}"
 backstage:
   enabled: false
   baseUrl: ""
@@ -479,7 +450,7 @@ security:
 gateway:
   tls:
     enabled: true
-    hostname: "*.${CP_BASE_DOMAIN}"
+    hostname: "*.${BASE_DOMAIN}"
     certificateRefs:
       - name: cp-gateway-tls
 EOF
@@ -488,8 +459,16 @@ kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-control-plane --timeout=300s
 ```
 
-:::warning
-`skip_tls_verify: true` disables JWKS TLS certificate validation. This is required here because the self-signed CA is not yet trusted by the Control Plane. For production, use CA-signed certificates and set `skip_tls_verify: false` (or remove the override entirely).
+:::note Webhook race condition
+If the install fails with `no endpoints available for service "controller-manager-webhook-service"`, this is a known transient race in OpenChoreo v1.1.1. Wait for the control plane deployments to become ready, then rerun the `helm upgrade --install` command.
+```bash
+kubectl wait --for=condition=Available deployment --all \
+  -n openchoreo-control-plane --timeout=300s
+```
+:::
+
+:::tip EKS Users
+EKS LoadBalancers return a hostname instead of an IP — resolve it with `dig` when you publish DNS records later. For internet-facing access, annotate the gateway Service with `service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing`.
 :::
 
 <details>
@@ -497,9 +476,9 @@ kubectl wait --for=condition=Available \
 
 - Backstage disabled (AMP provides its own console)
 - OIDC issuer set to `THUNDER_PUBLIC_URL` (matches the `iss` claim in Thunder-issued JWTs)
-- OIDC JWKS URL points to Thunder's in-cluster service (avoids external DNS dependency)
-- OpenChoreo API at `api.${CP_BASE_DOMAIN}`
-- TLS enabled with wildcard certificate
+- OIDC JWKS URL points to Thunder's in-cluster service (avoids external DNS dependency, and no TLS-verification overrides are needed since the in-cluster call is plain HTTP)
+- OpenChoreo API at `api.${BASE_DOMAIN}`
+- TLS enabled on the gateway with the wildcard certificate — Thunder, the Console, the API, and the gateway control plane all serve HTTPS under it
 
 </details>
 
@@ -527,34 +506,7 @@ kubectl create secret generic cluster-gateway-ca \
   -n openchoreo-data-plane --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-Install the Data Plane:
-
-```bash
-helm install openchoreo-data-plane \
-  oci://ghcr.io/openchoreo/helm-charts/openchoreo-data-plane \
-  --version 1.1.1 \
-  --namespace openchoreo-data-plane \
-  --create-namespace \
-  --set gateway.tls.enabled=false \
-  --set clusterAgent.tls.generateCerts=true \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-dp.yaml
-```
-
-Wait for the Data Plane LoadBalancer and configure TLS:
-
-```bash
-kubectl get svc gateway-default -n openchoreo-data-plane -w
-
-DP_LB_IP=$(kubectl get svc gateway-default -n openchoreo-data-plane \
-  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-if [ -z "$DP_LB_IP" ]; then
-  DP_LB_HOSTNAME=$(kubectl get svc gateway-default -n openchoreo-data-plane \
-    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-  DP_LB_IP=$(dig +short "$DP_LB_HOSTNAME" | head -1)
-fi
-export DP_DOMAIN="apps.openchoreo.${DP_LB_IP//./-}.nip.io"
-echo "Data Plane domain: ${DP_DOMAIN}"
-```
+Create the deployed-agents wildcard certificate, then install the Data Plane with TLS in one pass:
 
 ```bash
 kubectl apply -f - <<EOF
@@ -569,28 +521,25 @@ spec:
     name: openchoreo-ca
     kind: ClusterIssuer
   dnsNames:
-    - "*.${DP_DOMAIN}"
-    - "${DP_DOMAIN}"
+    - "*.${AGENTS_DOMAIN}"
+    - "${AGENTS_DOMAIN}"
   privateKey:
     rotationPolicy: Always
 EOF
 
 kubectl wait --for=condition=Ready certificate/dp-gateway-tls \
-  -n openchoreo-data-plane --timeout=60s
+  -n openchoreo-data-plane --timeout=300s
 
-helm upgrade openchoreo-data-plane \
+helm install openchoreo-data-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-data-plane \
   --version 1.1.1 \
   --namespace openchoreo-data-plane \
-  --reuse-values \
-  --values - <<EOF
-gateway:
-  tls:
-    enabled: true
-    hostname: "*.${DP_DOMAIN}"
-    certificateRefs:
-      - name: dp-gateway-tls
-EOF
+  --create-namespace \
+  --set clusterAgent.tls.generateCerts=true \
+  --set gateway.tls.enabled=true \
+  --set "gateway.tls.hostname=*.${AGENTS_DOMAIN}" \
+  --set "gateway.tls.certificateRefs[0].name=dp-gateway-tls" \
+  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-dp.yaml
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-data-plane --timeout=600s
@@ -620,11 +569,11 @@ $(echo "$CA_CERT" | sed 's/^/        /')
         name: gateway-default
         namespace: openchoreo-data-plane
         http:
-          host: "${DP_DOMAIN}"
+          host: "${AGENTS_DOMAIN}"
           listenerName: http
           port: 80
         https:
-          host: "${DP_DOMAIN}"
+          host: "${AGENTS_DOMAIN}"
           listenerName: https
           port: 443
   secretStoreRef:
@@ -791,21 +740,43 @@ kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VER
   -n openchoreo-observability-plane
 ```
 
-Install the Observability Plane:
+Create the gateway certificate, then install the Observability Plane:
 
 ```bash
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: obs-gateway-tls
+  namespace: openchoreo-observability-plane
+spec:
+  secretName: obs-gateway-tls
+  issuerRef:
+    name: openchoreo-ca
+    kind: ClusterIssuer
+  dnsNames:
+    - "*.${BASE_DOMAIN}"
+    - "${BASE_DOMAIN}"
+  privateKey:
+    rotationPolicy: Always
+EOF
+
+kubectl wait --for=condition=Ready certificate/obs-gateway-tls \
+  -n openchoreo-observability-plane --timeout=300s
+
 helm install openchoreo-observability-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \
   --version 1.1.1 \
   --namespace openchoreo-observability-plane \
   --create-namespace \
-  --set gateway.tls.enabled=false \
+  --set gateway.tls.enabled=true \
+  --set "gateway.tls.hostname=*.${BASE_DOMAIN}" \
+  --set "gateway.tls.certificateRefs[0].name=obs-gateway-tls" \
   --set clusterAgent.tls.generateCerts=true \
   --set observer.controlPlaneApiUrl="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --set observer.extraEnv.AUTH_SERVER_BASE_URL="${THUNDER_PUBLIC_URL}" \
   --set security.oidc.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set security.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
-  --set-string security.oidc.jwksUrlTlsInsecureSkipVerify=true \
   --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-op.yaml \
   --timeout 25m
 
@@ -859,49 +830,9 @@ helm upgrade --install observability-traces-opensearch \
   --timeout 10m
 ```
 
-Configure TLS for the Observability Plane gateway:
-
-```bash
-OBS_LB_IP=$(kubectl get svc gateway-default -n openchoreo-observability-plane \
-  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-if [ -z "$OBS_LB_IP" ]; then
-  OBS_LB_HOSTNAME=$(kubectl get svc gateway-default -n openchoreo-observability-plane \
-    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-  OBS_LB_IP=$(dig +short "$OBS_LB_HOSTNAME" | head -1)
-fi
-export OBS_DOMAIN="observer.${OBS_LB_IP//./-}.nip.io"
-
-kubectl apply -f - <<EOF
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: obs-gateway-tls
-  namespace: openchoreo-observability-plane
-spec:
-  secretName: obs-gateway-tls
-  issuerRef:
-    name: openchoreo-ca
-    kind: ClusterIssuer
-  dnsNames:
-    - "*.${OBS_LB_IP//./-}.nip.io"
-    - "${OBS_DOMAIN}"
-  privateKey:
-    rotationPolicy: Always
-EOF
-
-kubectl wait --for=condition=Ready certificate/obs-gateway-tls \
-  -n openchoreo-observability-plane --timeout=60s
-
-helm upgrade openchoreo-observability-plane \
-  oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \
-  --version 1.1.1 \
-  --namespace openchoreo-observability-plane \
-  --reuse-values \
-  --set gateway.tls.enabled=true \
-  --set "gateway.tls.hostname=*.${OBS_LB_IP//./-}.nip.io" \
-  --set "gateway.tls.certificateRefs[0].name=obs-gateway-tls" \
-  --timeout 10m
-```
+:::warning Production
+OpenSearch stores all traces, logs, and metrics. The default modules run it with ephemeral storage — set persistence before real use (`--set opensearch.persistence.enabled=true --set opensearch.persistence.size=100Gi` on the logs module that deploys OpenSearch, sized to your retention needs), or point the observability stack at a managed OpenSearch domain if your platform team operates one.
+:::
 
 Register the Observability Plane and link it to other planes:
 
@@ -954,13 +885,82 @@ kubectl get clusterdataplane,clusterworkflowplane,observabilityplane -n default
 
 All pods should be in `Running` or `Completed` state.
 
+### Step 10: Publish DNS Records
+
+The three plane gateways have LoadBalancers now — read their addresses and create the DNS records planned in [Plan Your Deployment](#plan-your-deployment):
+
+```bash
+for ns in openchoreo-control-plane openchoreo-observability-plane openchoreo-data-plane; do
+  printf '%-34s %s\n' "$ns:" \
+    "$(kubectl get svc gateway-default -n $ns \
+        -o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}')"
+done
+```
+
+| Record | Type | Points to |
+|---|---|---|
+| `console`, `api-amp`, `thunder`, `cp`, `api` `.${BASE_DOMAIN}` (or `*.${BASE_DOMAIN}`) | A / CNAME | control-plane gateway address |
+| `traces.${BASE_DOMAIN}` | A / CNAME | observability-plane gateway address |
+| `*.agents.${BASE_DOMAIN}` and `agents.${BASE_DOMAIN}` | A / CNAME | data-plane gateway address |
+
+Use A records for IPs (GKE, AKS) and CNAME records for hostnames (EKS). Verify resolution before continuing:
+
+```bash
+dig +short thunder.${BASE_DOMAIN} traces.${BASE_DOMAIN} test.${AGENTS_DOMAIN}
+```
+
 ---
 
 ## Phase 2: Agent Manager Installation
 
 With OpenChoreo and Thunder running, you can now install the Agent Manager components — the API, console, and extensions that provide the AI agent management capabilities.
 
+:::warning Production — managed PostgreSQL
+The Agent Manager chart below deploys an in-cluster PostgreSQL with a default password by default. For production, use a managed database (RDS, Cloud SQL, Azure Database) and add these values to the `wso2-agent-manager` install in Step 2:
+
+```bash
+  --set postgresql.enabled=false \
+  --set postgresql.external.host="your-db.example.com" \
+  --set postgresql.external.port=5432 \
+  --set postgresql.external.database=agentmanager \
+  --set postgresql.external.username=agentmanager \
+  --set postgresql.external.existingSecret=amp-db-credentials \
+  --set postgresql.external.existingSecretPasswordKey=password
+```
+
+Create the `amp-db-credentials` Secret in `${AMP_NS}` beforehand. Sizing, backups, and HA then come from your database service.
+:::
+
 <AmpInstallation version="${VERSION}" expandRegistryConfig={true} />
+
+### Wire the Remaining Public Endpoints
+
+Two settings are not covered by the shared installation steps above — apply them once all Phase 2 charts are installed.
+
+**External AI gateway endpoint** — register the `cp.` hostname on the control-plane gateway route and let the console render the right setup commands:
+
+```bash
+helm upgrade amp oci://${HELM_CHART_REGISTRY}/wso2-agent-manager \
+  --version ${VERSION} \
+  --namespace ${AMP_NS} \
+  --reuse-values \
+  --set "agentManagerService.ocIngress.gatewayMgmt.hostnames={${CP_GW_PUBLIC_HOST}}" \
+  --set console.config.gatewayControlPlaneUrl="https://${CP_GW_PUBLIC_HOST}"
+```
+
+**Deployed-agent endpoints** — point the default Environment's gateway at the public agents domain (the Environment's setting wholly replaces the data plane's, so without this override agent invoke URLs are built against a placeholder host) and route the workload publisher's token calls in-cluster:
+
+```bash
+helm upgrade amp-platform-resources oci://${HELM_CHART_REGISTRY}/wso2-amp-platform-resources-extension \
+  --version ${VERSION} \
+  --namespace ${DEFAULT_NS} \
+  --reuse-values \
+  --set global.oauth.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
+  --set environment.gateway.http.host="${AGENTS_DOMAIN}" \
+  --set environment.gateway.http.port=443 \
+  --set environment.gateway.https.host="${AGENTS_DOMAIN}" \
+  --set environment.gateway.https.port=443
+```
 
 ---
 
@@ -982,24 +982,83 @@ helm list -A | grep -E 'openchoreo|amp|gateway'
 
 ### Via the Plane Gateways
 
-Everything is hostname-routed through the three plane gateway LoadBalancers:
+Everything is hostname-routed through the three plane gateway LoadBalancers, over TLS:
 
 | Service | URL |
 |---------|-----|
 | **Agent Manager Console** | `https://${CONSOLE_PUBLIC_HOST}` |
 | **Agent Manager API** | `https://${API_PUBLIC_HOST}` |
+| **Thunder (OAuth login)** | `https://${THUNDER_PUBLIC_HOST}` |
 | **Traces Observer** | `https://${OBS_API_PUBLIC_HOST}` |
-| **OpenChoreo API** | `https://api.${CP_BASE_DOMAIN}` |
+| **OpenChoreo API** | `https://api.${BASE_DOMAIN}` |
+| **Gateway control plane** | `https://${CP_GW_PUBLIC_HOST}` |
 
-Thunder is reached via port-forwarding for OAuth login (matching the default `THUNDER_PUBLIC_URL`):
+Open the Console, log in, then create → build → deploy an agent; its invoke URL is published under `https://<org>-<project>.${AGENTS_DOMAIN}`.
 
-```bash
-kubectl port-forward -n amp-thunder svc/amp-thunder-extension-service 8090:8090 &
-```
-
-Port-forwarding also remains available as a fallback for reaching any individual service directly (all Agent Manager services are ClusterIP), e.g. `kubectl port-forward -n wso2-amp svc/amp-console 3000:3000`.
+Port-forwarding remains available as a debugging fallback for any individual service (all Agent Manager services are ClusterIP), e.g. `kubectl port-forward -n wso2-amp svc/amp-console 3000:3000`.
 
 **Default credentials:** `admin` / `admin`
+
+---
+
+## Appendix: Installing Without a Domain (nip.io)
+
+For evaluation on a cluster where you control no DNS zone, [nip.io](https://nip.io) turns LoadBalancer IPs into resolvable hostnames. The flow is the same as above with four differences.
+
+**1. Self-signed issuer.** In Step 3, create a self-signed chain under the same `openchoreo-ca` name instead of an ACME or corporate issuer:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-bootstrap
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openchoreo-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: openchoreo-ca
+  secretName: openchoreo-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: openchoreo-ca
+spec:
+  ca:
+    secretName: openchoreo-ca-secret
+EOF
+```
+
+Browsers will warn on every hostname (import `openchoreo-ca-secret`'s `ca.crt` into your trust store to avoid this), and the Control Plane install in Step 5 needs one extra override because it cannot verify Thunder's JWKS against an untrusted chain: add `--set-string openchoreoApi.config.security.authentication.jwt.jwks.skip_tls_verify=true` (and `--set-string security.oidc.jwksUrlTlsInsecureSkipVerify=true` on the Observability Plane install in Step 8).
+
+**2. Hostnames come from the first LoadBalancer.** The control-plane gateway must exist before you can derive a base domain, but Thunder needs the final hostnames at install time. So: run Step 5's namespace creation, then install *only* the kgateway-provisioned gateway by running the Control Plane install once with placeholder hostnames (`api.placeholder.tld`, issuer `https://thunder.placeholder.tld`, `gateway.tls.enabled=false`), wait for the LoadBalancer, and derive the base domain:
+
+```bash
+CP_LB_IP=$(kubectl get svc gateway-default -n openchoreo-control-plane \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+export BASE_DOMAIN="${CP_LB_IP//./-}.nip.io"
+```
+
+Now export the [Plan Your Deployment](#plan-your-deployment) variables from this `BASE_DOMAIN`, continue with Thunder (Step 4), and rerun the Step 5 install command — with the real values — as `helm upgrade`.
+
+**3. One caveat on the shared base domain.** All hostnames (`console.`, `traces.`, `*.agents.` …) resolve to the control-plane gateway's IP, but `traces.` and `*.agents.` must reach the *other* two gateways. Point them correctly by using per-gateway nip.io domains instead: derive `TRACES`/`AGENTS` hostnames from the observability and data-plane LoadBalancer IPs after those planes install, e.g. `export OBS_API_PUBLIC_HOST="traces.$(kubectl get svc gateway-default -n openchoreo-observability-plane -o jsonpath='{.status.loadBalancer.ingress[0].ip}' | tr . -).nip.io"` and the equivalent `AGENTS_DOMAIN` from the data-plane gateway — then use those values in the observability/data-plane certificates and in Phase 2.
+
+**4. Skip Step 10** (DNS records) — nip.io resolution is automatic.
+
+The Thunder reinstall warning applies with full force here: if you tear down and recreate the cluster, the LoadBalancer IP — and therefore every hostname — changes, and Thunder must be reinstalled with the new values.
 
 ---
 
@@ -1082,17 +1141,13 @@ kubectl delete namespace wso2-amp amp-thunder \
 
 ## Production Considerations
 
-This installation is designed for development and exploration. For production:
+The main flow above already covers real domains, trusted wildcard TLS, and gateway-served endpoints. Beyond it, plan for:
 
-1. **Use proper domains** — Replace nip.io with registered domain names and configure DNS
-2. **Wildcard TLS certificates** — Use DNS-01 validation for wildcard certificates from a trusted CA
-3. **Identity provider** — Replace Thunder dev mode with a proper IdP (Asgardeo, Auth0, Okta)
-4. **Thunder URL** — Set `THUNDER_PUBLIC_URL` to a publicly accessible domain with proper TLS
-5. **Secrets backend** — Disable OpenBao dev mode; configure persistent storage and proper auth
-6. **Observability storage** — Configure persistent volumes for OpenSearch
-7. **High availability** — Deploy multiple replicas across availability zones
-8. **Resource sizing** — Adjust requests/limits based on workload
-9. **Security hardening** — Apply network policies, RBAC, pod security standards
+1. **Managed dependencies** — apply the **Production** callouts inline above: external PostgreSQL, OpenBao without dev mode, OpenSearch persistence
+2. **Identity provider** — the seeded `admin`/`admin` user is for bootstrap only; connect your organization's IdP or manage users in Thunder before exposing the platform
+3. **High availability** — deploy multiple replicas across availability zones and adjust resource requests/limits to workload
+4. **Security hardening** — network policies, scoped RBAC, pod security standards
+5. **Certificate operations** — with Let's Encrypt, renewals are automatic; monitor cert-manager and keep the DNS-provider credentials Secret rotated
 
 ---
 
@@ -1159,10 +1214,12 @@ Both must match exactly. If they don't, update the Control Plane's `security.oid
 <details>
 <summary>Console shows "refused to connect" on login</summary>
 
-The console redirects to Thunder for OAuth login. Thunder must be accessible from the browser at the URL configured in `THUNDER_PUBLIC_URL`. For port-forwarding setups, ensure Thunder is forwarded:
+The console redirects the browser to Thunder for OAuth login at `THUNDER_PUBLIC_URL`. Check that the `thunder.${BASE_DOMAIN}` DNS record points at the control-plane gateway LoadBalancer and that the Thunder HTTPRoute exists:
 
 ```bash
-kubectl port-forward -n amp-thunder svc/amp-thunder-extension-service 8090:8090 &
+dig +short thunder.${BASE_DOMAIN}
+kubectl get httproute -n openchoreo-control-plane amp-thunder-extension
+curl -s -o /dev/null -w '%{http_code}\n' https://thunder.${BASE_DOMAIN}/.well-known/openid-configuration
 ```
 
 If you need to change Thunder's public URL after installation, you must uninstall, delete the PVC, and reinstall:

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -76,7 +76,7 @@ Three decisions shape the installation. Make them now — everything below is dr
 
 ### 1. Hostnames
 
-Pick a base domain you control (a delegated subdomain like `amp.yourdomain.com` works well). Every management surface is a hostname on one of the three plane gateway LoadBalancers — you publish exactly four DNS records after the platform installs:
+Pick a base domain you control (a delegated subdomain like `amp.yourdomain.com` works well). Every management surface is a hostname on one of the three plane gateway LoadBalancers — after the platform installs, you publish DNS records against just those three targets:
 
 | Hostname | Serves | DNS record → |
 |---|---|---|
@@ -88,7 +88,7 @@ Pick a base domain you control (a delegated subdomain like `amp.yourdomain.com` 
 | `traces.<base>` | Traces Observer | observability-plane gateway LB |
 | `*.agents.<base>` | Deployed-agent invocation endpoints (wildcard) | data-plane gateway LB |
 
-The first five share one record target (the control-plane gateway), so the four records are: `console`/`api-amp`/`thunder`/`cp`/`api` (five names, one LB — or a wildcard `*.<base>`), `traces`, and the `*.agents.<base>` wildcard.
+Concretely: `console`/`api-amp`/`thunder`/`cp`/`api` all point at the control-plane gateway (five records, or a single `*.<base>` wildcard), `traces` points at the observability-plane gateway, and `*.agents.<base>` plus the `agents.<base>` apex point at the data-plane gateway. [Step 10](#step-10-publish-dns-records) lists the exact records once the LoadBalancer addresses exist.
 
 ```bash
 export VERSION="0.0.0-dev"


### PR DESCRIPTION
## Purpose
The "On Your Environment" guide targeted managed clusters (EKS/GKE/AKS) but walked a development-shaped install: Thunder — the OAuth login every browser hits — reached via `kubectl port-forward`, hostnames derived from LoadBalancer IPs through nip.io with a placeholder-then-reconfigure Control Plane double-install, a self-signed CA compensated for by `skip_tls_verify` overrides in the mainline, dev-mode dependencies with no managed alternatives, and no step wiring the default Environment's gateway host — leaving deployed-agent invoke URLs pointing at a placeholder host on real clusters.

## Goals
Rewrite the guide production-first: a real domain, trusted TLS issued automatically by cert-manager, every management surface served through the three plane gateways (the platform's only LoadBalancers, per the LB consolidation in #1295), managed-dependency guidance inline, and a working end-to-end result including deployed-agent invoke URLs and external AI gateways — while keeping a no-domain evaluation path.

## Approach
- **Plan Your Deployment** (new): hostname table mapping the seven hostnames to the three gateway LoadBalancers, all variables derived from one `BASE_DOMAIN`, TLS-issuer and dependency decisions made before anything installs. Fixing hostnames up front resolves the Thunder ordering problem structurally (its issuer and console redirect URI are frozen at install time by the pre-install bootstrap hook) and lets the Control Plane install once with final values.
- **Tabbed TLS issuer step**: Let's Encrypt DNS-01 as the primary (publicly trusted wildcards, automatic renewal, no `skip_tls_verify` anywhere in the main flow), corporate CA as an equal alternative, self-signed relegated to the appendix. All three create the same `openchoreo-ca` ClusterIssuer name, so downstream Certificates are identical across choices.
- **Single-pass plane installs** with per-plane wildcard certificates created before install (DNS-01 needs only the zone, not the records); deployed agents get a dedicated `*.agents.<base>` wildcard; a new **Publish DNS Records** step lists the LoadBalancer addresses and the four records to create.
- **Wire the Remaining Public Endpoints** (new Phase 2 step): registers the external-AI-gateway hostname on the control-plane route (`gatewayMgmt.hostnames` + `gatewayControlPlaneUrl`), and points the default Environment's gateway at the public agents domain plus the workload publisher's token URL in-cluster — the same overrides the VM installer applies, without which invoke URLs are built against `am-gateway.localhost`.
- **Inline Production callouts** where each choice is made: managed PostgreSQL values (`postgresql.enabled=false` + `postgresql.external.*` + existingSecret), OpenBao without dev mode, OpenSearch persistence.
- **nip.io appendix**: the previous placeholder/derive flow condensed into a four-difference delta (self-signed issuer, LB-derived hostnames, per-gateway domains, no DNS step), carrying the skip-verify overrides and Thunder-reinstall caveat that only apply there.

## User stories
As a platform operator installing Agent Manager on a managed Kubernetes cluster, I want a guide that produces a TLS-secured, domain-based deployment without development workarounds, so that the result is usable by my organization without a rework pass.

## Release note
The "On Your Environment" installation guide is now production-first: real domains with automated Let's Encrypt or corporate-CA certificates, all endpoints served through the OpenChoreo plane gateways, inline managed-dependency guidance, and a nip.io appendix for evaluation without a domain.

## Documentation
This PR is documentation. Built successfully with `npm run build` (docusaurus); tabs, anchors, and admonitions verified in the rendered output.

## Training
N/A

## Certification
N/A — documentation restructure; no product behavior change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — documentation only; docusaurus build passes (broken links/anchors would fail it).
 - Integration tests
   > The command sequences mirror configurations verified elsewhere: the gateway-routing values were live-verified in #1295, and the Environment-gateway/token-URL overrides mirror the VM installer's tested `build_platform_resources_helm_args`/`thunder_helm_args`. A full walkthrough on a real cloud cluster (EKS or GKE) with a registered domain is the acceptance test and should gate any further hardening claims.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (documentation)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes (credential examples are placeholders)

## Samples
N/A

## Related PRs
Builds on #1295 (LB consolidation onto the plane gateways).

## Migrations (if applicable)
N/A — guide restructure; existing installs are unaffected.

## Test environment
Docs built with Node/docusaurus locally (macOS). Command sequences composed from configurations verified on k3d and the VM installer; cloud walkthrough pending as noted above.

## Learning
Thunder's bootstrap job is a Helm pre-install hook, so OAuth redirect URIs and the issuer are immutable after install — a production guide must fix hostnames before installing anything. cert-manager DNS-01 issuance needs only zone API access, letting certificates be created before any DNS record or LoadBalancer exists, which is what enables single-pass plane installs. The default Environment CR's gateway setting wholly replaces the ClusterDataPlane's ingress, so a guide that sets only the data-plane ingress produces broken invoke URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the “On Your Environment” installation guide into a production-oriented, domain-first flow.
  * Added TLS issuer and certificate setup options (Let’s Encrypt DNS-01, corporate CA, self-signed evaluation).
  * Introduced “Plan Your Deployment” to derive public hostnames/URLs from a single base domain.
  * Updated OpenBao, PostgreSQL, and OpenSearch guidance with stronger production warnings and persistence expectations.
  * Revised Observability, verification/access, nip.io, and troubleshooting sections, including DNS and HTTPRoute + OAuth connectivity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->