### PR TITLE
Properly level monitor/eval run logs for agent developers

### DIFF
--- a/evaluation-job/main.py
+++ b/evaluation-job/main.py
@@ -129,9 +129,14 @@ class JsonFormatter(logging.Formatter):
 def configure_logging() -> None:
     """Configure JSON logging from LOG_LEVEL env var (default: INFO).
 
-    The root logger stays at INFO so library internals (e.g. trace parser
-    debug messages) don't leak into run logs.  Only the evaluation-job's
-    own logger is set to the requested level.
+    Logs are read by agent developers who cannot see the monitor/eval source,
+    so INFO is reserved for run progress and per-evaluator summaries, DEBUG for
+    monitor/eval internals, and WARN/ERROR for things the developer can act on
+    (LLM misconfiguration, skipped evals, parse failures).
+
+    LOG_LEVEL is applied to both the evaluation-job logger and the
+    ``amp_evaluation`` library so DEBUG is actually usable in dev; the root
+    logger is kept at INFO so noisy third-party libraries stay quiet.
     """
     level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
@@ -139,6 +144,7 @@ def configure_logging() -> None:
     handler.setFormatter(JsonFormatter(datefmt="%Y-%m-%dT%H:%M:%S"))
     logging.basicConfig(level=logging.INFO, handlers=[handler])
     logging.getLogger(__name__).setLevel(level)
+    logging.getLogger("amp_evaluation").setLevel(level)
 
     # The openai/anthropic SDKs (used internally by any_llm) log retry attempts at
     # INFO via their own package loggers, not through evaluation-job's logger above.
