### PR TITLE
Keep agent OTel ingestion in-cluster on VM installs

### DIFF
--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -85,8 +85,8 @@ run_install() {
   mapfile -t CP_HELM_ARGS < <(build_cp_helm_args "$VM_IP")
   # Public agents base + gateway host for the default Environment (read by
   # build_platform_resources_helm_args via dynamic scope); mirrors
-  # render_dataplane_external_ingress. AMP_HOST_GATEWAY drives the agent OTEL
-  # endpoint override (deployed agents export traces to the public gateway).
+  # render_dataplane_external_ingress. Deployed agents export traces over the
+  # chart's default in-cluster runtime endpoint, not this public host.
   # shellcheck disable=SC2034
   local AMP_AGENTS_BASE="agents.${VM_IP}.sslip.io"
   # shellcheck disable=SC2034

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -195,15 +195,26 @@ build_cp_helm_args() {
 #    externalURL: the invoke URL is empty and try-out falls back to a relative /chat
 #    (405) — the very symptom this override exists to fix. Both bind listenerName
 #    http (TLS terminates at Caddy) and differ only in advertised scheme.
-# shellcheck disable=SC2154  # AMP_AGENTS_BASE/AMP_HOST_GATEWAY come from the caller's scope by design.
+#
+# 2. apiPlatformGatewayVhost.otelEndpointOverride is deliberately NOT set. Deployed
+#    agents run inside this cluster, so they reach the gateway runtime directly on
+#    the chart's default in-cluster endpoint
+#    ("api-platform-<org>-<env>-gateway-gateway-runtime.<org>-<env>:22893/otel").
+#    Overriding it with the public gateway host makes every agent egress to
+#    <AMP_HOST_GATEWAY>:443 instead, which the sandbox NetworkPolicy refuses on a
+#    private-network VM: it allows :443 to 0.0.0.0/0 EXCEPT RFC-1918, and there the
+#    public hostname resolves to the VM's own private address. Trace export then
+#    fails with "Connection refused". On a public VM the same override happens to
+#    work only because the hostname resolves outside those ranges. The in-cluster
+#    endpoint is what the sandbox policy explicitly permits and works on both.
+# shellcheck disable=SC2154  # AMP_AGENTS_BASE comes from the caller's scope by design.
 build_platform_resources_helm_args() {
   printf '%s\n' \
     "--set" "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
     "--set" "environment.gateway.http.host=${AMP_AGENTS_BASE}" \
     "--set" "environment.gateway.http.port=443" \
     "--set" "environment.gateway.https.host=${AMP_AGENTS_BASE}" \
-    "--set" "environment.gateway.https.port=443" \
-    "--set" "apiPlatformGatewayVhost.otelEndpointOverride=https://${AMP_HOST_GATEWAY}/otel"
+    "--set" "environment.gateway.https.port=443"
 }
 
 # build_thunder_helm_args <ip>

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -271,9 +271,12 @@ assert_eq "caddy cp no direct 9243" "" "$(grep -F '127.0.0.1:9243' <<<"$cf_cp")"
   AMP_AGENTS_BASE=agents.amp.example.com
   AMP_HOST_GATEWAY=gateway.amp.example.com
   pr="$(build_platform_resources_helm_args)"
-  assert_eq "platform-resources agent OTEL endpoint override (public gateway)" \
-    "apiPlatformGatewayVhost.otelEndpointOverride=https://gateway.amp.example.com/otel" \
-    "$(grep -F 'apiPlatformGatewayVhost.otelEndpointOverride' <<<"$pr")"
+  # Agents run in-cluster and must use the chart's default in-cluster runtime
+  # endpoint. Overriding it with the public gateway host breaks trace export on a
+  # private-network VM, where that hostname resolves into an RFC-1918 range the
+  # sandbox NetworkPolicy blocks on :443.
+  assert_eq "platform-resources leaves agent OTEL endpoint in-cluster" "no" \
+    "$(has "$pr" 'apiPlatformGatewayVhost.otelEndpointOverride')"
   assert_eq "platform-resources oauth tokenUrl (direct svc)" \
     "global.oauth.tokenUrl=http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/token" \
     "$(grep -F 'global.oauth.tokenUrl' <<<"$pr")"


### PR DESCRIPTION
## Purpose
Deployed agents on a **private-network** VM install never export traces. Every span batch fails in the agent pod with:

```
Transient error HTTPSConnectionPool(host='gateway.<DOMAIN_BASE>', port=443): Max retries exceeded
with url: /otel/v1/traces (Caused by NewConnectionError(... [Errno 111] Connection refused))
```

The VM installer set `apiPlatformGatewayVhost.otelEndpointOverride` to the public gateway URL, so agents egress to `<AMP_HOST_GATEWAY>:443` rather than reaching the gateway runtime in-cluster. The agent-sandbox NetworkPolicy allows `:443` to `0.0.0.0/0` but **excludes RFC-1918**, and on a private VM that hostname resolves to the VM's own private address — so the sandbox refuses the connection.

A public VM survives this only by accident: its hostname resolves outside those excluded ranges. Even there the traffic leaves the host and hairpins back in through `:443` to reach a service sitting in the same cluster.

## Goals
Make agent trace ingestion work on private-network VMs, and stop public/simple installs depending on a hairpin that only works because a public IP happens to pass the sandbox filter.

## Approach
Stop setting `apiPlatformGatewayVhost.otelEndpointOverride` and let the chart's default apply.

That override predates `52092a68`, which repointed the chart's default endpoint at the per-environment gateway runtime service (`api-platform-<org>-<env>-gateway-gateway-runtime.<org>-<env>:22893/otel`) precisely because — in that commit's own words — the in-cluster path "is what the sandbox NetworkPolicy egress allows (namespace label `amp.wso2.com/api-platform-gateway=true`, port 22893) and avoids the host-hairpin vhost, which a sandboxed pod cannot reach". The override's original justification (the old default pointed at `*.gateway.localhost`, unresolvable on a VM) no longer holds, so the installer should simply defer to the chart.

The console's `instrumentationUrl` deliberately stays on the public host: that endpoint is advertised to **external** agents, which do need a reachable public URL. Only the env var injected into in-cluster deployed agents changes.

## User stories
As an operator running Agent Manager on a private-network VM, traces from my deployed agents appear in the observer instead of silently failing to export.

## Release note
Fixed deployed-agent trace ingestion on VM installs, which failed on private-network VMs because agents exported telemetry over the public gateway host instead of the in-cluster gateway runtime.

## Documentation
N/A — the endpoint is internal and not documented; the VM page describes OTel ingest only for external agents, which is unchanged.

## Training
N/A — no training content covers agent telemetry routing.

## Certification
N/A — no certification exam covers this internal endpoint.

## Marketing
N/A — bug fix.

## Automation tests
 - Unit tests
   > `deployments/vm/tests/run.sh` passes (19 assertions). The assertion that previously required the override to equal the public gateway URL is inverted to require it is **absent**, so reintroducing the override fails the suite.
 - Integration tests
   > N/A — no harness provisions a VM. Verified manually against a live private-network install (see Test environment).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Worth noting this change *strengthens* the security posture: agent telemetry now stays inside the cluster on the port the sandbox policy explicitly permits, instead of leaving the host and re-entering over the public listener. It needs no relaxation of the sandbox's RFC-1918 egress restriction.

## Samples
N/A — no sample covers VM telemetry routing.

## Related PRs
N/A — no dependent PRs.

## Migrations (if applicable)
Existing VM installs keep the old override until the platform-resources release is upgraded. Clearing it in place works without a reinstall:

```bash
helm upgrade amp-platform-resources oci://ghcr.io/wso2/wso2-amp-platform-resources-extension \
  --version <release> -n default --reuse-values \
  --set apiPlatformGatewayVhost.otelEndpointOverride=""
```

Deployed agents are re-reconciled automatically and pick up the in-cluster endpoint; no agent redeploy is needed.

## Test environment
Verified on a private-network VM (Ubuntu 24.04, 4 vCPU, 16 GB RAM, 50 GB disk, no external IP, egress via Cloud NAT) running the advanced installer at release `1.0.0-alpha1` with a custom domain and cert-manager DNS-01 issuance.

Before: agent logs showed continuous `Connection refused` to the gateway host, ending in `Failed to export span batch`. Confirmed from inside the agent container via raw sockets that `:443` to the VM's private address and to the k3d node address were both refused, while the public internet, the gateway runtime ClusterIP on `:22893`, and CoreDNS were all reachable — matching the sandbox NetworkPolicy's `except` list exactly.

After clearing the override, the running agent picked up `AMP_OTEL_ENDPOINT=http://api-platform-default-default-gateway-gateway-runtime.default-default:22893/otel` automatically, and subsequent chats produced **zero** `Connection refused` and **zero** `Failed to export span batch` occurrences, with traces reaching the observer. Evaluation monitors (immediate and scheduled) also ran successfully on the same install.

## Learning
The failure was easy to misattribute. Short-lived `kubectl run --rm` probe pods reached the blocked addresses even when labelled to match the sandbox NetworkPolicy, which suggested the policy was not enforced at all; the restriction only reproduces against the real, long-lived agent pod, because a brief pod can start before kube-router programs its rules. Testing the actual workload rather than a stand-in was what made the RFC-1918 exclusion visible.
