### PR TITLE
Fix sandboxed agent connectivity to OTEL, LLM, and MCP gateways

### DIFF
--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	// Default Chat API configuration
 	DefaultChatAPI     DefaultChatAPIConfig
 	DefaultGatewayPort int
+	GatewayRuntime     GatewayRuntimeConfig
 
 	// JWT Signing configuration for agent API tokens
 	JWTSigning JWTSigningConfig
@@ -293,6 +294,14 @@ type PublicKeysConfig struct {
 type APIPlatformConfig struct {
 	BaseURL string // Base URL for API Platform
 	Enable  bool
+}
+
+// GatewayRuntimeConfig defines how Agent Manager derives the Kubernetes Service URL
+// used by platform-hosted agents to reach an API Platform gateway runtime.
+type GatewayRuntimeConfig struct {
+	NamePrefix    string
+	ServiceSuffix string
+	Port          int
 }
 
 // InternalServerConfig holds configuration for the internal server

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -144,6 +145,11 @@ func loadEnvs() {
 
 	config.InstrumentationURL = r.readOptionalString("INSTRUMENTATION_URL", "http://default-default.gateway.localhost:19080/otel")
 	config.DefaultGatewayPort = int(r.readOptionalInt64("DEFAULT_GATEWAY_PORT", 19080))
+	config.GatewayRuntime = GatewayRuntimeConfig{
+		NamePrefix:    r.readOptionalString("GATEWAY_RUNTIME_NAME_PREFIX", "api-platform-"),
+		ServiceSuffix: r.readOptionalString("GATEWAY_RUNTIME_SERVICE_SUFFIX", "-gateway-gateway-runtime"),
+		Port:          int(r.readOptionalInt64("GATEWAY_RUNTIME_PORT", 22893)),
+	}
 	config.KeyManagerConfigurations = KeyManagerConfigurations{
 		// Comma-separated list of allowed issuers and audiences
 		Issuer:   r.readOptionalStringList("KEY_MANAGER_ISSUER", "Agent Management Platform Local"),
@@ -261,12 +267,25 @@ func loadEnvs() {
 	validateServerPublicURL(config, r)
 	validateInstrumentationURL(config, r)
 	validateObserverURLs(config, r)
+	validateGatewayRuntimeConfig(config, r)
 	validateResourceLimitsConfig(config, r)
 	validateAgentWorkloadCORSConfig(agentWorkloadConfig, r)
 
 	r.logAndExitIfErrorsFound()
 
 	slog.Info("configReader: configs loaded")
+}
+
+func validateGatewayRuntimeConfig(cfg *Config, r *configReader) {
+	if strings.TrimSpace(cfg.GatewayRuntime.NamePrefix) == "" {
+		r.errors = append(r.errors, fmt.Errorf("GATEWAY_RUNTIME_NAME_PREFIX must be non-empty"))
+	}
+	if strings.TrimSpace(cfg.GatewayRuntime.ServiceSuffix) == "" {
+		r.errors = append(r.errors, fmt.Errorf("GATEWAY_RUNTIME_SERVICE_SUFFIX must be non-empty"))
+	}
+	if cfg.GatewayRuntime.Port < 1 || cfg.GatewayRuntime.Port > 65535 {
+		r.errors = append(r.errors, fmt.Errorf("GATEWAY_RUNTIME_PORT must be between 1 and 65535, got %d", cfg.GatewayRuntime.Port))
+	}
 }
 
 func validateHTTPServerConfigs(cfg *Config, r *configReader) {

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -99,6 +99,69 @@ func TestValidateOAuthAuthorizationServers(t *testing.T) {
 	}
 }
 
+func TestValidateGatewayRuntimeConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      GatewayRuntimeConfig
+		wantErrors  int
+		errContains string
+	}{
+		{
+			name: "valid configuration",
+			config: GatewayRuntimeConfig{
+				NamePrefix:    "api-platform-",
+				ServiceSuffix: "-gateway-gateway-runtime",
+				Port:          22893,
+			},
+		},
+		{
+			name: "empty prefix",
+			config: GatewayRuntimeConfig{
+				NamePrefix:    " ",
+				ServiceSuffix: "-runtime",
+				Port:          22893,
+			},
+			wantErrors:  1,
+			errContains: "GATEWAY_RUNTIME_NAME_PREFIX",
+		},
+		{
+			name: "empty suffix",
+			config: GatewayRuntimeConfig{
+				NamePrefix:    "gateway-",
+				ServiceSuffix: " ",
+				Port:          22893,
+			},
+			wantErrors:  1,
+			errContains: "GATEWAY_RUNTIME_SERVICE_SUFFIX",
+		},
+		{
+			name: "invalid port",
+			config: GatewayRuntimeConfig{
+				NamePrefix:    "gateway-",
+				ServiceSuffix: "-runtime",
+				Port:          70000,
+			},
+			wantErrors:  1,
+			errContains: "GATEWAY_RUNTIME_PORT",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{GatewayRuntime: tc.config}
+			r := &configReader{}
+			validateGatewayRuntimeConfig(cfg, r)
+
+			if len(r.errors) != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tc.wantErrors, len(r.errors), r.errors)
+			}
+			if tc.errContains != "" && !strings.Contains(r.errors[0].Error(), tc.errContains) {
+				t.Errorf("expected an error containing %q, got %v", tc.errContains, r.errors)
+			}
+		})
+	}
+}
+
 func TestValidateServerPublicURL(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+)
+
+func TestGatewayRuntimeInClusterURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		gateway  *models.Gateway
+		expected string
+	}{
+		{
+			name: "derives runtime service and namespace",
+			gateway: &models.Gateway{
+				Name: "api-platform-acme-dev",
+			},
+			expected: "http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893",
+		},
+		{
+			name: "trims gateway name",
+			gateway: &models.Gateway{
+				Name: " api-platform-acme-prod ",
+			},
+			expected: "http://api-platform-acme-prod-gateway-gateway-runtime.acme-prod:22893",
+		},
+		{
+			name: "custom name falls back to vhost",
+			gateway: &models.Gateway{
+				Name: "custom-gateway",
+			},
+			expected: "",
+		},
+		{
+			name: "empty derived namespace falls back to vhost",
+			gateway: &models.Gateway{
+				Name: gatewayNamePrefix,
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, gatewayRuntimeInClusterURL(tt.gateway))
+		})
+	}
+}
+
+func TestBuildProxyURLSelectsReachableGateway(t *testing.T) {
+	contextPath := "/llm/proxy"
+	gateway := &models.Gateway{
+		Name:  "api-platform-acme-dev",
+		Vhost: "https://dev-acme.gateway.example.com",
+	}
+
+	require.Equal(t,
+		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/llm/proxy",
+		buildProxyURL(gateway, &contextPath, true),
+	)
+	require.Equal(t,
+		"https://dev-acme.gateway.example.com/llm/proxy",
+		buildProxyURL(gateway, &contextPath, false),
+	)
+}
+
+func TestBuildMCPProxyURLSelectsReachableGateway(t *testing.T) {
+	contextPath := "/tools/"
+	gateway := &models.Gateway{
+		Name:  "api-platform-acme-dev",
+		Vhost: "https://dev-acme.gateway.example.com/",
+	}
+
+	require.Equal(t,
+		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/tools/mcp",
+		buildMCPProxyURL(gateway, &contextPath, true),
+	)
+	require.Equal(t,
+		"https://dev-acme.gateway.example.com/tools/mcp",
+		buildMCPProxyURL(gateway, &contextPath, false),
+	)
+}
+
+func TestBuildMCPProxyURLFallsBackToVhostForCustomGatewayName(t *testing.T) {
+	gateway := &models.Gateway{
+		Name:  "custom-gateway",
+		Vhost: "https://gateway.example.com/",
+	}
+
+	require.Equal(t, "https://gateway.example.com/mcp", buildMCPProxyURL(gateway, nil, true))
+}

