### PR TITLE
Simplify VM install: one-command bootstrap with tool preflight

### DIFF
--- a/.github/scripts/build-vm-bundle.sh
+++ b/.github/scripts/build-vm-bundle.sh
@@ -34,5 +34,7 @@ cp deployments/vm/bootstrap.sh "${OUT_DIR}/bootstrap.sh"
 
 echo "✅ Built VM install bundle: $BUNDLE"
 echo "   Contents (top level):"
-tar -tzf "$BUNDLE" | sed 's/^/     /' | head -n 20
+# head closes the pipe after 20 lines; under `set -o pipefail` the SIGPIPE tar/sed
+# then take would fail the build, so cap first and swallow the expected broken pipe.
+tar -tzf "$BUNDLE" | head -n 20 | sed 's/^/     /' || true
 echo "✅ Copied bootstrap.sh: ${OUT_DIR}/bootstrap.sh"

--- a/.github/scripts/build-vm-bundle.sh
+++ b/.github/scripts/build-vm-bundle.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# build-vm-bundle.sh — package the VM install bundle attached to a release.
+#
+# The bundle is a single tarball with everything install-vm.sh / install-advanced.sh
+# read at runtime, so the VM installer needs ONE download instead of a git clone
+# plus many raw.githubusercontent fetches (which GitHub rate-limits per IP). It
+# reproduces the repo layout so install.sh resolves DEPLOYMENTS_DIR (=deployments/)
+# and its single-cluster/values/k8s/scripts siblings exactly as in a checkout.
+#
+# Also copies bootstrap.sh alongside the tarball so it can be attached as its own
+# release asset (the stable curl entry point).
+#
+# Usage: build-vm-bundle.sh <version> <out-dir>   (run from the repo root)
+set -euo pipefail
+
+VERSION="${1:?usage: build-vm-bundle.sh <version> <out-dir>}"
+OUT_DIR="${2:?usage: build-vm-bundle.sh <version> <out-dir>}"
+mkdir -p "$OUT_DIR"
+
+BUNDLE="${OUT_DIR}/amp-vm-bundle-${VERSION}.tar.gz"
+
+# Directories the installer reads at runtime (see install.sh DEPLOYMENTS_DIR +
+# install-helpers.sh ../scripts). Charts are pulled from OCI registries at install
+# time, so helm-charts/ is intentionally excluded.
+tar -czf "$BUNDLE" \
+  deployments/vm \
+  deployments/quick-start \
+  deployments/single-cluster \
+  deployments/values \
+  deployments/k8s \
+  deployments/scripts
+
+cp deployments/vm/bootstrap.sh "${OUT_DIR}/bootstrap.sh"
+
+echo "✅ Built VM install bundle: $BUNDLE"
+echo "   Contents (top level):"
+tar -tzf "$BUNDLE" | sed 's/^/     /' | head -n 20
+echo "✅ Copied bootstrap.sh: ${OUT_DIR}/bootstrap.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,6 +600,13 @@ jobs:
             echo ""
             echo "### CLI (amctl)"
             echo "Prebuilt \`amctl\` binaries (Linux, macOS, Windows) and \`checksums.txt\` are attached to this release."
