### PR TITLE
Fix deployed-agent OTEL endpoint on VM installs

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
@@ -95,7 +95,12 @@ spec:
             # kgateway -> api-platform gateway runtime -> /otel RestApi, the same
             # path external agents use. Routing by hostname keeps this URL
             # independent of the namespace the gateway runtime is deployed in.
-            value: "http://${metadata.environmentName}-${metadata.componentNamespace}.{{ .Values.apiPlatformGatewayVhost.host }}:{{ .Values.apiPlatformGatewayVhost.port }}/otel"
+            #
+            # otelEndpointOverride replaces the whole URL when set (e.g. a VM
+            # install fronts a single public gateway host on :443, where the
+            # per-env "<env>-<org>.<host>:<port>" template does not fit). Leave
+            # empty for the default kgateway-routed vhost.
+            value: {{ if .Values.apiPlatformGatewayVhost.otelEndpointOverride }}{{ .Values.apiPlatformGatewayVhost.otelEndpointOverride | quote }}{{ else }}"http://${metadata.environmentName}-${metadata.componentNamespace}.{{ .Values.apiPlatformGatewayVhost.host }}:{{ .Values.apiPlatformGatewayVhost.port }}/otel"{{ end }}
         - op: add
           path: /spec/template/spec/containers/0/env/-
           value:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -134,6 +134,11 @@ environment:
 apiPlatformGatewayVhost:
   host: gateway.localhost
   port: 19080