--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -21,8 +21,17 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
+
+func gatewayRuntimeTestConfig() config.GatewayRuntimeConfig {
+	return config.GatewayRuntimeConfig{
+		NamePrefix:    "api-platform-",
+		ServiceSuffix: "-gateway-gateway-runtime",
+		Port:          22893,
+	}
+}
 
 func TestGatewayRuntimeInClusterURL(t *testing.T) {
 	tests := []struct {
@@ -54,7 +63,7 @@ func TestGatewayRuntimeInClusterURL(t *testing.T) {
 		{
 			name: "empty derived namespace falls back to vhost",
 			gateway: &models.Gateway{
-				Name: gatewayNamePrefix,
+				Name: gatewayRuntimeTestConfig().NamePrefix,
 			},
 			expected: "",
 		},
@@ -62,9 +71,20 @@ func TestGatewayRuntimeInClusterURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expected, gatewayRuntimeInClusterURL(tt.gateway))
+			require.Equal(t, tt.expected, gatewayRuntimeInClusterURL(tt.gateway, gatewayRuntimeTestConfig()))
 		})
 	}
+}
+
+func TestGatewayRuntimeInClusterURLUsesConfiguredValues(t *testing.T) {
+	gateway := &models.Gateway{Name: "custom-acme-dev"}
+	runtimeConfig := config.GatewayRuntimeConfig{
+		NamePrefix:    "custom-",
+		ServiceSuffix: "-runtime",
+		Port:          9443,
+	}
+
+	require.Equal(t, "http://custom-acme-dev-runtime.acme-dev:9443", gatewayRuntimeInClusterURL(gateway, runtimeConfig))
 }
 
 func TestBuildProxyURLSelectsReachableGateway(t *testing.T) {
@@ -77,12 +97,12 @@ func TestBuildProxyURLSelectsReachableGateway(t *testing.T) {
 	require.Equal(
 		t,
 		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/llm/proxy",
-		buildProxyURL(gateway, &contextPath, true),
+		buildProxyURL(gateway, &contextPath, true, gatewayRuntimeTestConfig()),
 	)
 	require.Equal(
 		t,
 		"https://dev-acme.gateway.example.com/llm/proxy",
-		buildProxyURL(gateway, &contextPath, false),
+		buildProxyURL(gateway, &contextPath, false, gatewayRuntimeTestConfig()),
 	)
 }
 
@@ -96,12 +116,12 @@ func TestBuildMCPProxyURLSelectsReachableGateway(t *testing.T) {
 	require.Equal(
 		t,
 		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/tools/mcp",
-		buildMCPProxyURL(gateway, &contextPath, true),
+		buildMCPProxyURL(gateway, &contextPath, true, gatewayRuntimeTestConfig()),
 	)
 	require.Equal(
 		t,
 		"https://dev-acme.gateway.example.com/tools/mcp",
-		buildMCPProxyURL(gateway, &contextPath, false),
+		buildMCPProxyURL(gateway, &contextPath, false, gatewayRuntimeTestConfig()),
 	)
 }
 
@@ -111,5 +131,5 @@ func TestBuildMCPProxyURLFallsBackToVhostForCustomGatewayName(t *testing.T) {
 		Vhost: "https://gateway.example.com/",
 	}
 
-	require.Equal(t, "https://gateway.example.com/mcp", buildMCPProxyURL(gateway, nil, true))
+	require.Equal(t, "https://gateway.example.com/mcp", buildMCPProxyURL(gateway, nil, true, gatewayRuntimeTestConfig()))
 }

--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -74,28 +74,32 @@ func TestBuildProxyURLSelectsReachableGateway(t *testing.T) {
 		Vhost: "https://dev-acme.gateway.example.com",
 	}
 