+
+            echo ""
+            echo "### VM install bundle"
+            echo "\`amp-vm-bundle-${VERSION}.tar.gz\` and \`bootstrap.sh\` are attached for the one-command VM install:"
+            echo '```'
+            echo "curl -fsSL https://github.com/${REGISTRY_ORG}/agent-manager/releases/download/amp/v${VERSION}/bootstrap.sh | sudo bash -s -- simple --host <PUBLIC_IP> --version ${VERSION}"
+            echo '```'
           } > /tmp/release-body.md
 
           {
@@ -616,6 +623,15 @@ jobs:
         with:
           name: amctl-dist
           path: dist/
+
+      - name: Package VM install bundle
+        run: |
+          bash .github/scripts/build-vm-bundle.sh \
+            "$TARGET_RELEASE" \
+            dist/
+        env:
+          TARGET_RELEASE: ${{ inputs.target_version }}
+        shell: bash
 
       - name: Create GitHub release
         id: create-release

--- a/deployments/vm/bootstrap.sh
+++ b/deployments/vm/bootstrap.sh
@@ -81,5 +81,6 @@ esac
 [[ -f "$installer" ]] || die "installer not found in bundle: ${installer}"
 
 log "Running ${MODE} installer from the bundle"
-# Preserve the invoker's working directory so a relative --config path still resolves.
-exec bash "$installer" "${args[@]}"
+# Run as a child (not exec) so the EXIT trap still fires and cleans up $WORKDIR; the
+# child inherits the invoker's working directory, so a relative --config path resolves.
+bash "$installer" "${args[@]}"

--- a/deployments/vm/bootstrap.sh
+++ b/deployments/vm/bootstrap.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# bootstrap.sh — one-command entry point for installing Agent Manager on a VM.
+#
+# Fetched and piped to bash; it downloads ONE versioned install bundle (a single
+# release asset — no git clone, no per-file raw.githubusercontent fetches, which
+# GitHub rate-limits per IP) and runs the selected installer from it.
+#
+# Usage (on the VM, as root):
+#   curl -fsSL <URL>/bootstrap.sh | sudo bash -s -- simple \
+#       --host <PUBLIC_IP> --version <release> [--email <addr>] [--no-external-gateways]
+#   curl -fsSL <URL>/bootstrap.sh | sudo bash -s -- advanced --config <amp-config.env>
+#
+# simple reads the release from --version; advanced reads AMP_VERSION from --config
+# (the operator pins it in one place). Override the bundle location with
+# AMP_BUNDLE_URL (and the repo with AMP_REPO) for testing against a fork/pre-release.
+set -euo pipefail
+
+REPO="${AMP_REPO:-wso2/agent-manager}"
+
+log() { printf '\033[0;34m[bootstrap]\033[0m %s\n' "$*"; }
+die() { printf '\033[0;31m[bootstrap] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: curl -fsSL <url>/bootstrap.sh | sudo bash -s -- <simple|advanced> [installer flags]
+
+  simple    --host <PUBLIC_IP> --version <release> [--email <addr>] [--no-external-gateways]
+  advanced  --config <amp-config.env> [--dry-run]   # release read from AMP_VERSION in the config
+EOF
+}
+
+MODE="${1:-}"; shift 2>/dev/null || true
+case "$MODE" in
+  simple|advanced) ;;
+  ""|-h|--help) usage; exit 0 ;;
+  *) die "first argument must be 'simple' or 'advanced' (got '${MODE}')" ;;
+esac
+
+[[ "$(id -u)" -eq 0 ]] || \
+  die "run with sudo — the installer opens the firewall and creates the cluster: curl -fsSL <url> | sudo bash -s -- <simple|advanced> ..."
+
+args=("$@")
+
+# Discover the requested release: --version from the args, else AMP_VERSION from --config.
+VERSION="${VERSION:-}" CONFIG=""
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --version) VERSION="${args[$((i + 1))]:-}" ;;
+    --config)  CONFIG="${args[$((i + 1))]:-}" ;;
+  esac
+done
+if [[ -z "$VERSION" && -n "$CONFIG" && -f "$CONFIG" ]]; then
+  # Strip the inline comment (the --init template annotates this line) before trimming.
+  VERSION="$(grep -E '^[[:space:]]*AMP_VERSION=' "$CONFIG" | head -n1 | cut -d= -f2- | sed 's/#.*//' | tr -d '" ')"
+fi
+[[ -n "$VERSION" ]] || \
+  die "could not determine the release version — pass --version <release> (simple) or set AMP_VERSION in --config (advanced)"
+
+BUNDLE_URL="${AMP_BUNDLE_URL:-https://github.com/${REPO}/releases/download/amp/v${VERSION}/amp-vm-bundle-${VERSION}.tar.gz}"
+
+command -v curl >/dev/null 2>&1 || die "curl is required to download the install bundle"
+command -v tar  >/dev/null 2>&1 || die "tar is required to unpack the install bundle"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+log "Downloading install bundle (release ${VERSION})"
+log "  ${BUNDLE_URL}"
+curl -fsSL --retry 5 --retry-all-errors -o "${WORKDIR}/bundle.tar.gz" "$BUNDLE_URL" \
+  || die "failed to download the install bundle — check the release tag amp/v${VERSION} exists (or set AMP_BUNDLE_URL)"
+tar -xzf "${WORKDIR}/bundle.tar.gz" -C "$WORKDIR" || die "failed to unpack the install bundle"
+
+# The bundle reproduces the repo layout (deployments/…); find the installer within it.
+VM_DIR="$(find "$WORKDIR" -type d -path '*/deployments/vm' -print -quit)"
+[[ -n "$VM_DIR" ]] || die "install bundle is missing deployments/vm"
+
+case "$MODE" in
+  simple)   installer="${VM_DIR}/install-vm.sh" ;;
+  advanced) installer="${VM_DIR}/install-advanced.sh" ;;
+esac
+[[ -f "$installer" ]] || die "installer not found in bundle: ${installer}"
+
+log "Running ${MODE} installer from the bundle"
+# Preserve the invoker's working directory so a relative --config path still resolves.
+exec bash "$installer" "${args[@]}"