@@ -332,7 +338,7 @@ def publish_scores(
     # Publish scores to agent-manager API
     url = f"{api_endpoint}/api/v1/publisher/monitors/{monitor_id}/runs/{run_id}/scores"
 
-    logger.info(
+    logger.debug(
         "Publishing scores monitor_id=%s run_id=%s evaluators=%d individual_scores=%d",
         monitor_id,
         run_id,
@@ -349,7 +355,7 @@ def publish_scores(
             response = requests.post(url, json=payload, headers=headers, timeout=30)
             response.raise_for_status()
 
-            logger.info("Successfully published scores to agent-manager")
+            logger.debug("Successfully published scores to agent-manager")
             return True
 
         except requests.exceptions.RequestException as e:
@@ -367,7 +373,7 @@ def publish_scores(
                     return False
             if attempt < PUBLISH_MAX_RETRIES - 1:
                 backoff = PUBLISH_INITIAL_BACKOFF * (2**attempt)
-                logger.info("Retrying in %d seconds...", backoff)
+                logger.debug("Retrying in %d seconds...", backoff)
                 time.sleep(backoff)
 
     return False
@@ -409,14 +415,14 @@ def _load_custom_code_evaluator(identifier: str, source: str, config: dict):
         else:
             instance = FunctionEvaluator(found_func, name=identifier)
 
-        logger.info(
+        logger.debug(
             "Loaded custom code evaluator: %s (function=%s)", identifier, getattr(found_func, "__name__", identifier)
         )
         instance = instance.with_config(**config) if config else instance
         return instance
 
     if found_cls is not None:
-        logger.info("Loaded custom code evaluator: %s (class=%s)", identifier, found_cls.__name__)
+        logger.debug("Loaded custom code evaluator: %s (class=%s)", identifier, found_cls.__name__)
         return found_cls(**config)
 
     raise ValueError(
@@ -493,7 +499,7 @@ def _create_custom_llm_judge(identifier: str, prompt_template: str, level: str, 
         def _build_prompt(trace: Trace, task=None) -> str:  # type: ignore[misc]
             return _eval_template(prompt_template, {"trace": trace, "task": task, **template_extra})
 
-    logger.info("Created custom LLM-as-judge evaluator: %s (level=%s)", identifier, level)
+    logger.debug("Created custom LLM-as-judge evaluator: %s (level=%s)", identifier, level)
     return FunctionLLMJudge(_build_prompt, name=identifier, **llm_config)
 
 
@@ -537,7 +543,7 @@ def main() -> None:
         judge_cfg.api_base = llm_api_base
         judge_cfg.api_key = llm_api_key
 
-        logger.info("Configured LLM client to route through OpenAI-compatible gateway at %s", llm_api_base)
+        logger.debug("Configured LLM client to route through OpenAI-compatible gateway at %s", llm_api_base)
 
     logger.info(
         "Starting monitor evaluation monitor=%s organization=%s project=%s agent=%s env=%s time_range=%s..%s sampling=%.2f",

--- a/libs/amp-evaluation/src/amp_evaluation/runner.py
+++ b/libs/amp-evaluation/src/amp_evaluation/runner.py
@@ -47,7 +47,7 @@ from .trace import Trace, parse_trace_for_evaluation, TraceFetcher, TraceLoader,
 from .trace.fetcher import OTELTrace, _safe_request_error
 from .evaluators.base import BaseEvaluator, validate_unique_evaluator_names
 from .evaluators.params import EvalMode
-from .models import EvaluatorSummary, EvaluatorScore, TaskContext
+from .models import EvaluatorSummary, EvaluatorScore, TaskContext, DataNotAvailableError
 from .dataset.models import Task, Dataset
 from .aggregators.base import normalize_aggregations
 from .config import Config
@@ -797,18 +797,21 @@ class Monitor(BaseRunner):
             for otel_trace in fetched:
                 try:
                     parsed = parse_trace_for_evaluation(otel_trace)
-                except Exception as parse_error:
+                except (ValueError, DataNotAvailableError) as parse_error:
+                    # Malformed/incomplete trace data: skip this trace but keep
+                    # going. Unexpected exceptions (programmer defects) are left to
+                    # propagate so the run is recorded as errored rather than
+                    # silently publishing an incomplete result.
                     parse_failures += 1
-                    logger.error(f"Error parsing trace: {parse_error}")
+                    logger.error("Error parsing trace trace_id=%s: %s", otel_trace.traceId, parse_error)
                     continue
                 selected += 1
                 yield parsed
 
-            sampling_note = f" (sampling_rate={sample_rate:.2f})" if sample_rate is not None else ""
+            sampling_note = f" (sampling_rate={sample_rate:.6g})" if sample_rate is not None else ""
             if parse_failures:
                 logger.info(
-                    "Trace selection%s: %d trace(s) selected for evaluation, "
-                    "%d trace(s) skipped (failed to parse)",
+                    "Trace selection%s: %d trace(s) selected for evaluation, %d trace(s) skipped (failed to parse)",
                     sampling_note,
                     selected,
                     parse_failures,

--- a/libs/amp-evaluation/src/amp_evaluation/runner.py
+++ b/libs/amp-evaluation/src/amp_evaluation/runner.py
@@ -357,7 +357,7 @@ class BaseRunner(ABC):
 
         scores_by_evaluator: Dict[str, List[EvaluatorScore]] = {e.name: [] for e in self._evaluators}
         evaluator_names = [e.name for e in self._evaluators]
-        logger.info(
+        logger.debug(
             "Starting evaluation: %d evaluator(s) %s",
             len(self._evaluators),
             evaluator_names,
@@ -380,7 +380,7 @@ class BaseRunner(ABC):
             task = tasks.get(trace.trace_id) if tasks else None
             trial_id = trial_info.get(trace.trace_id) if trial_info else None
 
-            logger.info("Evaluating trace %d trace_id=%s", idx, trace.trace_id)
+            logger.debug("Evaluating trace %d trace_id=%s", idx, trace.trace_id)
 
             try:
                 trace_scores = self.evaluate_trace(trace, task, trial_id=trial_id)
@@ -783,17 +783,38 @@ class Monitor(BaseRunner):
         """
 
         def _iter_parsed_traces() -> Iterable[Trace]:
+            # Traces stream lazily from the fetcher, so counts are tallied as we go
+            # and reported once the stream is exhausted rather than up front (which
+            # would force the whole result set into memory).
             fetched = self._fetch_traces(
                 start_time=start_time or "",
                 end_time=end_time or "",
             )
             if sample_rate is not None:
                 fetched = sample_traces(fetched, sample_rate)
+            selected = 0
+            parse_failures = 0
             for otel_trace in fetched:
                 try:
-                    yield parse_trace_for_evaluation(otel_trace)
+                    parsed = parse_trace_for_evaluation(otel_trace)
                 except Exception as parse_error:
+                    parse_failures += 1
                     logger.error(f"Error parsing trace: {parse_error}")
+                    continue
+                selected += 1
+                yield parsed
+
+            sampling_note = f" (sampling_rate={sample_rate:.2f})" if sample_rate is not None else ""
+            if parse_failures:
+                logger.info(
+                    "Trace selection%s: %d trace(s) selected for evaluation, "
+                    "%d trace(s) skipped (failed to parse)",
+                    sampling_note,
+                    selected,
+                    parse_failures,
+                )
+            else:
+                logger.info("Trace selection%s: %d trace(s) selected for evaluation", sampling_note, selected)
 
         eval_traces: Iterable[Trace] = traces if traces else _iter_parsed_traces()
 


### PR DESCRIPTION
## Purpose
Monitor/eval run logs are noisy and not leveled for their audience: the **agent developer**, who cannot see the monitor/eval source. Internal plumbing was logged at INFO (including one line per trace), while a config flaw made library DEBUG impossible to enable even in dev.

Resolves #1360

## Goals
Divide monitor/eval logs by audience and intent:
- **INFO** — useful to the agent developer (run start/summary, trace selection + sampling counts, per-evaluator pass/skip summary).
- **DEBUG** — monitor/eval internals for dev-time debugging.
- **WARN/ERROR** — things the developer can act on (LLM misconfiguration, skipped evals, parse failures).

## Approach
- **`configure_logging()`** now propagates `LOG_LEVEL` to the `amp_evaluation` library logger. Previously the root logger was pinned at INFO and only the job's own logger honored `LOG_LEVEL`, so library DEBUG was globally suppressed **even with `LOG_LEVEL=DEBUG`** (which `Dockerfile.dev` sets) — making "move noise to DEBUG" hide it entirely. Root stays at INFO so noisy third-party libs (openai/anthropic/httpx) stay quiet.
- Demoted internal plumbing INFO → DEBUG:
  - `runner.py` per-trace `Evaluating trace N trace_id=...` (biggest noise source, once per trace) and the duplicate `Starting evaluation: ...`.
  - `main.py` publish-to-agent-manager lines (Publishing/Successfully published/Retrying), custom evaluator load mechanics, LLM-as-judge creation, and gateway routing config.
- Added a single INFO **trace-selection summary** on the monitor path that respects the lazy-streaming design (tallied during iteration, reported at stream exhaustion): `Trace selection (sampling_rate=0.50): N trace(s) selected for evaluation, M skipped (failed to parse)` — gives sampling visibility and a digestible parse-failure count instead of scattered ERROR lines.
- **Unchanged (already correct):** fail-fast ERRORs for missing/misconfigured LLM & IDP creds, the WARNING skip-reason summary, and the run-complete/per-evaluator INFO summary.

## Release note
Monitor/eval run logs are now leveled for agent developers: run progress and trace-selection/sampling summaries at INFO, monitor internals at DEBUG (now enablable via `LOG_LEVEL=DEBUG`), and actionable LLM/eval issues at WARN/ERROR.

## Documentation
N/A — no user-facing product doc impact; behavior change is in log verbosity/leveling only.

## Automation tests
 - Unit tests
   > amp-evaluation: 744 passed, 1 skipped (boto3 not installed). evaluation-job: 50 passed. ruff clean on both. No new tests added — change is log-level reassignment plus a summary line; existing runner/job suites cover the affected paths.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (Python; no Java changes)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Python 3.13, macOS (Darwin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monitor runs now provide a final summary of selected and skipped traces, including sampling details when applicable.

* **Bug Fixes**
  * Trace parsing failures no longer stop the remaining evaluation traces from being processed.

* **Improvements**
  * Reduced routine evaluation and publishing log noise while retaining detailed information in debug logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->