-	require.Equal(t,
+	require.Equal(
+		t,
 		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/llm/proxy",
 		buildProxyURL(gateway, &contextPath, true),
 	)
-	require.Equal(t,
+	require.Equal(
+		t,
 		"https://dev-acme.gateway.example.com/llm/proxy",
 		buildProxyURL(gateway, &contextPath, false),
 	)
 }
 
 func TestBuildMCPProxyURLSelectsReachableGateway(t *testing.T) {
-	contextPath := "/tools/"
+	contextPath := "  /tools/  "
 	gateway := &models.Gateway{
 		Name:  "api-platform-acme-dev",
 		Vhost: "https://dev-acme.gateway.example.com/",
 	}
 
-	require.Equal(t,
+	require.Equal(
+		t,
 		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/tools/mcp",
 		buildMCPProxyURL(gateway, &contextPath, true),
 	)
-	require.Equal(t,
+	require.Equal(
+		t,
 		"https://dev-acme.gateway.example.com/tools/mcp",
 		buildMCPProxyURL(gateway, &contextPath, false),
 	)

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -365,8 +365,10 @@ func buildMCPProxyURL(gateway *models.Gateway, contextPath *string, isInternal b
 	}
 	base = strings.TrimRight(strings.TrimSpace(base), "/")
 	path := "/mcp"
-	if contextPath != nil && strings.TrimSpace(*contextPath) != "" {
-		path = strings.TrimRight(*contextPath, "/") + "/mcp"
+	if contextPath != nil {
+		if trimmedContextPath := strings.TrimSpace(*contextPath); trimmedContextPath != "" {
+			path = strings.TrimRight(trimmedContextPath, "/") + "/mcp"
+		}
 	}
 	return base + path
 }

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -129,6 +130,7 @@ type agentConfigurationService struct {
 	logger                    *slog.Logger
 	secretClient              secretmanagersvc.SecretManagementClient
 	encryptionKey             []byte
+	gatewayRuntimeConfig      config.GatewayRuntimeConfig
 }
 
 // rollbackResource tracks a proxy, its deployment, and API keys for cleanup
@@ -244,29 +246,15 @@ func (s *agentConfigurationService) ensureExternalAgentForAPIKey(ctx context.Con
 	return nil
 }
 
-const (
-	// gatewayNamePrefix prefixes every registered gateway name
-	// ("api-platform-<org>-<env>", from the apiGatewayName Helm helper). The per-env
-	// gateway namespace is the name with this prefix stripped ("<org>-<env>", the
-	// GATEWAY_NAMESPACE set by setup-gateway.sh / add-environment.sh).
-	gatewayNamePrefix = "api-platform-"
-	// gatewayRuntimeServiceSuffix is appended to the gateway name to form the
-	// in-cluster gateway runtime Service name.
-	gatewayRuntimeServiceSuffix = "-gateway-gateway-runtime"
-	// gatewayRuntimePort is the HTTP listener the gateway runtime Service exposes
-	// in-cluster (the /otel RestApi and the LLM/MCP proxy routes).
-	gatewayRuntimePort = 22893
-)
-
 // buildProxyURL constructs the proxy base URL from a gateway and an optional context path.
 // For internal (platform-hosted, sandboxed) agents it targets the in-cluster gateway runtime
 // Service directly, so pods reach the gateway via cluster DNS — which the sandbox
 // NetworkPolicy egress allows — instead of the external vhost, which a sandboxed pod cannot
 // route to. For external agents it uses the gateway's vhost (reachable from outside the cluster).
-func buildProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool) string {
+func buildProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool, runtimeConfig config.GatewayRuntimeConfig) string {
 	base := gateway.Vhost
 	if isInternal {
-		if inCluster := gatewayRuntimeInClusterURL(gateway); inCluster != "" {
+		if inCluster := gatewayRuntimeInClusterURL(gateway, runtimeConfig); inCluster != "" {
 			base = inCluster
 		}
 	}
@@ -277,18 +265,18 @@ func buildProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool
 }
 
 // gatewayRuntimeInClusterURL derives the in-cluster gateway runtime base URL from the
-// registered gateway name ("api-platform-<org>-<env>"): the runtime Service is
-// "<name>-gateway-gateway-runtime" in the per-env namespace "<org>-<env>" (the name with the
-// "api-platform-" prefix stripped), on port 22893 — matching the API-management trait's
-// runtime backend and the injected AMP_OTEL_ENDPOINT. Returns "" when the name doesn't follow
-// that convention (e.g. a custom gateway.name), so the caller safely falls back to the vhost.
-func gatewayRuntimeInClusterURL(gateway *models.Gateway) string {
+// registered gateway name. The configurable name prefix is removed to derive the namespace;
+// the configured Service suffix and port then form the runtime address. Returns "" when the
+// gateway name doesn't follow the configured convention, so the caller falls back to the vhost.
+func gatewayRuntimeInClusterURL(gateway *models.Gateway, runtimeConfig config.GatewayRuntimeConfig) string {
 	name := strings.TrimSpace(gateway.Name)
-	namespace := strings.TrimPrefix(name, gatewayNamePrefix)
+	namePrefix := strings.TrimSpace(runtimeConfig.NamePrefix)
+	serviceSuffix := strings.TrimSpace(runtimeConfig.ServiceSuffix)
+	namespace := strings.TrimPrefix(name, namePrefix)
 	if name == "" || namespace == "" || namespace == name {
 		return ""
 	}
-	return fmt.Sprintf("http://%s%s.%s:%d", name, gatewayRuntimeServiceSuffix, namespace, gatewayRuntimePort)
+	return fmt.Sprintf("http://%s%s.%s:%d", name, serviceSuffix, namespace, runtimeConfig.Port)
 }
 
 // buildLLMEnvVars constructs the two env vars (URL and API key) from the env config templates.
@@ -356,10 +344,10 @@ func buildEmptyMCPEnvVars(templates []EnvConfigTemplate) []client.EnvVar {
 // sandboxed) agents it targets the in-cluster gateway runtime Service (reachable under the
 // sandbox NetworkPolicy egress); for external agents — and for user-facing invoke URLs in API
 // responses — it uses the gateway's externally-reachable vhost.
-func buildMCPProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool) string {
+func buildMCPProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool, runtimeConfig config.GatewayRuntimeConfig) string {
 	base := gateway.Vhost
 	if isInternal {
-		if inCluster := gatewayRuntimeInClusterURL(gateway); inCluster != "" {
+		if inCluster := gatewayRuntimeInClusterURL(gateway, runtimeConfig); inCluster != "" {
 			base = inCluster
 		}
 	}
@@ -793,6 +781,7 @@ func NewAgentConfigurationService(
 	logger *slog.Logger,
 	secretClient secretmanagersvc.SecretManagementClient,
 	encryptionKey []byte,
+	gatewayRuntimeConfig config.GatewayRuntimeConfig,
 ) AgentConfigurationService {
 	svc := &agentConfigurationService{
 		db:                        db,
@@ -820,6 +809,7 @@ func NewAgentConfigurationService(
 		logger:                   logger,
 		secretClient:             secretClient,
 		encryptionKey:            encryptionKey,
+		gatewayRuntimeConfig:     gatewayRuntimeConfig,
 	}
 	// Register the deletion reconciler now that this service exists; MCPProxyService is
 	// constructed first and calls back into here when a proxy is deleted to strip the
@@ -1144,7 +1134,7 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		if proxy != nil {
 			proxyContext = proxy.Configuration.Context
 		}
-		proxyURL := buildProxyURL(gateway, proxyContext, !isExternalAgent)
+		proxyURL := buildProxyURL(gateway, proxyContext, !isExternalAgent, s.gatewayRuntimeConfig)
 
 		// Capture credentials for external agents.
 		if isExternalAgent {
@@ -1473,7 +1463,7 @@ func (s *agentConfigurationService) createMCPConfig(ctx context.Context, ouID, p
 			return nil, fmt.Errorf("failed to create MCP environment variables for %s: %w", envName, err)
 		}
 
-		proxyURL := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, !isExternalAgent)
+		proxyURL := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, !isExternalAgent, s.gatewayRuntimeConfig)
 		if isExternalAgent {
 			apiKey := ""
 			if proxyAPIKey != nil {
@@ -1801,7 +1791,7 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	// Internal-agent only: inject env vars into Component/ReleaseBinding.
 	// SecretReference is already created/updated by secretClient.CreateSecret above.
 	if !isExternalAgent {
-		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context, true)
+		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context, true, s.gatewayRuntimeConfig)
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		if uvErr := s.ocClient.UpdateComponentEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envVarsToInject); uvErr != nil {
 			s.logger.Error("failed to update Component CR env vars in Scenario A — Component CR in inconsistent state", "env", envName, "err", uvErr)
@@ -2057,7 +2047,7 @@ func (s *agentConfigurationService) processNewEnv(
 	// last-write-wins clobbering across multiple environments (HIGH-3).
 	if !isExternalAgent {
 		// Reuse the gateway already resolved for deployment (resolveGatewayForProvider)
-		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context, true)
+		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context, true, s.gatewayRuntimeConfig)
 
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		// Inject per-env URL into the ReleaseBinding for this specific environment.
@@ -2587,7 +2577,7 @@ func (s *agentConfigurationService) updateMCPConfigEnvironmentVariableNames(
 			s.logger.Warn("failed to load MCP SecretReference for env var rename", "environment", envName, "err", refErr)
 			continue
 		}
-		envVarsToInject := buildMCPEnvVars(newTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
+		envVarsToInject := buildMCPEnvVars(newTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true, s.gatewayRuntimeConfig), secretRefName)
 		if err := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); err != nil {
 			s.logger.Warn("failed to replace MCP env vars in ReleaseBinding", "environment", envName, "err", err)
 		}
@@ -2697,7 +2687,7 @@ func (s *agentConfigurationService) injectMCPMappingEnvVars(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	envVarsToInject := buildMCPEnvVars(envTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
+	envVarsToInject := buildMCPEnvVars(envTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true, s.gatewayRuntimeConfig), secretRefName)
 	if err := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); err != nil {
 		return err
 	}
@@ -3105,7 +3095,7 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to load MCP SecretReference for re-injection", "environment", envName, "err", refErr)
 								continue
 							}
-							envVarsToInject := buildMCPEnvVars(newEnvConfigTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
+							envVarsToInject := buildMCPEnvVars(newEnvConfigTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true, s.gatewayRuntimeConfig), secretRefName)
 							s.logger.Info("Phase 1b: atomically replacing MCP env vars in ReleaseBinding",
 								"environment", envName, "keysToRemove", changedOldKeys, "envVarsToAdd", len(envVarsToInject))
 							if rbErr := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); rbErr != nil {
@@ -3134,7 +3124,7 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to resolve gateway for re-injection", "environment", envName, "err", gwErr)
 								continue
 							}
-							proxyURL := buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context, true)
+							proxyURL := buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context, true, s.gatewayRuntimeConfig)
 							// Use persisted SecretReference from DB rather than deriving from mutable config name.
 							envVars1b, varErr1b := s.envVariableRepo.ListByConfigAndEnv(ctx, existingConfig.UUID, mapping.EnvironmentUUID)
 							secretRefName := ""
@@ -5034,7 +5024,7 @@ func (s *agentConfigurationService) buildConfigResponse(ctx context.Context, con
 				deployedProxy := buildAgentMCPConfigProxy(config, &mapping, mapping.MCPProxy, envName, config.OUID,
 					mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, envName))
 				// User-facing invoke URL in the config response: externally-reachable vhost.
-				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false)
+				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false, s.gatewayRuntimeConfig)
 				proxyInfo.URL = &url
 			}
 		}
