### PR TITLE
Dump cluster diagnostics on nightly heavy-tier failure

### DIFF
--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -78,6 +78,52 @@ jobs:
           # main, so this is main; on a manual branch run it's that branch.
           AMP_AGENT_REPO_BRANCH: ${{ github.ref_name }}
         run: nox -s heavy
+      - name: Dump cluster diagnostics on failure
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          echo "=== port-forward liveness (HTTP 000 = no connection / dropped forward) ==="
+          for p in 9000 8195 9243 22893 8090 9098 8200; do
+            code=$(curl -s -m3 -o /dev/null -w "%{http_code}" "http://localhost:$p" 2>/dev/null)
+            echo "  localhost:$p -> ${code:-000}"
+          done
+          echo "=== pods (all namespaces) ==="
+          kubectl get pods -A -o wide
+          echo "=== agent pod logs (incl. Running — the deploy may be healthy yet acked failed) ==="
+          kubectl get pods -A --no-headers 2>/dev/null \
+            | awk '/traceloop-/{print $1" "$2}' \
+            | while read -r ns pod; do
+                echo "----- $ns/$pod -----"
+                kubectl describe pod -n "$ns" "$pod" 2>/dev/null | sed -n '/Events:/,$p' | tail -25
+                kubectl logs -n "$ns" "$pod" --all-containers --tail=80 2>/dev/null
+              done
+          echo "=== OpenChoreo / gateway CRD kinds present ==="
+          mapfile -t KINDS < <(kubectl get crd -o name 2>/dev/null | grep -iE 'openchoreo|api-platform|wso2' | sed 's#.*/##')
+          printf '  %s\n' "${KINDS[@]}"
+          echo "=== agent CR instances + status (deploy/binding/release/component/workload) ==="
+          for k in "${KINDS[@]}"; do
+            while read -r ns name _; do
+              [ "$ns" = "NAMESPACE" ] && continue
+              case "$name" in
+                *traceloop-*)
+                  echo "--- $k $ns/$name ---"
+                  kubectl get "$k" "$name" -n "$ns" -o yaml 2>/dev/null | sed -n '/^status:/,$p' | head -50 ;;
+              esac
+            done < <(kubectl get "$k" -A 2>/dev/null)
+          done
+          echo "=== data-plane cluster-agent logs (sends deploy acks) ==="
+          kubectl logs -n openchoreo-data-plane deploy/cluster-agent-dataplane --tail=100 2>/dev/null
+          echo "=== gateway controller logs ==="
+          # Gateway stacks live in per-org-env namespaces ("<org>-<env>", e.g.
+          # default-default); also sweep openchoreo-data-plane for legacy installs.
+          for gwns in default-default openchoreo-data-plane; do
+            kubectl get pods -n "$gwns" --no-headers 2>/dev/null \
+              | awk '/gateway-controller/{print $1}' \
+              | while read -r p; do echo "----- $gwns/$p -----"; kubectl logs -n "$gwns" "$p" --tail=80 2>/dev/null; done
+          done
+          echo "=== recent events ==="
+          kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -80
       - uses: actions/upload-artifact@v7
         if: always()
         with:


### PR DESCRIPTION
## Purpose
When the nightly instrumentation-matrix `heavy-tier` job fails, it currently jumps straight from `nox -s heavy` to the artifact upload, leaving no cluster state to diagnose from. The per-cell reports carry only the driver-side error (e.g. a build timeout or a project-create `500`), not why the platform produced it — so a red night can't be triaged without re-running and manually watching a live cluster. N/A for issue links.

## Goals
Give the nightly heavy-tier the same on-failure cluster diagnostics the manual workflow already emits, so a failure is self-explaining from its logs alone.

## Approach
Add a `Dump cluster diagnostics on failure` step (`if: failure()`) to the nightly workflow's `heavy-tier` job, between `Run heavy tier` and the artifact upload. On failure it captures port-forward liveness, all pods, agent pod logs, OpenChoreo/gateway CR status, cluster-agent and gateway-controller logs, and recent events. The step is a verbatim copy of the one in `instrumentation-matrix-manual.yaml`, keeping the two jobs' diagnostics identical. No UI impact.

This already proved its worth: on a manual run it surfaced an `argo-workflow-controller` liveness-probe crashloop stalling the crewai builds — the root cause the reports alone couldn't show.

## User stories
N/A — CI diagnostics change, no user-facing behavior.

## Release note
N/A — internal CI tooling only.

## Documentation
N/A — no product doc impact; the step's behavior is self-describing in the workflow.

## Training
N/A — no training content impact.

## Certification
N/A — no impact on certification exams; this is a CI-only change.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > N/A — workflow YAML change. Validated with `actionlint` (parses cleanly; the pre-existing SC2162 warning is in the unrelated revalidation step, not this change).
 - Integration tests
   > N/A — the step only runs on job failure; it is a copy of the manual workflow's step already exercised in that job.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
N/A.

## Migrations (if applicable)
N/A.

## Test environment
GitHub Actions `ubuntu-latest` (the heavy-tier runner).

## Learning
Mirrored the existing manual-workflow diagnostics step rather than authoring a new one, so the two jobs stay in sync.


https://claude.ai/code/session_01DGktXf3CbHFznrfyKHc669


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by supporting cluster-internal service connectivity during environment setup.
  * Added configuration options for internal service endpoints, with sensible in-cluster defaults.

* **Chores**
  * Enhanced failure diagnostics for heavy-tier test runs, including cluster health, workload status, events, resource details, and relevant logs.
  * Existing artifact collection remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->