### PR TITLE
Add per-tool scope authorization to the agent-manager MCP server

### DIFF
--- a/agent-manager-service/mcp/README.md
+++ b/agent-manager-service/mcp/README.md
@@ -6,7 +6,9 @@ resources directly from the developer's workflow — no Console required.
 
 The server speaks MCP over Streamable HTTP and is protected by the existing
 JWT middleware, which means every tool call goes through the standard OAuth
-2.0 authorization-code + PKCE flow against Thunder.
+2.0 authorization-code + PKCE flow against Thunder. Each tool additionally
+declares the `rbac` permission(s) it requires; calls are denied unless the
+token carries the matching `amp:*` scopes (when `RBAC_ENABLED=true`).
 
 ## Quick start with Claude Code
 
@@ -95,16 +97,23 @@ registered by `wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml`
    (e.g., `builds.go`). Use snake_case JSON tags for keys.
 2. **Define a typed output struct** in the same file. Avoid
    `map[string]any` — typed structs give MCP clients a stable schema.
-3. **Register the tool** inside the package's `register*Tools` function
-   using `gomcp.AddTool` + `withToolLogging`. Provide a clear description;
-   the LLM relies on it to decide when to call the tool.
-4. **Implement the handler closure** — validate input, resolve org name
+3. **Pick the tool's permission(s)** from `rbac/permissions.go` — mirror the
+   permission the equivalent REST route declares in `api/*_routes.go`. Every
+   tool call is authorized against the caller's token scopes; a tool
+   registered without permissions panics at startup, and one registered by
+   bypassing `addTool` is denied on every call (fail-closed).
+4. **Register the tool** inside the package's `register*Tools` function using
+   `addTool(reg, server, tool, handler, perms...)`. Provide a clear
+   description; the LLM relies on it to decide when to call the tool.
+5. **Implement the handler closure** — validate input, resolve org name
    via `resolveOrgName`, call into the toolset handler interface, format
    the output struct, and return via `handleToolResult`.
-5. **Wire the toolset interface method** in `mcp/tools/types.go` and
+6. **Wire the toolset interface method** in `mcp/tools/types.go` and
    implement it in the corresponding `mcp/handlers/*_handler.go` (which
    delegates to the existing service-layer interface).
-6. **Add a license header** matching `agent-manager-service/.github/copyright_header.tmpl`.
+7. **Add a test spec** in the matching `*_specs_test.go`, including the
+   `permissions` field — the registration tests fail without it.
+8. **Add a license header** matching `agent-manager-service/.github/copyright_header.tmpl`.
 
 After saving, the dev-mode service hot-reloads. Refresh the MCP Server
 connection (reconnect) to refresh the cached tool list.

--- a/agent-manager-service/mcp/server.go
+++ b/agent-manager-service/mcp/server.go
@@ -30,9 +30,10 @@ func NewHTTPServer(toolsets *tools.Toolsets) http.Handler {
 		Version: "0.1.0",
 	}, nil)
 
-	if toolsets != nil {
-		toolsets.Register(server)
-	}
+	// Register's nil-receiver path is safe — it still installs the fail-closed
+	// authz middleware even when toolsets is nil — so this always runs
+	// unconditionally.
+	toolsets.Register(server)
 
 	return gomcp.NewStreamableHTTPHandler(func(r *http.Request) *gomcp.Server {
 		return server

--- a/agent-manager-service/mcp/setup.go
+++ b/agent-manager-service/mcp/setup.go
@@ -19,6 +19,8 @@ package mcp
 import (
 	"net/http"
 
+	"github.com/modelcontextprotocol/go-sdk/auth"
+
 	"github.com/wso2/agent-manager/agent-manager-service/mcp/handlers"
 	"github.com/wso2/agent-manager/agent-manager-service/mcp/tools"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
@@ -44,6 +46,12 @@ func RegisterRoute(mux *http.ServeMux, deps Dependencies, authMiddleware func(ht
 	}
 
 	handler := NewHTTPServer(toolsets)
-	mux.Handle("/mcp", authMiddleware(handler))
-	mux.Handle("/mcp/", authMiddleware(handler))
+	// The SDK's bearer-token middleware runs INSIDE our auth middleware: our
+	// middleware validates the JWT and puts claims on the request context
+	// first, then claimsTokenVerifier (mcp/tokeninfo.go) reads those claims
+	// to populate auth.TokenInfo for the SDK's per-request scope plumbing and
+	// session-hijack guard.
+	wrapped := authMiddleware(auth.RequireBearerToken(claimsTokenVerifier, nil)(handler))
+	mux.Handle("/mcp", wrapped)
+	mux.Handle("/mcp/", wrapped)
 }

--- a/agent-manager-service/mcp/setup_test.go
+++ b/agent-manager-service/mcp/setup_test.go
@@ -21,12 +21,34 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 )
+
+// testAuthMiddleware mimics jwtassertion.NewMockMiddleware — it pins fixed
+// claims on every request's context, standing in for our production JWT
+// middleware — but also sets Sub, since claimsTokenVerifier rejects an empty
+// sub (see mcp/tokeninfo.go). NewMockMiddleware itself doesn't expose a way
+// to set Sub, so this test builds its own equivalent rather than changing
+// that shared helper.
+func testAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims := &jwtassertion.TokenClaims{
+			Sub:   "test-user-id",
+			Scope: "test-scopes",
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		ctx := jwtassertion.ContextWithTokenClaimsAndScope(r.Context(), claims)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
 
 // bearerInjectingTransport adds a fixed Authorization header to every
 // outgoing request. claimsTokenVerifier ignores the raw token value — the
@@ -46,7 +68,7 @@ func (bearerInjectingTransport) RoundTrip(req *http.Request) (*http.Response, er
 // claimsTokenVerifier, nil)(handler)) — over a real HTTP round trip (not the
 // in-memory transport package tools tests use), and verifies that a tool
 // handler observes CallToolRequest.Extra.TokenInfo populated from the claims
-// jwtassertion.NewMockMiddleware puts on the request context.
+// testAuthMiddleware puts on the request context.
 func TestFullHTTPChainDeliversPerRequestTokenInfo(t *testing.T) {
 	var gotTokenInfo *auth.TokenInfo
 
@@ -65,8 +87,7 @@ func TestFullHTTPChainDeliversPerRequestTokenInfo(t *testing.T) {
 
 	// Mirrors mcp/setup.go RegisterRoute: the SDK's bearer-token middleware
 	// runs INSIDE our auth middleware.
-	authMiddleware := jwtassertion.NewMockMiddleware(t)
-	wrapped := authMiddleware(auth.RequireBearerToken(claimsTokenVerifier, nil)(streamableHandler))
+	wrapped := testAuthMiddleware(auth.RequireBearerToken(claimsTokenVerifier, nil)(streamableHandler))
 
 	httpServer := httptest.NewServer(wrapped)
 	t.Cleanup(httpServer.Close)

--- a/agent-manager-service/mcp/setup_test.go
+++ b/agent-manager-service/mcp/setup_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+)
+
+// bearerInjectingTransport adds a fixed Authorization header to every
+// outgoing request. claimsTokenVerifier ignores the raw token value — the
+// real identity comes from the claims our auth middleware already validated
+// and placed on the request context — so any non-empty bearer token
+// satisfies auth.RequireBearerToken's extraction step.
+type bearerInjectingTransport struct{}
+
+func (bearerInjectingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer test-raw-token")
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// TestFullHTTPChainDeliversPerRequestTokenInfo exercises the exact middleware
+// nesting RegisterRoute installs — authMiddleware(auth.RequireBearerToken(
+// claimsTokenVerifier, nil)(handler)) — over a real HTTP round trip (not the
+// in-memory transport package tools tests use), and verifies that a tool
+// handler observes CallToolRequest.Extra.TokenInfo populated from the claims
+// jwtassertion.NewMockMiddleware puts on the request context.
+func TestFullHTTPChainDeliversPerRequestTokenInfo(t *testing.T) {
+	var gotTokenInfo *auth.TokenInfo
+
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "test-full-chain", Version: "0.0.1"}, nil)
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "probe_tool",
+		Description: "records the TokenInfo observed on the incoming CallToolRequest",
+	}, func(_ context.Context, req *gomcp.CallToolRequest, _ struct{}) (*gomcp.CallToolResult, any, error) {
+		if req.Extra != nil {
+			gotTokenInfo = req.Extra.TokenInfo
+		}
+		return &gomcp.CallToolResult{}, nil, nil
+	})
+
+	streamableHandler := gomcp.NewStreamableHTTPHandler(func(*http.Request) *gomcp.Server { return server }, nil)
+
+	// Mirrors mcp/setup.go RegisterRoute: the SDK's bearer-token middleware
+	// runs INSIDE our auth middleware.
+	authMiddleware := jwtassertion.NewMockMiddleware(t)
+	wrapped := authMiddleware(auth.RequireBearerToken(claimsTokenVerifier, nil)(streamableHandler))
+
+	httpServer := httptest.NewServer(wrapped)
+	t.Cleanup(httpServer.Close)
+
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+	transport := &gomcp.StreamableClientTransport{
+		Endpoint:   httpServer.URL,
+		HTTPClient: &http.Client{Transport: bearerInjectingTransport{}},
+	}
+	session, err := client.Connect(context.Background(), transport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect failed: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	result, err := session.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name:      "probe_tool",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+
+	if gotTokenInfo == nil {
+		t.Fatal("tool handler observed no TokenInfo on CallToolRequest.Extra")
+	}
+	if len(gotTokenInfo.Scopes) == 0 {
+		t.Errorf("TokenInfo.Scopes = %v, want the mock middleware's \"test-scopes\"", gotTokenInfo.Scopes)
+	}
+	if gotTokenInfo.Expiration.IsZero() {
+		t.Error("TokenInfo.Expiration is zero, want the mock middleware's future expiry")
+	}
+}

--- a/agent-manager-service/mcp/tokeninfo.go
+++ b/agent-manager-service/mcp/tokeninfo.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/auth"
 
+	"github.com/wso2/agent-manager/agent-manager-service/mcp/tools"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 )
 
@@ -59,5 +60,8 @@ func claimsTokenVerifier(ctx context.Context, _ string, _ *http.Request) (*auth.
 		Scopes:     strings.Fields(claims.Scope),
 		UserID:     claims.Sub,
 		Expiration: claims.ExpiresAt.Time,
+		// Record the caller's org so authzMiddleware can confirm each per-request
+		// token targets the same org as the session (see mcp/tools/authz.go).
+		Extra: map[string]any{tools.TokenInfoOUIDKey: claims.OuId},
 	}, nil
 }

--- a/agent-manager-service/mcp/tokeninfo.go
+++ b/agent-manager-service/mcp/tokeninfo.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/auth"
+
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+)
+
+// claimsTokenVerifier adapts the SDK's auth.TokenVerifier interface to the
+// claims our own JWT middleware already validated and stored on the request
+// context. It deliberately ignores the raw bearer token string: by the time
+// this verifier runs (see RegisterRoute, which nests auth.RequireBearerToken
+// inside our auth middleware) the token has already been verified against
+// JWKS and its claims placed on the context. This adapter exists purely to
+// hand that already-validated identity to the SDK so it can (a) activate its
+// session-hijack guard, which compares TokenInfo.UserID across requests on
+// the same session, and (b) expose per-request scopes to tool handlers via
+// CallToolRequest.Extra.TokenInfo.
+func claimsTokenVerifier(ctx context.Context, _ string, _ *http.Request) (*auth.TokenInfo, error) {
+	claims := jwtassertion.GetTokenClaims(ctx)
+	if claims == nil {
+		return nil, fmt.Errorf("%w: no validated token claims on request context", auth.ErrInvalidToken)
+	}
+	if claims.ExpiresAt == nil {
+		// The SDK's RequireBearerToken middleware treats a zero Expiration as
+		// an immediate 401 anyway; return the error explicitly here so the
+		// reason is clear rather than relying on that implicit behavior.
+		return nil, fmt.Errorf("%w: token claims have no expiration", auth.ErrInvalidToken)
+	}
+	return &auth.TokenInfo{
+		Scopes:     strings.Fields(claims.Scope),
+		UserID:     claims.Sub,
+		Expiration: claims.ExpiresAt.Time,
+	}, nil
+}

