### PR TITLE
Hide native Administrators group from agent identity APIs

### DIFF
--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -227,6 +227,15 @@ func (c *thunderClient) GetUserGroups(ctx context.Context, userID string) ([]Thu
 
 // --- Groups ---
 
+// NativeAdministratorsGroupName is the group every ThunderID install seeds in its
+// default OU. Its members inherit NativeAdministratorRoleName and therefore
+// Thunder's built-in "system" scope, so group membership is a second path to
+// env-Thunder admin alongside direct role assignment: OU-scoped group listing
+// hides it, and both identity controllers reject reads and writes against it.
+// Thunder enforces unique group names per OU, so post-bootstrap the only group
+// with this name in the default OU is the native one.
+const NativeAdministratorsGroupName = "Administrators"
+
 // ListGroups returns groups scoped to ouID when non-empty, by fetching all pages
 // from Thunder and filtering client-side (Thunder has no OU-scoped list endpoint for groups).
 func (c *thunderClient) ListGroups(ctx context.Context, ouID string, offset, limit int) ([]ThunderGroup, int, error) {
@@ -235,6 +244,9 @@ func (c *thunderClient) ListGroups(ctx context.Context, ouID string, offset, lim
 		return nil, 0, err
 	}
 	if ouID == "" {
+		// The unfiltered instance-wide path deliberately keeps the native
+		// Administrators group: it is the raw view, and a caller sweeping every
+		// group in the instance must still see it.
 		url := fmt.Sprintf("%s/groups?offset=%d&limit=%d", c.baseURL, offset, limit)
 		body, err := c.doRequest(ctx, http.MethodGet, url, token, nil)
 		if err != nil {
@@ -261,7 +273,9 @@ func (c *thunderClient) ListGroups(ctx context.Context, ouID string, offset, lim
 			return nil, 0, fmt.Errorf("thunder list groups decode: %w", err)
 		}
 		for _, g := range wrapped.Groups {
-			if g.OuID == ouID {
+			// Both exclusions happen before paginateGroups runs, so
+			// offset/limit/total describe only the visible groups.
+			if g.OuID == ouID && g.Name != NativeAdministratorsGroupName {
 				all = append(all, g)
 			}
 		}
@@ -270,6 +284,61 @@ func (c *thunderClient) ListGroups(ctx context.Context, ouID string, offset, lim
 			break
 		}
 	}
+	return paginateGroups(all, offset, limit)
+}
+
+// listGroupsInOU returns every group in ouID from Thunder's OU-scoped endpoint,
+// excluding NativeAdministratorsGroupName. It is the single filtered source for
+// ListGroupsByOUId and GetAgentGroups, so the native group cannot leak through
+// either surface.
+func (c *thunderClient) listGroupsInOU(ctx context.Context, ouID string) ([]ThunderGroup, error) {
+	token, err := c.getSystemToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	const fetchSize = 100
+	var all []ThunderGroup
+	fetchOffset := 0
+	for {
+		url := fmt.Sprintf("%s/organization-units/%s/groups?offset=%d&limit=%d", c.baseURL, ouID, fetchOffset, fetchSize)
+		body, err := c.doRequest(ctx, http.MethodGet, url, token, nil)
+		if err != nil {
+			return nil, fmt.Errorf("thunder list groups by ou id: %w", err)
+		}
+		var wrapped thunderGroupList
+		if err := json.Unmarshal(body, &wrapped); err != nil {
+			return nil, fmt.Errorf("thunder list groups by ou id decode: %w", err)
+		}
+		for _, g := range wrapped.Groups {
+			if g.Name != NativeAdministratorsGroupName {
+				all = append(all, g)
+			}
+		}
+		fetchOffset += len(wrapped.Groups)
+		if fetchOffset >= wrapped.TotalResults || len(wrapped.Groups) == 0 {
+			break
+		}
+	}
+	return all, nil
+}
+
+// ListGroupsByOUId returns groups in ouID from Thunder's OU-scoped endpoint with
+// the native Administrators group excluded. Pagination is applied client-side
+// after the exclusion (like ListRoles) so offset/limit/total stay exact — a
+// server-side page filtered after the fact would return short pages and an
+// inflated total.
+func (c *thunderClient) ListGroupsByOUId(ctx context.Context, ouID string, offset, limit int) ([]ThunderGroup, int, error) {
+	all, err := c.listGroupsInOU(ctx, ouID)
+	if err != nil {
+		return nil, 0, err
+	}
+	return paginateGroups(all, offset, limit)
+}
+
+// paginateGroups applies offset/limit to an already-filtered group slice and
+// reports the post-filter total.
+func paginateGroups(all []ThunderGroup, offset, limit int) ([]ThunderGroup, int, error) {
 	total := len(all)
 	if offset < 0 {
 		offset = 0
@@ -282,27 +351,6 @@ func (c *thunderClient) ListGroups(ctx context.Context, ouID string, offset, lim
 		end = total
 	}
 	return all[offset:end], total, nil
-}
-
-// ListGroupsByOUId fetches groups directly from Thunder's OU-scoped endpoint.
-// Uses /organization-units/{ouId}/groups which is more efficient than fetching all groups.
-func (c *thunderClient) ListGroupsByOUId(ctx context.Context, ouID string, offset, limit int) ([]ThunderGroup, int, error) {
-	token, err := c.getSystemToken(ctx)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	url := fmt.Sprintf("%s/organization-units/%s/groups?offset=%d&limit=%d", c.baseURL, ouID, offset, limit)
-	body, err := c.doRequest(ctx, http.MethodGet, url, token, nil)
-	if err != nil {
-		return nil, 0, fmt.Errorf("thunder list groups by ou id: %w", err)
-	}
-
-	var wrapped thunderGroupList
-	if err := json.Unmarshal(body, &wrapped); err != nil {
-		return nil, 0, fmt.Errorf("thunder list groups by ou id decode: %w", err)
-	}
-	return wrapped.Groups, wrapped.TotalResults, nil
 }
 
 func (c *thunderClient) GetGroup(ctx context.Context, groupID string) (*ThunderGroup, error) {
@@ -553,21 +601,13 @@ func (c *thunderClient) GetAgentRoles(ctx context.Context, agentID string) ([]Th
 
 // GetAgentGroups returns the groups an agent identity belongs to, by fanning
 // out over every group in ouID and checking its member entries — Thunder has
-// no reverse-lookup endpoint for "groups this assignee belongs to".
+// no reverse-lookup endpoint for "groups this assignee belongs to". The native
+// Administrators group is excluded with the rest of the group surface, so an
+// agent mis-added to it is never reported as a member.
 func (c *thunderClient) GetAgentGroups(ctx context.Context, ouID, agentID string) ([]ThunderGroup, error) {
-	const pageSize = 50
-	var allGroups []ThunderGroup
-	offset := 0
-	for {
-		page, total, err := c.ListGroupsByOUId(ctx, ouID, offset, pageSize)
-		if err != nil {
-			return nil, fmt.Errorf("thunder get agent groups (list): %w", err)
-		}
-		allGroups = append(allGroups, page...)
-		offset += len(page)
-		if offset >= total || len(page) == 0 {
-			break
-		}
+	allGroups, err := c.listGroupsInOU(ctx, ouID)
+	if err != nil {
+		return nil, fmt.Errorf("thunder get agent groups (list): %w", err)
 	}
 
 	var agentGroups []ThunderGroup

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -236,17 +236,55 @@ func (c *thunderClient) GetUserGroups(ctx context.Context, userID string) ([]Thu
 // with this name in the default OU is the native one.
 const NativeAdministratorsGroupName = "Administrators"
 
+// isVisibleGroup reports whether a group may be surfaced through the identity
+// APIs. It is the single place the native-group exclusion is decided, so every
+// filtered read path stays in agreement.
+func isVisibleGroup(g ThunderGroup) bool {
+	return g.Name != NativeAdministratorsGroupName
+}
+
+// fetchAllGroups pages endpoint to exhaustion and returns the groups keep
+// accepts. Filtering during the sweep rather than after pagination is what lets
+// callers apply offset/limit to the visible set only.
+func (c *thunderClient) fetchAllGroups(ctx context.Context, token, endpoint, errLabel string,
+	keep func(ThunderGroup) bool,
+) ([]ThunderGroup, error) {
+	const fetchSize = 100
+	var all []ThunderGroup
+	fetchOffset := 0
+	for {
+		url := fmt.Sprintf("%s?offset=%d&limit=%d", endpoint, fetchOffset, fetchSize)
+		body, err := c.doRequest(ctx, http.MethodGet, url, token, nil)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", errLabel, err)
+		}
+		var wrapped thunderGroupList
+		if err := json.Unmarshal(body, &wrapped); err != nil {
+			return nil, fmt.Errorf("%s decode: %w", errLabel, err)
+		}
+		for _, g := range wrapped.Groups {
+			if keep(g) {
+				all = append(all, g)
+			}
+		}
+		fetchOffset += len(wrapped.Groups)
+		if fetchOffset >= wrapped.TotalResults || len(wrapped.Groups) == 0 {
+			break
+		}
+	}
+	return all, nil
+}
+
 // ListGroups returns groups scoped to ouID when non-empty, by fetching all pages
-// from Thunder and filtering client-side (Thunder has no OU-scoped list endpoint for groups).
+// from Thunder and filtering client-side (the instance-wide endpoint cannot scope
+// by OU). The ouID=="" branch is the raw instance-wide view and keeps the native
+// Administrators group; it has no production caller today.
 func (c *thunderClient) ListGroups(ctx context.Context, ouID string, offset, limit int) ([]ThunderGroup, int, error) {
 	token, err := c.getSystemToken(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
 	if ouID == "" {
-		// The unfiltered instance-wide path deliberately keeps the native
-		// Administrators group: it is the raw view, and a caller sweeping every
-		// group in the instance must still see it.
 		url := fmt.Sprintf("%s/groups?offset=%d&limit=%d", c.baseURL, offset, limit)
 		body, err := c.doRequest(ctx, http.MethodGet, url, token, nil)
 		if err != nil {
@@ -259,68 +297,25 @@ func (c *thunderClient) ListGroups(ctx context.Context, ouID string, offset, lim
 		return wrapped.Groups, wrapped.TotalResults, nil
 	}
 
-	const fetchSize = 100
-	var all []ThunderGroup
-	fetchOffset := 0
-	for {
-		url := fmt.Sprintf("%s/groups?offset=%d&limit=%d", c.baseURL, fetchOffset, fetchSize)
-		body, err := c.doRequest(ctx, http.MethodGet, url, token, nil)
-		if err != nil {
-			return nil, 0, fmt.Errorf("thunder list groups: %w", err)
-		}
-		var wrapped thunderGroupList
-		if err := json.Unmarshal(body, &wrapped); err != nil {
-			return nil, 0, fmt.Errorf("thunder list groups decode: %w", err)
-		}
-		for _, g := range wrapped.Groups {
-			// Both exclusions happen before paginateGroups runs, so
-			// offset/limit/total describe only the visible groups.
-			if g.OuID == ouID && g.Name != NativeAdministratorsGroupName {
-				all = append(all, g)
-			}
-		}
-		fetchOffset += len(wrapped.Groups)
-		if fetchOffset >= wrapped.TotalResults || len(wrapped.Groups) == 0 {
-			break
-		}
+	all, err := c.fetchAllGroups(ctx, token, c.baseURL+"/groups", "thunder list groups",
+		func(g ThunderGroup) bool { return g.OuID == ouID && isVisibleGroup(g) })
+	if err != nil {
+		return nil, 0, err
 	}
-	return paginateGroups(all, offset, limit)
+	groups, total := paginate(all, offset, limit)
+	return groups, total, nil
 }
 
-// listGroupsInOU returns every group in ouID from Thunder's OU-scoped endpoint,
-// excluding NativeAdministratorsGroupName. It is the single filtered source for
-// ListGroupsByOUId and GetAgentGroups, so the native group cannot leak through
-// either surface.
+// listGroupsInOU returns every visible group in ouID from Thunder's OU-scoped
+// endpoint. It is the single filtered source for ListGroupsByOUId and
+// GetAgentGroups, so the native group cannot leak through either surface.
 func (c *thunderClient) listGroupsInOU(ctx context.Context, ouID string) ([]ThunderGroup, error) {
 	token, err := c.getSystemToken(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	const fetchSize = 100
-	var all []ThunderGroup
-	fetchOffset := 0
-	for {
-		url := fmt.Sprintf("%s/organization-units/%s/groups?offset=%d&limit=%d", c.baseURL, ouID, fetchOffset, fetchSize)
-		body, err := c.doRequest(ctx, http.MethodGet, url, token, nil)
-		if err != nil {
-			return nil, fmt.Errorf("thunder list groups by ou id: %w", err)
-		}
-		var wrapped thunderGroupList
-		if err := json.Unmarshal(body, &wrapped); err != nil {
-			return nil, fmt.Errorf("thunder list groups by ou id decode: %w", err)
-		}
-		for _, g := range wrapped.Groups {
-			if g.Name != NativeAdministratorsGroupName {
-				all = append(all, g)
-			}
-		}
-		fetchOffset += len(wrapped.Groups)
-		if fetchOffset >= wrapped.TotalResults || len(wrapped.Groups) == 0 {
-			break
-		}
-	}
-	return all, nil
+	return c.fetchAllGroups(ctx, token, c.baseURL+"/organization-units/"+ouID+"/groups",
+		"thunder list groups by ou id", isVisibleGroup)
 }
 
 // ListGroupsByOUId returns groups in ouID from Thunder's OU-scoped endpoint with
@@ -333,24 +328,26 @@ func (c *thunderClient) ListGroupsByOUId(ctx context.Context, ouID string, offse
 	if err != nil {
 		return nil, 0, err
 	}
-	return paginateGroups(all, offset, limit)
+	groups, total := paginate(all, offset, limit)
+	return groups, total, nil
 }
 
-// paginateGroups applies offset/limit to an already-filtered group slice and
-// reports the post-filter total.
-func paginateGroups(all []ThunderGroup, offset, limit int) ([]ThunderGroup, int, error) {
+// paginate applies offset/limit to an already-filtered slice and reports the
+// post-filter total, so a caller that excludes reserved principals before
+// paginating keeps offset/limit/total consistent with what it returns.
+func paginate[T any](all []T, offset, limit int) ([]T, int) {
 	total := len(all)
 	if offset < 0 {
 		offset = 0
 	}
 	if offset >= total {
-		return []ThunderGroup{}, total, nil
+		return []T{}, total
 	}
 	end := offset + limit
 	if end > total {
 		end = total
 	}
-	return all[offset:end], total, nil
+	return all[offset:end], total
 }
 
 func (c *thunderClient) GetGroup(ctx context.Context, groupID string) (*ThunderGroup, error) {
@@ -697,18 +694,8 @@ func (c *thunderClient) ListRoles(ctx context.Context, ouID string, offset, limi
 			break
 		}
 	}
-	total := len(all)
-	if offset < 0 {
-		offset = 0
-	}
-	if offset >= total {
-		return []ThunderRole{}, total, nil
-	}
-	end := offset + limit
-	if end > total {
-		end = total
-	}
-	return all[offset:end], total, nil
+	roles, total := paginate(all, offset, limit)
+	return roles, total, nil
 }
 
 func (c *thunderClient) GetRole(ctx context.Context, roleID string) (*ThunderRole, error) {

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -336,4 +338,180 @@ func TestListRoles_Unfiltered_KeepsNativeAdministrator(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, total)
 	require.Len(t, roles, 2)
+}
+
+// ouGroupServer serves Thunder's OU-scoped group endpoint from a fixed group
+// list, honouring the offset/limit query so the client's own pagination is
+// exercised against realistic paging. reqs counts the group fetches.
+func ouGroupServer(t *testing.T, ouID string, groups []map[string]any, reqs *int) *httptest.Server {
+	t.Helper()
+	return newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/organization-units/"+ouID+"/groups", r.URL.Path)
+		if reqs != nil {
+			*reqs++
+		}
+		offset, err := strconv.Atoi(r.URL.Query().Get("offset"))
+		require.NoError(t, err)
+		limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
+		require.NoError(t, err)
+
+		page := []map[string]any{}
+		if offset < len(groups) {
+			end := offset + limit
+			if end > len(groups) {
+				end = len(groups)
+			}
+			page = groups[offset:end]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"totalResults": len(groups), "groups": page})
+	})
+}
+
+// TestListGroupsByOUId_ExcludesNativeAdministrators proves the OU-scoped group
+// listing hides Thunder's native Administrators group. Its members inherit the
+// native Administrator role and with it the built-in "system" scope, so the
+// group must never surface as a joinable group, and it must not count toward
+// the total either.
+func TestListGroupsByOUId_ExcludesNativeAdministrators(t *testing.T) {
+	srv := ouGroupServer(t, "ou-1", []map[string]any{
+		{"id": "g-admin", "name": NativeAdministratorsGroupName},
+		{"id": "g-readers", "name": "readers"},
+		{"id": "g-writers", "name": "writers"},
+	}, nil)
+	defer srv.Close()
+
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+	groups, total, err := client.ListGroupsByOUId(context.Background(), "ou-1", 0, 20)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "Administrators must not count toward the OU total")
+	require.Len(t, groups, 2)
+	assert.Equal(t, "readers", groups[0].Name)
+	assert.Equal(t, "writers", groups[1].Name)
+}
+
+// TestListGroupsByOUId_PaginatesAfterExclusion pins the reason the exclusion
+// lives below pagination: filtering a server-side page after the fact returned
+// short pages and an inflated total. Walking limit=1 pages must yield every
+// visible group exactly once and never a gap.
+func TestListGroupsByOUId_PaginatesAfterExclusion(t *testing.T) {
+	srv := ouGroupServer(t, "ou-1", []map[string]any{
+		{"id": "g-admin", "name": NativeAdministratorsGroupName},
+		{"id": "g-a", "name": "a"},
+		{"id": "g-b", "name": "b"},
+		{"id": "g-c", "name": "c"},
+	}, nil)
+	defer srv.Close()
+
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+
+	var names []string
+	for offset := 0; ; offset++ {
+		page, total, err := client.ListGroupsByOUId(context.Background(), "ou-1", offset, 1)
+		require.NoError(t, err)
+		assert.Equal(t, 3, total)
+		if len(page) == 0 {
+			break
+		}
+		require.Len(t, page, 1, "every page below the total must be full")
+		names = append(names, page[0].Name)
+	}
+	assert.Equal(t, []string{"a", "b", "c"}, names)
+}
+
+// TestListGroupsByOUId_PagesPastFetchSize proves the all-pages fetch keeps
+// walking past a single Thunder page, so a native group sitting beyond the
+// first page is still excluded.
+func TestListGroupsByOUId_PagesPastFetchSize(t *testing.T) {
+	all := make([]map[string]any, 0, 150)
+	for i := 0; i < 149; i++ {
+		all = append(all, map[string]any{"id": fmt.Sprintf("g-%d", i), "name": fmt.Sprintf("group-%d", i)})
+	}
+	all = append(all, map[string]any{"id": "g-admin", "name": NativeAdministratorsGroupName})
+
+	reqs := 0
+	srv := ouGroupServer(t, "ou-1", all, &reqs)
+	defer srv.Close()
+
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+	groups, total, err := client.ListGroupsByOUId(context.Background(), "ou-1", 0, 200)
+
+	require.NoError(t, err)
+	assert.Equal(t, 149, total)
+	assert.Len(t, groups, 149)
+	assert.Greater(t, reqs, 1, "must fetch beyond the first page")
+	for _, g := range groups {
+		assert.NotEqual(t, NativeAdministratorsGroupName, g.Name)
+	}
+}
+
+// TestGetAgentGroups_ExcludesNativeAdministrators proves an agent mis-added to
+// the native Administrators group is never reported as a member of it, so the
+// group cannot leak through the agent's group list either.
+func TestGetAgentGroups_ExcludesNativeAdministrators(t *testing.T) {
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/organization-units/ou-1/groups":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"totalResults": 2,
+				"groups": []map[string]any{
+					{"id": "g-admin", "name": NativeAdministratorsGroupName},
+					{"id": "g-readers", "name": "readers"},
+				},
+			})
+		case "/groups/g-admin/members", "/groups/g-readers/members":
+			// The agent is a member of both, so only the exclusion can keep the
+			// native group out of the result.
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"totalResults": 1,
+				"members":      []map[string]any{{"id": "agent-1", "type": "agent"}},
+			})
+		default:
+			t.Errorf("unexpected path %q — the native group must not be probed", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer srv.Close()
+
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+	groups, err := client.GetAgentGroups(context.Background(), "ou-1", "agent-1")
+
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "readers", groups[0].Name)
+}
+
+// TestListGroups_Unfiltered_KeepsNativeAdministrators pins the ouID="" contract,
+// mirroring ListRoles: the raw instance-wide sweep must still see the native
+// group. The ouID-scoped branch of the same method does exclude it.
+func TestListGroups_Unfiltered_KeepsNativeAdministrators(t *testing.T) {
+	payload := map[string]any{
+		"totalResults": 2,
+		"groups": []map[string]any{
+			{"id": "g-admin", "ouId": "ou-1", "name": NativeAdministratorsGroupName},
+			{"id": "g-readers", "ouId": "ou-1", "name": "readers"},
+		},
+	}
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/groups", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+	defer srv.Close()
+
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+
+	groups, total, err := client.ListGroups(context.Background(), "", 0, 20)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, groups, 2)
+
+	scoped, scopedTotal, err := client.ListGroups(context.Background(), "ou-1", 0, 20)
+	require.NoError(t, err)
+	assert.Equal(t, 1, scopedTotal, "the OU-scoped branch must exclude the native group")
+	require.Len(t, scoped, 1)
+	assert.Equal(t, "readers", scoped[0].Name)
 }

--- a/agent-manager-service/controllers/agent_identity_controller.go
+++ b/agent-manager-service/controllers/agent_identity_controller.go
@@ -103,6 +103,40 @@ func (c *agentIdentityController) envClient(w http.ResponseWriter, r *http.Reque
 
 // --- Groups ---
 
+// managedGroup fetches the group and treats Thunder's native Administrators
+// group as nonexistent (404, matching its exclusion from ListGroups): its
+// members inherit NativeAdministratorRoleName and with it Thunder's built-in
+// "system" scope, so adding an agent to that group is a second route to
+// env-Thunder admin that walks around the managedRole guard entirely — see
+// thundersvc.NativeAdministratorsGroupName. Writes the error response itself
+// when ok=false.
+//
+// Note the deliberate asymmetry with managedRole, which leaves
+// RemoveRoleAssignees and the read-only assignment lookups unguarded so an
+// existing mis-assignment can be cleaned up through the same API. This guard
+// covers every group operation including GetGroupMembers and
+// RemoveGroupMembers, matching the org-identity controller's
+// validateSystemGroup: an agent already mis-added to the native group must be
+// removed with direct Thunder admin access, not through AMP.
+func (c *agentIdentityController) managedGroup(w http.ResponseWriter, r *http.Request, client thundersvc.EnvIdentityClient, groupID string) (*thundersvc.ThunderGroup, bool) {
+	ctx := r.Context()
+	group, err := client.GetGroup(ctx, groupID)
+	if err != nil {
+		if thundersvc.IsNotFound(err) {
+			utils.WriteErrorResponse(w, http.StatusNotFound, "Group not found")
+			return nil, false
+		}
+		logger.GetLogger(ctx).Error("agent-identity: get group failed", "groupID", groupID, "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to get group")
+		return nil, false
+	}
+	if group.Name == thundersvc.NativeAdministratorsGroupName {
+		utils.WriteErrorResponse(w, http.StatusNotFound, "Group not found")
+		return nil, false
+	}
+	return group, true
+}
+
 func (c *agentIdentityController) ListGroups(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := logger.GetLogger(ctx)
@@ -119,8 +153,9 @@ func (c *agentIdentityController) ListGroups(w http.ResponseWriter, r *http.Requ
 	}
 
 	offset, limit := paginationParams(r)
-	// Unlike the org-identity controller, env-Thunder groups are all user-created
-	// and agent-scoped: there is no Administrators group to filter out here.
+	// The OU-scoped listing hides Thunder's native Administrators group
+	// (thundersvc.NativeAdministratorsGroupName) and paginates after that
+	// exclusion, so offset/limit/total need no adjustment here.
 	groups, total, err := client.ListGroupsByOUId(ctx, ouID, offset, limit)
 	if err != nil {
 		log.Error("agent-identity ListGroups failed", "error", err)
@@ -141,6 +176,9 @@ func (c *agentIdentityController) CreateGroup(w http.ResponseWriter, r *http.Req
 	}
 	if body.Name == "" {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if !validateReservedGroupName(w, body.Name) {
 		return
 	}
 
@@ -169,22 +207,14 @@ func (c *agentIdentityController) CreateGroup(w http.ResponseWriter, r *http.Req
 }
 
 func (c *agentIdentityController) GetGroup(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := logger.GetLogger(ctx)
 	groupID := r.PathValue(utils.PathParamGroupID)
 
 	client, ok := c.envClient(w, r)
 	if !ok {
 		return
 	}
-	group, err := client.GetGroup(ctx, groupID)
-	if err != nil {
-		if thundersvc.IsNotFound(err) {
-			utils.WriteErrorResponse(w, http.StatusNotFound, "Group not found")
-			return
-		}
-		log.Error("agent-identity GetGroup failed", "groupID", groupID, "error", err)
-		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to get group")
+	group, ok := c.managedGroup(w, r, client, groupID)
+	if !ok {
 		return
 	}
 	utils.WriteSuccessResponse(w, http.StatusOK, group)
@@ -200,19 +230,17 @@ func (c *agentIdentityController) UpdateGroup(w http.ResponseWriter, r *http.Req
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
+	// An empty name leaves the current one in place, so only a rename needs the guard.
+	if body.Name != "" && !validateReservedGroupName(w, body.Name) {
+		return
+	}
 
 	client, ok := c.envClient(w, r)
 	if !ok {
 		return
 	}
-	current, err := client.GetGroup(ctx, groupID)
-	if err != nil {
-		if thundersvc.IsNotFound(err) {
-			utils.WriteErrorResponse(w, http.StatusNotFound, "Group not found")
-			return
-		}
-		log.Error("agent-identity UpdateGroup: get group failed", "groupID", groupID, "error", err)
-		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to update group")
+	current, ok := c.managedGroup(w, r, client, groupID)
+	if !ok {
 		return
 	}
 	var namePtr *string
@@ -243,6 +271,9 @@ func (c *agentIdentityController) DeleteGroup(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return
 	}
+	if _, ok := c.managedGroup(w, r, client, groupID); !ok {
+		return
+	}
 	if err := client.DeleteGroup(ctx, groupID); err != nil {
 		if thundersvc.IsNotFound(err) {
 			utils.WriteErrorResponse(w, http.StatusNotFound, "Group not found")
@@ -262,6 +293,9 @@ func (c *agentIdentityController) GetGroupMembers(w http.ResponseWriter, r *http
 
 	client, ok := c.envClient(w, r)
 	if !ok {
+		return
+	}
+	if _, ok := c.managedGroup(w, r, client, groupID); !ok {
 		return
 	}
 	offset, limit := paginationParams(r)
@@ -295,6 +329,9 @@ func (c *agentIdentityController) AddGroupMembers(w http.ResponseWriter, r *http
 	if !ok {
 		return
 	}
+	if _, ok := c.managedGroup(w, r, client, groupID); !ok {
+		return
+	}
 	if err := client.AddGroupMemberEntries(ctx, groupID, agentMemberEntries(body.AgentIds)); err != nil {
 		log.Error("agent-identity AddGroupMembers failed", "groupID", groupID, "error", err)
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to add group members")
@@ -322,6 +359,9 @@ func (c *agentIdentityController) RemoveGroupMembers(w http.ResponseWriter, r *h
 	if !ok {
 		return
 	}
+	if _, ok := c.managedGroup(w, r, client, groupID); !ok {
+		return
+	}
 	if err := client.RemoveGroupMemberEntries(ctx, groupID, agentMemberEntries(body.AgentIds)); err != nil {
 		log.Error("agent-identity RemoveGroupMembers failed", "groupID", groupID, "error", err)
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to remove group members")
@@ -337,6 +377,9 @@ func (c *agentIdentityController) GetGroupRoles(w http.ResponseWriter, r *http.R
 
 	client, ok := c.envClient(w, r)
 	if !ok {
+		return
+	}
+	if _, ok := c.managedGroup(w, r, client, groupID); !ok {
 		return
 	}
 	roles, err := client.GetGroupRoles(ctx, groupID)
@@ -396,6 +439,9 @@ func (c *agentIdentityController) CreateRole(w http.ResponseWriter, r *http.Requ
 	}
 	if body.Name == "" {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if !validateReservedRoleName(w, body.Name) {
 		return
 	}
 	scopes := body.Scopes
@@ -517,6 +563,11 @@ func (c *agentIdentityController) UpdateRole(w http.ResponseWriter, r *http.Requ
 	var body spec.AgentIdentityRoleRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	// An empty name leaves the current one in place, so only a rename needs the
+	// guard; managedRole below blocks editing the native Administrator role itself.
+	if body.Name != "" && !validateReservedRoleName(w, body.Name) {
 		return
 	}
 	// scopes, when present, fully replaces the role's permissions. Decoding tells

--- a/agent-manager-service/controllers/agent_identity_controller.go
+++ b/agent-manager-service/controllers/agent_identity_controller.go
@@ -104,20 +104,14 @@ func (c *agentIdentityController) envClient(w http.ResponseWriter, r *http.Reque
 // --- Groups ---
 
 // managedGroup fetches the group and treats Thunder's native Administrators
-// group as nonexistent (404, matching its exclusion from ListGroups): its
-// members inherit NativeAdministratorRoleName and with it Thunder's built-in
-// "system" scope, so adding an agent to that group is a second route to
-// env-Thunder admin that walks around the managedRole guard entirely — see
-// thundersvc.NativeAdministratorsGroupName. Writes the error response itself
-// when ok=false.
+// group as nonexistent, matching its exclusion from the OU-scoped listing — see
+// thundersvc.NativeAdministratorsGroupName for why that group grants admin.
+// Writes the error response itself when ok=false.
 //
-// Note the deliberate asymmetry with managedRole, which leaves
-// RemoveRoleAssignees and the read-only assignment lookups unguarded so an
-// existing mis-assignment can be cleaned up through the same API. This guard
-// covers every group operation including GetGroupMembers and
-// RemoveGroupMembers, matching the org-identity controller's
-// validateSystemGroup: an agent already mis-added to the native group must be
-// removed with direct Thunder admin access, not through AMP.
+// Unlike managedRole, which leaves RemoveRoleAssignees and the read-only
+// assignment lookups open so a mis-assignment can be cleaned up through the
+// same API, this guards every group operation: an agent already mis-added to
+// the native group must be removed with direct Thunder admin access.
 func (c *agentIdentityController) managedGroup(w http.ResponseWriter, r *http.Request, client thundersvc.EnvIdentityClient, groupID string) (*thundersvc.ThunderGroup, bool) {
 	ctx := r.Context()
 	group, err := client.GetGroup(ctx, groupID)
@@ -130,8 +124,7 @@ func (c *agentIdentityController) managedGroup(w http.ResponseWriter, r *http.Re
 		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to get group")
 		return nil, false
 	}
-	if group.Name == thundersvc.NativeAdministratorsGroupName {
-		utils.WriteErrorResponse(w, http.StatusNotFound, "Group not found")
+	if !validateSystemGroup(w, group.Name) {
 		return nil, false
 	}
 	return group, true
@@ -153,9 +146,8 @@ func (c *agentIdentityController) ListGroups(w http.ResponseWriter, r *http.Requ
 	}
 
 	offset, limit := paginationParams(r)
-	// The OU-scoped listing hides Thunder's native Administrators group
-	// (thundersvc.NativeAdministratorsGroupName) and paginates after that
-	// exclusion, so offset/limit/total need no adjustment here.
+	// ListGroupsByOUId excludes the native Administrators group before paginating,
+	// so offset/limit/total need no adjustment here.
 	groups, total, err := client.ListGroupsByOUId(ctx, ouID, offset, limit)
 	if err != nil {
 		log.Error("agent-identity ListGroups failed", "error", err)
@@ -230,8 +222,7 @@ func (c *agentIdentityController) UpdateGroup(w http.ResponseWriter, r *http.Req
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-	// An empty name leaves the current one in place, so only a rename needs the guard.
-	if body.Name != "" && !validateReservedGroupName(w, body.Name) {
+	if !validateReservedGroupName(w, body.Name) {
 		return
 	}
 
@@ -565,9 +556,8 @@ func (c *agentIdentityController) UpdateRole(w http.ResponseWriter, r *http.Requ
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-	// An empty name leaves the current one in place, so only a rename needs the
-	// guard; managedRole below blocks editing the native Administrator role itself.
-	if body.Name != "" && !validateReservedRoleName(w, body.Name) {
+	// managedRole below blocks editing the native Administrator role itself.
+	if !validateReservedRoleName(w, body.Name) {
 		return
 	}
 	// scopes, when present, fully replaces the role's permissions. Decoding tells

--- a/agent-manager-service/controllers/agent_identity_controller_unit_test.go
+++ b/agent-manager-service/controllers/agent_identity_controller_unit_test.go
@@ -660,3 +660,145 @@ func TestAgentIdentityRemoveRoleAssignees_NativeAdministratorAllowed(t *testing.
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.True(t, removed, "cleanup removal must pass through to Thunder")
 }
+
+// adminGroupEnvClient returns an env client whose GetGroup always resolves the
+// native Administrators group. Every other func is left nil, so any read or
+// write that slips past the guard and reaches Thunder panics the test.
+func adminGroupEnvClient() *clientmocks.EnvIdentityClientMock {
+	return &clientmocks.EnvIdentityClientMock{
+		GetGroupFunc: func(_ context.Context, groupID string) (*thundersvc.ThunderGroup, error) {
+			return &thundersvc.ThunderGroup{ID: groupID, OuID: "ou-env", Name: thundersvc.NativeAdministratorsGroupName}, nil
+		},
+	}
+}
+
+// adminGroupRequest builds a request with the org/env/group path values shared
+// by every native-Administrators guard test.
+func adminGroupRequest(method, url, body string) *http.Request {
+	req := httptest.NewRequest(method, url, strings.NewReader(body))
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req.SetPathValue("groupID", "g-admin")
+	return req
+}
+
+// TestAgentIdentityGroupHandlers_NativeAdministratorsHidden proves the native
+// Administrators group is invisible and immutable through every agent-identity
+// group operation. Its members inherit the native Administrator role and with it
+// Thunder's "system" scope, so AddGroupMembers in particular is a route to
+// env-Thunder admin that walks around the managedRole guard.
+//
+// Unlike RemoveRoleAssignees on the role side, RemoveGroupMembers is guarded
+// too: this is the deliberate asymmetry documented on managedGroup, matching the
+// org-identity controller. Cleanup of a pre-existing mis-membership needs direct
+// Thunder access.
+func TestAgentIdentityGroupHandlers_NativeAdministratorsHidden(t *testing.T) {
+	const base = "/orgs/o1/environments/dev/agent-identities/groups/g-admin"
+	cases := []struct {
+		name   string
+		method string
+		url    string
+		body   string
+		invoke func(AgentIdentityController, http.ResponseWriter, *http.Request)
+	}{
+		{
+			"GetGroup", http.MethodGet, base, "",
+			func(c AgentIdentityController, w http.ResponseWriter, r *http.Request) { c.GetGroup(w, r) },
+		},
+		{
+			"UpdateGroup", http.MethodPut, base, `{"description":"x"}`,
+			func(c AgentIdentityController, w http.ResponseWriter, r *http.Request) { c.UpdateGroup(w, r) },
+		},
+		{
+			"DeleteGroup", http.MethodDelete, base, "",
+			func(c AgentIdentityController, w http.ResponseWriter, r *http.Request) { c.DeleteGroup(w, r) },
+		},
+		{
+			"GetGroupMembers", http.MethodGet, base + "/members", "",
+			func(c AgentIdentityController, w http.ResponseWriter, r *http.Request) { c.GetGroupMembers(w, r) },
+		},
+		{
+			"AddGroupMembers", http.MethodPost, base + "/members/add", `{"agentIds":["thunder-1"]}`,
+			func(c AgentIdentityController, w http.ResponseWriter, r *http.Request) { c.AddGroupMembers(w, r) },
+		},
+		{
+			"RemoveGroupMembers", http.MethodPost, base + "/members/remove", `{"agentIds":["thunder-1"]}`,
+			func(c AgentIdentityController, w http.ResponseWriter, r *http.Request) { c.RemoveGroupMembers(w, r) },
+		},
+		{
+			"GetGroupRoles", http.MethodGet, base + "/roles", "",
+			func(c AgentIdentityController, w http.ResponseWriter, r *http.Request) { c.GetGroupRoles(w, r) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := adminRoleController(adminGroupEnvClient())
+			w := httptest.NewRecorder()
+
+			tc.invoke(ctrl, w, adminGroupRequest(tc.method, tc.url, tc.body))
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		})
+	}
+}
+
+// TestAgentIdentityCreateGroup_ReservedNameRejected proves a second group cannot
+// be created under the native Administrators name, which would shadow the hidden
+// system group. CreateGroupFunc is nil, so any write reaching Thunder panics.
+func TestAgentIdentityCreateGroup_ReservedNameRejected(t *testing.T) {
+	ctrl := adminRoleController(&clientmocks.EnvIdentityClientMock{})
+
+	req := adminGroupRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/groups",
+		`{"name":"`+thundersvc.NativeAdministratorsGroupName+`"}`)
+	w := httptest.NewRecorder()
+
+	ctrl.CreateGroup(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestAgentIdentityUpdateGroup_ReservedRenameRejected proves an ordinary group
+// cannot be renamed into the native Administrators name. The guard runs before
+// the group is fetched, so GetGroupFunc is nil here too.
+func TestAgentIdentityUpdateGroup_ReservedRenameRejected(t *testing.T) {
+	ctrl := adminRoleController(&clientmocks.EnvIdentityClientMock{})
+
+	req := adminGroupRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/groups/g-1",
+		`{"name":"`+thundersvc.NativeAdministratorsGroupName+`"}`)
+	w := httptest.NewRecorder()
+
+	ctrl.UpdateGroup(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestAgentIdentityCreateRole_ReservedNameRejected proves a role cannot be
+// created under the native Administrator name. CreateRoleFunc is nil, so any
+// write reaching Thunder panics.
+func TestAgentIdentityCreateRole_ReservedNameRejected(t *testing.T) {
+	ctrl := adminRoleController(&clientmocks.EnvIdentityClientMock{})
+
+	req := adminRoleRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles",
+		`{"name":"`+thundersvc.NativeAdministratorRoleName+`"}`)
+	w := httptest.NewRecorder()
+
+	ctrl.CreateRole(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestAgentIdentityUpdateRole_ReservedRenameRejected proves an ordinary role
+// cannot be renamed into the native Administrator name. managedRole already
+// blocks editing the native role itself; this closes the other direction.
+func TestAgentIdentityUpdateRole_ReservedRenameRejected(t *testing.T) {
+	ctrl := adminRoleController(&clientmocks.EnvIdentityClientMock{})
+
+	req := adminRoleRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/r-1",
+		`{"name":"`+thundersvc.NativeAdministratorRoleName+`"}`)
+	w := httptest.NewRecorder()
+
+	ctrl.UpdateRole(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -437,44 +438,10 @@ func (c *identityController) ListGroups(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Check if Administrators group exists (first check current page, then early fetch if needed)
-	administratorsExists := false
-	for _, group := range groups {
-		if group.Name == "Administrators" {
-			administratorsExists = true
-			break
-		}
-	}
-
-	// If Administrators not in current page but might exist elsewhere, fetch first page to check
-	// (Administrators is typically a system group that appears early in listings)
-	if !administratorsExists && offset > 0 {
-		earlyGroups, _, err := c.client.ListGroupsByOUId(ctx, resolvedOrg.OUID, 0, limit)
-		if err == nil {
-			for _, group := range earlyGroups {
-				if group.Name == "Administrators" {
-					administratorsExists = true
-					break
-				}
-			}
-		}
-	}
-
-	// Filter out the Administrators group from public visibility
-	filteredGroups := make([]thundersvc.ThunderGroup, 0, len(groups))
-	for _, group := range groups {
-		if group.Name != "Administrators" {
-			filteredGroups = append(filteredGroups, group)
-		}
-	}
-
-	// Calculate adjusted total: consistently decrement by 1 if Administrators exists in the OU
-	adjustedTotal := total
-	if administratorsExists {
-		adjustedTotal = total - 1
-	}
-
-	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"groups": filteredGroups, "total": adjustedTotal, "offset": offset, "limit": limit})
+	// The OU-scoped group listing already hides Thunder's native Administrators
+	// group (thundersvc.NativeAdministratorsGroupName) and paginates after that
+	// exclusion, so offset/limit/total need no adjustment here.
+	utils.WriteSuccessResponse(w, http.StatusOK, map[string]any{"groups": groups, "total": total, "offset": offset, "limit": limit})
 }
 
 func (c *identityController) GetGroup(w http.ResponseWriter, r *http.Request) {
@@ -527,6 +494,9 @@ func (c *identityController) CreateGroup(w http.ResponseWriter, r *http.Request)
 	}
 	if body.Name == "" {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if !validateReservedGroupName(w, body.Name) {
 		return
 	}
 
@@ -588,6 +558,10 @@ func (c *identityController) UpdateGroup(w http.ResponseWriter, r *http.Request)
 	var body spec.UpdateGroupRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	// A nil/empty name leaves the current one in place, so only a rename needs the guard.
+	if body.Name != nil && *body.Name != "" && !validateReservedGroupName(w, *body.Name) {
 		return
 	}
 
@@ -922,6 +896,9 @@ func (c *identityController) CreateRole(w http.ResponseWriter, r *http.Request) 
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "name is required")
 		return
 	}
+	if !validateReservedRoleName(w, body.Name) {
+		return
+	}
 
 	ouID := resolvedOrg.OUID
 	if body.OuId != nil && *body.OuId != "" {
@@ -982,6 +959,11 @@ func (c *identityController) UpdateRole(w http.ResponseWriter, r *http.Request) 
 	var body spec.UpdateRoleRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	// validatePredefinedRole above only checked the role's current name; this stops
+	// an ordinary role being renamed into the native Administrator role's name.
+	if body.Name != nil && *body.Name != "" && !validateReservedRoleName(w, *body.Name) {
 		return
 	}
 
@@ -1487,8 +1469,34 @@ func validatePredefinedRole(w http.ResponseWriter, roleName string) bool {
 
 // validateSystemGroup checks if a group is a system group and blocks access if so
 func validateSystemGroup(w http.ResponseWriter, groupName string) bool {
-	if groupName == "Administrators" {
+	if groupName == thundersvc.NativeAdministratorsGroupName {
 		utils.WriteErrorResponse(w, http.StatusNotFound, "Group not found")
+		return false
+	}
+	return true
+}
+
+// validateReservedGroupName rejects creating or renaming a group to Thunder's
+// native Administrators group name. Without it a second group could shadow the
+// hidden system group and confuse an operator about which one grants admin.
+// Callers must pass the *requested* name, never the group's current one.
+func validateReservedGroupName(w http.ResponseWriter, groupName string) bool {
+	if groupName == thundersvc.NativeAdministratorsGroupName {
+		utils.WriteErrorResponse(w, http.StatusBadRequest,
+			fmt.Sprintf("%q is a reserved group name", thundersvc.NativeAdministratorsGroupName))
+		return false
+	}
+	return true
+}
+
+// validateReservedRoleName is validateReservedGroupName's counterpart for
+// Thunder's native Administrator role. validatePredefinedRole only inspects a
+// role's current name, so without this an ordinary role could be renamed to
+// Administrator.
+func validateReservedRoleName(w http.ResponseWriter, roleName string) bool {
+	if roleName == thundersvc.NativeAdministratorRoleName {
+		utils.WriteErrorResponse(w, http.StatusBadRequest,
+			fmt.Sprintf("%q is a reserved role name", thundersvc.NativeAdministratorRoleName))
 		return false
 	}
 	return true

--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -560,8 +560,7 @@ func (c *identityController) UpdateGroup(w http.ResponseWriter, r *http.Request)
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-	// A nil/empty name leaves the current one in place, so only a rename needs the guard.
-	if body.Name != nil && *body.Name != "" && !validateReservedGroupName(w, *body.Name) {
+	if !validateReservedGroupName(w, derefString(body.Name)) {
 		return
 	}
 
@@ -961,9 +960,7 @@ func (c *identityController) UpdateRole(w http.ResponseWriter, r *http.Request) 
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-	// validatePredefinedRole above only checked the role's current name; this stops
-	// an ordinary role being renamed into the native Administrator role's name.
-	if body.Name != nil && *body.Name != "" && !validateReservedRoleName(w, *body.Name) {
+	if !validateReservedRoleName(w, derefString(body.Name)) {
 		return
 	}
 
@@ -1476,28 +1473,29 @@ func validateSystemGroup(w http.ResponseWriter, groupName string) bool {
 	return true
 }
 
-// validateReservedGroupName rejects creating or renaming a group to Thunder's
-// native Administrators group name. Without it a second group could shadow the
-// hidden system group and confuse an operator about which one grants admin.
-// Callers must pass the *requested* name, never the group's current one.
-func validateReservedGroupName(w http.ResponseWriter, groupName string) bool {
-	if groupName == thundersvc.NativeAdministratorsGroupName {
+// validateReservedName rejects a request that would claim a name Thunder
+// reserves for one of its seeded principals, which would shadow the hidden
+// system resource and confuse an operator about which one grants admin.
+//
+// Callers pass the *requested* name, never the resource's current one — that is
+// validateSystemGroup/validatePredefinedRole's job. An absent name means the
+// caller is not renaming, and passes.
+func validateReservedName(w http.ResponseWriter, requested, reserved, kind string) bool {
+	if requested == reserved {
 		utils.WriteErrorResponse(w, http.StatusBadRequest,
-			fmt.Sprintf("%q is a reserved group name", thundersvc.NativeAdministratorsGroupName))
+			fmt.Sprintf("%q is a reserved %s name", reserved, kind))
 		return false
 	}
 	return true
 }
 
-// validateReservedRoleName is validateReservedGroupName's counterpart for
-// Thunder's native Administrator role. validatePredefinedRole only inspects a
-// role's current name, so without this an ordinary role could be renamed to
-// Administrator.
+func validateReservedGroupName(w http.ResponseWriter, groupName string) bool {
+	return validateReservedName(w, groupName, thundersvc.NativeAdministratorsGroupName, "group")
+}
+
+// validateReservedRoleName complements validatePredefinedRole, which only
+// inspects a role's current name — without this an ordinary role could be
+// renamed to Administrator.
 func validateReservedRoleName(w http.ResponseWriter, roleName string) bool {
-	if roleName == thundersvc.NativeAdministratorRoleName {
-		utils.WriteErrorResponse(w, http.StatusBadRequest,
-			fmt.Sprintf("%q is a reserved role name", thundersvc.NativeAdministratorRoleName))
-		return false
-	}
-	return true
+	return validateReservedName(w, roleName, thundersvc.NativeAdministratorRoleName, "role")
 }


### PR DESCRIPTION
## Purpose

Every ThunderID install auto-seeds two privileged principals in its default OU: the `Administrator` role, which carries Thunder's built-in `system` scope (the scope `amp-system-client` uses to call env-Thunder's admin API), and the `Administrators` group, which confers that role on its members.

The role was closed off for env-Thunder in #1334 (`Hide env-Thunder native Administrator role from agent identity APIs`): it is filtered out of the client's OU-scoped `ListRoles`, and `managedRole` 404s every single-role read/write against it. The group was hidden on the **org** side in #1060, but that work did not reach the agent-identity path.

**The group is the same escalation path and was left wide open on the env side.** `agent_identity_controller.go` even carried a comment asserting the opposite — *"there is no Administrators group to filter out here"*. Adding an agent identity to the `Administrators` group grants it the `Administrator` role, and therefore `system`, walking around the role guard entirely.

Two smaller gaps surfaced while tracing this:

- The org-identity side did hide the group (#1060), but with the `"Administrators"` literal hardcoded in 8 places plus a fragile listing hack: probe the first page to guess whether the group exists in the OU, then decrement `total` by 1. With `limit=1` that could return an empty page while reporting a non-zero total.
- Nothing stopped *creating* or *renaming* a group to `Administrators`, or a role to `Administrator`. `validatePredefinedRole` only ever inspected a role's **current** name, so renaming an ordinary role into the reserved name was allowed.

## Goals

- The native `Administrators` group is invisible and immutable through the agent-identity (env-Thunder) API, matching how the native `Administrator` role is already treated.
- One client-level chokepoint hides the group from every list surface — org and env — so the exclusion cannot be forgotten at a new call site.
- Group and role names reserved by Thunder cannot be claimed by a newly created or renamed resource.
- The org-side duplicated literal and pagination hack are removed.

## Approach

**`clients/thundersvc/identity_client.go` — the chokepoint.** Added `NativeAdministratorsGroupName`, documented alongside the existing `NativeAdministratorRoleName`. A new unexported `listGroupsInOU` pages Thunder's OU-scoped group endpoint to exhaustion and drops the native group; it is the single filtered source for both `ListGroupsByOUId` and `GetAgentGroups`, so the group cannot leak through either. `ListGroupsByOUId` now paginates client-side *after* the exclusion (via a shared `paginateGroups`), exactly as `ListRoles` does, so `offset`/`limit`/`total` are exact rather than approximated. `GetAgentGroups` uses the same helper, which let its own paging loop go — it now makes fewer round-trips than before. `ListGroups`' `ouID != ""` branch got the same filter; the `ouID == ""` raw instance-wide path stays unfiltered, mirroring the carve-out `ListRoles` already documents.

**`controllers/agent_identity_controller.go` — the guard.** New `managedGroup`, a direct analogue of `managedRole`: fetch the group, map not-found to 404, and 404 when the name matches the native group. Applied to all seven single-group handlers (`GetGroup`, `UpdateGroup`, `DeleteGroup`, `GetGroupMembers`, `AddGroupMembers`, `RemoveGroupMembers`, `GetGroupRoles`).

**Note one deliberate asymmetry with `managedRole`, recorded in `managedGroup`'s doc comment.** The role guard leaves `RemoveRoleAssignees` and the read-only assignment lookups open so an existing mis-assignment can be cleaned up through the same API. This guard covers *every* group operation, including `GetGroupMembers` and `RemoveGroupMembers`, matching the org-identity controller's `validateSystemGroup`. The consequence: an agent already mis-added to the native group must be removed with direct Thunder admin access, not through AMP. Worth a look before merge if any existing environment has a mis-added agent.

**`controllers/identity_controller.go` — dedup + reserved names.** Deleted the probe/`total - 1` hack (~35 lines), pointed `validateSystemGroup` at the new constant, and added `validateReservedGroupName` / `validateReservedRoleName` (400) wired into `CreateGroup`, `UpdateGroup`, `CreateRole`, `UpdateRole` on both the org and env paths. These read the **requested** name, never the current one.

No console changes are needed: the API 404s and omits the group from listings, so the `useAllGroups` pickers and group list pages stop seeing it with no client-side filtering. There is no `"Administrators"` literal anywhere in the console.

## User stories

- As a platform operator, an agent identity cannot be granted env-Thunder admin by being added to a group, just as it already cannot be by direct role assignment.
- As a console user, group listings and pickers show only groups I can actually manage, with correct pagination and totals.

## Release note

Fixed a privilege-escalation path where an agent identity could obtain environment Thunder administrator access by being added to Thunder's built-in `Administrators` group. The group is now hidden from the agent identity APIs, and Thunder's reserved `Administrators` / `Administrator` names can no longer be used for a new or renamed group or role.

## Documentation

N/A — no user-facing API surface is added or removed. The affected endpoints behave as though the native group does not exist, which is the already-documented behaviour for the native `Administrator` role.

## Training

N/A — internal authorization hardening, no training content impact.

## Certification

N/A — no impact on certification exams; this changes internal filtering of a Thunder-seeded principal, not a user-facing concept.

## Marketing

N/A — security hardening, not a promotable feature.

## Automation tests

- Unit tests

  Nine new tests, all passing; full unit tier green (`make test-unit`).

  `clients/thundersvc/identity_client_test.go`:
  - `TestListGroupsByOUId_ExcludesNativeAdministrators` — group absent, and not counted in `total`
  - `TestListGroupsByOUId_PaginatesAfterExclusion` — walks `limit=1` pages and asserts no short page and no gap; this is the case the deleted org hack got wrong
  - `TestListGroupsByOUId_PagesPastFetchSize` — 150 groups, native group beyond the first page, still excluded
  - `TestGetAgentGroups_ExcludesNativeAdministrators` — agent is a member of the native group and is still not reported in it
  - `TestListGroups_Unfiltered_KeepsNativeAdministrators` — pins the `ouID == ""` raw-path contract

  `controllers/agent_identity_controller_unit_test.go`:
  - `TestAgentIdentityGroupHandlers_NativeAdministratorsHidden` — table-driven over all seven handlers, each asserting 404. The mock leaves every mutating func `nil`, so any write that slips past the guard panics the test rather than silently passing.
  - `TestAgentIdentityCreateGroup_ReservedNameRejected`, `TestAgentIdentityUpdateGroup_ReservedRenameRejected`, `TestAgentIdentityCreateRole_ReservedNameRejected`, `TestAgentIdentityUpdateRole_ReservedRenameRejected` — 400 on each

- Integration tests

  None added. Group CRUD has no service layer (controllers call the Thunder client directly) and the existing tier has no env-Thunder fixture, so the behaviour is covered at the client and controller boundaries above. The end-to-end checks below were **not** run — they need a provisioned env-Thunder.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** — FindSecurityBugs is a Java/SpotBugs plugin and does not apply to this Go module. `golangci-lint` with the repo config (`.github/linters/.golangci.yaml`) reports 0 issues, including the `goheader` pass.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

N/A — no sample impact.

## Related PRs

- #1334 `Hide env-Thunder native Administrator role from agent identity APIs` — the role-side fix this mirrors
- #1060 `Add new admins group by default and remove Administrators group from thunder` — the org-side group hiding whose duplicated literal and pagination hack this consolidates into the client
- Follow-up worth filing separately: the Thunder bootstrap seeds a role literally named `admin` with the full `amp:*` permission set (`deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml`), but `constants/roles.go` lists `"Agent Manager Admin"`. `IsPredefinedRole("admin")` is therefore `false`, so that full-access role is returned without `isReadOnly` and is editable and deletable by anyone with `role:update`. Pre-existing and out of scope here.

## Migrations (if applicable)

N/A — no schema or data migration. The change is read-filtering and request validation only; nothing is written to Thunder or the database.

## Test environment

- Go 1.x per `.github/actions/setup-go` (repo-pinned toolchain)
- macOS 15 (darwin/arm64)
- No database required — the affected packages are in the fast unit tier
- Verified: `go build ./...`, `make test-unit` (pass), `golangci-lint run ./...` with the repo config (0 issues)

## Learning

The main insight was that the role fix and the group fix are the same vulnerability reached two ways, so they should share a mechanism rather than each grow their own literal. Following the role fix's own history was instructive: it started with the filter in the controller and was then deduplicated down into the client (commit `239956f1`). Putting the group filter in the client from the start meant the org-side controller hack could be deleted rather than mirrored, and made the `GetAgentGroups` leak obvious — it reads the same OU-scoped listing, so a controller-level filter would have missed it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid Thunder’s native **Administrators** group from OU-scoped group listings and agent group memberships.
  * Prevented users from viewing, modifying, deleting, or managing members and roles for the native Administrators group.
  * Preserved accurate pagination totals and offsets after filtering the hidden group.

* **Validation**
  * Blocked creating or renaming groups to **Administrators**.
  * Blocked creating or renaming roles to **Administrator**.
  * Instance-wide group listings continue to include the native Administrators group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->