### PR TITLE
Seed .env before setup-platform migrations

### DIFF
--- a/.github/actions/amp-dev-stack/action.yaml
+++ b/.github/actions/amp-dev-stack/action.yaml
@@ -51,18 +51,11 @@ runs:
         # COMPOSE_SERVICES restricts the compose bring-up to the service (+ its
         # postgres dependency), skipping the slow console image the heavy tier
         # doesn't use.
+        # setup-platform seeds agent-manager-service/.env from the tracked
+        # example, runs DB migrations against the compose-exposed Postgres, and
+        # only then starts the service — so it boots cleanly against a migrated
+        # schema with no extra host-side migrate/restart needed here.
         COMPOSE_SERVICES=agent-manager-service make setup-platform
-        # dev-migrate runs `go run -migrate` on the host (not in the compose
-        # container) and loads agent-manager-service/.env via ENV_FILE_PATH.
-        # That file is gitignored, so seed it from the tracked example — its DB
-        # creds match the compose-exposed Postgres on localhost:5432.
-        cp agent-manager-service/.env.example agent-manager-service/.env
-        make dev-migrate
-        # setup-platform started the service against a fresh, unmigrated DB, so
-        # it crashed on the missing schema and Air won't restart it on its own.
-        # Now that migrations have run, restart it so it boots cleanly. (Locally
-        # this is masked by a pre-populated postgres volume.)
-        docker compose -f deployments/docker-compose.yml restart agent-manager-service
         # Expose AMP API (9000) + amp-observer (9098). Bind 0.0.0.0 so the
         # agent-manager container can reach the forwards via the bridge gateway
         # (a 127.0.0.1-only forward is unreachable from inside the container).

--- a/deployments/setup/setup-platform.sh
+++ b/deployments/setup/setup-platform.sh
@@ -82,6 +82,15 @@ export CONSOLE_HOST_PATH="$(cd "$SCRIPT_DIR/../../console" && pwd)"
 echo "🐘 Starting Postgres and waiting for it to be healthy..."
 docker compose -f "$COMPOSE_FILE" up -d --wait postgres
 
+# The migration run loads agent-manager-service/.env via ENV_FILE_PATH and
+# panics if it is missing. That file is gitignored, so a fresh checkout (e.g.
+# CI) won't have it; seed it from the tracked example, whose DB creds match the
+# compose-exposed Postgres on localhost:5432.
+if [ ! -f "$PROJECT_ROOT/agent-manager-service/.env" ]; then
+    echo "🌱 Seeding agent-manager-service/.env from .env.example..."
+    cp "$PROJECT_ROOT/agent-manager-service/.env.example" "$PROJECT_ROOT/agent-manager-service/.env"
+fi
+
 echo "🗄️  Running database migrations..."
 if ! (cd "$PROJECT_ROOT/agent-manager-service" && ENV_FILE_PATH=.env go run -mod=readonly . -migrate -server=false); then
     echo "❌ Database migrations failed. Aborting platform setup."


### PR DESCRIPTION
## Purpose
The instrumentation-matrix `heavy` job fails during platform setup with a migration panic:

```
🗄️  Running database migrations...
panic: open .env: no such file or directory
  agent-manager-service/config/config_loader.go:55  loadEnvs()
❌ Database migrations failed. Aborting platform setup.
```

PR #1354 (commit `0a68e2ab`) moved DB migrations into `deployments/setup/setup-platform.sh`, running them with `ENV_FILE_PATH=.env` from `agent-manager-service/`. The config loader hard-panics when that file is missing. `agent-manager-service/.env` is gitignored, so a fresh checkout (the CI heavy tier) has no `.env` and crashes before the schema is created. Locally this was masked because developers already have a `.env` on disk. The `amp-dev-stack` action only seeded the file *after* `make setup-platform`, which is now too late.

Related to #1354

## Goals
Make `setup-platform.sh` self-sufficient so migrations succeed on a clean checkout, and remove the migration/restart steps from the composite action that are now redundant.

## Approach
- `deployments/setup/setup-platform.sh`: before running migrations, seed `agent-manager-service/.env` from the tracked `.env.example` when it is absent (its DB creds already match the compose-exposed Postgres on `localhost:5432`).
- `.github/actions/amp-dev-stack/action.yaml`: `setup-platform` now seeds, migrates, and only then starts the service against a migrated schema — so the trailing `cp .env.example .env`, `make dev-migrate`, and `docker compose restart agent-manager-service` steps are no longer needed and were removed.

## User stories
N/A — CI/build reliability fix.

## Release note
Fix instrumentation-matrix heavy-tier setup failing with a `.env` migration panic on fresh checkouts.

## Documentation
N/A — no user-facing behavior change.

## Training
N/A

## Certification
N/A — internal CI/setup script change with no product-feature impact.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — shell/CI wiring change, not covered by unit tests.
 - Integration tests
   > Validated by the instrumentation-matrix heavy tier, which is the job that was failing.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Regression from #1354.

## Migrations (if applicable)
N/A — no schema change; this fixes the invocation of existing migrations.

## Test environment
GitHub Actions ubuntu-latest (instrumentation-matrix heavy tier).

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform setup reliability for fresh environments and automated builds.
  * Ensured required service configuration is available before database migrations run.
  * Limited initial service startup to the necessary application service and its database dependency, reducing setup issues and startup overhead.
  * Removed redundant restart and migration steps from the setup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->