### PR TITLE
Capture per-env gateway pod logs in e2e dump

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -82,6 +82,24 @@ jobs:
           for pod in $(kubectl get pods -n workflows-default --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
             kubectl logs "$pod" -n workflows-default --all-containers=true --tail=200 > "/tmp/pod-logs/wf-pod-${pod}.txt" 2>&1 || true
           done
+          # Per-env API Platform Gateway + Thunder pods. Each environment's gateway
+          # stack lives in its own "<org>-<env>" namespace and its Thunder in
+          # "amp-thunder-<org>-<env>"; the gateway's Helm pre-install bootstrap Job
+          # runs there. Capturing these makes "failed pre-install: timed out
+          # waiting for the condition" debuggable (the bootstrap Job pod log is the
+          # only place the actual healthz/IDP/registration error appears). Also
+          # describe non-Running pods to surface exit reasons and scheduling events.
+          for ns in $(kubectl get ns --no-headers -o custom-columns=":metadata.name" 2>/dev/null \
+              | grep -E '^(default-|amp-thunder-)' || true); do
+            for pod in $(kubectl get pods -n "$ns" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+              kubectl logs "$pod" -n "$ns" --all-containers=true --tail=200 > "/tmp/pod-logs/ns-${ns}--${pod}.txt" 2>&1 || true
+            done
+            kubectl get pods -n "$ns" --no-headers 2>/dev/null \
+              | awk '$3 != "Running" && $3 != "Completed" { print $1 }' \
+              | while read -r p; do
+                  kubectl describe pod "$p" -n "$ns" > "/tmp/pod-logs/describe-${ns}--${p}.txt" 2>&1 || true
+                done
+          done
 
       - name: Upload pod logs
         if: failure()


### PR DESCRIPTION
## Purpose
When the e2e suite fails during environment setup, the most common failure is a per-environment API Platform Gateway install timing out:

```
🌐 Installing API Platform Gateway for 'e2e-xxx'...
Error: failed pre-install: 1 error occurred: * timed out waiting for the condition
```

The actual cause lives in the gateway's Helm **pre-install bootstrap Job** pod, which runs in the per-org-env gateway namespace (`<org>-<env>`). The "Dump pod logs on failure" step only collected logs for the fixed platform deployments (`amp-api`, `openchoreo-api`, observer, controller-manager) and the `workflows-default` namespace, so the bootstrap Job pod — the only place the real healthz/IDP/registration error surfaces — was never captured. That leaves this failure opaque in the uploaded artifact and forces a live re-run to diagnose.

## Goals
Make per-environment gateway (and per-env Thunder) provisioning failures debuggable straight from the uploaded `pod-logs` artifact, with no live cluster access required.

## Approach
Extend the failure-dump step to also, for every `<org>-<env>` gateway namespace and its matching `amp-thunder-<org>-<env>` Thunder namespace:
- dump each pod's logs (all containers, `--tail=200`), and
- `kubectl describe` any pod that is not `Running`/`Completed`, so exit reasons and scheduling events (e.g. `Insufficient cpu`) are captured.

The namespace set is discovered with a `^(default-|amp-thunder-)` name filter, matching the per-env gateway/Thunder naming convention. Every command is guarded with `|| true` and `2>&1`, consistent with the existing dump, so the step never fails the job. The filter was validated against a real failed run's `kubectl get pods -A` output: it selects exactly the per-env gateway/Thunder namespaces and describes the `Error` bootstrap pods and `Pending` Thunder pod.

## User stories
As an engineer triaging a red e2e run, I want the per-env gateway bootstrap Job logs in the artifact so that I can root-cause a `failed pre-install: timed out` without re-running the suite.

## Release note
N/A — CI diagnostics only; no product or runtime change.

## Documentation
N/A — no user-facing behavior change.

## Training
N/A

## Certification
N/A — CI-only change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `ruby -ryaml` parse of the workflow passes. The namespace/`describe` filter logic was run against a real failed run's `kubectl get pods -A` dump and selected exactly the intended per-env gateway/Thunder namespaces and non-Running pods.
 - Integration tests
   > Exercised by the next e2e run: on failure the uploaded `pod-logs` artifact will include `ns-<namespace>--<pod>.txt` and `describe-<namespace>--<pod>.txt` files for the per-env gateway/Thunder pods.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (no Java/application code changed; CI workflow only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
GitHub Actions e2e workflow on k3d (single-node k3s); workflow YAML validated locally with Ruby's YAML parser and the dump filters validated against a real failed-run pod listing.

## Learning
Helm's `failed pre-install: timed out waiting for the condition` for a chart with a pre-install hook Job means the hook Job never reached completion; the diagnostic signal is in that Job's pod, not in helm's output. A failure-log collector must enumerate the dynamic per-env namespaces to capture it, since the pods live outside the fixed platform namespaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic collection when end-to-end tests fail.
  * Failure reports now include logs and pod details from relevant API Gateway and Thunder environments, making troubleshooting information more comprehensive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->