### PR TITLE
Fix VM install preflight abort on egress-restricted networks

### DIFF
--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -177,6 +177,10 @@ _public_ip() {
     ip="$(echo "$ip" | tr -d '[:space:]')"
     [[ "$ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] && { echo "$ip"; return; }
   done
+  # Must succeed even when every endpoint is unreachable (egress-restricted VMs):
+  # the caller assigns the output under `set -e`, so a non-zero status here would
+  # abort the whole install instead of just skipping the public-IP DNS candidate.
+  return 0
 }
 
 # validate_dns <ip> [more_ips...] — confirm derived hosts resolve to one of the given

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -747,5 +747,18 @@ assert_eq "inotify empty current bumps"       "512"    "$(inotify_bump_target ""
 assert_eq "inotify non-numeric current bumps" "512"    "$(inotify_bump_target foo 512)"
 assert_eq "inotify watches floor"             "524288" "$(inotify_bump_target 8192 524288)"
 
+# --- _public_ip: succeeds with empty output when every endpoint is unreachable
+# (egress-restricted VM). install-advanced.sh assigns its output under set -e, so a
+# non-zero status would abort the install instead of skipping the public-IP candidate. ---
+(
+  # shellcheck disable=SC2329  # invoked indirectly by _public_ip
+  curl() { return 6; }   # shadow the binaries: every probe fails
+  # shellcheck disable=SC2329
+  wget() { return 4; }
+  out="$(_public_ip)"; rc=$?
+  assert_eq "_public_ip offline exit status"  "0" "$rc"
+  assert_eq "_public_ip offline output empty" ""  "$out"
+)
+
 if [[ -s "$FAILLOG" ]]; then echo "TESTS FAILED"; exit 1; fi
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Purpose
The advanced VM installer's DNS pre-flight silently aborts the entire installation on VMs without unrestricted outbound internet access. `_public_ip` (lib-advanced.sh) probes `api.ipify.org`, `ifconfig.me`, and `icanhazip.com` to learn the VM's public egress IP; when all three are unreachable, the helper returns a non-zero status, and the assignment `pub="$(_public_ip)"` in `install-advanced.sh` propagates it under `set -euo pipefail`, killing the install before it starts. The helper is documented as best-effort ("Empty if it can't be determined"), and the pre-flight is advisory in every TLS mode except `letsencrypt`, so an unreachable probe endpoint should never be fatal — particularly since the private-network TLS modes (`letsencrypt-dns`, `selfsigned`) explicitly target environments where these endpoints are often blocked.

## Goals
Make the public-IP probe genuinely best-effort: when no endpoint is reachable, the installer proceeds and the DNS pre-flight simply skips the public-IP candidate (falling back to the VM's local interface IPs, with the existing "verify DNS manually" messaging).

## Approach
Add an explicit `return 0` at the end of `_public_ip` so the function's exit status matches its documented contract, with a comment explaining why the status matters (the caller assigns its output under `set -e`). Added a regression test to `deployments/vm/tests/run.sh` that shadows `curl`/`wget` with failing functions and asserts `_public_ip` exits 0 with empty output.

## User stories
As an operator installing Agent Manager on a VM with restricted outbound internet (private/air-gapped network), I can run `install-advanced.sh` without the installation aborting at the DNS pre-flight because public IP-detection services are unreachable.

## Release note
Fixed the advanced VM installer aborting on networks where public IP-detection endpoints (api.ipify.org, ifconfig.me, icanhazip.com) are unreachable; the DNS pre-flight now treats public-IP detection as best-effort.

## Documentation
N/A — no behavior change on networks with outbound access; the fix restores the documented best-effort behavior of an internal helper.

## Training
N/A

## Certification
N/A — internal installer bug fix with no impact on product features or user-facing workflows.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Added a regression test in `deployments/vm/tests/run.sh` (`_public_ip offline exit status` / `_public_ip offline output empty`) that simulates all probe endpoints being unreachable. Full suite passes: `ALL TESTS PASSED`.
 - Integration tests
   > N/A — covered by the unit tier for the VM installer libs.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (shell script change; FindSecurityBugs targets Java)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM deployment behavior when public IP lookup services are unreachable.
  * Deployments now continue successfully and return an empty public IP result instead of failing in restricted network environments.

* **Tests**
  * Added coverage for scenarios where all public IP detection services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->