### PR TITLE
Grant the hook Role configmap access for CA publish

### DIFF
--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -538,6 +538,12 @@ rbac:
     - apiGroups: [""]
       resources: ["secrets"]
       verbs: ["get", "create", "patch"]
+    # The tls-certs hook also publishes the gateway-management CA as a ConfigMap
+    # (amp-api-gateway-mgmt-ca) for the control-plane gateway's BackendTLSPolicy;
+    # kubectl apply needs get + create/patch on configmaps.
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["get", "create", "patch"]
 
 # ServiceAccount used only by the pre-install/pre-upgrade hook Jobs.
 # This is the sole subject of the scoped RBAC Role. The SA and the


### PR DESCRIPTION
## Purpose

Every fresh install currently fails during the `agent-manager` chart's pre-install hooks, and the nightly e2e fails with it. The `tls-certs` hook Job was extended to publish the gateway-management CA as a ConfigMap (`amp-api-gateway-mgmt-ca`) for the control-plane gateway's `BackendTLSPolicy`, but the scoped hook `Role` only grants access to `secrets`. The Job runs as the `amp-hooks` ServiceAccount, so its `kubectl apply` of the ConfigMap is rejected:

```
configmaps "amp-api-gateway-mgmt-ca" is forbidden:
  User "system:serviceaccount:wso2-amp:amp-hooks" cannot get resource "configmaps" in the namespace "wso2-amp"
```

The Job then exhausts its backoff limit and the installer aborts.

## Goals

Let the hook Job manage the CA ConfigMap it is responsible for, so fresh installs (and the nightly e2e) complete again.

## Approach

Add a `configmaps` rule (`get`, `create`, `patch` — what `kubectl apply` needs) to `rbac.rules` in the `wso2-agent-manager` chart values, alongside the existing `secrets` rule. The Role stays scoped to the two resources the hooks actually touch.

## User stories

As an operator, a fresh `agent-manager` install completes without the pre-install hook failing on a ConfigMap permission error.

## Release note

Fixed a regression where fresh installs failed because the pre-install TLS-certs hook lacked permission to publish the gateway-management CA ConfigMap.

## Documentation

N/A — no user-facing documentation change.

## Training

N/A — no training-content impact.

## Certification

N/A — no impact on certification exams.

## Marketing

N/A — bug fix.

## Automation tests

- `helm template … --show-only templates/rbac.yaml` renders the hook `Role` with both `secrets` and `configmaps` (get/create/patch).
- Verified on a real k3d + sslip install that the `amp-api-tls-certs` hook previously died with `BackoffLimitExceeded` on the ConfigMap `Forbidden` error; this grant is the missing permission it needs.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report? N/A — Helm chart values change, no Java.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A.

## Related PRs

N/A.

## Migrations (if applicable)

N/A — the Role is re-applied on the next install/upgrade hook run.

## Test environment

k3d (Kubernetes v1.32) on Ubuntu; Helm 3.

## Learning

The hook `Role` grants must track what the hook Jobs actually do; the CA-ConfigMap publish step was added to the Job without extending the Role.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment permissions to allow TLS certificate setup jobs to create and update the gateway management CA configuration.
  * Improved compatibility with secure gateway backend connections using TLS policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->