@@ -5180,7 +5170,7 @@ func (s *agentConfigurationService) buildExternalAgentConfigResponse(
 				deployedProxy := buildAgentMCPConfigProxy(reloadedConfig, &mapping, mapping.MCPProxy, envName, config.OUID,
 					mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, envName))
 				// External agent's invoke URL: externally-reachable vhost.
-				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false)
+				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false, s.gatewayRuntimeConfig)
 				proxyInfo.URL = &url
 			} else {
 				s.logger.Warn(
@@ -5399,7 +5389,7 @@ func (s *agentConfigurationService) systemManagedLLMURL(
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for LLM proxy in %s: %w", environmentName, err)
 	}
-	return buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context, true), nil
+	return buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context, true, s.gatewayRuntimeConfig), nil
 }
 
 func (s *agentConfigurationService) systemManagedMCPURL(
@@ -5427,7 +5417,7 @@ func (s *agentConfigurationService) systemManagedMCPURL(
 		}
 		handle := mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, environmentName)
 		deployedProxy := buildAgentMCPConfigProxy(config, mapping, mapping.MCPProxy, environmentName, ouID, handle)
-		return buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), nil
+		return buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true, s.gatewayRuntimeConfig), nil
 	}
 	return "", nil
 }

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -244,16 +244,51 @@ func (s *agentConfigurationService) ensureExternalAgentForAPIKey(ctx context.Con
 	return nil
 }
 
+const (
+	// gatewayNamePrefix prefixes every registered gateway name
+	// ("api-platform-<org>-<env>", from the apiGatewayName Helm helper). The per-env
+	// gateway namespace is the name with this prefix stripped ("<org>-<env>", the
+	// GATEWAY_NAMESPACE set by setup-gateway.sh / add-environment.sh).
+	gatewayNamePrefix = "api-platform-"
+	// gatewayRuntimeServiceSuffix is appended to the gateway name to form the
+	// in-cluster gateway runtime Service name.
+	gatewayRuntimeServiceSuffix = "-gateway-gateway-runtime"
+	// gatewayRuntimePort is the HTTP listener the gateway runtime Service exposes
+	// in-cluster (the /otel RestApi and the LLM/MCP proxy routes).
+	gatewayRuntimePort = 22893
+)
+
 // buildProxyURL constructs the proxy base URL from a gateway and an optional context path.
-// For internal agents, it uses the in-cluster gateway runtime service name (ClusterIP)
-// so pods can reach the gateway without depending on external DNS.
-// For external agents, it uses the gateway's vhost (reachable from outside the cluster).
+// For internal (platform-hosted, sandboxed) agents it targets the in-cluster gateway runtime
+// Service directly, so pods reach the gateway via cluster DNS — which the sandbox
+// NetworkPolicy egress allows — instead of the external vhost, which a sandboxed pod cannot
+// route to. For external agents it uses the gateway's vhost (reachable from outside the cluster).
 func buildProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool) string {
 	base := gateway.Vhost
+	if isInternal {
+		if inCluster := gatewayRuntimeInClusterURL(gateway); inCluster != "" {
+			base = inCluster
+		}
+	}
 	if contextPath != nil {
 		return fmt.Sprintf("%s%s", base, *contextPath)
 	}
 	return base
+}
+
+// gatewayRuntimeInClusterURL derives the in-cluster gateway runtime base URL from the
+// registered gateway name ("api-platform-<org>-<env>"): the runtime Service is
+// "<name>-gateway-gateway-runtime" in the per-env namespace "<org>-<env>" (the name with the
+// "api-platform-" prefix stripped), on port 22893 — matching the API-management trait's
+// runtime backend and the injected AMP_OTEL_ENDPOINT. Returns "" when the name doesn't follow
+// that convention (e.g. a custom gateway.name), so the caller safely falls back to the vhost.
+func gatewayRuntimeInClusterURL(gateway *models.Gateway) string {
+	name := strings.TrimSpace(gateway.Name)
+	namespace := strings.TrimPrefix(name, gatewayNamePrefix)
+	if name == "" || namespace == "" || namespace == name {
+		return ""
+	}
+	return fmt.Sprintf("http://%s%s.%s:%d", name, gatewayRuntimeServiceSuffix, namespace, gatewayRuntimePort)
 }
 
 // buildLLMEnvVars constructs the two env vars (URL and API key) from the env config templates.
@@ -316,8 +351,19 @@ func buildEmptyMCPEnvVars(templates []EnvConfigTemplate) []client.EnvVar {
 	return envVars
 }
 