--- a/agent-manager-service/mcp/tokeninfo.go
+++ b/agent-manager-service/mcp/tokeninfo.go
@@ -48,6 +48,13 @@ func claimsTokenVerifier(ctx context.Context, _ string, _ *http.Request) (*auth.
 		// reason is clear rather than relying on that implicit behavior.
 		return nil, fmt.Errorf("%w: token claims have no expiration", auth.ErrInvalidToken)
 	}
+	if claims.Sub == "" {
+		// The streamable transport's session-hijack guard only activates when
+		// the session's userID is non-empty (it skips the check entirely for
+		// ""), so an empty sub would silently deactivate the guard we just
+		// wired up. Reject it instead of letting UserID default to "".
+		return nil, fmt.Errorf("%w: token missing sub claim", auth.ErrInvalidToken)
+	}
 	return &auth.TokenInfo{
 		Scopes:     strings.Fields(claims.Scope),
 		UserID:     claims.Sub,

--- a/agent-manager-service/mcp/tokeninfo_test.go
+++ b/agent-manager-service/mcp/tokeninfo_test.go
@@ -65,6 +65,30 @@ func TestClaimsTokenVerifierWithClaims(t *testing.T) {
 	}
 }
 
+// TestClaimsTokenVerifierRecordsOrg proves the verifier stamps the caller's
+// organization onto TokenInfo.Extra so authzMiddleware can confirm each
+// per-request token targets the same org as the session (see mcp/tools/authz.go
+// organization-consistency check).
+func TestClaimsTokenVerifierRecordsOrg(t *testing.T) {
+	claims := &jwtassertion.TokenClaims{
+		Sub:   "user-123",
+		Scope: "amp:agent:read",
+		OuId:  "org-abc",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	ctx := jwtassertion.ContextWithTokenClaims(context.Background(), claims)
+
+	info, err := claimsTokenVerifier(ctx, "ignored-raw-token", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := info.Extra["amp:ou-id"].(string); got != "org-abc" {
+		t.Fatalf("TokenInfo.Extra[amp:ou-id] = %q, want %q", got, "org-abc")
+	}
+}
+
 func TestClaimsTokenVerifierNoClaimsOnContext(t *testing.T) {
 	_, err := claimsTokenVerifier(context.Background(), "any-token", nil)
 	if !errors.Is(err, auth.ErrInvalidToken) {

--- a/agent-manager-service/mcp/tokeninfo_test.go
+++ b/agent-manager-service/mcp/tokeninfo_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/modelcontextprotocol/go-sdk/auth"
+
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+)
+
+func TestClaimsTokenVerifierWithClaims(t *testing.T) {
+	expiresAt := time.Now().Add(time.Hour)
+	claims := &jwtassertion.TokenClaims{
+		Sub:   "user-123",
+		Scope: "amp:agent:read amp:project:read",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+		},
+	}
+	ctx := jwtassertion.ContextWithTokenClaims(context.Background(), claims)
+
+	info, err := claimsTokenVerifier(ctx, "ignored-raw-token", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+		return
+	}
+	if info == nil {
+		t.Fatal("expected non-nil TokenInfo")
+		return
+	}
+	wantScopes := []string{"amp:agent:read", "amp:project:read"}
+	if len(info.Scopes) != len(wantScopes) {
+		t.Fatalf("Scopes = %v, want %v", info.Scopes, wantScopes)
+	}
+	for i, s := range wantScopes {
+		if info.Scopes[i] != s {
+			t.Fatalf("Scopes = %v, want %v", info.Scopes, wantScopes)
+		}
+	}
+	if info.UserID != claims.Sub {
+		t.Errorf("UserID = %q, want %q", info.UserID, claims.Sub)
+	}
+	if !info.Expiration.Equal(claims.ExpiresAt.Time) {
+		t.Errorf("Expiration = %v, want %v", info.Expiration, claims.ExpiresAt.Time)
+	}
+}
+
+func TestClaimsTokenVerifierNoClaimsOnContext(t *testing.T) {
+	_, err := claimsTokenVerifier(context.Background(), "any-token", nil)
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("err = %v, want wrapping auth.ErrInvalidToken", err)
+	}
+}
+
+func TestClaimsTokenVerifierNoExpiration(t *testing.T) {
+	claims := &jwtassertion.TokenClaims{
+		Sub:   "user-123",
+		Scope: "amp:agent:read",
+		// ExpiresAt intentionally left nil.
+	}
+	ctx := jwtassertion.ContextWithTokenClaims(context.Background(), claims)
+
+	_, err := claimsTokenVerifier(ctx, "ignored-raw-token", nil)
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("err = %v, want wrapping auth.ErrInvalidToken", err)
+	}
+}

--- a/agent-manager-service/mcp/tokeninfo_test.go
+++ b/agent-manager-service/mcp/tokeninfo_test.go
@@ -72,6 +72,22 @@ func TestClaimsTokenVerifierNoClaimsOnContext(t *testing.T) {
 	}
 }
 
+func TestClaimsTokenVerifierEmptySub(t *testing.T) {
+	claims := &jwtassertion.TokenClaims{
+		Sub:   "", // intentionally empty
+		Scope: "amp:agent:read",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	ctx := jwtassertion.ContextWithTokenClaims(context.Background(), claims)
+
+	_, err := claimsTokenVerifier(ctx, "ignored-raw-token", nil)
+	if !errors.Is(err, auth.ErrInvalidToken) {
+		t.Fatalf("err = %v, want wrapping auth.ErrInvalidToken", err)
+	}
+}
+
 func TestClaimsTokenVerifierNoExpiration(t *testing.T) {
 	claims := &jwtassertion.TokenClaims{
 		Sub:   "user-123",

--- a/agent-manager-service/mcp/tools/agents.go
+++ b/agent-manager-service/mcp/tools/agents.go
@@ -25,6 +25,7 @@ import (
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -135,8 +136,8 @@ type createExternalAgentOutput struct {
 	Note                        string       `json:"note"`
 }
 
-func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
-	gomcp.AddTool(server, &gomcp.Tool{
+func (t *Toolsets) registerAgentTools(server *gomcp.Server, reg *toolRegistry) {
+	addTool(reg, server, &gomcp.Tool{
 		Name: "list_agents",
 		Description: "List agents in a project. " +
 			"An agent is an AI application registered in Agent Manager. Provisioning indicates whether the platform hosts the agent internally or the agent runs externally.",
@@ -146,10 +147,10 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
 			"limit":        intProperty(fmt.Sprintf("Optional. Max agents to return (default %d, min %d, max %d).", utils.DefaultLimit, utils.MinLimit, utils.MaxLimit)),
 			"offset":       intProperty(fmt.Sprintf("Optional. Pagination offset (default %d, min %d).", utils.DefaultOffset, utils.MinOffset)),
 		}, []string{"project_name"}),
-	}, withToolLogging("list_agents", listAgents(t.AgentToolset)))
+	}, listAgents(t.AgentToolset), rbac.AgentRead)
 
 	if t.ProjectToolset != nil {
-		gomcp.AddTool(server, &gomcp.Tool{
+		addTool(reg, server, &gomcp.Tool{
 			Name: "list_project_agent_pairs",
 			Description: "List project-agent name pairs within an organization, with optional project and agent name filters. " +
 				"Each pair shows the project and the registered agent inside that project.",
@@ -162,9 +163,9 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
 				"agent_limit":    intProperty("Optional. Agent pagination limit (1-50)."),
 				"agent_offset":   intProperty("Optional. Agent pagination offset (>= 0)."),
 			}, nil),
-		}, withToolLogging("list_project_agent_pairs", listProjectAgentPairs(t.AgentToolset, t.ProjectToolset)))
+		}, listProjectAgentPairs(t.AgentToolset, t.ProjectToolset), rbac.AgentRead)
 	}
-	gomcp.AddTool(server, &gomcp.Tool{
+	addTool(reg, server, &gomcp.Tool{
 		Name: "create_external_agent",
 		Description: "Register an external agent in a project. " +
 			"Returns the agent identity, the API token, and step-by-step instrumentation instructions to follow in order to start sending observability data to the platform.",
@@ -176,9 +177,9 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
 			"description":  stringProperty("Optional. Short description about what the agent does."),
 			"language":     stringProperty("Required. Agent language for setup guide (python or ballerina)."),
 		}, []string{"project_name", "agent_name", "display_name", "language"}),
-	}, withToolLogging("create_external_agent", createExternalAgent(t.AgentToolset)))
+	}, createExternalAgent(t.AgentToolset), rbac.AgentCreate, rbac.AgentTokenManage)
 
