### PR TITLE
Update the Gateway operator to release to  0.10.0

### DIFF
--- a/agent-manager-service/api/gateway_internal_routes.go
+++ b/agent-manager-service/api/gateway_internal_routes.go
@@ -35,15 +35,6 @@ func RegisterGatewayInternalRoutes(mux *http.ServeMux, ctrl controllers.GatewayI
 
 	// Deployment sync endpoint (gateway-controller reconciles its local cache
 	// against this on connect and periodically).
-	//
-	// Intentionally registered with raw mux.HandleFunc rather than
-	// RouteRegistrar.HandleFuncWithValidationAndAuthz: that helper's
-	// RequirePermission middleware checks JWT scopes and is a no-op when
-	// RBAC_ENABLED=false, neither of which fits this route. Callers here are
-	// gateway-controller instances authenticating with an api-key header, not
-	// JWT-bearing org users, so the unconditional api-key check inside
-	// ctrl.GetDeployments (matching every other handler in this file) is the
-	// correct enforcement point, not a route-level gap.
 	mux.HandleFunc("GET /deployments", ctrl.GetDeployments)
 
 	// AI applications endpoint (bulk-sync for per-consumer rate limiting)

--- a/agent-manager-service/api/gateway_internal_routes.go
+++ b/agent-manager-service/api/gateway_internal_routes.go
@@ -33,6 +33,10 @@ func RegisterGatewayInternalRoutes(mux *http.ServeMux, ctrl controllers.GatewayI
 	// Subscription plans endpoint
 	mux.HandleFunc("GET /subscription-plans", ctrl.GetSubscriptionPlans)
 
+	// Deployment sync endpoint (gateway-controller reconciles its local cache
+	// against this on connect and periodically)
+	mux.HandleFunc("GET /deployments", ctrl.GetDeployments)
+
 	// AI applications endpoint (bulk-sync for per-consumer rate limiting)
 	mux.HandleFunc("GET /applications", ctrl.GetApplications)
 

--- a/agent-manager-service/api/gateway_internal_routes.go
+++ b/agent-manager-service/api/gateway_internal_routes.go
@@ -34,7 +34,16 @@ func RegisterGatewayInternalRoutes(mux *http.ServeMux, ctrl controllers.GatewayI
 	mux.HandleFunc("GET /subscription-plans", ctrl.GetSubscriptionPlans)
 
 	// Deployment sync endpoint (gateway-controller reconciles its local cache
-	// against this on connect and periodically)
+	// against this on connect and periodically).
+	//
+	// Intentionally registered with raw mux.HandleFunc rather than
+	// RouteRegistrar.HandleFuncWithValidationAndAuthz: that helper's
+	// RequirePermission middleware checks JWT scopes and is a no-op when
+	// RBAC_ENABLED=false, neither of which fits this route. Callers here are
+	// gateway-controller instances authenticating with an api-key header, not
+	// JWT-bearing org users, so the unconditional api-key check inside
+	// ctrl.GetDeployments (matching every other handler in this file) is the
+	// correct enforcement point, not a route-level gap.
 	mux.HandleFunc("GET /deployments", ctrl.GetDeployments)
 
 	// AI applications endpoint (bulk-sync for per-consumer rate limiting)

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -147,7 +147,7 @@ func loadEnvs() {
 	config.DefaultGatewayPort = int(r.readOptionalInt64("DEFAULT_GATEWAY_PORT", 19080))
 	config.GatewayRuntime = GatewayRuntimeConfig{
 		NamePrefix:    r.readOptionalString("GATEWAY_RUNTIME_NAME_PREFIX", "api-platform-"),
-		ServiceSuffix: r.readOptionalString("GATEWAY_RUNTIME_SERVICE_SUFFIX", "-gateway-gateway-runtime"),
+		ServiceSuffix: r.readOptionalString("GATEWAY_RUNTIME_SERVICE_SUFFIX", "-gw-gateway-gateway-runtime"),
 		Port:          int(r.readOptionalInt64("GATEWAY_RUNTIME_PORT", 22893)),
 	}
 	config.KeyManagerConfigurations = KeyManagerConfigurations{

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -110,7 +110,7 @@ func TestValidateGatewayRuntimeConfig(t *testing.T) {
 			name: "valid configuration",
 			config: GatewayRuntimeConfig{
 				NamePrefix:    "api-platform-",
-				ServiceSuffix: "-gateway-gateway-runtime",
+				ServiceSuffix: "-gw-gateway-gateway-runtime",
 				Port:          22893,
 			},
 		},

--- a/agent-manager-service/controllers/gateway_internal_controller.go
+++ b/agent-manager-service/controllers/gateway_internal_controller.go
@@ -41,6 +41,7 @@ type GatewayInternalController interface {
 	GetLLMProxyAPIKeys(w http.ResponseWriter, r *http.Request)
 	GetAPIKeys(w http.ResponseWriter, r *http.Request)
 	GetSubscriptionPlans(w http.ResponseWriter, r *http.Request)
+	GetDeployments(w http.ResponseWriter, r *http.Request)
 	GetApplications(w http.ResponseWriter, r *http.Request)
 	PushGatewayManifest(w http.ResponseWriter, r *http.Request)
 }
@@ -385,6 +386,32 @@ func (c *gatewayInternalController) GetSubscriptionPlans(w http.ResponseWriter, 
 	}
 
 	utils.WriteSuccessResponse(w, http.StatusOK, []struct{}{})
+}
+
+type controlPlaneDeploymentsResponse struct {
+	Deployments []struct{} `json:"deployments"`
+}
+
+// GetDeployments handles GET /api/internal/v1/deployments
+// gateway-controller calls this on connect (and periodically) to reconcile its
+// local deployment cache with what the control plane believes is deployed, via
+// pkg/controlplane.FetchControlPlaneDeployments. Deployment state currently
+// lives entirely in the RestApi/LlmProvider CRs the gateway-operator manages,
+// not in agent-manager's own DB, so there is nothing yet to report here —
+// returns an empty list, matching GetSubscriptionPlans/GetApplications above.
+func (c *gatewayInternalController) GetDeployments(w http.ResponseWriter, r *http.Request) {
+	apiKey := r.Header.Get("api-key")
+	if apiKey == "" {
+		http.Error(w, "API key is required", http.StatusUnauthorized)
+		return
+	}
+
+	if _, err := c.gatewayService.VerifyToken(apiKey); err != nil {
+		http.Error(w, "Invalid or expired API key", http.StatusUnauthorized)
+		return
+	}
+
+	utils.WriteSuccessResponse(w, http.StatusOK, controlPlaneDeploymentsResponse{Deployments: []struct{}{}})
 }
 
 // gatewayApplicationResponse is the bulk-sync response format for AI applications.

--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -28,7 +28,7 @@ import (
 func gatewayRuntimeTestConfig() config.GatewayRuntimeConfig {
 	return config.GatewayRuntimeConfig{
 		NamePrefix:    "api-platform-",
-		ServiceSuffix: "-gateway-gateway-runtime",
+		ServiceSuffix: "-gw-gateway-gateway-runtime",
 		Port:          22893,
 	}
 }
@@ -44,14 +44,14 @@ func TestGatewayRuntimeInClusterURL(t *testing.T) {
 			gateway: &models.Gateway{
 				Name: "api-platform-acme-dev",
 			},
-			expected: "http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893",
+			expected: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
 		},
 		{
 			name: "trims gateway name",
 			gateway: &models.Gateway{
 				Name: " api-platform-acme-prod ",
 			},
-			expected: "http://api-platform-acme-prod-gateway-gateway-runtime.acme-prod:22893",
+			expected: "http://api-platform-acme-prod-gw-gateway-gateway-runtime.acme-prod:22893",
 		},
 		{
 			name: "custom name falls back to vhost",
@@ -96,7 +96,7 @@ func TestBuildProxyURLSelectsReachableGateway(t *testing.T) {
 
 	require.Equal(
 		t,
-		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/llm/proxy",
+		"http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy",
 		buildProxyURL(gateway, &contextPath, true, gatewayRuntimeTestConfig()),
 	)
 	require.Equal(
@@ -115,7 +115,7 @@ func TestBuildMCPProxyURLSelectsReachableGateway(t *testing.T) {
 
 	require.Equal(
 		t,
-		"http://api-platform-acme-dev-gateway-gateway-runtime.acme-dev:22893/tools/mcp",
+		"http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/tools/mcp",
 		buildMCPProxyURL(gateway, &contextPath, true, gatewayRuntimeTestConfig()),
 	)
 	require.Equal(

--- a/agent-manager-service/services/llm_deployment_service.go
+++ b/agent-manager-service/services/llm_deployment_service.go
@@ -36,7 +36,7 @@ import (
 const (
 	deploymentLimitBuffer = 5
 	maxDeploymentsPerAPI  = 20
-	apiVersionLLMProvider = "gateway.api-platform.wso2.com/v1alpha1"
+	apiVersionLLMProvider = "gateway.api-platform.wso2.com/v1"
 	kindLLMProvider       = "LlmProvider"
 
 	// Policy names and versions

--- a/agent-manager-service/services/llm_proxy_deployment_service.go
+++ b/agent-manager-service/services/llm_proxy_deployment_service.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	apiVersionLLMProxy = "gateway.api-platform.wso2.com/v1alpha1"
+	apiVersionLLMProxy = "gateway.api-platform.wso2.com/v1"
 	kindLLMProxy       = "LlmProxy"
 )
 

--- a/agent-manager-service/services/mcp_proxy_deployment.go
+++ b/agent-manager-service/services/mcp_proxy_deployment.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	apiVersionMCPProxy              = "gateway.api-platform.wso2.com/v1alpha1"
+	apiVersionMCPProxy              = "gateway.api-platform.wso2.com/v1"
 	kindMCPProxy                    = "Mcp"
 	mcpSetHeadersPolicyName         = "set-headers"
 	mcpRemoveHeadersPolicyName      = "remove-headers"

--- a/agent-manager-service/utils/utils.go
+++ b/agent-manager-service/utils/utils.go
@@ -1142,13 +1142,13 @@ func GenerateCandidateName(displayName string) string {
 // MaxEnvNameLength returns the maximum environment name length for a given org.
 // The constraint comes from the gateway runtime Service name shape:
 //
-//	api-platform-<org>-<env>-gateway-gateway-runtime  ≤ 63 chars (k8s metadata.name)
+//	api-platform-<org>-<env>-gw-gateway-gateway-runtime  ≤ 63 chars (k8s metadata.name)
 //
-// Fixed portion: len("api-platform-") + len("-") + len("-gateway-gateway-runtime") = 13 + 1 + 24 = 38
-// So: len(env) ≤ 63 - 38 - len(org) = 25 - len(org).
+// Fixed portion: len("api-platform-") + len("-") + len("-gw-gateway-gateway-runtime") = 13 + 1 + 27 = 41
+// So: len(env) ≤ 63 - 41 - len(org) = 22 - len(org).
 // The returned value is never less than 1.
 func MaxEnvNameLength(orgName string) int {
-	maxLen := 25 - len(orgName)
+	maxLen := 22 - len(orgName)
 	if maxLen < 1 {
 		return 1
 	}

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - AMP_VERSION=v0.8.0
       # In-cluster API Platform gateway runtime Service URL convention.
       - GATEWAY_RUNTIME_NAME_PREFIX=api-platform-
-      - GATEWAY_RUNTIME_SERVICE_SUFFIX=-gateway-gateway-runtime
+      - GATEWAY_RUNTIME_SERVICE_SUFFIX=-gw-gateway-gateway-runtime
       - GATEWAY_RUNTIME_PORT=22893
       - OPEN_CHOREO_BASE_URL=http://api.openchoreo.localhost:8195
       # OpenBao/Vault Secret Management Configuration

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -12,7 +12,7 @@ data:
   # unset means clients surface "observer not configured".
   AM_OBSERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.amObserverPublicURL | default "" | quote }}
   GATEWAY_RUNTIME_NAME_PREFIX: {{ .Values.agentManagerService.config.gatewayRuntime.namePrefix | default "api-platform-" | quote }}
-  GATEWAY_RUNTIME_SERVICE_SUFFIX: {{ .Values.agentManagerService.config.gatewayRuntime.serviceSuffix | default "-gateway-gateway-runtime" | quote }}
+  GATEWAY_RUNTIME_SERVICE_SUFFIX: {{ .Values.agentManagerService.config.gatewayRuntime.serviceSuffix | default "-gw-gateway-gateway-runtime" | quote }}
   GATEWAY_RUNTIME_PORT: {{ .Values.agentManagerService.config.gatewayRuntime.port | default 22893 | quote }}
   SERVER_HOST: {{ .Values.agentManagerService.config.serverHost | quote }}
   SERVER_PORT: {{ .Values.agentManagerService.service.targetPort | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -143,7 +143,7 @@ agentManagerService:
     # sandboxed agents' OTEL and managed LLM/MCP traffic.
     gatewayRuntime:
       namePrefix: "api-platform-"
-      serviceSuffix: "-gateway-gateway-runtime"
+      serviceSuffix: "-gw-gateway-gateway-runtime"
       port: 22893
 
 

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-cr.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-cr.yaml
@@ -6,7 +6,7 @@
 #   3. The gateway-controller reads APIP_GW_GATEWAY_REGISTRATION_TOKEN from the Secret
 #      referenced by spec.controlPlane.tokenSecretRef (created by the bootstrap job)
 #   4. The gateway-controller connects to Agent Manager and stays registered
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: APIGateway
 metadata:
   name: {{ include "wso2-amp-gateway-extension.apiGatewayName" . }}

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-kgateway-route.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-kgateway-route.yaml
@@ -25,7 +25,7 @@ spec:
     - {{ include "wso2-amp-gateway-extension.gatewayHostname" . | quote }}
   rules:
     - backendRefs:
-        - name: {{ include "wso2-amp-gateway-extension.apiGatewayName" . }}-gateway-gateway-runtime
+        - name: {{ include "wso2-amp-gateway-extension.apiGatewayName" . }}-gw-gateway-gateway-runtime
           namespace: {{ .Values.apiGateway.namespace }}
           port: 22893
       timeouts:

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-otel-restapi.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-otel-restapi.yaml
@@ -2,7 +2,7 @@
 # RestApi: Routes OTEL trace requests through the API Platform gateway with jwt-auth
 # policy enforcement. Each gateway instance gets its own RestApi so traces from agents
 # in any environment are authenticated and forwarded to the OpenTelemetry collector.
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: RestApi
 metadata:
   name: {{ include "wso2-amp-gateway-extension.apiGatewayName" . }}-otel-restapi

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
@@ -109,7 +109,7 @@ spec:
     # The restapi-target label matches the gateway's apiSelector matchLabels (which the chart
     # sets to the same "api-platform-<org>-<env>" string via the apiGatewayName helper).
     - template:
-        apiVersion: gateway.api-platform.wso2.com/v1alpha1
+        apiVersion: gateway.api-platform.wso2.com/v1
         kind: RestApi
         metadata:
           name: ${metadata.name}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
@@ -102,7 +102,7 @@ spec:
           type: Static
           static:
             hosts:
-              - host: "api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}"
+              - host: "api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gw-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}"
                 port: 22893
 
     # Create RestApi resource (discovered by gateway via apiSelector scope: LabelSelector).
@@ -118,6 +118,7 @@ spec:
             gateway.api-platform.wso2.com/restapi-target: "api-platform-${metadata.componentNamespace}-${metadata.environmentName}"
           annotations:
             gateway.api-platform.wso2.com/artifact-id: "${has(environmentConfigs.artifactId) && environmentConfigs.artifactId != '' ? environmentConfigs.artifactId : parameters.artifactId}"
+            gateway.api-platform.wso2.com/project-id: "${metadata.labels['openchoreo.dev/project-uid']}"
         spec:
           displayName: ${parameters.apiName}-${metadata.environmentName}
           version: ${parameters.apiVersion}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
@@ -93,7 +93,7 @@ spec:
             name: ${parameters.otelEndpointEnvName}
             # In-cluster gateway runtime Service (per-org-env namespace): the
             # sandboxed agent reaches the runtime directly at
-            # "api-platform-<org>-<env>-gateway-gateway-runtime.<org>-<env>:22893/otel".
+            # "api-platform-<org>-<env>-gw-gateway-gateway-runtime.<org>-<env>:22893/otel".
             # Derived from the apiGatewayName convention ("api-platform-<org>-<env>")
             # + the per-env gateway namespace ("<org>-<env>"), matching the
             # API-management trait's runtime backend. This in-cluster path is what
@@ -105,7 +105,7 @@ spec:
             # install fronts a single public gateway host on :443, where the
             # per-env in-cluster Service does not apply). Leave empty for the
             # default in-cluster runtime endpoint.
-            value: {{ if .Values.apiPlatformGatewayVhost.otelEndpointOverride }}{{ .Values.apiPlatformGatewayVhost.otelEndpointOverride | quote }}{{ else }}"http://api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}:22893/otel"{{ end }}
+            value: {{ if .Values.apiPlatformGatewayVhost.otelEndpointOverride }}{{ .Values.apiPlatformGatewayVhost.otelEndpointOverride | quote }}{{ else }}"http://api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gw-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}:22893/otel"{{ end }}
         - op: add
           path: /spec/podTemplate/spec/containers/0/env/-
           value:

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -37,7 +37,7 @@ else
 fi
 
 # WSO2 API Platform / Gateway Operator versions
-GATEWAY_OPERATOR_VERSION="0.7.0"
+GATEWAY_OPERATOR_VERSION="0.10.0"
 GATEWAY_CHART_VERSION="1.1.0"
 
 # OpenChoreo community module versions compatible with OpenChoreo ${OPENCHOREO_VERSION}
@@ -1424,6 +1424,11 @@ fi
 
 log_step "Step 11/13: Installing Gateway Operator"
 log_info "Installing Gateway Operator..."
+# gateway-operator 0.10.0+'s own embedded default probe path is
+# /api/admin/v1/health, but gateway-controller ${GATEWAY_CHART_VERSION} only
+# serves /api/admin/v0.9/health (plus the legacy unversioned /health) — pin to
+# the version-agnostic legacy route so the self-installed controller doesn't
+# crash-loop on every health check.
 helm_install_idempotent \
     "gateway-operator" \
     "oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator" \
@@ -1432,7 +1437,9 @@ helm_install_idempotent \
     --version "${GATEWAY_OPERATOR_VERSION}" \
     --set "logging.level=debug" \
     --set gatewayApi.installStandardCRDs=false \
-    --set "gateway.helm.chartVersion=${GATEWAY_CHART_VERSION}"
+    --set "gateway.helm.chartVersion=${GATEWAY_CHART_VERSION}" \
+    --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/health \
+    --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/health
 
 log_success "Gateway Operator installed"
 

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -38,7 +38,15 @@ fi
 
 # WSO2 API Platform / Gateway Operator versions
 GATEWAY_OPERATOR_VERSION="0.10.0"
-GATEWAY_CHART_VERSION="1.1.0"
+# gateway-controller/gateway-runtime 1.1.x reject every RestApi/LlmProvider
+# deployment with a bare 404 despite correctly-configured basic auth (confirmed
+# via a live tcpdump of the operator's request — same 404 across 1.1.0 and
+# 1.1.5). 1.2.0-alpha2 does not have this bug (verified end-to-end: RestApi
+# reaches Programmed=True). Chart *version* and container *image tag* are
+# pinned separately below — setting chartVersion alone still runs an older
+# default image, so GATEWAY_IMAGE_VERSION must also be threaded through.
+GATEWAY_CHART_VERSION="1.2.0-alpha"
+GATEWAY_IMAGE_VERSION="1.2.0-alpha2"
 
 # OpenChoreo community module versions compatible with OpenChoreo ${OPENCHOREO_VERSION}
 OBSERVABILITY_LOGS_OPENSEARCH_VERSION="0.4.1"
@@ -1424,11 +1432,15 @@ fi
 
 log_step "Step 11/13: Installing Gateway Operator"
 log_info "Installing Gateway Operator..."
-# gateway-operator 0.10.0+'s own embedded default probe path is
-# /api/admin/v1/health, but gateway-controller ${GATEWAY_CHART_VERSION} only
-# serves /api/admin/v0.9/health (plus the legacy unversioned /health) — pin to
-# the version-agnostic legacy route so the self-installed controller doesn't
-# crash-loop on every health check.
+# Pinning gateway.helm.chartVersion alone is NOT enough: the chart's own
+# default values.yaml can still reference an older gateway-controller/
+# gateway-runtime image tag independent of the chart version, so the image
+# tag/repo must be set explicitly here too (confirmed by inspecting the
+# actual running pod images — chartVersion=1.2.0-alpha alone still ran an
+# older image until these were added).
+# Admin API on this image is served under /api/admin/v1 on the "admin" named
+# port — GET /health on the "rest" port goes through Gin + basic auth and
+# returns 401 for kube-probe (see gateway-controller admin OpenAPI spec).
 helm_install_idempotent \
     "gateway-operator" \
     "oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator" \
@@ -1438,8 +1450,14 @@ helm_install_idempotent \
     --set "logging.level=debug" \
     --set gatewayApi.installStandardCRDs=false \
     --set "gateway.helm.chartVersion=${GATEWAY_CHART_VERSION}" \
-    --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/health \
-    --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/health
+    --set "gateway.values.gateway.controller.image.tag=${GATEWAY_IMAGE_VERSION}" \
+    --set gateway.values.gateway.controller.image.repository=ghcr.io/wso2/api-platform/gateway-controller \
+    --set "gateway.values.gateway.gatewayRuntime.image.tag=${GATEWAY_IMAGE_VERSION}" \
+    --set gateway.values.gateway.gatewayRuntime.image.repository=ghcr.io/wso2/api-platform/gateway-runtime \
+    --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/api/admin/v1/health \
+    --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.port=admin \
+    --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/api/admin/v1/health \
+    --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.port=admin
 
 log_success "Gateway Operator installed"
 

--- a/deployments/setup/env.sh
+++ b/deployments/setup/env.sh
@@ -4,7 +4,7 @@ CLUSTER_NAME="${CLUSTER_NAME:-openchoreo-local-setup}"
 CLUSTER_CONTEXT="k3d-${CLUSTER_NAME}"
 
 # WSO2 API Platform / Gateway Operator versions
-GATEWAY_OPERATOR_VERSION="0.7.0"
+GATEWAY_OPERATOR_VERSION="0.10.0"
 GATEWAY_CHART_VERSION="1.1.0"
 
 # OpenChoreo community module versions compatible with OpenChoreo 1.1.1

--- a/deployments/setup/env.sh
+++ b/deployments/setup/env.sh
@@ -6,7 +6,7 @@ CLUSTER_CONTEXT="k3d-${CLUSTER_NAME}"
 # WSO2 API Platform / Gateway Operator versions
 GATEWAY_OPERATOR_VERSION="0.10.0"
 #injects the gateway-controller and gateway-runtime images into the operator's Deployment
-GATEWAY_CHART_VERSION="1.2.0-alpha"
+GATEWAY_CHART_VERSION="1.2.0-alpha2"
 GATEWAY_IMAGE_VERSION="1.2.0-alpha2"
 
 # OpenChoreo community module versions compatible with OpenChoreo 1.1.1

--- a/deployments/setup/env.sh
+++ b/deployments/setup/env.sh
@@ -5,7 +5,9 @@ CLUSTER_CONTEXT="k3d-${CLUSTER_NAME}"
 
 # WSO2 API Platform / Gateway Operator versions
 GATEWAY_OPERATOR_VERSION="0.10.0"
-GATEWAY_CHART_VERSION="1.1.0"
+#injects the gateway-controller and gateway-runtime images into the operator's Deployment
+GATEWAY_CHART_VERSION="1.2.0-alpha"
+GATEWAY_IMAGE_VERSION="1.2.0-alpha2"
 
 # OpenChoreo community module versions compatible with OpenChoreo 1.1.1
 OBSERVABILITY_LOGS_OPENSEARCH_VERSION="0.4.1"

--- a/deployments/setup/env.sh
+++ b/deployments/setup/env.sh
@@ -5,8 +5,7 @@ CLUSTER_CONTEXT="k3d-${CLUSTER_NAME}"
 
 # WSO2 API Platform / Gateway Operator versions
 GATEWAY_OPERATOR_VERSION="0.10.0"
-#injects the gateway-controller and gateway-runtime images into the operator's Deployment
-GATEWAY_CHART_VERSION="1.2.0-alpha2"
+GATEWAY_CHART_VERSION="1.2.0-alpha"
 GATEWAY_IMAGE_VERSION="1.2.0-alpha2"
 
 # OpenChoreo community module versions compatible with OpenChoreo 1.1.1

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -504,12 +504,6 @@ echo "7️⃣  Gateway Operator"
 if helm status gateway-operator -n openchoreo-data-plane &>/dev/null; then
     echo "⏭️  Gateway Operator already installed, skipping..."
 else
-    # gateway-operator 0.10.0+'s own embedded default probe path is
-    # /api/admin/v1/health, but gateway-controller ${GATEWAY_CHART_VERSION} only
-    # serves /api/admin/v0.9/health (plus the legacy unversioned /health) — a
-    # mismatch between the operator's default and its own pinned gateway chart
-    # version that would otherwise crash-loop the self-installed controller on
-    # every health check. Pin to the version-agnostic legacy route instead.
     helm install gateway-operator oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
         --version "${GATEWAY_OPERATOR_VERSION}" \
         --namespace openchoreo-data-plane \
@@ -517,8 +511,14 @@ else
         --set logging.level=debug \
         --set gatewayApi.installStandardCRDs=false \
         --set "gateway.helm.chartVersion=${GATEWAY_CHART_VERSION}" \
-        --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/health \
-        --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/health
+        --set "gateway.values.gateway.controller.image.tag=${GATEWAY_IMAGE_VERSION}" \
+        --set gateway.values.gateway.controller.image.repository=ghcr.io/wso2/api-platform/gateway-controller \
+        --set "gateway.values.gateway.gatewayRuntime.image.tag=${GATEWAY_IMAGE_VERSION}" \
+        --set gateway.values.gateway.gatewayRuntime.image.repository=ghcr.io/wso2/api-platform/gateway-runtime \
+        --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/api/admin/v1/health \
+        --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.port=admin \
+        --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/api/admin/v1/health \
+        --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.port=admin
     echo "✅ Gateway Operator installed successfully"
 fi
 echo ""

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -504,13 +504,21 @@ echo "7️⃣  Gateway Operator"
 if helm status gateway-operator -n openchoreo-data-plane &>/dev/null; then
     echo "⏭️  Gateway Operator already installed, skipping..."
 else
+    # gateway-operator 0.10.0+'s own embedded default probe path is
+    # /api/admin/v1/health, but gateway-controller ${GATEWAY_CHART_VERSION} only
+    # serves /api/admin/v0.9/health (plus the legacy unversioned /health) — a
+    # mismatch between the operator's default and its own pinned gateway chart
+    # version that would otherwise crash-loop the self-installed controller on
+    # every health check. Pin to the version-agnostic legacy route instead.
     helm install gateway-operator oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
         --version "${GATEWAY_OPERATOR_VERSION}" \
         --namespace openchoreo-data-plane \
         --create-namespace \
         --set logging.level=debug \
         --set gatewayApi.installStandardCRDs=false \
-        --set "gateway.helm.chartVersion=${GATEWAY_CHART_VERSION}"
+        --set "gateway.helm.chartVersion=${GATEWAY_CHART_VERSION}" \
+        --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/health \
+        --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/health
     echo "✅ Gateway Operator installed successfully"
 fi
 echo ""

--- a/deployments/values/otel-collector-rest-api.yaml
+++ b/deployments/values/otel-collector-rest-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.api-platform.wso2.com/v1alpha1
+apiVersion: gateway.api-platform.wso2.com/v1
 kind: RestApi
 metadata:
   name: amp-otel-collector-tracing-rest-api


### PR DESCRIPTION
## Purpose
Updating gateway-operator to 0.10.0 (previous commits on this branch) introduced two breaking changes that weren't fully propagated through agent-manager

- gateway-controller now rejects `gateway.api-platform.wso2.com/v1alpha1` manifests for LLM provider deployments 
- the new gateway chart adds a `gw` segment to the in-cluster runtime Service name 

The update includes fixes for the above mentioned problems raised by the gateway operator update
## Goals

## Approach
The current implementation uses the [1.2.0-Alpha2](https://github.com/wso2/api-platform/releases/tag/ai-gateway%2Fv1.2.0-alpha2) version of the api plaform gateway build and the operator helm chart [version 0.10.0](https://github.com/wso2/api-platform/releases/tag/helm-gateway-operator-0.10.0)

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Partially fixes #1383 , #1042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an internal `GET /deployments` endpoint for deployment synchronization/health of the gateway connection.
  * Endpoint uses API-key authentication.

* **Improvements**
  * Updated gateway-runtime service naming (`-gw-...`) across configuration, Helm templates, and generated in-cluster URLs.
  * Upgraded gateway-related Kubernetes custom resources and generated deployment manifests to the stable `v1` API version.
  * Refreshed Gateway Operator/chart/image pins and health probe settings in setup scripts.

* **Bug Fixes**
  * Corrected generated gateway runtime and proxy URLs plus related environment-name length calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->