### PR TITLE
Point VM MCP resource identifiers at the public hosts

### DIFF
--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -125,13 +125,23 @@ build_gateway_helm_args() {
 # issuer is the public Thunder URL too. jwksUrl stays on the in-cluster service.
 # observability_helm_args — hostname-driven core. Reads AMP_HOST_THUNDER and
 # AMP_HOST_OBSERVER.
+#
+# auth.audience is restated rather than left at the chart default because the
+# default's last entry is this service's own publicUrl, which publicUrl above
+# has just moved. An observer MCP token carries the RFC 8707 resource
+# identifier (publicUrl plus a trailing slash) as its `aud`, so leaving the
+# default in place means the observer rejects every token it mints for itself.
+# The first three entries mirror the chart and must stay: console and amctl
+# tokens arrive with aud amp or amp-api-client. Commas are escaped because
+# helm's --set otherwise splits the value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 observability_helm_args() {
   printf '%s\n' \
     "--set" "amObserver.auth.issuer=https://${AMP_HOST_THUNDER}" \
     "--set" "amObserver.ocIngress.hostname=${AMP_HOST_OBSERVER}" \
     "--set" "amObserver.publicUrl=https://${AMP_HOST_OBSERVER}" \
-    "--set" "amObserver.oauth.authorizationServers=https://${AMP_HOST_THUNDER}"
+    "--set" "amObserver.oauth.authorizationServers=https://${AMP_HOST_THUNDER}" \
+    "--set" "amObserver.auth.audience=amp\,amp-api-client\,am-obs-mcp\,https://${AMP_HOST_OBSERVER}/"
 }
 
 # build_observability_helm_args <ip> — sslip.io-from-IP wrapper.
