### PR TITLE
Fix high npm audit findings in docs site

### DIFF
--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -9377,9 +9377,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10641,9 +10641,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -11503,9 +11503,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -20316,9 +20316,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
@@ -20339,7 +20339,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",
@@ -20519,9 +20519,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
## Purpose
The `Security Audit` job in `.github/workflows/docs-pr-checks.yml` runs `npm audit --audit-level=high --omit=dev` in `documentation/` and is currently failing on the docs site. Newer advisories now flag existing pinned transitive Docusaurus dependencies even though the lockfile itself had not changed. The critical finding is `websocket-driver <=0.7.4` (GHSA-mp7j-qc5w-4988, GHSA-xv26-6w52-cph6), pulled in via `@docusaurus/core -> webpack-dev-server -> sockjs`. This is an independent maintenance fix and is not tied to any feature issue.

## Goals
Clear the failing `npm audit --audit-level=high --omit=dev` gate in `docs-pr-checks` so the docs site PR checks pass again, without any functional change to the documentation site.

## Approach
Resolved the findings with `npm audit fix`, which bumps the flagged transitive packages within their existing semver ranges: `websocket-driver` 0.7.4 -> 0.7.5 (the critical fix), plus moderate patches for `dompurify`, `js-yaml`, `http-proxy-middleware`, and `webpack-dev-server`. Only `documentation/package-lock.json` changes; `package.json` and the site content are untouched. The remaining findings are moderate and dev-only, which the audit gate (`--audit-level=high`) does not fail on.

## User stories
N/A - internal maintenance fix with no user-facing behavior change.

## Release note
N/A - no user-facing or functional change; documentation dependency lockfile update only.

## Documentation
N/A - this change only updates the documentation site's dependency lockfile and does not alter any product documentation content.

## Training
N/A - no training content impact.

## Certification
N/A - no impact on certification exams; this is a dependency lockfile update with no product behavior change.

## Marketing
N/A - no marketing impact.

## Automation tests
 - Unit tests
   > N/A - no application code changed. Verified `npm audit --audit-level=high --omit=dev` now exits 0 (previously exited 1 on the critical `websocket-driver` finding).
 - Integration tests
   > Verified `npm run build` in `documentation/` completes successfully after the fix, confirming the site still builds.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A - no Java code changed; this is an npm dependency lockfile update. The relevant check here is `npm audit`, which now passes at the high gate.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A - no samples related to this change.

## Related PRs
N/A - no related PRs.

## Migrations (if applicable)
N/A - no migration required; lockfile update only.

## Test environment
Node.js 20 (matching the CI workflow), npm 10, macOS. Verified `npm ci`, `npm audit --audit-level=high --omit=dev` (exits 0), and `npm run build` (succeeds).

## Learning
Reviewed the GitHub advisories for `websocket-driver` (GHSA-mp7j-qc5w-4988, GHSA-xv26-6w52-cph6) and confirmed the patched release is 0.7.5. Preferred `npm audit fix` because it only bumps transitive packages within their existing semver ranges, avoiding any major-version change or functional risk to the Docusaurus build.