-	gomcp.AddTool(server, &gomcp.Tool{
+	addTool(reg, server, &gomcp.Tool{
 		Name: "create_internal_agent_python",
 		Description: "Create an internal Python agent inside a project. " +
 			"An internal agent is hosted by the platform: Agent Manager fetches the source code, builds it, deploys it, and runs it for you. " +
@@ -214,7 +215,7 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server) {
 				"required": []string{"key", "value"},
 			}),
 		}, []string{"project_name", "agent_name", "display_name", "repository_url", "branch", "app_path", "interface_type", "env"}),
-	}, withToolLogging("create_internal_agent_python", createInternalAgentPython(t.AgentToolset)))
+	}, createInternalAgentPython(t.AgentToolset), rbac.AgentCreate)
 }
 
 func listAgents(handler AgentToolsetHandler) func(context.Context, *gomcp.CallToolRequest, listAgentsInput) (*gomcp.CallToolResult, any, error) {

--- a/agent-manager-service/mcp/tools/agents.go
+++ b/agent-manager-service/mcp/tools/agents.go
@@ -163,7 +163,7 @@ func (t *Toolsets) registerAgentTools(server *gomcp.Server, reg *toolRegistry) {
 				"agent_limit":    intProperty("Optional. Agent pagination limit (1-50)."),
 				"agent_offset":   intProperty("Optional. Agent pagination offset (>= 0)."),
 			}, nil),
