### PR TITLE
Hide env-Thunder native Administrator role from agent identity APIs

### DIFF
--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -601,6 +601,15 @@ func (c *thunderClient) GetAgentGroups(ctx context.Context, ouID, agentID string
 
 // --- Roles ---
 
+// NativeAdministratorRoleName is the role every ThunderID install seeds in its
+// default OU. It carries Thunder's built-in "system" scope (the admin-API
+// permission the amp-system-client authenticates with — see fetchSystemToken),
+// so it must never surface as an assignable agent-identity role: OU-scoped
+// ListRoles hides it, and the agent-identity controller rejects reads/writes
+// against it. Thunder enforces unique role names per OU, so post-bootstrap the
+// only role with this name in the default OU is the native one.
+const NativeAdministratorRoleName = "Administrator"
+
 // ListRoles returns roles scoped to ouID when non-empty, by fetching all pages
 // from Thunder and filtering client-side (Thunder has no OU-scoped list endpoint for roles).
 func (c *thunderClient) ListRoles(ctx context.Context, ouID string, offset, limit int) ([]ThunderRole, int, error) {
@@ -635,7 +644,11 @@ func (c *thunderClient) ListRoles(ctx context.Context, ouID string, offset, limi
 			return nil, 0, fmt.Errorf("thunder list roles decode: %w", err)
 		}
 		for _, role := range wrapped.Roles {
-			if role.OuID == ouID {
+			// The exclusion happens before the client-side pagination below so
+			// offset/limit/total stay consistent. The unfiltered ouID=="" branch
+			// above deliberately keeps the native role: rolesForAssignee and the
+			// scope-cleanup sweep must still see every role in the instance.
+			if role.OuID == ouID && role.Name != NativeAdministratorRoleName {
 				all = append(all, role)
 			}
 		}

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -282,3 +282,58 @@ func TestGetAgentRoleAssignments_SkipsDeletedGroup(t *testing.T) {
 	assert.Empty(t, assignments.Groups)
 	assert.Equal(t, []AssignmentEntry{{ID: "a1", Type: "agent"}}, assignments.Agents)
 }
+
+// TestListRoles_OUFiltered_ExcludesNativeAdministrator proves the OU-scoped role
+// listing hides Thunder's native Administrator role — it carries the built-in
+// "system" scope and must never surface as an assignable agent role — and that
+// the exclusion happens before client-side pagination so offset/limit/total stay
+// consistent.
+func TestListRoles_OUFiltered_ExcludesNativeAdministrator(t *testing.T) {
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/roles", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"totalResults": 3,
+			"roles": []map[string]any{
+				{"id": "r-admin", "ouId": "ou-1", "name": NativeAdministratorRoleName},
+				{"id": "r-readers", "ouId": "ou-1", "name": "readers"},
+				{"id": "r-elsewhere", "ouId": "ou-2", "name": "writers"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+	roles, total, err := client.ListRoles(context.Background(), "ou-1", 0, 20)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "Administrator must not count toward the OU total")
+	require.Len(t, roles, 1)
+	assert.Equal(t, "readers", roles[0].Name)
+}
+
+// TestListRoles_Unfiltered_KeepsNativeAdministrator pins the ouID="" contract:
+// rolesForAssignee and the scope-cleanup sweep walk every role in the instance
+// and must still see the native Administrator role (e.g. to report an agent
+// already mis-assigned to it).
+func TestListRoles_Unfiltered_KeepsNativeAdministrator(t *testing.T) {
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"totalResults": 2,
+			"roles": []map[string]any{
+				{"id": "r-admin", "ouId": "ou-1", "name": NativeAdministratorRoleName},
+				{"id": "r-readers", "ouId": "ou-1", "name": "readers"},
+			},
+		})
+	})
+	defer srv.Close()
+
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+	roles, total, err := client.ListRoles(context.Background(), "", 0, 20)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	require.Len(t, roles, 2)
+}

--- a/agent-manager-service/controllers/agent_identity_controller.go
+++ b/agent-manager-service/controllers/agent_identity_controller.go
@@ -461,23 +461,41 @@ func (c *agentIdentityController) CreateRole(w http.ResponseWriter, r *http.Requ
 	utils.WriteSuccessResponse(w, http.StatusCreated, role)
 }
 
