### PR TITLE
Restore data-plane pod log dump in e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -82,6 +82,14 @@ jobs:
           for pod in $(kubectl get pods -n workflows-default --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
             kubectl logs "$pod" -n workflows-default --all-containers=true --tail=200 > "/tmp/pod-logs/wf-pod-${pod}.txt" 2>&1 || true
           done
+          # User workload (agent runtime) pods live in per-env data-plane namespaces
+          # (dp-<org>-<project>-<env>-<hash>). These carry the actual agent invocation
+          # errors (e.g. "500 Connection error"), so capture logs for every pod in them.
+          for ns in $(kubectl get ns --no-headers -o custom-columns=":metadata.name" 2>/dev/null | grep '^dp-'); do
+            for pod in $(kubectl get pods -n "$ns" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+              kubectl logs "$pod" -n "$ns" --all-containers=true --tail=500 > "/tmp/pod-logs/dp-${ns}-${pod}.txt" 2>&1 || true
+            done
+          done
           # Per-env API Platform Gateway + Thunder pods. Each environment's gateway
           # stack lives in its own "<org>-<env>" namespace and its Thunder in
           # "amp-thunder-<org>-<env>"; the gateway's Helm pre-install bootstrap Job


### PR DESCRIPTION
## Purpose
The e2e failure dump lost its data-plane agent-runtime log capture. The per-env API Platform Gateway/Thunder log capture (added in `fea03a17`, PR #1315) was branched off a `main` that predated the data-plane log loop, so merging it inadvertently dropped that loop. Agent-runtime pods run in per-env data-plane namespaces (`dp-<org>-<project>-<env>-<hash>`) and carry the actual agent invocation errors (e.g. `500 Connection error`) behind the Agent-catalog and LLM-provider "deploys the agent" e2e failures — without those logs, those failures can't be diagnosed from the artifact.

## Goals
Restore data-plane agent-runtime pod log capture in the failure dump, keeping the gateway/Thunder capture that was just added.

## Approach
Re-add the `dp-*` namespace loop (all pod logs, `--tail=500`) alongside the existing `<org>-<env>` gateway + `amp-thunder-<org>-<env>` Thunder capture, so the dump now covers both the control-plane gateway bootstrap and the data-plane agent runtime.

## User stories
As an engineer triaging a red e2e run, I want the agent-runtime pod logs back in the artifact so that I can diagnose agent-invocation failures without re-running the suite.

## Release note
N/A — CI diagnostics only; no product or runtime change.

## Documentation
N/A — no user-facing behavior change.

## Training
N/A

## Certification
N/A — CI-only change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Workflow YAML parses (`ruby -ryaml`). Both dump loops (`^dp-` and `^(default-|amp-thunder-)`) are present.
 - Integration tests
   > Exercised by the next e2e run: on failure the uploaded `pod-logs` artifact will again include `dp-<namespace>-<pod>.txt` files alongside the gateway/Thunder `ns-*`/`describe-*` files.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (no Java/application code changed; CI workflow only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Related to #1315 (restores a loop dropped by that PR's stale merge base).

## Migrations (if applicable)
N/A

## Test environment
GitHub Actions e2e workflow on k3d (single-node k3s); workflow YAML validated locally with Ruby's YAML parser.

## Learning
Branching a change off a stale `main` and merging it can silently drop lines another commit added in the same region after the branch point — here, an entire log-capture loop. Rebasing on latest `main` before merge, or diffing the merged file against `main`, catches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for end-to-end test failures by capturing logs from all pods in data-plane environments.
  * Increased the amount of retained pod log output to provide more context when troubleshooting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->