### PR TITLE
Reduce e2e parallelism to fit single-node CPU

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,7 +27,10 @@ jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # Bumped from 60 to accommodate the reduced test parallelism below: with
+    # --procs=2 (was -p, i.e. one proc per vCPU) fewer suites run concurrently,
+    # so wall-clock grows even though each suite no longer thrashes on CPU.
+    timeout-minutes: 90
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -61,7 +64,15 @@ jobs:
           CHART_VERSION: ${{ env.HELM_CHART_VERSION }}
         run: |
           set -o pipefail
-          cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v -p --timeout 45m \
+          # --procs=2 (was -p, which auto-picks one proc per vCPU = 4 on the
+          # ubuntu-24.04 runner). The single-node k3d cluster cannot fit 4
+          # concurrent per-environment stacks (each env = its own Thunder +
+          # isolated API Platform Gateway controller/runtime + agent runtime
+          # pods); the node ran out of CPU, leaving pods Pending
+          # ("Insufficient cpu") and gateway bootstrap Jobs timing out. Two
+          # concurrent suites keep the resource footprint within the node.
+          # --timeout raised to 70m to match the longer wall-clock at --procs=2.
+          cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --procs=2 --timeout 70m \
             --poll-progress-after=600s --keep-going --junit-report=report.xml \
             ./tests/... 2>&1 | tee e2e-output.log
 


### PR DESCRIPTION
## Purpose
The e2e suite has been failing with a cascade of environment-provisioning errors — per-env API Platform Gateway `failed pre-install: timed out`, agent "deploys the agent" failures, and ultimately `FAIL! - Suite Timeout Elapsed`. The pod-log artifacts show the real cause: the single-node k3d cluster runs out of CPU. `kubectl get events` is full of `FailedScheduling ... Insufficient cpu` across agent-runtime pods (`dp-*`), per-env Thunder (`amp-thunder-default-e2e-*`, stuck `Pending`), and the catalog agent, and the observability-plane pods flap on startup probes.

The trigger is test parallelism versus per-environment footprint. The suite runs `ginkgo -p`, which auto-selects one parallel process per vCPU — four on the `ubuntu-24.04` runner. Each parallel suite provisions a *full* per-environment stack (its own Thunder, an isolated API Platform Gateway controller **and** runtime, plus agent build workflows and runtime pods) on top of the entire OpenChoreo platform, all on one k3d node. Four concurrent environments exceed the node's ~4 vCPU, so pods sit `Pending`, gateway bootstrap Jobs hit their backoff limit, helm times out, and the suite eventually trips the 45m ginkgo timeout while spinning on unschedulable pods.

## Goals
Bring the concurrent resource footprint within the single node's capacity so environment provisioning schedules and the suite completes.

## Approach
Pin the run to `--procs=2` (was `-p`) so at most two environments exist at once. Because fewer suites run concurrently the wall-clock grows (even though each suite no longer thrashes on CPU), so raise the ginkgo timeout to 70m and the job `timeout-minutes` to 90. Only the "Run e2e tests" step and the job timeout change; no test logic changes.

If two concurrent environments still overrun the node, the next levers are `--procs=1` or a larger runner.

## User stories
As an engineer relying on e2e, I want the suite to schedule its workloads and complete on the standard runner so that its result reflects product correctness, not CPU starvation.

## Release note
N/A — CI-only change; no product or runtime behavior changes.

## Documentation
N/A — no user-facing behavior change.

## Training
N/A

## Certification
N/A — CI-only change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Workflow YAML parses (`ruby -ryaml`). Change is limited to the ginkgo invocation (`--procs=2 --timeout 70m`) and the job `timeout-minutes`.
 - Integration tests
   > Validated by re-running the E2E workflow: the `Insufficient cpu` FailedScheduling events and gateway pre-install timeouts should clear once at most two environments are provisioned concurrently.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (no Java/application code changed; CI workflow only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Related to #1315 and #1316 (the failure-dump changes that surfaced the `Insufficient cpu` evidence behind this fix).

## Migrations (if applicable)
N/A

## Test environment
GitHub Actions E2E workflow on k3d (single-node k3s) on an `ubuntu-24.04` runner; workflow YAML validated locally with Ruby's YAML parser.

## Learning
`ginkgo -p` scales parallel processes to the host vCPU count, which is the wrong signal when every parallel suite provisions a heavy, node-shared environment: parallelism is bounded by cluster capacity, not runner cores. `FailedScheduling ... Insufficient cpu` on the shared node is the tell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased end-to-end test time limits to improve reliability for longer-running test suites.
  * Reduced test parallelism to better accommodate available cluster resources.
  * Preserved existing test reporting, logging, and result publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->