-		}, listProjectAgentPairs(t.AgentToolset, t.ProjectToolset), rbac.AgentRead)
+		}, listProjectAgentPairs(t.AgentToolset, t.ProjectToolset), rbac.AgentRead, rbac.ProjectRead)
 	}
 	addTool(reg, server, &gomcp.Tool{
 		Name: "create_external_agent",

--- a/agent-manager-service/mcp/tools/agents_specs_test.go
+++ b/agent-manager-service/mcp/tools/agents_specs_test.go
@@ -52,7 +52,7 @@ func agentToolSpecs() []toolTestSpec {
 		{
 			name:                "list_project_agent_pairs",
 			toolset:             "agent",
-			permissions:         []rbac.Permission{rbac.AgentRead},
+			permissions:         []rbac.Permission{rbac.AgentRead, rbac.ProjectRead},
 			descriptionKeywords: []string{"project", "agent"},
 			descriptionMinLen:   20,
 			requiredParams:      nil,

--- a/agent-manager-service/mcp/tools/agents_specs_test.go
+++ b/agent-manager-service/mcp/tools/agents_specs_test.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"testing"
 
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
@@ -29,6 +30,7 @@ func agentToolSpecs() []toolTestSpec {
 		{
 			name:                "list_agents",
 			toolset:             "agent",
+			permissions:         []rbac.Permission{rbac.AgentRead},
 			descriptionKeywords: []string{"list", "agent"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name"},
@@ -50,6 +52,7 @@ func agentToolSpecs() []toolTestSpec {
 		{
 			name:                "list_project_agent_pairs",
 			toolset:             "agent",
+			permissions:         []rbac.Permission{rbac.AgentRead},
 			descriptionKeywords: []string{"project", "agent"},
 			descriptionMinLen:   20,
 			requiredParams:      nil,
@@ -69,6 +72,7 @@ func agentToolSpecs() []toolTestSpec {
 		{
 			name:                "create_external_agent",
 			toolset:             "agent",
+			permissions:         []rbac.Permission{rbac.AgentCreate, rbac.AgentTokenManage},
 			descriptionKeywords: []string{"external", "agent"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name", "agent_name", "display_name", "language"},
@@ -103,6 +107,7 @@ func agentToolSpecs() []toolTestSpec {
 		{
 			name:                "create_internal_agent_python",
 			toolset:             "agent",
+			permissions:         []rbac.Permission{rbac.AgentCreate},
 			descriptionKeywords: []string{"internal", "python", "agent"},
 			descriptionMinLen:   20,
 			requiredParams: []string{

--- a/agent-manager-service/mcp/tools/authz.go
+++ b/agent-manager-service/mcp/tools/authz.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/modelcontextprotocol/go-sdk/auth"
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
@@ -31,6 +32,13 @@ import (
 // methodCallTool is the MCP method name for tool invocations. The SDK's own
 // constant is unexported.
 const methodCallTool = "tools/call"
+
+// TokenInfoOUIDKey is the auth.TokenInfo.Extra key under which the MCP token
+// verifier (mcp/tokeninfo.go) records the organization of the token that made
+// the current request. authzMiddleware compares it against the session's
+// organization so a per-request token cannot drive a tool against a different
+// org than the one whose identity established the session.
+const TokenInfoOUIDKey = "amp:ou-id"
 
 // toolRegistry records the rbac permissions each registered tool requires.
 // authzMiddleware enforces it fail-closed: a tool with no entry — one
@@ -79,6 +87,19 @@ func (reg *toolRegistry) authzMiddleware() gomcp.Middleware {
 			if !registered {
 				return denyResult(fmt.Sprintf("tool %q has no registered permissions", call.Params.Name)), nil
 			}
+			// Organization-consistency guard: tool handlers resolve the org from
+			// the session/initialize context (resolveOUID) while scopes are taken
+			// from the per-request token. Reject when the per-request token targets
+			// a different org than the session, so scopes granted in one org cannot
+			// authorize actions against another. This is an identity-integrity check
+			// like the SDK's sub-based session-hijack guard, so it applies
+			// regardless of RBAC_ENABLED. Skipped when there is no per-request
+			// TokenInfo (in-memory transports have no HTTP layer).
+			if call.Extra != nil && call.Extra.TokenInfo != nil {
+				if !sessionOrgMatchesRequest(ctx, call.Extra.TokenInfo) {
+					return denyResult("organization mismatch: request token is not scoped to the session organization"), nil
+				}
+			}
 			if !config.GetConfig().RBACEnabled {
 				return next(ctx, method, req)
 			}
@@ -111,6 +132,19 @@ func scopeChecker(ctx context.Context, call *gomcp.CallToolRequest) func(scope s
 	return func(scope string) bool {
 		return jwtassertion.HasAllScopes(ctx, []string{scope})
 	}
+}
+
+// sessionOrgMatchesRequest reports whether the organization on the per-request
+// token (recorded under TokenInfoOUIDKey by claimsTokenVerifier) equals the
+// organization of the session's claims on ctx. A session with no claims yields
+// an empty org, which only matches a request that likewise carries no org.
+func sessionOrgMatchesRequest(ctx context.Context, info *auth.TokenInfo) bool {
+	var sessionOUID string
+	if claims := jwtassertion.GetTokenClaims(ctx); claims != nil {
+		sessionOUID = claims.OuId
+	}
+	requestOUID, _ := info.Extra[TokenInfoOUIDKey].(string)
+	return requestOUID == sessionOUID
 }
 
 func denyResult(message string) *gomcp.CallToolResult {

--- a/agent-manager-service/mcp/tools/authz.go
+++ b/agent-manager-service/mcp/tools/authz.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
+)
+
+// methodCallTool is the MCP method name for tool invocations. The SDK's own
+// constant is unexported.
+const methodCallTool = "tools/call"
+
+// toolRegistry records the rbac permissions each registered tool requires.
+// authzMiddleware enforces it fail-closed: a tool with no entry — one
+// registered by bypassing addTool — is always denied.
+type toolRegistry struct {
+	permissions map[string][]rbac.Permission
+}
+
+func newToolRegistry() *toolRegistry {
+	return &toolRegistry{permissions: make(map[string][]rbac.Permission)}
+}
+
+// addTool is the only sanctioned way to register an MCP tool. It requires the
+// permissions the caller's token must hold (ALL semantics), records them for
+// authzMiddleware, and wires the standard logging wrapper. Panics when no
+// permission is declared: that is a registration bug, caught at startup and
+// by every test run, not a runtime condition.
+func addTool[T any](reg *toolRegistry, server *gomcp.Server, tool *gomcp.Tool,
+	handler func(context.Context, *gomcp.CallToolRequest, T) (*gomcp.CallToolResult, any, error),
+	perms ...rbac.Permission,
+) {
+	if len(perms) == 0 {
+		panic(fmt.Sprintf("mcp tool %q registered without permissions", tool.Name))
+	}
+	reg.permissions[tool.Name] = perms
+	gomcp.AddTool(server, tool, withToolLogging(tool.Name, handler))
+}
+
+// authzMiddleware returns a server middleware that authorizes every tools/call
+// against the registry, mirroring middleware.RequirePermission semantics:
+// RBAC_ENABLED=false skips the scope check (zero-downtime rollout switch),
+// while the unknown-tool denial applies regardless. Denials are returned as
+// IsError tool results so MCP clients surface an actionable message instead
+// of a protocol error.
+func (reg *toolRegistry) authzMiddleware() gomcp.Middleware {
+	return func(next gomcp.MethodHandler) gomcp.MethodHandler {
+		return func(ctx context.Context, method string, req gomcp.Request) (gomcp.Result, error) {
+			if method != methodCallTool {
+				return next(ctx, method, req)
+			}
+			call, ok := req.(*gomcp.CallToolRequest)
+			if !ok {
+				return denyResult(fmt.Sprintf("unexpected %s request type", methodCallTool)), nil
+			}
+			perms, registered := reg.permissions[call.Params.Name]
+			if !registered {
+				return denyResult(fmt.Sprintf("tool %q has no registered permissions", call.Params.Name)), nil
+			}
+			if !config.GetConfig().RBACEnabled {
+				return next(ctx, method, req)
+			}
+			for _, perm := range perms {
+				if !jwtassertion.HasAllScopes(ctx, []string{perm.Scope()}) {
+					return denyResult(fmt.Sprintf("insufficient permissions: this tool requires the %s scope", perm.Scope())), nil
+				}
+			}
+			return next(ctx, method, req)
+		}
+	}
+}
+
+func denyResult(message string) *gomcp.CallToolResult {
+	return &gomcp.CallToolResult{
+		IsError: true,
+		Content: []gomcp.Content{&gomcp.TextContent{Text: message}},
+	}
+}

--- a/agent-manager-service/mcp/tools/authz.go
+++ b/agent-manager-service/mcp/tools/authz.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -81,13 +82,34 @@ func (reg *toolRegistry) authzMiddleware() gomcp.Middleware {
 			if !config.GetConfig().RBACEnabled {
 				return next(ctx, method, req)
 			}
+			hasScope := scopeChecker(ctx, call)
 			for _, perm := range perms {
-				if !jwtassertion.HasAllScopes(ctx, []string{perm.Scope()}) {
+				if !hasScope(perm.Scope()) {
 					return denyResult(fmt.Sprintf("insufficient permissions: this tool requires the %s scope", perm.Scope())), nil
 				}
 			}
 			return next(ctx, method, req)
 		}
+	}
+}
+
+// scopeChecker returns a function that reports whether a given scope is
+// present for the current request. It prefers the per-request scopes the SDK
+// attaches via call.Extra.TokenInfo (populated by claimsTokenVerifier through
+// auth.RequireBearerToken — see mcp/tokeninfo.go and mcp/setup.go) since those
+// reflect the token that made this specific HTTP request. When Extra.TokenInfo
+// is absent — in-memory transports and tests have no HTTP layer, so it's
+// always nil there — it falls back to the scopes jwtassertion put on the
+// session context.
+func scopeChecker(ctx context.Context, call *gomcp.CallToolRequest) func(scope string) bool {
+	if call.Extra != nil && call.Extra.TokenInfo != nil {
+		scopes := call.Extra.TokenInfo.Scopes
+		return func(scope string) bool {
+			return slices.Contains(scopes, scope)
+		}
+	}
+	return func(scope string) bool {
+		return jwtassertion.HasAllScopes(ctx, []string{scope})
 	}
 }
 

--- a/agent-manager-service/mcp/tools/authz_e2e_test.go
+++ b/agent-manager-service/mcp/tools/authz_e2e_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
+)
+
+// callListProjects invokes list_projects over the in-memory client session and
+// returns the result. list_projects requires rbac.ProjectRead.
+func callListProjects(t *testing.T, session *gomcp.ClientSession) *gomcp.CallToolResult {
+	t.Helper()
+	result, err := session.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name:      "list_projects",
+		Arguments: map[string]any{"org_name": testOrgName},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	return result
+}
+
+func newFullToolsets() (*Toolsets, *MockToolsetHandler) {
+	mock := NewMockToolsetHandler()
+	return &Toolsets{
+		ProjectToolset:    mock,
+		AgentToolset:      mock,
+		BuildToolset:      mock,
+		DeploymentToolset: mock,
+	}, mock
+}
+
+func TestE2EToolAllowedWithScope(t *testing.T) {
+	setRBACEnabled(t, true)
+	toolsets, _ := newFullToolsets()
+	session := setupTestServerWithClaims(t, toolsets, &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: rbac.ProjectRead.Scope(),
+	})
+	result := callListProjects(t, session)
+	if result.IsError {
+		t.Fatalf("expected success, got error result: %+v", result.Content)
+	}
+}
+
+func TestE2EToolDeniedWithoutScope(t *testing.T) {
+	setRBACEnabled(t, true)
+	toolsets, mock := newFullToolsets()
+	session := setupTestServerWithClaims(t, toolsets, &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: rbac.AgentRead.Scope(), // wrong scope for list_projects
+	})
+	result := callListProjects(t, session)
+	if !result.IsError {
+		t.Fatal("expected denial, got success")
+	}
+	text, ok := result.Content[0].(*gomcp.TextContent)
+	if !ok {
+		t.Fatalf("content is %T, want *gomcp.TextContent", result.Content[0])
+	}
+	if want := "insufficient permissions: this tool requires the amp:project:read scope"; text.Text != want {
+		t.Fatalf("denial text = %q, want %q", text.Text, want)
+	}
+	if calls := mock.calls["ListProjects"]; len(calls) != 0 {
+		t.Fatalf("handler was invoked %d times despite denial", len(calls))
+	}
+}
+
+func TestE2EToolAllowedWhenRBACDisabled(t *testing.T) {
+	setRBACEnabled(t, false)
+	toolsets, _ := newFullToolsets()
+	session := setupTestServerWithClaims(t, toolsets, &jwtassertion.TokenClaims{
+		OuId: testOrgName, // no scopes at all
+	})
+	result := callListProjects(t, session)
+	if result.IsError {
+		t.Fatalf("expected success with RBAC disabled, got error result: %+v", result.Content)
+	}
+}
+
+func TestE2ERogueToolFailsClosed(t *testing.T) {
+	setRBACEnabled(t, false) // fail-closed must hold even with RBAC disabled
+	toolsets, _ := newFullToolsets()
+
+	server := gomcp.NewServer(&gomcp.Implementation{
+		Name:    "test-agent-manager-mcp",
+		Version: "0.0.1",
+	}, nil)
+	toolsets.Register(server)
+
+	// Bypass addTool deliberately: register a tool directly with the SDK.
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "rogue_tool",
+		Description: "registered without going through addTool",
+		InputSchema: createSchema(map[string]any{}, nil),
+	}, func(context.Context, *gomcp.CallToolRequest, struct{}) (*gomcp.CallToolResult, any, error) {
+		return &gomcp.CallToolResult{
+			Content: []gomcp.Content{&gomcp.TextContent{Text: "should never run"}},
+		}, nil, nil
+	})
+
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: unionScopes(),
+	})
+	clientTransport, serverTransport := gomcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("failed to connect server: %v", err)
+	}
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test-mcp-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("failed to connect client: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	result, err := session.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name:      "rogue_tool",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("rogue tool executed — fail-closed middleware did not deny it")
+	}
+	text, ok := result.Content[0].(*gomcp.TextContent)
+	if !ok {
+		t.Fatalf("content is %T, want *gomcp.TextContent", result.Content[0])
+	}
+	if !strings.Contains(text.Text, `tool "rogue_tool" has no registered permissions`) {
+		t.Fatalf("unexpected denial text: %q", text.Text)
+	}
+}
+
+func TestE2EMultiPermissionToolDeniedWithPartialScopes(t *testing.T) {
+	setRBACEnabled(t, true)
+	toolsets, mock := newFullToolsets()
+	// create_external_agent requires AgentCreate AND AgentTokenManage.
+	session := setupTestServerWithClaims(t, toolsets, &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: rbac.AgentCreate.Scope(),
+	})
+	result, err := session.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name: "create_external_agent",
+		Arguments: map[string]any{
+			"project_name": testProjectName,
+			"agent_name":   testAgentName,
+			"display_name": testDisplayName,
+			"language":     "python",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("expected denial with only one of two required scopes")
+	}
+	if calls := mock.calls["CreateAgent"]; len(calls) != 0 {
+		t.Fatalf("handler was invoked %d times despite denial", len(calls))
+	}
+}

--- a/agent-manager-service/mcp/tools/authz_test.go
+++ b/agent-manager-service/mcp/tools/authz_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
+)
+
+// setRBACEnabled flips the process-global RBAC switch for one test and
+// restores it on cleanup. Tests using it must not run in parallel.
+func setRBACEnabled(t *testing.T, enabled bool) {
+	t.Helper()
+	cfg := config.GetConfig()
+	orig := cfg.RBACEnabled
+	cfg.RBACEnabled = enabled
+	t.Cleanup(func() { cfg.RBACEnabled = orig })
+}
+
+// callToolViaMiddleware runs a synthetic tools/call for toolName through the
+// registry's middleware with a next handler that records whether it ran.
+func callToolViaMiddleware(t *testing.T, reg *toolRegistry, ctx context.Context, toolName string) (result gomcp.Result, nextCalled bool) {
+	t.Helper()
+	next := func(_ context.Context, _ string, _ gomcp.Request) (gomcp.Result, error) {
+		nextCalled = true
+		return &gomcp.CallToolResult{}, nil
+	}
+	req := &gomcp.CallToolRequest{Params: &gomcp.CallToolParamsRaw{Name: toolName}}
+	result, err := reg.authzMiddleware()(next)(ctx, "tools/call", req)
+	if err != nil {
+		t.Fatalf("middleware returned unexpected error: %v", err)
+	}
+	return result, nextCalled
+}
+
+func denialText(t *testing.T, result gomcp.Result) string {
+	t.Helper()
+	callResult, ok := result.(*gomcp.CallToolResult)
+	if !ok {
+		t.Fatalf("result is %T, want *gomcp.CallToolResult", result)
+	}
+	if !callResult.IsError {
+		t.Fatal("expected IsError=true denial result")
+	}
+	if len(callResult.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(callResult.Content))
+	}
+	text, ok := callResult.Content[0].(*gomcp.TextContent)
+	if !ok {
+		t.Fatalf("content is %T, want *gomcp.TextContent", callResult.Content[0])
+	}
+	return text.Text
+}
+
+func TestAddToolPanicsWithoutPermissions(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when registering a tool without permissions")
+		}
+		if !strings.Contains(r.(string), "no_perm_tool") {
+			t.Fatalf("panic message %q does not name the tool", r)
+		}
+	}()
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "t", Version: "0"}, nil)
+	addTool(newToolRegistry(), server, &gomcp.Tool{
+		Name:        "no_perm_tool",
+		Description: "a tool registered without permissions",
+		InputSchema: createSchema(map[string]any{}, nil),
+	}, func(context.Context, *gomcp.CallToolRequest, struct{}) (*gomcp.CallToolResult, any, error) {
+		return &gomcp.CallToolResult{}, nil, nil
+	})
+}
+
+func TestAddToolRecordsPermissions(t *testing.T) {
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "t", Version: "0"}, nil)
+	reg := newToolRegistry()
+	addTool(reg, server, &gomcp.Tool{
+		Name:        "two_perm_tool",
+		Description: "a tool with two permissions",
+		InputSchema: createSchema(map[string]any{}, nil),
+	}, func(context.Context, *gomcp.CallToolRequest, struct{}) (*gomcp.CallToolResult, any, error) {
+		return &gomcp.CallToolResult{}, nil, nil
+	}, rbac.AgentCreate, rbac.AgentTokenManage)
+
+	got := reg.permissions["two_perm_tool"]
+	if len(got) != 2 || got[0] != rbac.AgentCreate || got[1] != rbac.AgentTokenManage {
+		t.Fatalf("registry permissions = %v, want [AgentCreate AgentTokenManage]", got)
+	}
+}
+
+func TestAuthzMiddlewareDeniesUnregisteredTool(t *testing.T) {
+	setRBACEnabled(t, false) // fail-closed applies even with RBAC disabled
+	reg := newToolRegistry()
+	result, nextCalled := callToolViaMiddleware(t, reg, context.Background(), "rogue_tool")
+	if nextCalled {
+		t.Fatal("next handler ran for an unregistered tool")
+	}
+	if got, want := denialText(t, result), `tool "rogue_tool" has no registered permissions`; got != want {
+		t.Fatalf("denial text = %q, want %q", got, want)
+	}
+}
+
+func TestAuthzMiddlewareSkipsCheckWhenRBACDisabled(t *testing.T) {
+	setRBACEnabled(t, false)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	// No claims on context at all — must still pass with RBAC disabled.
+	_, nextCalled := callToolViaMiddleware(t, reg, context.Background(), "some_tool")
+	if !nextCalled {
+		t.Fatal("next handler did not run with RBAC disabled")
+	}
+}
+
+func TestAuthzMiddlewareDeniesMissingScope(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: rbac.AgentRead.Scope(), // has read, not build
+	})
+	result, nextCalled := callToolViaMiddleware(t, reg, ctx, "some_tool")
+	if nextCalled {
+		t.Fatal("next handler ran despite missing scope")
+	}
+	if got, want := denialText(t, result), "insufficient permissions: this tool requires the amp:agent:build scope"; got != want {
+		t.Fatalf("denial text = %q, want %q", got, want)
+	}
+}
+
+func TestAuthzMiddlewareAllowsMatchingScope(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: rbac.AgentBuild.Scope(),
+	})
+	_, nextCalled := callToolViaMiddleware(t, reg, ctx, "some_tool")
+	if !nextCalled {
+		t.Fatal("next handler did not run despite matching scope")
+	}
+}
+
+func TestAuthzMiddlewareRequiresAllPermissions(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["multi_tool"] = []rbac.Permission{rbac.AgentCreate, rbac.AgentTokenManage}
+	// Only one of the two scopes present.
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: rbac.AgentCreate.Scope(),
+	})
+	result, nextCalled := callToolViaMiddleware(t, reg, ctx, "multi_tool")
+	if nextCalled {
+		t.Fatal("next handler ran with only one of two required scopes")
+	}
+	if got, want := denialText(t, result), "insufficient permissions: this tool requires the amp:agent:token-manage scope"; got != want {
+		t.Fatalf("denial text = %q, want %q", got, want)
+	}
+}
+
+func TestAuthzMiddlewarePassesThroughOtherMethods(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	next := func(_ context.Context, _ string, _ gomcp.Request) (gomcp.Result, error) {
+		return &gomcp.ListToolsResult{}, nil
+	}
+	req := &gomcp.ListToolsRequest{Params: &gomcp.ListToolsParams{}}
+	result, err := reg.authzMiddleware()(next)(context.Background(), "tools/list", req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result.(*gomcp.ListToolsResult); !ok {
+		t.Fatalf("tools/list result was intercepted: got %T", result)
+	}
+}

--- a/agent-manager-service/mcp/tools/authz_test.go
+++ b/agent-manager-service/mcp/tools/authz_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/auth"
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
@@ -47,6 +48,24 @@ func callToolViaMiddleware(t *testing.T, reg *toolRegistry, ctx context.Context,
 		return &gomcp.CallToolResult{}, nil
 	}
 	req := &gomcp.CallToolRequest{Params: &gomcp.CallToolParamsRaw{Name: toolName}}
+	result, err := reg.authzMiddleware()(next)(ctx, "tools/call", req)
+	if err != nil {
+		t.Fatalf("middleware returned unexpected error: %v", err)
+	}
+	return result, nextCalled
+}
+
+// callToolViaMiddlewareWithExtra is callToolViaMiddleware but lets the caller
+// attach a RequestExtra (e.g. carrying per-request auth.TokenInfo), mirroring
+// what the SDK's streamable transport stamps onto every JSON-RPC request when
+// auth.RequireBearerToken is wired in front of it (see mcp/setup.go).
+func callToolViaMiddlewareWithExtra(t *testing.T, reg *toolRegistry, ctx context.Context, toolName string, extra *gomcp.RequestExtra) (result gomcp.Result, nextCalled bool) {
+	t.Helper()
+	next := func(_ context.Context, _ string, _ gomcp.Request) (gomcp.Result, error) {
+		nextCalled = true
+		return &gomcp.CallToolResult{}, nil
+	}
+	req := &gomcp.CallToolRequest{Params: &gomcp.CallToolParamsRaw{Name: toolName}, Extra: extra}
 	result, err := reg.authzMiddleware()(next)(ctx, "tools/call", req)
 	if err != nil {
 		t.Fatalf("middleware returned unexpected error: %v", err)
@@ -150,6 +169,22 @@ func TestAuthzMiddlewareDeniesMissingScope(t *testing.T) {
 	}
 }
 
+// TestAuthzMiddlewareDeniesWhenNoClaimsOnContext pins that RBAC enabled with
+// no claims/scopes at all on the context (not even an empty scope string)
+// fails closed rather than open.
+func TestAuthzMiddlewareDeniesWhenNoClaimsOnContext(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	result, nextCalled := callToolViaMiddleware(t, reg, context.Background(), "some_tool")
+	if nextCalled {
+		t.Fatal("next handler ran despite no claims on context")
+	}
+	if got, want := denialText(t, result), "insufficient permissions: this tool requires the amp:agent:build scope"; got != want {
+		t.Fatalf("denial text = %q, want %q", got, want)
+	}
+}
+
 func TestAuthzMiddlewareAllowsMatchingScope(t *testing.T) {
 	setRBACEnabled(t, true)
 	reg := newToolRegistry()
@@ -161,6 +196,45 @@ func TestAuthzMiddlewareAllowsMatchingScope(t *testing.T) {
 	_, nextCalled := callToolViaMiddleware(t, reg, ctx, "some_tool")
 	if !nextCalled {
 		t.Fatal("next handler did not run despite matching scope")
+	}
+}
+
+// TestAuthzMiddlewarePerRequestScopeAllowsWithEmptySession proves the
+// per-request auth.TokenInfo source is consulted (and is sufficient on its
+// own): the session context carries no scopes at all, yet the call is allowed
+// because call.Extra.TokenInfo has the required scope.
+func TestAuthzMiddlewarePerRequestScopeAllowsWithEmptySession(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	extra := &gomcp.RequestExtra{TokenInfo: &auth.TokenInfo{Scopes: []string{rbac.AgentBuild.Scope()}}}
+	_, nextCalled := callToolViaMiddlewareWithExtra(t, reg, context.Background(), "some_tool", extra)
+	if !nextCalled {
+		t.Fatal("next handler did not run despite matching per-request scope")
+	}
+}
+
+// TestAuthzMiddlewarePerRequestScopeTakesPrecedenceOverSession proves that
+// when call.Extra.TokenInfo is present, it is authoritative even if the
+// SESSION context separately carries the required scope: a request whose
+// per-request TokenInfo lacks the scope is denied.
+func TestAuthzMiddlewarePerRequestScopeTakesPrecedenceOverSession(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	// Session context has the required scope...
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: rbac.AgentBuild.Scope(),
+	})
+	// ...but the per-request TokenInfo does not.
+	extra := &gomcp.RequestExtra{TokenInfo: &auth.TokenInfo{Scopes: []string{rbac.AgentRead.Scope()}}}
+	result, nextCalled := callToolViaMiddlewareWithExtra(t, reg, ctx, "some_tool", extra)
+	if nextCalled {
+		t.Fatal("next handler ran despite per-request TokenInfo lacking the required scope")
+	}
+	if got, want := denialText(t, result), "insufficient permissions: this tool requires the amp:agent:build scope"; got != want {
+		t.Fatalf("denial text = %q, want %q", got, want)
 	}
 }
 

