### PR TITLE
Add configurable gateway timeout for the platform hosted agents

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -2304,6 +2304,23 @@ func WithArtifactID(artifactID string) TraitOption {
 	}
 }
 
+const (
+	DefaultResilienceTimeoutSeconds int32 = 30
+	MinResilienceTimeoutSeconds     int32 = 1
+	MaxResilienceTimeoutSeconds     int32 = 3600
+)
+
+func FormatResilienceTimeout(seconds int32) string {
+	return fmt.Sprintf("%ds", seconds)
+}
+
+// transforming to gateway policy format
+func WithResilienceTimeout(seconds int32) TraitOption {
+	return func(params map[string]interface{}) {
+		params["resilienceTimeout"] = FormatResilienceTimeout(seconds)
+	}
+}
+
 // APIKeyAuthPolicy returns the policy map for API key authentication.
 func APIKeyAuthPolicy() map[string]interface{} {
 	return map[string]interface{}{
@@ -2427,11 +2444,12 @@ func (c *openChoreoClient) buildTrait(ctx context.Context, namespaceName, projec
 
 func (c *openChoreoClient) buildAPIConfigurationTraitParameters(componentName string, opts ...TraitOption) (map[string]interface{}, error) {
 	params := map[string]interface{}{
-		"apiName":          componentName,
-		"apiVersion":       "v1.0",
-		"context":          fmt.Sprintf("/%s", componentName),
-		"upstreamPort":     config.GetConfig().DefaultChatAPI.DefaultHTTPPort,
-		"upstreamBasePath": config.GetConfig().DefaultChatAPI.DefaultBasePath,
+		"apiName":           componentName,
+		"apiVersion":        "v1.0",
+		"context":           fmt.Sprintf("/%s", componentName),
+		"upstreamPort":      config.GetConfig().DefaultChatAPI.DefaultHTTPPort,
+		"upstreamBasePath":  config.GetConfig().DefaultChatAPI.DefaultBasePath,
+		"resilienceTimeout": FormatResilienceTimeout(DefaultResilienceTimeoutSeconds),
 	}
 	for _, opt := range opts {
 		opt(params)

--- a/agent-manager-service/db_migrations/037_add_agent_streaming_timeout.go
+++ b/agent-manager-service/db_migrations/037_add_agent_streaming_timeout.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dbmigrations
+
+import (
+	"gorm.io/gorm"
+)
+
+var migration037 = migration{
+	ID: 37,
+	Migrate: func(db *gorm.DB) error {
+		return db.Exec(`
+		ALTER TABLE agent_configs
+			ADD COLUMN IF NOT EXISTS resilience_timeout_seconds INTEGER;
+		`).Error
+	},
+}

--- a/agent-manager-service/db_migrations/migration_list.go
+++ b/agent-manager-service/db_migrations/migration_list.go
@@ -16,7 +16,7 @@
 
 package dbmigrations
 
-const latestVersion = 36
+const latestVersion = 37
 
 // migration list sorted by version.  Add new migrations to the end of the list.
 // Previous migrations should not be modified.
@@ -57,4 +57,5 @@ var migrations = []migration{
 	migration034,
 	migration035,
 	migration036,
+	migration037,
 }

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -12247,6 +12247,11 @@ components:
           $ref: "#/components/schemas/OAuthConfig"
           nullable: true
           description: OAuth configuration for this environment's agent endpoint
+        resilienceTimeoutSeconds:
+          type: integer
+          description: Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Defaults to 30 seconds when unset.
+          minimum: 1
+          maximum: 3600
         configurations:
           type: object
           description: Configuration data containing env vars and file mounts

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -11834,6 +11834,11 @@ components:
           $ref: "#/components/schemas/OAuthConfig"
           nullable: true
           description: Current OAuth configuration for the agent endpoint
+        resilienceTimeoutSeconds:
+          type: integer
+          description: Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Defaults to 30 seconds when unset.
+          minimum: 1
+          maximum: 3600
     EnvironmentVariable:
       type: object
       required:
@@ -14071,6 +14076,11 @@ components:
         oauthConfig:
           description: OAuth configuration for the agent endpoint in this environment. Omit to keep the current value.
           $ref: "#/components/schemas/OAuthConfig"
+        resilienceTimeoutSeconds:
+          type: integer
+          description: Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Omit to keep the current value.
+          minimum: 1
+          maximum: 3600
 
     PromoteAgentRequest:
       type: object

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -14143,6 +14143,11 @@ components:
           description: Enable OAuth security for the agent endpoint in the target environment. Mutually exclusive with enableApiKeySecurity.
         oauthConfig:
           $ref: "#/components/schemas/OAuthConfig"
+        resilienceTimeoutSeconds:
+          type: integer
+          description: Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in the target environment. Omit to inherit the source environment's value.
+          minimum: 1
+          maximum: 3600
 
     PromoteAgentResponse:
       type: object

--- a/agent-manager-service/models/agent.go
+++ b/agent-manager-service/models/agent.go
@@ -50,6 +50,7 @@ type Configurations struct {
 	CorsConfig                *CorsConfig  `json:"corsConfig,omitempty"`
 	EnableOAuthSecurity       *bool        `json:"enableOAuthSecurity,omitempty"`
 	OAuthConfig               *OAuthConfig `json:"oauthConfig,omitempty"`
+	ResilienceTimeoutSeconds  *int32       `json:"resilienceTimeoutSeconds,omitempty"`
 }
 
 type CorsConfig struct {

--- a/agent-manager-service/models/agent_config.go
+++ b/agent-manager-service/models/agent_config.go
@@ -44,12 +44,13 @@ type AgentConfig struct {
 	CORSAllowCredentials   bool      `gorm:"column:cors_allow_credentials;not null;default:false"`
 	// OAuth security. EnableApiKeySecurity and EnableOAuthSecurity are mutually
 	// exclusive — enforced at the service layer before persistence.
-	EnableOAuthSecurity   bool     `gorm:"column:enable_oauth_security;not null;default:false"`
-	OAuthIssuers          []string `gorm:"column:oauth_issuers;type:jsonb;serializer:json;not null;default:'[]'"`
-	OAuthAudiences        []string `gorm:"column:oauth_audiences;type:jsonb;serializer:json;not null;default:'[]'"`
-	OAuthHeaderName       string   `gorm:"column:oauth_header_name;not null;default:'Authorization'"`
-	OAuthAuthHeaderPrefix string   `gorm:"column:oauth_auth_header_prefix;not null;default:'Bearer'"`
-	OAuthForwardToken     bool     `gorm:"column:oauth_forward_token;not null;default:true"`
+	EnableOAuthSecurity      bool     `gorm:"column:enable_oauth_security;not null;default:false"`
+	OAuthIssuers             []string `gorm:"column:oauth_issuers;type:jsonb;serializer:json;not null;default:'[]'"`
+	OAuthAudiences           []string `gorm:"column:oauth_audiences;type:jsonb;serializer:json;not null;default:'[]'"`
+	OAuthHeaderName          string   `gorm:"column:oauth_header_name;not null;default:'Authorization'"`
+	OAuthAuthHeaderPrefix    string   `gorm:"column:oauth_auth_header_prefix;not null;default:'Bearer'"`
+	OAuthForwardToken        bool     `gorm:"column:oauth_forward_token;not null;default:true"`
+	ResilienceTimeoutSeconds *int32   `gorm:"column:resilience_timeout_seconds"`
 }
 
 func (AgentConfig) TableName() string { return "agent_configs" }

--- a/agent-manager-service/repositories/agent_config_repository.go
+++ b/agent-manager-service/repositories/agent_config_repository.go
@@ -82,6 +82,7 @@ func (r *AgentConfigRepo) Upsert(config *models.AgentConfig) error {
 			"oauth_header_name":           config.OAuthHeaderName,
 			"oauth_auth_header_prefix":    config.OAuthAuthHeaderPrefix,
 			"oauth_forward_token":         config.OAuthForwardToken,
+			"resilience_timeout_seconds":  config.ResilienceTimeoutSeconds,
 			"updated_at":                  clause.Expr{SQL: "NOW()"},
 		}),
 	}).Create(config).Error

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -327,6 +327,19 @@ func mapInputInterface(specInterface *spec.InputInterface) *client.InputInterfac
 
 	return config
 }
+func resolveResilienceTimeoutSeconds(existingConfig *models.AgentConfig, requested *int32, withDefaults bool) int32 {
+	resolved := int32(0)
+	if withDefaults {
+		resolved = client.DefaultResilienceTimeoutSeconds
+	}
+	if existingConfig != nil && existingConfig.ResilienceTimeoutSeconds != nil {
+		resolved = *existingConfig.ResilienceTimeoutSeconds
+	}
+	if requested != nil && *requested >= client.MinResilienceTimeoutSeconds && *requested <= client.MaxResilienceTimeoutSeconds {
+		resolved = *requested
+	}
+	return resolved
+}
 
 // buildCreateTraitRequests collects all traits needed during agent creation into a single
 // list so they can be attached in one GET-UPDATE cycle, avoiding resource version conflicts.
@@ -986,8 +999,9 @@ func (s *agentManagerService) GetAgent(ctx context.Context, ouID string, project
 						AllowHeaders:     agentConfig.CORSAllowHeaders,
 						AllowCredentials: &agentConfig.CORSAllowCredentials,
 					},
-					EnableOAuthSecurity: &agentConfig.EnableOAuthSecurity,
-					OAuthConfig:         oauthConfigFromAgentConfig(agentConfig),
+					EnableOAuthSecurity:      &agentConfig.EnableOAuthSecurity,
+					OAuthConfig:              oauthConfigFromAgentConfig(agentConfig),
+					ResilienceTimeoutSeconds: agentConfig.ResilienceTimeoutSeconds,
 				}
 			}
 
@@ -2652,6 +2666,7 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	// Resolve config values: request > DB > defaults
 	tracingCfg := resolveTracingConfig(existingConfig, req.EnableAutoInstrumentation, true)
 	apiCfg := resolveAPIConfig(existingConfig, req.EnableApiKeySecurity, req.CorsConfig, req.EnableOAuthSecurity, req.OauthConfig, true)
