### PR TITLE
Store Thunder CA bundle via file to avoid E2BIG

### DIFF
--- a/deployments/scripts/add-environment-thunder.sh
+++ b/deployments/scripts/add-environment-thunder.sh
@@ -776,10 +776,19 @@ main() {
     ca_bundle="${mozilla_bundle}
 ${ca_pem}"
 
-    # Store the combined bundle as a ConfigMap.
+    # Store the combined bundle as a ConfigMap. Pass the bundle through a temp
+    # file with --from-file rather than --from-literal: the Mozilla CA bundle is
+    # ~230KB, which exceeds the Linux per-argument limit (MAX_ARG_STRLEN, 128KB)
+    # and makes kubectl exit with "Argument list too long" before it emits any
+    # YAML, so the piped `kubectl apply` then fails with "no objects passed to
+    # apply". (macOS has a larger limit, so this only bites on Linux/CI.)
+    local ca_bundle_file
+    ca_bundle_file="$(mktemp)"
+    printf '%s' "$ca_bundle" >"$ca_bundle_file"
     kubectl create configmap "$ca_cm_name" -n "$ns" \
-      --from-literal=ca-bundle.crt="${ca_bundle}" \
+      --from-file=ca-bundle.crt="$ca_bundle_file" \
       --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    rm -f "$ca_bundle_file"
     echo "🔐 Combined CA bundle (Mozilla + platform Thunder CA) stored in ${ns}/${ca_cm_name}"
   fi
   fi # SKIP_CA_BUNDLE_TRUST


### PR DESCRIPTION
## Purpose
The nightly `Nightly Dev Build` e2e suite has been failing for several days. Every spec that provisions a per-environment Thunder identity provider (`add-environment.sh`, agent promotion, deployment pipelines, environment management, and the agent-catalog second-environment chat test) fails in `BeforeAll`/setup with:

```
add-environment-thunder.sh: line 780: /usr/bin/kubectl: Argument list too long
error: no objects passed to apply
⚠️  Thunder ID provisioning failed.
```

The root cause is the combined CA-bundle ConfigMap creation in `add-environment-thunder.sh`. It builds the trusted-issuer bundle (Mozilla `cacert.pem` ~230KB + the platform Thunder CA) and hands it to kubectl as a single command-line argument via `--from-literal=ca-bundle.crt="${ca_bundle}"`. On Linux this exceeds the per-argument limit (`MAX_ARG_STRLEN`, 128KB), so kubectl aborts with `E2BIG` ("Argument list too long") *before* emitting any YAML; the piped `kubectl apply` then receives nothing and fails with "no objects passed to apply", and Thunder provisioning bails out.

macOS has a much larger single-argument limit, so the same command succeeds during local runs — the failure only reproduces on Linux/CI. This is a pre-existing issue introduced when the Mozilla CA bundle trust was added; it is unrelated to the recent gateway-consolidation change.

## Goals
Provision the per-environment Thunder CA-bundle ConfigMap without placing the ~230KB payload on the command line, restoring the nightly e2e suite on Linux.

## Approach
Write the combined bundle to a temp file and create the ConfigMap with `--from-file=ca-bundle.crt=<file>` instead of `--from-literal`. `--from-file` reads the file content directly, so the payload never becomes a command-line argument and the Linux per-argument limit no longer applies. The temp file is removed immediately after. The rendered ConfigMap is byte-identical to the previous `--from-literal` output, so no downstream behavior changes.

## User stories
As a platform operator installing AMP on Linux, I want per-environment Thunder provisioning to succeed so that adding environments and promoting agents works out of the box.

## Release note
Fixed a failure provisioning the per-environment Thunder identity provider on Linux, where creating the combined CA-bundle ConfigMap aborted with "Argument list too long" because the ~230KB Mozilla CA bundle exceeded the OS command-line argument limit.

## Documentation
N/A — internal provisioning script fix with no user-facing behavior or interface change.

## Training
N/A — no training impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — bug fix.

## Automation tests
 - Unit tests
   > `bash -n deployments/scripts/add-environment-thunder.sh` passes. Verified that `kubectl create configmap --from-file=...` produces byte-identical `-o yaml` output to the previous `--from-literal=...` for a ~230KB bundle (same key, same content), confirming behavioral equivalence.
 - Integration tests
   > The fix targets the exact command that fails on Linux CI; the E2BIG limit is a per-argument OS limit that `--from-file` sidesteps entirely. Full validation is via the nightly e2e suite once merged.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (no Java/application code changed; shell script only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A — no migration required.

## Test environment
k3d (k3s) single-node cluster on Linux CI runners (Ubuntu); reproduction confirmed against Linux `MAX_ARG_STRLEN` (128KB per argument). Behavioral-equivalence check run on macOS (Darwin) with kubectl client-side dry-run.

## Learning
Linux caps a single `exec` argument at `MAX_ARG_STRLEN` (32 pages = 128KB), independent of the much larger total `ARG_MAX`. A payload under `ARG_MAX` can still trigger `E2BIG` if one argument alone exceeds 128KB. kubectl's `--from-file` avoids this by reading file contents rather than accepting them as an argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability for environments with large trusted-issuer certificate bundles.
  * Prevented Kubernetes command-line argument-length issues during certificate configuration.
  * Added temporary-file cleanup after certificate setup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->