### PR TITLE
Grant the monitor scheduler namespace:view

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/authz-cluster-role.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/authz-cluster-role.yaml
@@ -3,6 +3,10 @@
 # Grants only the actions required to create and monitor WorkflowRuns in OpenChoreo.
 # workflowrun:create → CreateWorkflowRun (org-bound tokens require this explicit action)
 # workflowrun:view   → GetWorkflowRun
+# namespace:view     → ListNamespaces, which ResolveNamespace calls to map the org to its
+#                      OpenChoreo namespace before building the WorkflowRun. Without it the
+#                      list comes back authorized-but-empty rather than 403, so a scheduled
+#                      run fails with "no organization found for namespace resolution".
 # Note: ExpireWorkflowRun (workflowrun:update) is called by the system client on monitor
 # deletion, not by the org-bound publisher app — so it is intentionally omitted here.
 apiVersion: openchoreo.dev/v1alpha1
@@ -18,3 +22,4 @@ spec:
   actions:
     - workflowrun:create
     - workflowrun:view
+    - namespace:view


### PR DESCRIPTION
## Purpose

Scheduled (`future`) monitors are created successfully but never run. Every scheduler cycle picks them up and fails, so `next_run_time` stays frozen at its creation value and no run rows are produced. From the console the monitor simply looks created-but-idle.

The scheduler logs the cause once a minute, per monitor:

```
INFO  Found monitors to trigger  count=2
ERROR Failed to execute monitor run  error="no organization found for namespace resolution"
ERROR Failed to trigger monitor  monitor=future-monitor  error="no organization found for namespace resolution"
```

`ExecuteMonitorRun` resolves the org's OpenChoreo namespace before it can build the WorkflowRun, and that resolution lists namespaces. The scheduler makes that call with the per-org publisher app (`amp-publisher-<ouid>`), which is bound to the `amp-monitor-scheduler` ClusterAuthzRole. That role granted only `workflowrun:create` and `workflowrun:view`.

Two things made this hard to see. The namespace list comes back **authorized but filtered to empty** rather than `403`, so the code takes the `len(orgs) == 0` branch and reports a *resolution* failure rather than a *permission* one. And monitors of type `past` are unaffected, because they execute inline on the API request, which injects no org-bound client and therefore falls back to the system client whose rights already cover the lookup — so only the scheduled path is broken.

## Goals

Let the monitor scheduler resolve the org namespace it already needs, so scheduled monitors actually run.

## Approach

Add `namespace:view` to the `amp-monitor-scheduler` ClusterAuthzRole. This is the same action the built-in `namespace-reader` role uses for listing namespaces, and it is the minimum needed for the resolution step. The role stays otherwise unchanged and still omits `workflowrun:update`, which the system client performs on monitor deletion.

## User stories

As an operator, a monitor I schedule to run on an interval actually executes on that interval instead of silently never starting.

## Release note

Fixed scheduled evaluation monitors never running because the monitor scheduler lacked permission to resolve the organization's namespace.

## Documentation

N/A — no user-facing configuration changes; this restores intended behavior of an existing feature.

## Training

N/A — no training content impact.

## Certification

N/A — no impact on certification exam content.

## Marketing

N/A — bug fix.

## Automation tests

- Unit tests
  > N/A — the change is a declarative permission in a Helm template with no branching logic to unit test. `helm template` renders the role with the added action.
- Integration tests
  > Verified on a live install. With two scheduled monitors stuck in the failing state, adding `namespace:view` to the live ClusterAuthzRole caused the very next scheduler cycle to succeed, with no code change or restart:
  > ```
  > 13:29:42 ERROR Failed to trigger monitor  monitor=future-monitor  "no organization found..."
  > 13:30:42 INFO  Monitor triggered successfully  monitor=future-monitor  workflowRunName=future-monitor-bd0fef4f
  > 13:30:42 INFO  Monitor triggered successfully  monitor=mon-futer-2     workflowRunName=mon-futer-2-548f92dd
  > ```
  > Both monitors produced `monitor_runs` rows and `next_run_time` advanced to the following interval.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java sources touched.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Note on least privilege: this widens the scheduler role by one read-only action. It is a view on namespaces the scheduler must already map to in order to submit a WorkflowRun, and no write actions are added.

## Samples

N/A — no samples relate to this change.

## Related PRs

None.

## Migrations (if applicable)

None required. Existing installs pick the action up when the platform-resources extension chart is upgraded; the scheduler retries every cycle, so previously stuck monitors resume on the next tick with no manual intervention.

## Test environment

Ubuntu 26.04 LTS VM, k3d 5.9.0 / k3s 1.32.9, Helm 3.21.3, verified against the `1.0.0-alpha1` chart release.

## Learning

Worth noting for similar authz work: a list endpoint that filters by permission returns an empty result rather than an error, so a missing read action surfaces as a downstream "not found" far from its cause. Where a resolution step can only fail because the caller could not see anything, distinguishing "no results" from "not allowed to see results" would point straight at the role.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled workflow execution by enabling required namespace visibility.
  * Prevented authorized scheduled runs from appearing empty or failing during namespace resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->