+	resilienceTimeoutSeconds := resolveResilienceTimeoutSeconds(existingConfig, nil, true)
 	if err := validateAuthExclusivity(apiCfg); err != nil {
 		return "", err
 	}
@@ -2717,7 +2732,7 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	if err != nil {
 		return "", err
 	}
-	deployTraitEnvConfigs := buildTraitEnvConfigs(agentName, policies, "", isPythonBuildpack, isBallerinaBuildpack, enableAutoInstrumentation, deployInstrumentationImage)
+	deployTraitEnvConfigs := buildTraitEnvConfigs(agentName, policies, "", resilienceTimeoutSeconds, isPythonBuildpack, isBallerinaBuildpack, enableAutoInstrumentation, deployInstrumentationImage)
 
 	// Replace Component CR workflow parameters with env vars and file mounts from deploy request
 	// This replaces all existing env vars to ensure the component CR matches the deploy request
@@ -2756,6 +2771,9 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 			traitOpts = append(traitOpts, client.WithUpstreamBasePath(agent.InputInterface.BasePath))
 		} else {
 			traitOpts = append(traitOpts, client.WithUpstreamBasePath(config.GetConfig().DefaultChatAPI.DefaultBasePath))
+		}
+		if resilienceTimeoutSeconds > 0 {
+			traitOpts = append(traitOpts, client.WithResilienceTimeout(resilienceTimeoutSeconds))
 		}
 		traitOpts = append(traitOpts, client.WithPolicies(policies))
 
