### PR TITLE
Derive MCP resource identifiers from mergeable scalars

### DIFF
--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1569,7 +1569,8 @@ data:
     # authorization checks expect.
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
-    {{- $identifier := printf "%s/" (index $.Values.thunder.bootstrap .baseUrlValue) }}
+    {{- $base := index $.Values.thunder.bootstrap .baseUrlValue | required (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
+    {{- $identifier := printf "%s/" (trimSuffix "/" $base) }}
     MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
     log_info "MCP resource server '{{ $identifier }}' ready (id: $MCP_RS_ID)"
 

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1569,8 +1569,9 @@ data:
     # authorization checks expect.
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
-    MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ .identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
-    log_info "MCP resource server '{{ .identifier }}' ready (id: $MCP_RS_ID)"
+    {{- $identifier := printf "%s/" (index $.Values.thunder.bootstrap .baseUrlValue) }}
+    MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
+    log_info "MCP resource server '{{ $identifier }}' ready (id: $MCP_RS_ID)"
 
     # Remediation: a resource server seeded by an older bootstrap carries a
     # non-empty handle. The handle is immutable and would prefix every derived
@@ -1587,7 +1588,7 @@ data:
     fi
     MCP_RS_HANDLE=$(echo "$BODY" | grep -o '"handle":"[^"]*"' | head -1 | cut -d'"' -f4)
     if [[ -n "$MCP_RS_HANDLE" ]]; then
-      log_warning "Resource server '{{ .identifier }}' has legacy handle '$MCP_RS_HANDLE'; deleting and recreating it with an empty handle..."
+      log_warning "Resource server '{{ $identifier }}' has legacy handle '$MCP_RS_HANDLE'; deleting and recreating it with an empty handle..."
       RESPONSE=$(api_call DELETE "/resource-servers/${MCP_RS_ID}")
       HTTP_CODE="${RESPONSE: -3}"
       BODY="${RESPONSE%???}"
@@ -1595,12 +1596,12 @@ data:
         log_error "Failed to delete legacy resource server ${MCP_RS_ID} (HTTP $HTTP_CODE): $BODY"
         exit 1
       fi
-      MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ .identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
-      log_info "MCP resource server '{{ .identifier }}' recreated (id: $MCP_RS_ID)"
+      MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
+      log_info "MCP resource server '{{ $identifier }}' recreated (id: $MCP_RS_ID)"
     fi
     MCP_AMP_ROOT=$(create_or_get_resource "$MCP_RS_ID" "Agent Manager" "amp" "Root of the amp permission tree")
     register_amp_permissions "$MCP_RS_ID" "{{ .permissionSet }}" "$MCP_AMP_ROOT"
-    log_info "MCP resource server '{{ .identifier }}': '{{ .permissionSet }}' permission set registered."
+    log_info "MCP resource server '{{ $identifier }}': '{{ .permissionSet }}' permission set registered."
     {{- end }}
     log_success "MCP resource servers registered."
 

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -513,15 +513,27 @@ thunder:
     # re-run the bootstrap job (it automatically replaces MCP resource servers
     # created by an older bootstrap with a non-empty handle); a helm upgrade
     # alone will not re-seed.
+    #
+    # Each resource server's identifier is derived by the bootstrap template from
+    # the base URL named in baseUrlValue, with the trailing slash appended. The
+    # base URLs live as their own scalars below rather than inline here so a
+    # deployment can override just the host: `helm --set` merges a scalar, but
+    # `--set mcpResourceServers[0].identifier=...` REPLACES the whole list element
+    # and silently drops name/handle/description/permissionSet. Point each base
+    # URL at the externally reachable origin of its MCP endpoint's service — the
+    # same value as agent-manager's serverPublicURL and the observability
+    # extension's amObserver.publicUrl. Defaults suit a k3d/local install.
+    agentManagerMcpBaseUrl: "http://localhost:9000"
+    observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"
         handle: ""
-        identifier: "http://localhost:9000/"
+        baseUrlValue: "agentManagerMcpBaseUrl"
         description: "Resource identifier for the agent-manager MCP endpoint"
         permissionSet: "amp-minus-observability"
       - name: "AMP Observer MCP"
         handle: ""
-        identifier: "http://traces.amp.localhost:11080/"
+        baseUrlValue: "observerMcpBaseUrl"
         description: "Resource identifier for the observer MCP endpoint"
         permissionSet: "observability-only"
     # AMP Console Client configuration

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -243,21 +243,23 @@ thunder_helm_args() {
     "--set" "thunder.configuration.cors.allowedOrigins[0]=https://${AMP_HOST_CONSOLE}"
 
   # RFC 8707 resource indicators for the two MCP endpoints. Thunder matches the
-  # authorize request's `resource` parameter against these identifiers verbatim
-  # and answers invalid_target on any mismatch, so they must be the hosts an MCP
-  # client actually dials — not the chart's localhost defaults, which describe a
-  # k3d install. Both MCP endpoints are served by services already exposed here:
-  # the agent-manager one by amp-api (chart default http://localhost:9000/) and
-  # the observer one by the observer itself (default the observability
-  # extension's amObserver.publicUrl). Keep the trailing slash: clients send the
-  # canonical origin with one, and the comparison is exact.
+  # authorize request's `resource` parameter against each resource server's
+  # identifier verbatim and answers invalid_target on any mismatch, so the
+  # identifiers must be the hosts an MCP client actually dials — not the chart's
+  # localhost defaults, which describe a k3d install. Both MCP endpoints are
+  # served by services already exposed here: the agent-manager one by amp-api and
+  # the observer one by the observer itself.
   #
-  # Indices are positional, so they track the order of thunder.bootstrap
-  # .mcpResourceServers in wso2-amp-thunder-extension/values.yaml — agent-manager
-  # first, observer second. Reordering that list silently retargets these.
+  # The bootstrap template builds each identifier from a base-URL scalar and
+  # appends the trailing slash, so override those two scalars rather than the
+  # mcpResourceServers list. A scalar --set merges; --set on a list element
+  # replaces the whole element and would drop its name/handle/description/
+  # permissionSet, which makes Thunder reject the resource server (empty name)
+  # and the bootstrap fail. Pass the base URL without a trailing slash — the
+  # template adds it.
   printf '%s\n' \
-    "--set" "thunder.bootstrap.mcpResourceServers[0].identifier=https://${AMP_HOST_API}/" \
-    "--set" "thunder.bootstrap.mcpResourceServers[1].identifier=https://${AMP_HOST_OBSERVER}/"
+    "--set" "thunder.bootstrap.agentManagerMcpBaseUrl=https://${AMP_HOST_API}" \
+    "--set" "thunder.bootstrap.observerMcpBaseUrl=https://${AMP_HOST_OBSERVER}"
 
   # The console client's registered redirect URI lives under `setup` (<=main) and
   # was renamed to `bootstrap` (>=0.15.0, which is what the registration template

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -184,12 +184,17 @@ assert_eq "thunder console redirectUri (legacy setup key)" \
 # RFC 8707 resource indicators. Thunder compares the authorize request's
 # `resource` verbatim, so these must name the hosts an MCP client dials, with the
 # trailing slash the client sends. Index 0 is agent-manager, index 1 the observer.
-assert_eq "thunder MCP resource identifier (agent-manager)" \
-  "thunder.bootstrap.mcpResourceServers[0].identifier=https://api.amp.203.0.113.10.sslip.io/" \
-  "$(grep -F 'mcpResourceServers[0].identifier' <<<"$th")"
-assert_eq "thunder MCP resource identifier (observer)" \
-  "thunder.bootstrap.mcpResourceServers[1].identifier=https://observer.amp.203.0.113.10.sslip.io/" \
-  "$(grep -F 'mcpResourceServers[1].identifier' <<<"$th")"
+# MCP base URLs are set as mergeable scalars (not list-element overrides, which
+# helm --set would replace whole, dropping name/handle/permissionSet). No trailing
+# slash — the bootstrap template appends it.
+assert_eq "thunder MCP base URL (agent-manager)" \
+  "thunder.bootstrap.agentManagerMcpBaseUrl=https://api.amp.203.0.113.10.sslip.io" \
+  "$(grep -F 'agentManagerMcpBaseUrl' <<<"$th")"
+assert_eq "thunder MCP base URL (observer)" \
+  "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.203.0.113.10.sslip.io" \
+  "$(grep -F 'observerMcpBaseUrl' <<<"$th")"
+assert_eq "thunder no fragile mcpResourceServers list override" "no" \
+  "$(has "$th" 'mcpResourceServers[')"
 
 # --- render_k3d_vm_config ---
 k3d_in="$(printf '%s\n' \
@@ -370,12 +375,12 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
     "$(grep -F 'jwt.issuer' <<<"$core_th")"
   # The advanced path reaches the same core, so the MCP resource indicators must
   # follow the configured domain here too.
-  assert_eq "core thunder MCP resource identifier (agent-manager)" \
-    "thunder.bootstrap.mcpResourceServers[0].identifier=https://api.amp.example.com/" \
-    "$(grep -F 'mcpResourceServers[0].identifier' <<<"$core_th")"
-  assert_eq "core thunder MCP resource identifier (observer)" \
-    "thunder.bootstrap.mcpResourceServers[1].identifier=https://observer.amp.example.com/" \
-    "$(grep -F 'mcpResourceServers[1].identifier' <<<"$core_th")"
+  assert_eq "core thunder MCP base URL (agent-manager)" \
+    "thunder.bootstrap.agentManagerMcpBaseUrl=https://api.amp.example.com" \
+    "$(grep -F 'agentManagerMcpBaseUrl' <<<"$core_th")"
+  assert_eq "core thunder MCP base URL (observer)" \
+    "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.example.com" \
+    "$(grep -F 'observerMcpBaseUrl' <<<"$core_th")"
 
   core_obs="$(observability_helm_args)"
   assert_eq "core observability audience carries the public observer URL" \


### PR DESCRIPTION
## Purpose
A VM install fails outright. The Thunder bootstrap job dies, which leaves Thunder unseeded, fails the default env-Thunder provisioning, and aborts the base installer (`exit 1`). Nothing usable comes up. This was found by running the simple path end to end on a fresh VM against the `amp/v0.0.0-dev-20260724` tag (which carries #1396, #1398, #1399).

The cause is the way the VM installer set the MCP resource-server identifiers, introduced in #1398. It overrode `thunder.bootstrap.mcpResourceServers[0].identifier` via `helm --set`, and **`--set` on a list element replaces the whole element rather than merging into it**. The `name`, `handle`, `description`, and `permissionSet` defined next to the identifier in `values.yaml` were dropped, so the bootstrap called `create_or_get_rs` with an empty name:

```
create_or_get_rs "" "" "https://api.amp.<host>/" "" "$DEFAULT_OU_ID"
                  ^^ name  ^^ handle          ^^ description   ← all wiped by --set
```

Thunder rejects a resource server with no name (`HTTP 400 invalid_request_format`), and the now-empty `permissionSet` would have failed the permission registration a step later.

Related to #1396 and #1398.

## Goals
Let a deployment override the MCP resource-server identifiers by host without disturbing the rest of each list element, so the VM install seeds Thunder and the MCP surface works, while a k3d install is unchanged.

## Approach
Move each identifier's host into its own scalar value — `thunder.bootstrap.agentManagerMcpBaseUrl` and `observerMcpBaseUrl` — and have the bootstrap template build the identifier from the scalar named by each list element's new `baseUrlValue` field, appending the trailing slash the RFC 8707 resource indicator requires. `helm --set` merges a scalar, so overriding these two leaves every other field of the list elements intact. The defaults are the previous localhost identifiers, so a k3d install registers exactly what it did before.

The installer (`lib-vm.sh`) now sets those two scalars from the API and observer hosts it already derives, instead of the list-element identifiers.

## User stories
As an operator installing Agent Manager on a VM, the platform comes up and an MCP client pointed at the public hosts is issued a correctly scoped token, rather than the install failing during Thunder bootstrap.

## Release note
Fixed a VM install failure where the Thunder bootstrap rejected the MCP resource servers because the installer's identifier override dropped their other fields.

## Documentation
No documentation change. The exposed hosts and routing are unaffected; this is an internal bootstrap-configuration fix.

## Training
N/A — no training content covers the VM installation path.

## Certification
N/A — no certification exam covers the VM installation path.

## Marketing
N/A — a bug fix.

## Automation tests
 - Unit tests
   > `deployments/vm/tests/run.sh` updated: the installer now emits the two scalar base-URL overrides (no trailing slash) instead of the list-element identifiers, asserted for both the sslip and custom-domain paths, plus a negative assertion that no `mcpResourceServers[` list override is emitted. Suite passes.
 - Integration tests
   > None automated. Validation was manual against a live Thunder; see **Test environment**.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — chart/shell only, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
- #1398 — introduced the list-element `--set` this replaces.
- #1396 — added the MCP resource servers this configures.

## Migrations (if applicable)
N/A for the supported VM flow (fresh install). An existing cluster re-runs the Thunder bootstrap job as documented in #1396.

## Test environment
The failure and the fix were both exercised on a fresh Ubuntu 26.04 VM (simple/sslip.io path, tag `amp/v0.0.0-dev-20260724`), against the real `thunderid:0.45.0` bootstrap.

**Failure, reproduced and isolated.** With the shipped (broken) config, the bootstrap job fails creating the first MCP resource server with `HTTP 400 invalid_request_format`. Re-running the bootstrap in a debug pod three ways pinned the cause: (1) as-is → 400; (2) my sslip identifier swapped back to the localhost default, name still empty → identical 400 (so the identifier value is not at fault); (3) `name`, `description`, and `permissionSet` restored, sslip identifier kept → script 60 completes and both MCP resource servers are created, with Thunder accepting `https://api.amp.<host>/`.

**Fix, verified two ways.** `helm template` with the new scalar override renders `create_or_get_rs "AMP Agent Manager MCP" "" "https://api.amp.<host>/" "Resource identifier for the agent-manager MCP endpoint" "$DEFAULT_OU_ID"` — name and permissionSet preserved, identifier derived with the trailing slash — and without the override it renders the localhost default. That rendered call is exactly the one shown to succeed against real Thunder in step (3) above, so the two compose: the chart change produces the correct call, and that call is known to seed Thunder cleanly. `helm lint` passes.

**End-to-end on the VM.** Packaged the fixed chart, cleared the `amp-thunder` namespace for a fresh DB, and re-installed the Thunder extension standalone with the exact overrides the installer emits (`build_thunder_helm_args`, which now sets the two base-URL scalars). The pre-install bootstrap job that previously failed (`Failed 0/1`, HTTP 400 on the first MCP resource server) now reports **`Complete 1/1`** and `✅ Setup completed successfully!`, and the Thunder deployment comes up Running. This is the same job whose failure aborted the full install.

## Learning
The defect and its earlier miss share one root: a `--set` that emits the right flag can still do the wrong thing, because `--set` merges maps but replaces list elements. #1398's tests asserted the installer emitted `mcpResourceServers[0].identifier=…`; they never rendered the chart to see that the emitted flag wiped the element's other fields. The lesson is to verify the rendered/observed effect, not the emitted flag — which is why this change is checked with `helm template` (and a live bootstrap), not only by asserting the override string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * MCP resource server identifiers are now derived automatically from configured base URLs.
  * Base URLs are normalized with a trailing slash for more consistent resource matching.
  * Updated deployment configuration supports separate Agent Manager and Observer MCP base URLs.
  * Existing legacy MCP resource servers are recreated using the correct derived identifier during bootstrap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->