### PR TITLE
Store OpenBao tokens in chart Secret instead of plaintext env

### DIFF
--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/deployment.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/deployment.yaml
@@ -105,25 +105,27 @@ spec:
                   key: {{ .Values.agentManagerService.config.github.existingSecretKey | default "github-token" }}
             {{- if or .Values.agentManagerService.config.openbao.token .Values.agentManagerService.config.openbao.existingSecret }}
             - name: OPENBAO_TOKEN
-              {{- if .Values.agentManagerService.config.openbao.existingSecret }}
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.agentManagerService.config.openbao.existingSecret }}
                   name: {{ .Values.agentManagerService.config.openbao.existingSecret }}
                   key: {{ .Values.agentManagerService.config.openbao.existingSecretKey | default "openbao-token" }}
-              {{- else }}
-              value: {{ .Values.agentManagerService.config.openbao.token | quote }}
-              {{- end }}
+                  {{- else }}
+                  name: {{ include "agent-management-platform.agentManagerService.fullname" . }}
+                  key: openbao-token
+                  {{- end }}
             {{- end }}
             {{- if or .Values.agentManagerService.config.workflowPlaneOpenbao.token .Values.agentManagerService.config.workflowPlaneOpenbao.existingSecret }}
             - name: WORKFLOW_PLANE_OPENBAO_TOKEN
-              {{- if .Values.agentManagerService.config.workflowPlaneOpenbao.existingSecret }}
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.agentManagerService.config.workflowPlaneOpenbao.existingSecret }}
                   name: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.existingSecret }}
                   key: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.existingSecretKey | default "openbao-token" }}
-              {{- else }}
-              value: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.token | quote }}
-              {{- end }}
+                  {{- else }}
+                  name: {{ include "agent-management-platform.agentManagerService.fullname" . }}
+                  key: workflow-plane-openbao-token
+                  {{- end }}
             {{- end }}
             - name: ENCRYPTION_KEY
               valueFrom:

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/secret.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agentManagerService.enabled }}
-{{- if or (not .Values.agentManagerService.config.apiKey.existingSecret) (not .Values.agentManagerService.config.github.existingSecret) (not .Values.agentManagerService.config.encryptionKey.existingSecret) (and .Values.agentManagerService.config.thunder.clientSecret (not .Values.agentManagerService.config.thunder.existingSecret)) }}
+{{- if or (not .Values.agentManagerService.config.apiKey.existingSecret) (not .Values.agentManagerService.config.github.existingSecret) (not .Values.agentManagerService.config.encryptionKey.existingSecret) (and .Values.agentManagerService.config.thunder.clientSecret (not .Values.agentManagerService.config.thunder.existingSecret)) (and .Values.agentManagerService.config.openbao.token (not .Values.agentManagerService.config.openbao.existingSecret)) (and .Values.agentManagerService.config.workflowPlaneOpenbao.token (not .Values.agentManagerService.config.workflowPlaneOpenbao.existingSecret)) }}
 {{- $secretName := include "agent-management-platform.agentManagerService.fullname" . -}}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
 apiVersion: v1
@@ -25,6 +25,12 @@ stringData:
   {{- end }}
   {{- if and .Values.agentManagerService.config.thunder.clientSecret (not .Values.agentManagerService.config.thunder.existingSecret) }}
   thunder-client-secret: {{ .Values.agentManagerService.config.thunder.clientSecret | quote }}
+  {{- end }}
+  {{- if and .Values.agentManagerService.config.openbao.token (not .Values.agentManagerService.config.openbao.existingSecret) }}
+  openbao-token: {{ .Values.agentManagerService.config.openbao.token | quote }}
+  {{- end }}
+  {{- if and .Values.agentManagerService.config.workflowPlaneOpenbao.token (not .Values.agentManagerService.config.workflowPlaneOpenbao.existingSecret) }}
+  workflow-plane-openbao-token: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.token | quote }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -208,6 +208,8 @@ agentManagerService:
       # Secret containing the token instead.
       token: "root"
       existingSecret: ""
+      # Key to read from existingSecret. Applies ONLY when existingSecret is set;
+      # the chart-managed Secret always uses the fixed key "openbao-token".
       existingSecretKey: "openbao-token"
 
     # Workflow Plane OpenBao configuration (for Git Secrets)
@@ -220,6 +222,9 @@ agentManagerService:
       # For production, use existingSecret instead.
       token: "root"
       existingSecret: ""
