### PR TITLE
Reduce nightly e2e parallelism to fit CPU

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -250,7 +250,10 @@ jobs:
     name: E2E
     needs: [compute-version, package-charts, update-dev-tag]
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # Bumped from 60 to accommodate the reduced test parallelism below: with
+    # --procs=2 (was -p, i.e. one proc per vCPU) fewer suites run concurrently,
+    # so wall-clock grows even though each suite no longer thrashes on CPU.
+    timeout-minutes: 90
     permissions:
       contents: read
       checks: write
@@ -296,7 +299,15 @@ jobs:
           CHART_VERSION: ${{ needs.compute-version.outputs.dev-version }}
         run: |
           set -o pipefail
-          cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v -p --timeout 45m \
+          # --procs=2 (was -p, which auto-picks one proc per vCPU = 4 on the
+          # ubuntu-24.04 runner). The single-node k3d cluster cannot fit 4
+          # concurrent per-environment stacks (each env = its own Thunder +
+          # isolated API Platform Gateway controller/runtime + agent runtime
+          # pods); the node ran out of CPU, leaving pods Pending
+          # ("Insufficient cpu") and gateway bootstrap Jobs timing out. Two
+          # concurrent suites keep the resource footprint within the node.
+          # --timeout raised to 70m to match the longer wall-clock at --procs=2.
+          cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --procs=2 --timeout 70m \
             --poll-progress-after=600s --keep-going --junit-report=report.xml \
             ./tests/... 2>&1 | tee e2e-output.log
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,9 +251,9 @@ jobs:
     needs: [compute-version, package-charts, update-dev-tag]
     runs-on: ubuntu-24.04
     # Bumped from 60 to accommodate the reduced test parallelism below: with
-    # --procs=2 (was -p, i.e. one proc per vCPU) fewer suites run concurrently,
-    # so wall-clock grows even though each suite no longer thrashes on CPU.
-    timeout-minutes: 90
+    # --procs=1 (was -p, i.e. one proc per vCPU) suites run serially, so
+    # wall-clock grows even though no suite thrashes on CPU any more.
+    timeout-minutes: 120
     permissions:
       contents: read
       checks: write
@@ -299,15 +299,15 @@ jobs:
           CHART_VERSION: ${{ needs.compute-version.outputs.dev-version }}
         run: |
           set -o pipefail
-          # --procs=2 (was -p, which auto-picks one proc per vCPU = 4 on the
-          # ubuntu-24.04 runner). The single-node k3d cluster cannot fit 4
-          # concurrent per-environment stacks (each env = its own Thunder +
-          # isolated API Platform Gateway controller/runtime + agent runtime
-          # pods); the node ran out of CPU, leaving pods Pending
-          # ("Insufficient cpu") and gateway bootstrap Jobs timing out. Two
-          # concurrent suites keep the resource footprint within the node.
-          # --timeout raised to 70m to match the longer wall-clock at --procs=2.
-          cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --procs=2 --timeout 70m \
+          # --procs=1 (was -p, which auto-picks one proc per vCPU = 4 on the
+          # ubuntu-24.04 runner). The single-node k3d cluster cannot fit
+          # multiple concurrent per-environment stacks (each env = its own
+          # Thunder + isolated API Platform Gateway controller/runtime + agent
+          # runtime pods); the node ran out of CPU, leaving pods Pending
+          # ("Insufficient cpu") and gateway bootstrap Jobs timing out. Running
+          # suites serially keeps the footprint to one environment at a time.
+          # --timeout raised to 90m to match the longer serial wall-clock.
+          cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --procs=1 --timeout 90m \
             --poll-progress-after=600s --keep-going --junit-report=report.xml \
             ./tests/... 2>&1 | tee e2e-output.log
 
