### PR TITLE
Harden dependency-validation workflow

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -24,15 +24,25 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
+
+      - name: Fetch PR head as data
+        run: |
+          git fetch --no-tags origin \
+            "pull/${{ github.event.pull_request.number }}/head:pr-head"
 
       - name: Detect modified go.mod files
         id: detect-changes
         run: |
           # Get the base branch SHA
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          # Pin to the event SHA and verify the fetched ref matches, so detection
+          # and validation use the same commit even if the PR head moved.
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          FETCHED_SHA="$(git rev-parse pr-head)"
+          if [ "$HEAD_SHA" != "$FETCHED_SHA" ]; then
+            echo "::error::PR head moved after the workflow was triggered (event: $HEAD_SHA, fetched: $FETCHED_SHA). Re-run the workflow."
+            exit 1
+          fi
 
           echo "Comparing $BASE_SHA...$HEAD_SHA"
 
@@ -73,7 +83,7 @@ jobs:
 
       - name: Comment on PR - Validation Failed
         if: steps.validate.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -140,7 +150,7 @@ jobs:
 
       - name: Comment on PR - Validation Passed
         if: steps.validate.outcome == 'success' && steps.detect-changes.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Purpose

Fixes the `Dependency Validation` workflow, which was failing at checkout and carried a security risk.

## Changes

- **Remove the unsafe fork checkout.** The `pull_request_target` job checked out fork code via `head.sha` with `allow-unsafe-pr-checkout: true`, exposing the trusted `GITHUB_TOKEN` and secrets to untrusted PR code (a "pwn request" risk). It now checks out the base repo and fetches the PR head as a git ref, so the fork's `go.mod` is analyzed as data and never executed.
- **Fix invalid fetch depth.** Removed `--depth=0` (not a valid depth); full history is already available via `fetch-depth: 0` on the checkout step.
- **Bump `actions/github-script` from v7 to v8** to run on Node 24 and clear the Node 20 deprecation warning.

No change to the validation logic or PR-gating behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency validation for pull requests from forked repositories.
  * Validation now compares dependency file changes safely against the pull request base.
  * Updated pull request validation comments to use the latest supported scripting action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->