### PR TITLE
Fix env-Thunder provisioning on VM installs

### DIFF
--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -275,12 +275,17 @@ install_default_env_thunder() {
         script_base_url="$(dirname "$script_url")"
     fi
 
-    # AMP_API_URL uses the host-facing ingress (this runs off-cluster, not the
-    # gateway Job's in-cluster DNS); AMS is confirmed healthy before this runs.
+    # AMP_API_URL and IDP_TOKEN_URL address the host-facing ingress (this runs
+    # off-cluster, not on the gateway Job's in-cluster DNS); AMS is confirmed
+    # healthy before this runs. The localhost defaults hold only where the routes
+    # are still bound to *.amp.localhost — a deployment that rehosts them (the VM
+    # installers publish *.amp.<host> instead) must export both, or the route
+    # match fails with a 404 and no env-Thunder is ever created.
     ENV_NAME=default \
         DISPLAY_NAME="Default" \
         ORG_NAME=default \
-        AMP_API_URL="http://api.amp.localhost:8080/api/v1" \
+        AMP_API_URL="${AMP_API_URL:-http://api.amp.localhost:8080/api/v1}" \
+        IDP_TOKEN_URL="${IDP_TOKEN_URL:-http://thunder.amp.localhost:8080/oauth2/token}" \
         SCRIPT_BASE_URL="${script_base_url}" \
         bash "${script_path}"
     local status=$?

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1567,7 +1567,19 @@ if ! install_default_env_thunder; then
     echo "  ENV_NAME=default DISPLAY_NAME=Default ORG_NAME=default \\"
     echo "  AMP_API_URL=${AMP_API_URL:-http://api.amp.localhost:8080/api/v1} \\"
     echo "  IDP_TOKEN_URL=${IDP_TOKEN_URL:-http://thunder.amp.localhost:8080/oauth2/token} \\"
-    echo "  bash ${DEPLOYMENTS_DIR}/scripts/add-environment-thunder.sh"
+    # install_default_env_thunder() prefers the bundled script and falls back to
+    # downloading it; a standalone (curl-piped) install has no scripts/ directory,
+    # so pointing at the bundled path there would send the operator to a file that
+    # does not exist. Name the release copy instead, and pass SCRIPT_BASE_URL so
+    # the script fetches its own siblings from that same release rather than main.
+    env_thunder_script="${DEPLOYMENTS_DIR}/scripts/add-environment-thunder.sh"
+    if [[ -f "${env_thunder_script}" ]]; then
+        echo "  bash ${env_thunder_script}"
+    else
+        env_thunder_base="https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts"
+        echo "  SCRIPT_BASE_URL=${env_thunder_base} \\"
+        echo "  bash <(curl -fsSL ${env_thunder_base}/add-environment-thunder.sh)"
+    fi
     exit 1
 fi
 log_success "Default environment Thunder identity provider provisioned"

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1555,16 +1555,23 @@ echo ""
 
 log_info "Provisioning Thunder identity provider for the default environment..."
 ENV_THUNDER_PROVISIONED=false
+# Fatal: without env-Thunder the gateway extension silently skips its
+# ThunderKeyManager identity provider (install_gateway_extension only sets
+# bootstrap.identityProviders when this release exists), so the gateway keeps a
+# keymanager that Agent Manager has no mirror row for. That drift surfaces much
+# later as an empty Identity Providers page, long after the installer claimed
+# success — fail here instead, while the cause is still on screen.
 if ! install_default_env_thunder; then
-    log_warning "Default environment Thunder provisioning failed (non-fatal)"
+    log_error "Default environment Thunder provisioning failed"
     echo "Re-run manually once the platform is ready:"
     echo "  ENV_NAME=default DISPLAY_NAME=Default ORG_NAME=default \\"
-    echo "  AMP_API_URL=http://api.amp.localhost:8080/api/v1 \\"
+    echo "  AMP_API_URL=${AMP_API_URL:-http://api.amp.localhost:8080/api/v1} \\"
+    echo "  IDP_TOKEN_URL=${IDP_TOKEN_URL:-http://thunder.amp.localhost:8080/oauth2/token} \\"
     echo "  bash ${DEPLOYMENTS_DIR}/scripts/add-environment-thunder.sh"
-else
-    log_success "Default environment Thunder identity provider provisioned"
-    ENV_THUNDER_PROVISIONED=true
+    exit 1
 fi
+log_success "Default environment Thunder identity provider provisioned"
+ENV_THUNDER_PROVISIONED=true
 echo ""
 
 # Install observability extension

--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -217,10 +217,14 @@ run_advanced_install() {
   export PLATFORM_THUNDER_ISSUER="https://${AMP_HOST_THUNDER}"
   export PLATFORM_THUNDER_JWKS_URL="https://${AMP_HOST_THUNDER}/oauth2/jwks"
   # install_default_env_thunder() runs off-cluster and calls both the AMP API and
-  # platform Thunder's token endpoint over the host-facing ingress; its localhost
-  # defaults 404 here because the routes are bound to the custom-domain hosts.
-  export AMP_API_URL="https://${AMP_HOST_API}/api/v1"
-  export IDP_TOKEN_URL="https://${AMP_HOST_THUNDER}/oauth2/token"
+  # platform Thunder's token endpoint. Its *.amp.localhost defaults 404 here, since
+  # this install binds those routes to the custom-domain hosts. Address them by
+  # their real hostnames on the control-plane kgateway's loopback port: the
+  # consolidated :443 listener does not exist yet (apply_advanced_tls runs only
+  # after the base installer returns), so an HTTPS URL would refuse the connection.
+  ensure_loopback_alias "$AMP_HOST_API" "$AMP_HOST_THUNDER"
+  export AMP_API_URL="http://${AMP_HOST_API}:8080/api/v1"
+  export IDP_TOKEN_URL="http://${AMP_HOST_THUNDER}:8080/oauth2/token"
 
   # k3d: publish :443 (the consolidated gateway) to the host; keep the plane ports
   # loopback-bound (only :443 faces the network). Render to mktemp files, not fixed

--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -216,6 +216,11 @@ run_advanced_install() {
   export SKIP_CA_BUNDLE_TRUST=true
   export PLATFORM_THUNDER_ISSUER="https://${AMP_HOST_THUNDER}"
   export PLATFORM_THUNDER_JWKS_URL="https://${AMP_HOST_THUNDER}/oauth2/jwks"
+  # install_default_env_thunder() runs off-cluster and calls both the AMP API and
+  # platform Thunder's token endpoint over the host-facing ingress; its localhost
+  # defaults 404 here because the routes are bound to the custom-domain hosts.
+  export AMP_API_URL="https://${AMP_HOST_API}/api/v1"
+  export IDP_TOKEN_URL="https://${AMP_HOST_THUNDER}/oauth2/token"
 
   # k3d: publish :443 (the consolidated gateway) to the host; keep the plane ports
   # loopback-bound (only :443 faces the network). Render to mktemp files, not fixed

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -125,6 +125,12 @@ run_install() {
   export SKIP_CA_BUNDLE_TRUST=true
   export PLATFORM_THUNDER_ISSUER="https://${thunder_host_full}"
   export PLATFORM_THUNDER_JWKS_URL="https://${thunder_host_full}/oauth2/jwks"
+  # install_default_env_thunder() runs off-cluster and calls both the AMP API and
+  # platform Thunder's token endpoint over the host-facing ingress. Its localhost
+  # defaults resolve here but 404: the k3d loopback ports answer, while the routes
+  # are bound to the sslip.io hosts below, so no hostname matches.
+  export AMP_API_URL="https://$(vm_host api "$VM_IP")/api/v1"
+  export IDP_TOKEN_URL="https://${thunder_host_full}/oauth2/token"
 
   # Loopback-bound k3d config.
   render_k3d_vm_config <"${QS_DIR}/k3d-config.yaml" >/tmp/k3d-config-vm.yaml

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -126,11 +126,17 @@ run_install() {
   export PLATFORM_THUNDER_ISSUER="https://${thunder_host_full}"
   export PLATFORM_THUNDER_JWKS_URL="https://${thunder_host_full}/oauth2/jwks"
   # install_default_env_thunder() runs off-cluster and calls both the AMP API and
-  # platform Thunder's token endpoint over the host-facing ingress. Its localhost
-  # defaults resolve here but 404: the k3d loopback ports answer, while the routes
-  # are bound to the sslip.io hosts below, so no hostname matches.
-  export AMP_API_URL="https://$(vm_host api "$VM_IP")/api/v1"
-  export IDP_TOKEN_URL="https://${thunder_host_full}/oauth2/token"
+  # platform Thunder's token endpoint. Its *.amp.localhost defaults resolve here
+  # but 404, because this install binds those routes to the sslip.io hosts. Address
+  # them by their real hostnames on the control-plane kgateway's loopback port:
+  # Caddy is not up yet (start_caddy runs only after the base installer returns),
+  # so :443 would simply refuse the connection. ensure_loopback_alias makes the
+  # hostname resolve to 127.0.0.1 so the Host header still matches the route.
+  local api_host; api_host="$(vm_host api "$VM_IP")"
+  [[ -n "$api_host" ]] || die "could not derive the API host for ${VM_IP}"
+  ensure_loopback_alias "$api_host" "$thunder_host_full"
+  export AMP_API_URL="http://${api_host}:8080/api/v1"
+  export IDP_TOKEN_URL="http://${thunder_host_full}:8080/oauth2/token"
 
   # Loopback-bound k3d config.
   render_k3d_vm_config <"${QS_DIR}/k3d-config.yaml" >/tmp/k3d-config-vm.yaml

--- a/deployments/vm/lib-bootstrap.sh
+++ b/deployments/vm/lib-bootstrap.sh
@@ -71,7 +71,29 @@ ensure_firewall() {
   else
     log "No ufw/firewalld found; assuming the host firewall is open for ${port}"
   fi
-  log "Ensure inbound ${port}/tcp is open in your cloud security group (raw TCP, no TLS-terminating proxy in front) — Caddy needs it."
+  log "Ensure inbound ${port}/tcp is open in your cloud security group (raw TCP, no TLS-terminating proxy in front) — the TLS listener needs it."
+}
+
+# ensure_loopback_alias HOST... — points each hostname at 127.0.0.1 in /etc/hosts.
+#
+# The installer has to call the platform through its own routes before the public
+# TLS listener exists (Caddy and the consolidated gateway are both brought up only
+# after the base installer returns). The plane ports are loopback-bound, so the
+# request has to go to 127.0.0.1 while still carrying the route's hostname in the
+# Host header — which is exactly what resolving the hostname to loopback gives us.
+# Entries stay after the install: the host resolving its own service names to
+# itself is what a caller on this VM wants anyway.
+ensure_loopback_alias() {
+  local host entry
+  for host in "$@"; do
+    [[ -n "$host" ]] || continue
+    entry="127.0.0.1 ${host}"
+    # Exact-line match: only ever matches an entry this helper wrote, so a
+    # hostname already mapped elsewhere is left alone rather than duplicated.
+    grep -qxF "$entry" /etc/hosts 2>/dev/null && continue
+    printf '%s\n' "$entry" >>/etc/hosts
+    log "Mapped ${host} to 127.0.0.1 for in-install API calls"
+  done
 }
 
 ensure_disk() {


### PR DESCRIPTION
## Purpose

A VM install completes and reports success, but the console's **Identity Providers** page is empty and the platform gateway ends up holding a `ThunderKeyManager` key manager that Agent Manager has no mirror row for.

The trigger is `install_default_env_thunder()`, which hardcoded the Agent Manager API URL to `api.amp.localhost:8080` and inherited the same `*.amp.localhost` default for the token endpoint. Those hold for a quick-start install, where the routes really are bound to `*.amp.localhost`. The VM installers rebind every route to a public host, so the loopback ports still answer but no route hostname matches and the calls return 404. Provisioning aborts before the env-Thunder release is ever created.

Because the step was non-fatal, the installer logged a warning and carried on to a success banner. The consequence only became visible much later, well after the cause had scrolled off screen: `install_gateway_extension()` sets `bootstrap.identityProviders` only when the env-Thunder release exists, so the gateway bootstrap job seeded an empty list and the `gateway_identity_providers` mirror table stayed empty.

Related: https://github.com/wso2/agent-manager/issues/1329

## Goals

Make the default-environment Thunder provisioning work on installs that publish routes on a host other than `*.amp.localhost`, and stop a failure in that step from silently producing a half-configured platform that still claims to have installed cleanly.

## Approach

`install_default_env_thunder()` now honors caller-provided `AMP_API_URL` and `IDP_TOKEN_URL`, falling back to the existing localhost values so quick-start behavior is unchanged. Both VM entrypoints export the host-facing values alongside the env-Thunder settings they already export (`THUNDER_HOST_BASE_DOMAIN`, `PLATFORM_THUNDER_ISSUER`, and friends): `install-vm.sh` derives them from `vm_host`, and `install-advanced.sh` from the configured domain hosts.

The provisioning failure is now fatal. The drift it causes is invisible at install time and expensive to diagnose later, so failing while the error is still on screen is the better trade. The re-run hint printed on failure now echoes the URLs actually in effect rather than the localhost pair, which would simply fail again on a VM.

## User stories

As an operator installing Agent Manager on a VM, the default environment's identity provider is registered so that the console lists it and agent tokens validate against a key manager Agent Manager knows about.

## Release note

Fixed default-environment Thunder provisioning failing on VM installs, which left the platform gateway's identity provider unregistered in Agent Manager.

## Documentation

N/A — no user-facing behavior or documented flag changes; this restores the intended behavior of an existing install step.

## Training

N/A — no training content impact.

## Certification

N/A — installer-internal fix with no impact on certification exam content.

## Marketing

N/A — bug fix with no marketing impact.

## Automation tests

- Unit tests
  > `deployments/vm/tests/run.sh` passes in full. The suite covers the VM installer's rendering and validation logic; these changes add exported environment variables and do not alter any rendered manifest, so no assertions changed.
- Integration tests
  > Verified manually against a live VM install (see Test environment). Reproduced the original failure using the released scripts, confirmed the same script succeeds with host-facing URLs, and confirmed the `helm status` guard in `install_gateway_extension()` flips from failing to passing, which is what gates `bootstrap.identityProviders`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — shell scripts only, no Java sources are touched.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no samples relate to this change.

## Related PRs

None.

## Migrations (if applicable)

None required. Existing installs affected by this bug can be repaired in place by re-running `deployments/scripts/add-environment-thunder.sh` with `AMP_API_URL` and `IDP_TOKEN_URL` pointed at the install's host-facing ingress; the script is idempotent.

## Test environment

Ubuntu 26.04 LTS VM (4 vCPU, 8 GB RAM), Docker 29.6.2, k3d 5.9.0, kubectl 1.36.2, Helm 3.21.3, k3s 1.32.9. Verified against the `1.0.0-alpha1` chart release. Bash syntax checked with `bash -n` on all four modified scripts.

## Learning

The failure mode is worth noting for similar install steps: this step runs off-cluster and therefore depends on the host-facing ingress, while neighboring steps run in-cluster and use cluster DNS. Any hardcoded `*.localhost` URL in an off-cluster step is a latent bug for every deployment that rehosts its routes. The non-fatal handling is what turned a clear 404 into a puzzle discovered much later, at a place far removed from the cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick-start and VM installation reliability by using host-accessible API and identity-provider endpoints.
  * Installation now correctly supports custom-domain and VM ingress routes instead of local defaults.
  * Identity-provider provisioning failures now stop installation and provide clear commands for manual recovery.
  * Added clearer setup guidance for required hostnames and endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->