--- a/agent-manager-service/mcp/tools/authz_test.go
+++ b/agent-manager-service/mcp/tools/authz_test.go
@@ -227,13 +227,89 @@ func TestAuthzMiddlewarePerRequestScopeTakesPrecedenceOverSession(t *testing.T) 
 		OuId:  testOrgName,
 		Scope: rbac.AgentBuild.Scope(),
 	})
-	// ...but the per-request TokenInfo does not.
-	extra := &gomcp.RequestExtra{TokenInfo: &auth.TokenInfo{Scopes: []string{rbac.AgentRead.Scope()}}}
+	// ...but the per-request TokenInfo does not (org matches so the scope is
+	// the only failing dimension).
+	extra := &gomcp.RequestExtra{TokenInfo: &auth.TokenInfo{
+		Scopes: []string{rbac.AgentRead.Scope()},
+		Extra:  map[string]any{"amp:ou-id": testOrgName},
+	}}
 	result, nextCalled := callToolViaMiddlewareWithExtra(t, reg, ctx, "some_tool", extra)
 	if nextCalled {
 		t.Fatal("next handler ran despite per-request TokenInfo lacking the required scope")
 	}
 	if got, want := denialText(t, result), "insufficient permissions: this tool requires the amp:agent:build scope"; got != want {
+		t.Fatalf("denial text = %q, want %q", got, want)
+	}
+}
+
+// TestAuthzMiddlewareDeniesOrgMismatch proves the per-request token must target
+// the same organization as the MCP session. Tool handlers resolve the org from
+// the session/initialize context (resolveOUID) while scopes are taken from the
+// per-request token, so a token for org A that carries the required scope must
+// not be allowed to drive a tool against org B's data. The request here has the
+// required scope but a different ouId than the session — it must be denied.
+func TestAuthzMiddlewareDeniesOrgMismatch(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	// Session established for org B, and it even carries the required scope.
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId:  "org-b",
+		Scope: rbac.AgentBuild.Scope(),
+	})
+	// Per-request token is for org A but carries the required scope.
+	extra := &gomcp.RequestExtra{TokenInfo: &auth.TokenInfo{
+		Scopes: []string{rbac.AgentBuild.Scope()},
+		Extra:  map[string]any{"amp:ou-id": "org-a"},
+	}}
+	result, nextCalled := callToolViaMiddlewareWithExtra(t, reg, ctx, "some_tool", extra)
+	if nextCalled {
+		t.Fatal("next handler ran despite request/session organization mismatch")
+	}
+	if got, want := denialText(t, result), "organization mismatch: request token is not scoped to the session organization"; got != want {
+		t.Fatalf("denial text = %q, want %q", got, want)
+	}
+}
+
+// TestAuthzMiddlewareAllowsMatchingOrg is the happy path: a single-token client
+// whose per-request org equals the session org passes the consistency check.
+func TestAuthzMiddlewareAllowsMatchingOrg(t *testing.T) {
+	setRBACEnabled(t, true)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId:  "org-a",
+		Scope: rbac.AgentBuild.Scope(),
+	})
+	extra := &gomcp.RequestExtra{TokenInfo: &auth.TokenInfo{
+		Scopes: []string{rbac.AgentBuild.Scope()},
+		Extra:  map[string]any{"amp:ou-id": "org-a"},
+	}}
+	_, nextCalled := callToolViaMiddlewareWithExtra(t, reg, ctx, "some_tool", extra)
+	if !nextCalled {
+		t.Fatal("next handler did not run despite matching organization")
+	}
+}
+
+// TestAuthzMiddlewareDeniesOrgMismatchEvenWhenRBACDisabled proves the org
+// consistency check is an identity-integrity guard, not scope authorization:
+// it holds even when RBAC_ENABLED is false (mirroring the SDK's sub-based
+// session-hijack guard, which is always active).
+func TestAuthzMiddlewareDeniesOrgMismatchEvenWhenRBACDisabled(t *testing.T) {
+	setRBACEnabled(t, false)
+	reg := newToolRegistry()
+	reg.permissions["some_tool"] = []rbac.Permission{rbac.AgentBuild}
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), &jwtassertion.TokenClaims{
+		OuId: "org-b",
+	})
+	extra := &gomcp.RequestExtra{TokenInfo: &auth.TokenInfo{
+		Extra: map[string]any{"amp:ou-id": "org-a"},
+	}}
+	result, nextCalled := callToolViaMiddlewareWithExtra(t, reg, ctx, "some_tool", extra)
+	if nextCalled {
+		t.Fatal("next handler ran despite org mismatch with RBAC disabled")
+	}
+	if got, want := denialText(t, result), "organization mismatch: request token is not scoped to the session organization"; got != want {
 		t.Fatalf("denial text = %q, want %q", got, want)
 	}
 }