-func (c *agentIdentityController) GetRole(w http.ResponseWriter, r *http.Request) {
+// managedRole fetches the role and treats Thunder's native Administrator role
+// as nonexistent (404, matching its exclusion from ListRoles): it carries the
+// built-in "system" scope, and exposing it through this API is how agent
+// identities were acquiring env-Thunder admin — see
+// thundersvc.NativeAdministratorRoleName. Writes the error response itself when
+// ok=false. RemoveRoleAssignees deliberately skips this guard so an existing
+// mis-assignment can still be cleaned up through the same API.
+func (c *agentIdentityController) managedRole(w http.ResponseWriter, r *http.Request, client thundersvc.EnvIdentityClient, roleID string) (*thundersvc.ThunderRole, bool) {
 	ctx := r.Context()
-	log := logger.GetLogger(ctx)
+	role, err := client.GetRole(ctx, roleID)
+	if err != nil {
+		if thundersvc.IsNotFound(err) {
+			utils.WriteErrorResponse(w, http.StatusNotFound, "Role not found")
+			return nil, false
+		}
+		logger.GetLogger(ctx).Error("agent-identity: get role failed", "roleID", roleID, "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to get role")
+		return nil, false
+	}
+	if role.Name == thundersvc.NativeAdministratorRoleName {
+		utils.WriteErrorResponse(w, http.StatusNotFound, "Role not found")
+		return nil, false
+	}
+	return role, true
+}
+
+func (c *agentIdentityController) GetRole(w http.ResponseWriter, r *http.Request) {
 	roleID := r.PathValue(utils.PathParamRoleID)
 
 	client, ok := c.envClient(w, r)
 	if !ok {
 		return
 	}
-	role, err := client.GetRole(ctx, roleID)
-	if err != nil {
-		if thundersvc.IsNotFound(err) {
-			utils.WriteErrorResponse(w, http.StatusNotFound, "Role not found")
-			return
-		}
-		log.Error("agent-identity GetRole failed", "roleID", roleID, "error", err)
-		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to get role")
+	role, ok := c.managedRole(w, r, client, roleID)
+	if !ok {
 		return
 	}
 	utils.WriteSuccessResponse(w, http.StatusOK, role)
@@ -504,14 +522,8 @@ func (c *agentIdentityController) UpdateRole(w http.ResponseWriter, r *http.Requ
 	if !ok {
 		return
 	}
-	current, err := client.GetRole(ctx, roleID)
-	if err != nil {
-		if thundersvc.IsNotFound(err) {
-			utils.WriteErrorResponse(w, http.StatusNotFound, "Role not found")
-			return
-		}
-		log.Error("agent-identity UpdateRole: get role failed", "roleID", roleID, "error", err)
-		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to update role")
+	current, ok := c.managedRole(w, r, client, roleID)
+	if !ok {
 		return
 	}
 
@@ -616,6 +628,9 @@ func (c *agentIdentityController) DeleteRole(w http.ResponseWriter, r *http.Requ
 	if !ok {
 		return
 	}
+	if _, ok := c.managedRole(w, r, client, roleID); !ok {
+		return
+	}
 	if err := client.DeleteRole(ctx, roleID); err != nil {
 		if thundersvc.IsNotFound(err) {
 			utils.WriteErrorResponse(w, http.StatusNotFound, "Role not found")
@@ -663,6 +678,9 @@ func (c *agentIdentityController) AddRoleAssignees(w http.ResponseWriter, r *htt
 
 	client, ok := c.envClient(w, r)
 	if !ok {
+		return
+	}
+	if _, ok := c.managedRole(w, r, client, roleID); !ok {
 		return
 	}
 	if err := client.AddRoleAssignees(ctx, roleID, assignments); err != nil {

--- a/agent-manager-service/controllers/agent_identity_controller.go
+++ b/agent-manager-service/controllers/agent_identity_controller.go
@@ -467,7 +467,9 @@ func (c *agentIdentityController) CreateRole(w http.ResponseWriter, r *http.Requ
 // identities were acquiring env-Thunder admin — see
 // thundersvc.NativeAdministratorRoleName. Writes the error response itself when
 // ok=false. RemoveRoleAssignees deliberately skips this guard so an existing
-// mis-assignment can still be cleaned up through the same API.
+// mis-assignment can still be cleaned up through the same API, and the
+// read-only GetRoleAssignments/GetGroupRoles stay unguarded for the same
+// reason — finding which agents and groups to clean up requires seeing them.
 func (c *agentIdentityController) managedRole(w http.ResponseWriter, r *http.Request, client thundersvc.EnvIdentityClient, roleID string) (*thundersvc.ThunderRole, bool) {
 	ctx := r.Context()
 	role, err := client.GetRole(ctx, roleID)

--- a/agent-manager-service/controllers/agent_identity_controller_unit_test.go
+++ b/agent-manager-service/controllers/agent_identity_controller_unit_test.go
@@ -567,16 +567,23 @@ func adminRoleController(envClient *clientmocks.EnvIdentityClientMock) AgentIden
 	return NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
 }
 
+// adminRoleRequest builds a request with the org/env/role path values shared by
+// every native-Administrator guard test.
+func adminRoleRequest(method, url, body string) *http.Request {
+	req := httptest.NewRequest(method, url, strings.NewReader(body))
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req.SetPathValue("roleID", "r-admin")
+	return req
+}
+
 // TestAgentIdentityGetRole_NativeAdministratorHidden proves the native
 // Administrator role is invisible through the agent-identity API: fetching it by
 // ID returns 404, consistent with it being filtered from the role listing.
 func TestAgentIdentityGetRole_NativeAdministratorHidden(t *testing.T) {
 	ctrl := adminRoleController(adminRoleEnvClient())
 
-	req := httptest.NewRequest(http.MethodGet, "/orgs/o1/environments/dev/agent-identities/roles/r-admin", nil)
-	req.SetPathValue("orgName", "o1")
-	req.SetPathValue("envName", "dev")
-	req.SetPathValue("roleID", "r-admin")
+	req := adminRoleRequest(http.MethodGet, "/orgs/o1/environments/dev/agent-identities/roles/r-admin", "")
 	w := httptest.NewRecorder()
 
 	ctrl.GetRole(w, req)
@@ -591,12 +598,8 @@ func TestAgentIdentityGetRole_NativeAdministratorHidden(t *testing.T) {
 func TestAgentIdentityUpdateRole_NativeAdministratorRejected(t *testing.T) {
 	ctrl := adminRoleController(adminRoleEnvClient())
 
-	req := httptest.NewRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/r-admin",
-		strings.NewReader(`{"name":"renamed","scopes":[]}`))
-	req.SetPathValue("orgName", "o1")
-	req.SetPathValue("envName", "dev")
-	req.SetPathValue("roleID", "r-admin")
-	req = req.WithContext(middleware.WithResolvedOrg(req.Context(), middleware.ResolvedOrg{OUID: "ou-org"}))
+	req := adminRoleRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/r-admin",
+		`{"name":"renamed","scopes":[]}`)
 	w := httptest.NewRecorder()
 
 	ctrl.UpdateRole(w, req)
@@ -610,10 +613,7 @@ func TestAgentIdentityUpdateRole_NativeAdministratorRejected(t *testing.T) {
 func TestAgentIdentityDeleteRole_NativeAdministratorRejected(t *testing.T) {
 	ctrl := adminRoleController(adminRoleEnvClient())
 
-	req := httptest.NewRequest(http.MethodDelete, "/orgs/o1/environments/dev/agent-identities/roles/r-admin", nil)
-	req.SetPathValue("orgName", "o1")
-	req.SetPathValue("envName", "dev")
-	req.SetPathValue("roleID", "r-admin")
+	req := adminRoleRequest(http.MethodDelete, "/orgs/o1/environments/dev/agent-identities/roles/r-admin", "")
 	w := httptest.NewRecorder()
 
 	ctrl.DeleteRole(w, req)
@@ -628,11 +628,8 @@ func TestAgentIdentityDeleteRole_NativeAdministratorRejected(t *testing.T) {
 func TestAgentIdentityAddRoleAssignees_NativeAdministratorRejected(t *testing.T) {
 	ctrl := adminRoleController(adminRoleEnvClient())
 
-	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles/r-admin/assignments/add",
-		strings.NewReader(`{"assignments":[{"id":"thunder-1","type":"agent"}]}`))
-	req.SetPathValue("orgName", "o1")
-	req.SetPathValue("envName", "dev")
-	req.SetPathValue("roleID", "r-admin")
+	req := adminRoleRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles/r-admin/assignments/add",
+		`{"assignments":[{"id":"thunder-1","type":"agent"}]}`)
 	w := httptest.NewRecorder()
 
 	ctrl.AddRoleAssignees(w, req)
@@ -654,11 +651,8 @@ func TestAgentIdentityRemoveRoleAssignees_NativeAdministratorAllowed(t *testing.
 	}
 	ctrl := adminRoleController(envClient)
 
-	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles/r-admin/assignments/remove",
-		strings.NewReader(`{"assignments":[{"id":"thunder-1","type":"agent"}]}`))
-	req.SetPathValue("orgName", "o1")
-	req.SetPathValue("envName", "dev")
-	req.SetPathValue("roleID", "r-admin")
+	req := adminRoleRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles/r-admin/assignments/remove",
+		`{"assignments":[{"id":"thunder-1","type":"agent"}]}`)
 	w := httptest.NewRecorder()
 
 	ctrl.RemoveRoleAssignees(w, req)

--- a/agent-manager-service/controllers/agent_identity_controller_unit_test.go
+++ b/agent-manager-service/controllers/agent_identity_controller_unit_test.go
@@ -546,3 +546,123 @@ func TestAgentIdentityGetRoleAssignments_UsesAgentSemantics(t *testing.T) {
 	assert.Len(t, body.Groups, 1)
 	assert.Equal(t, "readers", body.Groups[0].Name)
 }
+
+// adminRoleEnvClient returns an env client whose GetRole always resolves the
+// native Administrator role. Every mutating func is left nil, so any write
+// reaching Thunder panics the test.
+func adminRoleEnvClient() *clientmocks.EnvIdentityClientMock {
+	return &clientmocks.EnvIdentityClientMock{
+		GetRoleFunc: func(_ context.Context, roleID string) (*thundersvc.ThunderRole, error) {
+			return &thundersvc.ThunderRole{ID: roleID, OuID: "ou-env", Name: thundersvc.NativeAdministratorRoleName}, nil
+		},
+	}
+}
+
+func adminRoleController(envClient *clientmocks.EnvIdentityClientMock) AgentIdentityController {
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveIdentityFunc: func(_ context.Context, _, _ string) (thundersvc.EnvIdentityClient, error) {
+			return envClient, nil
+		},
+	}
+	return NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+}
+
+// TestAgentIdentityGetRole_NativeAdministratorHidden proves the native
+// Administrator role is invisible through the agent-identity API: fetching it by
+// ID returns 404, consistent with it being filtered from the role listing.
+func TestAgentIdentityGetRole_NativeAdministratorHidden(t *testing.T) {
+	ctrl := adminRoleController(adminRoleEnvClient())
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/o1/environments/dev/agent-identities/roles/r-admin", nil)
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req.SetPathValue("roleID", "r-admin")
+	w := httptest.NewRecorder()
+
+	ctrl.GetRole(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestAgentIdentityUpdateRole_NativeAdministratorRejected proves the native
+// Administrator role cannot be updated through the agent-identity API — an
+// UpdateRole with scopes would otherwise strip its "system" permission and cut
+// off the amp-system-client. UpdateRoleFunc is nil, so any write panics.
+func TestAgentIdentityUpdateRole_NativeAdministratorRejected(t *testing.T) {
+	ctrl := adminRoleController(adminRoleEnvClient())
+
+	req := httptest.NewRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/r-admin",
+		strings.NewReader(`{"name":"renamed","scopes":[]}`))
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req.SetPathValue("roleID", "r-admin")
+	req = req.WithContext(middleware.WithResolvedOrg(req.Context(), middleware.ResolvedOrg{OUID: "ou-org"}))
+	w := httptest.NewRecorder()
+
+	ctrl.UpdateRole(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestAgentIdentityDeleteRole_NativeAdministratorRejected proves the native
+// Administrator role cannot be deleted through the agent-identity API.
+// DeleteRoleFunc is nil, so any delete reaching Thunder panics.
+func TestAgentIdentityDeleteRole_NativeAdministratorRejected(t *testing.T) {
+	ctrl := adminRoleController(adminRoleEnvClient())
+
+	req := httptest.NewRequest(http.MethodDelete, "/orgs/o1/environments/dev/agent-identities/roles/r-admin", nil)
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req.SetPathValue("roleID", "r-admin")
+	w := httptest.NewRecorder()
+
+	ctrl.DeleteRole(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestAgentIdentityAddRoleAssignees_NativeAdministratorRejected proves agents
+// and groups cannot be assigned to the native Administrator role — the path by
+// which agent identities were acquiring the "system" scope.
+// AddRoleAssigneesFunc is nil, so any assignment reaching Thunder panics.
+func TestAgentIdentityAddRoleAssignees_NativeAdministratorRejected(t *testing.T) {
+	ctrl := adminRoleController(adminRoleEnvClient())
+
+	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles/r-admin/assignments/add",
+		strings.NewReader(`{"assignments":[{"id":"thunder-1","type":"agent"}]}`))
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req.SetPathValue("roleID", "r-admin")
+	w := httptest.NewRecorder()
+
+	ctrl.AddRoleAssignees(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestAgentIdentityRemoveRoleAssignees_NativeAdministratorAllowed pins the
+// deliberate asymmetry with AddRoleAssignees: removal from the native
+// Administrator role stays open so an existing mis-assignment can be cleaned up
+// through the same API — the guard must never be applied symmetrically.
+func TestAgentIdentityRemoveRoleAssignees_NativeAdministratorAllowed(t *testing.T) {
+	removed := false
+	envClient := adminRoleEnvClient()
+	envClient.RemoveRoleAssigneesFunc = func(_ context.Context, roleID string, req thundersvc.RoleAssignmentsRequest) error {
+		removed = true
+		assert.Equal(t, "r-admin", roleID)
+		return nil
+	}
+	ctrl := adminRoleController(envClient)
+
+	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles/r-admin/assignments/remove",
+		strings.NewReader(`{"assignments":[{"id":"thunder-1","type":"agent"}]}`))
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req.SetPathValue("roleID", "r-admin")
+	w := httptest.NewRecorder()
+
+	ctrl.RemoveRoleAssignees(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, removed, "cleanup removal must pass through to Thunder")
+}

--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -855,7 +855,7 @@ func (c *identityController) ListRoles(w http.ResponseWriter, r *http.Request) {
 		limit = 20
 	}
 
-	roles, _, err := c.client.ListRoles(ctx, resolvedOrg.OUID, offset, limit)
+	roles, total, err := c.client.ListRoles(ctx, resolvedOrg.OUID, offset, limit)
 	if err != nil {
 		log.Error("ListRoles failed", "ouID", resolvedOrg.OUID, "error", err)
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to list roles")
@@ -863,13 +863,14 @@ func (c *identityController) ListRoles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The OU-scoped ListRoles already restricts to the caller's OU and hides
-	// Thunder's native Administrator role (thundersvc.NativeAdministratorRoleName);
-	// only the display-only IsReadOnly flag is computed here.
+	// Thunder's native Administrator role (thundersvc.NativeAdministratorRoleName),
+	// so its total is the true post-filter count; only the display-only
+	// IsReadOnly flag is computed here.
 	for i := range roles {
 		roles[i].IsReadOnly = constants.IsPredefinedRole(roles[i].Name)
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"roles": roles, "total": len(roles), "offset": 0, "limit": limit})
+	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"roles": roles, "total": total, "offset": offset, "limit": limit})
 }
 
 func (c *identityController) GetRole(w http.ResponseWriter, r *http.Request) {

--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -862,18 +862,14 @@ func (c *identityController) ListRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Filter roles to only include those belonging to the caller's OU
-	// Thunder's ListRoles endpoint returns all roles, not OU-scoped
-	// Also exclude the "Administrator" role from public visibility
-	filteredRoles := make([]thundersvc.ThunderRole, 0, len(roles))
-	for _, role := range roles {
-		if role.OuID == resolvedOrg.OUID && role.Name != "Administrator" {
-			role.IsReadOnly = constants.IsPredefinedRole(role.Name)
-			filteredRoles = append(filteredRoles, role)
-		}
+	// The OU-scoped ListRoles already restricts to the caller's OU and hides
+	// Thunder's native Administrator role (thundersvc.NativeAdministratorRoleName);
+	// only the display-only IsReadOnly flag is computed here.
+	for i := range roles {
+		roles[i].IsReadOnly = constants.IsPredefinedRole(roles[i].Name)
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"roles": filteredRoles, "total": len(filteredRoles), "offset": 0, "limit": limit})
+	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"roles": roles, "total": len(roles), "offset": 0, "limit": limit})
 }
 
 func (c *identityController) GetRole(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Purpose

Agent identities in environment Thunder instances were acquiring the built-in `system` scope — full env-Thunder admin-API access. Every ThunderID install seeds a native **Administrator** role (carrying the `system` scope) in its default OU, and the agent-identity API surfaced it like any other role: it appeared in the role listing/assignment picker, and `AddRoleAssignees` accepted it without validation, so agents or agent groups could be assigned to it. An `UpdateRole` against it could also strip its `system` permission and cut off the `amp-system-client` that agent-manager uses to manage the environment.

## Goals

- The native Administrator role never surfaces through the agent-identity API: it is excluded from the OU-scoped role listing (before client-side pagination, so offset/limit/total stay consistent) and `GetRole` on it returns 404.
- It cannot be tampered with or granted: `UpdateRole`, `DeleteRole`, and `AddRoleAssignees` reject it with 404.
- Existing mis-assignments stay fixable: `RemoveRoleAssignees` deliberately skips the guard, and the unfiltered `ListRoles("")` walk (used by `GetAgentRoles` and the scope-cleanup sweep) still sees the role, so an agent already assigned to it remains visible and removable.

## Approach

- `thundersvc`: new `NativeAdministratorRoleName` constant; the OU-filtered branch of `ListRoles` skips the native role. Name matching is safe — Thunder enforces unique role names per OU, so post-bootstrap the only "Administrator" in the default OU is the native one. This mirrors the org-side `identity_controller.go`, which already excludes the same role by name.
- `agent_identity_controller`: new `managedRole` helper fetches the role and treats the native Administrator as nonexistent; wired into `GetRole`, `UpdateRole`, `DeleteRole`, and `AddRoleAssignees`. `RemoveRoleAssignees` and `GetRoleAssignments` intentionally stay open for cleanup/audit.

No API schema change; write paths were already validated (`resolveScopeGroups` only admits `<proxy-handle>:<action>` catalog scopes), so no role AMP creates can carry `system`.

## User stories

N/A — security hardening; no user-facing feature change.

## Release note

Fixed the environment identity provider's native Administrator role (carrying the `system` scope) being listed and assignable to agent identities.

## Documentation

N/A — no behavior documented for the native role; it should never have been visible.

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

- Unit tests: Yes.
  - `TestListRoles_OUFiltered_ExcludesNativeAdministrator`, `TestListRoles_Unfiltered_KeepsNativeAdministrator` (thundersvc)
  - `TestAgentIdentityGetRole_NativeAdministratorHidden`, `TestAgentIdentityUpdateRole_NativeAdministratorRejected`, `TestAgentIdentityDeleteRole_NativeAdministratorRejected`, `TestAgentIdentityAddRoleAssignees_NativeAdministratorRejected`, `TestAgentIdentityRemoveRoleAssignees_NativeAdministratorAllowed` (controllers)
- Integration tests: No — covered by DB-free unit tests; no repository/DB surface in this change.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — Java-focused tooling; Go code covered by golangci-lint with the repo's CI config
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations

N/A — no schema or data changes. Note for operators: agents already assigned to the Administrator role keep it until removed; `RemoveRoleAssignees` remains available for that cleanup.

## Test environment

Go 1.25 (darwin/arm64); `make test-unit`, `go build -tags=integration ./...`, `golangci-lint run --config .github/linters/.golangci.yaml` on touched packages.

## Learning

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native Administrator roles are now hidden from organization-scoped role listings.
  * Native Administrator roles return “Not found” when fetched, updated, deleted, or assigned new assignees.
  * Removing assignees from the native Administrator role remains supported.
  * Role totals and pagination results now accurately reflect filtered listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->