+      # Key to read from existingSecret. Applies ONLY when existingSecret is set.
+      # The chart-managed Secret packs both OpenBao tokens into one Secret, so this
+      # token is stored there under the distinct key "workflow-plane-openbao-token".
       existingSecretKey: "openbao-token"
 
     # Agent resource limits — operator-configured upper bounds enforced on PUT /resource-configs

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -201,8 +201,11 @@ agentManagerService:
       # KV secrets engine path
       path: "secret"
       version: "v2"
-      # OpenBao token (for dev mode, use "root")
-      # For production, use existingSecret to reference a secret containing the token
+      # OpenBao token (for dev mode, use "root"). When set, it is stored in the
+      # chart-managed Secret and injected via secretKeyRef — never as a plaintext
+      # env var in the pod spec.
+      # For production, use existingSecret to reference an externally-managed
+      # Secret containing the token instead.
       token: "root"
       existingSecret: ""
       existingSecretKey: "openbao-token"
@@ -212,7 +215,9 @@ agentManagerService:
     workflowPlaneOpenbao:
       # Workflow plane OpenBao URL
       url: "http://openbao.openbao.svc.cluster.local:8200"
-      # OpenBao token
+      # OpenBao token. When set, it is stored in the chart-managed Secret and
+      # injected via secretKeyRef — never as a plaintext env var in the pod spec.
+      # For production, use existingSecret instead.
       token: "root"
       existingSecret: ""
       existingSecretKey: "openbao-token"


### PR DESCRIPTION
## Purpose

The Helm chart injected `OPENBAO_TOKEN` and `WORKFLOW_PLANE_OPENBAO_TOKEN` as **plaintext `value:` env vars** in the amp-api pod spec whenever `existingSecret` was not configured. Anyone with `get pod` in the namespace could read the OpenBao token from the pod spec — and with it decrypt all platform secrets (LLM provider API keys, etc.). Every other secret in this chart (api-key, github-token, encryption-key, thunder-client-secret) already avoids this by routing through the chart-managed Secret and referencing it via `secretKeyRef`. OpenBao was the lone exception.

Reported in the WSO2 Security Hackathon 2026 vuln report (the "OPENBAO_TOKEN plaintext fallback in Helm deployment.yaml" finding).

## Approach

Make OpenBao follow the convention already established in this chart — no new pattern invented:

- **`secret.yaml`** — add `openbao-token` and `workflow-plane-openbao-token` to the chart-managed Secret, guarded to render only when a `token` is set and no `existingSecret` is provided (same shape as the existing api-key/github-token guards). The top-level render guard is extended so the Secret still renders.
- **`deployment.yaml`** — delete both plaintext `value:` branches. Both env vars now **always** use `secretKeyRef`, choosing the source by branch: external secret + `existingSecretKey` when `existingSecret` is set, otherwise the chart-managed Secret with the fixed key.
- **`values.yaml`** — keep `token: "root"` as the dev default (non-breaking), update comments to note the token is now stored in a chart-managed Secret and that production should use `existingSecret`.

Non-breaking: dev/quickstart-on-k8s keeps working with the in-values `token`; production continues to use `existingSecret`.

## Release note

Harden Helm chart: OpenBao tokens are now stored in a Kubernetes Secret and injected via `secretKeyRef` instead of as plaintext env vars in the pod spec.

## Automation tests

**Unit:** N/A — Helm template change; verified with `helm template` / `helm lint`.
**Integration:** N/A.

Verification performed:
- `helm template` (defaults): tokens present in chart Secret, both env vars reference the chart Secret via `secretKeyRef`, **zero** plaintext `value:` for either env var.
- `helm template` (with `existingSecret` set): chart Secret omits the OpenBao keys; env vars reference the external secret + key.
- `helm lint`: passes (only the pre-existing icon INFO).

## Security checks

- Does the PR introduce sensitive data (tokens/passwords) in plaintext? **No** — this PR removes plaintext token exposure from the pod spec.
- Does the PR add or modify authentication/authorization logic? **No.**
- Does the PR introduce new external dependencies? **No.**

## Migrations

N/A — no DB migrations.

## Related PRs

Companion to the RBAC scoping change (wildcard ClusterRole → namespaced Secret verbs) from the same vuln report.

## Samples / Documentation / Training / Certification / Marketing / Test environment / Learning

N/A — internal chart hardening, no user-facing API or doc surface change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * OpenBao authentication tokens are now stored in Kubernetes Secrets and injected securely into the service.
  * Production configurations are guided toward using existing Secrets instead of inline token values.
* **Documentation**
  * Updated configuration guidance explains Secret handling for OpenBao and workflow-plane authentication tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->