--- a/agent-manager-service/mcp/tools/builds.go
+++ b/agent-manager-service/mcp/tools/builds.go
@@ -25,6 +25,7 @@ import (
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -86,8 +87,8 @@ type buildAgentOutput struct {
 	Note        string             `json:"note,omitempty"`
 }
 
-func (t *Toolsets) registerBuildTools(server *gomcp.Server) {
-	gomcp.AddTool(server, &gomcp.Tool{
+func (t *Toolsets) registerBuildTools(server *gomcp.Server, reg *toolRegistry) {
+	addTool(reg, server, &gomcp.Tool{
 		Name: "list_builds",
 		Description: "List builds for an agent. " +
 			"A build is a versioned packaging job that turns agent source into a runnable image using a specific commit and build parameters. " +
@@ -99,9 +100,9 @@ func (t *Toolsets) registerBuildTools(server *gomcp.Server) {
 			"limit":        intProperty(fmt.Sprintf("Optional. Max builds to return (default %d, min %d, max %d).", utils.DefaultLimit, utils.MinLimit, utils.MaxLimit)),
 			"offset":       intProperty(fmt.Sprintf("Optional. Pagination offset (default %d, min %d).", utils.DefaultOffset, utils.MinOffset)),
 		}, []string{"project_name", "agent_name"}),
-	}, withToolLogging("list_builds", listBuilds(t.BuildToolset)))
+	}, listBuilds(t.BuildToolset), rbac.AgentRead)
 
-	gomcp.AddTool(server, &gomcp.Tool{
+	addTool(reg, server, &gomcp.Tool{
 		Name: "get_build_details",
 		Description: "Return detailed information for a specific build, including status, steps, duration, commit, and build parameters. " +
 			"If the build is still running, completion may take a few minutes.",
@@ -111,9 +112,9 @@ func (t *Toolsets) registerBuildTools(server *gomcp.Server) {
 			"agent_name":   stringProperty("Required. Agent name that owns the build."),
 			"build_name":   stringProperty("Required. Build name to fetch details for."),
 		}, []string{"project_name", "agent_name", "build_name"}),
-	}, withToolLogging("get_build_details", getBuildDetails(t.BuildToolset)))
+	}, getBuildDetails(t.BuildToolset), rbac.AgentRead)
 
-	gomcp.AddTool(server, &gomcp.Tool{
+	addTool(reg, server, &gomcp.Tool{
 		Name: "build_agent",
 		Description: "Start a new build for an existing agent. " +
 			"A build packages the agent source into a runnable image from a specific commit and build parameters. " +
@@ -124,7 +125,7 @@ func (t *Toolsets) registerBuildTools(server *gomcp.Server) {
 			"agent_name":   stringProperty("Required. Agent name to trigger build for."),
 			"commit_id":    stringProperty("Optional. Commit ID to build. Defaults to latest."),
 		}, []string{"project_name", "agent_name"}),
-	}, withToolLogging("build_agent", buildAgent(t.BuildToolset)))
+	}, buildAgent(t.BuildToolset), rbac.AgentBuild)
 }
 
 func listBuilds(handler BuildToolsetHandler) func(context.Context, *gomcp.CallToolRequest, listBuildsInput) (*gomcp.CallToolResult, any, error) {

--- a/agent-manager-service/mcp/tools/builds_specs_test.go
+++ b/agent-manager-service/mcp/tools/builds_specs_test.go
@@ -16,7 +16,11 @@
 
 package tools
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
+)
 
 // Returns the test specs for tools registered by registerBuildTools.
 // New tools added to builds.go must have a spec here — registration_test.go fails the build otherwise.