--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -198,8 +198,8 @@ run_advanced_install() {
 
   preflight_dns strict
 
-  log "Phase 1/2: bootstrap (Docker + tools + firewall)"
-  ensure_prerequisites
+  log "Phase 1/2: preflight (verify tools + firewall)"
+  verify_prerequisites openssl
   ensure_inotify_limits
   if [[ "$TLS_MODE" == upstream ]]; then ensure_firewall "${UPSTREAM_LISTEN_PORT:-80}"; else ensure_firewall 443; fi
   ensure_disk

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -14,7 +14,9 @@
 # TLS is always Let's Encrypt, 443-only: certificates issue via the TLS-ALPN-01
 # challenge inside the :443 handshake, so only inbound 443 is required (no port
 # 80). The public :443 must reach the VM as raw TCP (no TLS-terminating proxy in
-# front). Docker, k3d, kubectl, helm and lsof are installed automatically if missing.
+# front). Docker, k3d, kubectl, helm, curl and lsof must already be installed on the
+# VM — the installer verifies they are present and exits with install hints if any
+# are missing.
 set -euo pipefail
 
 VM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -142,8 +144,8 @@ run_install() {
   start_caddy
 }
 
-log "Phase 1/2: bootstrap (Docker + tools + firewall)"
-ensure_prerequisites
+log "Phase 1/2: preflight (verify tools + firewall)"
+verify_prerequisites
 ensure_inotify_limits
 ensure_firewall 443
 ensure_disk

--- a/deployments/vm/lib-bootstrap.sh
+++ b/deployments/vm/lib-bootstrap.sh
@@ -6,46 +6,56 @@
 command -v log >/dev/null 2>&1 || log() { printf '\033[0;34m[bootstrap]\033[0m %s\n' "$*"; }
 command -v die >/dev/null 2>&1 || die() { printf '\033[0;31m[bootstrap] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 
-ensure_docker() {
-  if ! command -v docker >/dev/null 2>&1; then
-    log "Installing Docker via get.docker.com"
-    curl -fsSL https://get.docker.com | sh
-  else
-    log "Docker CLI present"
-  fi
-  systemctl enable --now docker
-  local _
-  for _ in $(seq 1 15); do docker info >/dev/null 2>&1 && return; sleep 2; done
-  die "Docker daemon did not become ready"
+# The VM installer NO LONGER installs host tooling. Piping remote installers
+# (get.docker.com, k3d, dl.k8s.io, get-helm-3) added several unauthenticated
+# GitHub/network round-trips that get rate-limited (429) behind shared NAT and
+# silently mutated host state. Instead we verify the tools are already present and
+# fail with actionable hints — mirroring OpenChoreo's k3d installer, which also only
+# checks (command -v) for docker/k3d/kubectl/helm.
+
+# _tool_hint <tool> — print a one-line "how to install" hint for a required tool.
+_tool_hint() {
+  case "$1" in
+    docker)  echo "Docker Engine — https://docs.docker.com/engine/install/" ;;
+    k3d)     echo "k3d — https://k3d.io/#installation" ;;
+    kubectl) echo "kubectl — https://kubernetes.io/docs/tasks/tools/#kubectl" ;;
+    helm)    echo "Helm 3 — https://helm.sh/docs/intro/install/" ;;
+    curl)    echo "curl — install via your OS package manager (e.g. apt-get install -y curl)" ;;
+    lsof)    echo "lsof — install via your OS package manager (e.g. apt-get install -y lsof)" ;;
+    openssl) echo "OpenSSL — install via your OS package manager (e.g. apt-get install -y openssl)" ;;
+    *)       echo "$1 — install via your OS package manager" ;;
+  esac
 }
 