@@ -219,7 +229,8 @@ build_platform_resources_helm_args() {
 
 # build_thunder_helm_args <ip>
 # Prints helm args, one token per line.
-# thunder_helm_args — hostname-driven core. Reads AMP_HOST_THUNDER, AMP_HOST_CONSOLE.
+# thunder_helm_args — hostname-driven core. Reads AMP_HOST_THUNDER, AMP_HOST_CONSOLE,
+# AMP_HOST_API, AMP_HOST_OBSERVER.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 thunder_helm_args() {
   printf '%s\n' \
@@ -230,6 +241,23 @@ thunder_helm_args() {
     "--set" "thunder.configuration.gateClient.scheme=https" \
     "--set" "thunder.configuration.gateClient.port=443" \
     "--set" "thunder.configuration.cors.allowedOrigins[0]=https://${AMP_HOST_CONSOLE}"
+
+  # RFC 8707 resource indicators for the two MCP endpoints. Thunder matches the
+  # authorize request's `resource` parameter against these identifiers verbatim
+  # and answers invalid_target on any mismatch, so they must be the hosts an MCP
+  # client actually dials — not the chart's localhost defaults, which describe a
+  # k3d install. Both MCP endpoints are served by services already exposed here:
+  # the agent-manager one by amp-api (chart default http://localhost:9000/) and
+  # the observer one by the observer itself (default the observability
+  # extension's amObserver.publicUrl). Keep the trailing slash: clients send the
+  # canonical origin with one, and the comparison is exact.
+  #
+  # Indices are positional, so they track the order of thunder.bootstrap
+  # .mcpResourceServers in wso2-amp-thunder-extension/values.yaml — agent-manager
+  # first, observer second. Reordering that list silently retargets these.
+  printf '%s\n' \
+    "--set" "thunder.bootstrap.mcpResourceServers[0].identifier=https://${AMP_HOST_API}/" \
+    "--set" "thunder.bootstrap.mcpResourceServers[1].identifier=https://${AMP_HOST_OBSERVER}/"
 
   # The console client's registered redirect URI lives under `setup` (<=main) and
   # was renamed to `bootstrap` (>=0.15.0, which is what the registration template
@@ -244,9 +272,11 @@ thunder_helm_args() {
 # build_thunder_helm_args <ip> — sslip.io-from-IP wrapper.
 build_thunder_helm_args() {
   local ip="$1"
-  local AMP_HOST_THUNDER AMP_HOST_CONSOLE
+  local AMP_HOST_THUNDER AMP_HOST_CONSOLE AMP_HOST_API AMP_HOST_OBSERVER
   AMP_HOST_THUNDER="$(vm_host thunder "$ip")"
   AMP_HOST_CONSOLE="$(vm_host console "$ip")"
+  AMP_HOST_API="$(vm_host api "$ip")"
+  AMP_HOST_OBSERVER="$(vm_host observer "$ip")"
   thunder_helm_args
 }
 

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -128,6 +128,12 @@ assert_eq "observability publicUrl -> public observer host" \
 assert_eq "observability oauth authorizationServers -> public thunder" \
   "amObserver.oauth.authorizationServers=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'amObserver.oauth.authorizationServers' <<<"$obs")"
+# The observer mints MCP tokens whose aud is its own public URL plus a trailing
+# slash, so the audience list has to follow publicUrl off the chart's localhost
+# default. Commas stay escaped or helm splits the value into a list.
+assert_eq "observability audience carries the public observer URL" \
+  'amObserver.auth.audience=amp\,amp-api-client\,am-obs-mcp\,https://observer.amp.203.0.113.10.sslip.io/' \
+  "$(grep -F 'amObserver.auth.audience' <<<"$obs")"
 
 # --- render_dataplane_external_ingress: public host on :443, both http+https entries
 #     bound to the internal http listener (amp-api advertises the https variant) ---
@@ -175,6 +181,15 @@ assert_eq "thunder console redirectUri (bootstrap key)" \
 assert_eq "thunder console redirectUri (legacy setup key)" \
   "thunder.setup.ampConsoleClient.redirectUris[0]=https://console.amp.203.0.113.10.sslip.io/login" \
   "$(grep -F 'thunder.setup.ampConsoleClient.redirectUris' <<<"$th")"
+# RFC 8707 resource indicators. Thunder compares the authorize request's
+# `resource` verbatim, so these must name the hosts an MCP client dials, with the
+# trailing slash the client sends. Index 0 is agent-manager, index 1 the observer.
+assert_eq "thunder MCP resource identifier (agent-manager)" \
+  "thunder.bootstrap.mcpResourceServers[0].identifier=https://api.amp.203.0.113.10.sslip.io/" \
+  "$(grep -F 'mcpResourceServers[0].identifier' <<<"$th")"
+assert_eq "thunder MCP resource identifier (observer)" \
+  "thunder.bootstrap.mcpResourceServers[1].identifier=https://observer.amp.203.0.113.10.sslip.io/" \
+  "$(grep -F 'mcpResourceServers[1].identifier' <<<"$th")"
 
 # --- render_k3d_vm_config ---
 k3d_in="$(printf '%s\n' \
@@ -353,6 +368,19 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core thunder jwt.issuer" \
     "thunder.configuration.jwt.issuer=https://thunder.amp.example.com" \
     "$(grep -F 'jwt.issuer' <<<"$core_th")"
+  # The advanced path reaches the same core, so the MCP resource indicators must
+  # follow the configured domain here too.
+  assert_eq "core thunder MCP resource identifier (agent-manager)" \
+    "thunder.bootstrap.mcpResourceServers[0].identifier=https://api.amp.example.com/" \
+    "$(grep -F 'mcpResourceServers[0].identifier' <<<"$core_th")"
+  assert_eq "core thunder MCP resource identifier (observer)" \
+    "thunder.bootstrap.mcpResourceServers[1].identifier=https://observer.amp.example.com/" \
+    "$(grep -F 'mcpResourceServers[1].identifier' <<<"$core_th")"
+
+  core_obs="$(observability_helm_args)"
+  assert_eq "core observability audience carries the public observer URL" \
+    'amObserver.auth.audience=amp\,amp-api-client\,am-obs-mcp\,https://observer.amp.example.com/' \
+    "$(grep -F 'amObserver.auth.audience' <<<"$core_obs")"
 
   core_gw="$(gateway_helm_args)"
   assert_eq "core gateway vhost" \


### PR DESCRIPTION
## Purpose
#1396 introduces two settings whose defaults describe a k3d install, and the VM installers override neither. On a VM the platform would advertise `localhost` URLs to clients that can only reach it by its public hostnames, so the MCP surface it adds would not work there.

**MCP resource identifiers.** `thunder.bootstrap.mcpResourceServers[*].identifier` defaults to `http://localhost:9000/` (agent-manager) and `http://traces.amp.localhost:11080/` (observer). The chart's own comment says the identifier "must be the externally reachable base URL of the service (the same value as agent-manager's `serverPublicURL` / the observability extension's `amObserver.publicUrl`), slash included." The VM installers set both of those values but leave the identifiers alone. Since Thunder matches an authorize request's RFC 8707 `resource` parameter against a registered identifier verbatim and answers `invalid_target` on any mismatch, an MCP client dialling a VM is refused outright.

**Observer audience.** `amObserver.auth.audience` defaults to `amp,amp-api-client,am-obs-mcp,http://traces.amp.localhost:11080/`, whose last entry is the observer's own `publicUrl`, with the chart noting "Keep the audience URL entry in sync with publicUrl below." `observability_helm_args` already moves `publicUrl` to the VM's observer host but not the audience, so the observer would reject the very tokens minted for it.

Neither is a regression. The MCP resource servers are new in #1396, and console and `amctl` tokens arrive with `aud` `amp` or `amp-api-client`, which stay listed. What breaks without this is the MCP surface specifically; the console, observability UI, agent deployment and in-cluster OTel path are unaffected either way.

Related to #1396

## Goals
Make both VM install paths derive the MCP resource identifiers and the observer audience from the hostnames the installer already knows, so #1396's MCP surface works on a VM the same way it does on k3d.

## Approach
The overrides go into the shared hostname-driven cores in `deployments/vm/lib-vm.sh` (`thunder_helm_args` and `observability_helm_args`) rather than into either installer, because the simple and advanced paths both call them; adding them once covers both.

`thunder_helm_args` previously read only `AMP_HOST_THUNDER` and `AMP_HOST_CONSOLE`, so `build_thunder_helm_args` now derives `AMP_HOST_API` and `AMP_HOST_OBSERVER` as well. The advanced path already had all four in scope.

The audience is restated in full rather than appended to, since Helm's `--set` replaces a scalar. The first three entries mirror the chart and must stay, or console and `amctl` tokens stop validating. Commas are escaped because `--set` otherwise splits the value into a list.

Two things a reviewer should weigh:

- **The resource-server indices are positional.** `mcpResourceServers[0]` / `[1]` track the order in `wso2-amp-thunder-extension/values.yaml` (agent-manager first, observer second). Reordering that list silently retargets these overrides. A template in the chart that derived each identifier from the corresponding `HOST_*` value would be sturdier than an installer-side override, and I would rather have that if you are open to it — this is the version that does not require changing #1396.
- **The Thunder bootstrap is a pre-install-only hook.** Fresh VM installs are fine, which is the only supported VM flow. On an existing cluster a `helm upgrade` will not re-seed the resource servers, matching the caveat already documented in #1396.

## User stories
As an operator running Agent Manager on a VM, I can point an MCP client at the platform's public hostnames and have Thunder issue it a correctly scoped token, instead of being refused with `invalid_target`.

## Release note
Fixed the MCP resource identifiers and observer token audience on VM installations, which previously kept their local-development defaults and rejected MCP clients.

## Documentation
No documentation change. #1396 adds no new hostname, port, Service or HTTPRoute — both MCP endpoints are served by services the VM already exposes (`api.<host>` and `observer.<host>`), so the VM guide's routing diagrams and exposed-host tables remain accurate as written.

## Training
N/A — no training content covers the VM installation path.

## Certification
N/A — no certification exam covers the VM installation path.

## Marketing
N/A — a configuration correction, not a promotable feature.

## Automation tests
 - Unit tests
   > Six assertions added to `deployments/vm/tests/run.sh`, covering both install paths: the two resource identifiers and the observer audience for the sslip.io path (`build_thunder_helm_args` / `build_observability_helm_args`), and the same three against a custom domain through the hostname-driven cores that the advanced path calls. Suite passes at 172 assertions, run locally — see **Test environment**, no CI job executes it.
   >
   > Confirmed non-vacuous: reverting `lib-vm.sh` alone and re-running fails 6 of 6 with the suite exiting 1. Two further negative assertions were written and then removed on purpose — the localhost defaults live in the chart and never appear in the emitted helm args, so those assertions could not fail under any change and would have been noise.
 - Integration tests
   > None. Verifying this end to end needs a VM plus a released chart carrying #1396's values, which does not exist yet; see **Test environment** for what that leaves unproven.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell only, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — installer configuration, no sample accompanies it.

## Related PRs
- #1396 — adds the settings this corrects for VM installs. **Merge this after #1396**; until then the `mcpResourceServers` overrides set a path the chart does not yet define, which Helm accepts and ignores.

## Migrations (if applicable)
N/A for the supported VM flow, which is a fresh install. An existing VM cluster would need the Thunder bootstrap job re-run for the resource servers to be seeded at all, which is the same constraint #1396 documents.

## Test environment
Unit tests run locally on macOS with Bash 3.2, and `bash -n` is clean on both edited files.

**Nothing here runs in CI.** No workflow matches `deployments/vm/**` — every job in `.github/workflows/` is path-filtered to `documentation/`, `deployments/helm-charts/`, the Go services, the CLI or the console — and `shellcheck` is not configured anywhere in the repository. `deployments/vm/tests/run.sh` is invoked by no workflow either, so the suite this PR extends only ever runs when someone runs it by hand. The checks on this PR are therefore CodeRabbit and the CLA only, and a green tick here says nothing about the change. Reviewers should run `bash deployments/vm/tests/run.sh` locally.

**Not yet verified on a VM.** #1396 is unmerged and no release carries its chart values, so there is no artifact to install that would exercise this. The change is derived by reading #1396's chart defaults against the installer's existing overrides rather than observed failing and then fixed. The specific claim worth re-testing once #1396 lands is that an MCP client authorizing against a VM receives a token instead of `invalid_target`, and that the observer accepts it.

For context on the surrounding paths, both VM install flows were installed from scratch and verified earlier this cycle — the simple path on sslip.io and the advanced path on a custom domain with ACME DNS-01 — so the hostname derivations this change reuses (`vm_host api`, `vm_host observer`) are known good on real installs.

## Learning
The pattern behind this is that a chart default doubles as documentation of an invariant, and the invariant is only enforced where someone remembers it. Both settings here carry a comment stating they must match another value — `serverPublicURL`, `publicUrl` — that the VM installers already override, so the defect is not that a value was wrong but that a stated relationship between two values had no mechanism holding it. Deriving them in the chart from a shared host input would remove the class; overriding them in the installer only fixes this instance, which is why it is flagged above as the weaker of the two options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observability authentication configuration with explicit audience values.
  * Corrected MCP resource server identifiers to use fully qualified public HTTPS URLs, including trailing slashes.
  * Ensured MCP and OAuth settings remain consistent across standard and advanced deployment configurations.
* **Tests**
  * Expanded deployment validation to cover observability audiences and MCP resource indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->