### PR TITLE
Fix high-severity npm audit vulns in docs site

### DIFF
--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -6701,9 +6701,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -6799,9 +6799,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -12155,9 +12155,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -18674,9 +18674,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Purpose
The documentation site's **Security Audit** CI check runs `npm audit --audit-level=high --omit=dev` in `documentation/` and currently fails on three high-severity advisories in transitive dependencies. This blocks any PR that touches `documentation/`:

- `body-parser` <1.20.6 — DoS when an invalid `limit` value silently disables size enforcement ([GHSA-v422-hmwv-36x6](https://github.com/advisories/GHSA-v422-hmwv-36x6))
- `brace-expansion` <1.1.16 — DoS via exponential-time expansion of consecutive non-expanding `{}` groups ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp))
- `js-yaml` 4.0.0–4.2.0 — quadratic CPU consumption from YAML merge-key chains ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m))

## Goals
Get the Security Audit check back to green by clearing all high-severity vulnerabilities, using the smallest possible change and without any breaking major dependency bumps.

## Approach
Ran `npm audit fix` (without `--force`) in `documentation/`. All three advisories had patched releases reachable within the existing semver ranges, so only `package-lock.json` changed — no `package.json` edits and no major upgrades. The transitive packages were bumped to their nearest safe patch: `body-parser` 1.20.6, `brace-expansion` 1.1.16, `js-yaml` 4.3.0, and `shell-quote` 1.10.0.

The remaining 22 moderate advisories (the `webpack-dev-server` → `sockjs` → `uuid` chain pulled in by Docusaurus) have no fix available and are below the `high` audit threshold, so they do not affect this check.

## User stories
N/A — dependency-hygiene fix, no user-facing behavior change.

## Release note
Resolve high-severity npm audit vulnerabilities in the documentation site's dependencies.

## Documentation
N/A — no documentation content changes; only the docs site lockfile is updated.

## Training
N/A — no training-content impact.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — no marketing impact.

## Automation tests
 - Unit tests
   > N/A — no code changes.
 - Integration tests
   > Verified `npm audit --audit-level=high --omit=dev` reports 0 high / 0 critical (was 3 high), and that `npm ci` and `npm run build` both succeed against the updated lockfile.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/source changes; this is an npm lockfile-only update.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples affected.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no migration required.

## Test environment
- Node.js 20 (matching the CI `setup-node` version)
- npm 12.x

## Learning
Used the npm advisory database and `npm audit fix` (deliberately without `--force`) to keep the change limited to patch-level transitive bumps in the lockfile, avoiding breaking major upgrades.