-func buildMCPProxyURL(vhost string, contextPath *string) string {
-	base := strings.TrimRight(strings.TrimSpace(vhost), "/")
+// buildMCPProxyURL constructs the MCP proxy URL from a gateway and the proxy's optional
+// context path, appending the "/mcp" route. Like buildProxyURL: for internal (platform-hosted,
+// sandboxed) agents it targets the in-cluster gateway runtime Service (reachable under the
+// sandbox NetworkPolicy egress); for external agents — and for user-facing invoke URLs in API
+// responses — it uses the gateway's externally-reachable vhost.
+func buildMCPProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool) string {
+	base := gateway.Vhost
+	if isInternal {
+		if inCluster := gatewayRuntimeInClusterURL(gateway); inCluster != "" {
+			base = inCluster
+		}
+	}
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
 	path := "/mcp"
 	if contextPath != nil && strings.TrimSpace(*contextPath) != "" {
 		path = strings.TrimRight(*contextPath, "/") + "/mcp"
@@ -1425,7 +1471,7 @@ func (s *agentConfigurationService) createMCPConfig(ctx context.Context, ouID, p
 			return nil, fmt.Errorf("failed to create MCP environment variables for %s: %w", envName, err)
 		}
 
-		proxyURL := buildMCPProxyURL(gateway.Vhost, deployedProxy.Configuration.Context)
+		proxyURL := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, !isExternalAgent)
 		if isExternalAgent {
 			apiKey := ""
 			if proxyAPIKey != nil {
@@ -2539,7 +2585,7 @@ func (s *agentConfigurationService) updateMCPConfigEnvironmentVariableNames(
 			s.logger.Warn("failed to load MCP SecretReference for env var rename", "environment", envName, "err", refErr)
 			continue
 		}
-		envVarsToInject := buildMCPEnvVars(newTemplates, buildMCPProxyURL(gateway.Vhost, deployedProxy.Configuration.Context), secretRefName)
+		envVarsToInject := buildMCPEnvVars(newTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
 		if err := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); err != nil {
 			s.logger.Warn("failed to replace MCP env vars in ReleaseBinding", "environment", envName, "err", err)
 		}
@@ -2649,7 +2695,7 @@ func (s *agentConfigurationService) injectMCPMappingEnvVars(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	envVarsToInject := buildMCPEnvVars(envTemplates, buildMCPProxyURL(gateway.Vhost, deployedProxy.Configuration.Context), secretRefName)
+	envVarsToInject := buildMCPEnvVars(envTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
 	if err := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); err != nil {
 		return err
 	}
@@ -3057,7 +3103,7 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to load MCP SecretReference for re-injection", "environment", envName, "err", refErr)
 								continue
 							}
-							envVarsToInject := buildMCPEnvVars(newEnvConfigTemplates, buildMCPProxyURL(gateway.Vhost, deployedProxy.Configuration.Context), secretRefName)
+							envVarsToInject := buildMCPEnvVars(newEnvConfigTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
 							s.logger.Info("Phase 1b: atomically replacing MCP env vars in ReleaseBinding",
 								"environment", envName, "keysToRemove", changedOldKeys, "envVarsToAdd", len(envVarsToInject))
 							if rbErr := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); rbErr != nil {
@@ -4985,7 +5031,8 @@ func (s *agentConfigurationService) buildConfigResponse(ctx context.Context, con
 			if gateway, err := s.resolveGatewayForMCPArtifact(ctx, mapping.ArtifactUUID, config.OUID, mapping.EnvironmentUUID); err == nil {
 				deployedProxy := buildAgentMCPConfigProxy(config, &mapping, mapping.MCPProxy, envName, config.OUID,
 					mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, envName))
-				url := buildMCPProxyURL(gateway.Vhost, deployedProxy.Configuration.Context)
+				// User-facing invoke URL in the config response: externally-reachable vhost.
+				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false)
 				proxyInfo.URL = &url
 			}
 		}
@@ -5130,7 +5177,8 @@ func (s *agentConfigurationService) buildExternalAgentConfigResponse(
 			} else if gateway, err := s.resolveGatewayForMCPArtifact(ctx, mapping.ArtifactUUID, config.OUID, mapping.EnvironmentUUID); err == nil {
 				deployedProxy := buildAgentMCPConfigProxy(reloadedConfig, &mapping, mapping.MCPProxy, envName, config.OUID,
 					mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, envName))
-				url := buildMCPProxyURL(gateway.Vhost, deployedProxy.Configuration.Context)
+				// External agent's invoke URL: externally-reachable vhost.
+				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false)
 				proxyInfo.URL = &url
 			} else {
 				s.logger.Warn(
@@ -5377,7 +5425,7 @@ func (s *agentConfigurationService) systemManagedMCPURL(
 		}
 		handle := mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, environmentName)
 		deployedProxy := buildAgentMCPConfigProxy(config, mapping, mapping.MCPProxy, environmentName, ouID, handle)
-		return buildMCPProxyURL(gateway.Vhost, deployedProxy.Configuration.Context), nil
+		return buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), nil
 	}
 	return "", nil
 }

--- a/agent-manager-service/services/llm_proxy_provisioner.go
+++ b/agent-manager-service/services/llm_proxy_provisioner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -110,6 +111,7 @@ type LLMProxyProvisioner struct {
 	llmProviderAPIKeyService  *LLMProviderAPIKeyService
 	secretClient              secretmanagersvc.SecretManagementClient
 	encryptionKey             []byte
+	gatewayRuntimeConfig      config.GatewayRuntimeConfig
 }
 
 // NewLLMProxyProvisioner creates a new LLMProxyProvisioner.
@@ -123,6 +125,7 @@ func NewLLMProxyProvisioner(
 	llmProviderAPIKeyService *LLMProviderAPIKeyService,
 	secretClient secretmanagersvc.SecretManagementClient,
 	encryptionKey []byte,
+	gatewayRuntimeConfig config.GatewayRuntimeConfig,
 ) *LLMProxyProvisioner {
 	return &LLMProxyProvisioner{
 		logger:                    logger,
@@ -134,6 +137,7 @@ func NewLLMProxyProvisioner(
 		llmProviderAPIKeyService:  llmProviderAPIKeyService,
 		secretClient:              secretClient,
 		encryptionKey:             encryptionKey,
+		gatewayRuntimeConfig:      gatewayRuntimeConfig,
 	}
 }
 
@@ -321,7 +325,7 @@ func (p *LLMProxyProvisioner) ProvisionProxy(ctx context.Context, params Provisi
 		rb.ProxySecretLoc = &proxySecretLoc
 	}
 
-	proxyURL := buildProxyURL(params.Gateway, proxy.Configuration.Context, true)
+	proxyURL := buildProxyURL(params.Gateway, proxy.Configuration.Context, true, p.gatewayRuntimeConfig)
 
 	p.logger.Info(
 		"Provisioned LLM proxy",

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/catalog"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
@@ -86,6 +87,7 @@ type monitorExecutor struct {
 	monitorLLMMappingRepo repositories.MonitorLLMMappingRepository
 	gatewayRepo           repositories.GatewayRepository
 	llmProviderRepo       repositories.LLMProviderRepository
+	gatewayRuntimeConfig  config.GatewayRuntimeConfig
 }
 
 // NewMonitorExecutor creates a new monitor executor instance
@@ -98,6 +100,7 @@ func NewMonitorExecutor(
 	monitorLLMMappingRepo repositories.MonitorLLMMappingRepository,
 	gatewayRepo repositories.GatewayRepository,
 	llmProviderRepo repositories.LLMProviderRepository,
+	gatewayRuntimeConfig config.GatewayRuntimeConfig,
 ) MonitorExecutor {
 	return &monitorExecutor{
 		ocClient:              ocClient,
@@ -108,6 +111,7 @@ func NewMonitorExecutor(
 		monitorLLMMappingRepo: monitorLLMMappingRepo,
 		gatewayRepo:           gatewayRepo,
 		llmProviderRepo:       llmProviderRepo,
+		gatewayRuntimeConfig:  gatewayRuntimeConfig,
 	}
 }
 
@@ -275,7 +279,7 @@ func (e *monitorExecutor) resolveProxyURL(ctx context.Context, ouID, environment
 		return "", fmt.Errorf("no active gateway found for environment %s", environmentID)
 	}
 
-	return buildProxyURL(gateways[0], proxy.Configuration.Context, true), nil
+	return buildProxyURL(gateways[0], proxy.Configuration.Context, true, e.gatewayRuntimeConfig), nil
 }
 
 // buildWorkflowRunRequest constructs the workflow run request for a monitor.

--- a/agent-manager-service/tests/monitor_executor_test.go
+++ b/agent-manager-service/tests/monitor_executor_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/db"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
@@ -114,7 +115,7 @@ func TestExecuteMonitorRun_CRStructure(t *testing.T) {
 		},
 	}
 
-	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()))
+	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()), config.GatewayRuntimeConfig{})
 
 	startTime := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
 	endTime := time.Date(2026, 1, 15, 11, 0, 0, 0, time.UTC)