@@ -334,6 +334,24 @@ jobs:
             for pod in $(kubectl get pods -n "$ns" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
               kubectl logs "$pod" -n "$ns" --all-containers=true --tail=500 > "/tmp/pod-logs/dp-${ns}-${pod}.txt" 2>&1 || true
             done
+          done
+          # Per-env API Platform Gateway + Thunder pods. Each environment's gateway
+          # stack lives in its own "<org>-<env>" namespace and its Thunder in
+          # "amp-thunder-<org>-<env>"; the gateway's Helm pre-install bootstrap Job
+          # runs there. Capturing these makes "failed pre-install: timed out
+          # waiting for the condition" debuggable (the bootstrap Job pod log is the
+          # only place the actual healthz/IDP/registration error appears). Also
+          # describe non-Running pods to surface exit reasons and scheduling events.
+          for ns in $(kubectl get ns --no-headers -o custom-columns=":metadata.name" 2>/dev/null \
+              | grep -E '^(default-|amp-thunder-)' || true); do
+            for pod in $(kubectl get pods -n "$ns" --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+              kubectl logs "$pod" -n "$ns" --all-containers=true --tail=200 > "/tmp/pod-logs/ns-${ns}--${pod}.txt" 2>&1 || true
+            done
+            kubectl get pods -n "$ns" --no-headers 2>/dev/null \
+              | awk '$3 != "Running" && $3 != "Completed" { print $1 }' \
+              | while read -r p; do
+                  kubectl describe pod "$p" -n "$ns" > "/tmp/pod-logs/describe-${ns}--${p}.txt" 2>&1 || true
+                done
           done
 
       - name: Upload pod logs


### PR DESCRIPTION
## Purpose
The nightly build's e2e job keeps failing with the same cascade — per-env API Platform Gateway `failed pre-install: timed out`, agent "deploys the agent" failures, and finally `FAIL! - Suite Timeout Elapsed`. The pod-log artifacts show the cause: the single-node k3d cluster runs out of CPU (`kubectl get events` is full of `FailedScheduling ... Insufficient cpu` across agent-runtime pods, per-env Thunder, and the catalog agent).

The trigger is test parallelism versus per-environment footprint. The nightly's e2e job runs `ginkgo -p`, which auto-selects one parallel process per vCPU — four on the `ubuntu-24.04` runner. Each parallel suite provisions a full per-environment stack (own Thunder, an isolated API Platform Gateway controller **and** runtime, plus agent build/runtime pods) on top of the whole OpenChoreo platform, all on one k3d node. Four concurrent environments exceed the node's ~4 vCPU.

Important: the parallelism fix was previously applied to `.github/workflows/e2e.yaml` (the manually-dispatched *E2E Tests* workflow), but the **nightly** build has its own duplicate e2e job in `.github/workflows/nightly.yml`, which is what actually runs on the nightly schedule/dispatch. That job never picked up the change — hence the continued failures.

## Goals
Bring the nightly e2e job's concurrent resource footprint within the single node's capacity so provisioning schedules and the suite completes, and make any remaining provisioning failure debuggable from the artifact.

## Approach
1. Run the suite **serially** (`--procs=1`, was `-p`) so only one per-environment stack exists at a time — the surest way to stay under the node's CPU after repeated `Insufficient cpu` failures. Raise the ginkgo timeout to 90m and the job `timeout-minutes` to 120 to cover the longer serial wall-clock.
2. Mirror the per-env gateway/Thunder failure-log capture into this workflow's dump step (it previously existed only in the E2E Tests workflow): dump pods in every `<org>-<env>` gateway namespace and its matching `amp-thunder-<org>-<env>` namespace, and `describe` non-Running pods, so if provisioning still fails the bootstrap Job's error is captured.

No test logic changes. If serial execution proves unnecessarily slow once green, `--procs=2` or a larger runner can dial it back.

Note: the two workflows still carry duplicate e2e job definitions. De-duplicating them (a reusable workflow) is worth a follow-up, but is out of scope here.

## User stories
As an engineer watching the nightly build, I want its e2e job to schedule its workloads and complete on the standard runner so that a red nightly reflects a real regression, not CPU starvation.

## Release note
N/A — CI-only change; no product or runtime behavior changes.

## Documentation
N/A — no user-facing behavior change.

## Training
N/A

## Certification
N/A — CI-only change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Workflow YAML parses (`ruby -ryaml`). Changes are limited to the nightly e2e job's ginkgo invocation (`--procs=1 --timeout 90m`), its `timeout-minutes`, and the failure-dump step. The new dump filter was validated against a real failed-run pod listing: it selects exactly the per-env gateway/Thunder namespaces and describes the `Error` bootstrap pods and `Pending` Thunder pod.
 - Integration tests
   > Validated by the next nightly (or a manual dispatch of the nightly workflow): the `Insufficient cpu` FailedScheduling events and gateway pre-install timeouts should clear with serial execution; if anything still fails, the artifact will now include the gateway bootstrap Job logs.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (no Java/application code changed; CI workflow only)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Related to #1317 (same parallelism fix for the E2E Tests workflow), #1315 and #1316 (the failure-dump changes for the E2E Tests workflow whose gateway capture this PR mirrors into the nightly).

## Migrations (if applicable)
N/A

## Test environment
GitHub Actions nightly workflow on k3d (single-node k3s) on an `ubuntu-24.04` runner; workflow YAML validated locally with Ruby's YAML parser, and the dump filter validated against a real failed-run pod listing.

## Learning
When two workflows carry duplicate job definitions, a fix applied to one silently misses the other. `ginkgo -p` also scales to host vCPUs, which is the wrong signal when every parallel suite provisions a heavy, node-shared environment: parallelism is bounded by cluster capacity, not runner cores. `FailedScheduling ... Insufficient cpu` on the shared node is the tell.
