### PR TITLE
Pin Air in the service dev image

### DIFF
--- a/agent-manager-service/Dockerfile.dev
+++ b/agent-manager-service/Dockerfile.dev
@@ -1,8 +1,11 @@
 FROM public.ecr.aws/docker/library/golang:1.25-alpine
 
-# Install Air for hot-reloading and bash/openssl for key generation
+# Install Air for hot-reloading and bash/openssl for key generation.
+# Air is pinned: the image ships GOTOOLCHAIN=local, so any Air release that
+# needs a newer Go than the base image above fails the build. Bump this pin
+# and the base image together.
 RUN apk add --no-cache bash openssl && \
-    go install github.com/air-verse/air@latest
+    go install github.com/air-verse/air@v1.67.1
 
 WORKDIR /app
 

--- a/agent-manager-service/README.md
+++ b/agent-manager-service/README.md
@@ -45,7 +45,7 @@ agent-manager-service/
 - **Go**: Version 1.25.0 or later
 - **PostgreSQL**: Version 12 or later
 - **Make**: For build automation
-- **air** go install github.com/air-verse/air@latest
+- **air** go install github.com/air-verse/air@v1.67.1
 - **moq**   go install github.com/matryer/moq@v0.5.3
 
 ## Local Development


### PR DESCRIPTION
## Purpose
The nightly instrumentation matrix `heavy-tier` job (and any other fresh `make setup-platform`, including local ones) fails while standing up the dev stack. The service dev image installs Air with a floating `@latest`, and Air v1.67.2 raised its `go` directive to 1.26. `Dockerfile.dev` builds on `golang:1.25-alpine`, and the official golang images ship `GOTOOLCHAIN=local`, so Go errors out rather than fetching a 1.26 toolchain:

```
go: github.com/air-verse/air@latest: github.com/air-verse/air@v1.67.2
    requires go >= 1.26.0 (running go 1.25.12; GOTOOLCHAIN=local)
make: *** [Makefile:120: setup-platform] Error 1
```

## Goals
Unblock the dev stack build, and stop an upstream release from being able to break every CI run and every developer machine without a commit in this repo.

## Approach
Pin the install to `air@v1.67.1` — the newest release whose `go.mod` still declares `go 1.25`, so it matches the base image. A comment on the `RUN` records why the pin exists and that it should be bumped together with the base image when the service moves to Go 1.26.

The alternative, bumping the base image to `golang:1.26-alpine`, was not taken here: `agent-manager-service/go.mod` targets `go 1.25.7`, so it would widen the dev/CI toolchain gap for a reason unrelated to this failure. It remains the natural follow-up whenever the service itself moves to 1.26.

## User stories
N/A — build tooling fix with no user-facing behavior.

## Release note
Pin Air to v1.67.1 in the Agent Manager service dev image so dev stack builds no longer break on Air releases that require a newer Go toolchain than the base image.

## Documentation
N/A — no doc impact; the change is internal to the development Dockerfile and does not alter any documented workflow or command.

## Training
N/A

## Certification
N/A — build tooling change with no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — no application code changed; the change is a Dockerfile build argument.
 - Integration tests
   > Verified by building the image directly: `docker build -f Dockerfile.dev .` succeeds, and `air -v` in the resulting image reports `v1.67.1, built with Go go1.25.12`. The same build failed before this change. Full coverage comes from the next nightly matrix run, which stands up the stack via this image.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data migration.

## Test environment
macOS 15 (darwin 25.5.0), Docker buildx, base image `public.ecr.aws/docker/library/golang:1.25-alpine` (Go 1.25.12).

## Learning
Air's v1.67.2 release (2026-07-22) was the first to require Go 1.26; v1.67.1 and everything before it declare `go 1.25`. Worth remembering that the official `golang` Docker images set `GOTOOLCHAIN=local`, which turns a bumped `go` directive upstream into a hard build failure rather than a transparent toolchain download.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the development hot-reload tooling to a specific version for more consistent development environments.
  * Retained required shell and security utility installation in the development image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->