### PR TITLE
Correct the simple VM path's exposed hosts and teardown

### DIFF
--- a/documentation/docs/getting-started/on-a-vm.mdx
+++ b/documentation/docs/getting-started/on-a-vm.mdx
@@ -27,7 +27,7 @@ Install Agent Manager on a Linux VM where Docker is the only host dependency. Pi
 <Tabs groupId="vm-installer">
 <TabItem value="simple" label="Simple (IP + automatic TLS)" default>
 
-The simple installer exposes the platform over HTTPS using [sslip.io](https://sslip.io) hostnames derived from the VM's public IP, so there's no domain registration and no client `/etc/hosts` edits.
+The simple installer exposes the platform over HTTPS using [sslip.io](https://sslip.io) hostnames derived from the VM's public IP, so there's no domain registration.
 
 ## Prerequisites
 
@@ -111,6 +111,7 @@ flowchart TB
             api["amp-api"]
             thunder["Thunder OAuth"]
             cp["Gateway control plane<br/>(external AI gateways)"]
+            envthunder["Per-environment Thunder"]
             observer["Agent Manager Observer"]
             gw["AI Gateway<br/>OTel ingest · LLM proxy"]
             agents["Deployed agents"]
@@ -120,28 +121,37 @@ flowchart TB
     browser -->|"HTTPS :443"| caddy
     le <-->|"TLS-ALPN-01<br/>inside the :443 handshake"| caddy
     caddy -->|"console.amp.&lt;IP&gt;.sslip.io<br/>api.amp.&lt;IP&gt;.sslip.io<br/>thunder.amp.&lt;IP&gt;.sslip.io<br/>cp.amp.&lt;IP&gt;.sslip.io"| cpgw
+    caddy -->|"*.thunder.amp.&lt;IP&gt;.sslip.io<br/>on-demand TLS"| cpgw
     caddy -->|"observer.amp.&lt;IP&gt;.sslip.io"| opgw
     caddy -->|"gateway.amp.&lt;IP&gt;.sslip.io<br/>*.agents.&lt;IP&gt;.sslip.io<br/>on-demand TLS"| dpgw
     cpgw --> console
     cpgw --> api
     cpgw --> thunder
     cpgw --> cp
+    cpgw --> envthunder
     opgw --> observer
     dpgw --> gw
     dpgw --> agents
 ```
 
-Every public hostname resolves to the VM's IP (via sslip.io) and arrives at Caddy on `:443`; Caddy terminates TLS and reverse-proxies to the matching loopback port. The Agent Manager services are ClusterIP inside the cluster: Caddy forwards the console, API, Thunder, and gateway-control-plane hosts to the OpenChoreo control-plane kgateway (loopback `:8080`), the observer host to the observability-plane kgateway (loopback `:11080`), and the OTel-ingest host plus the deployed-agent wildcard to the data-plane kgateway (loopback `:19080`) — each gateway routes by the preserved `Host` header. Certificates are obtained over that same `:443` using the TLS-ALPN-01 challenge, so no inbound port 80 is needed. The deployed-agent wildcard gets its certificate on demand at first request.
+Every public hostname resolves to the VM's IP (via sslip.io) and arrives at Caddy on `:443`; Caddy terminates TLS and reverse-proxies to the matching loopback port. The Agent Manager services are ClusterIP inside the cluster: Caddy forwards the console, API, Thunder, gateway-control-plane, and per-environment Thunder hosts to the OpenChoreo control-plane kgateway (loopback `:8080`), the observer host to the observability-plane kgateway (loopback `:11080`), and the OTel-ingest host plus the deployed-agent wildcard to the data-plane kgateway (loopback `:19080`) — each gateway routes by the preserved `Host` header. Certificates are obtained over that same `:443` using the TLS-ALPN-01 challenge, so no inbound port 80 is needed.
+
+Two of these tiers are **dynamic** — a new host appears the first time you deploy into a new org/project, and each time you create an environment — so a wildcard certificate cannot be issued for them via TLS-ALPN-01 up front. Caddy instead issues one concrete certificate per hostname **on demand**, at the first request to it.
 
 | URL | Purpose |
 |---|---|
 | `https://console.amp.<IP>.sslip.io` | Console UI |
 | `https://api.amp.<IP>.sslip.io` | Agent Manager API (used by `amctl`) |
 | `https://thunder.amp.<IP>.sslip.io` | Thunder OAuth (login) |
+| `https://<org>-<env>.thunder.<IP>.sslip.io` | Per-environment Thunder (one host per environment, created on demand) |
 | `https://observer.amp.<IP>.sslip.io` | Agent Manager Observer |
-| `https://gateway.amp.<IP>.sslip.io/otel` | OTel trace ingest from deployed agents |
+| `https://gateway.amp.<IP>.sslip.io/otel` | OTel trace ingest for **externally-hosted** agents (see below) |
 | `https://<org>-<project>.agents.<IP>.sslip.io/...` | Deployed-agent invocation endpoints (one wildcard host per org/project) |
 | `https://cp.amp.<IP>.sslip.io` | Gateway control plane; connect external gateways here (on by default) |
+
+:::note Agents deployed on this VM do not use the public OTel host
+`gateway.amp.<IP>.sslip.io/otel` exists for agents running **outside** the platform, which set [`AMP_OTEL_ENDPOINT`](../components/amp-instrumentation.mdx) themselves. Agents deployed by Agent Manager run inside the cluster and export their traces straight to the in-cluster gateway runtime instead, so their traffic never leaves the VM or passes through Caddy.
+:::
 
 ## Log in
 
@@ -153,7 +163,9 @@ The **`admin`** account is provisioned with the `Agent Manager Admin` role durin
 
 When you deploy an agent, its endpoint is published on a per-project host `<org>-<project>.agents.<IP>.sslip.io` and routed by Caddy to the OpenChoreo data-plane gateway. Because these hostnames are dynamic (a new one per org/project), Caddy issues their TLS certificates **on demand** at the first request (via the same ACME challenge as the fixed hosts), rather than up front. Invocations are authenticated with a user token that the gateway validates against the public Thunder issuer.
 
-Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error**, most visibly `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` in Chrome. That first connection is consumed by Caddy answering the ACME challenge, so the browser briefly sees the challenge certificate instead of the real one. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host; the certificate is then cached in the `amp-caddy-data` volume.
+Because issuance is on demand and uses TLS-ALPN-01 (the challenge runs inside the `:443` handshake), the **very first request to a newly-deployed agent host can fail with a one-time certificate error**. That first connection is consumed by Caddy answering the ACME challenge, so the client briefly sees the challenge certificate instead of the real one. Every client hits this — only the wording differs: Chromium-based browsers (Chrome, Edge, Brave) report `ERR_CERTIFICATE_TRANSPARENCY_REQUIRED`, while other browsers and command-line clients report their own untrusted-certificate error. Issuance completes within a second or two; reload the page (or open it in a fresh tab) and it serves the trusted Let's Encrypt certificate. This only affects the first hit per new agent host; the certificate is then cached in the `amp-caddy-data` volume.
+
+The same applies to the per-environment Thunder hosts (`<org>-<env>.thunder.<IP>.sslip.io`): they are created when you add an environment and get their certificates on demand the same way, so the first request to a brand-new environment's Thunder can show the same one-time error.
 
 amp-api advertises each agent endpoint with the `https://` scheme (the installer sets `tlsEnabled` on the service), so the console (and any other caller) invokes it over TLS directly through the wildcard site.
 
@@ -165,16 +177,17 @@ Because the challenge happens inside the TLS handshake, the public `:443` must r
 
 ## Persistence and teardown
 
-Application data (PostgreSQL), issued certificates, and the k3d cluster persist across Docker/host restarts via named volumes. To tear down completely, delete the cluster, then remove the Caddy front door and its volumes (which hold the issued certificates and ACME account):
+Application data (PostgreSQL), issued certificates, and the k3d cluster persist across Docker/host restarts via named volumes. Everything the installer created lives either inside the k3d cluster or in the Caddy container and its two volumes, so tearing down is the three commands below, plus one optional cleanup:
 
 ```bash
-cd agent-manager/deployments/quick-start
-sudo ./uninstall.sh --delete-cluster                    # delete the k3d cluster (workloads + app data)
+sudo k3d cluster delete amp-local                        # delete the cluster (workloads + app data)
 sudo docker rm -f amp-caddy                              # remove the Caddy front door
 sudo docker volume rm amp-caddy-data amp-caddy-config    # drop the cached certs + ACME account
+
+sudo rm -f /opt/amp/Caddyfile                            # optional: the generated Caddy config
 ```
 
-Use `sudo`; the installer runs Docker and k3d as root. Plain `./uninstall.sh` (without `--delete-cluster`) only removes the Helm releases and leaves the cluster running; `uninstall.sh` does not touch the Caddy container or its volumes, so remove those separately as shown.
+Use `sudo`; the installer runs Docker and k3d as root. Note that the installer leaves no repository checkout on the VM — `bootstrap.sh` unpacks the versioned bundle into a temporary directory and deletes it on exit — so teardown is done with the commands above rather than an uninstall script. Deleting the cluster removes the platform's data; deleting the Caddy volumes discards the issued certificates and the ACME account, so a reinstall re-requests them from Let's Encrypt (which counts against its rate limits).
 
 ## Connect an external gateway
 
@@ -187,7 +200,7 @@ Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `h
 - **Certificates never issue / hosts unreachable from outside.** Open inbound `:443` in your cloud security group / NACL, and make sure the public `:443` reaches the VM as **raw TCP**: a TLS-terminating load balancer in front breaks the TLS-ALPN-01 challenge. The installer can't verify external reachability from inside the VM, so this surfaces as Caddy failing to obtain certificates (`docker logs amp-caddy`).
 - **Certificate not issued.** Check `docker logs amp-caddy`. Let's Encrypt rate limits on sslip.io are high but not infinite; if hit, retry shortly.
 - **Login redirect mismatch.** Confirm you reached the console via its `console.amp.<IP>.sslip.io` URL, not the raw IP.
-- **Certificate error on first agent invocation** (`ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` or similar): the per-agent certificate is issued on demand, and the first request races with that issuance. Reload the page after a second or two; it only happens once per new agent host (see [Deployed-agent invocation](#deployed-agent-invocation)).
+- **Certificate error on first agent invocation** (`ERR_CERTIFICATE_TRANSPARENCY_REQUIRED` in Chromium-based browsers, an untrusted-certificate warning elsewhere): the per-agent certificate is issued on demand, and the first request races with that issuance. Reload the page after a second or two; it only happens once per new agent host (see [Deployed-agent invocation](#deployed-agent-invocation)).
 
 </TabItem>
 <TabItem value="advanced" label="Advanced">


### PR DESCRIPTION
## Purpose
Three statements in the **Simple** tab of the "Run Agent Manager on a VM with Docker" guide no longer describe what the installer does. All three were found by following the page end to end on a clean Ubuntu VM and comparing each claim against the resulting install.

1. **Teardown cannot be executed as written.** The page says to run `cd agent-manager/deployments/quick-start && sudo ./uninstall.sh --delete-cluster`. The simple installer downloads a versioned bundle rather than cloning the repository, and `bootstrap.sh` unpacks that bundle into a `mktemp -d` which its `EXIT` trap removes, so no checkout and no `uninstall.sh` exist on the VM afterwards. A reader following the teardown section has nothing to `cd` into.
2. **The OTel ingest host is attributed to the wrong agents.** `gateway.amp.<IP>.sslip.io/otel` is listed as "OTel trace ingest from deployed agents". Agents deployed by the platform run inside the cluster and export to the in-cluster gateway runtime; the public host exists for externally hosted agents that set `AMP_OTEL_ENDPOINT` themselves.
3. **Per-environment Thunder is undocumented.** The installer has always written a `*.thunder.<IP>.sslip.io` wildcard site into the Caddyfile, one host per org/environment created as environments are added. It appears in neither the exposed-hosts table nor the routing diagram, even though the Advanced tab documents the equivalent tier.

Related to #1388, which does the same accuracy pass over the Advanced tab of this page.

## Goals
Make the Simple tab's exposed-host inventory, routing diagram, and teardown instructions match the installer, so that a reader can complete both install and teardown from the page alone.

## Approach
- **Teardown** now deletes the cluster directly with `sudo k3d cluster delete amp-local` — which is exactly what `uninstall.sh --delete-cluster` did via its fast path — followed by the existing Caddy container and volume removal, plus the generated `/opt/amp/Caddyfile`. Added an explicit note that the installer leaves no checkout behind, so a reader who goes looking for an uninstall script knows why there isn't one.
- **OTel host** row now reads "OTel trace ingest for **externally-hosted** agents", with an admonition explaining that platform-deployed agents export in-cluster and never traverse Caddy, linking to the instrumentation reference where `AMP_OTEL_ENDPOINT` is documented.
- **Per-environment Thunder** added as a row in the exposed-hosts table and as a node in the routing diagram, with its own labelled Caddy → control-plane-kgateway edge. The prose above the table now names both dynamic tiers and explains once why they need on-demand TLS instead of an up-front wildcard, and the existing first-request certificate-error note is extended to cover new environments as well as new agents.

## User stories
As an operator evaluating Agent Manager on a VM, I can see every hostname the install exposes and can tear the install down again without hunting for a script the installer never placed on the machine.

## Release note
N/A — documentation only, no product change.

## Documentation
This PR is the documentation change: `documentation/docs/getting-started/on-a-vm.mdx`.

## Training
N/A — no training content covers the VM installation guide.

## Certification
N/A — no certification exam covers the VM installation path.

## Marketing
N/A — a correction to existing installation documentation, not a promotable feature.

## Automation tests
 - Unit tests
   > N/A — documentation only, no code paths changed.
 - Integration tests
   > N/A — documentation only. Verification was manual, against a live install; see **Test environment**.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — this page is itself the walkthrough; no separate sample accompanies it.

## Related PRs
- #1388 — the same accuracy pass over the Advanced tab of this page.

## Migrations (if applicable)
N/A — documentation only; nothing to migrate.

## Test environment
Every claim below was checked against a clean simple install, not a repaired one.

- **VM:** Ubuntu 26.04 LTS, 4 vCPU / 8 GB RAM / 58 GB disk, public IP, inbound `443/tcp` only.
- **Host tooling** installed by following the page's own prerequisite links: Docker 29.6.2, k3d v5.9.0, kubectl v1.36.3, Helm v3.21.3, plus `lsof`.
- **Install:** `bootstrap.sh simple` completed with exit 0 in ~11 minutes (the page estimates 8–15). 52/52 pods `Running`, none failing.
- **Exposed hosts:** all six fixed hostnames served publicly-trusted Let's Encrypt certificates (`ssl_verify_result=0`) over `:443`.
- **Teardown claim:** `sudo find / -name uninstall.sh` returned no results, and neither `~/agent-manager` nor `/root/agent-manager` exists — confirming the documented path is unreachable.
- **Per-environment Thunder claim:** the generated `/opt/amp/Caddyfile` contains a `*.thunder.<IP>.sslip.io` site block proxying to `127.0.0.1:8080` with the on-demand TLS block.
- **OTel claim:** a deployed agent's pod carries `AMP_OTEL_ENDPOINT=http://api-platform-default-default-gateway-gateway-runtime.default-default:22893/otel`, and its startup log confirms it exports there; the console's `instrumentationUrl` remains the public host, which is what an externally hosted agent uses.
- **Docs build:** `npm run build` in `documentation/` succeeds with `onBrokenLinks: 'throw'`, so the new cross-reference resolves. The edited diagram was additionally rendered with `@mermaid-js/mermaid-cli` to confirm it still parses and lays out cleanly.

## Learning
The failure mode worth recording is that all three errors were invisible from the repository: each one only shows up by running the page against a machine that has never had the platform on it. The teardown break in particular is a second-order effect of a change made elsewhere — moving the installer from a git clone to a versioned bundle silently invalidated a path in the docs that nothing links the two together. Re-walking an installation guide on a clean host after the installer's delivery mechanism changes is the only reliable way to catch that class of drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the “Run Agent Manager on a VM” guide to reflect per-environment Thunder tier behavior, including expanded “What gets exposed” routing/certificate details and environment-specific Thunder hostname guidance.
  - Clarified that externally hosted agent endpoints are handled differently in the gateway/OTEL description.
  - Improved guidance on first-invocation, one-time certificate errors for newly created per-environment Thunder hosts when adding an environment.
  - Reworked Simple installer teardown instructions with an explicit command sequence and clearer notes on what’s removed vs persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->