@@ -188,7 +189,7 @@ func TestExecuteMonitorRun_EvaluatorsJSON(t *testing.T) {
 		},
 	}
 
-	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()))
+	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()), config.GatewayRuntimeConfig{})
 
 	result, err := executor.ExecuteMonitorRun(context.Background(), services.ExecuteMonitorRunParams{
 		OUID:       monitor.OUID,
@@ -283,7 +284,7 @@ func TestExecuteMonitorRun_DBRecordCreated(t *testing.T) {
 		},
 	}
 
-	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()))
+	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()), config.GatewayRuntimeConfig{})
 
 	startTime := time.Now().Add(-2 * time.Hour).Truncate(time.Millisecond)
 	endTime := time.Now().Add(-1 * time.Hour).Truncate(time.Millisecond)
@@ -394,7 +395,7 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 		},
 	}
 
-	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()))
+	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()), config.GatewayRuntimeConfig{})
 
 	_, err = executor.ExecuteMonitorRun(context.Background(), services.ExecuteMonitorRunParams{
 		OUID:       monitor.OUID,
@@ -433,7 +434,7 @@ func TestExecuteMonitorRun_NilEvaluatorsReturnsError(t *testing.T) {
 		},
 	}
 
-	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()))
+	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()), config.GatewayRuntimeConfig{})
 
 	_, err := executor.ExecuteMonitorRun(context.Background(), services.ExecuteMonitorRunParams{
 		OUID:       monitor.OUID,
@@ -481,7 +482,7 @@ func TestExecuteMonitorRun_PerOrgPublisherCredentials(t *testing.T) {
 		},
 	}
 
-	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()))
+	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()), config.GatewayRuntimeConfig{})
 
 	result, err := executor.ExecuteMonitorRun(context.Background(), services.ExecuteMonitorRunParams{
 		OUID:       monitor.OUID,
@@ -520,7 +521,7 @@ func TestExecuteMonitorRun_FallbackPublisherCredentials(t *testing.T) {
 		},
 	}
 
-	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()))
+	executor := services.NewMonitorExecutor(mockClient, slog.Default(), repositories.NewMonitorRepo(db.GetDB()), repositories.NewCustomEvaluatorRepo(db.GetDB()), repositories.NewOrgPublisherCredentialRepo(db.GetDB()), repositories.NewMonitorLLMMappingRepository(db.GetDB()), repositories.NewGatewayRepo(db.GetDB()), repositories.NewLLMProviderRepo(db.GetDB()), config.GatewayRuntimeConfig{})
 
 	result, err := executor.ExecuteMonitorRun(context.Background(), services.ExecuteMonitorRunParams{
 		OUID:       monitor.OUID,

--- a/agent-manager-service/wiring/params.go
+++ b/agent-manager-service/wiring/params.go
@@ -107,6 +107,10 @@ func ProvideConfigFromPtr(config *config.Config) config.Config {
 	return *config
 }
 
+func ProvideGatewayRuntimeConfig(cfg config.Config) config.GatewayRuntimeConfig {
+	return cfg.GatewayRuntime
+}
+
 func ProvideAuthMiddleware(config config.Config) jwtassertion.Middleware {
 	var resourceMetadataURL string
 	if config.ServerPublicURL != "" {

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -46,6 +46,7 @@ import (
 // Provider sets
 var configProviderSet = wire.NewSet(
 	ProvideConfigFromPtr,
+	ProvideGatewayRuntimeConfig,
 	ProvideEncryptionKey,
 )
 

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -194,7 +194,6 @@ func ProvideInstrumentationCatalog(cfg config.Config) (*instrumentation.Catalog,
 func validateDefaultCoversBuildpackPython(cat *instrumentation.Catalog) error {
 	entry, ok := cat.Get(cat.Default())
 	if !ok {
-		// Already validated by Load, but be defensive.
 		return fmt.Errorf("default instrumentation version %q not in effective set", cat.Default())
 	}
 	bpPython := utils.SupportedPythonVersions()

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -91,7 +91,8 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	llmProviderAPIKeyService := services.NewLLMProviderAPIKeyService(llmProviderRepository, gatewayRepository, gatewayEventsService, apiKeyRepository)
 	aiApplicationRepository := ProvideAIApplicationRepository(db)
 	aiApplicationService := services.NewAIApplicationService(aiApplicationRepository, gatewayRepository, gatewayEventsService, logger)
-	agentConfigurationService := services.NewAgentConfigurationService(db, agentConfigurationRepository, envAgentModelMappingRepository, envAgentMCPMappingRepository, agentEnvConfigVariableRepository, llmProviderRepository, mcpProxyRepository, gatewayRepository, llmProxyService, mcpProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, gatewayEventsService, apiKeyRepository, infraResourceManager, openChoreoClient, llmProviderAPIKeyService, aiApplicationService, agentIdentityInjectionService, logger, secretManagementClient, v)
+	gatewayRuntimeConfig := ProvideGatewayRuntimeConfig(configConfig)
+	agentConfigurationService := services.NewAgentConfigurationService(db, agentConfigurationRepository, envAgentModelMappingRepository, envAgentMCPMappingRepository, agentEnvConfigVariableRepository, llmProviderRepository, mcpProxyRepository, gatewayRepository, llmProxyService, mcpProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, gatewayEventsService, apiKeyRepository, infraResourceManager, openChoreoClient, llmProviderAPIKeyService, aiApplicationService, agentIdentityInjectionService, logger, secretManagementClient, v, gatewayRuntimeConfig)
 	agentKindRepository := ProvideAgentKindRepository(db)
 	agentKindService := services.NewAgentKindService(agentKindRepository, openChoreoClient)
 	artifactRepository := ProvideArtifactRepository(db)
@@ -103,10 +104,10 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	customEvaluatorRepository := ProvideCustomEvaluatorRepository(db)
 	orgPublisherCredentialRepository := ProvideOrgPublisherCredentialRepository(db)
 	monitorLLMMappingRepository := repositories.NewMonitorLLMMappingRepository(db)
-	monitorExecutor := services.NewMonitorExecutor(openChoreoClient, logger, monitorRepository, customEvaluatorRepository, orgPublisherCredentialRepository, monitorLLMMappingRepository, gatewayRepository, llmProviderRepository)
+	monitorExecutor := services.NewMonitorExecutor(openChoreoClient, logger, monitorRepository, customEvaluatorRepository, orgPublisherCredentialRepository, monitorLLMMappingRepository, gatewayRepository, llmProviderRepository, gatewayRuntimeConfig)
 	evaluatorManagerService := services.NewEvaluatorManagerService(logger, customEvaluatorRepository, monitorRepository)
 	scoreRepository := ProvideScoreRepository(db)
-	llmProxyProvisioner := services.NewLLMProxyProvisioner(logger, llmProviderRepository, gatewayRepository, llmProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, llmProviderAPIKeyService, secretManagementClient, v)
+	llmProxyProvisioner := services.NewLLMProxyProvisioner(logger, llmProviderRepository, gatewayRepository, llmProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, llmProviderAPIKeyService, secretManagementClient, v, gatewayRuntimeConfig)
 	publisherCredentialProvisioner, err := ProvidePublisherProvisioner(configConfig, v, logger, secretManagementClient, openChoreoClient, orgPublisherCredentialRepository)
 	if err != nil {
 		return nil, err
@@ -265,7 +266,8 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	llmProviderAPIKeyService := services.NewLLMProviderAPIKeyService(llmProviderRepository, gatewayRepository, gatewayEventsService, apiKeyRepository)
 	aiApplicationRepository := ProvideAIApplicationRepository(db)
 	aiApplicationService := services.NewAIApplicationService(aiApplicationRepository, gatewayRepository, gatewayEventsService, logger)
-	agentConfigurationService := services.NewAgentConfigurationService(db, agentConfigurationRepository, envAgentModelMappingRepository, envAgentMCPMappingRepository, agentEnvConfigVariableRepository, llmProviderRepository, mcpProxyRepository, gatewayRepository, llmProxyService, mcpProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, gatewayEventsService, apiKeyRepository, infraResourceManager, openChoreoClient, llmProviderAPIKeyService, aiApplicationService, agentIdentityInjectionService, logger, secretManagementClient, v)
+	gatewayRuntimeConfig := ProvideGatewayRuntimeConfig(configConfig)
+	agentConfigurationService := services.NewAgentConfigurationService(db, agentConfigurationRepository, envAgentModelMappingRepository, envAgentMCPMappingRepository, agentEnvConfigVariableRepository, llmProviderRepository, mcpProxyRepository, gatewayRepository, llmProxyService, mcpProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, gatewayEventsService, apiKeyRepository, infraResourceManager, openChoreoClient, llmProviderAPIKeyService, aiApplicationService, agentIdentityInjectionService, logger, secretManagementClient, v, gatewayRuntimeConfig)
 	agentKindRepository := ProvideAgentKindRepository(db)
 	agentKindService := services.NewAgentKindService(agentKindRepository, openChoreoClient)
 	artifactRepository := ProvideArtifactRepository(db)
@@ -275,10 +277,10 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	customEvaluatorRepository := ProvideCustomEvaluatorRepository(db)
 	orgPublisherCredentialRepository := ProvideOrgPublisherCredentialRepository(db)
 	monitorLLMMappingRepository := repositories.NewMonitorLLMMappingRepository(db)
-	monitorExecutor := services.NewMonitorExecutor(openChoreoClient, logger, monitorRepository, customEvaluatorRepository, orgPublisherCredentialRepository, monitorLLMMappingRepository, gatewayRepository, llmProviderRepository)
+	monitorExecutor := services.NewMonitorExecutor(openChoreoClient, logger, monitorRepository, customEvaluatorRepository, orgPublisherCredentialRepository, monitorLLMMappingRepository, gatewayRepository, llmProviderRepository, gatewayRuntimeConfig)
 	evaluatorManagerService := services.NewEvaluatorManagerService(logger, customEvaluatorRepository, monitorRepository)
 	scoreRepository := ProvideScoreRepository(db)
-	llmProxyProvisioner := services.NewLLMProxyProvisioner(logger, llmProviderRepository, gatewayRepository, llmProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, llmProviderAPIKeyService, secretManagementClient, v)
+	llmProxyProvisioner := services.NewLLMProxyProvisioner(logger, llmProviderRepository, gatewayRepository, llmProxyService, llmProxyDeploymentService, llmProxyAPIKeyService, llmProviderAPIKeyService, secretManagementClient, v, gatewayRuntimeConfig)
 	publisherCredentialProvisioner, err := ProvidePublisherProvisioner(configConfig, v, logger, secretManagementClient, openChoreoClient, orgPublisherCredentialRepository)
 	if err != nil {
 		return nil, err
@@ -390,6 +392,7 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 // Provider sets
 var configProviderSet = wire.NewSet(
 	ProvideConfigFromPtr,
+	ProvideGatewayRuntimeConfig,
 	ProvideEncryptionKey,
 )
 
@@ -460,7 +463,6 @@ func ProvideInstrumentationCatalog(cfg config.Config) (*instrumentation.Catalog,
 func validateDefaultCoversBuildpackPython(cat *instrumentation.Catalog) error {
 	entry, ok := cat.Get(cat.Default())
 	if !ok {
-
 		return fmt.Errorf("default instrumentation version %q not in effective set", cat.Default())
 	}
 	bpPython := utils.SupportedPythonVersions()

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -67,6 +67,10 @@ services:
       - KEY_MANAGER_ISSUER=Agent Management Platform Local,http://thunder.amp.localhost:8080
       - KEY_MANAGER_AUDIENCE=amp,localhost,amp-publisher-*,amp-api-client,amp-console-client,amctl,am-mcp,http://localhost:9000/
       - AMP_VERSION=v0.8.0
+      # In-cluster API Platform gateway runtime Service URL convention.
+      - GATEWAY_RUNTIME_NAME_PREFIX=api-platform-
+      - GATEWAY_RUNTIME_SERVICE_SUFFIX=-gateway-gateway-runtime
+      - GATEWAY_RUNTIME_PORT=22893
       - OPEN_CHOREO_BASE_URL=http://api.openchoreo.localhost:8195
       # OpenBao/Vault Secret Management Configuration
       # NOTE: Run ./deployments/setup/port-forward.sh to forward OpenBao from k3d cluster

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -11,6 +11,9 @@ data:
   # (console bootstrap, CLI) via /api/v1/config. No internal fallback:
   # unset means clients surface "observer not configured".
   AM_OBSERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.amObserverPublicURL | default "" | quote }}
+  GATEWAY_RUNTIME_NAME_PREFIX: {{ .Values.agentManagerService.config.gatewayRuntime.namePrefix | default "api-platform-" | quote }}
+  GATEWAY_RUNTIME_SERVICE_SUFFIX: {{ .Values.agentManagerService.config.gatewayRuntime.serviceSuffix | default "-gateway-gateway-runtime" | quote }}
+  GATEWAY_RUNTIME_PORT: {{ .Values.agentManagerService.config.gatewayRuntime.port | default 22893 | quote }}
   SERVER_HOST: {{ .Values.agentManagerService.config.serverHost | quote }}
   SERVER_PORT: {{ .Values.agentManagerService.service.targetPort | quote }}
   LOG_LEVEL: {{ .Values.agentManagerService.config.logLevel | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -139,6 +139,13 @@ agentManagerService:
     # clients surface "observer not configured".
     amObserverPublicURL: ""
 
+    # In-cluster API Platform gateway runtime Service URL convention used for
+    # sandboxed agents' OTEL and managed LLM/MCP traffic.
+    gatewayRuntime:
+      namePrefix: "api-platform-"
+      serviceSuffix: "-gateway-gateway-runtime"
+      port: 22893
+
 
     # TLS Configuration
     tlsEnabled: false

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
@@ -91,16 +91,21 @@ spec:
           path: /spec/podTemplate/spec/containers/0/env/-
           value:
             name: ${parameters.otelEndpointEnvName}
-            # kgateway-routed vhost ("<env>-<org>.<domain>"): traces flow through
-            # kgateway -> api-platform gateway runtime -> /otel RestApi, the same
-            # path external agents use. Routing by hostname keeps this URL
-            # independent of the namespace the gateway runtime is deployed in.
+            # In-cluster gateway runtime Service (per-org-env namespace): the
+            # sandboxed agent reaches the runtime directly at
+            # "api-platform-<org>-<env>-gateway-gateway-runtime.<org>-<env>:22893/otel".
+            # Derived from the apiGatewayName convention ("api-platform-<org>-<env>")
+            # + the per-env gateway namespace ("<org>-<env>"), matching the
+            # API-management trait's runtime backend. This in-cluster path is what
+            # the sandbox NetworkPolicy egress allows (namespace label
+            # amp.wso2.com/api-platform-gateway=true, port 22893) and avoids the
+            # host-hairpin vhost, which a sandboxed pod cannot reach.
             #
             # otelEndpointOverride replaces the whole URL when set (e.g. a VM
             # install fronts a single public gateway host on :443, where the
-            # per-env "<env>-<org>.<host>:<port>" template does not fit). Leave
-            # empty for the default kgateway-routed vhost.
-            value: {{ if .Values.apiPlatformGatewayVhost.otelEndpointOverride }}{{ .Values.apiPlatformGatewayVhost.otelEndpointOverride | quote }}{{ else }}"http://${metadata.environmentName}-${metadata.componentNamespace}.{{ .Values.apiPlatformGatewayVhost.host }}:{{ .Values.apiPlatformGatewayVhost.port }}/otel"{{ end }}
+            # per-env in-cluster Service does not apply). Leave empty for the
+            # default in-cluster runtime endpoint.
+            value: {{ if .Values.apiPlatformGatewayVhost.otelEndpointOverride }}{{ .Values.apiPlatformGatewayVhost.otelEndpointOverride | quote }}{{ else }}"http://api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}:22893/otel"{{ end }}
         - op: add
           path: /spec/podTemplate/spec/containers/0/env/-
           value:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
@@ -196,6 +196,21 @@ spec:
                   - namespaceSelector:
                       matchLabels:
                         kubernetes.io/metadata.name: openchoreo-data-plane
+              # API Platform gateways may live outside openchoreo-data-plane
+              # (per-org-environment namespaces). Agents send OTEL traces and managed
+              # LLM/MCP requests to the gateway runtime's telemetry/proxy port; this rule
+              # allows that egress to gateway namespaces (add-environment.sh and
+              # setup-gateway.sh stamp the label at install time), scoped to the
+              # runtime port only.
+              - to:
+                  - namespaceSelector:
+                      matchLabels:
+                        amp.wso2.com/api-platform-gateway: "true"
+                ports:
+                  # API Platform gateway runtime port — matches the in-cluster
+                  # AMP_OTEL_ENDPOINT / LLM and MCP proxy URLs injected on agent pods.
+                  - port: 22893
+                    protocol: TCP
               - ports:
                   - port: 443
                     protocol: TCP

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -137,19 +137,16 @@ environment:
     #   host: am-gateway.localhost
     #   port: 443
 
-# API Platform Gateway vhost used to build kgateway-routed URLs, e.g. the OTEL
-# trace endpoint injected into agents: http://<env>-<org>.<host>:<port>/otel.
-# Routing by hostname through kgateway keeps these URLs independent of the
-# namespace the api-platform gateway runtime is deployed in. The host must be
-# resolvable from inside the cluster (local k3d setups install a CoreDNS
-# rewrite for *.gateway.localhost).
+# API Platform Gateway vhost used for externally reachable gateway URLs.
+# Sandboxed platform agents use the per-environment gateway runtime's in-cluster
+# Service for OTEL and managed LLM/MCP proxy traffic instead.
 apiPlatformGatewayVhost:
   host: gateway.localhost
   port: 19080
   # Full override for the agent OTEL endpoint. When set, it replaces the
-  # "http://<env>-<org>.<host>:<port>/otel" template entirely — used on installs
-  # that front a single public gateway host on :443 (e.g. a VM install), where
-  # the per-env template does not apply. Empty = use the template above.
+  # in-cluster runtime URL entirely — used on installs that front a single
+  # public gateway host on :443 (e.g. a VM install), where the per-environment
+  # Kubernetes Service does not apply. Empty = derive the in-cluster Service.
   otelEndpointOverride: ""
 
 # Deployment Pipeline configuration
@@ -220,4 +217,3 @@ gatewayTls:
     name: openchoreo-data-plane-selfsigned-issuer
     # Issuer kind: Issuer or ClusterIssuer
     kind: Issuer
-

--- a/deployments/scripts/add-environment.sh
+++ b/deployments/scripts/add-environment.sh
@@ -345,6 +345,13 @@ fi
 echo ""
 echo "🌐 Installing API Platform Gateway for '${ENV_NAME}'..."
 
+# Ensure the gateway namespace exists and carries the label the sandbox
+# NetworkPolicy (agent-api ComponentType) matches for agent gateway egress.
+# Without it, agents in this environment cannot reach the gateway's OTEL or
+# managed LLM/MCP endpoints when it runs outside openchoreo-data-plane.
+kubectl create namespace "${GATEWAY_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - > /dev/null
+kubectl label namespace "${GATEWAY_NAMESPACE}" "amp.wso2.com/api-platform-gateway=true" --overwrite > /dev/null
+
 # Release name must match the gateway runtime service lookup expected by
 # the kgateway routes (api-platform-<org>-<env> derives from _helpers.tpl
 # apiGatewayName). DO NOT duplicate the org segment.

--- a/deployments/setup/setup-gateway.sh
+++ b/deployments/setup/setup-gateway.sh
@@ -91,6 +91,14 @@ fi
 
 echo ""
 echo "🌐 Installing gateway chart..."
+
+# Ensure the gateway namespace exists and carries the label the sandbox
+# NetworkPolicy (agent-api ComponentType) matches for agent telemetry egress.
+# Without it, agents in this (default) environment cannot reach the gateway's
+# OTEL or managed LLM/MCP endpoints when it runs outside openchoreo-data-plane.
+kubectl create namespace "${GATEWAY_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - > /dev/null
+kubectl label namespace "${GATEWAY_NAMESPACE}" "amp.wso2.com/api-platform-gateway=true" --overwrite > /dev/null
+
 helm "${HELM_ARGS[@]}"
 
 echo "⏳ Waiting for Gateway to be ready..."


### PR DESCRIPTION
## Purpose
> Sandboxed agents could not reach external gateway vhosts, causing OTEL traces and managed LLM/MCP requests to fail.
Resolves #1355 

## Goals
- Allow sandboxed agents to reach the API Platform gateway.
- Use in-cluster gateway endpoints for OTEL, LLM, and MCP traffic.
- Preserve public gateway URLs for external agents and user-facing responses.

## Approach
- Added NetworkPolicy egress for gateway namespaces on port 22893.
- Labelled gateway namespaces during setup.
- Changed the default OTEL endpoint to the in-cluster gateway runtime.
- Routed internal LLM/MCP proxy URLs through the in-cluster runtime.
- Added unit tests covering internal, external, and fallback URL behavior.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Full Agent Manager service unit suite passed.
 - Integration tests
   > Integration compilation passed and manually tested with an agent.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved proxy URL routing for internal agents by using derived in-cluster gateway runtime endpoints for both LLM and MCP.
  - Preserved external gateway routing for user-facing proxy URLs, including correct fallback behavior for custom gateway names.
  - Improved MCP URL construction by normalizing context paths and consistently appending `/mcp`.

- **Configuration**
  - Added configurable gateway runtime naming (prefix/suffix/port) with validation.

- **Deployment**
  - Telemetry endpoints now default to in-cluster gateway services, with override support retained.
  - Setup now creates and labels the gateway namespace; sandbox networking allows required gateway egress.

- **Tests**
  - Added unit coverage for URL derivation and reachable/not-reachable routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->