### PR TITLE
Allow fork PR checkout in dependency validation workflow

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Detect modified go.mod files
         id: detect-changes


### PR DESCRIPTION
## Purpose
The `Dependency Validation` workflow was failing at the checkout step:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. To opt in, set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

`actions/checkout@v6` now blocks checking out fork PR code from a `pull_request_target` workflow unless explicitly opted in. This broke dependency validation on PRs (e.g. #1359).

## Approach
Set `allow-unsafe-pr-checkout: true` on the `actions/checkout` step that fetches the PR head SHA, as suggested by the action's error message. The workflow only reads `go.mod`/`go.sum` and runs the trusted engineering-governance validation script against them — it does not execute fork code.

> Temporary fix to unblock the dependency validation check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation workflow configuration to support checking out pull request code in the validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->