### PR TITLE
Prevent silent mcp proxy deploy failure from oversized endpoint handle

### DIFF
--- a/agent-manager-service/services/mcp_proxy_service.go
+++ b/agent-manager-service/services/mcp_proxy_service.go
@@ -47,6 +47,14 @@ import (
 // must fit Thunder's 100-char handle cap; kebab is a strict subset of both.
 var mcpProxyHandleRe = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
 
+// maxMCPProxyDeploymentHandleLength bounds the per-(endpoint,environment) gateway artifact
+// name/displayName that deployment builds via mcpProxyEnvArtifactHandle. The gateway rejects a
+// displayName outside 1-100 chars, and that rejection happens asynchronously after Create/Update
+// has already returned 201/200, so a too-long handle deploys nothing while the caller sees
+// success — surfacing later only as 404s on the MCP route. Validate it up front instead and fail
+// with a clear, actionable error.
+const maxMCPProxyDeploymentHandleLength = 100
+
 const (
 	mcpJSONRPCVersion      = "2.0"
 	mcpProtocolVersion     = "2025-06-18"
@@ -149,6 +157,9 @@ func (s *MCPProxyService) Create(ctx context.Context, orgUUID, createdBy string,
 	}
 
 	if err := validateMCPEndpoints(ctx, req.Endpoints); err != nil {
+		return nil, err
+	}
+	if err := validateMCPProxyDeploymentHandleLengths(handle, req.Endpoints); err != nil {
 		return nil, err
 	}
 	if err := s.validateMCPEndpointSecurity(ctx, orgUUID, req.Endpoints); err != nil {
@@ -387,6 +398,9 @@ func (s *MCPProxyService) Update(ctx context.Context, orgUUID, proxyID string, r
 	// don't hold the row lock. Auth is encrypted inside the transaction because it may need
 	// to preserve the previously stored secret when the client omits it.
 	if err := validateMCPEndpoints(ctx, req.Endpoints); err != nil {
+		return nil, err
+	}
+	if err := validateMCPProxyDeploymentHandleLengths(handle, req.Endpoints); err != nil {
 		return nil, err
 	}
 	if err := s.validateMCPEndpointSecurity(ctx, orgUUID, req.Endpoints); err != nil {
@@ -1061,6 +1075,29 @@ func convertModelMCPProxyToListItem(proxy *models.MCPProxy) models.MCPProxyListI
 // and at least one valid target environment UUID. It also enforces the hard rule that an
 // environment maps to at most one endpoint within the proxy. It performs the network
 // checks, so call it outside a DB transaction.
+// validateMCPProxyDeploymentHandleLengths rejects a proxy whose deployed gateway artifact
+// name/displayName would exceed the gateway's length limit. The console derives short endpoint
+// handles, but a blank-name endpoint whose handle falls back to a long upstream hostname, or a
+// direct API caller supplying its own long id, can push the composite past the limit. Catching
+// it here turns a silent async deploy failure into an immediate, explicit 400.
+func validateMCPProxyDeploymentHandleLengths(proxyHandle string, endpoints []models.MCPProxyEndpointDTO) error {
+	for _, endpoint := range endpoints {
+		endpointHandle := strings.TrimSpace(endpoint.ID)
+		for _, env := range endpoint.Environments {
+			// Build the exact string deployment will emit, so this check stays in lockstep with
+			// the derivation instead of re-deriving its length by hand.
+			artifactHandle := mcpProxyEnvArtifactHandle(proxyHandle, endpointHandle, env.EnvironmentUUID)
+			if len(artifactHandle) > maxMCPProxyDeploymentHandleLength {
+				return fmt.Errorf(
+					"%w: endpoint %q would produce a %d-character gateway deployment name, exceeding the limit of %d; shorten the endpoint name/id or the proxy id",
+					utils.ErrInvalidInput, endpointHandle, len(artifactHandle), maxMCPProxyDeploymentHandleLength,
+				)
+			}
+		}
+	}
+	return nil
+}
+
 func validateMCPEndpoints(ctx context.Context, endpoints []models.MCPProxyEndpointDTO) error {
 	if len(endpoints) == 0 {
 		return fmt.Errorf("%w: at least one endpoint is required", utils.ErrInvalidInput)

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/mcpEndpoints.ts
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/mcpEndpoints.ts
@@ -358,7 +358,13 @@ export function deriveEndpointHandle(
   let handle = base;
   let suffix = 2;
   while (usedHandles.has(handle)) {
-    handle = `${base}-${suffix}`;
+    // Reserve room for the suffix so the collision-resolved handle still honours
+    // MAX_DERIVED_ENDPOINT_HANDLE_LENGTH (a bare `${base}-${suffix}` would overrun it).
+    const suffixStr = `-${suffix}`;
+    const truncatedBase =
+      boundHandle(base, MAX_DERIVED_ENDPOINT_HANDLE_LENGTH - suffixStr.length) ||
+      positional;
+    handle = `${truncatedBase}${suffixStr}`;
     suffix += 1;
   }
   usedHandles.add(handle);
@@ -418,11 +424,16 @@ function slugify(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-// Truncates an already-slugified handle to the max length, stripping any hyphen the cut
-// leaves dangling so the result stays a clean `[a-z0-9-]` handle.
-function boundHandle(handle: string): string {
-  if (handle.length <= MAX_DERIVED_ENDPOINT_HANDLE_LENGTH) return handle;
-  return handle.slice(0, MAX_DERIVED_ENDPOINT_HANDLE_LENGTH).replace(/-+$/g, "");
+// Truncates an already-slugified handle to `max` (default MAX_DERIVED_ENDPOINT_HANDLE_LENGTH),
+// stripping any hyphen the cut leaves dangling so the result stays a clean `[a-z0-9-]` handle.
+// Callers reserving room for a de-dup suffix pass a smaller `max` so the suffixed handle still
+// honours MAX_DERIVED_ENDPOINT_HANDLE_LENGTH.
+function boundHandle(
+  handle: string,
+  max: number = MAX_DERIVED_ENDPOINT_HANDLE_LENGTH,
+): string {
+  if (handle.length <= max) return handle;
+  return handle.slice(0, max).replace(/-+$/g, "");
 }
 
 function hostFromUrl(url: string): string {

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/mcpEndpoints.ts
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/mcpEndpoints.ts
@@ -319,8 +319,21 @@ function pruneAclPolicy(
 }
 
 /**
- * Derives an endpoint handle (id) from its name, falling back to the URL host and finally
- * a positional `endpoint-N`. The result is slugified to the `[a-z0-9-]` handle charset.
+ * Longest handle we derive from a blank-name endpoint. The backend composes the deployed
+ * gateway artifact's name/displayName as `{proxyHandle}-{endpointHandle}-{envUUID}`, which
+ * must stay within the gateway's 100-char displayName limit. A raw URL host
+ *  slugifies to ~70 chars and blows that budget once the proxy handle and
+ * 32-char environment suffix are added — deploying then fails gateway-side. Bounding the
+ * derived handle keeps the blank-name case well clear; the backend still validates the
+ * full composite for callers that bypass this derivation.
+ */
+const MAX_DERIVED_ENDPOINT_HANDLE_LENGTH = 30;
+
+/**
+ * Derives an endpoint handle (id) from its name, then the fetched server name, then the URL
+ * host, and finally a positional `endpoint-N`. The result is slugified to the `[a-z0-9-]`
+ * handle charset and bounded to MAX_DERIVED_ENDPOINT_HANDLE_LENGTH so the backend's composite
+ * artifact handle stays within the gateway's length limit.
  *
  * When `usedHandles` is supplied, the derived handle is de-duplicated against it (two new
  * endpoints sharing a name or URL host would otherwise collide, which the backend rejects
@@ -328,14 +341,17 @@ function pruneAclPolicy(
  * chosen handle is added to the set so subsequent calls see it.
  */
 export function deriveEndpointHandle(
-  draft: Pick<EndpointDraft, "name" | "url">,
+  draft: Pick<EndpointDraft, "name" | "url" | "serverName">,
   index: number,
   usedHandles?: Set<string>,
 ): string {
+  const positional = `endpoint-${index + 1}`;
   const base =
-    slugify(draft.name ?? "") ||
-    slugify(hostFromUrl(draft.url)) ||
-    `endpoint-${index + 1}`;
+    boundHandle(
+      slugify(draft.name ?? "") ||
+        slugify(draft.serverName ?? "") ||
+        slugify(hostFromUrl(draft.url)),
+    ) || positional;
 
   if (!usedHandles) return base;
 
@@ -400,6 +416,13 @@ function slugify(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+// Truncates an already-slugified handle to the max length, stripping any hyphen the cut
+// leaves dangling so the result stays a clean `[a-z0-9-]` handle.
+function boundHandle(handle: string): string {
+  if (handle.length <= MAX_DERIVED_ENDPOINT_HANDLE_LENGTH) return handle;
+  return handle.slice(0, MAX_DERIVED_ENDPOINT_HANDLE_LENGTH).replace(/-+$/g, "");
 }
 
 function hostFromUrl(url: string): string {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

A blank endpoint name made the console derive the endpoint handle from the upstream URL hostname, which for long hosts produced a long handle. The backend composes the per-(endpoint,environment) gateway artifact name as {proxyHandle}-{endpointHandle}-{envUUID}, pushing it past the gateway's 100-char displayName limit. Deployment was ack'd as failed
asynchronously after Create returned 201, so no route was programmed and the user only discovered it later as 404s on the MCP endpoint.

Frontend (console):
- deriveEndpointHandle now prefers the fetched server name over the raw URL
  hostname, and caps the derived handle at MAX_DERIVED_ENDPOINT_HANDLE_LENGTH
  (30) so a blank name can no longer generate an oversized handle.

Backend (agent-manager-service):
- Add validateMCPProxyDeploymentHandleLengths, which builds the exact composite
  via mcpProxyEnvArtifactHandle and rejects >100-char names with a clear 400.
- Wired into both Create and Update so the failure surfaces up front instead of silently at deploy time; also protects direct API callers that bypass the console's handle derivation.
  

Resolves https://github.com/wso2/agent-manager/issues/1402
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented MCP proxy deployments from proceeding when generated deployment handles exceed the gateway’s length limit.
  - Added immediate validation during proxy creation and updates, providing a clear input error instead of delayed deployment failures.
  - Improved endpoint handle generation by using available endpoint details, limiting handle length, and preserving unique handles when multiple endpoints are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->