@@ -2810,6 +2828,10 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	// Upsert — the repo's DoUpdates map includes that column, so omitting
 	// the value would NULL out a customer's pin on every redeploy.
 	if targetEnv != nil {
+		var deployResilienceTimeoutSeconds *int32
+		if resilienceTimeoutSeconds > 0 {
+			deployResilienceTimeoutSeconds = &resilienceTimeoutSeconds
+		}
 		agentConfig := &models.AgentConfig{
 			OUID:                      ouID,
 			ProjectName:               projectName,
@@ -2829,6 +2851,7 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 			OAuthHeaderName:           apiCfg.OAuthHeaderName,
 			OAuthAuthHeaderPrefix:     apiCfg.OAuthAuthHeaderPrefix,
 			OAuthForwardToken:         apiCfg.OAuthForwardToken,
+			ResilienceTimeoutSeconds:  deployResilienceTimeoutSeconds,
 		}
 		if configErr := s.agentConfigRepo.Upsert(agentConfig); configErr != nil {
 			s.logger.Error("Failed to persist instrumentation config to database", "agentName", agentName, "environment", lowestEnv, "error", configErr)
@@ -3110,7 +3133,7 @@ func buildComponentTypeEnvConfigs(env *models.EnvironmentResponse) map[string]in
 // instrumentationImage, when non-empty, pins the OTEL init-container image for this environment
 // (overriding the Component's create-time default) so the AMP instrumentation version can be
 // changed per-environment on deploy/promote without re-attaching the Component trait.
-func buildTraitEnvConfigs(agentName string, policies []map[string]interface{}, artifactID string, isPythonBuildpack, isBallerinaBuildpack bool, autoInstrumentation bool, instrumentationImage string) map[string]interface{} {
+func buildTraitEnvConfigs(agentName string, policies []map[string]interface{}, artifactID string, resilienceTimeoutSeconds int32, isPythonBuildpack, isBallerinaBuildpack bool, autoInstrumentation bool, instrumentationImage string) map[string]interface{} {
 	instanceName := func(traitType client.TraitType) string {
 		return agentName + "-" + string(traitType)
 	}
@@ -3119,6 +3142,9 @@ func buildTraitEnvConfigs(agentName string, policies []map[string]interface{}, a
 	}
 	if artifactID != "" {
 		apiTraitCfg["artifactId"] = artifactID
+	}
+	if resilienceTimeoutSeconds > 0 {
+		apiTraitCfg["resilienceTimeout"] = client.FormatResilienceTimeout(resilienceTimeoutSeconds)
 	}
 	traitEnvConfigs := map[string]interface{}{
 		instanceName(client.TraitAPIManagement): apiTraitCfg,
@@ -3658,6 +3684,7 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 		// where set; any unset field falls back to the source env's values.
 		tracingCfg := resolveTracingConfig(existingConfig, req.EnableAutoInstrumentation, false)
 		apiCfg := resolveAPIConfig(existingConfig, req.EnableApiKeySecurity, req.CorsConfig, req.EnableOAuthSecurity, req.OauthConfig, false)
+		resilienceTimeoutSeconds := resolveResilienceTimeoutSeconds(existingConfig, nil, false)
 		if err := validateAuthExclusivity(apiCfg); err != nil {
 			return err
 		}
@@ -3702,7 +3729,7 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 		if resolveErr != nil {
 			return resolveErr
 		}
-		traitEnvConfigs = buildTraitEnvConfigs(agentName, policies, targetArtifactID, promotePythonBuildpack, promoteBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation, promoteInstrumentationImage)
+		traitEnvConfigs = buildTraitEnvConfigs(agentName, policies, targetArtifactID, resilienceTimeoutSeconds, promotePythonBuildpack, promoteBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation, promoteInstrumentationImage)
 		promoteCTConfigs = buildComponentTypeEnvConfigs(targetEnv)
 
 		apiKey, apiKeyErr := s.generateAgentAPIKey(ctx, ouID, projectName, agentName, req.TargetEnvironment)
@@ -3714,6 +3741,10 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			injectAgentAPIKeySecretRef(traitEnvConfigs, agentName, apiKeySecretRef, apiKeySecretProperty)
 		}
 
+		var promoteResilienceTimeoutSeconds *int32
+		if resilienceTimeoutSeconds > 0 {
+			promoteResilienceTimeoutSeconds = &resilienceTimeoutSeconds
+		}
 		// Persist config for the target environment
 		agentConfig := &models.AgentConfig{
 			OUID:                      ouID,
@@ -3734,6 +3765,7 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			OAuthHeaderName:           apiCfg.OAuthHeaderName,
 			OAuthAuthHeaderPrefix:     apiCfg.OAuthAuthHeaderPrefix,
 			OAuthForwardToken:         apiCfg.OAuthForwardToken,
+			ResilienceTimeoutSeconds:  promoteResilienceTimeoutSeconds,
 		}
 		if upsertErr := s.agentConfigRepo.Upsert(agentConfig); upsertErr != nil {
 			s.logger.Error("Failed to persist agent config for target environment", "agentName", agentName, "environment", req.TargetEnvironment, "error", upsertErr)
@@ -3890,6 +3922,7 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, ouI
 	}
 	tracingCfg := resolveTracingConfig(existingConfig, req.EnableAutoInstrumentation, false)
 	apiCfg := resolveAPIConfig(existingConfig, req.EnableApiKeySecurity, req.CorsConfig, req.EnableOAuthSecurity, req.OauthConfig, false)
+	resilienceTimeoutSeconds := resolveResilienceTimeoutSeconds(existingConfig, req.ResilienceTimeoutSeconds, false)
 	if err := validateAuthExclusivity(apiCfg); err != nil {
 		return err
 	}
@@ -3929,7 +3962,7 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, ouI
 	if resolveErr != nil {
 		return resolveErr
 	}
-	traitEnvConfigs := buildTraitEnvConfigs(agentName, policies, artifact.UUID.String(), isPythonBuildpack, isBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation, instrumentationImage)
+	traitEnvConfigs := buildTraitEnvConfigs(agentName, policies, artifact.UUID.String(), resilienceTimeoutSeconds, isPythonBuildpack, isBallerinaBuildpack, tracingCfg.EnableAutoInstrumentation, instrumentationImage)
 
 	// Re-attach the per-env agent API key secret ref. buildTraitEnvConfigs omits it and the update
 	// below REPLACES the binding's trait configs, so without this a non-lowest env falls back to the
@@ -3949,6 +3982,10 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, ouI
 		return fmt.Errorf("failed to update deploy settings: %w", updateErr)
 	}
 
+	var settingsResilienceTimeoutSeconds *int32
+	if resilienceTimeoutSeconds > 0 {
+		settingsResilienceTimeoutSeconds = &resilienceTimeoutSeconds
+	}
 	// Persist resolved config so subsequent deploy/promote calls see the current values.
 	agentConfig := &models.AgentConfig{
 		OUID:                      ouID,
@@ -3969,6 +4006,7 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, ouI
 		OAuthHeaderName:           apiCfg.OAuthHeaderName,
 		OAuthAuthHeaderPrefix:     apiCfg.OAuthAuthHeaderPrefix,
 		OAuthForwardToken:         apiCfg.OAuthForwardToken,
+		ResilienceTimeoutSeconds:  settingsResilienceTimeoutSeconds,
 	}
 	if upsertErr := s.agentConfigRepo.Upsert(agentConfig); upsertErr != nil {
 		s.logger.Error("Failed to persist agent deploy settings", "agentName", agentName, "environment", req.EnvironmentName, "error", upsertErr)

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -327,7 +327,13 @@ func mapInputInterface(specInterface *spec.InputInterface) *client.InputInterfac
 
 	return config
 }
-func resolveResilienceTimeoutSeconds(existingConfig *models.AgentConfig, requested *int32, withDefaults bool) int32 {
+
+// resolveResilienceTimeoutSeconds resolves the effective resilience timeout from
+// (in precedence order) an explicit request value, the persisted config, and the
+// default. An explicitly requested value outside [MinResilienceTimeoutSeconds,
+// MaxResilienceTimeoutSeconds] is rejected rather than silently discarded — unlike
+// an omitted (nil) request, which falls through to the existing/default value.
+func resolveResilienceTimeoutSeconds(existingConfig *models.AgentConfig, requested *int32, withDefaults bool) (int32, error) {
 	resolved := int32(0)
 	if withDefaults {
 		resolved = client.DefaultResilienceTimeoutSeconds
@@ -335,10 +341,14 @@ func resolveResilienceTimeoutSeconds(existingConfig *models.AgentConfig, request
 	if existingConfig != nil && existingConfig.ResilienceTimeoutSeconds != nil {
 		resolved = *existingConfig.ResilienceTimeoutSeconds
 	}
-	if requested != nil && *requested >= client.MinResilienceTimeoutSeconds && *requested <= client.MaxResilienceTimeoutSeconds {
+	if requested != nil {
+		if *requested < client.MinResilienceTimeoutSeconds || *requested > client.MaxResilienceTimeoutSeconds {
+			return 0, fmt.Errorf("%w: resilienceTimeoutSeconds must be between %d and %d seconds, got %d",
+				utils.ErrInvalidInput, client.MinResilienceTimeoutSeconds, client.MaxResilienceTimeoutSeconds, *requested)
+		}
 		resolved = *requested
 	}
-	return resolved
+	return resolved, nil
 }
 
 // buildCreateTraitRequests collects all traits needed during agent creation into a single
@@ -2666,7 +2676,10 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	// Resolve config values: request > DB > defaults
 	tracingCfg := resolveTracingConfig(existingConfig, req.EnableAutoInstrumentation, true)
 	apiCfg := resolveAPIConfig(existingConfig, req.EnableApiKeySecurity, req.CorsConfig, req.EnableOAuthSecurity, req.OauthConfig, true)
-	resilienceTimeoutSeconds := resolveResilienceTimeoutSeconds(existingConfig, nil, true)
+	resilienceTimeoutSeconds, err := resolveResilienceTimeoutSeconds(existingConfig, nil, true)
+	if err != nil {
+		return "", err
+	}
 	if err := validateAuthExclusivity(apiCfg); err != nil {
 		return "", err
 	}
@@ -3676,15 +3689,18 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			existingConfig = cfg
 		}
 
-		// Deploy-settings precedence (CORS, API key security, auto instrumentation):
-		//   request fields → source env's saved AgentConfig → off.
+		// Deploy-settings precedence (CORS, API key security, auto instrumentation,
+		// resilience timeout): request fields → source env's saved AgentConfig → off.
 		// When useConfigFromSourceEnv=true, the validator guarantees the request fields
 		// are nil, so the resolved settings fall through to the source env's saved
 		// AgentConfig. When useConfigFromSourceEnv=false the request takes precedence
 		// where set; any unset field falls back to the source env's values.
 		tracingCfg := resolveTracingConfig(existingConfig, req.EnableAutoInstrumentation, false)
 		apiCfg := resolveAPIConfig(existingConfig, req.EnableApiKeySecurity, req.CorsConfig, req.EnableOAuthSecurity, req.OauthConfig, false)
-		resilienceTimeoutSeconds := resolveResilienceTimeoutSeconds(existingConfig, nil, false)
+		resilienceTimeoutSeconds, err := resolveResilienceTimeoutSeconds(existingConfig, req.ResilienceTimeoutSeconds, false)
+		if err != nil {
+			return err
+		}
 		if err := validateAuthExclusivity(apiCfg); err != nil {
 			return err
 		}
@@ -3922,7 +3938,10 @@ func (s *agentManagerService) UpdateAgentDeploySettings(ctx context.Context, ouI
 	}
 	tracingCfg := resolveTracingConfig(existingConfig, req.EnableAutoInstrumentation, false)
 	apiCfg := resolveAPIConfig(existingConfig, req.EnableApiKeySecurity, req.CorsConfig, req.EnableOAuthSecurity, req.OauthConfig, false)
-	resilienceTimeoutSeconds := resolveResilienceTimeoutSeconds(existingConfig, req.ResilienceTimeoutSeconds, false)
+	resilienceTimeoutSeconds, err := resolveResilienceTimeoutSeconds(existingConfig, req.ResilienceTimeoutSeconds, false)
+	if err != nil {
+		return err
+	}
 	if err := validateAuthExclusivity(apiCfg); err != nil {
 		return err
 	}

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -19,6 +19,7 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync/atomic"
@@ -1480,14 +1481,14 @@ func TestDeployAgent_APIAgent_ResilienceTimeout(t *testing.T) {
 	}
 }
 
-// covers the "editable immediately without redeploy" path: 
+// covers the "editable immediately without redeploy" path:
 func TestUpdateAgentDeploySettings_ResilienceTimeout(t *testing.T) {
 	tests := []struct {
 		name                string
 		existingConfig      *models.AgentConfig
 		requested           *int32
 		wantPersisted       *int32
-		wantEnvOverridePush string 
+		wantEnvOverridePush string
 	}{
 		{"request sets a new value", nil, int32Ptr(90), int32Ptr(90), "90s"},
 		{"omitted request keeps existing DB value", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, nil, int32Ptr(60), "60s"},
@@ -1510,6 +1511,10 @@ func TestUpdateAgentDeploySettings_ResilienceTimeout(t *testing.T) {
 				UpdateReleaseBindingTraitConfigsFunc: func(_ context.Context, _, _, _ string, traitConfigs map[string]interface{}, _ map[string]interface{}) error {
 					pushedTraitEnvConfigs = traitConfigs
 					return nil
+				},
+				// No API key has been minted for this test agent, so simulate that.
+				GetSecretReferenceFunc: func(_ context.Context, _, _ string) (*client.SecretReferenceInfo, error) {
+					return nil, fmt.Errorf("secret reference not found")
 				},
 			}
 			artifactRepo := &repomocks.ArtifactRepositoryMock{

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,6 +34,8 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/instrumentation"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -1322,4 +1325,236 @@ func TestListAgents_LabelsPassThroughUnmodified(t *testing.T) {
 		require.Len(t, result, 1)
 		assert.Equal(t, "agent-1", result[0].Name)
 	})
+}
+
+func int32Ptr(v int32) *int32 {
+	return &v
+}
+
+// mirrors what buildAPIConfigurationTraitParameters does
+// internally when a trait is actually attached. used to inspect
+// the parameters a TraitRequest's Opts would produce without needing a real
+// OpenChoreo client.
+func applyTraitOpts(opts []client.TraitOption) map[string]interface{} {
+	params := map[string]interface{}{}
+	for _, opt := range opts {
+		opt(params)
+	}
+	return params
+}
+
+func findTraitRequest(traits []client.TraitRequest, traitType client.TraitType) *client.TraitRequest {
+	for i := range traits {
+		if traits[i].TraitType == traitType {
+			return &traits[i]
+		}
+	}
+	return nil
+}
+
+func TestResolveResilienceTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  *models.AgentConfig
+		requested *int32
+		withDef   bool
+		want      int32
+	}{
+		{"nothing set, withDefaults=true falls back to default", nil, nil, true, client.DefaultResilienceTimeoutSeconds},
+		{"nothing set, withDefaults=false yields zero (no override)", nil, nil, false, 0},
+		{"existing DB value is used", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, nil, false, 60},
+		{"request overrides existing DB value", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, int32Ptr(90), false, 90},
+		{"out-of-bounds request is ignored, falls back to existing", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, int32Ptr(10000), false, 60},
+		{"minimum bound is accepted", nil, int32Ptr(client.MinResilienceTimeoutSeconds), false, client.MinResilienceTimeoutSeconds},
+		{"maximum bound is accepted", nil, int32Ptr(client.MaxResilienceTimeoutSeconds), false, client.MaxResilienceTimeoutSeconds},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveResilienceTimeoutSeconds(tc.existing, tc.requested, tc.withDef)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// OpenChoreo client and repository mocks needed to drive DeployAgent
+func deployAPIAgentMocks(existingConfig *models.AgentConfig) (*agentManagerService, *client.ComponentDeploymentConfigRequest) {
+	var capturedDeployConfig client.ComponentDeploymentConfigRequest
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+			return &models.OrganizationResponse{Name: name}, nil
+		},
+		GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+			return &models.AgentResponse{
+				Provisioning:   models.Provisioning{Type: string(utils.InternalAgent)},
+				Type:           models.AgentType{Type: string(utils.AgentTypeAPI)},
+				InputInterface: &models.InputInterface{Port: 8000, BasePath: "/"},
+			}, nil
+		},
+		GetProjectDeploymentPipelineFunc: func(_ context.Context, _, _ string) (*models.DeploymentPipelineResponse, error) {
+			return &models.DeploymentPipelineResponse{PromotionPaths: []models.PromotionPath{
+				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}}},
+			}}, nil
+		},
+		GetComponentConfigurationsFunc: func(context.Context, string, string, string, string) ([]models.EnvVars, error) {
+			return nil, nil
+		},
+		GetEnvironmentFunc: func(_ context.Context, _, name string) (*models.EnvironmentResponse, error) {
+			return &models.EnvironmentResponse{Name: name, UUID: "env-uuid"}, nil
+		},
+		IsDeploymentInProgressFunc: func(context.Context, string, string, string) (bool, error) {
+			return false, nil
+		},
+		ReplaceComponentEnvVarsFunc: func(context.Context, string, string, string, []client.EnvVar) error {
+			return nil
+		},
+		ReplaceComponentFileMountsFunc: func(context.Context, string, string, string, []client.FileVar) error {
+			return nil
+		},
+		UpdateComponentDeploymentConfigFunc: func(_ context.Context, _, _, _ string, req client.ComponentDeploymentConfigRequest) error {
+			capturedDeployConfig = req
+			return nil
+		},
+		DeployFunc: func(context.Context, string, string, string, client.DeployRequest) error {
+			return nil
+		},
+		UpdateReleaseBindingTraitConfigsFunc: func(context.Context, string, string, string, map[string]interface{}, map[string]interface{}) error {
+			return nil
+		},
+	}
+	injector := &agentIdentityInjectorStub{
+		EnvVarsForEnvironmentFunc: func(context.Context, string, string, string, string) ([]client.EnvVar, error) {
+			return nil, nil
+		},
+	}
+	artifactRepo := &repomocks.ArtifactRepositoryMock{
+		GetByHandleFunc: func(handle, orgUUID string) (*models.Artifact, error) {
+			return &models.Artifact{UUID: uuid.Must(uuid.NewV7()), Handle: handle, Kind: models.KindAgent, OUID: orgUUID}, nil
+		},
+	}
+	agentConfigRepo := &repomocks.AgentConfigRepositoryMock{
+		GetFunc: func(string, string, string, string) (*models.AgentConfig, error) {
+			if existingConfig == nil {
+				return nil, repositories.ErrAgentConfigNotFound
+			}
+			return existingConfig, nil
+		},
+		UpsertFunc: func(*models.AgentConfig) error {
+			return nil
+		},
+	}
+	s := &agentManagerService{
+		ocClient:               ocClient,
+		agentIdentityInjection: injector,
+		artifactRepo:           artifactRepo,
+		agentConfigRepo:        agentConfigRepo,
+		logger:                 discardLogger(),
+	}
+	return s, &capturedDeployConfig
+}
+
+// covers the deploy-time wiring of ResilienceTimeoutSeconds into the
+// api-management trait's resilienceTimeout parameter.
+func TestDeployAgent_APIAgent_ResilienceTimeout(t *testing.T) {
+	tests := []struct {
+		name                  string
+		existingConfig        *models.AgentConfig
+		wantResilienceTimeout string
+	}{
+		{"persisted value within bounds produces \"<N>s\"", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(45)}, "45s"},
+		{"no persisted config falls back to \"30s\"", nil, "30s"},
+		{"persisted nil falls back to \"30s\"", &models.AgentConfig{}, "30s"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, capturedDeployConfig := deployAPIAgentMocks(tc.existingConfig)
+
+			env, err := s.DeployAgent(context.Background(), "acme", "proj1", "my-agent", &spec.DeployAgentRequest{ImageId: "registry.example.com/my-agent:v1"})
+
+			require.NoError(t, err)
+			assert.Equal(t, "dev", env)
+			apiTrait := findTraitRequest(capturedDeployConfig.TraitsToAttach, client.TraitAPIManagement)
+			require.NotNil(t, apiTrait, "expected an api-management trait to be attached for an API agent deploy")
+			params := applyTraitOpts(apiTrait.Opts)
+			assert.Equal(t, tc.wantResilienceTimeout, params["resilienceTimeout"])
+		})
+	}
+}
+
+// covers the "editable immediately without redeploy" path: 
+func TestUpdateAgentDeploySettings_ResilienceTimeout(t *testing.T) {
+	tests := []struct {
+		name                string
+		existingConfig      *models.AgentConfig
+		requested           *int32
+		wantPersisted       *int32
+		wantEnvOverridePush string 
+	}{
+		{"request sets a new value", nil, int32Ptr(90), int32Ptr(90), "90s"},
+		{"omitted request keeps existing DB value", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, nil, int32Ptr(60), "60s"},
+		{"nothing set omits the override, no key pushed", nil, nil, nil, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var pushedTraitEnvConfigs map[string]interface{}
+			var persisted *models.AgentConfig
+			ocClient := &clientmocks.OpenChoreoClientMock{
+				GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+					return &models.OrganizationResponse{Name: name}, nil
+				},
+				GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+					return &models.AgentResponse{Type: models.AgentType{Type: string(utils.AgentTypeAPI)}}, nil
+				},
+				GetEnvironmentFunc: func(_ context.Context, _, name string) (*models.EnvironmentResponse, error) {
+					return &models.EnvironmentResponse{Name: name, UUID: "env-uuid"}, nil
+				},
+				UpdateReleaseBindingTraitConfigsFunc: func(_ context.Context, _, _, _ string, traitConfigs map[string]interface{}, _ map[string]interface{}) error {
+					pushedTraitEnvConfigs = traitConfigs
+					return nil
+				},
+			}
+			artifactRepo := &repomocks.ArtifactRepositoryMock{
+				GetByHandleFunc: func(handle, orgUUID string) (*models.Artifact, error) {
+					return &models.Artifact{UUID: uuid.Must(uuid.NewV7()), Handle: handle, Kind: models.KindAgent, OUID: orgUUID}, nil
+				},
+			}
+			agentConfigRepo := &repomocks.AgentConfigRepositoryMock{
+				GetFunc: func(string, string, string, string) (*models.AgentConfig, error) {
+					if tc.existingConfig == nil {
+						return nil, repositories.ErrAgentConfigNotFound
+					}
+					return tc.existingConfig, nil
+				},
+				UpsertFunc: func(cfg *models.AgentConfig) error {
+					persisted = cfg
+					return nil
+				},
+			}
+			s := &agentManagerService{
+				ocClient:        ocClient,
+				artifactRepo:    artifactRepo,
+				agentConfigRepo: agentConfigRepo,
+				logger:          discardLogger(),
+			}
+
+			err := s.UpdateAgentDeploySettings(context.Background(), "acme", "proj1", "my-agent", &spec.UpdateAgentDeploySettingsRequest{
+				EnvironmentName:          "dev",
+				ResilienceTimeoutSeconds: tc.requested,
+			})
+
+			require.NoError(t, err)
+			if tc.wantPersisted == nil {
+				assert.Nil(t, persisted.ResilienceTimeoutSeconds)
+			} else {
+				require.NotNil(t, persisted.ResilienceTimeoutSeconds)
+				assert.Equal(t, *tc.wantPersisted, *persisted.ResilienceTimeoutSeconds)
+			}
+			apiTraitCfg, _ := pushedTraitEnvConfigs["my-agent-api-configuration"].(map[string]interface{})
+			if tc.wantEnvOverridePush == "" {
+				_, present := apiTraitCfg["resilienceTimeout"]
+				assert.False(t, present, "expected no resilienceTimeout override to be pushed")
+			} else {
+				assert.Equal(t, tc.wantEnvOverridePush, apiTraitCfg["resilienceTimeout"])
+			}
+		})
+	}
 }

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -1360,18 +1360,25 @@ func TestResolveResilienceTimeoutSeconds(t *testing.T) {
 		requested *int32
 		withDef   bool
 		want      int32
+		wantErr   bool
 	}{
-		{"nothing set, withDefaults=true falls back to default", nil, nil, true, client.DefaultResilienceTimeoutSeconds},
-		{"nothing set, withDefaults=false yields zero (no override)", nil, nil, false, 0},
-		{"existing DB value is used", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, nil, false, 60},
-		{"request overrides existing DB value", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, int32Ptr(90), false, 90},
-		{"out-of-bounds request is ignored, falls back to existing", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, int32Ptr(10000), false, 60},
-		{"minimum bound is accepted", nil, int32Ptr(client.MinResilienceTimeoutSeconds), false, client.MinResilienceTimeoutSeconds},
-		{"maximum bound is accepted", nil, int32Ptr(client.MaxResilienceTimeoutSeconds), false, client.MaxResilienceTimeoutSeconds},
+		{"nothing set, withDefaults=true falls back to default", nil, nil, true, client.DefaultResilienceTimeoutSeconds, false},
+		{"nothing set, withDefaults=false yields zero (no override)", nil, nil, false, 0, false},
+		{"existing DB value is used", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, nil, false, 60, false},
+		{"request overrides existing DB value", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, int32Ptr(90), false, 90, false},
+		{"out-of-bounds request is rejected", &models.AgentConfig{ResilienceTimeoutSeconds: int32Ptr(60)}, int32Ptr(10000), false, 0, true},
+		{"minimum bound is accepted", nil, int32Ptr(client.MinResilienceTimeoutSeconds), false, client.MinResilienceTimeoutSeconds, false},
+		{"maximum bound is accepted", nil, int32Ptr(client.MaxResilienceTimeoutSeconds), false, client.MaxResilienceTimeoutSeconds, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := resolveResilienceTimeoutSeconds(tc.existing, tc.requested, tc.withDef)
+			got, err := resolveResilienceTimeoutSeconds(tc.existing, tc.requested, tc.withDef)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, utils.ErrInvalidInput)
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -1562,4 +1569,41 @@ func TestUpdateAgentDeploySettings_ResilienceTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestUpdateAgentDeploySettings_ResilienceTimeout_OutOfBoundsRejected guards
+// against an explicitly-requested out-of-bounds value being silently discarded:
+// the call must fail with ErrInvalidInput before it touches the release
+// binding or persists anything. UpdateReleaseBindingTraitConfigsFunc and
+// UpsertFunc are deliberately left nil so an unwanted call panics the test.
+func TestUpdateAgentDeploySettings_ResilienceTimeout_OutOfBoundsRejected(t *testing.T) {
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+			return &models.OrganizationResponse{Name: name}, nil
+		},
+		GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+			return &models.AgentResponse{Type: models.AgentType{Type: string(utils.AgentTypeAPI)}}, nil
+		},
+		GetEnvironmentFunc: func(_ context.Context, _, name string) (*models.EnvironmentResponse, error) {
+			return &models.EnvironmentResponse{Name: name, UUID: "env-uuid"}, nil
+		},
+	}
+	agentConfigRepo := &repomocks.AgentConfigRepositoryMock{
+		GetFunc: func(string, string, string, string) (*models.AgentConfig, error) {
+			return nil, repositories.ErrAgentConfigNotFound
+		},
+	}
+	s := &agentManagerService{
+		ocClient:        ocClient,
+		agentConfigRepo: agentConfigRepo,
+		logger:          discardLogger(),
+	}
+
+	err := s.UpdateAgentDeploySettings(context.Background(), "acme", "proj1", "my-agent", &spec.UpdateAgentDeploySettingsRequest{
+		EnvironmentName:          "dev",
+		ResilienceTimeoutSeconds: int32Ptr(10000),
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, utils.ErrInvalidInput)
 }

