### PR TITLE
Correct the VM installation guide for both install paths

### DIFF
--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -27,7 +27,7 @@ Install Agent Manager on a Linux VM where Docker is the only host dependency. Pi
 <Tabs groupId="vm-installer">
 <TabItem value="simple" label="Simple (IP + automatic TLS)" default>
 
-The simple installer exposes the platform over HTTPS using [sslip.io](https://sslip.io) hostnames derived from the VM's public IP, so there's no domain registration and no client `/etc/hosts` edits.
+The simple installer exposes the platform over HTTPS using [sslip.io](https://sslip.io) hostnames derived from the VM's public IP, so there's no domain registration.
 
 ## Prerequisites
 
@@ -111,6 +111,7 @@ flowchart TB
             api["amp-api"]
             thunder["Thunder OAuth"]
             cp["Gateway control plane<br/>(external AI gateways)"]
+            envthunder["Per-environment Thunder"]
             observer["Agent Manager Observer"]
             gw["AI Gateway<br/>OTel ingest · LLM proxy"]
             agents["Deployed agents"]
@@ -120,28 +121,37 @@ flowchart TB
     browser -->|"HTTPS :443"| caddy
     le <-->|"TLS-ALPN-01<br/>inside the :443 handshake"| caddy
     caddy -->|"console.amp.&lt;IP&gt;.sslip.io<br/>api.amp.&lt;IP&gt;.sslip.io<br/>thunder.amp.&lt;IP&gt;.sslip.io<br/>cp.amp.&lt;IP&gt;.sslip.io"| cpgw
+    caddy -->|"*.thunder.amp.&lt;IP&gt;.sslip.io<br/>on-demand TLS"| cpgw
     caddy -->|"observer.amp.&lt;IP&gt;.sslip.io"| opgw
     caddy -->|"gateway.amp.&lt;IP&gt;.sslip.io<br/>*.agents.&lt;IP&gt;.sslip.io<br/>on-demand TLS"| dpgw
     cpgw --> console
     cpgw --> api
     cpgw --> thunder
     cpgw --> cp
+    cpgw --> envthunder
     opgw --> observer
     dpgw --> gw
     dpgw --> agents
 ```
 
-Every public hostname resolves to the VM's IP (via sslip.io) and arrives at Caddy on `:443`; Caddy terminates TLS and reverse-proxies to the matching loopback port. The Agent Manager services are ClusterIP inside the cluster: Caddy forwards the console, API, Thunder, and gateway-control-plane hosts to the OpenChoreo control-plane kgateway (loopback `:8080`), the observer host to the observability-plane kgateway (loopback `:11080`), and the OTel-ingest host plus the deployed-agent wildcard to the data-plane kgateway (loopback `:19080`) — each gateway routes by the preserved `Host` header. Certificates are obtained over that same `:443` using the TLS-ALPN-01 challenge, so no inbound port 80 is needed. The deployed-agent wildcard gets its certificate on demand at first request.
+Every public hostname resolves to the VM's IP (via sslip.io) and arrives at Caddy on `:443`; Caddy terminates TLS and reverse-proxies to the matching loopback port. The Agent Manager services are ClusterIP inside the cluster: Caddy forwards the console, API, Thunder, gateway-control-plane, and per-environment Thunder hosts to the OpenChoreo control-plane kgateway (loopback `:8080`), the observer host to the observability-plane kgateway (loopback `:11080`), and the OTel-ingest host plus the deployed-agent wildcard to the data-plane kgateway (loopback `:19080`) — each gateway routes by the preserved `Host` header. Certificates are obtained over that same `:443` using the TLS-ALPN-01 challenge, so no inbound port 80 is needed.
+
+Two of these tiers are **dynamic** — a new host appears the first time you deploy into a new org/project, and each time you create an environment — so a wildcard certificate cannot be issued for them via TLS-ALPN-01 up front. Caddy instead issues one concrete certificate per hostname **on demand**, at the first request to it.
 
 | URL | Purpose |
 |---|---|
 | `https://console.amp.<IP>.sslip.io` | Console UI |
 | `https://api.amp.<IP>.sslip.io` | Agent Manager API (used by `amctl`) |
 | `https://thunder.amp.<IP>.sslip.io` | Thunder OAuth (login) |
+| `https://<org>-<env>.thunder.<IP>.sslip.io` | Per-environment Thunder (one host per environment, created on demand) |
 | `https://observer.amp.<IP>.sslip.io` | Agent Manager Observer |
-| `https://gateway.amp.<IP>.sslip.io/otel` | OTel trace ingest from deployed agents |
+| `https://gateway.amp.<IP>.sslip.io/otel` | OTel trace ingest for **externally-hosted** agents (see below) |
 | `https://<org>-<project>.agents.<IP>.sslip.io/...` | Deployed-agent invocation endpoints (one wildcard host per org/project) |
 | `https://cp.amp.<IP>.sslip.io` | Gateway control plane; connect external gateways here (on by default) |
+
+:::note Agents deployed on this VM do not use the public OTel host
+`gateway.amp.<IP>.sslip.io/otel` exists for agents running **outside** the platform, which set [`AMP_OTEL_ENDPOINT`](../components/amp-instrumentation.mdx) themselves. Agents deployed by Agent Manager run inside the cluster and export their traces straight to the in-cluster gateway runtime instead, so their traffic never leaves the VM or passes through Caddy.
+:::
 
 ## Log in
 
@@ -153,7 +163,9 @@ The **`admin`** account is provisioned with the `Agent Manager Admin` role durin
 
 When you deploy an agent, its endpoint is published on a per-project host `<org>-<project>.agents.<IP>.sslip.io` and routed by Caddy to the OpenChoreo data-plane gateway. Because these hostnames are dynamic (a new one per org/project), Caddy issues their TLS certificates **on demand** at the first request (via the same ACME challenge as the fixed hosts), rather than up front. Invocations are authenticated with a user token that the gateway validates against the public Thunder issuer.
 
-Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error**, most visibly `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` in Chrome. That first connection is consumed by Caddy answering the ACME challenge, so the browser briefly sees the challenge certificate instead of the real one. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host; the certificate is then cached in the `amp-caddy-data` volume.
+Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error**. That first connection is consumed by Caddy answering the ACME challenge, so the client briefly sees the challenge certificate instead of the real one. Every client hits this — only the wording differs: Chromium-based browsers (Chrome, Edge, Brave) report `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED`, while other browsers and command-line clients report their own untrusted-certificate error. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host; the certificate is then cached in the `amp-caddy-data` volume.
+
+The same applies to the per-environment Thunder hosts (`<org>-<env>.thunder.<IP>.sslip.io`): they are created when you add an environment and get their certificates on demand the same way, so the first request to a brand-new environment's Thunder can show the same one-time error.
 
 amp-api advertises each agent endpoint with the `https://` scheme (the installer sets `tlsEnabled` on the service), so the console (and any other caller) invokes it over TLS directly through the wildcard site.
 
@@ -165,16 +177,17 @@ Because the challenge happens inside the TLS handshake, the public `:443` must r
 
 ## Persistence and teardown
 
-Application data (PostgreSQL), issued certificates, and the k3d cluster persist across Docker/host restarts via named volumes. To tear down completely, delete the cluster, then remove the Caddy front door and its volumes (which hold the issued certificates and ACME account):
+Application data (PostgreSQL), issued certificates, and the k3d cluster persist across Docker/host restarts via named volumes. Everything the installer created lives either inside the k3d cluster or in the Caddy container and its two volumes, so tearing down is the three commands below, plus one optional cleanup:
 
 ```bash
-cd agent-manager/deployments/quick-start
-sudo ./uninstall.sh --delete-cluster                    # delete the k3d cluster (workloads + app data)
+sudo k3d cluster delete amp-local                        # delete the cluster (workloads + app data)
 sudo docker rm -f amp-caddy                              # remove the Caddy front door
 sudo docker volume rm amp-caddy-data amp-caddy-config    # drop the cached certs + ACME account
+
+sudo rm -f /opt/amp/Caddyfile                            # optional: the generated Caddy config
 ```
 
-Use `sudo`; the installer runs Docker and k3d as root. Plain `./uninstall.sh` (without `--delete-cluster`) only removes the Helm releases and leaves the cluster running; `uninstall.sh` does not touch the Caddy container or its volumes, so remove those separately as shown.
+Use `sudo`; the installer runs Docker and k3d as root. Note that the installer leaves no repository checkout on the VM — `bootstrap.sh` unpacks the versioned bundle into a temporary directory and deletes it on exit — so teardown is done with the commands above rather than an uninstall script. Deleting the cluster removes the platform's data; deleting the Caddy volumes discards the issued certificates and the ACME account, so a reinstall re-requests them from Let's Encrypt (which counts against its rate limits).
 
 ## Connect an external gateway
 
@@ -187,7 +200,7 @@ Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `h
 - **Certificates never issue / hosts unreachable from outside.** Open inbound `:443` in your cloud security group / NACL, and make sure the public `:443` reaches the VM as **raw TCP**: a TLS-terminating load balancer in front breaks the TLS-ALPN-01 challenge. The installer can't verify external reachability from inside the VM, so this surfaces as Caddy failing to obtain certificates (`docker logs amp-caddy`).
 - **Certificate not issued.** Check `docker logs amp-caddy`. Let's Encrypt rate limits on sslip.io are high but not infinite; if hit, retry shortly.
 - **Login redirect mismatch.** Confirm you reached the console via its `console.amp.<IP>.sslip.io` URL, not the raw IP.
-- **Certificate error on first agent invocation** (`ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` or similar): the per-agent certificate is issued on demand, and the first request races with that issuance. Reload the page after a second or two; it only happens once per new agent host (see [Deployed-agent invocation](#deployed-agent-invocation)).
+- **Certificate error on first agent invocation** (`ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` in Chromium-based browsers, an untrusted-certificate warning elsewhere): the per-agent certificate is issued on demand, and the first request races with that issuance. Reload the page after a second or two; it only happens once per new agent host (see [Deployed-agent invocation](#deployed-agent-invocation)).
 
 </TabItem>
 <TabItem value="advanced" label="Advanced">

--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -192,7 +192,9 @@ Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `h
 </TabItem>
 <TabItem value="advanced" label="Advanced">
 
-The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you have your own domain. It issues **publicly-trusted certificates** via cert-manager's ACME **DNS-01** challenge and terminates TLS on `:443` at the in-cluster gateway (no Caddy). Because DNS-01 validates by writing a DNS TXT record rather than by connecting to the VM, the same flow works whether the VM is **public** or reachable only from a **private network** — issuance needs outbound access only.
+The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you have your own domain. It issues **publicly-trusted certificates** via cert-manager's ACME **DNS-01** challenge and terminates TLS on `:443` at a single in-cluster gateway. Because DNS-01 validates by writing a DNS TXT record rather than by connecting to the VM, the same flow works whether the VM is **public** or reachable only from a **private network** — issuance needs outbound access only.
+
+Setup is the same for both up to and including the install; only how clients reach the VM differs. Work through [Prerequisites](#adv-prerequisites), [Configure](#adv-configure), and [Install](#adv-install), then follow either [Public network](#adv-public) or [Private network](#adv-private).
 
 If you just want a quick IP-based demo with automatic TLS, prefer the **Simple** tab.
 
@@ -205,12 +207,7 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 
 ## Configure {#adv-configure}
 
-The config file is plain shell. Fetch the bootstrap script and create an `amp-config.env` from the keys below (the installer's `--init` also emits an annotated template):
-
-```bash
-# on the VM
-curl -fsSL https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-dev/bootstrap.sh -o bootstrap.sh
-```
+The config file is plain shell — one `KEY=value` assignment per line. Generate an annotated template with `install-advanced.sh --init` (see [Install](#adv-install) for how to get the script), then fill in the keys below. Keep the file `chmod 600`: it holds your DNS-provider credential.
 
 | Key | Required | Purpose |
 |---|---|---|
@@ -223,7 +220,7 @@ curl -fsSL https://github.com/wso2/agent-manager/releases/download/amp/v0.0.0-de
 | `HOST_CONSOLE`, `HOST_API`, `HOST_THUNDER`, `HOST_OBSERVER`, `HOST_GATEWAY`, `HOST_CP` | no | Override an individual service hostname (default `<svc>.<DOMAIN_BASE>`) |
 | `AGENTS_BASE` | no | Base for deployed-agent hostnames (default `agents.<DOMAIN_BASE>`) |
 
-With `DOMAIN_BASE=amp.mycompany.com`, the derived hosts are `console.amp.mycompany.com`, `api.amp.mycompany.com`, `thunder.amp.mycompany.com`, `observer.amp.mycompany.com`, `gateway.amp.mycompany.com`, `cp.amp.mycompany.com`, and deployed agents at `<org>-<project>.agents.amp.mycompany.com`. cert-manager issues one **wildcard** certificate covering all of these (including the deployed-agent and env-Thunder tiers), so there are no per-host certificate steps.
+With `DOMAIN_BASE=amp.mycompany.com`, the derived hosts are `console.amp.mycompany.com`, `api.amp.mycompany.com`, `thunder.amp.mycompany.com`, `observer.amp.mycompany.com`, `gateway.amp.mycompany.com`, and `cp.amp.mycompany.com`, plus two dynamic tiers: deployed agents at `<org>-<project>.agents.amp.mycompany.com` and per-environment Thunder at `<org>-<env>.thunder.amp.mycompany.com`. cert-manager issues one **wildcard** certificate covering all of them, so there are no per-host certificate steps.
 
 ### DNS provider credentials {#adv-dns-provider}
 
@@ -264,67 +261,225 @@ AZURE_SUBSCRIPTION_ID=<subscription-id>
 AZURE_RESOURCE_GROUP=<zone-resource-group>
 ```
 
-### DNS records {#adv-dns-records}
+## How TLS and routing work {#adv-tls}
 
-Certificate issuance itself needs **no A records** — cert-manager proves control by writing the `_acme-challenge` TXT record via your provider credential. You only need A records so clients can **reach** the services: point the service hosts (and the two wildcards below) at the VM's IP — the **public** IP for a public VM, or the **private** IP for a private VM (a public zone may hold a private A record; split-horizon is fine).
+cert-manager (installed in the cluster) runs the ACME DNS-01 challenge, issues one **wildcard certificate** into a Kubernetes Secret, and auto-renews it.
 
-```
-*.amp.mycompany.com          A  <VM_IP>   # console/api/thunder/observer/gateway/cp
-*.agents.amp.mycompany.com   A  <VM_IP>   # deployed agents (one level deeper)
-```
-
-## How TLS works {#adv-tls}
-
-cert-manager (installed in the cluster) runs the ACME DNS-01 challenge, issues a wildcard certificate into a Kubernetes Secret, and auto-renews it. The OpenChoreo kgateway terminates TLS on `:443` using that Secret and routes each hostname to the right service. There is no Caddy container and no host-side ACME client.
+Routing uses a **front-proxy** model. A single consolidated Gateway (`amp-consolidated-gateway`) is the only thing listening on `:443`; it terminates TLS with the wildcard certificate and then forwards **by `Host` header** to each plane's own `gateway-default` gateway, which keeps its native routes. Three HTTPRoutes do the forwarding, and because two of the planes live in other namespaces, each cross-namespace hop is authorised by a ReferenceGrant.
 
 ```mermaid
 flowchart TB
+    client["Browser / API client"]
     le["Let's Encrypt (ACME)<br/>public CA"]
-    dns["Your DNS zone<br/>(provider API: cloudflare / route53 / clouddns / azuredns)"]
+    dnszone["Your DNS zone<br/>(cloudflare / route53 / clouddns / azuredns)"]
 
-    subgraph vm["VM (:443 — public or private-network only)"]
-        cm["cert-manager<br/>ACME DNS-01 · issues + auto-renews"]
+    subgraph vm["VM (only :443 is exposed — public or private-network only)"]
+        cm["cert-manager<br/>ACME DNS-01 · issues + auto-renews<br/>Secret: amp-wildcard-tls"]
+
         subgraph k3d["k3d cluster"]
-            gw["kgateway :443<br/>terminates TLS with the wildcard cert"]
-            svc["Console · amp-api · Thunder ·<br/>Observer · Gateway · Deployed agents"]
+            cons["amp-consolidated-gateway :443<br/>terminates TLS with the wildcard cert"]
+
+            r1["amp-frontproxy-controlplane"]
+            r2["amp-frontproxy-observability"]
+            r3["amp-frontproxy-dataplane"]
+
+            cpgw["control plane<br/>gateway-default :8080"]
+            obsgw["observability plane<br/>gateway-default :11080"]
+            dpgw["data plane<br/>gateway-default :19080"]
+
+            cpsvc["Console · amp-api · Thunder ·<br/>gateway control plane · env-Thunder"]
+            obssvc["Agent Manager Observer"]
+            dpsvc["AI Gateway (LLM proxy · OTel ingest<br/>for externally-hosted agents)<br/>Deployed agents"]
         end
     end
 
-    client["Browser / API client"] -->|"HTTPS :443"| gw
-    cm -->|"1 · write _acme-challenge TXT (outbound)"| dns
-    le -->|"2 · read TXT, never connects to the VM"| dns
+    client -->|"HTTPS :443"| cons
+    cm -->|"1 · write _acme-challenge TXT (outbound)"| dnszone
+    le -->|"2 · read TXT, never connects to the VM"| dnszone
     le -->|"3 · issue wildcard cert (outbound)"| cm
-    cm -.->|"cert Secret"| gw
-    gw --> svc
+    cm -.->|"cert Secret"| cons
+
+    cons --> r1
+    cons --> r2
+    cons --> r3
+    r1 -->|"console · api · thunder · cp<br/>*.thunder (per-environment Thunder)"| cpgw
+    r2 -->|"observer"| obsgw
+    r3 -->|"gateway · *.agents (deployed agents)"| dpgw
+    cpgw --> cpsvc
+    obsgw --> obssvc
+    dpgw --> dpsvc
 ```
+
+The two wildcard routes matter because those tiers are **dynamic**: deploying into a new org/project adds a `<org>-<project>.agents.<DOMAIN_BASE>` host (agents in an existing project share theirs), and each environment you create adds a `<org>-<env>.thunder.<DOMAIN_BASE>` host. `*.agents` and `*.thunder` are matched by the front-proxy routes and covered by the wildcard certificate up front, so nothing has to be re-issued or re-attached after install.
+
+Note that `gateway.<DOMAIN_BASE>/otel` carries traces only from agents hosted **outside** the platform, which set [`AMP_OTEL_ENDPOINT`](../components/amp-instrumentation.mdx) themselves. Agents deployed by Agent Manager export straight to the in-cluster gateway runtime, so their traces never reach the `:443` listener at all.
 
 ## Install {#adv-install}
 
-Validate and preview without touching the cluster first:
+Download and unpack the versioned install bundle, then generate an annotated config template with `--init`:
 
 ```bash
-sudo bash bootstrap.sh advanced --config amp-config.env --dry-run
+# on the VM
+VER=<AMP_VERSION>   # e.g. an amp/v* release tag, without the "amp/v" prefix
+curl -fsSL "https://github.com/wso2/agent-manager/releases/download/amp/v${VER}/amp-vm-bundle-${VER}.tar.gz" | tar xz
+deployments/vm/install-advanced.sh --init > amp-config.env
+chmod 600 amp-config.env
 ```
 
-This loads the config, runs the advisory DNS check, and prints the derived hosts, helm overrides, and the cert-manager resources it will apply. When it looks right, run the real install:
+Edit `amp-config.env` with the keys from [Configure](#adv-configure), then validate and preview without touching the cluster:
 
 ```bash
-sudo bash bootstrap.sh advanced --config amp-config.env
+sudo deployments/vm/install-advanced.sh --config amp-config.env --dry-run
 ```
 
-It downloads the versioned install bundle (from `AMP_VERSION`) and runs in three phases: preflight (verify tools + firewall), platform install, and TLS (cert-manager issues the wildcard cert via DNS-01, then kgateway serves `:443`). Allow 8-15 minutes plus a few minutes for issuance. It needs `sudo` because it opens the firewall and creates the cluster. On completion it prints the access URLs.
+The dry run loads the config, runs the advisory DNS check, and prints the derived hosts, the wildcard certificate's SAN list, the helm overrides, and every cert-manager and gateway resource it would apply. It never contacts the cluster and it redacts the DNS-provider credential. When it looks right, run the real install:
 
-While testing, set `ACME_SERVER` to Let's Encrypt **staging** to avoid production rate limits (the certificate will be untrusted, but it proves the whole DNS-01 flow); switch to production for a trusted certificate.
+```bash
+sudo deployments/vm/install-advanced.sh --config amp-config.env
+```
+
+The installer runs in three phases: preflight (verify tools + firewall), platform install, and TLS (cert-manager issues the wildcard certificate via DNS-01, then the consolidated gateway serves `:443`). Allow 15-20 minutes plus a few minutes for issuance. It needs `sudo` because it opens the firewall and creates the cluster. On completion it prints the access URLs.
+
+There are **no per-setting command-line flags** on the advanced path — everything comes from the config file.
+
+:::tip Use Let's Encrypt staging first
+Set `ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory` for your first run. Staging exercises the entire DNS-01 flow but has far looser rate limits than production, which enforces a weekly cap per registered domain that is easy to burn through while iterating. The staging certificate is **not** publicly trusted, so browsers and `curl` will warn — that is expected. Once a staging run succeeds end to end, remove `ACME_SERVER` (or point it at production), delete the cluster, and reinstall for a trusted certificate.
+
+If you opened the console in a browser while the staging certificate was being served and clicked through the warning, clear that decision after switching to production. Browsers remember the approval for the rest of the session and keep reporting the page as insecure even once the trusted certificate is in place — Chrome shows "active content with certificate errors" while simultaneously reporting the certificate itself as valid and trusted. Quit **every** window of that browser profile (for an incognito window, closing one tab is not enough — the session survives until all incognito windows are closed) and reopen it.
+:::
+
+If you prefer a single command and already have `amp-config.env`, `bootstrap.sh` downloads the bundle and runs the same installer for you:
+
+```bash
+curl -fsSL "https://github.com/wso2/agent-manager/releases/download/amp/v${VER}/bootstrap.sh" \
+  | sudo bash -s -- advanced --config amp-config.env
+```
+
+Note that `bootstrap.sh` cannot emit the template — it needs a version before it can download the bundle, so use the `--init` flow above to create the config.
+
+## Public network {#adv-public}
+
+Use this path when the VM has a public IP and clients reach it directly over the internet.
+
+Open inbound **`443/tcp` only** in your cloud security group or firewall. Nothing else needs to be reachable: certificate issuance is egress-only, and every service is multiplexed behind the single `:443` listener by `Host` header.
+
+### DNS records {#adv-dns-records}
+
+Certificate issuance itself needs **no A records** — cert-manager proves control of the zone by writing the `_acme-challenge` TXT record through your provider credential. A records exist only so clients can **reach** the services. Point them at the VM's public IP:
+
+```
+*.amp.mycompany.com          A  <VM_PUBLIC_IP>   # console/api/thunder/observer/gateway/cp
+thunder.amp.mycompany.com    A  <VM_PUBLIC_IP>   # explicit — see the warning below
+*.thunder.amp.mycompany.com  A  <VM_PUBLIC_IP>   # per-environment Thunder
+*.agents.amp.mycompany.com   A  <VM_PUBLIC_IP>   # deployed agents
+```
+
+:::warning `thunder.<DOMAIN_BASE>` needs its own explicit A record
+A DNS wildcard never matches a name that already exists as a node in the zone ([RFC 4592](https://datatracker.ietf.org/doc/html/rfc4592#section-2.2.1)). Creating `*.thunder.amp.mycompany.com` brings `thunder.amp.mycompany.com` into existence as an *empty non-terminal*, which immediately stops `*.amp.mycompany.com` from covering it. Without the explicit record, `thunder.amp.mycompany.com` resolves to nothing and **OAuth login breaks**, even though every other host works. Add the explicit A record whenever you add the deeper `*.thunder` wildcard.
+
+Verify all four tiers resolve before installing:
+
+```bash
+for h in console.amp.mycompany.com thunder.amp.mycompany.com \
+         x-y.agents.amp.mycompany.com default.thunder.amp.mycompany.com; do
+  printf '%-40s %s\n' "$h" "$(dig +short "$h" A)"
+done
+```
+:::
+
+## Private network {#adv-private}
+
+Use this path when the VM has **no public IP** and is reachable only from inside your network. The advanced installer supports this unchanged, because DNS-01 validation never requires an inbound connection — the ACME CA reads a TXT record from your DNS provider instead of calling the VM. The result is a **publicly-trusted certificate on a private host**, with no private CA to distribute.
+
+The VM still needs **outbound** internet access to pull images and charts and to reach the ACME and DNS-provider APIs. On Google Cloud that means a **Cloud NAT** gateway attached to the VM's subnet; the equivalent is a NAT gateway on AWS or Azure.
+
+### Reaching the console
+
+You have two options. If your network has private DNS and routing to the VM, add the same records as the [public path](#adv-dns-records) but pointing at the VM's **private** IP, and connect normally — a public zone may hold private A records, and split-horizon DNS is fine too.
+
+Be aware that publishing private addresses in a **public** zone often does not survive the trip to the client. Many resolvers — home routers, corporate DNS, and public resolvers alike — drop RFC-1918 answers for public domains as DNS-rebinding protection, returning an empty result even though the record is correct. The symptom is a name that resolves from the authoritative nameserver but not from the client, and the browser reports `ERR_NAME_NOT_RESOLVED`. Compare the two before assuming the record is wrong:
+
+```bash
+dig +short <host> A                                    # your resolver
+dig +short @<authoritative-ns> <host> A                # the zone itself
+```
+
+If they disagree, use the tunnel plus `/etc/hosts` approach below rather than relying on DNS.
+
+Otherwise, tunnel to the VM and resolve the hostnames locally. On Google Cloud, Identity-Aware Proxy forwards TCP without giving the VM a public address:
+
+```mermaid
+flowchart LR
+    dev["Your workstation<br/>/etc/hosts → 127.0.0.1"]
+    tun["gcloud compute start-iap-tunnel<br/>localhost:443 → VM :443"]
+    iap["Cloud IAP<br/>source range 35.235.240.0/20"]
+    gw["Private VM :443<br/>amp-consolidated-gateway"]
+    nat["Cloud NAT<br/>(egress only)"]
+    ext["ACME CA + DNS-provider API"]
+
+    dev --> tun --> iap --> gw
+    gw --> nat --> ext
+```
+
+Allow IAP to reach `:443`. The stock `default-allow-https` rule only applies to instances tagged `https-server`, so an untagged VM needs an explicit rule for the IAP source range:
+
+```bash
+gcloud compute firewall-rules create allow-iap-https \
+  --direction=INGRESS --action=allow --rules=tcp:443 \
+  --source-ranges=35.235.240.0/20
+```
+
+Open the tunnel, binding it to the same port the gateway serves so the hostnames work unmodified. Port 443 is privileged, so on Linux and macOS this needs `sudo` (or a one-off `setcap`/`authbind` grant for the `gcloud` Python interpreter); without it the tunnel exits with a permission error on bind:
+
+```bash
+sudo gcloud compute start-iap-tunnel <VM_NAME> 443 --local-host-port=localhost:443
+```
+
+Then point every service hostname at the tunnel in your workstation's `/etc/hosts`:
+
+```
+127.0.0.1  console.amp.mycompany.com api.amp.mycompany.com thunder.amp.mycompany.com
+127.0.0.1  observer.amp.mycompany.com gateway.amp.mycompany.com cp.amp.mycompany.com
+```
+
+:::note Deployed agents need their own `/etc/hosts` entries
+`/etc/hosts` has no wildcard support, so the `*.agents` and `*.thunder` tiers are not covered by the lines above. Each time you deploy an agent or create an environment, add its exact hostname:
+
+```
+127.0.0.1  <org>-<project>.agents.amp.mycompany.com
+127.0.0.1  <org>-<env>.thunder.amp.mycompany.com
+```
+
+If agent invocation fails with a DNS error while the console works, this is almost always why. A local DNS resolver that supports wildcards (dnsmasq, or a private DNS zone) avoids the per-agent edits.
+:::
+
+TLS still validates normally through the tunnel: the certificate is publicly trusted and the `Host` header is preserved, so the browser sees the real hostname and the gateway routes on it.
 
 ## Persistence and teardown {#adv-persistence}
 
-Application data (PostgreSQL), the issued certificate (a Kubernetes Secret, auto-renewed by cert-manager), and the k3d cluster persist across restarts. To tear down completely:
+Application data (PostgreSQL), the issued certificate (a Kubernetes Secret, auto-renewed by cert-manager), and the k3d cluster persist across restarts. To tear down completely, delete the cluster — everything the installer created lives inside it, including the certificate and the gateway resources:
 
 ```bash
-sudo k3d cluster delete amp-local     # delete the cluster (workloads, app data, and the cert)
+sudo k3d cluster delete amp-local     # delete the cluster (workloads, app data, cert, gateways)
 ```
 
-**Changing the domain or hostnames after install requires a teardown first.** The platform install is idempotent in the "create if missing" sense, so editing `DOMAIN_BASE` (or the `HOST_*` overrides) and re-running does **not** reconfigure already-installed services. To move an existing install to a different domain, delete the cluster and install again with the new config.
+To remove only the TLS and routing layer while keeping the platform running — for example to re-issue against a different ACME server after a staging run — delete the resources the installer applies in its third phase:
+
+```bash
+kubectl delete httproute amp-frontproxy-controlplane amp-frontproxy-observability \
+  amp-frontproxy-dataplane -n openchoreo-control-plane
+kubectl delete gateway amp-consolidated-gateway -n openchoreo-control-plane
+kubectl delete certificate amp-wildcard-tls -n openchoreo-control-plane
+kubectl delete secret amp-wildcard-tls -n openchoreo-control-plane
+kubectl delete referencegrant amp-frontproxy-to-services -n openchoreo-observability-plane
+kubectl delete referencegrant amp-frontproxy-to-services -n openchoreo-data-plane
+kubectl delete clusterissuer amp-acme-dns01
+kubectl delete secret amp-dns01-credentials amp-acme-dns01-account-key -n cert-manager
+```
+
+Delete the `amp-wildcard-tls` Secret as well as the Certificate — cert-manager will not re-issue into a Secret that already holds a valid certificate, so leaving it behind silently keeps the old (for example, staging) certificate in place. The ACME account key Secret only needs deleting if you are also changing `ACME_EMAIL` or the ACME server.
+
+**Changing the domain or hostnames after install requires a full teardown first.** The platform install is idempotent in the "create if missing" sense, so editing `DOMAIN_BASE` (or the `HOST_*` overrides) and re-running does **not** reconfigure already-installed services. To move an existing install to a different domain, delete the cluster and install again with the new config.
 
 ## Connect an external gateway {#adv-external-gw}
 
@@ -335,6 +490,10 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 - **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER`, or a missing provider credential). Fix `amp-config.env` and re-run.
 - **Certificate never becomes Ready.** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit — re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
 - **Cert issued but a host is unreachable.** Confirm the service host's A record points at the VM (public or private IP) and that clients can reach `:443` on it. Issuance does not need this, but client access does.
+- **Login fails but every other host works.** `thunder.<DOMAIN_BASE>` is probably not resolving because the deeper `*.thunder` wildcard shadows it. Check with `dig +short thunder.<DOMAIN_BASE> A` and add the explicit A record (see [DNS records](#adv-dns-records)).
+- **A host returns a connection failure rather than an HTTP status.** The front-proxy route for that plane is not bound. List them with `kubectl get httproute -n openchoreo-control-plane` and check that each `amp-frontproxy-*` route reports `Accepted=True` and `ResolvedRefs=True`; a failed `ResolvedRefs` on the observability or data-plane route usually means its ReferenceGrant is missing. Note that a gateway-level `404` is a *healthy* response from an unrouted path — it proves TLS terminated and the request reached the gateway.
+- **Deployed agent unreachable while the console works.** On a public VM, confirm the `*.agents.<DOMAIN_BASE>` A record exists; on a private VM, add the agent's exact hostname to `/etc/hosts` (see [Private network](#adv-private)), since `/etc/hosts` cannot match wildcards.
+- **Certificate is untrusted after switching to production.** cert-manager will not re-issue into a Secret that still holds a valid staging certificate. Delete the Certificate and its Secret so it re-issues (see [Persistence and teardown](#adv-persistence)).
 - **Changed the domain but the console still shows the old hostnames.** Re-running with a new `DOMAIN_BASE` does not reconfigure existing releases. Delete the cluster and reinstall (see [Persistence and teardown](#adv-persistence)).
 
 </TabItem>

--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -16,7 +16,7 @@ For production, run Agent Manager on a properly operated Kubernetes platform wit
 :::
 
 :::info Stronger agent isolation tiers
-Agents run sandboxed under the standard **runc** runtime by default. Agent Manager also supports stronger per-environment isolation tiers — **gVisor** (userspace kernel) and **Kata Containers** (per-agent VM) — but they have hardware/OS requirements and need a dedicated node. For more information, see the [gVisor](../administration/isolation-tiers/gvisor.mdx) and [Kata Containers](../administration/isolation-tiers/kata.mdx) setup guides.
+Agents run sandboxed under the standard **runc** runtime by default. Agent Manager also supports stronger per-environment isolation tiers, **gVisor** (userspace kernel) and **Kata Containers** (per-agent VM), but they have hardware/OS requirements and need a dedicated node. For more information, see the [gVisor](../administration/isolation-tiers/gvisor.mdx) and [Kata Containers](../administration/isolation-tiers/kata.mdx) setup guides.
 :::
 
 Install Agent Manager on a Linux VM where Docker is the only host dependency. Pick the path that fits you:
@@ -31,7 +31,7 @@ The simple installer exposes the platform over HTTPS using [sslip.io](https://ss
 
 ## Prerequisites
 
-You need an SSH client to log into the VM. On the VM itself, install the tools below **before** running the installer — it **verifies** they are present and exits with install hints if any are missing; it does **not** install host tooling for you. The whole stack runs on Docker: k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container.
+You need an SSH client to log into the VM. On the VM itself, install the tools below **before** running the installer. It **verifies** they are present and exits with install hints if any are missing; it does **not** install host tooling for you. The whole stack runs on Docker: k3d runs the Kubernetes cluster as Docker containers, and Caddy runs as a container.
 
 | Tool | Version | Purpose |
 | --- | --- | --- |
@@ -40,7 +40,7 @@ You need an SSH client to log into the VM. On the VM itself, install the tools b
 | [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) | v1.33+ | Kubernetes CLI |
 | [Helm](https://helm.sh/docs/intro/install/) | v3.12+ | Package manager |
 
-`curl` and `lsof` are also required — usually preinstalled, but on a minimal image install them with your OS package manager (for example `sudo apt-get install -y curl lsof`).
+`curl` and `lsof` are also required. They are usually preinstalled, but on a minimal image install them with your OS package manager (for example `sudo apt-get install -y curl lsof`).
 
 Verify everything is installed:
 
@@ -134,9 +134,9 @@ flowchart TB
     dpgw --> agents
 ```
 
-Every public hostname resolves to the VM's IP (via sslip.io) and arrives at Caddy on `:443`; Caddy terminates TLS and reverse-proxies to the matching loopback port. The Agent Manager services are ClusterIP inside the cluster: Caddy forwards the console, API, Thunder, gateway-control-plane, and per-environment Thunder hosts to the OpenChoreo control-plane kgateway (loopback `:8080`), the observer host to the observability-plane kgateway (loopback `:11080`), and the OTel-ingest host plus the deployed-agent wildcard to the data-plane kgateway (loopback `:19080`) — each gateway routes by the preserved `Host` header. Certificates are obtained over that same `:443` using the TLS-ALPN-01 challenge, so no inbound port 80 is needed.
+Every public hostname resolves to the VM's IP (via sslip.io) and arrives at Caddy on `:443`; Caddy terminates TLS and reverse-proxies to the matching loopback port. The Agent Manager services are ClusterIP inside the cluster: Caddy forwards the console, API, Thunder, gateway-control-plane, and per-environment Thunder hosts to the OpenChoreo control-plane kgateway (loopback `:8080`), the observer host to the observability-plane kgateway (loopback `:11080`), and the OTel-ingest host plus the deployed-agent wildcard to the data-plane kgateway (loopback `:19080`). Each gateway routes by the preserved `Host` header. Certificates are obtained over that same `:443` using the TLS-ALPN-01 challenge, so no inbound port 80 is needed.
 
-Two of these tiers are **dynamic** — a new host appears the first time you deploy into a new org/project, and each time you create an environment — so a wildcard certificate cannot be issued for them via TLS-ALPN-01 up front. Caddy instead issues one concrete certificate per hostname **on demand**, at the first request to it.
+Two of these tiers are **dynamic**: a new host appears the first time you deploy into a new org/project, and each time you create an environment. A wildcard certificate cannot be issued for them via TLS-ALPN-01 up front, so Caddy issues one concrete certificate per hostname **on demand**, at the first request to it.
 
 | URL | Purpose |
 |---|---|
@@ -163,7 +163,7 @@ The **`admin`** account is provisioned with the `Agent Manager Admin` role durin
 
 When you deploy an agent, its endpoint is published on a per-project host `<org>-<project>.agents.<IP>.sslip.io` and routed by Caddy to the OpenChoreo data-plane gateway. Because these hostnames are dynamic (a new one per org/project), Caddy issues their TLS certificates **on demand** at the first request (via the same ACME challenge as the fixed hosts), rather than up front. Invocations are authenticated with a user token that the gateway validates against the public Thunder issuer.
 
-Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error**. That first connection is consumed by Caddy answering the ACME challenge, so the client briefly sees the challenge certificate instead of the real one. Every client hits this — only the wording differs: Chromium-based browsers (Chrome, Edge, Brave) report `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED`, while other browsers and command-line clients report their own untrusted-certificate error. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host; the certificate is then cached in the `amp-caddy-data` volume.
+Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error**. That first connection is consumed by Caddy answering the ACME challenge, so the client briefly sees the challenge certificate instead of the real one. Every client hits this; only the wording differs. Chromium-based browsers (Chrome, Edge, Brave) report `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED`, while other browsers and command-line clients report their own untrusted-certificate error. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host; the certificate is then cached in the `amp-caddy-data` volume.
 
 The same applies to the per-environment Thunder hosts (`<org>-<env>.thunder.<IP>.sslip.io`): they are created when you add an environment and get their certificates on demand the same way, so the first request to a brand-new environment's Thunder can show the same one-time error.
 
@@ -187,7 +187,7 @@ sudo docker volume rm amp-caddy-data amp-caddy-config    # drop the cached certs
 sudo rm -f /opt/amp/Caddyfile                            # optional: the generated Caddy config
 ```
 
-Use `sudo`; the installer runs Docker and k3d as root. Note that the installer leaves no repository checkout on the VM — `bootstrap.sh` unpacks the versioned bundle into a temporary directory and deletes it on exit — so teardown is done with the commands above rather than an uninstall script. Deleting the cluster removes the platform's data; deleting the Caddy volumes discards the issued certificates and the ACME account, so a reinstall re-requests them from Let's Encrypt (which counts against its rate limits).
+Use `sudo`; the installer runs Docker and k3d as root. Note that the installer leaves no repository checkout on the VM, because `bootstrap.sh` unpacks the versioned bundle into a temporary directory and deletes it on exit. Teardown is therefore done with the commands above rather than an uninstall script. Deleting the cluster removes the platform's data; deleting the Caddy volumes discards the issued certificates and the ACME account, so a reinstall re-requests them from Let's Encrypt (which counts against its rate limits).
 
 ## Connect an external gateway
 
@@ -205,7 +205,7 @@ Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `h
 </TabItem>
 <TabItem value="advanced" label="Advanced">
 
-The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you have your own domain. It issues **publicly-trusted certificates** via cert-manager's ACME **DNS-01** challenge and terminates TLS on `:443` at a single in-cluster gateway. Because DNS-01 validates by writing a DNS TXT record rather than by connecting to the VM, the same flow works whether the VM is **public** or reachable only from a **private network** — issuance needs outbound access only.
+The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you have your own domain. It issues **publicly-trusted certificates** via cert-manager's ACME **DNS-01** challenge and terminates TLS on `:443` at a single in-cluster gateway. Because DNS-01 validates by writing a DNS TXT record rather than by connecting to the VM, the same flow works whether the VM is **public** or reachable only from a **private network**. Issuance needs outbound access only.
 
 Setup is the same for both up to and including the install; only how clients reach the VM differs. Work through [Prerequisites](#adv-prerequisites), [Configure](#adv-configure), and [Install](#adv-install), then switch the **Public network / Private network** selector below to the one matching your VM. Everything after that selector applies to both again.
 
@@ -213,14 +213,14 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 
 ## Prerequisites {#adv-prerequisites}
 
-- **Docker, k3d, kubectl, Helm, curl, and `lsof`** must already be installed on the VM. The installer **verifies** they are present and exits with install hints if any are missing — it does **not** install them for you.
-- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access (to pull images/charts and reach the ACME + DNS-provider APIs). Inbound `:443` is needed only for clients to reach the services — **not** for certificate issuance — so a fully private VM works.
+- **Docker, k3d, kubectl, Helm, curl, and `lsof`** must already be installed on the VM. The installer **verifies** they are present and exits with install hints if any are missing. It does **not** install them for you.
+- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access (to pull images/charts and reach the ACME + DNS-provider APIs). Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works.
 - **A domain you control**, hosted on one of the supported DNS providers: **Cloudflare**, **AWS Route 53**, **Google Cloud DNS**, or **Azure DNS**.
 - **A DNS-provider API credential** scoped to edit that zone's records. cert-manager uses it to write the `_acme-challenge` TXT record; you do **not** create TXT records by hand.
 
 ## Configure {#adv-configure}
 
-The config file is plain shell — one `KEY=value` assignment per line. Generate an annotated template with `install-advanced.sh --init` (see [Install](#adv-install) for how to get the script), then fill in the keys below. Keep the file `chmod 600`: it holds your DNS-provider credential.
+The config file is plain shell, one `KEY=value` assignment per line. Generate an annotated template with `install-advanced.sh --init` (see [Install](#adv-install) for how to get the script), then fill in the keys below. Keep the file `chmod 600`: it holds your DNS-provider credential.
 
 | Key | Required | Purpose |
 |---|---|---|
@@ -286,7 +286,7 @@ flowchart TB
     le["Let's Encrypt (ACME)<br/>public CA"]
     dnszone["Your DNS zone<br/>(cloudflare / route53 / clouddns / azuredns)"]
 
-    subgraph vm["VM (only :443 is exposed — public or private-network only)"]
+    subgraph vm["VM (only :443 is exposed; public or private-network only)"]
         cm["cert-manager<br/>ACME DNS-01 · issues + auto-renews<br/>Secret: amp-wildcard-tls"]
 
         subgraph k3d["k3d cluster"]
@@ -353,12 +353,12 @@ sudo deployments/vm/install-advanced.sh --config amp-config.env
 
 The installer runs in three phases: preflight (verify tools + firewall), platform install, and TLS (cert-manager issues the wildcard certificate via DNS-01, then the consolidated gateway serves `:443`). Allow 15-20 minutes plus a few minutes for issuance. It needs `sudo` because it opens the firewall and creates the cluster. On completion it prints the access URLs.
 
-There are **no per-setting command-line flags** on the advanced path — everything comes from the config file.
+There are **no per-setting command-line flags** on the advanced path; everything comes from the config file.
 
 :::tip Use Let's Encrypt staging first
-Set `ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory` for your first run. Staging exercises the entire DNS-01 flow but has far looser rate limits than production, which enforces a weekly cap per registered domain that is easy to burn through while iterating. The staging certificate is **not** publicly trusted, so browsers and `curl` will warn — that is expected. Once a staging run succeeds end to end, remove `ACME_SERVER` (or point it at production), delete the cluster, and reinstall for a trusted certificate.
+Set `ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory` for your first run. Staging exercises the entire DNS-01 flow but has far looser rate limits than production, which enforces a weekly cap per registered domain that is easy to burn through while iterating. The staging certificate is **not** publicly trusted, so browsers and `curl` will warn, which is expected. Once a staging run succeeds end to end, remove `ACME_SERVER` (or point it at production), delete the cluster, and reinstall for a trusted certificate.
 
-If you opened the console in a browser while the staging certificate was being served and clicked through the warning, clear that decision after switching to production. Browsers remember the approval for the rest of the session and keep reporting the page as insecure even once the trusted certificate is in place — Chrome shows "active content with certificate errors" while simultaneously reporting the certificate itself as valid and trusted. Quit **every** window of that browser profile (for an incognito window, closing one tab is not enough — the session survives until all incognito windows are closed) and reopen it.
+If you opened the console in a browser while the staging certificate was being served and clicked through the warning, clear that decision after switching to production. Browsers remember the approval for the rest of the session and keep reporting the page as insecure even once the trusted certificate is in place. Chrome shows "active content with certificate errors" while simultaneously reporting the certificate itself as valid and trusted. Quit **every** window of that browser profile (for an incognito window, closing one tab is not enough, because the session survives until all incognito windows are closed) and reopen it.
 :::
 
 If you prefer a single command and already have `amp-config.env`, `bootstrap.sh` downloads the bundle and runs the same installer for you:
@@ -368,11 +368,11 @@ curl -fsSL "https://github.com/wso2/agent-manager/releases/download/amp/v${VER}/
   | sudo bash -s -- advanced --config amp-config.env
 ```
 
-Note that `bootstrap.sh` cannot emit the template — it needs a version before it can download the bundle, so use the `--init` flow above to create the config.
+Note that `bootstrap.sh` cannot emit the template, because it needs a version before it can download the bundle. Use the `--init` flow above to create the config.
 
 ## How clients reach the VM {#adv-reachability}
 
-The install is identical either way; what differs is DNS and how you get a browser to the console. Pick the one that matches your VM — the sections after this apply to both.
+The install is identical either way; what differs is DNS and how you get a browser to the console. Pick the one that matches your VM. The sections after this apply to both.
 
 <Tabs groupId="vm-network">
 <TabItem value="public" label="Public network" default>
@@ -383,11 +383,11 @@ Open inbound **`443/tcp` only** in your cloud security group or firewall. Nothin
 
 ### DNS records {#adv-dns-records}
 
-Certificate issuance itself needs **no A records** — cert-manager proves control of the zone by writing the `_acme-challenge` TXT record through your provider credential. A records exist only so clients can **reach** the services. Point them at the VM's public IP:
+Certificate issuance itself needs **no A records**, because cert-manager proves control of the zone by writing the `_acme-challenge` TXT record through your provider credential. A records exist only so clients can **reach** the services. Point them at the VM's public IP:
 
 ```
 *.amp.mycompany.com          A  <VM_PUBLIC_IP>   # console/api/thunder/observer/gateway/cp
-thunder.amp.mycompany.com    A  <VM_PUBLIC_IP>   # explicit — see the warning below
+thunder.amp.mycompany.com    A  <VM_PUBLIC_IP>   # explicit, see the warning below
 *.thunder.amp.mycompany.com  A  <VM_PUBLIC_IP>   # per-environment Thunder
 *.agents.amp.mycompany.com   A  <VM_PUBLIC_IP>   # deployed agents
 ```
@@ -408,15 +408,15 @@ done
 </TabItem>
 <TabItem value="private" label="Private network">
 
-Use this when the VM has **no public IP** and is reachable only from inside your network. The advanced installer supports this unchanged, because DNS-01 validation never requires an inbound connection — the ACME CA reads a TXT record from your DNS provider instead of calling the VM. The result is a **publicly-trusted certificate on a private host**, with no private CA to distribute.
+Use this when the VM has **no public IP** and is reachable only from inside your network. The advanced installer supports this unchanged, because DNS-01 validation never requires an inbound connection: the ACME CA reads a TXT record from your DNS provider instead of calling the VM. The result is a **publicly-trusted certificate on a private host**, with no private CA to distribute.
 
-The VM still needs **outbound** internet access to pull images and charts and to reach the ACME and DNS-provider APIs. On Google Cloud that means a **Cloud NAT** gateway attached to the VM's subnet; the equivalent is a NAT gateway on AWS or Azure.
+The VM still needs **outbound** internet access to pull images and charts and to reach the ACME and DNS-provider APIs. On Google Cloud, for example, that means a **Cloud NAT** gateway attached to the VM's subnet; AWS and Azure have equivalent NAT gateways.
 
 ### Reaching the console
 
-You have two options. If your network has private DNS and routing to the VM, add the same four records listed under **Public network** but pointing at the VM's **private** IP, and connect normally — a public zone may hold private A records, and split-horizon DNS is fine too.
+You have two options. If your network has private DNS and routing to the VM, add the same four records listed under **Public network** but pointing at the VM's **private** IP, and connect normally. A public zone may hold private A records, and split-horizon DNS is fine too.
 
-Be aware that publishing private addresses in a **public** zone often does not survive the trip to the client. Many resolvers — home routers, corporate DNS, and public resolvers alike — drop RFC-1918 answers for public domains as DNS-rebinding protection, returning an empty result even though the record is correct. The symptom is a name that resolves from the authoritative nameserver but not from the client, and the browser reports `ERR_NAME_NOT_RESOLVED`. Compare the two before assuming the record is wrong:
+Be aware that publishing private addresses in a **public** zone often does not survive the trip to the client. Many resolvers (home routers, corporate DNS, and public resolvers alike) drop RFC-1918 answers for public domains as DNS-rebinding protection, returning an empty result even though the record is correct. The symptom is a name that resolves from the authoritative nameserver but not from the client, and the browser reports `ERR_NAME_NOT_RESOLVED`. Compare the two before assuming the record is wrong:
 
 ```bash
 dig +short <host> A                                    # your resolver
@@ -425,7 +425,7 @@ dig +short @<authoritative-ns> <host> A                # the zone itself
 
 If they disagree, use the tunnel plus `/etc/hosts` approach below rather than relying on DNS.
 
-Otherwise, tunnel to the VM and resolve the hostnames locally. On Google Cloud, Identity-Aware Proxy forwards TCP without giving the VM a public address:
+Otherwise, tunnel to the VM and resolve the hostnames locally. On Google Cloud, for example, Identity-Aware Proxy forwards TCP without giving the VM a public address:
 
 ```mermaid
 flowchart LR
@@ -479,13 +479,13 @@ TLS still validates normally through the tunnel: the certificate is publicly tru
 
 ## Persistence and teardown {#adv-persistence}
 
-Application data (PostgreSQL), the issued certificate (a Kubernetes Secret, auto-renewed by cert-manager), and the k3d cluster persist across restarts. To tear down completely, delete the cluster — everything the installer created lives inside it, including the certificate and the gateway resources:
+Application data (PostgreSQL), the issued certificate (a Kubernetes Secret, auto-renewed by cert-manager), and the k3d cluster persist across restarts. To tear down completely, delete the cluster. Everything the installer created lives inside it, including the certificate and the gateway resources:
 
 ```bash
 sudo k3d cluster delete amp-local     # delete the cluster (workloads, app data, cert, gateways)
 ```
 
-To remove only the TLS and routing layer while keeping the platform running — for example to re-issue against a different ACME server after a staging run — delete the resources the installer applies in its third phase:
+To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 
 ```bash
 kubectl delete httproute amp-frontproxy-controlplane amp-frontproxy-observability \
@@ -499,7 +499,7 @@ kubectl delete clusterissuer amp-acme-dns01
 kubectl delete secret amp-dns01-credentials amp-acme-dns01-account-key -n cert-manager
 ```
 
-Delete the `amp-wildcard-tls` Secret as well as the Certificate — cert-manager will not re-issue into a Secret that already holds a valid certificate, so leaving it behind silently keeps the old (for example, staging) certificate in place. The ACME account key Secret only needs deleting if you are also changing `ACME_EMAIL` or the ACME server.
+Delete the `amp-wildcard-tls` Secret as well as the Certificate. cert-manager will not re-issue into a Secret that already holds a valid certificate, so leaving it behind silently keeps the old (for example, staging) certificate in place. The ACME account key Secret only needs deleting if you are also changing `ACME_EMAIL` or the ACME server.
 
 **Changing the domain or hostnames after install requires a full teardown first.** The platform install is idempotent in the "create if missing" sense, so editing `DOMAIN_BASE` (or the `HOST_*` overrides) and re-running does **not** reconfigure already-installed services. To move an existing install to a different domain, delete the cluster and install again with the new config.
 
@@ -510,10 +510,10 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 ## Troubleshooting {#adv-troubleshooting}
 
 - **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER`, or a missing provider credential). Fix `amp-config.env` and re-run.
-- **Certificate never becomes Ready.** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit — re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
+- **Certificate never becomes Ready.** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
 - **Cert issued but a host is unreachable.** Confirm the service host's A record points at the VM (public or private IP) and that clients can reach `:443` on it. Issuance does not need this, but client access does.
 - **Login fails but every other host works.** `thunder.<DOMAIN_BASE>` is probably not resolving because the deeper `*.thunder` wildcard shadows it. Check with `dig +short thunder.<DOMAIN_BASE> A` and add the explicit A record (see **DNS records** under [How clients reach the VM](#adv-reachability)).
-- **A host returns a connection failure rather than an HTTP status.** The front-proxy route for that plane is not bound. List them with `kubectl get httproute -n openchoreo-control-plane` and check that each `amp-frontproxy-*` route reports `Accepted=True` and `ResolvedRefs=True`; a failed `ResolvedRefs` on the observability or data-plane route usually means its ReferenceGrant is missing. Note that a gateway-level `404` is a *healthy* response from an unrouted path — it proves TLS terminated and the request reached the gateway.
+- **A host returns a connection failure rather than an HTTP status.** The front-proxy route for that plane is not bound. List them with `kubectl get httproute -n openchoreo-control-plane` and check that each `amp-frontproxy-*` route reports `Accepted=True` and `ResolvedRefs=True`; a failed `ResolvedRefs` on the observability or data-plane route usually means its ReferenceGrant is missing. Note that a gateway-level `404` is a *healthy* response from an unrouted path: it proves TLS terminated and the request reached the gateway.
 - **Deployed agent unreachable while the console works.** On a public VM, confirm the `*.agents.<DOMAIN_BASE>` A record exists; on a private VM, add the agent's exact hostname to `/etc/hosts` (see the **Private network** tab under [How clients reach the VM](#adv-reachability)), since `/etc/hosts` cannot match wildcards.
 - **Certificate is untrusted after switching to production.** cert-manager will not re-issue into a Secret that still holds a valid staging certificate. Delete the Certificate and its Secret so it re-issues (see [Persistence and teardown](#adv-persistence)).
 - **Changed the domain but the console still shows the old hostnames.** Re-running with a new `DOMAIN_BASE` does not reconfigure existing releases. Delete the cluster and reinstall (see [Persistence and teardown](#adv-persistence)).

--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -207,7 +207,7 @@ Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `h
 
 The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you have your own domain. It issues **publicly-trusted certificates** via cert-manager's ACME **DNS-01** challenge and terminates TLS on `:443` at a single in-cluster gateway. Because DNS-01 validates by writing a DNS TXT record rather than by connecting to the VM, the same flow works whether the VM is **public** or reachable only from a **private network** — issuance needs outbound access only.
 
-Setup is the same for both up to and including the install; only how clients reach the VM differs. Work through [Prerequisites](#adv-prerequisites), [Configure](#adv-configure), and [Install](#adv-install), then follow either [Public network](#adv-public) or [Private network](#adv-private).
+Setup is the same for both up to and including the install; only how clients reach the VM differs. Work through [Prerequisites](#adv-prerequisites), [Configure](#adv-configure), and [Install](#adv-install), then switch the **Public network / Private network** selector below to the one matching your VM. Everything after that selector applies to both again.
 
 If you just want a quick IP-based demo with automatic TLS, prefer the **Simple** tab.
 
@@ -370,9 +370,14 @@ curl -fsSL "https://github.com/wso2/agent-manager/releases/download/amp/v${VER}/
 
 Note that `bootstrap.sh` cannot emit the template — it needs a version before it can download the bundle, so use the `--init` flow above to create the config.
 
-## Public network {#adv-public}
+## How clients reach the VM {#adv-reachability}
 
-Use this path when the VM has a public IP and clients reach it directly over the internet.
+The install is identical either way; what differs is DNS and how you get a browser to the console. Pick the one that matches your VM — the sections after this apply to both.
+
+<Tabs groupId="vm-network">
+<TabItem value="public" label="Public network" default>
+
+Use this when the VM has a public IP and clients reach it directly over the internet.
 
 Open inbound **`443/tcp` only** in your cloud security group or firewall. Nothing else needs to be reachable: certificate issuance is egress-only, and every service is multiplexed behind the single `:443` listener by `Host` header.
 
@@ -400,15 +405,16 @@ done
 ```
 :::
 
-## Private network {#adv-private}
+</TabItem>
+<TabItem value="private" label="Private network">
 
-Use this path when the VM has **no public IP** and is reachable only from inside your network. The advanced installer supports this unchanged, because DNS-01 validation never requires an inbound connection — the ACME CA reads a TXT record from your DNS provider instead of calling the VM. The result is a **publicly-trusted certificate on a private host**, with no private CA to distribute.
+Use this when the VM has **no public IP** and is reachable only from inside your network. The advanced installer supports this unchanged, because DNS-01 validation never requires an inbound connection — the ACME CA reads a TXT record from your DNS provider instead of calling the VM. The result is a **publicly-trusted certificate on a private host**, with no private CA to distribute.
 
 The VM still needs **outbound** internet access to pull images and charts and to reach the ACME and DNS-provider APIs. On Google Cloud that means a **Cloud NAT** gateway attached to the VM's subnet; the equivalent is a NAT gateway on AWS or Azure.
 
 ### Reaching the console
 
-You have two options. If your network has private DNS and routing to the VM, add the same records as the [public path](#adv-dns-records) but pointing at the VM's **private** IP, and connect normally — a public zone may hold private A records, and split-horizon DNS is fine too.
+You have two options. If your network has private DNS and routing to the VM, add the same four records listed under **Public network** but pointing at the VM's **private** IP, and connect normally — a public zone may hold private A records, and split-horizon DNS is fine too.
 
 Be aware that publishing private addresses in a **public** zone often does not survive the trip to the client. Many resolvers — home routers, corporate DNS, and public resolvers alike — drop RFC-1918 answers for public domains as DNS-rebinding protection, returning an empty result even though the record is correct. The symptom is a name that resolves from the authoritative nameserver but not from the client, and the browser reports `ERR_NAME_NOT_RESOLVED`. Compare the two before assuming the record is wrong:
 
@@ -468,6 +474,9 @@ If agent invocation fails with a DNS error while the console works, this is almo
 
 TLS still validates normally through the tunnel: the certificate is publicly trusted and the `Host` header is preserved, so the browser sees the real hostname and the gateway routes on it.
 
+</TabItem>
+</Tabs>
+
 ## Persistence and teardown {#adv-persistence}
 
 Application data (PostgreSQL), the issued certificate (a Kubernetes Secret, auto-renewed by cert-manager), and the k3d cluster persist across restarts. To tear down completely, delete the cluster — everything the installer created lives inside it, including the certificate and the gateway resources:
@@ -503,9 +512,9 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 - **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER`, or a missing provider credential). Fix `amp-config.env` and re-run.
 - **Certificate never becomes Ready.** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit — re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
 - **Cert issued but a host is unreachable.** Confirm the service host's A record points at the VM (public or private IP) and that clients can reach `:443` on it. Issuance does not need this, but client access does.
-- **Login fails but every other host works.** `thunder.<DOMAIN_BASE>` is probably not resolving because the deeper `*.thunder` wildcard shadows it. Check with `dig +short thunder.<DOMAIN_BASE> A` and add the explicit A record (see [DNS records](#adv-dns-records)).
+- **Login fails but every other host works.** `thunder.<DOMAIN_BASE>` is probably not resolving because the deeper `*.thunder` wildcard shadows it. Check with `dig +short thunder.<DOMAIN_BASE> A` and add the explicit A record (see **DNS records** under [How clients reach the VM](#adv-reachability)).
 - **A host returns a connection failure rather than an HTTP status.** The front-proxy route for that plane is not bound. List them with `kubectl get httproute -n openchoreo-control-plane` and check that each `amp-frontproxy-*` route reports `Accepted=True` and `ResolvedRefs=True`; a failed `ResolvedRefs` on the observability or data-plane route usually means its ReferenceGrant is missing. Note that a gateway-level `404` is a *healthy* response from an unrouted path — it proves TLS terminated and the request reached the gateway.
-- **Deployed agent unreachable while the console works.** On a public VM, confirm the `*.agents.<DOMAIN_BASE>` A record exists; on a private VM, add the agent's exact hostname to `/etc/hosts` (see [Private network](#adv-private)), since `/etc/hosts` cannot match wildcards.
+- **Deployed agent unreachable while the console works.** On a public VM, confirm the `*.agents.<DOMAIN_BASE>` A record exists; on a private VM, add the agent's exact hostname to `/etc/hosts` (see the **Private network** tab under [How clients reach the VM](#adv-reachability)), since `/etc/hosts` cannot match wildcards.
 - **Certificate is untrusted after switching to production.** cert-manager will not re-issue into a Secret that still holds a valid staging certificate. Delete the Certificate and its Secret so it re-issues (see [Persistence and teardown](#adv-persistence)).
 - **Changed the domain but the console still shows the old hostnames.** Re-running with a new `DOMAIN_BASE` does not reconfigure existing releases. Delete the cluster and reinstall (see [Persistence and teardown](#adv-persistence)).
 


### PR DESCRIPTION
## Purpose
"Run Agent Manager on a VM with Docker" was written against an earlier shape of both installers and has drifted from what they actually do. Every correction below was found by running the page end to end on clean VMs — one per path — and checking each claim against the resulting install rather than against the source.

**Advanced tab.** The page ran two quite different situations together: a VM with a public IP whose clients reach it over the internet, and a VM reachable only from inside a private network. They need different DNS records and different access instructions, and merging them left both under-served. The install workflow was also wrong: the page implied a config file could be produced by fetching `bootstrap.sh`, which has no `--init` handler and structurally cannot have one — it must resolve a release version before it can download the bundle that contains the installer. Finally the TLS diagram did not describe the front-proxy model the installer applies.

**Simple tab.** Three claims no longer match the installer. Teardown pointed at `agent-manager/deployments/quick-start/uninstall.sh`, but since the move to a versioned bundle there is no repository checkout on the VM at all — `bootstrap.sh` unpacks into a `mktemp -d` and its `EXIT` trap removes it — so `sudo find / -name uninstall.sh` returns nothing and the documented command cannot run. The gateway host was attributed to deployed agents' trace ingest, when platform-deployed agents export to the in-cluster gateway runtime and that host serves externally-hosted agents. And per-environment Thunder was undocumented despite the installer always writing a `*.thunder` wildcard site for it.

Related to #1390, which is the fix that made the OTel attribution wrong.

## Goals
Make both tabs describe the installers as they behave, so a reader can complete an install *and* a teardown from the page alone, on either a public or a private-network VM.

## Approach
**Advanced tab**
- Split into `Public network` and `Private network` sections, each carrying the DNS records, reachability and access instructions that case needs.
- Corrected the install sequence to download bundle → `install-advanced.sh --init` → fill → `--config`, and stated explicitly that `bootstrap.sh` cannot emit the template.
- Replaced the TLS diagram with the front-proxy model: one consolidated gateway terminating TLS on `:443` and forwarding by `Host` header to each plane's own gateway, with cross-namespace hops authorised by ReferenceGrants.
- Documented three traps hit while running the page: the `thunder.<DOMAIN_BASE>` wildcard-shadowing break, the browser certificate exception surviving the staging→production switch, and resolvers dropping RFC-1918 answers for public zones.
- Noted that the IAP tunnel binds a privileged port and needs `sudo`.

**Simple tab**
- Teardown now deletes the cluster directly with `sudo k3d cluster delete amp-local`, which is all `uninstall.sh --delete-cluster` did via its fast path, plus the Caddy container and volumes, and says the installer leaves no checkout behind so nobody hunts for a script that was never placed.
- Scoped `gateway.amp.<IP>.sslip.io/otel` to externally-hosted agents, with an admonition explaining that platform-deployed agents export in-cluster and never traverse Caddy.
- Added per-environment Thunder to the exposed-hosts table and the routing diagram, and extended the on-demand-TLS first-request note to cover new environments as well as new agents.

**Both tabs**
- Agent hosts are keyed by org/project, not by agent — a second agent in an existing project reuses that project's host.
- The one-time first-request certificate error is not a Chrome defect: every client racing the ACME challenge sees an untrusted certificate, and only the error string is Chromium's.

## User stories
As an operator evaluating Agent Manager on a VM — public or private-network — I can follow the page to a working install, see every hostname it exposes, and tear it down again without hunting for a script the installer never placed on the machine.

## Release note
N/A — documentation only, no product change.

## Documentation
This PR is the documentation change: `documentation/docs/getting-started/on-a-vm.mdx`.

## Training
N/A — no training content covers the VM installation guide.

## Certification
N/A — no certification exam covers the VM installation path.

## Marketing
N/A — corrections to existing installation documentation, not a promotable feature.

## Automation tests
 - Unit tests
   > N/A — documentation only, no code paths changed.
 - Integration tests
   > N/A — documentation only. Verification was manual against two live installs; see **Test environment**.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — the page is itself the walkthrough; no separate sample accompanies it.

## Related PRs
- #1390 — kept agent OTel ingestion in-cluster on VM installs, which is what made the simple tab's OTel attribution incorrect.

## Migrations (if applicable)
N/A — documentation only; nothing to migrate.

## Test environment
Both paths were installed from scratch on fresh VMs; no claim below was checked against a cluster that had been repaired by hand.

**Common:** Ubuntu 26.04 LTS, 4 vCPU / 8 GB RAM / 58 GB disk, inbound `443/tcp` only. Host tooling installed by following the page's own prerequisite links — Docker 29.6.2, k3d v5.9.0, kubectl v1.36.3, Helm v3.21.3, `lsof`.

**Simple path.** Completed exit 0 in ~11 minutes (page estimates 8–15); 52/52 pods `Running`. All six fixed hostnames served publicly-trusted certificates (`ssl_verify_result=0`). `sudo find / -name uninstall.sh` returned nothing and no `agent-manager` checkout existed, confirming the teardown path was unreachable. The generated `/opt/amp/Caddyfile` contained the `*.thunder.<IP>.sslip.io` site block with on-demand TLS.

**Advanced path, public network.** Custom domain delegated to Google Cloud DNS, `clouddns` DNS-01. Dry run confirmed the derived hosts, SAN list, helm overrides and every applied resource, with the provider credential redacted and no cluster contact. Install completed exit 0 in ~15 minutes (page estimates 15–20 plus issuance); 54/54 pods `Running`. One production Let's Encrypt wildcard certificate reached `Ready=True` covering all eight SANs. All three `amp-frontproxy-*` HTTPRoutes reported `Accepted=True` and `ResolvedRefs=True`. Both dynamic tiers were reachable and trusted with no manual attach. `thunder.<DOMAIN_BASE>` resolved only because of the explicit A record, reproducing the RFC 4592 behaviour exactly as the new warning describes.

**OTel attribution.** On both installs a deployed agent carried `AMP_OTEL_ENDPOINT=http://api-platform-<org>-<env>-gateway-gateway-runtime.<org>-<env>:22893/otel`, its startup log confirmed it exported there, its pod log contained zero export failures, and the public gateway host appeared nowhere in its pod spec.

**Docs build.** `npm run build` succeeds with `onBrokenLinks: 'throw'`, so the new cross-references resolve. Both edited diagrams were additionally rendered with `@mermaid-js/mermaid-cli` to confirm they still parse and lay out cleanly.

## Learning
The common thread is that none of these errors were visible from the repository — each one only surfaces by running the page against a machine that has never had the platform on it. The teardown break is the clearest case: it is a second-order effect of a change made elsewhere, because moving the installer from a git clone to a versioned bundle silently invalidated a path in the docs, and nothing links the two. The `bootstrap.sh --init` claim is the same shape. Re-walking an installation guide on a clean host after the installer's delivery mechanism changes is the only reliable way to catch that class of drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded VM installation guidance for Simple and Advanced setup paths.
  * Documented stronger agent isolation options, HTTPS routing, per-environment Thunder access, and certificate troubleshooting.
  * Added front-proxy architecture, wildcard TLS certificate setup, DNS requirements, and private-network access instructions.
  * Clarified configuration file permissions, dry-run installation previews, installation phases, persistence, teardown, and hostname changes.
  * Added troubleshooting guidance for cert-manager, routing, login, connectivity, and certificate issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->