### PR TITLE
fix: quick-start install.sh fails to find thunder-naming.sh in the packaged Docker image

### DIFF
--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -463,11 +463,15 @@ install_gateway_extension() {
 
 # ---------------------------------------------------------------------------
 # Load the shared Thunder naming helpers (thunder_release_name/etc.) — the
-# single source of truth for this derivation, see
-# deployments/scripts/thunder-naming.sh. Always run from a checked-out repo
-# (install.sh sources this file locally, never via curl | bash), so a plain
-# relative source is enough — no network-fetch fallback needed here.
+# single source of truth for this derivation, see deployments/scripts/
+# thunder-naming.sh. install.sh sources this file locally (never via
+# curl | bash), so no network-fetch fallback is needed here — but the layout
+# on disk differs between a repo checkout (scripts/ one level up from
+# quick-start/) and the packaged quick-start image (scripts/ copied flat
+# alongside install.sh — see the Dockerfile). DEPLOYMENTS_DIR is computed by
+# install.sh to account for exactly this, and is already used the same way
+# elsewhere in this file (install_default_env_thunder's bundled_script) — reuse
+# it here too instead of hardcoding a checkout-only relative path.
 # ---------------------------------------------------------------------------
-# shellcheck source=../scripts/thunder-naming.sh
-source "$(dirname "${BASH_SOURCE[0]}")/../scripts/thunder-naming.sh"
+source "${DEPLOYMENTS_DIR}/scripts/thunder-naming.sh"
 


### PR DESCRIPTION
## Purpose
The published quick-start Docker image (`ghcr.io/wso2/amp-quick-start`) fails immediately on `./install.sh` with `No such file or directory` trying to load `thunder-naming.sh`. That image ships `scripts/` flat alongside `install.sh`, not one directory up like a repo checkout, but `install-helpers.sh` hardcoded the checkout-only path.

## Goals
Make `install-helpers.sh` resolve `thunder-naming.sh` correctly regardless of which of the two supported layouts it's running from.

## Approach
- Replaced the hardcoded `$(dirname "${BASH_SOURCE[0]}")/../scripts/thunder-naming.sh` with `${DEPLOYMENTS_DIR}/scripts/thunder-naming.sh`.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

N/A
 
## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick-start installation reliability across both repository checkouts and packaged deployment images.
  * Ensured the correct naming helper is loaded regardless of the installation directory layout.

* **Documentation**
  * Added comments clarifying supported filesystem layouts and helper-file loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->