+  # Full override for the agent OTEL endpoint. When set, it replaces the
+  # "http://<env>-<org>.<host>:<port>/otel" template entirely — used on installs
+  # that front a single public gateway host on :443 (e.g. a VM install), where
+  # the per-env template does not apply. Empty = use the template above.
+  otelEndpointOverride: ""
 
 # Deployment Pipeline configuration
 deploymentPipeline:

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -83,11 +83,14 @@ run_install() {
   mapfile -t GATEWAY_HELM_ARGS < <(build_gateway_helm_args "$VM_IP")
   # shellcheck disable=SC2034
   mapfile -t CP_HELM_ARGS < <(build_cp_helm_args "$VM_IP")
-  # Public agents base for the default Environment's gateway host (read by
+  # Public agents base + gateway host for the default Environment (read by
   # build_platform_resources_helm_args via dynamic scope); mirrors
-  # render_dataplane_external_ingress.
+  # render_dataplane_external_ingress. AMP_HOST_GATEWAY drives the agent OTEL
+  # endpoint override (deployed agents export traces to the public gateway).
   # shellcheck disable=SC2034
   local AMP_AGENTS_BASE="agents.${VM_IP}.sslip.io"
+  # shellcheck disable=SC2034
+  local AMP_HOST_GATEWAY; AMP_HOST_GATEWAY="$(vm_host gateway "$VM_IP")"
   # shellcheck disable=SC2034
   mapfile -t PLATFORM_RESOURCES_HELM_ARGS < <(build_platform_resources_helm_args)
   # shellcheck disable=SC2034

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -192,14 +192,15 @@ build_cp_helm_args() {
 #    externalURL: the invoke URL is empty and try-out falls back to a relative /chat
 #    (405) — the very symptom this override exists to fix. Both bind listenerName
 #    http (TLS terminates at Caddy) and differ only in advertised scheme.
-# shellcheck disable=SC2154  # AMP_AGENTS_BASE comes from the caller's scope by design.
+# shellcheck disable=SC2154  # AMP_AGENTS_BASE/AMP_HOST_GATEWAY come from the caller's scope by design.
 build_platform_resources_helm_args() {
   printf '%s\n' \
     "--set" "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
     "--set" "environment.gateway.http.host=${AMP_AGENTS_BASE}" \
     "--set" "environment.gateway.http.port=443" \
     "--set" "environment.gateway.https.host=${AMP_AGENTS_BASE}" \
-    "--set" "environment.gateway.https.port=443"
+    "--set" "environment.gateway.https.port=443" \
+    "--set" "apiPlatformGatewayVhost.otelEndpointOverride=https://${AMP_HOST_GATEWAY}/otel"
 }
 
 # build_thunder_helm_args <ip>

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -263,7 +263,11 @@ assert_eq "caddy cp no direct 9243" "" "$(grep -F '127.0.0.1:9243' <<<"$cf_cp")"
 #     with try-out 405ing against its own host). Reads AMP_AGENTS_BASE from scope. ---
 (
   AMP_AGENTS_BASE=agents.amp.example.com
+  AMP_HOST_GATEWAY=gateway.amp.example.com
   pr="$(build_platform_resources_helm_args)"
+  assert_eq "platform-resources agent OTEL endpoint override (public gateway)" \
+    "apiPlatformGatewayVhost.otelEndpointOverride=https://gateway.amp.example.com/otel" \
+    "$(grep -F 'apiPlatformGatewayVhost.otelEndpointOverride' <<<"$pr")"
   assert_eq "platform-resources oauth tokenUrl (direct svc)" \
     "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
     "$(grep -F 'global.oauth.tokenUrl' <<<"$pr")"


### PR DESCRIPTION
## Purpose

On a VM install, deployed agents fail to export traces:

```
NameResolutionError: Failed to resolve 'default-default.gateway.localhost'
… while exporting span batch to http://default-default.gateway.localhost:19080/otel/v1/traces
```

The env-injection trait builds the agent OTEL endpoint as `http://<env>-<org>.<apiPlatformGatewayVhost.host>:<port>/otel` (default host `gateway.localhost`), which is meant to resolve in-cluster via a CoreDNS rewrite for `*.gateway.localhost`. On a VM that host is never adjusted, so agents target `default-default.gateway.localhost:19080` — which the VM's CoreDNS doesn't rewrite, and which no longer matches the data-plane route (consolidated onto the single public gateway host on `:443`).

## Goals

Deployed agents on a VM export traces to a reachable endpoint — the same public gateway `/otel` the console already advertises for OTEL ingest.

## Approach

The per-env `<env>-<org>.<host>:<port>` template (http, `:19080`) can't express the VM's single public gateway on `:443`, so add a full-endpoint override, `apiPlatformGatewayVhost.otelEndpointOverride`:
- When set, the trait injects it verbatim as the OTEL endpoint.
- Empty (default) keeps the per-env template, so local/k3d dev is unchanged.

The VM installer's `build_platform_resources_helm_args` sets it to `https://<gateway-host>/otel` (`AMP_HOST_GATEWAY`), matching `console.config.instrumentationUrl`.

## User stories

As an operator, agents deployed on a VM report traces to the observability stack instead of failing with DNS errors.

## Release note

Fixed deployed agents failing to export traces on VM installs (they targeted an unresolvable in-cluster gateway host); they now use the public gateway OTEL endpoint.

## Documentation

N/A — value carries an inline comment; default preserves existing behavior.

## Training

N/A.

## Certification

N/A.

## Marketing

N/A — bug fix.

## Automation tests

- `helm template` renders the trait's OTEL env value as the full override when set, and as the per-env template when empty.
- `deployments/vm/tests/run.sh` passes; `build_platform_resources_helm_args` emits `apiPlatformGatewayVhost.otelEndpointOverride=https://<gateway>/otel`.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report? N/A — Helm chart + shell change, no Java.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A.

## Related PRs

N/A (independent VM-install fix).

## Migrations (if applicable)

N/A — picked up on the next install; existing agents pick it up on redeploy.

## Test environment

k3d + OpenChoreo on Ubuntu; Helm 3/4.

## Learning

The env-injection trait's per-env hostname template assumes an in-cluster `*.gateway.localhost` CoreDNS rewrite; a single-public-gateway install (VM) needs a full-endpoint override instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom OpenTelemetry (OTEL) endpoint.
  * VM deployments now automatically configure agents to export telemetry through the platform gateway.
  * Existing endpoint behavior remains unchanged when no override is provided.

* **Tests**
  * Added validation that VM-generated deployment settings include the configured OTEL endpoint override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->