### PR TITLE
Skip nightly cleanup when only the dev tag exists

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,8 +78,32 @@ jobs:
             exit 1
           fi
 
-      - name: Delete previous 0.0.0-dev-* tags for ${{ matrix.package }}
+      # GHCR refuses to delete a package's last remaining tagged version
+      # ("You must delete the package instead"). A package that has only
+      # ever had nightly dev builds (e.g. right after a rename, before its
+      # first real release) has no other tag to fall back on, so deleting
+      # its sole 0.0.0-dev-* tag would hit that error. Detect this case and
+      # skip cleanup for it instead of failing the job.
+      - name: Check tagged versions for ${{ matrix.package }}
+        id: check-tags
         if: steps.check-package.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          tags=$(gh api "orgs/${REGISTRY_ORG}/packages/container/${PACKAGE}/versions" \
+            --paginate --jq '.[].metadata.container.tags[]?')
+          total=$(printf '%s\n' "$tags" | grep -c . || true)
+          dev_only=$(printf '%s\n' "$tags" | grep -c '^0\.0\.0-dev-' || true)
+          if [ "$total" -gt 0 ] && [ "$total" -eq "$dev_only" ]; then
+            echo "::warning::${PACKAGE} has no tagged version besides its nightly dev tag(s) yet; GHCR won't allow deleting the last tagged version, so skipping cleanup until a real release tag exists."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Delete previous 0.0.0-dev-* tags for ${{ matrix.package }}
+        if: steps.check-package.outputs.exists == 'true' && steps.check-tags.outputs.skip != 'true'
         uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The nightly "Cleanup Previous Nightly Images" job fails for `amp-observer` (see [this run](https://github.com/wso2/agent-manager/actions/runs/29636226542/job/88060852601)) with: `You cannot delete the last tagged version of a package. You must delete the package instead.` `amp-observer` was recently renamed from `amp-traces-observer` and has never been through a real release, so its only tag is the nightly `0.0.0-dev-*` build the cleanup step is trying to delete, and GHCR refuses to remove a package's last remaining tag.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Skip the delete step (with a warning annotation) when a package's only existing tags are the `0.0.0-dev-*` tags about to be removed, instead of failing the job. Cleanup resumes automatically once the package has a real release tag to anchor on.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Added a `check-tags` step alongside the existing package-existence probe in `cleanup-images`. It lists a package's tags via `gh api .../versions --paginate` and compares the total tag count against the count matching the `0.0.0-dev-*` pattern. If every existing tag is a dev tag, it sets `skip=true`, and the delete step's `if:` condition now also checks that output before running.

## User stories
> Summary of user stories addressed by this change

N/A - CI/ops-only change, no user-facing behavior.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fix nightly image cleanup so it no longer fails for packages that only have nightly dev tags and no release tag yet.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

N/A - internal CI workflow change only, no product documentation impact.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A - no training content affected.

## Certification
> Type “Sent” when you have provided new/updated certification questions...

N/A - no certification exam impact.

## Marketing
> Link to drafts of marketing content...

N/A - internal CI fix, nothing user-facing to promote.

## Automation tests
 - Unit tests
   > Code coverage information

N/A - GitHub Actions workflow change, no unit test harness applies.

 - Integration tests
   > Details about the test cases and coverage

Verified against the failing run's logs that `amp-observer` currently has exactly one tagged version (the dev tag) versus zero for every other tag category, confirming the new check would set `skip=true` for it. Will also observe the next scheduled nightly run to confirm the job goes green.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A - GitHub Actions YAML change, not covered by that tooling
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A - no sample changes.

## Related PRs
> List any other related PRs

N/A

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A - no data or schema migrations.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

N/A - GitHub Actions workflow; verified via `gh run view` log inspection, no separate test environment applicable.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Compared the failing `amp-observer` package's tag list (only `0.0.0-dev-*`) against a package with full release history (`amp-console`, which retains `v0.18.0` etc.), and traced `amp-observer`'s package name to a recent rename (`agent-manager-observer`, commit 27ea5eed) that post-dates the last release cut (v0.18.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly container image cleanup to avoid deleting the final tagged version of a package.
  * Added safeguards to skip cleanup when no fallback tag is available, preventing cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->