-ensure_prerequisites() {
-  local arch; arch="$(dpkg --print-architecture)"   # amd64 | arm64
-  local pkgs=()
-  command -v curl >/dev/null 2>&1 || pkgs+=(curl)
-  command -v lsof >/dev/null 2>&1 || pkgs+=(lsof)
-  command -v openssl >/dev/null 2>&1 || pkgs+=(openssl)
-  if (( ${#pkgs[@]} )); then
-    log "Installing base packages: ${pkgs[*]}"
-    apt-get update -qq && apt-get install -y -qq "${pkgs[@]}"
+# verify_prerequisites [extra-tool ...] — confirm the required host tools are present
+# (and the Docker daemon is reachable) BEFORE any cluster work. Core set:
+# docker/k3d/kubectl/helm/curl; callers may append extras (e.g. openssl). All missing
+# tools are reported together with install hints, then the installer exits non-zero.
+verify_prerequisites() {
+  # lsof is required by the wrapped quick-start installer (install.sh port checks),
+  # so include it here to fail fast in this friendly preflight rather than deep inside.
+  local -a required=(docker k3d kubectl helm curl lsof) missing=()
+  required+=("$@")
+  local t
+  for t in "${required[@]}"; do
+    command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+  done
+
+  if (( ${#missing[@]} )); then
+    log "Missing required tools: ${missing[*]}"
+    log "This installer does not install host tooling — install these and re-run:"
+    for t in "${missing[@]}"; do
+      printf '    - %s\n' "$(_tool_hint "$t")" >&2
+    done
+    die "prerequisites not met (${#missing[@]} missing) — install the tools above first"
   fi
 
-  ensure_docker
+  # Docker present but the daemon may be down or not permitted for this user.
+  if ! docker info >/dev/null 2>&1; then
+    die "Docker is installed but its daemon is not reachable — start it (e.g. 'sudo systemctl enable --now docker') and ensure this user can run it, then re-run"
+  fi
 
-  if ! command -v k3d >/dev/null 2>&1; then
-    log "Installing k3d"
-    curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-  fi
-  if ! command -v kubectl >/dev/null 2>&1; then
-    log "Installing kubectl (${arch})"
-    local kver; kver="$(curl -fsSL https://dl.k8s.io/release/stable.txt)"
-    curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${kver}/bin/linux/${arch}/kubectl"
-    chmod +x /usr/local/bin/kubectl
-  fi
-  if ! command -v helm >/dev/null 2>&1; then
-    log "Installing helm"
-    curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-  fi
+  log "Prerequisites present: ${required[*]}"
 }
 
 # ensure_firewall <port> — open the given inbound TCP port on the OS firewall.

--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -201,7 +201,7 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 The compute, disk, and tooling prerequisites are:
 
 - **Git** to clone this repository and fetch the installer. This is the one tool you need *before* running the script (the script can't install what you use to download it); on a minimal image install it with `sudo apt-get update && sudo apt-get install -y git` (Debian/Ubuntu).
-- **Docker.** The whole stack runs on it. If it isn't already installed, the script installs it for you, along with k3d, kubectl, helm, lsof, and openssl.
+- **Docker, k3d, kubectl, Helm, curl, `lsof`, and `openssl`** must already be installed on the VM (the whole stack runs on Docker: k3d runs the cluster as containers and Caddy runs as a container). The installer **verifies** these are present and exits with install hints if any are missing — it does **not** install them for you.
 - A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, with SSH access (sudo).
 
 In addition, the advanced installer needs:

--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -27,11 +27,35 @@ The simple installer exposes the platform over HTTPS using [sslip.io](https://ss
 
 ## Prerequisites
 
-You need an SSH client to log into the VM. On the VM itself, install these tools **before** running the installer — it **verifies** they are present and exits with install hints if any are missing; it does **not** install host tooling for you:
-- **Docker**, **k3d**, **kubectl**, **Helm 3**, **curl**, and **lsof**. The whole stack runs on Docker (k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container). See the [Docker](https://docs.docker.com/engine/install/), [k3d](https://k3d.io/#installation), [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl), and [Helm](https://helm.sh/docs/intro/install/) install guides; `curl` and `lsof` come from your OS package manager.
-- A Linux VM with a **static (reserved) public IP** and SSH access (sudo). The install derives every hostname, TLS certificate, and OAuth issuer from the IP (`*.amp.<IP>.sslip.io`), so a **changing IP breaks the install**, and stopping the VM (for example to resize its disk) releases an ephemeral IP. Reserve the address before installing. If the IP ever changes, reinstall against the new IP.
+You need an SSH client to log into the VM. On the VM itself, install the tools below **before** running the installer — it **verifies** they are present and exits with install hints if any are missing; it does **not** install host tooling for you. The whole stack runs on Docker: k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container.
+
+| Tool | Version | Purpose |
+| --- | --- | --- |
+| [Docker](https://docs.docker.com/engine/install/) | v26+ (8 GB RAM, 4 CPU) | Container runtime |
+| [k3d](https://k3d.io/#installation) | v5.8+ | Local Kubernetes cluster |
+| [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) | v1.33+ | Kubernetes CLI |
+| [Helm](https://helm.sh/docs/intro/install/) | v3.12+ | Package manager |
+
+`curl` and `lsof` are also required — usually preinstalled, but on a minimal image install them with your OS package manager (for example `sudo apt-get install -y curl lsof`).
+
+Verify everything is installed:
+
+```bash
+docker --version
+k3d --version
+kubectl version --client
+helm version --short
+```
+
+Verify the Docker daemon is running:
+
+```bash
+docker info > /dev/null
+```
+
+The VM also needs:
+- A **static (reserved) public IP** and SSH access (sudo). The install derives every hostname, TLS certificate, and OAuth issuer from the IP (`*.amp.<IP>.sslip.io`), so a **changing IP breaks the install**, and stopping the VM (for example to resize its disk) releases an ephemeral IP. Reserve the address before installing. If the IP ever changes, reinstall against the new IP.
 - **At least 50 GB of disk.** Building and running agents pushes the in-cluster image store past 13 GB; on a smaller disk the node hits `DiskPressure`, which evicts pods and can take cluster DNS down mid-build.
-- **At least 4 vCPUs and 8 GB of RAM** to run the full k3d + OpenChoreo + Agent Manager stack comfortably.
 - **Inbound `443/tcp` open** in the cloud security group / firewall, and only 443. Certificates issue via the TLS-ALPN-01 ACME challenge, which runs inside the `:443` TLS handshake, so no inbound port 80 is ever needed. The `:443` exposure must be **TCP passthrough** (not a TLS-terminating load balancer in front), since the challenge happens inside the handshake.
 
 ## Install

--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -27,9 +27,8 @@ The simple installer exposes the platform over HTTPS using [sslip.io](https://ss
 
 ## Prerequisites
 
-You only need an SSH client to log into the VM; everything else runs on the VM.
-- **Git** to clone this repository and fetch the installer. This is the one tool you need *before* running the script (the script can't install what you use to download it). Most images have it; on a minimal one install it with `sudo apt-get update && sudo apt-get install -y git` (Debian/Ubuntu).
-- **Docker** is required; the whole stack runs on it (k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container). If Docker isn't already installed, the script installs it for you, along with k3d, kubectl, helm, and lsof.
+You need an SSH client to log into the VM. On the VM itself, install these tools **before** running the installer — it **verifies** they are present and exits with install hints if any are missing; it does **not** install host tooling for you:
+- **Docker**, **k3d**, **kubectl**, **Helm 3**, **curl**, and **lsof**. The whole stack runs on Docker (k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container). See the [Docker](https://docs.docker.com/engine/install/), [k3d](https://k3d.io/#installation), [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl), and [Helm](https://helm.sh/docs/intro/install/) install guides; `curl` and `lsof` come from your OS package manager.
 - A Linux VM with a **static (reserved) public IP** and SSH access (sudo). The install derives every hostname, TLS certificate, and OAuth issuer from the IP (`*.amp.<IP>.sslip.io`), so a **changing IP breaks the install**, and stopping the VM (for example to resize its disk) releases an ephemeral IP. Reserve the address before installing. If the IP ever changes, reinstall against the new IP.
 - **At least 50 GB of disk.** Building and running agents pushes the in-cluster image store past 13 GB; on a smaller disk the node hits `DiskPressure`, which evicts pods and can take cluster DNS down mid-build.
 - **At least 4 vCPUs and 8 GB of RAM** to run the full k3d + OpenChoreo + Agent Manager stack comfortably.
@@ -37,30 +36,27 @@ You only need an SSH client to log into the VM; everything else runs on the VM.
 
 ## Install
 
-SSH into the VM, get the installer, and run it with `sudo`:
+SSH into the VM and run the one-command installer with `sudo`. It downloads a single versioned install bundle (no repository clone) and runs from it:
 
 ```bash
-# on the VM
-git clone https://github.com/wso2/agent-manager.git
-cd agent-manager/deployments/vm
-git checkout tags/amp/v0.0.0-dev
-
-sudo ./install-vm.sh \
-  --host <VM_PUBLIC_IP> \
-  --version 0.0.0-dev \
-  --email you@example.com
+# on the VM (Docker, k3d, kubectl, helm already installed)
+curl -fsSL https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-dev/bootstrap.sh \
+  | sudo bash -s -- simple \
+      --host <VM_PUBLIC_IP> \
+      --version 0.0.0-dev \
+      --email you@example.com
 ```
 
 Pass `--host` the VM's **public** IPv4 address. A cloud VM usually can't read its own public IP (it's NAT'd behind the address you used to SSH in), so the installer needs it to build the `*.amp.<IP>.sslip.io` hostnames.
 
-The installer runs in two phases: bootstrap (Docker + tools + firewall) and the platform install + Caddy startup. Allow 8-15 minutes. It needs `sudo` because it installs Docker, opens the firewall, and creates the cluster.
+The installer runs in two phases: preflight (verify the required tools + open the firewall) and the platform install + Caddy startup. Allow 8-15 minutes. It needs `sudo` because it opens the firewall and creates the cluster. Downloading one bundle instead of cloning the repo and fetching each file separately avoids the GitHub rate-limiting that can throttle a per-file install.
 
 ### Options
 
 | Flag | Default | Purpose |
 |---|---|---|
 | `--host` | _(required)_ | The VM's public IPv4 address |
-| `--version` | _(required)_ | Agent Manager release to install; use the same `amp/v*` tag you checked out above |
+| `--version` | _(required)_ | Agent Manager release to install; an existing `amp/v*` [release](https://github.com/wso2/agent-manager/releases) (the `bootstrap.sh` URL embeds the same version) |
 | `--email` | _(none)_ | ACME contact for expiry notices |
 | `--no-external-gateways` | off | Drop the gateway control-plane endpoint if you won't connect external gateways |
 


### PR DESCRIPTION
## Purpose

The "Deploy on a VM" install is cumbersome and fragile: it requires cloning the whole repository and checking out a release tag, and then makes roughly 30 separate network fetches (piped tool installers plus per-file `raw.githubusercontent.com` downloads). GitHub rate-limits unauthenticated requests per IP (HTTP 429) behind shared/corporate NAT, so a single throttled response can abort the install. The installer also installs host tooling (Docker/k3d/kubectl/helm) itself, silently mutating the machine.

Related to #1329.

## Goals

Give the simple VM install a single copy-paste command, stop cloning the repository, cut the GitHub round-trips down to one bundle download, and stop installing host tooling — verify it is present instead. The broader #1329 items (removing Caddy and moving TLS to cert-manager) are follow-up; the simple path's Caddy + sslip.io + Let's Encrypt TLS is intentionally unchanged here.

## Approach

- **`deployments/vm/bootstrap.sh` (new):** a `curl -fsSL … | sudo bash -s -- simple|advanced …` entry point that downloads one versioned install bundle (a release asset), unpacks it, and runs the selected installer from it — no git clone, no per-file fetches. `AMP_BUNDLE_URL`/`AMP_REPO` allow overriding the source for testing.
- **`deployments/vm/lib-bootstrap.sh`:** replaced the install-everything `ensure_prerequisites` with `verify_prerequisites`, which checks `docker`/`k3d`/`kubectl`/`helm`/`curl`/`lsof` (plus `openssl` for the advanced path) are on `PATH` and the Docker daemon is reachable, and exits with actionable install hints if any are missing. The installer no longer installs host tooling. This mirrors the OpenChoreo k3d installer's `command -v` preflight.
- **`.github/scripts/build-vm-bundle.sh` + `.github/workflows/release.yml`:** package `amp-vm-bundle-<version>.tar.gz` and `bootstrap.sh` and attach them as release assets. The bundle reproduces the repo layout the installer resolves at runtime; bundling `deployments/scripts/` also removes the previous raw-GitHub fallback for `add-environment-thunder.sh`.
- **Docs:** the Simple tab of the VM guide now shows the one-command install and lists the prerequisites the operator installs beforehand.

## User stories

As an operator evaluating Agent Manager on a VM, I can install it with a single command on a machine that already has the standard container tooling, without cloning the repository or hitting GitHub rate limits.

## Release note

The simple VM installer now runs from a single `curl … | sudo bash` command that downloads one release bundle instead of cloning the repository, and it verifies the required tools (Docker, k3d, kubectl, Helm, curl, lsof) are present rather than installing them.

## Documentation

Updated in this PR: `documentation/docs/getting-started/on-a-vm.mdx` (Simple tab). The Advanced tab is untouched and will be revised with the follow-up cert-manager work.

## Training

N/A — no training-content impact.

## Certification

N/A — installer packaging change only, no impact on certification exams.

## Marketing

N/A — internal install-experience improvement.

## Automation tests

 - Unit tests
   > `deployments/vm/tests/run.sh` (pure-function suite) passes; the new and changed shell scripts are `shellcheck`-clean.
 - Integration tests
   > Validated the full flow on a fresh Ubuntu 26.04 VM: the preflight correctly reports missing tools together and does not install them; the one-command bootstrap downloads and unpacks the bundle and runs the installer with no git clone; the install completes end-to-end (13/13 steps) to a running platform with trusted Let's Encrypt certificates. End-to-end console/api routing will be re-confirmed against a matched nightly `0.0.0-dev-*` build (the previous check hit script/chart version skew because no published charts match the branch yet).

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell/CI/docs change, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no samples.

## Related PRs

N/A.

## Migrations (if applicable)

N/A — no migration; existing installs are unaffected.

## Test environment

Ubuntu 26.04 LTS VM (Docker CE, k3d v5.9.0, kubectl v1.36.x, Helm v3.21.x); shell tooling additionally verified on macOS (bash 3.2 compatibility retained) and Linux.

## Learning

Compared the on-demand/wildcard TLS constraints of the current Caddy + sslip.io approach with cert-manager's ACME model (which informs the follow-up), and modeled the single-bundle/preflight delivery on the OpenChoreo k3d one-command installer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a versioned VM installation bundle for releases.
  * Added a one-command bootstrap installer for simple and advanced VM deployments.
  * Release pages now include bundle downloads and installation instructions.

* **Updates**
  * VM installers now verify required tools and provide installation guidance instead of installing host tooling automatically.
  * Updated VM documentation with prerequisites, static IP requirements, and the new installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->