@@ -25,6 +29,7 @@ func buildToolSpecs() []toolTestSpec {
 		{
 			name:                "list_builds",
 			toolset:             "build",
+			permissions:         []rbac.Permission{rbac.AgentRead},
 			descriptionKeywords: []string{"list", "build"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name", "agent_name"},
@@ -50,6 +55,7 @@ func buildToolSpecs() []toolTestSpec {
 		{
 			name:                "get_build_details",
 			toolset:             "build",
+			permissions:         []rbac.Permission{rbac.AgentRead},
 			descriptionKeywords: []string{"build"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name", "agent_name", "build_name"},
@@ -79,6 +85,7 @@ func buildToolSpecs() []toolTestSpec {
 		{
 			name:                "build_agent",
 			toolset:             "build",
+			permissions:         []rbac.Permission{rbac.AgentBuild},
 			descriptionKeywords: []string{"build"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name", "agent_name"},

--- a/agent-manager-service/mcp/tools/deployments.go
+++ b/agent-manager-service/mcp/tools/deployments.go
@@ -23,6 +23,7 @@ import (
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -78,8 +79,8 @@ type updateDeploymentStateOutput struct {
 	State       string `json:"state"`
 }
 
-func (t *Toolsets) registerDeploymentTools(server *gomcp.Server) {
-	gomcp.AddTool(server, &gomcp.Tool{
+func (t *Toolsets) registerDeploymentTools(server *gomcp.Server, reg *toolRegistry) {
+	addTool(reg, server, &gomcp.Tool{
 		Name: "list_deployments",
 		Description: "List an agent's deployments across environments. " +
 			"A deployment is a released agent image running in a specific environment, and each deployment includes its current state such as active, in-progress, failed, not-deployed, or suspended.",
@@ -88,9 +89,9 @@ func (t *Toolsets) registerDeploymentTools(server *gomcp.Server) {
 			"project_name": stringProperty("Required. Project name where the agent exists."),
 			"agent_name":   stringProperty("Required. Name of the agent to check deployments for."),
 		}, []string{"project_name", "agent_name"}),
-	}, withToolLogging("list_deployments", listDeployments(t.DeploymentToolset)))
+	}, listDeployments(t.DeploymentToolset), rbac.AgentRead)
 
-	gomcp.AddTool(server, &gomcp.Tool{
+	addTool(reg, server, &gomcp.Tool{
 		Name: "deploy_agent",
 		Description: "Deploy an existing agent image. " +
 			"A deployment releases a built agent image to the lowest environment in the deployment pipeline. " +
@@ -108,9 +109,9 @@ func (t *Toolsets) registerDeploymentTools(server *gomcp.Server) {
 				"secret_ref":   stringProperty("Optional. Reference to existing secret."),
 			}, []string{"key"})),
 		}, []string{"project_name", "agent_name", "image_id"}),
-	}, withToolLogging("deploy_agent", deployAgent(t.DeploymentToolset)))
+	}, deployAgent(t.DeploymentToolset), rbac.AgentDeployNonProduction)
 
-	gomcp.AddTool(server, &gomcp.Tool{
+	addTool(reg, server, &gomcp.Tool{
 		Name: "update_deployment_state",
 		Description: "Change the state of an agent deployment in a specific environment. " +
 			"`redeploy` requests a fresh rollout of the current deployment, and `undeploy` removes the deployment from that environment.",
@@ -121,7 +122,7 @@ func (t *Toolsets) registerDeploymentTools(server *gomcp.Server) {
 			"environment":  stringProperty("Required. Environment name."),
 			"state":        enumProperty("Required. Desired deployment action for the selected environment.", []string{"redeploy", "undeploy"}),
 		}, []string{"project_name", "agent_name", "environment", "state"}),
-	}, withToolLogging("update_deployment_state", updateDeploymentState(t.DeploymentToolset)))
+	}, updateDeploymentState(t.DeploymentToolset), rbac.AgentSuspend)
 }
 
 func listDeployments(handler DeploymentToolsetHandler) func(context.Context, *gomcp.CallToolRequest, listDeploymentsInput) (*gomcp.CallToolResult, any, error) {

--- a/agent-manager-service/mcp/tools/deployments_specs_test.go
+++ b/agent-manager-service/mcp/tools/deployments_specs_test.go
@@ -16,7 +16,11 @@
 
 package tools
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
+)
 
 // Returns the test specs for tools registered by registerDeploymentTools.
 // New tools added to deployments.go must have a spec here — registration_test.go fails the build otherwise.
@@ -25,6 +29,7 @@ func deploymentToolSpecs() []toolTestSpec {
 		{
 			name:                "list_deployments",
 			toolset:             "deployment",
+			permissions:         []rbac.Permission{rbac.AgentRead},
 			descriptionKeywords: []string{"deployment"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name", "agent_name"},
@@ -50,6 +55,7 @@ func deploymentToolSpecs() []toolTestSpec {
 		{
 			name:                "deploy_agent",
 			toolset:             "deployment",
+			permissions:         []rbac.Permission{rbac.AgentDeployNonProduction},
 			descriptionKeywords: []string{"deploy"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name", "agent_name", "image_id"},
@@ -80,6 +86,7 @@ func deploymentToolSpecs() []toolTestSpec {
 		{
 			name:                "update_deployment_state",
 			toolset:             "deployment",
+			permissions:         []rbac.Permission{rbac.AgentSuspend},
 			descriptionKeywords: []string{"deployment", "state"},
 			descriptionMinLen:   20,
 			requiredParams: []string{

--- a/agent-manager-service/mcp/tools/projects.go
+++ b/agent-manager-service/mcp/tools/projects.go
@@ -24,6 +24,7 @@ import (
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -50,8 +51,8 @@ type listProjectsOutput struct {
 	Projects []listProjectItem `json:"projects"`
 }
 
-func (t *Toolsets) registerProjectTools(server *gomcp.Server) {
-	gomcp.AddTool(server, &gomcp.Tool{
+func (t *Toolsets) registerProjectTools(server *gomcp.Server, reg *toolRegistry) {
+	addTool(reg, server, &gomcp.Tool{
 		Name: "list_projects",
 		Description: "List projects in an organization. " +
 			"A project is a logical container that groups agents and related resources within an organization. " +
@@ -61,9 +62,9 @@ func (t *Toolsets) registerProjectTools(server *gomcp.Server) {
 			"limit":    intProperty(fmt.Sprintf("Optional. Max projects to return (default %d, min %d, max %d).", utils.DefaultLimit, utils.MinLimit, utils.MaxLimit)),
 			"offset":   intProperty(fmt.Sprintf("Optional. Pagination offset (default %d, min %d).", utils.DefaultOffset, utils.MinOffset)),
 		}, nil),
-	}, withToolLogging("list_projects", listProjects(t.ProjectToolset)))
+	}, listProjects(t.ProjectToolset), rbac.ProjectRead)
 
-	gomcp.AddTool(server, &gomcp.Tool{
+	addTool(reg, server, &gomcp.Tool{
 		Name: "create_project",
 		Description: "Create a new project in an organization. " +
 			"A project is a logical container for agents and related resources within an organization.",
@@ -73,7 +74,7 @@ func (t *Toolsets) registerProjectTools(server *gomcp.Server) {
 			"display_name": stringProperty("Required. Project display name."),
 			"description":  stringProperty("Optional. Project description."),
 		}, []string{"project_name", "display_name"}),
-	}, withToolLogging("create_project", createProject(t.ProjectToolset)))
+	}, createProject(t.ProjectToolset), rbac.ProjectCreate)
 }
 
 func listProjects(handler ProjectToolsetHandler) func(context.Context, *gomcp.CallToolRequest, listProjectsInput) (*gomcp.CallToolResult, any, error) {

--- a/agent-manager-service/mcp/tools/projects_specs_test.go
+++ b/agent-manager-service/mcp/tools/projects_specs_test.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"testing"
 
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
@@ -29,6 +30,7 @@ func projectToolSpecs() []toolTestSpec {
 		{
 			name:                "list_projects",
 			toolset:             "project",
+			permissions:         []rbac.Permission{rbac.ProjectRead},
 			descriptionKeywords: []string{"list", "project"},
 			descriptionMinLen:   20,
 			requiredParams:      nil,
@@ -44,6 +46,7 @@ func projectToolSpecs() []toolTestSpec {
 		{
 			name:                "create_project",
 			toolset:             "project",
+			permissions:         []rbac.Permission{rbac.ProjectCreate},
 			descriptionKeywords: []string{"create", "project"},
 			descriptionMinLen:   20,
 			requiredParams:      []string{"project_name", "display_name"},

--- a/agent-manager-service/mcp/tools/register.go
+++ b/agent-manager-service/mcp/tools/register.go
@@ -26,11 +26,15 @@ func (tools *Toolsets) Register(server *gomcp.Server) {
 
 // register is Register minus the exported surface: it returns the registry so
 // same-package tests can assert the tool→permission wiring directly.
-// A nil receiver returns an empty registry without touching the server,
-// matching the old behavior (production always passes a non-nil Toolsets,
-// and NewHTTPServer skips Register entirely for nil toolsets).
+// The fail-closed authorization middleware is installed on the server before
+// the nil-receiver check, so even a server built with nil toolsets (no tools
+// registered at all) denies every tools/call rather than silently having no
+// authz middleware installed. Installing it before any tools are added is
+// safe: sessions only exist after Connect, which happens after Register
+// returns in both production and tests.
 func (tools *Toolsets) register(server *gomcp.Server) *toolRegistry {
 	reg := newToolRegistry()
+	server.AddReceivingMiddleware(reg.authzMiddleware())
 	if tools == nil {
 		return reg
 	}
@@ -46,6 +50,5 @@ func (tools *Toolsets) register(server *gomcp.Server) *toolRegistry {
 	if tools.DeploymentToolset != nil {
 		tools.registerDeploymentTools(server, reg)
 	}
-	server.AddReceivingMiddleware(reg.authzMiddleware())
 	return reg
 }

--- a/agent-manager-service/mcp/tools/register.go
+++ b/agent-manager-service/mcp/tools/register.go
@@ -18,20 +18,34 @@ package tools
 
 import gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
+// Register registers every configured toolset on the server and installs the
+// authorization middleware that enforces each tool's declared permissions.
 func (tools *Toolsets) Register(server *gomcp.Server) {
+	tools.register(server)
+}
+
+// register is Register minus the exported surface: it returns the registry so
+// same-package tests can assert the tool→permission wiring directly.
+// A nil receiver returns an empty registry without touching the server,
+// matching the old behavior (production always passes a non-nil Toolsets,
+// and NewHTTPServer skips Register entirely for nil toolsets).
+func (tools *Toolsets) register(server *gomcp.Server) *toolRegistry {
+	reg := newToolRegistry()
 	if tools == nil {
-		return
+		return reg
 	}
 	if tools.ProjectToolset != nil {
-		tools.registerProjectTools(server)
+		tools.registerProjectTools(server, reg)
 	}
 	if tools.AgentToolset != nil {
-		tools.registerAgentTools(server)
+		tools.registerAgentTools(server, reg)
 	}
 	if tools.BuildToolset != nil {
-		tools.registerBuildTools(server)
+		tools.registerBuildTools(server, reg)
 	}
 	if tools.DeploymentToolset != nil {
-		tools.registerDeploymentTools(server)
+		tools.registerDeploymentTools(server, reg)
 	}
+	server.AddReceivingMiddleware(reg.authzMiddleware())
+	return reg
 }

--- a/agent-manager-service/mcp/tools/registration_test.go
+++ b/agent-manager-service/mcp/tools/registration_test.go
@@ -19,6 +19,8 @@ package tools
 import (
 	"context"
 	"testing"
+
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // Verifies that every tool described by allToolSpecs is actually registered on a fully-wired MCP server.
@@ -40,5 +42,41 @@ func TestToolRegistration(t *testing.T) {
 		if !registered[spec.name] {
 			t.Errorf("expected tool %q not registered", spec.name)
 		}
+	}
+}
+
+// Verifies every tool spec declares permissions and that the registry built by
+// registration matches the specs exactly — a tool added without declaring its
+// permission fails here (and addTool panics before this test even runs).
+func TestToolPermissionsMatchSpecs(t *testing.T) {
+	mock := NewMockToolsetHandler()
+	toolsets := &Toolsets{
+		ProjectToolset:    mock,
+		AgentToolset:      mock,
+		BuildToolset:      mock,
+		DeploymentToolset: mock,
+	}
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "t", Version: "0"}, nil)
+	reg := toolsets.register(server)
+
+	for _, spec := range allToolSpecs {
+		if len(spec.permissions) == 0 {
+			t.Errorf("tool spec %q declares no permissions", spec.name)
+			continue
+		}
+		got := reg.permissions[spec.name]
+		if len(got) != len(spec.permissions) {
+			t.Errorf("tool %q: registered permissions %v, spec expects %v", spec.name, got, spec.permissions)
+			continue
+		}
+		for i := range got {
+			if got[i] != spec.permissions[i] {
+				t.Errorf("tool %q: registered permissions %v, spec expects %v", spec.name, got, spec.permissions)
+				break
+			}
+		}
+	}
+	if len(reg.permissions) != len(allToolSpecs) {
+		t.Errorf("registry has %d tools, specs describe %d", len(reg.permissions), len(allToolSpecs))
 	}
 }

--- a/agent-manager-service/mcp/tools/registration_test.go
+++ b/agent-manager-service/mcp/tools/registration_test.go
@@ -18,6 +18,7 @@ package tools
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -65,18 +66,56 @@ func TestToolPermissionsMatchSpecs(t *testing.T) {
 			continue
 		}
 		got := reg.permissions[spec.name]
-		if len(got) != len(spec.permissions) {
+		if !slices.Equal(got, spec.permissions) {
 			t.Errorf("tool %q: registered permissions %v, spec expects %v", spec.name, got, spec.permissions)
-			continue
-		}
-		for i := range got {
-			if got[i] != spec.permissions[i] {
-				t.Errorf("tool %q: registered permissions %v, spec expects %v", spec.name, got, spec.permissions)
-				break
-			}
 		}
 	}
 	if len(reg.permissions) != len(allToolSpecs) {
 		t.Errorf("registry has %d tools, specs describe %d", len(reg.permissions), len(allToolSpecs))
+	}
+}
+
+// TestNilToolsetsInstallsFailClosedMiddleware verifies that a server built
+// from a nil *Toolsets still gets the authz middleware installed: any
+// tools/call — even one bypassing addTool entirely — is denied.
+func TestNilToolsetsInstallsFailClosedMiddleware(t *testing.T) {
+	setRBACEnabled(t, false) // fail-closed must hold even with RBAC disabled
+
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "test-nil-toolsets", Version: "0.0.1"}, nil)
+	var toolsets *Toolsets
+	toolsets.Register(server)
+
+	// Bypass addTool deliberately: register a tool directly with the SDK.
+	gomcp.AddTool(server, &gomcp.Tool{
+		Name:        "rogue_tool",
+		Description: "registered without going through addTool",
+		InputSchema: createSchema(map[string]any{}, nil),
+	}, func(context.Context, *gomcp.CallToolRequest, struct{}) (*gomcp.CallToolResult, any, error) {
+		return &gomcp.CallToolResult{
+			Content: []gomcp.Content{&gomcp.TextContent{Text: "should never run"}},
+		}, nil, nil
+	})
+
+	ctx := context.Background()
+	clientTransport, serverTransport := gomcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("failed to connect server: %v", err)
+	}
+	client := gomcp.NewClient(&gomcp.Implementation{Name: "test-mcp-client", Version: "0.0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("failed to connect client: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	result, err := session.CallTool(context.Background(), &gomcp.CallToolParams{
+		Name:      "rogue_tool",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("rogue tool executed on a nil-Toolsets server — fail-closed middleware did not deny it")
 	}
 }

--- a/agent-manager-service/mcp/tools/setup_test.go
+++ b/agent-manager-service/mcp/tools/setup_test.go
@@ -18,10 +18,12 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 )
 
 // constants for testing
@@ -53,8 +55,17 @@ func setupTestServer(t *testing.T) (*gomcp.ClientSession, *MockToolsetHandler) {
 // lower-level helper used when a test needs to register only a subset of toolsets
 func setupTestServerWithToolsets(t *testing.T, toolsets *Toolsets) *gomcp.ClientSession {
 	t.Helper()
+	return setupTestServerWithClaims(t, toolsets, &jwtassertion.TokenClaims{
+		OuId:  testOrgName,
+		Scope: unionScopes(),
+	})
+}
 
-	// create an in-memory MCP server with all toolsets registered to the same mock handler
+// lowest-level helper: lets authz tests pin the exact token claims (and
+// therefore scopes) the session context carries.
+func setupTestServerWithClaims(t *testing.T, toolsets *Toolsets, claims *jwtassertion.TokenClaims) *gomcp.ClientSession {
+	t.Helper()
+
 	server := gomcp.NewServer(&gomcp.Implementation{
 		Name:    "test-agent-manager-mcp",
 		Version: "0.0.1",
@@ -62,18 +73,16 @@ func setupTestServerWithToolsets(t *testing.T, toolsets *Toolsets) *gomcp.Client
 
 	toolsets.Register(server)
 
-	// Tools resolve the caller's OU ID from token claims on the connection
-	// context, mirroring how the assertion middleware injects them in prod.
-	ctx := jwtassertion.ContextWithTokenClaims(context.Background(), &jwtassertion.TokenClaims{
-		OuId: testOrgName,
-	})
+	// Claims + scope string on the connection context, mirroring how the
+	// assertion middleware injects them in prod (HasAllScopes reads the
+	// scope key, not the claims struct).
+	ctx := jwtassertion.ContextWithTokenClaimsAndScope(context.Background(), claims)
 	clientTransport, serverTransport := gomcp.NewInMemoryTransports()
 
 	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
 		t.Fatalf("failed to connect server: %v", err)
 	}
 
-	// create an in-memory client and connect to the in-memory MCP server
 	client := gomcp.NewClient(&gomcp.Implementation{
 		Name:    "test-mcp-client",
 		Version: "0.0.1",
@@ -94,6 +103,10 @@ type toolTestSpec struct {
 
 	// Toolset group names, used by partial-registration tests
 	toolset string // "project", "agent", "build", "deployment"
+
+	// Permissions the tool must declare via addTool. Required: the
+	// registration test fails any tool whose spec leaves this empty.
+	permissions []rbac.Permission
 
 	// Description validation.
 	descriptionKeywords []string
@@ -118,3 +131,21 @@ var allToolSpecs = func() []toolTestSpec {
 	specs = append(specs, deploymentToolSpecs()...)
 	return specs
 }()
+
+// unionScopes returns a space-separated scope string covering every
+// permission any tool declares, so wiring tests are never blocked by authz.
+func unionScopes() string {
+	seen := make(map[string]struct{})
+	scopes := make([]string, 0)
+	for _, spec := range allToolSpecs {
+		for _, perm := range spec.permissions {
+			scope := perm.Scope()
+			if _, ok := seen[scope]; ok {
+				continue
+			}
+			seen[scope] = struct{}{}
+			scopes = append(scopes, scope)
+		}
+	}
+	return strings.Join(scopes, " ")
+}

--- a/agent-manager-service/middleware/jwtassertion/test_utils.go
+++ b/agent-manager-service/middleware/jwtassertion/test_utils.go
@@ -87,3 +87,12 @@ func extractOrgFromPath(path string) string {
 	}
 	return ""
 }
+
+// ContextWithTokenClaimsAndScope mirrors what the production auth middleware
+// puts on the request context: the parsed claims AND the raw scope string that
+// HasAllScopes reads. ContextWithTokenClaims alone is not enough for tests that
+// exercise scope checks, because HasAllScopes uses a separate context key.
+func ContextWithTokenClaimsAndScope(ctx context.Context, claims *TokenClaims) context.Context {
+	ctx = ContextWithTokenClaims(ctx, claims)
+	return context.WithValue(ctx, scopesKey, claims.Scope)
+}


### PR DESCRIPTION
## Purpose
The agent-manager MCP server at `/mcp` authenticates callers via the existing JWT middleware, but never checked the `amp:*` OAuth scopes the token carries. Any authenticated user could invoke any MCP tool — e.g. a caller whose roles only grant `amp:project:read` could call `deploy_agent`. There was also no mechanism forcing the author of a new MCP tool to think about authorization, unlike REST routes where every route declares its permission at registration.

## Goals
- Authorize every MCP tool call against the caller's token scopes, using the same `rbac.Permission` vocabulary and semantics as the REST routes.
- Make permission declaration structurally required at tool registration — a tool that skips it fails closed (always denied), never open.
- Honor the `RBAC_ENABLED` kill switch exactly like the REST middleware for consistent rollout.
- Evaluate scopes per request (not per MCP session) and activate the MCP SDK's session-hijack prevention.

## Approach
- **Declaration:** a package-local `addTool` helper (`mcp/tools/authz.go`) replaces direct `gomcp.AddTool` calls. It takes the tool's required `rbac.Permission`(s) as a mandatory argument (ALL semantics), panics at startup if none are declared, and records them in a `toolRegistry`.
- **Enforcement:** `Toolsets.Register` installs a single server-level receiving middleware that intercepts `tools/call`. A tool absent from the registry is denied unconditionally (fail-closed — bypassing the helper yields a tool that always 403s). With `RBAC_ENABLED=true`, every declared permission's scope must be present; denials return an LLM-friendly `IsError` tool result naming the missing scope.
- **Per-request tokens:** the go-sdk derives session context from the initialize-time token, so a `claimsTokenVerifier` (`mcp/tokeninfo.go`) adapts the already-validated JWT claims into the SDK's `auth.TokenInfo` via `auth.RequireBearerToken` nested inside our JWT middleware. This makes scopes evaluable per request (`RequestExtra.TokenInfo`), activates the SDK's session-user binding (403 on session reuse by a different `sub`), and rejects tokens missing `exp` or `sub`.
- All 12 existing tools declare permissions mirroring their REST-route equivalents (e.g. `create_project`→`project:create`, `build_agent`→`agent:build`, `deploy_agent`→`agent:deploy-non-production`, `create_external_agent`→`agent:create`+`agent:token-manage`). No new permissions and no role changes.
- `mcp/README.md` documents the new registration steps.

## User stories
- As a platform operator, I can rely on MCP tool access being governed by the same role/scope model as the Console and REST APIs.
- As a developer adding an MCP tool, I cannot forget authorization — registration without a permission fails tests and startup, and an unregistered tool is denied at runtime.

## Release note
MCP tool calls on the agent-manager server are now authorized against the caller's OAuth scopes (per request), matching REST API permissions; tools registered without declared permissions are denied by default.

## Documentation
`agent-manager-service/mcp/README.md` updated in this PR ("Adding a new tool" now covers permission declaration and the fail-closed behavior). No external product-doc impact — the `/mcp` endpoint's client-facing contract is unchanged apart from denials when scopes are missing.

## Training
N/A — internal platform authorization hardening, no training content impact.

## Certification
N/A — no user-facing feature change requiring certification content; enforcement mirrors the existing REST RBAC model.

## Marketing
N/A — security hardening of an existing feature.

## Automation tests
 - Unit tests
   > New tests in `mcp/tools/authz_test.go`, `mcp/tools/authz_e2e_test.go`, `mcp/tokeninfo_test.go`, plus `TestToolPermissionsMatchSpecs` gating every tool spec to declare permissions. `make test-unit` passes; `mcp` packages at ~54% coverage.
 - Integration tests
   > End-to-end tests run real in-memory MCP client/server sessions through the actual middleware: allowed-with-scope, denied-without-scope (handler not invoked), RBAC-disabled bypass, multi-permission partial-scope denial, rogue-tool fail-closed proof (tool registered via raw `gomcp.AddTool` is denied), and a full HTTP-chain test proving per-request `TokenInfo` delivery. `go build -tags=integration ./...` compiles clean.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no (Java-only tool; this is Go — `golangci-lint` with the repo's CI config passes with 0 issues)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes; existing MCP quick-start in `mcp/README.md` still applies.

## Related PRs
None.

## Migrations (if applicable)
None — no schema or config changes. With `RBAC_ENABLED=false` (default) behavior is unchanged except that unregistered tools are now denied; with it enabled, callers whose roles grant the equivalent REST permissions keep working since the scopes are identical.

## Test environment
Go 1.x (repo toolchain) on macOS (darwin/arm64); unit tier only (no database required).

## Learning
The go-sdk (`modelcontextprotocol/go-sdk` v1.5.0) derives all session method-call contexts from the initialize request, and its session-hijack guard only activates when `auth.TokenInfo` is present on the request context — verified against the vendored SDK source. This shaped the decision to nest `auth.RequireBearerToken` inside the existing JWT middleware and prefer per-request `RequestExtra.TokenInfo` scopes over session-context checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.0 authorization with PKCE for MCP connections.
  * Added permission-based access controls for MCP tools.
  * Tool requests now verify required permissions and deny unauthorized calls.
  * Added fail-closed protection for tools without registered permissions.
  * MCP tool documentation now explains authorization requirements and setup steps.

* **Tests**
  * Added coverage for token handling, permission checks, multi-permission tools, and unauthorized access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->