### PR TITLE
Document platform authorization model and agent MCP authz

### DIFF
--- a/documentation/docs/reference/authorization.mdx
+++ b/documentation/docs/reference/authorization.mdx
@@ -310,17 +310,17 @@ Rather than grant scopes one at a time, AMP ships four predefined roles. Each bu
 | Gateways | Full | — | — | Full |
 | Deployment pipelines | Full | View | View | Full |
 | Git secrets | Full | Full | — | — |
-| LLM providers & templates | Full | Read / connect | Full | Read / configure |
-| MCP servers | Full | Read / connect | Full | Read / configure |
+| LLM providers & templates | Full | Read; connect, configure guardrail | Full | Provider read, configure guardrail (no templates) |
+| MCP servers | Full | Read, connect, configure guardrail, manage API keys | Full | Read, configure guardrail |
 | LLM proxies | Full | Full | — | — |
 | Evaluators | Full | View | Full | — |
-| Agents (lifecycle) | Full | Create, build, deploy (non-prod) | Read, build, deploy (non-prod) | Build, deploy (all), promote, rollback, suspend |
-| Monitors | Full | Create / run | View | View |
+| Agents (lifecycle) | Full | Create, read, update, delete, build, deploy (non-prod), manage tokens & API keys | Read, build, deploy (non-prod), manage API keys | Read, build, deploy (all), promote, rollback, suspend, manage API keys |
+| Monitors | Full | Create, read, update, delete, run, read scores | View | View |
 | Observability | All reads | All reads | Traces, metrics | Logs, build logs, metrics |
 | Roles & groups | Full | — | — | — |
 | Agent identities | Full | — | — | — |
 
-"Full" means every action in that area. This table summarizes the intent of each role; the authoritative, exhaustive scope-per-role mapping lives in `agent-manager-service/rbac/predefined_roles.go`.
+"Full" means every action in that capability area; "View" means read-only access. This table summarizes each role; the authoritative, exhaustive scope-per-role mapping lives in `agent-manager-service/rbac/predefined_roles.go`.
 
 ## REST and MCP share the model
 