--- a/agent-manager-service/spec/model_configuration_response.go
+++ b/agent-manager-service/spec/model_configuration_response.go
@@ -35,6 +35,7 @@ type ConfigurationResponse struct {
 	EnableOAuthSecurity *bool        `json:"enableOAuthSecurity,omitempty"`
 	CorsConfig          *CORSConfig  `json:"corsConfig,omitempty"`
 	OauthConfig         *OAuthConfig `json:"oauthConfig,omitempty"`
+	// Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Defaults to 30 seconds when unset.
 	ResilienceTimeoutSeconds *int32                              `json:"resilienceTimeoutSeconds,omitempty"`
 	Configurations           ConfigurationResponseConfigurations `json:"configurations"`
 }
@@ -324,6 +325,7 @@ func (o *ConfigurationResponse) SetOauthConfig(v OAuthConfig) {
 	o.OauthConfig = &v
 }
 
+// GetResilienceTimeoutSeconds returns the ResilienceTimeoutSeconds field value if set, zero value otherwise.
 func (o *ConfigurationResponse) GetResilienceTimeoutSeconds() int32 {
 	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
 		var ret int32
@@ -332,6 +334,8 @@ func (o *ConfigurationResponse) GetResilienceTimeoutSeconds() int32 {
 	return *o.ResilienceTimeoutSeconds
 }
 
+// GetResilienceTimeoutSecondsOk returns a tuple with the ResilienceTimeoutSeconds field value if set, nil otherwise
+// and a boolean to check if the value has been set.
 func (o *ConfigurationResponse) GetResilienceTimeoutSecondsOk() (*int32, bool) {
 	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
 		return nil, false
@@ -339,6 +343,7 @@ func (o *ConfigurationResponse) GetResilienceTimeoutSecondsOk() (*int32, bool) {
 	return o.ResilienceTimeoutSeconds, true
 }
 
+// HasResilienceTimeoutSeconds returns a boolean if a field has been set.
 func (o *ConfigurationResponse) HasResilienceTimeoutSeconds() bool {
 	if o != nil && !IsNil(o.ResilienceTimeoutSeconds) {
 		return true
@@ -347,6 +352,7 @@ func (o *ConfigurationResponse) HasResilienceTimeoutSeconds() bool {
 	return false
 }
 
+// SetResilienceTimeoutSeconds gets a reference to the given int32 and assigns it to the ResilienceTimeoutSeconds field.
 func (o *ConfigurationResponse) SetResilienceTimeoutSeconds(v int32) {
 	o.ResilienceTimeoutSeconds = &v
 }

--- a/agent-manager-service/spec/model_configuration_response.go
+++ b/agent-manager-service/spec/model_configuration_response.go
@@ -32,10 +32,11 @@ type ConfigurationResponse struct {
 	// Whether API key security is enabled for this environment's agent endpoint
 	EnableApiKeySecurity *bool `json:"enableApiKeySecurity,omitempty"`
 	// Whether OAuth security is enabled for this environment's agent endpoint
-	EnableOAuthSecurity *bool                               `json:"enableOAuthSecurity,omitempty"`
-	CorsConfig          *CORSConfig                         `json:"corsConfig,omitempty"`
-	OauthConfig         *OAuthConfig                        `json:"oauthConfig,omitempty"`
-	Configurations      ConfigurationResponseConfigurations `json:"configurations"`
+	EnableOAuthSecurity *bool        `json:"enableOAuthSecurity,omitempty"`
+	CorsConfig          *CORSConfig  `json:"corsConfig,omitempty"`
+	OauthConfig         *OAuthConfig `json:"oauthConfig,omitempty"`
+	ResilienceTimeoutSeconds *int32                              `json:"resilienceTimeoutSeconds,omitempty"`
+	Configurations           ConfigurationResponseConfigurations `json:"configurations"`
 }
 
 // NewConfigurationResponse instantiates a new ConfigurationResponse object
@@ -323,6 +324,33 @@ func (o *ConfigurationResponse) SetOauthConfig(v OAuthConfig) {
 	o.OauthConfig = &v
 }
 
+func (o *ConfigurationResponse) GetResilienceTimeoutSeconds() int32 {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		var ret int32
+		return ret
+	}
+	return *o.ResilienceTimeoutSeconds
+}
+
+func (o *ConfigurationResponse) GetResilienceTimeoutSecondsOk() (*int32, bool) {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		return nil, false
+	}
+	return o.ResilienceTimeoutSeconds, true
+}
+
+func (o *ConfigurationResponse) HasResilienceTimeoutSeconds() bool {
+	if o != nil && !IsNil(o.ResilienceTimeoutSeconds) {
+		return true
+	}
+
+	return false
+}
+
+func (o *ConfigurationResponse) SetResilienceTimeoutSeconds(v int32) {
+	o.ResilienceTimeoutSeconds = &v
+}
+
 // GetConfigurations returns the Configurations field value
 func (o *ConfigurationResponse) GetConfigurations() ConfigurationResponseConfigurations {
 	if o == nil {
@@ -377,6 +405,9 @@ func (o ConfigurationResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.OauthConfig) {
 		toSerialize["oauthConfig"] = o.OauthConfig
+	}
+	if !IsNil(o.ResilienceTimeoutSeconds) {
+		toSerialize["resilienceTimeoutSeconds"] = o.ResilienceTimeoutSeconds
 	}
 	toSerialize["configurations"] = o.Configurations
 	return toSerialize, nil

--- a/agent-manager-service/spec/model_configurations.go
+++ b/agent-manager-service/spec/model_configurations.go
@@ -33,6 +33,8 @@ type Configurations struct {
 	// Enable OAuth security for the agent endpoint. Mutually exclusive with enableApiKeySecurity.
 	EnableOAuthSecurity *bool        `json:"enableOAuthSecurity,omitempty"`
 	OauthConfig         *OAuthConfig `json:"oauthConfig,omitempty"`
+	// Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Defaults to 30 seconds when unset.
+	ResilienceTimeoutSeconds *int32 `json:"resilienceTimeoutSeconds,omitempty"`
 }
 
 // NewConfigurations instantiates a new Configurations object
@@ -331,6 +333,38 @@ func (o *Configurations) SetOauthConfig(v OAuthConfig) {
 	o.OauthConfig = &v
 }
 
+// GetResilienceTimeoutSeconds returns the ResilienceTimeoutSeconds field value if set, zero value otherwise.
+func (o *Configurations) GetResilienceTimeoutSeconds() int32 {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		var ret int32
+		return ret
+	}
+	return *o.ResilienceTimeoutSeconds
+}
+
+// GetResilienceTimeoutSecondsOk returns a tuple with the ResilienceTimeoutSeconds field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Configurations) GetResilienceTimeoutSecondsOk() (*int32, bool) {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		return nil, false
+	}
+	return o.ResilienceTimeoutSeconds, true
+}
+
+// HasResilienceTimeoutSeconds returns a boolean if a field has been set.
+func (o *Configurations) HasResilienceTimeoutSeconds() bool {
+	if o != nil && !IsNil(o.ResilienceTimeoutSeconds) {
+		return true
+	}
+
+	return false
+}
+
+// SetResilienceTimeoutSeconds gets a reference to the given int32 and assigns it to the ResilienceTimeoutSeconds field.
+func (o *Configurations) SetResilienceTimeoutSeconds(v int32) {
+	o.ResilienceTimeoutSeconds = &v
+}
+
 func (o Configurations) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -364,6 +398,9 @@ func (o Configurations) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.OauthConfig) {
 		toSerialize["oauthConfig"] = o.OauthConfig
+	}
+	if !IsNil(o.ResilienceTimeoutSeconds) {
+		toSerialize["resilienceTimeoutSeconds"] = o.ResilienceTimeoutSeconds
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/spec/model_promote_agent_request.go
+++ b/agent-manager-service/spec/model_promote_agent_request.go
@@ -39,6 +39,8 @@ type PromoteAgentRequest struct {
 	// Enable OAuth security for the agent endpoint in the target environment. Mutually exclusive with enableApiKeySecurity.
 	EnableOAuthSecurity *bool        `json:"enableOAuthSecurity,omitempty"`
 	OauthConfig         *OAuthConfig `json:"oauthConfig,omitempty"`
+	// Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in the target environment. Omit to inherit the source environment's value.
+	ResilienceTimeoutSeconds *int32 `json:"resilienceTimeoutSeconds,omitempty"`
 }
 
 // NewPromoteAgentRequest instantiates a new PromoteAgentRequest object
@@ -407,6 +409,38 @@ func (o *PromoteAgentRequest) SetOauthConfig(v OAuthConfig) {
 	o.OauthConfig = &v
 }
 
+// GetResilienceTimeoutSeconds returns the ResilienceTimeoutSeconds field value if set, zero value otherwise.
+func (o *PromoteAgentRequest) GetResilienceTimeoutSeconds() int32 {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		var ret int32
+		return ret
+	}
+	return *o.ResilienceTimeoutSeconds
+}
+
+// GetResilienceTimeoutSecondsOk returns a tuple with the ResilienceTimeoutSeconds field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PromoteAgentRequest) GetResilienceTimeoutSecondsOk() (*int32, bool) {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		return nil, false
+	}
+	return o.ResilienceTimeoutSeconds, true
+}
+
+// HasResilienceTimeoutSeconds returns a boolean if a field has been set.
+func (o *PromoteAgentRequest) HasResilienceTimeoutSeconds() bool {
+	if o != nil && !IsNil(o.ResilienceTimeoutSeconds) {
+		return true
+	}
+
+	return false
+}
+
+// SetResilienceTimeoutSeconds gets a reference to the given int32 and assigns it to the ResilienceTimeoutSeconds field.
+func (o *PromoteAgentRequest) SetResilienceTimeoutSeconds(v int32) {
+	o.ResilienceTimeoutSeconds = &v
+}
+
 func (o PromoteAgentRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -445,6 +479,9 @@ func (o PromoteAgentRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.OauthConfig) {
 		toSerialize["oauthConfig"] = o.OauthConfig
+	}
+	if !IsNil(o.ResilienceTimeoutSeconds) {
+		toSerialize["resilienceTimeoutSeconds"] = o.ResilienceTimeoutSeconds
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/spec/model_update_agent_deploy_settings_request.go
+++ b/agent-manager-service/spec/model_update_agent_deploy_settings_request.go
@@ -31,6 +31,8 @@ type UpdateAgentDeploySettingsRequest struct {
 	// Enable OAuth security for the agent endpoint in this environment. Mutually exclusive with enableApiKeySecurity. Omit to keep the current value.
 	EnableOAuthSecurity *bool        `json:"enableOAuthSecurity,omitempty"`
 	OauthConfig         *OAuthConfig `json:"oauthConfig,omitempty"`
+	// Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Omit to keep the current value.
+	ResilienceTimeoutSeconds *int32 `json:"resilienceTimeoutSeconds,omitempty"`
 }
 
 // NewUpdateAgentDeploySettingsRequest instantiates a new UpdateAgentDeploySettingsRequest object
@@ -278,6 +280,38 @@ func (o *UpdateAgentDeploySettingsRequest) SetOauthConfig(v OAuthConfig) {
 	o.OauthConfig = &v
 }
 
+// GetResilienceTimeoutSeconds returns the ResilienceTimeoutSeconds field value if set, zero value otherwise.
+func (o *UpdateAgentDeploySettingsRequest) GetResilienceTimeoutSeconds() int32 {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		var ret int32
+		return ret
+	}
+	return *o.ResilienceTimeoutSeconds
+}
+
+// GetResilienceTimeoutSecondsOk returns a tuple with the ResilienceTimeoutSeconds field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *UpdateAgentDeploySettingsRequest) GetResilienceTimeoutSecondsOk() (*int32, bool) {
+	if o == nil || IsNil(o.ResilienceTimeoutSeconds) {
+		return nil, false
+	}
+	return o.ResilienceTimeoutSeconds, true
+}
+
+// HasResilienceTimeoutSeconds returns a boolean if a field has been set.
+func (o *UpdateAgentDeploySettingsRequest) HasResilienceTimeoutSeconds() bool {
+	if o != nil && !IsNil(o.ResilienceTimeoutSeconds) {
+		return true
+	}
+
+	return false
+}
+
+// SetResilienceTimeoutSeconds gets a reference to the given int32 and assigns it to the ResilienceTimeoutSeconds field.
+func (o *UpdateAgentDeploySettingsRequest) SetResilienceTimeoutSeconds(v int32) {
+	o.ResilienceTimeoutSeconds = &v
+}
+
 func (o UpdateAgentDeploySettingsRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -306,6 +340,9 @@ func (o UpdateAgentDeploySettingsRequest) ToMap() (map[string]interface{}, error
 	}
 	if !IsNil(o.OauthConfig) {
 		toSerialize["oauthConfig"] = o.OauthConfig
+	}
+	if !IsNil(o.ResilienceTimeoutSeconds) {
+		toSerialize["resilienceTimeoutSeconds"] = o.ResilienceTimeoutSeconds
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/tests/promote_agent_test.go
+++ b/agent-manager-service/tests/promote_agent_test.go
@@ -314,7 +314,7 @@ func TestPromoteAgent(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
 		require.Equal(t, utils.ErrCodeValidation, errResp.Code)
 		require.Equal(t,
-			"useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, instrumentationVersion, enableApiKeySecurity, corsConfig, enableOAuthSecurity, and oauthConfig",
+			"useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, instrumentationVersion, enableApiKeySecurity, corsConfig, enableOAuthSecurity, oauthConfig, and resilienceTimeoutSeconds",
 			errResp.Message)
 
 		// The agent must not have been promoted.

--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -129,6 +129,7 @@ func convertToConfigurations(configs *models.Configurations) *spec.Configuration
 		EnableAutoInstrumentation: configs.EnableAutoInstrumentation,
 		EnableApiKeySecurity:      configs.EnableApiKeySecurity,
 		EnableOAuthSecurity:       configs.EnableOAuthSecurity,
+		ResilienceTimeoutSeconds:  configs.ResilienceTimeoutSeconds,
 	}
 	// Surface the pinned AMP instrumentation version on reads so the deploy/promote
 	// UI shows the currently-applied version instead of falling back to the platform

--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -172,6 +172,7 @@ func PopulateConfigurationResponseFromAgentConfig(resp *spec.ConfigurationRespon
 	resp.InstrumentationVersion = cfg.InstrumentationVersion
 	resp.EnableApiKeySecurity = spec.PtrBool(cfg.EnableApiKeySecurity)
 	resp.EnableOAuthSecurity = spec.PtrBool(cfg.EnableOAuthSecurity)
+	resp.ResilienceTimeoutSeconds = cfg.ResilienceTimeoutSeconds
 	resp.CorsConfig = &spec.CORSConfig{
 		Enabled:          spec.PtrBool(cfg.CORSEnabled),
 		AllowOrigin:      cfg.CORSAllowOrigins,

--- a/agent-manager-service/utils/utils.go
+++ b/agent-manager-service/utils/utils.go
@@ -849,8 +849,9 @@ func ValidatePromoteAgentRequest(payload *spec.PromoteAgentRequest) error {
 			payload.EnableApiKeySecurity != nil ||
 			payload.CorsConfig != nil ||
 			payload.EnableOAuthSecurity != nil ||
-			payload.OauthConfig != nil {
-			return fmt.Errorf("useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, instrumentationVersion, enableApiKeySecurity, corsConfig, enableOAuthSecurity, and oauthConfig")
+			payload.OauthConfig != nil ||
+			payload.ResilienceTimeoutSeconds != nil {
+			return fmt.Errorf("useConfigFromSourceEnv=true is mutually exclusive with env, files, enableAutoInstrumentation, instrumentationVersion, enableApiKeySecurity, corsConfig, enableOAuthSecurity, oauthConfig, and resilienceTimeoutSeconds")
 		}
 	}
 

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -2040,6 +2040,9 @@ type ConfigurationResponse struct {
 
 	// ProjectName Name of the project
 	ProjectName string `json:"projectName"`
+
+	// ResilienceTimeoutSeconds Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Defaults to 30 seconds when unset.
+	ResilienceTimeoutSeconds *int `json:"resilienceTimeoutSeconds,omitempty"`
 }
 
 // Configurations defines model for Configurations.
@@ -2071,6 +2074,9 @@ type Configurations struct {
 
 	// OauthConfig OAuth security configuration for the agent endpoint. Callers authenticate with a standard Authorization Bearer token validated by the gateway.
 	OauthConfig *OAuthConfig `json:"oauthConfig,omitempty"`
+
+	// ResilienceTimeoutSeconds Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Defaults to 30 seconds when unset.
+	ResilienceTimeoutSeconds *int `json:"resilienceTimeoutSeconds,omitempty"`
 }
 
 // CostRateLimit defines model for CostRateLimit.
@@ -4319,6 +4325,9 @@ type PromoteAgentRequest struct {
 	// OauthConfig OAuth security configuration for the agent endpoint. Callers authenticate with a standard Authorization Bearer token validated by the gateway.
 	OauthConfig *OAuthConfig `json:"oauthConfig,omitempty"`
 
+	// ResilienceTimeoutSeconds Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in the target environment. Omit to inherit the source environment's value.
+	ResilienceTimeoutSeconds *int `json:"resilienceTimeoutSeconds,omitempty"`
+
 	// SourceEnvironment Source environment to promote from
 	SourceEnvironment string `json:"sourceEnvironment"`
 
@@ -4945,6 +4954,9 @@ type UpdateAgentDeploySettingsRequest struct {
 
 	// OauthConfig OAuth security configuration for the agent endpoint. Callers authenticate with a standard Authorization Bearer token validated by the gateway.
 	OauthConfig *OAuthConfig `json:"oauthConfig,omitempty"`
+
+	// ResilienceTimeoutSeconds Max duration (seconds) the gateway keeps a response open between the agent and the client before cutting it off, for this agent's endpoint in this environment. Omit to keep the current value.
+	ResilienceTimeoutSeconds *int `json:"resilienceTimeoutSeconds,omitempty"`
 }
 
 // UpdateAgentKindRequest defines model for UpdateAgentKindRequest.

--- a/console/workspaces/libs/types/src/api/deployments.ts
+++ b/console/workspaces/libs/types/src/api/deployments.ts
@@ -44,6 +44,7 @@ export interface UpdateAgentDeploySettingsRequest {
   enableOAuthSecurity?: boolean;
   corsConfig?: CorsConfig;
   oauthConfig?: OAuthConfig;
+  resilienceTimeoutSeconds?: number;
 }
 
 export type UpdateAgentDeploySettingsPathParams = AgentPathParams;
@@ -139,6 +140,11 @@ export interface ConfigurationResponse {
   enableOAuthSecurity?: boolean;
   corsConfig?: CorsConfig;
   oauthConfig?: OAuthConfig;
+  /**
+   * Max duration (seconds) the gateway keeps a response open between the agent and the
+   * client before cutting it off, for this agent's endpoint in this environment.
+   */
+  resilienceTimeoutSeconds?: number;
   configurations: ConfigurationData;
 }
 

--- a/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
@@ -413,6 +413,12 @@ export function DeployCard(props: DeployCardProps) {
     ? corsOrigins.includes("*") ? "All origins" : `${corsOrigins.length} origin${corsOrigins.length !== 1 ? "s" : ""}`
     : "Disabled";
 
+  const resilienceTimeoutSeconds = envConfig?.resilienceTimeoutSeconds ?? 30;
+  const isWholeMinutes = resilienceTimeoutSeconds >= 60 && resilienceTimeoutSeconds % 60 === 0;
+  const resilienceTimeoutLabel = isWholeMinutes
+    ? `${resilienceTimeoutSeconds / 60}m`
+    : `${resilienceTimeoutSeconds}s`;
+
   const kindName = agent?.kindName;
 
   const { data: kindVersions } = useListAgentKindVersions(
@@ -676,6 +682,21 @@ export function DeployCard(props: DeployCardProps) {
                           size="small"
                           label={authLabel}
                           color={authMode === "none" ? "default" : "success"}
+                          variant="outlined"
+                          sx={{ height: 18, fontSize: "0.65rem", cursor: "default" }}
+                        />
+                      </Tooltip>
+                    </Box>
+                  )}
+                  {isApiAgent && (
+                    <Box display="flex" alignItems="center" gap={1}>
+                      <Clock size={14} style={{ opacity: 0.6 }} />
+                      <Typography variant="body2">Gateway Timeout</Typography>
+                      <Tooltip title="Max duration the gateway keeps a response open between this agent and the client before cutting it off">
+                        <Chip
+                          size="small"
+                          label={resilienceTimeoutLabel}
+                          color="default"
                           variant="outlined"
                           sx={{ height: 18, fontSize: "0.65rem", cursor: "default" }}
                         />

--- a/console/workspaces/pages/deploy/src/subComponent/SecurityConfigSections.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/SecurityConfigSections.tsx
@@ -39,8 +39,11 @@ import {
   FormControlLabel,
   FormHelperText,
   FormLabel,
+  Grid,
+  MenuItem,
   Radio,
   RadioGroup,
+  Select,
   Switch,
   TextField,
   Typography,
@@ -53,6 +56,22 @@ import {
   useMemo,
   useState,
 } from "react";
+
+const DEFAULT_RESILIENCE_TIMEOUT_SECONDS = 30;
+const MIN_RESILIENCE_TIMEOUT_SECONDS = 1;
+const MAX_RESILIENCE_TIMEOUT_SECONDS = 3600;
+
+type TimeoutUnit = "seconds" | "minutes";
+
+// Displays a persisted seconds value in the larger unit when it divides evenly, purely so the
+// input doesn't show "600" when "10 minutes" reads more naturally — the persisted value is
+// always seconds regardless of which unit the user views/edits it in.
+function toDurationAndUnit(seconds: number): { duration: string; unit: TimeoutUnit } {
+  if (seconds >= 60 && seconds % 60 === 0) {
+    return { duration: String(seconds / 60), unit: "minutes" };
+  }
+  return { duration: String(seconds), unit: "seconds" };
+}
 
 export interface SecurityConfigHandle {
   // Returns true when the current selection is valid (e.g. OAuth has an issuer).
@@ -117,6 +136,17 @@ export const SecurityConfigSections = forwardRef<SecurityConfigHandle, SecurityC
       "authorization", "Content-Type", "Origin", "X-API-Key",
     ]);
     const [corsAllowCredentials, setCorsAllowCredentials] = useState(false);
+    const [timeoutDuration, setTimeoutDuration] = useState("30");
+    const [timeoutUnit, setTimeoutUnit] = useState<TimeoutUnit>("seconds");
+
+    useEffect(() => {
+      if (!open) return;
+      const seconds =
+        configurations?.resilienceTimeoutSeconds ?? DEFAULT_RESILIENCE_TIMEOUT_SECONDS;
+      const { duration, unit } = toDurationAndUnit(seconds);
+      setTimeoutDuration(duration);
+      setTimeoutUnit(unit);
+    }, [open, configurations?.resilienceTimeoutSeconds]);
 
     // Seed CORS from the env-scoped config on open; reset to defaults when no persisted config
     // exists so stale edits from a previous open don't leak across reopens.
@@ -175,14 +205,31 @@ export const SecurityConfigSections = forwardRef<SecurityConfigHandle, SecurityC
     const hasWildcardOrigin = corsAllowAll || corsOrigins.includes("*");
     const oauthInvalid = isApiAgent && authMode === "oauth" && oauthIssuers.length === 0;
 
+    const resilienceTimeoutSeconds = timeoutUnit === "minutes"
+      ? Number(timeoutDuration) * 60
+      : Number(timeoutDuration);
+    const timeoutInvalid = isApiAgent && (
+      timeoutDuration.trim() === ""
+      || !Number.isFinite(resilienceTimeoutSeconds)
+      || resilienceTimeoutSeconds < MIN_RESILIENCE_TIMEOUT_SECONDS
+      || resilienceTimeoutSeconds > MAX_RESILIENCE_TIMEOUT_SECONDS
+    );
+
+
+    const handleTimeoutBlur = () => {
+      if (!timeoutInvalid) return;
+      setTimeoutDuration(String(DEFAULT_RESILIENCE_TIMEOUT_SECONDS));
+      setTimeoutUnit("seconds");
+    };
+
     useEffect(() => {
-      onValidityChange?.(!oauthInvalid);
-    }, [oauthInvalid, onValidityChange]);
+      onValidityChange?.(!oauthInvalid && !timeoutInvalid);
+    }, [oauthInvalid, timeoutInvalid, onValidityChange]);
 
     useImperativeHandle(
       ref,
       () => ({
-        validate: () => !oauthInvalid,
+        validate: () => !oauthInvalid && !timeoutInvalid,
         buildBody: () => {
           if (!isApiAgent) return {};
           return {
@@ -204,13 +251,17 @@ export const SecurityConfigSections = forwardRef<SecurityConfigHandle, SecurityC
               allowHeaders: corsHeaders,
               allowCredentials: hasWildcardOrigin ? false : corsAllowCredentials,
             },
+            resilienceTimeoutSeconds: timeoutInvalid
+              ? DEFAULT_RESILIENCE_TIMEOUT_SECONDS
+              : resilienceTimeoutSeconds,
           };
         },
       }),
       [
         isApiAgent, oauthInvalid, authMode, oauthIssuers, oauthAudiences, oauthHeaderName,
         oauthHeaderPrefix, oauthForwardToken, corsEnabled, corsOrigins, corsMethods,
-        corsHeaders, corsAllowCredentials, hasWildcardOrigin,
+        corsHeaders, corsAllowCredentials, hasWildcardOrigin, timeoutInvalid,
+        resilienceTimeoutSeconds,
       ],
     );
 
@@ -526,6 +577,50 @@ export const SecurityConfigSections = forwardRef<SecurityConfigHandle, SecurityC
               </Form.Stack>
             </Collapse>
           </Form.Stack>
+        </Form.Section>
+        <Form.Section>
+          <Form.Header>Gateway Timeout</Form.Header>
+          <Form.Subheader>
+            Max duration the gateway keeps a response open between this agent and the client
+          </Form.Subheader>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <FormControl fullWidth size="small" error={timeoutInvalid}>
+                <FormLabel>Duration</FormLabel>
+                <TextField
+                  size="small"
+                  type="number"
+                  placeholder="e.g. 30"
+                  value={timeoutDuration}
+                  onChange={(e) => setTimeoutDuration(e.target.value)}
+                  onBlur={handleTimeoutBlur}
+                  disabled={disabled}
+                  error={timeoutInvalid}
+                  helperText={
+                    timeoutInvalid
+                      ? `Enter a duration between ${MIN_RESILIENCE_TIMEOUT_SECONDS}s and `
+                        + `${MAX_RESILIENCE_TIMEOUT_SECONDS / 60}m`
+                      : undefined
+                  }
+                  slotProps={{ input: { inputProps: { min: 1, step: 1 } } }}
+                />
+              </FormControl>
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <FormControl fullWidth size="small">
+                <FormLabel>Unit</FormLabel>
+                <Select
+                  size="small"
+                  value={timeoutUnit}
+                  onChange={(e) => setTimeoutUnit(e.target.value as TimeoutUnit)}
+                  disabled={disabled}
+                >
+                  <MenuItem value="seconds">Seconds</MenuItem>
+                  <MenuItem value="minutes">Minutes</MenuItem>
+                </Select>
+              </FormControl>
+            </Grid>
+          </Grid>
         </Form.Section>
       </>
     );

--- a/console/workspaces/pages/deploy/src/subComponent/SecurityConfigSections.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/SecurityConfigSections.tsx
@@ -211,6 +211,7 @@ export const SecurityConfigSections = forwardRef<SecurityConfigHandle, SecurityC
     const timeoutInvalid = isApiAgent && (
       timeoutDuration.trim() === ""
       || !Number.isFinite(resilienceTimeoutSeconds)
+      || !Number.isInteger(resilienceTimeoutSeconds)
       || resilienceTimeoutSeconds < MIN_RESILIENCE_TIMEOUT_SECONDS
       || resilienceTimeoutSeconds > MAX_RESILIENCE_TIMEOUT_SECONDS
     );

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
@@ -62,8 +62,7 @@ gateway:
     key: "token"
 
 # APIGateway CR configuration (deployed by gateway-operator)
-# Development mode: relaxes security checks (e.g. auto-generates encryption keys).
-# Set to false in production and configure gateway.controller.encryptionKeys instead.
+# Development mode
 developmentMode: true
 
 # kgateway ingress the gw-route HTTPRoute attaches to. This is the shared

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
@@ -60,6 +60,10 @@ spec:
           type: string
           description: "Artifact UUID injected as gateway.api-platform.wso2.com/artifact-id annotation on the RestApi"
           default: ""
+        resilienceTimeout:
+          type: string
+          description: "Max streaming/request duration for this API's routes (gateway duration string, e.g. '30s'). Applied as spec.resilience.timeout on the generated RestApi."
+          default: "30s"
       required:
         - apiName
 
@@ -76,6 +80,10 @@ spec:
         artifactId:
           type: string
           description: "Per-environment artifact UUID override. When set, takes precedence over parameters.artifactId."
+          default: ""
+        resilienceTimeout:
+          type: string
+          description: "Per-environment resilience.timeout override. When set, takes precedence over parameters.resilienceTimeout."
           default: ""
 
   creates:
@@ -129,6 +137,10 @@ spec:
           policies: |
             ${has(environmentConfigs.policies) ? dyn(environmentConfigs.policies) : dyn(parameters.policies)}
           operations: ${parameters.operations}
+          # idleTimeout is always disabled ("0s") — not user-configurable.
+          resilience:
+            timeout: "${has(environmentConfigs.resilienceTimeout) && environmentConfigs.resilienceTimeout != '' ? environmentConfigs.resilienceTimeout : parameters.resilienceTimeout}"
+            idleTimeout: "0s"
 
   patches:
     # --- Patch HTTPRoute: Route traffic through WSO2 API Platform router ---
@@ -166,3 +178,19 @@ spec:
                 path:
                   type: ReplacePrefixMatch
                   replacePrefixMatch: /${metadata.environmentName}-${metadata.componentNamespace}-${metadata.componentName}
+
+        # --- Patch HTTPRoute: Disable this outer kgateway hop's own request timeout ---
+        # Real enforcement now lives in the RestApi's own spec.resilience.timeout (set
+        # above from parameters.resilienceTimeout), which the WSO2 API Platform Gateway
+        # enforces at the actual upstream hop. Leaving this outer hop's hardcoded 30s in
+        # place would silently cut off any SSE/streaming response before the user's
+        # configured resilience.timeout ever gets a chance to apply — the same reasoning
+        # already applied to /mcp and /api/internal/v1/ws in oc-ingress.yaml.
+        # Uses "add" (not "replace"): the internal HTTPRoute has no pre-existing
+        # /spec/rules/0/timeouts key, and JSON Patch "replace" requires the target
+        # path to already exist, while "add" both creates it (internal route) and
+        # overwrites it (external route) as needed.
+        - op: add
+          path: /spec/rules/0/timeouts
+          value:
+            request: 0s

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
@@ -315,6 +315,7 @@ spec:
             backendRefs:
             - name: ${metadata.componentName}
               port: ${workload.endpoints[endpoint].port}
+            # Overwritten to 0s by the api-configuration trait's HTTPRoute patch
             timeouts:
               request: 30s
 

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -37,7 +37,7 @@ else
 fi
 
 # WSO2 API Platform / Gateway Operator versions
-GATEWAY_OPERATOR_VERSION="0.10.0"
+GATEWAY_OPERATOR_VERSION="0.10.1"
 # gateway-controller/gateway-runtime 1.1.x reject every RestApi/LlmProvider
 # deployment with a bare 404 despite correctly-configured basic auth (confirmed
 # via a live tcpdump of the operator's request — same 404 across 1.1.0 and
@@ -45,8 +45,12 @@ GATEWAY_OPERATOR_VERSION="0.10.0"
 # reaches Programmed=True). Chart *version* and container *image tag* are
 # pinned separately below — setting chartVersion alone still runs an older
 # default image, so GATEWAY_IMAGE_VERSION must also be threaded through.
-GATEWAY_CHART_VERSION="1.2.0-alpha"
-GATEWAY_IMAGE_VERSION="1.2.0-alpha2"
+GATEWAY_CHART_VERSION="1.2.0-beta"
+GATEWAY_IMAGE_VERSION="1.2.0-beta"
+
+# The 1.2.0-beta gateway chart requires an encryption key to be mounted from a Kubernetes Secret
+GATEWAY_ENCRYPTION_SECRET_NAME="gateway-encryption-keys"
+GATEWAY_ENCRYPTION_SECRET_KEY="default-aesgcm256-v1.bin"
 
 # OpenChoreo community module versions compatible with OpenChoreo ${OPENCHOREO_VERSION}
 OBSERVABILITY_LOGS_OPENSEARCH_VERSION="0.4.1"
@@ -1454,6 +1458,8 @@ helm_install_idempotent \
     --set gateway.values.gateway.controller.image.repository=ghcr.io/wso2/api-platform/gateway-controller \
     --set "gateway.values.gateway.gatewayRuntime.image.tag=${GATEWAY_IMAGE_VERSION}" \
     --set gateway.values.gateway.gatewayRuntime.image.repository=ghcr.io/wso2/api-platform/gateway-runtime \
+    --set gateway.values.gateway.controller.encryptionKeys.enabled=true \
+    --set "gateway.values.gateway.controller.encryptionKeys.secretName=${GATEWAY_ENCRYPTION_SECRET_NAME}" \
     --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/api/admin/v1/health \
     --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.port=admin \
     --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/api/admin/v1/health \

--- a/deployments/scripts/add-environment.sh
+++ b/deployments/scripts/add-environment.sh
@@ -355,6 +355,22 @@ echo "🌐 Installing API Platform Gateway for '${ENV_NAME}'..."
 kubectl create namespace "${GATEWAY_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - > /dev/null
 kubectl label namespace "${GATEWAY_NAMESPACE}" "amp.wso2.com/api-platform-gateway=true" --overwrite > /dev/null
 
+# gateway-controller 1.2.0-beta requires an AES-256 at-rest encryption key,
+# mounted from a Secret in the SAME namespace as the gateway release 
+GATEWAY_ENCRYPTION_SECRET_NAME="${GATEWAY_ENCRYPTION_SECRET_NAME:-gateway-encryption-keys}"
+GATEWAY_ENCRYPTION_SECRET_KEY="${GATEWAY_ENCRYPTION_SECRET_KEY:-default-aesgcm256-v1.bin}"
+if kubectl get secret "${GATEWAY_ENCRYPTION_SECRET_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
+    echo "⏭️  Gateway encryption key secret '${GATEWAY_ENCRYPTION_SECRET_NAME}' already exists in '${GATEWAY_NAMESPACE}', leaving it untouched."
+else
+    echo "🔑 Provisioning gateway at-rest encryption key in '${GATEWAY_NAMESPACE}'..."
+    key_tmp="$(mktemp)"
+    openssl rand 32 > "${key_tmp}"
+    kubectl create secret generic "${GATEWAY_ENCRYPTION_SECRET_NAME}" -n "${GATEWAY_NAMESPACE}" \
+        "--from-file=${GATEWAY_ENCRYPTION_SECRET_KEY}=${key_tmp}"
+    rm -f "${key_tmp}" # don't leave the plaintext key on disk
+    echo "✅ Gateway encryption key secret created"
+fi
+
 # Release name must match the gateway runtime service lookup expected by
 # the kgateway routes (api-platform-<org>-<env> derives from _helpers.tpl
 # apiGatewayName). DO NOT duplicate the org segment.

--- a/deployments/setup/env.sh
+++ b/deployments/setup/env.sh
@@ -4,9 +4,13 @@ CLUSTER_NAME="${CLUSTER_NAME:-openchoreo-local-setup}"
 CLUSTER_CONTEXT="k3d-${CLUSTER_NAME}"
 
 # WSO2 API Platform / Gateway Operator versions
-GATEWAY_OPERATOR_VERSION="0.10.0"
-GATEWAY_CHART_VERSION="1.2.0-alpha"
-GATEWAY_IMAGE_VERSION="1.2.0-alpha2"
+GATEWAY_OPERATOR_VERSION="0.10.1"
+GATEWAY_CHART_VERSION="1.2.0-beta"
+GATEWAY_IMAGE_VERSION="1.2.0-beta"
+
+
+GATEWAY_ENCRYPTION_SECRET_NAME="gateway-encryption-keys"
+GATEWAY_ENCRYPTION_SECRET_KEY="default-aesgcm256-v1.bin"
 
 # OpenChoreo community module versions compatible with OpenChoreo 1.1.1
 OBSERVABILITY_LOGS_OPENSEARCH_VERSION="0.4.1"

--- a/deployments/setup/setup-gateway.sh
+++ b/deployments/setup/setup-gateway.sh
@@ -99,6 +99,20 @@ echo "🌐 Installing gateway chart..."
 kubectl create namespace "${GATEWAY_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f - > /dev/null
 kubectl label namespace "${GATEWAY_NAMESPACE}" "amp.wso2.com/api-platform-gateway=true" --overwrite > /dev/null
 
+GATEWAY_ENCRYPTION_SECRET_NAME="${GATEWAY_ENCRYPTION_SECRET_NAME:-gateway-encryption-keys}"
+GATEWAY_ENCRYPTION_SECRET_KEY="${GATEWAY_ENCRYPTION_SECRET_KEY:-default-aesgcm256-v1.bin}"
+if kubectl get secret "${GATEWAY_ENCRYPTION_SECRET_NAME}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
+    echo "⏭️  Gateway encryption key secret '${GATEWAY_ENCRYPTION_SECRET_NAME}' already exists in '${GATEWAY_NAMESPACE}', leaving it untouched."
+else
+    echo "🔑 Provisioning gateway at-rest encryption key in '${GATEWAY_NAMESPACE}'..."
+    key_tmp="$(mktemp)"
+    openssl rand 32 > "${key_tmp}"
+    kubectl create secret generic "${GATEWAY_ENCRYPTION_SECRET_NAME}" -n "${GATEWAY_NAMESPACE}" \
+        "--from-file=${GATEWAY_ENCRYPTION_SECRET_KEY}=${key_tmp}"
+    rm -f "${key_tmp}" # don't leave the plaintext key on disk
+    echo "✅ Gateway encryption key secret created"
+fi
+
 helm "${HELM_ARGS[@]}"
 
 echo "⏳ Waiting for Gateway to be ready..."

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -515,6 +515,8 @@ else
         --set gateway.values.gateway.controller.image.repository=ghcr.io/wso2/api-platform/gateway-controller \
         --set "gateway.values.gateway.gatewayRuntime.image.tag=${GATEWAY_IMAGE_VERSION}" \
         --set gateway.values.gateway.gatewayRuntime.image.repository=ghcr.io/wso2/api-platform/gateway-runtime \
+        --set gateway.values.gateway.controller.encryptionKeys.enabled=true \
+        --set "gateway.values.gateway.controller.encryptionKeys.secretName=${GATEWAY_ENCRYPTION_SECRET_NAME}" \
         --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.path=/api/admin/v1/health \
         --set gateway.values.gateway.controller.deployment.livenessProbe.httpGet.port=admin \
         --set gateway.values.gateway.controller.deployment.readinessProbe.httpGet.path=/api/admin/v1/health \


### PR DESCRIPTION
## Purpose
The api platform gateway hardcodes a 30-second request timeout on every route it generates for an agent's API endpoint. This silently cuts off any response that takes longer than 30s — most notably streaming/SSE responses (chat completions, long-running tool calls) with no way for a user to configure it per agent.
fixes : #1383

## Goals

- Make the gateway's response timeout for an agent's API endpoint configurable per agent, per environment, instead of a fixed 30s.
- Preserve today's effective behavior by default: unset stays at 30s.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable **Gateway Timeout** (`resilienceTimeoutSeconds`) for API agents (min **1s**, max **3600s**, default **30s**), exposed through API/console deploy, promotion, and retrieval, and wired into gateway trait/Helm configuration.
  * Added persistence support via a new database column and UI display/edit (with seconds/minutes formatting).
* **Bug Fixes**
  * Enforced min/max validation and updated request validation to prevent combining timeout overrides with source-env mode.
* **Chores**
  * Updated gateway operator/chart/runtime version pins and added automatic provisioning of gateway encryption key secrets during install/setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->