### PR TITLE
[UI Improvements] Remove unused EndpointCard, rename MCP Proxy to MCP Server, and enhance MCPCapabilitiesView

### DIFF
--- a/console/workspaces/core-ui/src/Layouts/OxygenLayout/navigationItems.tsx
+++ b/console/workspaces/core-ui/src/Layouts/OxygenLayout/navigationItems.tsx
@@ -752,7 +752,7 @@ export function useNavigationItems(): Array<
                   ),
                 },
                 {
-                  label: "MCP Proxies",
+                  label: "MCP Servers",
                   type: "item" as const,
                   icon: <MCPLogo size={20} />,
                   href: generatePath(mcpProxiesOrgRoute.path, { orgId }),

--- a/console/workspaces/libs/api-client/src/hooks/agent-mcp-proxies.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agent-mcp-proxies.ts
@@ -44,7 +44,7 @@ export function useAddAgentMCPProxy() {
     unknown,
     { params: AddAgentMCPProxyPathParams; body: AddAgentMCPProxyRequest }
   >({
-    action: { verb: "create", target: "MCP proxy" },
+    action: { verb: "create", target: "MCP server" },
     mutationFn: ({ params, body }) => addAgentMCPProxy(params, body, getToken),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({

--- a/console/workspaces/libs/api-client/src/hooks/mcp-proxies.ts
+++ b/console/workspaces/libs/api-client/src/hooks/mcp-proxies.ts
@@ -60,7 +60,7 @@ export function useCreateMCPProxy() {
     unknown,
     { params: CreateMCPProxyPathParams; body: MCPProxy }
   >({
-    action: { verb: "create", target: "mcp proxy" },
+    action: { verb: "create", target: "mcp server" },
     mutationFn: ({ params, body }) => createMCPProxy(params, body, getToken),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["mcp-proxies"] });
@@ -85,7 +85,7 @@ export function useUpdateMCPProxy() {
     unknown,
     { params: UpdateMCPProxyPathParams; body: MCPProxy }
   >({
-    action: { verb: "update", target: "mcp proxy" },
+    action: { verb: "update", target: "mcp server" },
     mutationFn: ({ params, body }) => updateMCPProxy(params, body, getToken),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["mcp-proxies"] });
@@ -98,7 +98,7 @@ export function useDeleteMCPProxy() {
   const { getToken } = useAuthHooks();
   const queryClient = useQueryClient();
   return useApiMutation<void, unknown, DeleteMCPProxyPathParams>({
-    action: { verb: "delete", target: "mcp proxy" },
+    action: { verb: "delete", target: "mcp server" },
     mutationFn: (params) => deleteMCPProxy(params, getToken),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["mcp-proxies"] });

--- a/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
@@ -188,7 +188,7 @@ export const CatalogAgentFlow: React.FC = () => {
 
     if ((llmProviders.length > 0 || mcpProxies.length > 0) && !initialEnvironmentName) {
       setLastSubmittedValidationErrors({
-        llmProvider: "Unable to resolve the initial deployment environment for LLM provider / MCP proxy configuration.",
+        llmProvider: "Unable to resolve the initial deployment environment for LLM provider / MCP Server configuration.",
       });
       return;
     }

--- a/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
@@ -118,7 +118,7 @@ export const InternalAgentFlow: React.FC = () => {
 
     if ((llmProviders.length > 0 || mcpProxies.length > 0) && !initialEnvironmentName) {
       setLastSubmittedValidationErrors({
-        llmProvider: "Unable to resolve the initial deployment environment for LLM provider / MCP proxy configuration.",
+        llmProvider: "Unable to resolve the initial deployment environment for LLM provider / MCP Server configuration.",
       });
       return;
     }

--- a/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
@@ -73,7 +73,7 @@ const ProxyDisplay: React.FC<{
   proxy: ProxyInfo | null;
   isSelected: boolean;
   fallbackLabel?: string;
-}> = ({ proxy, isSelected, fallbackLabel = "Select MCP proxy" }) => {
+}> = ({ proxy, isSelected, fallbackLabel = "Select MCP Server" }) => {
   return (
     <Stack direction="row" spacing={2} flexGrow={1} alignItems="center">
       <Avatar
@@ -152,7 +152,7 @@ const EntryCard: React.FC<EntryCardProps> = ({
   const firstProxyEntry = Object.values(entry.selectedProxyByEnv).find(
     (e): e is { id: string; name: string } => e !== null && e !== undefined,
   );
-  const displayName = firstProxyEntry?.name ?? `MCP Proxy ${index + 1}`;
+  const displayName = firstProxyEntry?.name ?? `MCP Server ${index + 1}`;
 
   const handleEnvTabChange = useCallback(
     (_: React.SyntheticEvent, v: number) => setSelectedEnvIndex(v),
@@ -199,7 +199,7 @@ const EntryCard: React.FC<EntryCardProps> = ({
       >
         <Stack direction="row" alignItems="center" justifyContent="space-between" flexGrow={1} pr={1}>
           <Typography variant="subtitle2">{displayName}</Typography>
-          <IconButton size="small" aria-label="Remove MCP proxy" onClick={handleRemoveClick}>
+          <IconButton size="small" aria-label="Remove MCP Server" onClick={handleRemoveClick}>
             <Trash2 size={16} />
           </IconButton>
         </Stack>
@@ -231,7 +231,7 @@ const EntryCard: React.FC<EntryCardProps> = ({
                 startIcon={<Plus size={16} />}
                 onClick={handleOpenDrawer}
               >
-                Select MCP Proxy for {selectedEnvLabel}
+                Select MCP Server for {selectedEnvLabel}
               </Button>
             )}
           </Box>
@@ -461,7 +461,7 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
 
   return (
     <Form.Section>
-      <Form.Subheader>MCP Proxies (Optional)</Form.Subheader>
+      <Form.Subheader>MCP Servers (Optional)</Form.Subheader>
 
       <Stack spacing={1}>
         {mcpProxies.map((entry, index) => {
@@ -516,18 +516,18 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
       >
         <DrawerHeader
           icon={<ServerCog size={24} />}
-          title="Select MCP Proxy"
+          title="Select MCP Server"
           onClose={handleDrawerClose}
         />
         <DrawerContent>
           <Stack>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
               {editingIndex === null
-                ? "Select an MCP proxy for this configuration."
-                : "Change the MCP proxy for this configuration."}
+                ? "Select an MCP server for this configuration."
+                : "Change the MCP server for this configuration."}
             </Typography>
             <SearchBar
-              placeholder="Search MCP proxies"
+              placeholder="Search MCP servers"
               size="small"
               fullWidth
               value={proxySearchQuery}
@@ -555,8 +555,8 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
                     <ListingTable.Container>
                       <ListingTable.EmptyState
                         illustration={<Search size={64} />}
-                        title={isSearchMode ? "No MCP proxies match your search" : "No MCP proxies available"}
-                        description={isSearchMode ? "Try a different keyword or clear the search filter." : "No MCP proxies found. Add MCP proxies from the organization MCP Proxies page first."}
+                        title={isSearchMode ? "No MCP servers match your search" : "No MCP servers available"}
+                        description={isSearchMode ? "Try a different keyword or clear the search filter." : "No MCP servers found. Add MCP servers from the organization MCP Servers page first."}
                         action={
                           (!isSearchMode && orgId) ? (
                             <Button
@@ -573,7 +573,7 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
                                 )
                               }
                             >
-                              Add MCP Proxy
+                              Register MCP Server
                             </Button>
                           ) : undefined
                         }
@@ -624,7 +624,7 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
                 >
                   <Plus size={16} />
                   <Typography variant="body2" color="primary">
-                    Add MCP Proxy
+                    Register MCP Server
                   </Typography>
                   <ExternalLink size={14} />
                 </Box>

--- a/console/workspaces/pages/configure-agent/src/Configure/subComponents/AddMCPToolConfigPanel.tsx
+++ b/console/workspaces/pages/configure-agent/src/Configure/subComponents/AddMCPToolConfigPanel.tsx
@@ -326,7 +326,7 @@ export function AddMCPToolConfigPanel({
                     <ListingTable.EmptyState
                       illustration={<ServerCog size={64} />}
                       title="No MCP servers available"
-                      description="No MCP servers found. Add MCP servers from the organization MCP Proxies page first."
+                      description="No MCP servers found. Add MCP servers from the organization MCP Servers page first."
                       action={
                         orgId ? (
                           <Button
@@ -343,7 +343,7 @@ export function AddMCPToolConfigPanel({
                               )
                             }
                           >
-                            Add MCP Server
+                            Register MCP Server
                           </Button>
                         ) : undefined
                       }
@@ -485,7 +485,7 @@ export function AddMCPToolConfigPanel({
                       This tool uses OAuth (AgentID) security. These values
                       are injected into the agent&apos;s pod at runtime, use
                       them in your code to request a token. Scopes are
-                      configured on this MCP proxy&apos;s own security
+                      configured on this MCP Server&apos;s own security
                       settings.
                     </Typography>
                   </Alert>

--- a/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
@@ -857,7 +857,7 @@ export const ViewMCPServerComponent = () => {
                 This tool uses OAuth (AgentID) security. These values are
                 injected into your agent&apos;s pod at runtime, use them in
                 your code to request a token. Scopes are configured on this
-                MCP proxy&apos;s own security settings.
+                MCP Server&apos;s own security settings.
               </Typography>
             </Alert>
             <Form.Section>
@@ -926,12 +926,12 @@ export const ViewMCPServerComponent = () => {
             <Card variant="outlined">
               <CardContent sx={{ position: "relative" }}>
                 {configProxyHref && (
-                  <Tooltip title="View MCP proxy" placement="top" arrow>
+                  <Tooltip title="View MCP Server" placement="top" arrow>
                     <IconButton
                       size="small"
                       color="primary"
                       onClick={() => navigate(configProxyHref)}
-                      aria-label={`View MCP proxy ${configProxy.name ?? configProxyName} in the organization`}
+                      aria-label={`View MCP Server ${configProxy.name ?? configProxyName} in the organization`}
                       sx={{ position: "absolute", top: 8, right: 8 }}
                     >
                       <ExternalLink size={16} />

--- a/console/workspaces/pages/deployment-pipelines/src/EnvironmentViewPage.tsx
+++ b/console/workspaces/pages/deployment-pipelines/src/EnvironmentViewPage.tsx
@@ -45,7 +45,6 @@ import {
 } from "@agent-management-platform/api-client";
 import {
   absoluteRouteMap,
-  type GatewayListenerSpec,
   type GatewayResponse,
   type GatewayStatus,
 } from "@agent-management-platform/types";
@@ -95,53 +94,6 @@ function InfoCard({ label, value }: { label: string; value: string }) {
   );
 }
 
-interface EndpointCardProps {
-  label: string;
-  scheme: "http" | "https";
-  endpoint: GatewayListenerSpec;
-  onCopy: (value: string, message: string) => void;
-}
-
-function EndpointCard({ label, scheme, endpoint, onCopy }: EndpointCardProps) {
-  const url = endpoint.host
-    ? `${scheme}://${endpoint.host}${endpoint.port ? `:${endpoint.port}` : ""}`
-    : undefined;
-  const displayValue = url ?? "Not configured";
-
-  return (
-    <Card variant="outlined" sx={{ height: "100%" }}>
-      <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
-        <Stack spacing={0.5}>
-          <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
-            {label}
-          </Typography>
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <Typography
-              variant="body2"
-              color={url ? "text.primary" : "text.secondary"}
-              sx={{ fontFamily: "monospace", wordBreak: "break-all", flex: 1, fontSize: "0.8rem" }}
-            >
-              {displayValue}
-            </Typography>
-            {url && (
-              <Tooltip title={`Copy ${label}`}>
-                <IconButton
-                  size="small"
-                  aria-label={`Copy ${label}`}
-                  onClick={() => onCopy(url, `${label} copied to clipboard`)}
-                  sx={{ flexShrink: 0 }}
-                >
-                  <Copy size={14} />
-                </IconButton>
-              </Tooltip>
-            )}
-          </Stack>
-        </Stack>
-      </CardContent>
-    </Card>
-  );
-}
-
 export function EnvironmentViewPage() {
   const { orgId, envName } = useParams<{ orgId: string; envName: string }>();
   const navigate = useNavigate();
@@ -178,9 +130,6 @@ export function EnvironmentViewPage() {
       );
     });
   };
-
-  const httpEndpoint = env?.gateway?.ingress?.external?.http;
-  const httpsEndpoint = env?.gateway?.ingress?.external?.https;
 
   const displayName = env?.displayName ?? env?.name ?? envName ?? "";
 
@@ -258,41 +207,15 @@ export function EnvironmentViewPage() {
 
       {env && !envError && (
         <Stack spacing={3}>
-          <Stack spacing={1.5}>
-            {env.dnsPrefix || httpEndpoint || httpsEndpoint ? (
+          {env.dnsPrefix && (
+            <Stack spacing={1.5}>
               <Grid container spacing={2}>
-                {env.dnsPrefix && (
-                  <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-                    <InfoCard label="DNS Prefix" value={env.dnsPrefix} />
-                  </Grid>
-                )}
-                {httpEndpoint && (
-                  <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-                    <EndpointCard
-                      label="HTTP Endpoint"
-                      scheme="http"
-                      endpoint={httpEndpoint}
-                      onCopy={handleCopy}
-                    />
-                  </Grid>
-                )}
-                {httpsEndpoint && (
-                  <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-                    <EndpointCard
-                      label="HTTPS Endpoint"
-                      scheme="https"
-                      endpoint={httpsEndpoint}
-                      onCopy={handleCopy}
-                    />
-                  </Grid>
-                )}
+                <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                  <InfoCard label="DNS Prefix" value={env.dnsPrefix} />
+                </Grid>
               </Grid>
-            ) : (
-              <Typography variant="body2" color="text.secondary">
-                No external ingress configured for this environment.
-              </Typography>
-            )}
-          </Stack>
+            </Stack>
+          )}
 
           <Stack spacing={1.5}>
             <Typography variant="overline" color="text.secondary">

--- a/console/workspaces/pages/mcp-proxies/src/AddMCPProxy.Organization.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/AddMCPProxy.Organization.tsx
@@ -25,9 +25,9 @@ export const AddMCPProxyOrganization = () => {
 
   return (
     <PageLayout
-      title="Create MCP Proxy from Endpoint"
+      title="Register MCP Server"
       backHref={backHref}
-      backLabel="Back to MCP Proxy list"
+      backLabel="Back to MCP Server list"
       disableIcon
     >
       <AddMCPProxyForm onCancel={() => navigate(backHref)} />

--- a/console/workspaces/pages/mcp-proxies/src/MCPProxies.Organization.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/MCPProxies.Organization.tsx
@@ -20,7 +20,7 @@ export const MCPProxiesOrganization = () => {
       <Route
         index
         element={
-          <PageLayout title="MCP Proxies" disableIcon>
+          <PageLayout title="MCP Servers" disableIcon>
             <MCPProxyTable />
           </PageLayout>
         }

--- a/console/workspaces/pages/mcp-proxies/src/components/MCPCapabilitiesView.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/components/MCPCapabilitiesView.tsx
@@ -33,6 +33,9 @@ export interface MCPCapabilitiesViewProps {
   resources?: CapabilityItem[];
   prompts?: CapabilityItem[];
   sectionTitleVariant?: "subtitle1" | "h6";
+  // Access-control status for a tool, e.g. from the ACL policy — Resources/Prompts
+  // aren't gated by it here, so this only annotates the Tools section.
+  getToolStatus?: (tool: CapabilityItem) => "allowed" | "denied" | undefined;
 }
 
 export function MCPCapabilitiesView({
@@ -40,6 +43,7 @@ export function MCPCapabilitiesView({
   resources = [],
   prompts = [],
   sectionTitleVariant = "subtitle1",
+  getToolStatus,
 }: MCPCapabilitiesViewProps) {
   return (
     <Stack>
@@ -47,6 +51,7 @@ export function MCPCapabilitiesView({
         title="Tools"
         items={tools}
         titleVariant={sectionTitleVariant}
+        getItemStatus={getToolStatus}
       />
       <CapabilitySection
         title="Resources"
@@ -66,10 +71,12 @@ function CapabilitySection({
   title,
   items,
   titleVariant,
+  getItemStatus,
 }: {
   title: string;
   items: CapabilityItem[];
   titleVariant: "subtitle1" | "h6";
+  getItemStatus?: (item: CapabilityItem) => "allowed" | "denied" | undefined;
 }) {
   const [open, setOpen] = useState(false);
   const [expandedItem, setExpandedItem] = useState("");
@@ -98,6 +105,7 @@ function CapabilitySection({
           {items.map((item, index) => {
             const name = getItemName(item) ?? `${title.slice(0, -1)} ${index + 1}`;
             const key = `${name}-${index}`;
+            const status = getItemStatus?.(item);
             return (
               <Accordion
                 key={key}
@@ -107,9 +115,19 @@ function CapabilitySection({
                 variant="outlined"
               >
                 <AccordionSummary expandIcon={<ChevronDown size={16} />}>
-                  <Typography variant="subtitle2" fontWeight={600}>
-                    {name}
-                  </Typography>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Typography variant="subtitle2" fontWeight={600}>
+                      {name}
+                    </Typography>
+                    {status && (
+                      <Chip
+                        label={status === "allowed" ? "Allowed" : "Denied"}
+                        size="small"
+                        variant="outlined"
+                        color={status === "allowed" ? "success" : "default"}
+                      />
+                    )}
+                  </Stack>
                 </AccordionSummary>
                 <AccordionDetails>
                   <MCPItemDetails item={item} />

--- a/console/workspaces/pages/mcp-proxies/src/index.ts
+++ b/console/workspaces/pages/mcp-proxies/src/index.ts
@@ -18,8 +18,8 @@ import {
 import type { PageMetadata } from "@agent-management-platform/types";
 
 export const metaData: PageMetadata = {
-  title: "MCP Proxies",
-  description: "A page component for MCP Proxy management",
+  title: "MCP Servers",
+  description: "A page component for MCP Server management",
   icon: MCPLogo,
   path: "/mcp-proxies",
   component: MCPProxiesOrganization,

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/AddMCPProxyForm.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/AddMCPProxyForm.tsx
@@ -35,10 +35,29 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
+import { useFormValidation } from "@agent-management-platform/views";
+import { z } from "zod";
 import { type EndpointDraft } from "./EndpointFormFields";
 import { EndpointsEditorSection } from "./EndpointsEditorSection";
 import { draftToEndpoint } from "./mcpEndpoints";
 import { MCP_SPEC_VERSION } from "../constants";
+
+const DEFAULT_PROXY_VERSION = "0.0.1";
+
+const SEMVER_PATTERN =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+
+interface AddMCPProxyFormValues {
+  version: string;
+}
+
+const addMCPProxySchema = z.object({
+  version: z
+    .string()
+    .trim()
+    .min(1, "Version is required")
+    .regex(SEMVER_PATTERN, "Use a semantic version, e.g. 0.0.1"),
+});
 
 interface AddMCPProxyFormProps {
   onCancel: () => void;
@@ -53,14 +72,25 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
   });
 
   const [proxyName, setProxyName] = useState("");
-  const [proxyVersion, setProxyVersion] = useState("");
+  const [proxyVersion, setProxyVersion] = useState(DEFAULT_PROXY_VERSION);
   const [proxyDescription, setProxyDescription] = useState("");
   const [proxyContext, setProxyContext] = useState("");
   const [endpoints, setEndpoints] = useState<EndpointDraft[]>([]);
   const [addOpen, setAddOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
+  const { errors, validateField, validateForm, setFieldError } =
+    useFormValidation<AddMCPProxyFormValues>(addMCPProxySchema);
+
   const isCreating = createMCPProxy.isPending;
+
+  const handleVersionChange = useCallback(
+    (value: string) => {
+      setProxyVersion(value);
+      setFieldError("version", validateField("version", value));
+    },
+    [validateField, setFieldError],
+  );
 
   const handleNameChange = useCallback(
     (value: string) => {
@@ -83,15 +113,16 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
           setProxyContext(`/default/${toHandle(draft.serverName)}`);
         }
       }
-      if (!proxyVersion && draft.serverVersion) {
-        setProxyVersion(draft.serverVersion);
+      if (proxyVersion === DEFAULT_PROXY_VERSION && draft.serverVersion) {
+        handleVersionChange(draft.serverVersion);
       }
     },
-    [proxyContext, proxyName, proxyVersion],
+    [proxyContext, proxyName, proxyVersion, handleVersionChange],
   );
 
   const handleCreate = useCallback(async () => {
     if (!orgId || endpoints.length === 0) return;
+    if (!validateForm({ version: proxyVersion })) return;
 
     const name = proxyName.trim();
 
@@ -128,11 +159,13 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
     proxyDescription,
     proxyName,
     proxyVersion,
+    validateForm,
   ]);
 
   const canCreate =
     Boolean(proxyName.trim()) &&
     Boolean(proxyVersion.trim()) &&
+    !errors.version &&
     endpoints.length > 0 &&
     !isCreating;
 
@@ -153,12 +186,17 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
                 onChange={(event) => handleNameChange(event.target.value)}
               />
             </FormControl>
-            <FormControl sx={{ width: { xs: "100%", md: 300 } }}>
+            <FormControl
+              sx={{ width: { xs: "100%", md: 300 } }}
+              error={Boolean(errors.version)}
+            >
               <FormLabel required>Version</FormLabel>
               <TextField
                 fullWidth
                 value={proxyVersion}
-                onChange={(event) => setProxyVersion(event.target.value)}
+                onChange={(event) => handleVersionChange(event.target.value)}
+                error={Boolean(errors.version)}
+                helperText={errors.version}
               />
             </FormControl>
           </Form.Stack>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/AddMCPProxyForm.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/AddMCPProxyForm.tsx
@@ -64,10 +64,10 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
 
   const handleNameChange = useCallback(
     (value: string) => {
-      const previousContext = proxyName ? `/default/${proxyName}` : "";
+      const previousContext = proxyName ? `/default/${toHandle(proxyName)}` : "";
       setProxyName(value);
       if (!proxyContext || proxyContext === previousContext) {
-        setProxyContext(value ? `/default/${value}` : "");
+        setProxyContext(value ? `/default/${toHandle(value)}` : "");
       }
     },
     [proxyContext, proxyName],
@@ -79,7 +79,9 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
     (draft: Omit<EndpointDraft, "id">) => {
       if (!proxyName && draft.serverName) {
         setProxyName(draft.serverName);
-        if (!proxyContext) setProxyContext(`/default/${draft.serverName}`);
+        if (!proxyContext) {
+          setProxyContext(`/default/${toHandle(draft.serverName)}`);
+        }
       }
       if (!proxyVersion && draft.serverVersion) {
         setProxyVersion(draft.serverVersion);

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/AddMCPProxyForm.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/AddMCPProxyForm.tsx
@@ -169,7 +169,7 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
               minRows={3}
               value={proxyDescription}
               onChange={(event) => setProxyDescription(event.target.value)}
-              placeholder="Primary MCP Proxy"
+              placeholder="Primary MCP Server"
             />
           </FormControl>
 
@@ -188,8 +188,9 @@ export function AddMCPProxyForm({ onCancel }: AddMCPProxyFormProps) {
         <Form.Header>Endpoints</Form.Header>
         <Form.Stack spacing={2}>
           <Typography variant="body2" color="text.secondary">
-            Add a backend endpoint and assign it to one or more environments.
-            Environments without an endpoint are simply left unconfigured.
+            {environments.length > 1
+              ? "Add a backend endpoint and assign it to one or more environments. Environments without an endpoint are simply left unconfigured."
+              : "Add a backend endpoint for this MCP Server."}
           </Typography>
 
           <EndpointsEditorSection

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/AuthHeaderRow.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/AuthHeaderRow.tsx
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Checkbox,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Eye, EyeOff } from "@wso2/oxygen-ui-icons-react";
+
+export interface AuthHeaderRowProps {
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+  headerValue: string;
+  onHeaderChange: (value: string) => void;
+  valueValue: string;
+  onValueChange: (value: string) => void;
+  onValueFocus?: () => void;
+  showValue: boolean;
+  onToggleShowValue: () => void;
+  error?: boolean;
+  caption?: string | null;
+  captionColor?: "error" | "text.secondary";
+  monospaceValue?: boolean;
+  iconButtonSize?: "small" | "medium";
+}
+
+// Postman-style auth header row: a checkbox that excludes the header from the
+// fetch/save without losing the typed key/value, plus Key/Value fields.
+export function AuthHeaderRow({
+  enabled,
+  onEnabledChange,
+  headerValue,
+  onHeaderChange,
+  valueValue,
+  onValueChange,
+  onValueFocus,
+  showValue,
+  onToggleShowValue,
+  error = false,
+  caption,
+  captionColor = "text.secondary",
+  monospaceValue = false,
+  iconButtonSize,
+}: AuthHeaderRowProps) {
+  return (
+    <Stack spacing={1}>
+      <Typography variant="subtitle2" fontWeight={600}>
+        Headers
+      </Typography>
+      <Stack direction="row" spacing={1.5} alignItems="center" useFlexGap>
+        <Checkbox
+          size="small"
+          checked={enabled}
+          onChange={(event) => onEnabledChange(event.target.checked)}
+          aria-label="Enable header"
+        />
+        <FormControl sx={{ flex: 1 }} error={error}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Key"
+            value={headerValue}
+            onChange={(event) => onHeaderChange(event.target.value)}
+            disabled={!enabled}
+            error={error}
+          />
+        </FormControl>
+        <FormControl sx={{ flex: 1 }} error={error}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="Value"
+            value={valueValue}
+            onFocus={onValueFocus}
+            onChange={(event) => onValueChange(event.target.value)}
+            disabled={!enabled}
+            error={error}
+            type={showValue ? "text" : "password"}
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      size={iconButtonSize}
+                      aria-label={
+                        showValue ? "Hide header value" : "Show header value"
+                      }
+                      onClick={onToggleShowValue}
+                      edge="end"
+                      disabled={!enabled}
+                    >
+                      {showValue ? <EyeOff size={18} /> : <Eye size={18} />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
+            }}
+            sx={
+              monospaceValue
+                ? { "& .MuiInputBase-input": { fontFamily: "monospace" } }
+                : undefined
+            }
+          />
+        </FormControl>
+      </Stack>
+      {caption && (
+        <Typography variant="caption" color={captionColor} sx={{ pl: 5 }}>
+          {caption}
+        </Typography>
+      )}
+    </Stack>
+  );
+}
+
+export default AuthHeaderRow;

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/EditMCPProxyDrawer.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/EditMCPProxyDrawer.tsx
@@ -170,7 +170,7 @@ export function EditMCPProxyDrawer({
 
   const errorMessage = useMemo(() => {
     if (!updateError) return null;
-    return (updateError as Error)?.message ?? "Failed to update MCP proxy";
+    return (updateError as Error)?.message ?? "Failed to update MCP Server";
   }, [updateError]);
 
   const isValid =
@@ -183,7 +183,7 @@ export function EditMCPProxyDrawer({
     <DrawerWrapper open={open} onClose={onClose}>
       <DrawerHeader
         icon={<Edit size={24} />}
-        title="Edit MCP Proxy"
+        title="Edit MCP Server"
         onClose={onClose}
       />
       <DrawerContent>
@@ -196,7 +196,7 @@ export function EditMCPProxyDrawer({
             )}
 
             <Form.Section>
-              <Form.Header>MCP Proxy Details</Form.Header>
+              <Form.Header>MCP Server Details</Form.Header>
               <Form.Stack spacing={2}>
                 <FormControl fullWidth error={Boolean(errors.name)}>
                   <FormLabel required>Name</FormLabel>
@@ -262,10 +262,9 @@ export function EditMCPProxyDrawer({
               <Form.Header>Endpoints</Form.Header>
               <Form.Stack spacing={2}>
                 <Typography variant="body2" color="text.secondary">
-                  Endpoints map backend MCP servers to environments. Editing an
-                  endpoint updates the upstream URL, authentication, and
-                  capabilities for the environments it serves. Environments left
-                  without an endpoint become unconfigured.
+                  {environments.length > 1
+                    ? "Endpoints map backend MCP servers to environments. Editing an endpoint updates the upstream URL, authentication, and capabilities for the environments it serves. Environments left without an endpoint become unconfigured."
+                    : "Editing an endpoint updates the upstream URL, authentication, and capabilities for this MCP Server."}
                 </Typography>
 
                 <EndpointsEditorSection

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/EndpointFormFields.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/EndpointFormFields.tsx
@@ -36,22 +36,16 @@ import {
   Form,
   FormControl,
   FormLabel,
-  IconButton,
-  InputAdornment,
   Stack,
   TextField,
   Tooltip,
   Typography,
 } from "@wso2/oxygen-ui";
-import {
-  ChevronDown,
-  Eye,
-  EyeOff,
-  HelpCircle,
-} from "@wso2/oxygen-ui-icons-react";
+import { ChevronDown, HelpCircle } from "@wso2/oxygen-ui-icons-react";
 import { useSnackBar } from "@agent-management-platform/views";
 import { validateEndpointUrl } from "@agent-management-platform/shared-component";
 import { MCPCapabilitiesView } from "../components/MCPCapabilitiesView";
+import { AuthHeaderRow } from "./AuthHeaderRow";
 
 // EndpointDraft is a single endpoint captured in the form. Its `id` maps to the backend
 // endpoint handle (unique within the parent proxy); a fresh draft carries a temporary
@@ -113,6 +107,9 @@ export function EndpointFormFields({
     useState(hasStoredCredential);
   const [showAuthValue, setShowAuthValue] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(hasStoredCredential);
+  // Mirrors Postman's per-header checkbox: unchecking excludes the header from the
+  // fetch/save without losing the typed key/value.
+  const [authEnabled, setAuthEnabled] = useState(true);
   const [selectedEnvIds, setSelectedEnvIds] = useState<string[]>(
     initialDraft?.environments ?? [],
   );
@@ -123,10 +120,25 @@ export function EndpointFormFields({
   const [urlError, setUrlError] = useState<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
 
+  // When exactly one environment is available, there's nothing to choose between —
+  // assign it automatically instead of showing a single-option selector.
+  useEffect(() => {
+    const onlyEnvId =
+      availableEnvironments.length === 1 ? availableEnvironments[0].id : null;
+    if (!onlyEnvId) return;
+    setSelectedEnvIds((prev) => (prev.length === 0 ? [onlyEnvId] : prev));
+  }, [availableEnvironments]);
+
   const trimmedUrl = url.trim();
   const isFetched = Boolean(fetchedInfo);
   const isFetching = fetchServerInfo.isPending;
   const canAdd = isFetched && selectedEnvIds.length > 0;
+  // Unchecking the header excludes it from the fetch/save entirely, same as leaving
+  // it blank. An untouched masked credential means "keep the stored value", so it
+  // resolves to empty (omitted) rather than replaying the sentinel to the backend.
+  const effectiveAuthHeader = authEnabled ? authHeader.trim() : "";
+  const effectiveAuthValue = authEnabled ? authValue.trim() : "";
+  const resolvedAuthValue = isCredentialMasked ? "" : effectiveAuthValue;
   // In edit mode, Save stays disabled until the user actually changes something; a
   // brand-new endpoint (no initialDraft) is always a change. The credential counts as
   // changed only once the masked stored value has been replaced, and a re-fetch counts
@@ -135,8 +147,8 @@ export function EndpointFormFields({
     !initialDraft ||
     name.trim() !== initialDraft.name ||
     trimmedUrl !== initialDraft.url ||
-    authHeader.trim() !== initialDraft.authHeader ||
-    (!isCredentialMasked && authValue.trim().length > 0) ||
+    effectiveAuthHeader !== initialDraft.authHeader ||
+    Boolean(resolvedAuthValue) ||
     !sameIdSet(selectedEnvIds, initialDraft.environments) ||
     capabilitiesChanged(fetchedInfo, initialDraft.fetchedInfo);
   const canSave = canAdd && hasChanges;
@@ -153,9 +165,9 @@ export function EndpointFormFields({
 
   const performFetch = useCallback(async () => {
     const urlValidationError = validateEndpointUrl(trimmedUrl, {
-      requiredMessage: "Enter a valid MCP Proxy endpoint URL.",
-      invalidMessage: "Enter a valid MCP Proxy endpoint URL.",
-      protocolMessage: "Enter a valid MCP Proxy endpoint URL.",
+      requiredMessage: "Enter a valid MCP Server endpoint URL.",
+      invalidMessage: "Enter a valid MCP Server endpoint URL.",
+      protocolMessage: "Enter a valid MCP Server endpoint URL.",
     });
     if (urlValidationError) {
       setUrlError(urlValidationError);
@@ -163,10 +175,9 @@ export function EndpointFormFields({
     }
     setUrlError(null);
 
-    const header = authHeader.trim();
     // The stored credential is never returned, so it can't be replayed to the
     // live fetch — ask the user to re-enter it before re-fetching.
-    if (header && isCredentialMasked) {
+    if (effectiveAuthHeader && isCredentialMasked) {
       setIsCredentialMasked(false);
       setAuthValue("");
       setAdvancedOpen(true);
@@ -175,8 +186,7 @@ export function EndpointFormFields({
       );
       return;
     }
-    const value = authValue.trim();
-    if (Boolean(header) !== Boolean(value)) {
+    if (Boolean(effectiveAuthHeader) !== Boolean(effectiveAuthValue)) {
       setAdvancedOpen(true);
       setAuthError("Enter both an authentication header and value.");
       return;
@@ -184,8 +194,15 @@ export function EndpointFormFields({
     setAuthError(null);
 
     const body =
-      header && value
-        ? { url: trimmedUrl, auth: { type: "api-key" as const, header, value } }
+      effectiveAuthHeader && effectiveAuthValue
+        ? {
+            url: trimmedUrl,
+            auth: {
+              type: "api-key" as const,
+              header: effectiveAuthHeader,
+              value: effectiveAuthValue,
+            },
+          }
         : { url: trimmedUrl };
 
     const generation = ++fetchGenerationRef.current;
@@ -218,7 +235,15 @@ export function EndpointFormFields({
         pushSnackBar({ message, type: "error" });
       }
     }
-  }, [authHeader, authValue, fetchServerInfo, orgId, pushSnackBar, trimmedUrl]);
+  }, [
+    effectiveAuthHeader,
+    effectiveAuthValue,
+    isCredentialMasked,
+    fetchServerInfo,
+    orgId,
+    pushSnackBar,
+    trimmedUrl,
+  ]);
 
   // Auto-fetch server info shortly after the URL or auth fields settle, instead of
   // requiring an explicit "Fetch" click. `performFetch` is re-created on every render
@@ -251,17 +276,14 @@ export function EndpointFormFields({
     }
     if (!trimmedUrl) return;
     debouncedFetch();
-  }, [trimmedUrl, authHeader, authValue, debouncedFetch]);
+  }, [trimmedUrl, authHeader, authValue, authEnabled, debouncedFetch]);
 
   const handleAdd = useCallback(() => {
     if (!fetchedInfo || selectedEnvIds.length === 0) return;
-    // An untouched masked credential means "keep the stored value" — emit an empty
-    // authValue so the save path omits it and the backend preserves the secret.
-    const resolvedAuthValue = isCredentialMasked ? "" : authValue.trim();
     onAdd({
       name: name.trim(),
       url: trimmedUrl,
-      authHeader: authHeader.trim(),
+      authHeader: effectiveAuthHeader,
       authValue: resolvedAuthValue,
       environments: selectedEnvIds,
       fetchedInfo,
@@ -273,11 +295,10 @@ export function EndpointFormFields({
         initialDraft?.serverVersion,
     });
   }, [
-    authHeader,
-    authValue,
+    effectiveAuthHeader,
+    resolvedAuthValue,
     fetchedInfo,
     initialDraft,
-    isCredentialMasked,
     name,
     onAdd,
     selectedEnvIds,
@@ -293,11 +314,6 @@ export function EndpointFormFields({
 
   return (
     <Form.Stack spacing={2.5}>
-      <Typography variant="body2" color="text.secondary">
-        Point to your MCP server and choose the environments this endpoint
-        serves. Capabilities are fetched automatically once the URL is valid.
-      </Typography>
-
       <FormControl fullWidth>
         <FormLabel>Endpoint Name</FormLabel>
         <TextField
@@ -310,7 +326,7 @@ export function EndpointFormFields({
       </FormControl>
 
       <FormControl fullWidth error={Boolean(urlError)}>
-        <FormLabel required>MCP Proxy Endpoint URL</FormLabel>
+        <FormLabel required>MCP Server Endpoint URL</FormLabel>
         <TextField
           fullWidth
           value={url}
@@ -319,7 +335,7 @@ export function EndpointFormFields({
             clearFetched();
             setUrlError(null);
           }}
-          placeholder="Enter URL of your MCP Proxy"
+          placeholder="Enter URL of your MCP Server"
           error={Boolean(urlError)}
           helperText={urlError}
         />
@@ -342,123 +358,92 @@ export function EndpointFormFields({
           </Stack>
         </AccordionSummary>
         <AccordionDetails>
-          <Form.Stack spacing={2}>
-            <Typography variant="subtitle2" fontWeight={600}>
-              Configure Authentication Header
-            </Typography>
-            <Form.Stack
-              direction={{ xs: "column", md: "row" }}
-              spacing={2}
-              useFlexGap
-            >
-              <FormControl sx={{ flex: 1 }} error={Boolean(authError)}>
-                <FormLabel>Header</FormLabel>
-                <TextField
-                  fullWidth
-                  value={authHeader}
-                  onChange={(event) => {
-                    setAuthHeader(event.target.value);
-                    clearFetched();
-                    setAuthError(null);
-                  }}
-                  placeholder="Header"
-                  error={Boolean(authError)}
-                />
-              </FormControl>
-              <FormControl sx={{ flex: 1 }} error={Boolean(authError)}>
-                <FormLabel>Value</FormLabel>
-                <TextField
-                  fullWidth
-                  value={authValue}
-                  onFocus={() => {
-                    // Reveal a blank field so the user replaces the hidden
-                    // stored credential rather than editing the mask.
-                    if (isCredentialMasked) {
-                      setAuthValue("");
-                      setIsCredentialMasked(false);
-                      clearFetched();
-                    }
-                  }}
-                  onChange={(event) => {
-                    setAuthValue(event.target.value);
-                    setIsCredentialMasked(false);
-                    clearFetched();
-                    setAuthError(null);
-                  }}
-                  placeholder="Value"
-                  error={Boolean(authError)}
-                  helperText={
-                    authError ??
-                    (isCredentialMasked
-                      ? "Leave unchanged to keep the stored value."
-                      : undefined)
-                  }
-                  type={showAuthValue ? "text" : "password"}
-                  slotProps={{
-                    input: {
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            aria-label={
-                              showAuthValue
-                                ? "Hide header value"
-                                : "Show header value"
-                            }
-                            onClick={() => setShowAuthValue((prev) => !prev)}
-                            edge="end"
-                          >
-                            {showAuthValue ? (
-                              <EyeOff size={18} />
-                            ) : (
-                              <Eye size={18} />
-                            )}
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    },
-                  }}
-                />
-              </FormControl>
-            </Form.Stack>
-          </Form.Stack>
+          <AuthHeaderRow
+            enabled={authEnabled}
+            onEnabledChange={(enabled) => {
+              setAuthEnabled(enabled);
+              clearFetched();
+              setAuthError(null);
+            }}
+            headerValue={authHeader}
+            onHeaderChange={(value) => {
+              setAuthHeader(value);
+              clearFetched();
+              setAuthError(null);
+            }}
+            valueValue={authValue}
+            onValueFocus={() => {
+              // Reveal a blank field so the user replaces the hidden
+              // stored credential rather than editing the mask.
+              if (isCredentialMasked) {
+                setAuthValue("");
+                setIsCredentialMasked(false);
+                clearFetched();
+              }
+            }}
+            onValueChange={(value) => {
+              setAuthValue(value);
+              setIsCredentialMasked(false);
+              clearFetched();
+              setAuthError(null);
+            }}
+            showValue={showAuthValue}
+            onToggleShowValue={() => setShowAuthValue((prev) => !prev)}
+            error={Boolean(authError)}
+            caption={
+              authError ??
+              (isCredentialMasked
+                ? "Leave unchanged to keep the stored value."
+                : null)
+            }
+            captionColor={authError ? "error" : "text.secondary"}
+          />
         </AccordionDetails>
       </Accordion>
 
-      <FormControl fullWidth>
-        <FormLabel required>Environments</FormLabel>
-        <Autocomplete
-          multiple
-          options={availableEnvironments}
-          size="small"
-          value={availableEnvironments.filter(
-            (env) => env.id != null && selectedEnvIds.includes(env.id),
+      {availableEnvironments.length !== 1 && (
+        <FormControl fullWidth>
+          <FormLabel required={availableEnvironments.length > 1}>
+            Environments
+          </FormLabel>
+          {availableEnvironments.length > 1 ? (
+            <>
+              <Autocomplete
+                multiple
+                options={availableEnvironments}
+                size="small"
+                value={availableEnvironments.filter(
+                  (env) => env.id != null && selectedEnvIds.includes(env.id),
+                )}
+                onChange={(_, selected) =>
+                  setSelectedEnvIds(
+                    selected
+                      .map((env) => env.id)
+                      .filter((id): id is string => Boolean(id)),
+                  )
+                }
+                getOptionLabel={(option) => option.displayName || option.name}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+                renderInput={(params) => (
+                  <TextField {...params} placeholder="Select environment(s)" />
+                )}
+                sx={{ mt: 0.5 }}
+              />
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ mt: 0.5 }}
+              >
+                An environment can be assigned to only one endpoint.
+              </Typography>
+            </>
+          ) : (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              All environments are already assigned
+            </Typography>
           )}
-          onChange={(_, selected) =>
-            setSelectedEnvIds(
-              selected
-                .map((env) => env.id)
-                .filter((id): id is string => Boolean(id)),
-            )
-          }
-          getOptionLabel={(option) => option.displayName || option.name}
-          isOptionEqualToValue={(option, value) => option.id === value.id}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              placeholder={
-                availableEnvironments.length === 0
-                  ? "All environments are already assigned"
-                  : "Select environment(s)"
-              }
-            />
-          )}
-          disabled={availableEnvironments.length === 0}
-          sx={{ mt: 0.5 }}
-        />
-        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
-          An environment can be assigned to only one endpoint.
-        </Typography>
-      </FormControl>
+        </FormControl>
+      )}
 
       <Collapse in={isFetching || isFetched} timeout="auto" unmountOnExit>
         <Stack spacing={2}>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/EndpointsEditorSection.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/EndpointsEditorSection.tsx
@@ -232,7 +232,7 @@ export function EndpointsEditorSection({
         </Box>
       )}
 
-      {environments.length > 0 ? (
+      {environments.length > 1 ? (
         <Typography variant="caption" color="text.secondary">
           {usedEnvIds.size} of {environments.length} environments have an
           endpoint.

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyConnectionTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyConnectionTab.tsx
@@ -30,8 +30,6 @@ import {
   FormControl,
   FormLabel,
   Grid,
-  IconButton,
-  InputAdornment,
   Skeleton,
   Stack,
   TextField,
@@ -39,8 +37,9 @@ import {
   Typography,
   useTheme,
 } from "@wso2/oxygen-ui";
-import { ChevronDown, Eye, EyeOff, HelpCircle } from "@wso2/oxygen-ui-icons-react";
+import { ChevronDown, HelpCircle } from "@wso2/oxygen-ui-icons-react";
 import { validateEndpointUrl } from "@agent-management-platform/shared-component";
+import { AuthHeaderRow } from "./AuthHeaderRow";
 
 const MASKED_CREDENTIAL_VALUE = "••••••••••••";
 
@@ -64,6 +63,9 @@ export function MCPProxyConnectionTab({
 
   const [endpoint, setEndpoint] = useState("");
   const [authHeader, setAuthHeader] = useState("");
+  // Mirrors Postman's per-header checkbox: unchecking excludes the header from
+  // save without losing the typed key/value.
+  const [authEnabled, setAuthEnabled] = useState(true);
   const [credentialValue, setCredentialValue] = useState("");
   const [isCredentialMasked, setIsCredentialMasked] = useState(false);
   const [showCredential, setShowCredential] = useState(false);
@@ -83,6 +85,7 @@ export function MCPProxyConnectionTab({
   const resetFromConfig = useCallback(() => {
     setEndpoint(config?.upstream?.main?.url ?? "");
     setAuthHeader(config?.upstream?.main?.auth?.header ?? "");
+    setAuthEnabled(true);
     const hasCredential = Boolean(config?.upstream?.main?.auth?.header);
     setCredentialValue(hasCredential ? MASKED_CREDENTIAL_VALUE : "");
     setIsCredentialMasked(hasCredential);
@@ -99,24 +102,27 @@ export function MCPProxyConnectionTab({
 
   const validateEndpoint = useCallback((value: string): string | null => {
     const err = validateEndpointUrl(value, {
-      requiredMessage: "MCP Proxy Endpoint URL is required",
+      requiredMessage: "MCP Server Endpoint URL is required",
     });
     setEndpointError(err);
     return err;
   }, []);
 
   const credentialChanged =
-    !isCredentialMasked && credentialValue.trim() !== MASKED_CREDENTIAL_VALUE;
+    authEnabled &&
+    !isCredentialMasked &&
+    credentialValue.trim() !== MASKED_CREDENTIAL_VALUE;
+  const effectiveAuthHeader = authEnabled ? authHeader.trim() : "";
 
   const isDirty = useMemo(() => {
     if (!config) return false;
     const savedUrl = (config.upstream?.main?.url ?? "").trim();
     const savedHeader = (config.upstream?.main?.auth?.header ?? "").trim();
     if (endpoint.trim() !== savedUrl) return true;
-    if (authHeader.trim() !== savedHeader) return true;
+    if (effectiveAuthHeader !== savedHeader) return true;
     if (credentialChanged) return true;
     return false;
-  }, [config, endpoint, authHeader, credentialChanged]);
+  }, [config, endpoint, effectiveAuthHeader, credentialChanged]);
 
   const handleDiscard = useCallback(() => {
     resetFromConfig();
@@ -132,16 +138,15 @@ export function MCPProxyConnectionTab({
       return;
     }
 
-    const trimmedHeader = authHeader.trim();
     const existingAuth = config.upstream?.main?.auth;
     // Preserve any existing auth (including its type); only override header,
     // and value when the user typed a new one — otherwise the backend keeps
-    // the stored credential.
-    const auth = trimmedHeader
+    // the stored credential. Unchecking the header excludes it entirely.
+    const auth = effectiveAuthHeader
       ? {
           type: "api-key" as const,
           ...existingAuth,
-          header: trimmedHeader,
+          header: effectiveAuthHeader,
           ...(credentialChanged ? { value: credentialValue.trim() } : {}),
         }
       : undefined;
@@ -171,7 +176,7 @@ export function MCPProxyConnectionTab({
   }, [
     config,
     endpoint,
-    authHeader,
+    effectiveAuthHeader,
     credentialChanged,
     credentialValue,
     onUpdate,
@@ -200,7 +205,7 @@ export function MCPProxyConnectionTab({
       <Grid container spacing={3}>
         <Grid size={{ xs: 12 }}>
           <FormControl fullWidth>
-            <FormLabel required>MCP Proxy Endpoint URL</FormLabel>
+            <FormLabel required>MCP Server Endpoint URL</FormLabel>
             <TextField
               size="small"
               value={endpoint}
@@ -211,7 +216,7 @@ export function MCPProxyConnectionTab({
               onBlur={() => validateEndpoint(endpoint)}
               error={!!endpointError}
               helperText={endpointError}
-              placeholder="Enter URL of your MCP Proxy"
+              placeholder="Enter URL of your MCP Server"
               sx={{
                 "& .MuiInputBase-input": {
                   fontFamily: "monospace",
@@ -229,79 +234,35 @@ export function MCPProxyConnectionTab({
                 <Typography variant="subtitle2" fontWeight={600}>
                   Advanced Configurations
                 </Typography>
-                <Tooltip title="Configure an optional authentication header sent to the MCP proxy endpoint.">
+                <Tooltip title="Configure an optional authentication header sent to the MCP Server endpoint.">
                   <HelpCircle size={16} />
                 </Tooltip>
               </Stack>
             </AccordionSummary>
             <AccordionDetails>
-              <Stack spacing={2}>
-                <Typography variant="subtitle2" fontWeight={600}>
-                  Configure Authentication Header
-                </Typography>
-                <Grid container spacing={2}>
-                  <Grid size={{ xs: 12, md: 6 }}>
-                    <FormControl fullWidth>
-                      <FormLabel>Header</FormLabel>
-                      <TextField
-                        size="small"
-                        value={authHeader}
-                        onChange={(e) => setAuthHeader(e.target.value)}
-                        placeholder="Header"
-                      />
-                    </FormControl>
-                  </Grid>
-                  <Grid size={{ xs: 12, md: 6 }}>
-                    <FormControl fullWidth>
-                      <FormLabel>Value</FormLabel>
-                      <TextField
-                        size="small"
-                        type={showCredential ? "text" : "password"}
-                        value={credentialValue}
-                        placeholder="Value"
-                        onFocus={() => {
-                          if (isCredentialMasked) {
-                            setCredentialValue("");
-                            setIsCredentialMasked(false);
-                          }
-                        }}
-                        onChange={(e) => setCredentialValue(e.target.value)}
-                        slotProps={{
-                          input: {
-                            endAdornment: (
-                              <InputAdornment position="end">
-                                <IconButton
-                                  size="small"
-                                  onClick={() => setShowCredential((p) => !p)}
-                                  aria-label={
-                                    showCredential
-                                      ? "Hide header value"
-                                      : "Show header value"
-                                  }
-                                  edge="end"
-                                >
-                                  {showCredential ? (
-                                    <EyeOff size={18} />
-                                  ) : (
-                                    <Eye size={18} />
-                                  )}
-                                </IconButton>
-                              </InputAdornment>
-                            ),
-                          },
-                        }}
-                        sx={{ "& .MuiInputBase-input": { fontFamily: "monospace" } }}
-                      />
-                    </FormControl>
-                  </Grid>
-                </Grid>
-                {hasStoredCredential && (
-                  <Typography variant="caption" color="text.secondary">
-                    The stored value is hidden. Leave it unchanged to keep the
-                    current credential, or enter a new value to replace it.
-                  </Typography>
-                )}
-              </Stack>
+              <AuthHeaderRow
+                enabled={authEnabled}
+                onEnabledChange={setAuthEnabled}
+                headerValue={authHeader}
+                onHeaderChange={setAuthHeader}
+                valueValue={credentialValue}
+                onValueFocus={() => {
+                  if (isCredentialMasked) {
+                    setCredentialValue("");
+                    setIsCredentialMasked(false);
+                  }
+                }}
+                onValueChange={setCredentialValue}
+                showValue={showCredential}
+                onToggleShowValue={() => setShowCredential((p) => !p)}
+                caption={
+                  hasStoredCredential
+                    ? "The stored value is hidden. Leave it unchanged to keep the current credential, or enter a new value to replace it."
+                    : null
+                }
+                monospaceValue
+                iconButtonSize="small"
+              />
             </AccordionDetails>
           </Accordion>
         </Grid>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyManageToolsTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyManageToolsTab.tsx
@@ -293,7 +293,7 @@ export function MCPProxyManageToolsTab({
           No Capabilities Available
         </Typography>
         <Typography variant="body2" color="text.secondary">
-          This MCP proxy has no tools, resources, or prompts. Access control
+          This MCP Server has no tools, resources, or prompts. Access control
           rules require at least one capability.
         </Typography>
       </Stack>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyOverviewTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyOverviewTab.tsx
@@ -15,32 +15,19 @@
  * under the License.
  */
 
+import { useMemo } from "react";
 import type {
   MCPEndpointConfig,
   MCPProxy,
 } from "@agent-management-platform/types";
-import {
-  Card,
-  Chip,
-  FormControl,
-  FormLabel,
-  Grid,
-  IconButton,
-  InputAdornment,
-  Skeleton,
-  Stack,
-  TextField,
-  Tooltip,
-  Typography,
-} from "@wso2/oxygen-ui";
-import { Copy } from "@wso2/oxygen-ui-icons-react";
+import { Card, Chip, Grid, Skeleton, Stack, Typography } from "@wso2/oxygen-ui";
+import { MCPCapabilitiesView } from "../components/MCPCapabilitiesView";
 import {
   getAuthenticationTypeLabel,
   getCapabilityId,
   isToolBlockedByAcl,
   resolveAuthenticationType,
 } from "./mcpEndpoints";
-import { useCopyWithFeedback } from "./useCopyWithFeedback";
 
 // One chip per environment the selected endpoint is bound to, with its deployment
 // status — the same shape ViewMCPProxy already derives for the chips shown next to
@@ -64,7 +51,32 @@ export function MCPProxyOverviewTab({
   envChips = [],
   isLoading = false,
 }: MCPProxyOverviewTabProps) {
-  const handleCopy = useCopyWithFeedback();
+  const toolCapabilities = config?.capabilities?.tools ?? [];
+
+  // Tool identifiers found on this endpoint, extracted once per capabilities
+  // change rather than on every filter/lookup below.
+  const toolEntries = useMemo(() => {
+    const identifiers: string[] = [];
+    for (const raw of config?.capabilities?.tools ?? []) {
+      const identifier = getCapabilityId("tool", raw);
+      if (identifier) identifiers.push(identifier);
+    }
+    return identifiers;
+  }, [config?.capabilities?.tools]);
+
+  // Computed once per tool list / ACL policy change rather than per tool and
+  // per render — isToolBlockedByAcl re-parses the ACL policy's params each
+  // call. Mirrors the same memoized-Set pattern in MCPProxySecurityTab.tsx.
+  const blockedToolIds = useMemo(
+    () =>
+      new Set(
+        toolEntries.filter((identifier) =>
+          isToolBlockedByAcl(config, identifier),
+        ),
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reads config.policies
+    [toolEntries, config?.policies],
+  );
 
   if (isLoading) {
     return (
@@ -89,13 +101,20 @@ export function MCPProxyOverviewTab({
     return null;
   }
 
-  const toolCapabilities = config?.capabilities?.tools ?? [];
   const totalToolsCount = toolCapabilities.length;
   const disabledToolsCount = toolCapabilities.filter((raw) => {
     const id = getCapabilityId("tool", raw);
-    return id ? isToolBlockedByAcl(config, id) : false;
+    return id ? blockedToolIds.has(id) : false;
   }).length;
   const allowedToolsCount = totalToolsCount - disabledToolsCount;
+
+  const getToolStatus = (
+    raw: Record<string, unknown>,
+  ): "allowed" | "denied" | undefined => {
+    const id = getCapabilityId("tool", raw);
+    if (!id) return undefined;
+    return blockedToolIds.has(id) ? "denied" : "allowed";
+  };
 
   // Auth Type reflects the proxy's inbound security (the Security tab) — which
   // method clients must authenticate with — not the upstream auth used to reach
@@ -103,8 +122,6 @@ export function MCPProxyOverviewTab({
   const authTypeLabel = getAuthenticationTypeLabel(
     resolveAuthenticationType(config),
   );
-
-  const upstreamUrl = config?.upstream?.main?.url;
 
   return (
     <Stack spacing={3}>
@@ -176,37 +193,13 @@ export function MCPProxyOverviewTab({
           </Card>
         </Grid>
       </Grid>
-      {upstreamUrl && (
-        <FormControl fullWidth>
-          <FormLabel sx={{ fontSize: "0.75rem", fontWeight: 500, mb: 0.5 }}>
-            Upstream URL
-          </FormLabel>
-          <TextField
-            value={upstreamUrl}
-            size="small"
-            fullWidth
-            slotProps={{
-              input: {
-                readOnly: true,
-                sx: { fontFamily: "monospace", fontSize: "0.8125rem" },
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Tooltip title="Copy Upstream URL">
-                      <IconButton
-                        size="small"
-                        aria-label="Copy Upstream URL"
-                        onClick={() => handleCopy(upstreamUrl, "Upstream URL")}
-                      >
-                        <Copy size={14} />
-                      </IconButton>
-                    </Tooltip>
-                  </InputAdornment>
-                ),
-              },
-            }}
-          />
-        </FormControl>
-      )}
+      <MCPCapabilitiesView
+        tools={config?.capabilities?.tools}
+        resources={config?.capabilities?.resources}
+        prompts={config?.capabilities?.prompts}
+        sectionTitleVariant="h6"
+        getToolStatus={getToolStatus}
+      />
     </Stack>
   );
 }

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyRewriteTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyRewriteTab.tsx
@@ -556,7 +556,7 @@ export function MCPProxyRewriteTab({
           No Capabilities Available
         </Typography>
         <Typography variant="body2" color="text.secondary">
-          This MCP proxy has no tools, resources, or prompts to rewrite.
+          This MCP Server has no tools, resources, or prompts to rewrite.
         </Typography>
       </Stack>
     );
@@ -578,7 +578,7 @@ export function MCPProxyRewriteTab({
           </Typography>
           <Typography variant="body2" color="text.secondary">
             Rewrite the user-facing names of tools, resources, and prompts
-            exposed by this MCP proxy.
+            exposed by this MCP Server.
           </Typography>
         </Stack>
         <Stack direction="row" alignItems="center" spacing={1}>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
@@ -510,7 +510,7 @@ export function MCPProxySecurityTab({
                 No Tools Available
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                This MCP proxy has no tools. Scope bindings require at least one
+                This MCP Server has no tools. Scope bindings require at least one
                 tool.
               </Typography>
             </Stack>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
@@ -221,6 +221,9 @@ export function MCPProxySecurityTab({
     { orgName: orgName ?? "", proxyId: proxyId ?? "" },
     { enabled: authenticationType === "identity" && !!proxyId },
   );
+  // The persisted source of truth, used to diff against on Save (see
+  // computeScopeReconciliation) — not what the Autocomplete offers as
+  // suggestions, since that also needs not-yet-saved scopes (see scopeOptions).
   const catalogScopes: MCPProxyScopeResponse[] = useMemo(
     () => scopesData?.scopes ?? [],
     [scopesData],
@@ -301,6 +304,24 @@ export function MCPProxySecurityTab({
       prev.map((row) => (row.tool === tool ? { ...row, scopes } : row)),
     );
   }, []);
+
+  // What the Autocomplete offers: catalogScopes (persisted) plus any scope just
+  // added via "+ Add Scope" on another row but not yet saved — without this,
+  // every other row's Autocomplete would fail to recognize the same action and
+  // keep offering to "add" it again instead of suggesting the one the user
+  // already just created. Save still reconciles against catalogScopes alone.
+  const scopeOptions = useMemo<ScopeOption[]>(() => {
+    const knownActions = new Set(catalogScopes.map((s) => s.action));
+    const pending: ScopeOption[] = [];
+    for (const scope of toolScopeRows.flatMap((row) => row.scopes)) {
+      if (knownActions.has(scope.action)) continue;
+      knownActions.add(scope.action);
+      // Not marked isNew here: to every other row it's already a real,
+      // selectable scope, not something still being typed.
+      pending.push({ ...scope, isNew: false });
+    }
+    return [...catalogScopes, ...pending];
+  }, [catalogScopes, toolScopeRows]);
 
   // Selecting the synthetic "+ Add Scope" option just commits a pending
   // placeholder to the row — it isn't created on the server until Save,
@@ -550,7 +571,7 @@ export function MCPProxySecurityTab({
                           multiple
                           size="small"
                           disableCloseOnSelect
-                          options={catalogScopes}
+                          options={scopeOptions}
                           value={row.scopes}
                           onChange={(_e, value) =>
                             handleToolScopeRowScopesChange(

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyTable.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxyTable.tsx
@@ -71,9 +71,9 @@ export function MCPProxyTable() {
     <ResourceListShell
       searchValue={searchValue}
       onSearchChange={setSearchValue}
-      searchPlaceholder="Search MCP proxies..."
+      searchPlaceholder="Search MCP servers..."
       addButton={{
-        label: "Add MCP Proxy",
+        label: "Register MCP Server",
         component: Link,
         to: generatePath(
           absoluteRouteMap.children.org.children.mcpProxies.children.add.path,
@@ -86,12 +86,12 @@ export function MCPProxyTable() {
       isSearchEmpty={!filteredProxies.length}
       emptyState={{
         illustration: <MCPLogo size={64} />,
-        title: "No MCP Proxies Yet",
-        description: "Add an MCP Proxy to provide tools for agents.",
+        title: "No MCP Servers Yet",
+        description: "Add an MCP Server to provide tools for agents.",
       }}
       searchEmptyState={{
         illustration: <Plus size={64} />,
-        title: "No MCP proxies match your search",
+        title: "No MCP servers match your search",
         description: "Try a different keyword or clear the search filter.",
       }}
     >
@@ -110,7 +110,7 @@ export function MCPProxyTable() {
         </ListingTable.Head>
         <ListingTable.Body>
           {filteredProxies.map((proxy: MCPProxyListItem) => {
-            const displayName = proxy.name ?? proxy.id ?? "MCP Proxy";
+            const displayName = proxy.name ?? proxy.id ?? "MCP Server";
             const proxyId = proxy.id;
             return (
               <ListingTable.Row
@@ -141,7 +141,7 @@ export function MCPProxyTable() {
                         flexShrink: 0,
                       }}
                     >
-                      {getAvatarInitials(displayName, { fallback: "MP" })}
+                      {getAvatarInitials(displayName, { fallback: "MS" })}
                     </Avatar>
                     <Typography variant="body2" fontWeight={500} noWrap>
                       {displayName}
@@ -163,13 +163,13 @@ export function MCPProxyTable() {
                   onClick={(event) => event.stopPropagation()}
                 >
                   {proxyId ? (
-                    <Tooltip title="Delete MCP Proxy">
+                    <Tooltip title="Delete MCP Server">
                       <IconButton
                         color="error"
                         size="small"
                         onClick={() =>
                           addConfirmation({
-                            title: "Delete MCP Proxy",
+                            title: "Delete MCP Server",
                             description: `Are you sure you want to delete ${displayName}? This action cannot be undone.`,
                             confirmButtonText: "Delete",
                             confirmButtonColor: "error",

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/ViewMCPProxy.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/ViewMCPProxy.tsx
@@ -207,7 +207,7 @@ export function ViewMCPProxy() {
     [orgId, proxy, selectedEndpointId, updateMCPProxy],
   );
 
-  const displayName = proxy?.name ?? proxy?.id ?? proxyId ?? "MCP Proxy";
+  const displayName = proxy?.name ?? proxy?.id ?? proxyId ?? "MCP Server";
   const hasEndpoints = endpoints.length > 0;
   // The proxy fetch's own isLoading flips to false as soon as `proxy` arrives,
   // but selecting the first endpoint (when the URL doesn't already name one)
@@ -229,7 +229,7 @@ export function ViewMCPProxy() {
       <PageLayout
         title={displayName}
         backHref={backHref}
-        backLabel="Back to MCP Proxies"
+        backLabel="Back to MCP Servers"
         isLoading={isLoading}
         titleTail={
           proxy?.version ? (
@@ -250,7 +250,7 @@ export function ViewMCPProxy() {
               startIcon={<Edit size={16} />}
               onClick={() => setEditDrawerOpen(true)}
             >
-              Edit MCP Proxy
+              Edit MCP Server
             </Button>
           ) : undefined
         }
@@ -266,7 +266,7 @@ export function ViewMCPProxy() {
           <Alert severity="error" icon={<AlertTriangle size={18} />}>
             {error instanceof Error
               ? error.message
-              : "Failed to load MCP proxy. Please try again."}
+              : "Failed to load MCP Server. Please try again."}
           </Alert>
         ) : null}
 
@@ -332,7 +332,7 @@ export function ViewMCPProxy() {
               </Grid>
             </Grid>
 
-            {hasEndpoints && (
+            {endpoints.length > 1 && (
               <Stack
                 direction="row"
                 spacing={1}
@@ -464,8 +464,8 @@ export function ViewMCPProxy() {
             ) : (
               <Card variant="outlined" sx={{ p: 3 }}>
                 <Alert severity="info">
-                  This MCP proxy has no endpoints configured. Use &quot;Edit MCP
-                  Proxy&quot; above to add one.
+                  This MCP Server has no endpoints configured. Use &quot;Edit MCP
+                  Server&quot; above to add one.
                 </Alert>
               </Card>
             )}

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/ViewMCPProxy.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/ViewMCPProxy.tsx
@@ -59,7 +59,6 @@ import {
   normalizeVersion,
 } from "@agent-management-platform/shared-component";
 import { PageLayout } from "@agent-management-platform/views";
-import { MCPCapabilitiesView } from "../components/MCPCapabilitiesView";
 import { MCPProxyManageToolsTab } from "./MCPProxyManageToolsTab";
 import { MCPProxyConnectionTab } from "./MCPProxyConnectionTab";
 import { MCPProxyOverviewTab } from "./MCPProxyOverviewTab";
@@ -74,7 +73,6 @@ import { useCopyWithFeedback } from "./useCopyWithFeedback";
 // instead of resetting to Overview/first-environment.
 const TAB_DEFS = [
   { label: "Overview", slug: "overview" },
-  { label: "Capabilities", slug: "capabilities" },
   { label: "Connection", slug: "connection" },
   { label: "Manage Tools", slug: "manage-tools" },
   { label: "Security", slug: "security" },
@@ -91,6 +89,9 @@ export function ViewMCPProxy() {
   const tabIndex = tabSlug
     ? Math.max(0, TAB_DEFS.findIndex((tab) => tab.slug === tabSlug))
     : 0;
+  // Render blocks below key off the slug, not the raw index, so reordering or
+  // removing a tab in TAB_DEFS doesn't require manually renumbering every block.
+  const activeTabSlug = TAB_DEFS[tabIndex]?.slug;
   const selectedEndpointId = searchParams.get("endpoint") ?? "";
 
   const setSelectedEndpointId = useCallback(
@@ -394,7 +395,7 @@ export function ViewMCPProxy() {
                 </Stack>
                 <Divider />
                 <Box sx={{ p: 3 }}>
-                  {tabIndex === 0 && (
+                  {activeTabSlug === "overview" && (
                     <MCPProxyOverviewTab
                       proxy={proxy}
                       config={selectedConfig}
@@ -402,15 +403,7 @@ export function ViewMCPProxy() {
                       isLoading={isTabContentLoading}
                     />
                   )}
-                  {tabIndex === 1 && (
-                    <MCPCapabilitiesView
-                      tools={selectedConfig?.capabilities?.tools}
-                      resources={selectedConfig?.capabilities?.resources}
-                      prompts={selectedConfig?.capabilities?.prompts}
-                      sectionTitleVariant="h6"
-                    />
-                  )}
-                  {tabIndex === 2 && (
+                  {activeTabSlug === "connection" && (
                     <MCPProxyConnectionTab
                       config={selectedConfig}
                       selectedEndpointId={selectedEndpointId}
@@ -419,7 +412,7 @@ export function ViewMCPProxy() {
                       isUpdating={updateMCPProxy.isPending}
                     />
                   )}
-                  {tabIndex === 3 && (
+                  {activeTabSlug === "manage-tools" && (
                     <MCPProxyManageToolsTab
                       config={selectedConfig}
                       selectedEndpointId={selectedEndpointId}
@@ -429,7 +422,7 @@ export function ViewMCPProxy() {
                       isUpdating={updateMCPProxy.isPending}
                     />
                   )}
-                  {tabIndex === 4 && (
+                  {activeTabSlug === "security" && (
                     <MCPProxySecurityTab
                       config={selectedConfig}
                       selectedEndpointId={selectedEndpointId}
@@ -440,7 +433,7 @@ export function ViewMCPProxy() {
                       isUpdating={updateMCPProxy.isPending}
                     />
                   )}
-                  {tabIndex === 5 && (
+                  {activeTabSlug === "rewrite" && (
                     <MCPProxyRewriteTab
                       config={selectedConfig}
                       selectedEndpointId={selectedEndpointId}
@@ -450,7 +443,7 @@ export function ViewMCPProxy() {
                       isUpdating={updateMCPProxy.isPending}
                     />
                   )}
-                  {tabIndex === 6 && (
+                  {activeTabSlug === "policies" && (
                     <MCPProxyPoliciesTab
                       config={selectedConfig}
                       selectedEndpointId={selectedEndpointId}


### PR DESCRIPTION
## Purpose

<img width="1728" height="998" alt="image" src="https://github.com/user-attachments/assets/ea4e1850-598f-478b-834f-b6535bc52ff2" />


Issue: https://github.com/wso2/agent-manager/issues/1324

This pull request standardizes the terminology across the codebase by renaming all references to "MCP Proxy" or "MCP proxy" to "MCP Server". This change affects UI labels, button texts, tooltips, API action descriptions, and documentation strings. Additionally, some unused code related to endpoint display in the deployment pipeline environment view has been removed for simplification.

**Terminology Standardization:**

* All user-facing strings, labels, button texts, tooltips, and placeholder texts referring to "MCP Proxy" have been updated to "MCP Server" throughout the UI, including in forms, drawers, sections, empty states, and navigation items (`MCPProxySection.tsx`, `AddMCPToolConfigPanel.tsx`, `ViewMCPServer.Component.tsx`, `AddMCPProxy.Organization.tsx`, `MCPProxies.Organization.tsx`, `navigationItems.tsx`). [[1]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL76-R76) [[2]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL155-R155) [[3]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL202-R202) [[4]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL234-R234) [[5]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL464-R464) [[6]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL519-R530) [[7]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL558-R559) [[8]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL576-R576) [[9]](diffhunk://#diff-d0796b891f2df9a8f509c6617dd13d1158cb53d4aa36fb98bca60b1e89ffb1faL627-R627) [[10]](diffhunk://#diff-acaa40a2610a0b4f3d73b6cae3383a16d7619da7b32b2ec6cabca8774a0e33c4L329-R329) [[11]](diffhunk://#diff-acaa40a2610a0b4f3d73b6cae3383a16d7619da7b32b2ec6cabca8774a0e33c4L346-R346) [[12]](diffhunk://#diff-acaa40a2610a0b4f3d73b6cae3383a16d7619da7b32b2ec6cabca8774a0e33c4L488-R488) [[13]](diffhunk://#diff-94132f252c0467a62640dfcf420dc8155c07127eb4a8100cbfb9cceba64d73ebL860-R860) [[14]](diffhunk://#diff-94132f252c0467a62640dfcf420dc8155c07127eb4a8100cbfb9cceba64d73ebL929-R934) [[15]](diffhunk://#diff-769da210abf9f99f4a22ccb8327e095413d007b31b9b192c867d0b0055fe1c7fL28-R30) [[16]](diffhunk://#diff-e4f534b496258c7a962bd5f1d2d5b78efa346295cc9e957ed49600ca5e6f164dL23-R23) [[17]](diffhunk://#diff-939325ca79b4fb1c3fe78586bfd67fba7fca058ebf48f33927f2dc2b9a657081L755-R755) [[18]](diffhunk://#diff-067fe3b5317d01300b8e8b5f8de598a9fd4a0f50e832a764eb484937fdcd1c64L191-R191) [[19]](diffhunk://#diff-acd04f93fc8d3696115727a312d2c55018d63d7451ee8381bd53cc614b8fe6cdL121-R121)

* API action descriptions and mutation targets have been updated to use "MCP server" instead of "MCP proxy" (`agent-mcp-proxies.ts`, `mcp-proxies.ts`). [[1]](diffhunk://#diff-f356d6c6a6da8677a31fb6cd2cbdb1c594a657b3abae8fdda53c1e157281d5dfL47-R47) [[2]](diffhunk://#diff-ba30830a949ee458a8900916335fd76e09381bbea3039dd8147fabb69e0ca2e3L63-R63) [[3]](diffhunk://#diff-ba30830a949ee458a8900916335fd76e09381bbea3039dd8147fabb69e0ca2e3L88-R88) [[4]](diffhunk://#diff-ba30830a949ee458a8900916335fd76e09381bbea3039dd8147fabb69e0ca2e3L101-R101)

**Code Simplification:**

* The unused `EndpointCard` component and related endpoint display logic were removed from the deployment pipeline environment view, simplifying the code and UI (`EnvironmentViewPage.tsx`). [[1]](diffhunk://#diff-94a41c804deaac9bcdde735e66575446d00b2d0cb27dd772aecb02513d26bee5L48) [[2]](diffhunk://#diff-94a41c804deaac9bcdde735e66575446d00b2d0cb27dd772aecb02513d26bee5L98-L144) [[3]](diffhunk://#diff-94a41c804deaac9bcdde735e66575446d00b2d0cb27dd772aecb02513d26bee5L182-L184) [[4]](diffhunk://#diff-94a41c804deaac9bcdde735e66575446d00b2d0cb27dd772aecb02513d26bee5R210-R218)

These changes ensure consistent terminology and improve clarity for users interacting with MCP server-related features.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional authentication controls for MCP Server endpoint headers/values, including masked credential handling.
  * Tool capability views can now show per-tool **Allowed/Denied** status indicators.
  * Version input now validates semantic versions and enables submission only when valid.
* **Updates**
  * Renamed “MCP Proxies” to **“MCP Servers”** across navigation, pages, labels, and actions.
  * Simplified environment external ingress to DNS-only; removed HTTP/HTTPS endpoint cards.
  * MCP Server details: removed the Capabilities tab and the upstream URL display; updated endpoint environment selection and related helper text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->