--- a/documentation/docs/reference/authorization.mdx
+++ b/documentation/docs/reference/authorization.mdx
@@ -1,0 +1,351 @@
+# Authorization
+
+WSO2 Agent Manager (AMP) authorizes every action against a single, platform-wide permission model. Access is governed by OAuth 2.0 scopes issued by the bundled Thunder identity provider: each capability on the platform maps to one scope, and a caller can perform a capability only if its access token carries the matching scope.
+
+## One model, every entry point
+
+The same scopes gate the same capabilities no matter how you reach the platform:
+
+- the **Console** (the web UI),
+- the **REST API** (`agent-manager-service` and `agent-manager-observer`), and
+- the **MCP servers** (the [main MCP server](./mcp-server.mdx) and the [Observer MCP server](./observer-mcp-server.mdx)).
+
+Because the model is shared, an MCP tool and its equivalent REST route enforce the **identical** scope. Triggering a build through the `build_agent` MCP tool and calling `POST /orgs/{org}/.../builds` both require `amp:agent:build`; there is no separate "MCP permission" to reason about. Learn the scope once and it applies everywhere.
+
+## How a scope is named
+
+Scopes follow a fixed three-part shape, built from the `amp` resource server:
+
+```
+amp:<resource>:<action>
+```
+
+For example, `amp:project:read`, `amp:agent:build`, and `amp:observability:trace-read`. The `<resource>` identifies what you are acting on and `<action>` identifies what you are doing to it.
+
+## Scope catalog
+
+The tables below list every scope the platform defines, grouped by resource. The observability scopes (in their own group) are enforced by `agent-manager-observer`; all others are enforced by `agent-manager-service`.
+
+<details>
+<summary><strong>Organization</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:org:view` | View organization details |
+| `amp:org:modify-settings` | Modify organization settings |
+| `amp:org:invite-member` | Invite a member to the organization |
+| `amp:org:remove-member` | Remove a member from the organization |
+| `amp:org:assign-role` | Assign roles to members |
+| `amp:org:manage-idp` | Manage the organization's identity providers |
+| `amp:org:manage-service-account` | Manage organization service accounts |
+
+</details>
+
+<details>
+<summary><strong>Project</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:project:create` | Create a project |
+| `amp:project:read` | View projects |
+| `amp:project:update` | Update a project |
+| `amp:project:delete` | Delete a project |
+
+</details>
+
+<details>
+<summary><strong>Environment</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:environment:create` | Create an environment |
+| `amp:environment:read` | View environments |
+| `amp:environment:update` | Update an environment |
+| `amp:environment:delete` | Delete an environment |
+
+</details>
+
+<details>
+<summary><strong>Gateway</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:gateway:create` | Register a gateway |
+| `amp:gateway:read` | View gateways |
+| `amp:gateway:update` | Update a gateway |
+| `amp:gateway:delete` | Delete a gateway |
+| `amp:gateway:token-manage` | Manage gateway tokens |
+
+</details>
+
+<details>
+<summary><strong>Infrastructure</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:data-plane:read` | View data planes |
+| `amp:deployment-pipeline:read` | View deployment pipelines |
+| `amp:deployment-pipeline:create` | Create a deployment pipeline |
+| `amp:deployment-pipeline:update` | Update a deployment pipeline |
+| `amp:deployment-pipeline:delete` | Delete a deployment pipeline |
+
+</details>
+
+<details>
+<summary><strong>Git secret</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:git-secret:create` | Create a Git secret |
+| `amp:git-secret:read` | View Git secrets |
+| `amp:git-secret:delete` | Delete a Git secret |
+
+</details>
+
+<details>
+<summary><strong>LLM provider template</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:llm-provider-template:create` | Create an LLM provider template |
+| `amp:llm-provider-template:read` | View LLM provider templates |
+| `amp:llm-provider-template:update` | Update an LLM provider template |
+| `amp:llm-provider-template:delete` | Delete an LLM provider template |
+
+</details>
+
+<details>
+<summary><strong>LLM provider</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:llm-provider:create` | Create an LLM provider |
+| `amp:llm-provider:read` | View LLM providers |
+| `amp:llm-provider:update` | Update an LLM provider |
+| `amp:llm-provider:delete` | Delete an LLM provider |
+| `amp:llm-provider:configure-guardrail` | Configure guardrails on an LLM provider |
+| `amp:llm-provider:connect` | Connect to an LLM provider |
+| `amp:llm-provider:deploy` | Deploy an LLM provider |
+| `amp:llm-provider:api-key-manage` | Manage LLM provider API keys |
+
+</details>
+
+<details>
+<summary><strong>MCP server</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:mcp-server:create` | Create an MCP server |
+| `amp:mcp-server:read` | View MCP servers |
+| `amp:mcp-server:update` | Update an MCP server |
+| `amp:mcp-server:delete` | Delete an MCP server |
+| `amp:mcp-server:configure-guardrail` | Configure guardrails on an MCP server |
+| `amp:mcp-server:connect` | Connect to an MCP server |
+| `amp:mcp-server:api-key-manage` | Manage MCP server API keys |
+
+</details>
+
+<details>
+<summary><strong>Scope catalog</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:scope:create` | Create a scope |
+| `amp:scope:read` | View scopes |
+| `amp:scope:update` | Update a scope |
+| `amp:scope:delete` | Delete a scope |
+
+</details>
+
+<details>
+<summary><strong>Agent identity</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:agent-identity:read` | View agent identity roles and assignments |
+| `amp:agent-identity:create` | Create agent identity roles |
+| `amp:agent-identity:update` | Update agent identity roles and assignments |
+| `amp:agent-identity:delete` | Delete agent identity roles |
+
+</details>
+
+<details>
+<summary><strong>LLM proxy</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:llm-proxy:create` | Create an LLM proxy |
+| `amp:llm-proxy:read` | View LLM proxies |
+| `amp:llm-proxy:update` | Update an LLM proxy |
+| `amp:llm-proxy:delete` | Delete an LLM proxy |
+| `amp:llm-proxy:deploy` | Deploy an LLM proxy |
+| `amp:llm-proxy:api-key-manage` | Manage LLM proxy API keys |
+
+</details>
+
+<details>
+<summary><strong>Evaluator</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:evaluator:create` | Create an evaluator |
+| `amp:evaluator:read` | View evaluators |
+| `amp:evaluator:update` | Update an evaluator |
+| `amp:evaluator:delete` | Delete an evaluator |
+
+</details>
+
+<details>
+<summary><strong>Agent</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:agent:create` | Create an agent |
+| `amp:agent:read` | View agents |
+| `amp:agent:update` | Update an agent |
+| `amp:agent:delete` | Delete an agent |
+| `amp:agent:build` | Trigger an agent build |
+| `amp:agent:deploy-non-production` | Deploy an agent to a non-production environment |
+| `amp:agent:deploy-production` | Deploy an agent to a production environment |
+| `amp:agent:promote` | Promote an agent between environments |
+| `amp:agent:rollback` | Roll back an agent deployment |
+| `amp:agent:suspend` | Suspend an agent deployment |
+| `amp:agent:token-manage` | Manage agent identity tokens |
+| `amp:agent:api-key-manage` | Manage agent API keys |
+
+</details>
+
+<details>
+<summary><strong>Agent kind</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:agent-kind:read` | View agent kinds |
+| `amp:agent-kind:create` | Create an agent kind |
+| `amp:agent-kind:update` | Update an agent kind |
+| `amp:agent-kind:delete` | Delete an agent kind |
+
+</details>
+
+<details>
+<summary><strong>Monitor</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:monitor:create` | Create a monitor |
+| `amp:monitor:read` | View monitors |
+| `amp:monitor:update` | Update a monitor |
+| `amp:monitor:delete` | Delete a monitor |
+| `amp:monitor:execute` | Execute a monitor |
+| `amp:monitor:score-read` | View monitor scores |
+| `amp:monitor:score-publish` | Publish monitor scores |
+
+</details>
+
+<details>
+<summary><strong>Observability</strong> (enforced by <code>agent-manager-observer</code>)</summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:observability:trace-read` | Read traces and spans |
+| `amp:observability:log-read` | Read runtime logs |
+| `amp:observability:build-log-read` | Read build logs |
+| `amp:observability:metric-read` | Read metrics |
+
+</details>
+
+<details>
+<summary><strong>Role management</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:role:create` | Create a role |
+| `amp:role:read` | View roles |
+| `amp:role:update` | Update a role |
+| `amp:role:delete` | Delete a role |
+
+</details>
+
+<details>
+<summary><strong>Group management</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:group:create` | Create a group |
+| `amp:group:read` | View groups |
+| `amp:group:update` | Update a group |
+| `amp:group:delete` | Delete a group |
+
+</details>
+
+<details>
+<summary><strong>Catalog &amp; repository</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:catalog:read` | View the catalog |
+| `amp:repository:read` | View repositories |
+
+</details>
+
+<details>
+<summary><strong>Profile</strong></summary>
+
+| Scope | Grants |
+| --- | --- |
+| `amp:profile:read` | View your own profile |
+| `amp:profile:update-attributes` | Update your own profile attributes |
+
+</details>
+
+## Predefined roles
+
+Rather than grant scopes one at a time, AMP ships four predefined roles. Each bundles a set of scopes tuned to a persona, and is registered as a role-to-scope binding in Thunder at bootstrap. A user's token carries the scopes of the roles assigned to them.
+
+| Capability area | Agent Manager Admin | Developer | AI Lead | Platform Engineer |
+| --- | --- | --- | --- | --- |
+| Organization | Full | View | View | View |
+| Projects | Full | Full | View | View |
+| Environments | Full | View | View | Full |
+| Gateways | Full | — | — | Full |
+| Deployment pipelines | Full | View | View | Full |
+| Git secrets | Full | Full | — | — |
+| LLM providers & templates | Full | Read / connect | Full | Read / configure |
+| MCP servers | Full | Read / connect | Full | Read / configure |
+| LLM proxies | Full | Full | — | — |
+| Evaluators | Full | View | Full | — |
+| Agents (lifecycle) | Full | Create, build, deploy (non-prod) | Read, build, deploy (non-prod) | Build, deploy (all), promote, rollback, suspend |
+| Monitors | Full | Create / run | View | View |
+| Observability | All reads | All reads | Traces, metrics | Logs, build logs, metrics |
+| Roles & groups | Full | — | — | — |
+| Agent identities | Full | — | — | — |
+
+"Full" means every action in that area. This table summarizes the intent of each role; the authoritative, exhaustive scope-per-role mapping lives in `agent-manager-service/rbac/predefined_roles.go`.
+
+## REST and MCP share the model
+
+Every MCP tool authorizes against the same scope its REST equivalent does. A few examples from the [main MCP server](./mcp-server.mdx):
+
+| MCP tool | Required scope |
+| --- | --- |
+| `list_projects` | `amp:project:read` |
+| `create_project` | `amp:project:create` |
+| `build_agent` | `amp:agent:build` |
+| `deploy_agent` | `amp:agent:deploy-non-production` |
+| `create_external_agent` | `amp:agent:create` + `amp:agent:token-manage` |
+
+The observability tools on the [Observer MCP server](./observer-mcp-server.mdx) map the same way — the trace tools require `amp:observability:trace-read`, and `get_runtime_logs`, `get_build_logs`, and `get_metrics` require `amp:observability:log-read`, `amp:observability:build-log-read`, and `amp:observability:metric-read` respectively.
+
+### Two MCP OAuth clients, disjoint scopes
+
+Because the two MCP servers are addressed separately, AMP ships two pre-registered OAuth clients whose scope allowances do not overlap:
+
+- **`am-mcp`** (main MCP server) is allowed every `amp:*` scope **except** the four `amp:observability:*-read` scopes.
+- **`am-obs-mcp`** (Observer MCP server) is allowed **only** the four `amp:observability:*-read` scopes (plus the OIDC scopes).
+
+A token obtained for one server therefore cannot be reused against the other. See [MCP Server](./mcp-server.mdx#default-oauth-client) and [Observer MCP Server](./observer-mcp-server.mdx#configuring-ai-assistants) for the client details.
+
+## Next steps
+
+- [Authorize agent access to MCP tools](../tutorials/authorize-agent-access-to-mcp-tools.mdx) — define your own scopes on a resource and grant them to agents through roles.
+- [MCP Server](./mcp-server.mdx) and [Observer MCP Server](./observer-mcp-server.mdx) — the tools each scope unlocks.

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -8,6 +8,8 @@ The MCP server is exposed by `agent-manager-service` at the `/mcp` path on the p
 
 A single OAuth client (`am-mcp`) is pre-registered in Thunder out of the box, so most users do not need to provision their own client to get started.
 
+Each tool is authorized against the same `amp:*` scopes as its REST API equivalent — for example, `build_agent` requires `amp:agent:build`. See [Authorization](./authorization.mdx) for the full scope catalog, the predefined roles, and how the model applies across the Console, REST API, and MCP servers.
+
 ## Available Tools
 
 The MCP server provides **12 tools** organized into four toolsets covering the agent lifecycle — from creating a project through deploying an agent. Trace, log, and metrics tools live on a separate server; see [Observer MCP Server](./observer-mcp-server.mdx).

--- a/documentation/docs/reference/observer-mcp-server.mdx
+++ b/documentation/docs/reference/observer-mcp-server.mdx
@@ -12,7 +12,7 @@ Unlike the main MCP server's tools, every `am-obs-mcp` tool call is scoped by an
 
 The observer MCP server provides **7 tools** organized into two toolsets: Observability (runtime logs, build logs, metrics) and Tracing (traces and spans).
 
-When `RBAC_ENABLED` is set on the observer, every tool call is authorized against the token's scopes — the trace tools require `amp:observability:trace-read`, and `get_runtime_logs`/`get_build_logs`/`get_metrics` require `amp:observability:log-read`/`build-log-read`/`metric-read` respectively — mirroring the REST routes' per-route checks. Publisher (`amp-publisher-*`) tokens are always confined to trace reads, regardless of the flag.
+When `RBAC_ENABLED` is set on the observer, every tool call is authorized against the token's scopes — the trace tools require `amp:observability:trace-read`, and `get_runtime_logs`/`get_build_logs`/`get_metrics` require `amp:observability:log-read`/`build-log-read`/`metric-read` respectively — mirroring the REST routes' per-route checks. Publisher (`amp-publisher-*`) tokens are always confined to trace reads, regardless of the flag. These scopes are part of the platform-wide model documented in [Authorization](./authorization.mdx).
 
 <details>
 <summary><strong>Observability Toolset (3 tools)</strong></summary>

--- a/documentation/docs/tutorials/authorize-agent-access-to-mcp-tools.mdx
+++ b/documentation/docs/tutorials/authorize-agent-access-to-mcp-tools.mdx
@@ -1,0 +1,186 @@
+---
+sidebar_position: 11
+---
+
+# Authorize Agent Access to MCP Tools
+
+When you front an MCP server through the platform as an **identity-secured MCP proxy**, you decide which agents may invoke which tools. This tutorial walks through the full authorization workflow: you register the resource, define permissions over its tools, bundle those permissions into roles, and grant the roles to agents (or groups). The result is that two agents can hit the *same* proxy endpoint and get *different* capabilities.
+
+## The model
+
+Agent authorization is built from four pieces:
+
+| Piece | What it is |
+| --- | --- |
+| **Resource** | The thing being accessed. Today this is an **MCP proxy**. Its handle becomes the prefix for every scope you define on it. |
+| **Permission (scope)** | An action on the resource, mapped to a set of the resource's tools. A scope is named `<proxy>:<action>` — e.g. `booking:read`. |
+| **Role** | A named bundle of scopes, defined in an environment. |
+| **Assignment** | A role granted to an **agent** or a **group**. |
+
+An agent presents an access token, and the platform filters that token's scopes down to exactly the scopes of the agent's assigned roles **at mint time**. When the agent calls a tool through the gateway, per-tool authorization checks the token's scopes against the scope that covers the tool.
+
+The example below secures a booking MCP server with two scopes and two roles:
+
+| | `booking:read` | `booking:write` |
+| --- | --- | --- |
+| **Tools** | `list_bookings`, `get_booking` | `create_booking`, `edit_booking`, `remove_booking` |
+| **`booking-reader`** role | ✅ | — |
+| **`booking-admin`** role | ✅ | ✅ |
+
+An agent assigned `booking-reader` can list bookings but not create them; an agent assigned `booking-admin` can do both — through the same endpoint.
+
+:::info Platform-deployed vs. external agents
+The authorization mechanism is identical for every agent. The only difference is how an agent obtains its identity: an agent **deployed on the platform** has its identity credentials injected automatically at deploy time, while an **external agent** is handed a client ID and secret that it presents itself. Either way, the token it ends up with carries only the scopes of its assigned roles.
+:::
+
+## Prerequisites
+
+- `amctl` installed and logged in against your control plane (see [CLI Installation](../getting-started/cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
+- An AI Gateway registered and active for the environment you are configuring (see [Register an AI Gateway](../administration/register-ai-gateway.mdx)).
+- A reachable upstream MCP server URL.
+
+This tutorial uses the [`amctl api`](../reference/cli/api.mdx) command to call the control plane directly, which makes every step precise and copy-pasteable. The examples use the `default` organization, `default` project, and `default` environment — substitute your own.
+
+---
+
+## Step 1: Register the resource
+
+Register the upstream MCP server as an identity-secured MCP proxy. The proxy's `id` becomes the scope prefix and a resource server in the environment's Thunder identity provider, and — with a `context` — the gateway path.
+
+First discover the upstream server's tools:
+
+```bash
+echo '{"url": "https://upstream.example.com/mcp"}' \
+  | amctl api /orgs/default/mcp-proxies/fetch-server-info -X POST --input -
+```
+
+Then create the proxy with identity security enabled, passing the discovered tools as the endpoint's capabilities:
+
+```bash
+amctl api /orgs/default/mcp-proxies -X POST --input - <<'JSON'
+{
+  "id": "booking",
+  "name": "Booking MCP",
+  "description": "Proxy for the upstream bookings MCP server",
+  "version": "v1.0",
+  "context": "/booking",
+  "mcpSpecVersion": "2025-06-18",
+  "endpoints": [{
+    "id": "primary",
+    "name": "primary",
+    "upstream": {"main": {"url": "https://upstream.example.com/mcp"}},
+    "capabilities": {"tools": [ /* tools from fetch-server-info */ ]},
+    "security": {"enabled": true, "identity": {"enabled": true}},
+    "environments": [{"environmentUuid": "<environment-uuid>"}]
+  }]
+}
+JSON
+```
+
+You can also register a proxy through the Console — see [Register an MCP Proxy](./register-mcp-proxy.mdx) — but the rest of this tutorial uses the API for the parts that define authorization.
+
+---
+
+## Step 2: Define permissions over the tools
+
+A **scope** on the proxy names an action and lists the tools it covers. Create one scope per capability level you want to grant. The scope string is `<proxy>:<action>`, so the calls below produce `booking:read` and `booking:write`.
+
+```bash
+# booking:read — covers the read-only tools
+echo '{"action": "read", "description": "Read-only booking access",
+       "tools": ["list_bookings", "get_booking"]}' \
+  | amctl api /orgs/default/mcp-proxies/booking/scopes -X POST --input -
+
+# booking:write — covers the mutating tools
+echo '{"action": "write", "description": "Create, edit and remove bookings",
+       "tools": ["create_booking", "edit_booking", "remove_booking"]}' \
+  | amctl api /orgs/default/mcp-proxies/booking/scopes -X POST --input -
+```
+
+:::caution Cover every tool you want to gate
+A tool that is **not** covered by any scope has no authorization rule and is allowed for any *authenticated* caller (default-permit). Denial only happens for a tool whose covering scope the caller was not granted. Make sure every tool you intend to restrict is listed under some scope.
+:::
+
+List the scopes to confirm:
+
+```bash
+amctl api /orgs/default/mcp-proxies/booking/scopes
+```
+
+---
+
+## Step 3: Bundle scopes into a role
+
+Roles are defined per environment. Create a role with the set of scopes it should grant — the scopes must already exist (Step 2).
+
+```bash
+# booking-reader — read only
+echo '{"name": "booking-reader", "description": "Read-only booking role",
+       "scopes": ["booking:read"]}' \
+  | amctl api /orgs/default/environments/default/agent-identities/roles -X POST --input -
+
+# booking-admin — read and write
+echo '{"name": "booking-admin", "description": "Full booking access role",
+       "scopes": ["booking:read", "booking:write"]}' \
+  | amctl api /orgs/default/environments/default/agent-identities/roles -X POST --input -
+```
+
+Fetch the roles back to get each role's ID, which you'll need to assign it:
+
+```bash
+amctl api /orgs/default/environments/default/agent-identities/roles
+```
+
+---
+
+## Step 4: Assign the role to an agent or group
+
+Assignments grant a role to a principal. Each assignment names the principal's ID and its `type` — `agent` to grant a single agent identity, or `group` to grant every member of a group at once.
+
+First resolve the agent's identity ID (`thunderAgentId`):
+
+```bash
+amctl api /orgs/default/environments/default/agent-identities/agents
+```
+
+Then add the assignment, using the role ID from Step 3:
+
+```bash
+# Grant booking-reader to an agent
+echo '{"assignments": [{"id": "<thunder-agent-id>", "type": "agent"}]}' \
+  | amctl api /orgs/default/environments/default/agent-identities/roles/<role-id>/assignments/add -X POST --input -
+```
+
+To grant a role to a whole group instead, set `"type": "group"` and pass the group's ID:
+
+```bash
+echo '{"assignments": [{"id": "<group-id>", "type": "group"}]}' \
+  | amctl api /orgs/default/environments/default/agent-identities/roles/<role-id>/assignments/add -X POST --input -
+```
+
+Verify the assignments on a role:
+
+```bash
+amctl api /orgs/default/environments/default/agent-identities/roles/<role-id>/assignments
+```
+
+---
+
+## Step 5: See it in effect
+
+Once a role is assigned, the platform enforces it automatically:
+
+1. The agent obtains an access token. Its scopes are **filtered to the scopes of its assigned roles at mint time** — a `booking-reader` agent that requests `booking:read booking:write` receives a token carrying only `booking:read`.
+2. The agent calls a tool through the gateway endpoint (`/booking/mcp`).
+3. The gateway authenticates the token, then authorizes the specific tool against the token's scopes:
+   - `booking-reader` calling `list_bookings` → **allowed** (`booking:read` covers it).
+   - `booking-reader` calling `create_booking` → **denied** (`booking:write` required, not granted).
+   - `booking-admin` calling either → **allowed**.
+
+Changing who can do what is now a matter of editing scopes and role assignments — the agents themselves do not change.
+
+## Next steps
+
+- [Authorization](../reference/authorization.mdx) — the platform-wide scope and role model these agent scopes plug into.
+- [Register an MCP Proxy](./register-mcp-proxy.mdx) — the full proxy registration reference, including the Console flow.
+- [Configure Agent MCP Proxies](./configure-agent-mcp-proxies.mdx) — attach a proxy to an agent so it can call the tools.

--- a/documentation/docs/tutorials/configure-agent-mcp-proxies.mdx
+++ b/documentation/docs/tutorials/configure-agent-mcp-proxies.mdx
@@ -170,6 +170,6 @@ Use the **Search by name or description...** box to filter. Multiple configurati
 
 - MCP proxy credentials are **never exposed** to agent code directly — only the injected environment variables (platform agents) or the gateway endpoint + API key (external agents) are available at runtime.
 - For platform agents, the MCP server URL and API key values are injected at deploy time per environment, and are empty in any environment the proxy is not configured for. Changing the org-level proxy does not redeploy the agent automatically — the agent resolves the endpoint on its next deployment.
-- For external agents, the Endpoint URL routes traffic through the AI Gateway, applying any security, access control, and rewrite rules configured on the proxy for that environment.
+- For external agents, the Endpoint URL routes traffic through the AI Gateway, applying any security, access control, and rewrite rules configured on the endpoint serving that environment.
 - The external agent API Key is displayed only right after it is generated or rotated. If lost, rotate the key from the tool configuration's API key section (per environment) to obtain a new value.
 - A single proxy attached from the Configure page maps to every environment in the agent's pipeline; the proxy supplies each environment's endpoint. To use different proxies per environment, attach them during agent creation.

--- a/documentation/docs/tutorials/register-mcp-proxy.mdx
+++ b/documentation/docs/tutorials/register-mcp-proxy.mdx
@@ -22,6 +22,10 @@ An MCP proxy is **multi-environment**. You attach one or more **endpoints** to i
 - Environments **without** an endpoint are simply left unconfigured (no artifact, and agents referencing the proxy there receive empty connection values).
 - If an environment has no active AI Gateway yet, that environment is skipped and deployed on the next proxy update once a gateway becomes available.
 
+### Where configuration lives
+
+The endpoint is the unit of configuration. Its upstream connection, capabilities, access control, rewrite, security, and gateway policies are all stored **on the endpoint**, not on the environment. An environment is deployed with the configuration of the endpoint it is bound to, so several environments can share one endpoint's config, and editing that endpoint changes all of them. To vary settings across environments, put them on separate endpoints. The one exception is **scopes** (used for [agent authorization](./authorize-agent-access-to-mcp-tools.mdx)): they are defined once for the whole proxy and apply across every endpoint and environment.
+
 Agents do not embed the proxy — they **reference** it. Each agent resolves the proxy's per-environment endpoint at its own deploy time, so changing a proxy does not automatically redeploy the agents that use it; they pick up the change on their next deployment.
 
 ## Prerequisites
@@ -93,12 +97,12 @@ The **Add Endpoint** dialog maps a backend MCP server to one or more environment
 
 Click a proxy in the list to open its detail page. The header shows the proxy name, version, context, and description (click the edit icon to rename or re-version).
 
-Because a proxy is configured per environment, the detail page has two controls above the tabs:
+Configuration lives on the endpoints, so the detail page has two controls above the tabs:
 
-- **Environment** selector — choose which configured environment's settings the tabs display and edit. Only environments that have an endpoint appear here; if none are configured, the page shows *"This MCP proxy has no environments configured."*
+- **Environment** selector — choose an environment to view and edit the configuration of the endpoint that serves it. Only environments that have an endpoint appear here; if none are configured, the page shows *"This MCP proxy has no environments configured."* Because one endpoint can serve several environments, a change you make with one environment selected applies to every environment sharing that endpoint.
 - **Manage Endpoints** — opens the **Manage Endpoints** dialog to add, edit, or remove endpoints after creation. Editing an endpoint updates the upstream URL, authentication, and capabilities for every environment it serves; environments left without an endpoint become unconfigured.
 
-Configuration is organized into the tabs below. When you change a setting, an **unsaved changes** banner appears — click **Save** to persist or **Cancel**/**Discard** to revert. All tabs except **Overview** and **Capabilities** apply to the environment currently selected above.
+Configuration is organized into the tabs below. When you change a setting, an **unsaved changes** banner appears — click **Save** to persist or **Cancel**/**Discard** to revert. Every tab except **Overview** and **Capabilities** edits the endpoint serving the selected environment.
 
 ### Overview Tab
 

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -84,6 +84,7 @@ const sidebars: SidebarsConfig = {
       label: 'Reference',
       collapsed: false,
       items: [
+        'reference/authorization',
         'reference/mcp-server',
         'reference/observer-mcp-server',
         {
@@ -118,7 +119,8 @@ const sidebars: SidebarsConfig = {
         'tutorials/secure-agent-endpoints-with-oauth',
         'tutorials/configure-cors-for-agent-endpoints',
         'tutorials/configure-agent-llm-configuration',
-        'tutorials/configure-agent-mcp-proxies'
+        'tutorials/configure-agent-mcp-proxies',
+        'tutorials/authorize-agent-access-to-mcp-tools'
       ],
     },
     {


### PR DESCRIPTION
## Purpose

Document the platform-wide authorization model and the agent-identity MCP authorization workflow. These features (per-tool RBAC on the service and observer MCP servers, and role-based agent access to MCP proxy tools) shipped recently but had no user-facing documentation.

## Goals

- Give operators one reference for the AMP authorization model: the full scope catalog, the predefined roles, and the fact that the Console, REST API, and both MCP servers all enforce the same scopes for the same capabilities.
- Give users a task-oriented guide for authorizing agents against a resource: register an MCP proxy, define scopes over its tools, bundle scopes into roles, and assign roles to agents or groups.

## Approach

Two new pages under `documentation/` (the "Next"/unreleased docs version):

- `docs/reference/authorization.mdx` — the platform authorization reference: scope naming, the full `amp:*` scope catalog grouped by resource, the predefined-role capability matrix (Admin / Developer / AI Lead / Platform Engineer), and REST↔MCP parity including the `am-mcp` vs `am-obs-mcp` scope split.
- `docs/tutorials/authorize-agent-access-to-mcp-tools.mdx` — the resource → scope → role → assignment workflow, with a worked `booking-reader`/`booking-admin` example and `amctl api` commands.

Plus: an Authorization pointer in `reference/mcp-server.mdx` and `reference/observer-mcp-server.mdx`, and both pages registered in `sidebars.ts`.

Also clarifies the MCP proxy configuration model in the two existing MCP proxy tutorials (`register-mcp-proxy.mdx`, `configure-agent-mcp-proxies.mdx`). Configuration — connection, capabilities, access control, rewrite, security, and policies — is stored per **endpoint**; an endpoint binds to one or more environments, and each environment is deployed with the config of its bound endpoint. Scopes are the one proxy-global exception. The previous wording described this as per-environment, which contradicted the data model.

Scope/tool facts were pulled from `rbac/permissions.go`, `rbac/predefined_roles.go`, and the MCP tool spec tests; the endpoint/environment model was verified against `models/mcp_proxy.go` and `models/mcp_proxy_scope.go`, so the docs match the code.

## User stories

N/A — documentation only.

## Release note

Add documentation for the platform authorization model and agent-identity MCP tool authorization.

## Documentation

This PR is the documentation. Verified with `make -C documentation build` (clean) and by driving the rendered pages in a local dev server.

## Training

N/A — no training material impact.

## Certification

N/A — no certification impact.

## Marketing

N/A — no marketing impact.

## Automation tests

### Unit tests

N/A — documentation only; no code paths changed.

### Integration tests

N/A — documentation only.

Validation: `make -C documentation build` completes successfully (Docusaurus fails on broken links by default, so all cross-links resolve).

## Security checks

- Does this PR add or modify any dependencies? **No**
- Does this PR add or modify any authentication/authorization logic? **No** — it documents existing authorization behavior; no code changes.
- Does this PR handle sensitive data (PII, credentials, secrets)? **No**

## Samples

N/A — no sample apps changed.

## Related PRs

Documents the features from #1380 (per-tool MCP authz on agent-manager-service) and #1396 (observer authz).

## Migrations

N/A — no schema or data migrations.

## Test environment

Local dev (`make -C documentation build` + `docusaurus start`).

## Learning

N/A.
