### PR TITLE
Don't fail nightly cleanup when a GHCR package doesn't exist yet

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,11 @@ jobs:
           - wso2-amp-evaluation-extension
           - wso2-amp-api-platform-gateway-extension
     steps:
+      # Best-effort: the package may not exist yet (e.g. right after an image
+      # is renamed, before its first build/push creates the GHCR package), in
+      # which case the action 404s. Don't let that block build/e2e downstream.
       - name: Delete previous 0.0.0-dev-* tags for ${{ matrix.package }}
+        continue-on-error: true
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,11 +55,31 @@ jobs:
           - wso2-amp-evaluation-extension
           - wso2-amp-api-platform-gateway-extension
     steps:
-      # Best-effort: the package may not exist yet (e.g. right after an image
-      # is renamed, before its first build/push creates the GHCR package), in
-      # which case the action 404s. Don't let that block build/e2e downstream.
+      # The package may not exist yet (e.g. right after an image is renamed,
+      # before its first build/push creates the GHCR package), in which case
+      # ghcr-cleanup-action 404s and fails the job. Probe existence first so
+      # we can skip cleanup in that specific case without masking real
+      # failures (auth errors, GHCR outages) from the cleanup step itself.
+      - name: Check if package ${{ matrix.package }} exists
+        id: check-package
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          err=$(mktemp)
+          if gh api "orgs/${REGISTRY_ORG}/packages/container/${PACKAGE}" >/dev/null 2>"$err"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          elif grep -q "HTTP 404" "$err"; then
+            echo "::warning::Package ${PACKAGE} not found yet — skipping cleanup."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Failed to check package ${PACKAGE}:"
+            cat "$err" >&2
+            exit 1
+          fi
+
       - name: Delete previous 0.0.0-dev-* tags for ${{ matrix.package }}
-        continue-on-error: true
+        if: steps.check-package.outputs.exists == 'true'
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The nightly build has been failing entirely (before build/e2e even start) since the `amp-observer` rename in 27ea5eed
- `Cleanup Previous Nightly Images (amp-observer)` 404s because the GHCR package isn't created until an image is first pushed under the new name — `dataaxiom/ghcr-cleanup-action` returns "Package not found"
- Since that step isn't `continue-on-error`, the whole job (and everything downstream: build-images, package-charts, e2e) fails
- Mark the cleanup step `continue-on-error: true` — it's inherently best-effort ("delete previous dev tags if any exist")

## Test plan
- [ ] Trigger a manual `Nightly Dev Build` run and confirm `Cleanup Previous Nightly Images (amp-observer)` no longer blocks `Build`/`Package`/`E2E`
- [ ] Confirm subsequent nightly runs (once `amp-observer` package exists) still correctly delete stale `0.0.0-dev-*` tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly cleanup reliability by allowing non-critical image deletion failures without blocking subsequent build and end-to-end jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->