### PR TITLE
Install agent-sandbox module in CI dev stack

### DIFF
--- a/.github/actions/amp-dev-stack/action.yaml
+++ b/.github/actions/amp-dev-stack/action.yaml
@@ -47,6 +47,13 @@ runs:
         # OpenChoreo + builds & loads amp-observer + instrumentation images
         # from source into k3d.
         make setup-openchoreo
+        # Agent Sandbox module: installs the SandboxTemplate CRDs and the
+        # openchoreo-agent-sandbox-access ClusterRole. Without it the
+        # cluster-agent-dataplane service account cannot patch the
+        # SandboxTemplate every agent deploy now renders, so every deploy
+        # 403s. Part of the local `make setup` chain; must run after
+        # setup-openchoreo (needs the openchoreo-data-plane namespace).
+        make setup-sandbox
         # Build + start the core platform (agent-manager-service via compose).
         # COMPOSE_SERVICES restricts the compose bring-up to the service (+ its
         # postgres dependency), skipping the slow console image the heavy tier


### PR DESCRIPTION
## Purpose
The instrumentation-matrix **heavy tier** is failing all 16 cells with `pipeline-error: deployment failed`, while builds and `ComponentRelease`s are healthy. Root cause is a CI dev-stack gap, not a code regression in the agents or observer.

Agent deploys now render a `SandboxTemplate` (`extensions.agents.x-k8s.io`) as part of the isolation-tier plumbing. Applying that resource requires the `openchoreo-agent-sandbox-access` ClusterRole (installed by the agent-sandbox module) so that `cluster-agent-dataplane` can patch `sandboxtemplates`. The `amp-dev-stack` composite action claims to mirror the local `make setup` chain but never ran `make setup-sandbox`, so every deploy in CI fails at the `ReleaseBinding` stage with:

```
Failed to apply resources to target plane: failed to apply resource
sandboxtemplate-…: sandboxtemplates.extensions.agents.x-k8s.io "…" is forbidden:
User "system:serviceaccount:openchoreo-data-plane:cluster-agent-dataplane"
cannot patch resource "sandboxtemplates" in API group "extensions.agents.x-k8s.io"
```

RBAC is evaluated at the Kubernetes authorization layer on the parsed apiGroup/resource, so the 403 occurs regardless of whether the CRD is already installed.

## Goals
Make the CI dev stack install the agent-sandbox module so deploys can apply `SandboxTemplate` resources, restoring the heavy tier to green.

## Approach
Add `make setup-sandbox` to `.github/actions/amp-dev-stack/action.yaml`, immediately after `make setup-openchoreo`. `setup-sandbox` installs the agent-sandbox helm module — the `SandboxTemplate` CRDs and the `openchoreo-agent-sandbox-access` ClusterRole that grants `cluster-agent-dataplane` the required patch permission. It only depends on the `openchoreo-data-plane` namespace created by `setup-openchoreo`, and mirrors the local `make setup` chain (which already includes `setup-sandbox`).

I compared the full local `make setup` chain against the CI action to confirm nothing else was missing: DB migrations already run inside `setup-platform.sh` (added by #1354); `setup-colima` (macOS-only) and `setup-console-local` (UI) are intentionally skipped; and `setup-gvisor`/`setup-kata` aren't exercised by the heavy tier (default-tier deploys, no isolation node). `setup-sandbox` was the only gap blocking deploys.

### Note on default env-Thunder (deliberate CI omission)
#1354 also moved default env-Thunder provisioning out of `setup-openchoreo.sh` (which this action runs) into the new Makefile `setup-default-env-thunder` target (which this action does not run), so the CI dev stack no longer provisions the default env-Thunder identity instance. This is intentional and does not affect the heavy tier: the default *Environment CR* is still created by `setup-openchoreo`'s platform resources (deploys resolve the environment fine), and the heavy tier authenticates agent invocations with a gateway-managed `X-API-Key`, not env-Thunder. The env-Thunder resolver is only used by the agent-OAuth-identity and MCP-proxy flows, which the heavy tier's traceloop samples don't exercise. It is therefore left out here for the same reason as `setup-colima`/`setup-console-local` — unused by this workflow, and adding it would introduce an unnecessary helm-install + RBAC-token step.

## User stories
N/A — CI infrastructure fix.

## Release note
N/A — CI-only change; no user-facing impact.

## Documentation
N/A — no doc impact; internal CI action only.

## Training
N/A

## Certification
N/A — no impact on certification exams; CI-only change.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — no application code changed.
 - Integration tests
   > Validated by the instrumentation-matrix heavy tier itself: the deploy step that previously 403'd should now succeed once the agent-sandbox RBAC is present.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/application code changed (CI workflow YAML only).
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
GitHub Actions `ubuntu-latest` runner (k3d dev stack).

## Learning
Kubernetes RBAC authorization is evaluated on the RequestInfo (verb/apiGroup/resource) parsed from the request URL, before any CRD-existence check — so a missing RBAC grant surfaces as a 403 forbidden even when the target CRD is not installed, rather than a "no matches for kind" error.
