### PR TITLE
Fix docs-release version validation to allow pre-release tags

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           # Validate version format (e.g., v0.8.x, v0.8.0, or v1.0.0-alpha1)
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.(x|[0-9]+(-[a-zA-Z0-9.]+)?)$ ]]; then
-            echo "Error: Invalid version format. Expected: vX.Y.x, vX.Y.Z, or vX.Y.Z-rc.N"
+            echo "Error: Invalid version format. Expected: vX.Y.x, vX.Y.Z, or vX.Y.Z-<pre-release>"
             exit 1
           fi
 

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -25,9 +25,9 @@ jobs:
     steps:
       - name: Validate inputs
         run: |
-          # Validate version format (e.g., v0.8.x or v0.8.0)
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.(x|[0-9]+)$ ]]; then
-            echo "Error: Invalid version format. Expected: vX.Y.x or vX.Y.Z"
+          # Validate version format (e.g., v0.8.x, v0.8.0, or v1.0.0-alpha1)
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.(x|[0-9]+(-[a-zA-Z0-9.]+)?)$ ]]; then
+            echo "Error: Invalid version format. Expected: vX.Y.x, vX.Y.Z, or vX.Y.Z-rc.N"
             exit 1
           fi
 
@@ -39,11 +39,12 @@ jobs:
 
           # Semantic comparison between VERSION and DOCKER_TAG
           # Extract major.minor from VERSION (already validated by regex above)
-          V_MAJOR="${VERSION#v}"
-          V_MAJOR="${V_MAJOR%%.*}"
-          V_MINOR="${VERSION#v*.}"
-          V_MINOR="${V_MINOR%%.*}"
-          V_PATCH="${VERSION##*.}"
+          V_NO_PREFIX="${VERSION#v}"
+          V_MAJOR="${V_NO_PREFIX%%.*}"
+          V_REST="${V_NO_PREFIX#*.}"
+          V_MINOR="${V_REST%%.*}"
+          V_PATCH="${V_REST#*.}"
+          V_PATCH="${V_PATCH%%-*}"
 
           # Extract major.minor from DOCKER_TAG (already validated by regex above)
           DT_NO_PREFIX="${DOCKER_TAG#v}"


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The Documentation Release workflow (`.github/workflows/docs-release.yml`) rejected pre-release doc versions like `v1.0.0-alpha1` for the `version` input. This blocked cutting documentation for alpha/rc releases. The `version` regex now accepts an optional pre-release suffix consistent with `docker_tag`.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation release validation for fully pinned versions.
  * Added support for optional version pre-release suffixes, such as `-alpha1`.
  * Enhanced version comparisons to correctly handle pre-release components when matching Docker tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->