### PR TITLE
Wait for observer-auth-config claim before patching (fixes observer 403 log/trace race)

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1365,11 +1365,18 @@ for _ in $(seq 1 30); do
     sleep 4
 done
 if [ -z "$obs_auth_claim" ]; then
-    log_warning "observer-auth-config has no service-account 'sub' claim after waiting - skipping (observer log/trace queries will 403 until it is patched)"
+    # Distinguish a genuinely-absent configmap from one that is present but whose
+    # service-account claim never surfaced (or kubectl kept failing) so the message
+    # is not misleading.
+    if kubectl get configmap observer-auth-config -n openchoreo-observability-plane &>/dev/null; then
+        log_warning "observer-auth-config present but its service-account claim never surfaced after waiting - skipping (observer log/trace queries will 403 until it is patched)"
+    else
+        log_warning "observer-auth-config not found - skipping observer claim patch"
+    fi
 else
     patched_obs_yaml=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml \
         | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
-    if echo "$patched_obs_yaml" | grep -q "claim: client_id"; then
+    if echo "$patched_obs_yaml" | grep -qE "claim:[[:space:]]*['\"]?client_id['\"]?"; then
         echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
         kubectl rollout restart deployment/observer -n openchoreo-observability-plane
         kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1350,8 +1350,23 @@ fi
 # ThunderID v0.45: the observer resolves service accounts from its own config
 # (observer-auth-config), still keyed on 'claim: sub'. Patch to client_id, else
 # agent build-log / observability queries return 403.
+#
+# The observability plane populates observer-auth-config asynchronously: the
+# configmap can exist for a while before its service-account 'claim: sub' is
+# written. Patching too early sees no 'sub', silently skips, and leaves the
+# observer on 'sub' (403 on every log/trace query). Wait for the claim to
+# surface (either 'sub' to patch, or 'client_id' if a prior run already did).
 log_info "Patching observer-auth-config: service_account entitlement claim -> client_id..."
-if kubectl get configmap observer-auth-config -n openchoreo-observability-plane &>/dev/null; then
+obs_auth_claim=""
+for _ in $(seq 1 30); do
+    obs_auth_claim=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml 2>/dev/null \
+        | grep -oE "claim:[[:space:]]*['\"]?(sub|client_id)['\"]?" | head -1)
+    [ -n "$obs_auth_claim" ] && break
+    sleep 4
+done
+if [ -z "$obs_auth_claim" ]; then
+    log_warning "observer-auth-config has no service-account 'sub' claim after waiting - skipping (observer log/trace queries will 403 until it is patched)"
+else
     patched_obs_yaml=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml \
         | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
     if echo "$patched_obs_yaml" | grep -q "claim: client_id"; then
@@ -1362,8 +1377,6 @@ if kubectl get configmap observer-auth-config -n openchoreo-observability-plane 
     else
         log_warning "observer-auth-config has no 'sub' claim to patch - skipping"
     fi
-else
-    log_warning "observer-auth-config not found - skipping observer claim patch"
 fi
 
 # Register Observability Plane with Control Plane

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -311,19 +311,26 @@ install_observability_plane() {
         sleep 4
     done
     if [ -z "$obs_auth_claim" ]; then
-        echo "❌ observer-auth-config has no service-account 'sub' claim after waiting"
-        return 1
+        # Distinguish a genuinely-absent configmap (skip) from one that is present
+        # but whose service-account claim never surfaced (fail) so the outcome is
+        # not misleading.
+        if kubectl get configmap observer-auth-config -n openchoreo-observability-plane &>/dev/null; then
+            echo "❌ observer-auth-config present but its service-account claim never surfaced after waiting"
+            return 1
+        fi
+        echo "⚠️  observer-auth-config not found — skipping observer claim patch"
+    else
+        patched_obs_yaml=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml \
+            | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
+        if ! echo "$patched_obs_yaml" | grep -qE "claim:[[:space:]]*['\"]?client_id['\"]?"; then
+            echo "❌ Failed to patch observer-auth-config entitlement claim to client_id"
+            return 1
+        fi
+        echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
+        kubectl rollout restart deployment/observer -n openchoreo-observability-plane
+        kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s
+        echo "✅ observer-auth-config patched (client_id claim)"
     fi
-    patched_obs_yaml=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml \
-        | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
-    if ! echo "$patched_obs_yaml" | grep -q "claim: client_id"; then
-        echo "❌ Failed to patch observer-auth-config entitlement claim to client_id"
-        return 1
-    fi
-    echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
-    kubectl rollout restart deployment/observer -n openchoreo-observability-plane
-    kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s
-    echo "✅ observer-auth-config patched (client_id claim)"
 
     # Registering the Observability Plane with the control plane
     echo "🔗 Registering Observability Plane..."

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -297,21 +297,33 @@ install_observability_plane() {
     # The observer resolves service accounts from its own config (observer-auth-config),
     # still keyed on 'claim: sub'. Patch it to 'client_id' (like openchoreo-api-config),
     # else agent build-log queries get 403.
+    #
+    # observer-auth-config is populated asynchronously: the configmap can exist
+    # before its service-account 'claim: sub' is written. Patching too early sees
+    # no 'sub' and would fail below; wait for the claim to surface (either 'sub'
+    # to patch, or 'client_id' if a prior run already did).
     echo "🔧 Patching observer-auth-config: service_account entitlement claim → client_id..."
-    if kubectl get configmap observer-auth-config -n openchoreo-observability-plane &>/dev/null; then
-        patched_obs_yaml=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml \
-            | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
-        if ! echo "$patched_obs_yaml" | grep -q "claim: client_id"; then
-            echo "❌ Failed to patch observer-auth-config entitlement claim to client_id"
-            return 1
-        fi
-        echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
-        kubectl rollout restart deployment/observer -n openchoreo-observability-plane
-        kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s
-        echo "✅ observer-auth-config patched (client_id claim)"
-    else
-        echo "⚠️  observer-auth-config not found — skipping observer claim patch"
+    obs_auth_claim=""
+    for _ in $(seq 1 30); do
+        obs_auth_claim=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml 2>/dev/null \
+            | grep -oE "claim:[[:space:]]*['\"]?(sub|client_id)['\"]?" | head -1)
+        [ -n "$obs_auth_claim" ] && break
+        sleep 4
+    done
+    if [ -z "$obs_auth_claim" ]; then
+        echo "❌ observer-auth-config has no service-account 'sub' claim after waiting"
+        return 1
     fi
+    patched_obs_yaml=$(kubectl get configmap observer-auth-config -n openchoreo-observability-plane -o yaml \
+        | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
+    if ! echo "$patched_obs_yaml" | grep -q "claim: client_id"; then
+        echo "❌ Failed to patch observer-auth-config entitlement claim to client_id"
+        return 1
+    fi
+    echo "$patched_obs_yaml" | kubectl apply --server-side --field-manager=helm --force-conflicts -f -
+    kubectl rollout restart deployment/observer -n openchoreo-observability-plane
+    kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s
+    echo "✅ observer-auth-config patched (client_id claim)"
 
     # Registering the Observability Plane with the control plane
     echo "🔗 Registering Observability Plane..."


### PR DESCRIPTION
## Purpose
On a fresh install the console log and trace views fail (`502`/`500`): `agent-manager-observer`'s outbound calls to the OpenChoreo observer are denied `403`. The observer resolves service accounts by their token claim, and the install patches its `observer-auth-config` from `claim: sub` to `claim: client_id` (ThunderID v0.45 tokens carry the identity in `client_id`; `sub` is a random UUID, and the `amp-observer-reader` ClusterAuthzRoleBinding keys on `client_id`). That patch silently skips, leaving the observer on `sub` so the binding never matches.

Resolves #1418

## Goals
Make the `observer-auth-config` `sub`→`client_id` patch apply reliably so the observer authorizes service-account log/trace queries, instead of racing the configmap's population and silently skipping.

## Approach
`observer-auth-config` is populated asynchronously by the observability plane: the configmap can exist before its service-account `claim: sub` is written. The patch ran as soon as the configmap appeared, found no `sub` to replace, took the warn-and-continue branch (`observer-auth-config has no 'sub' claim to patch - skipping`), and left the observer on `sub`. The control-plane `openchoreo-api-config` patch and the built-in binding migration in the same run succeed, so only the observer stayed broken and the install completed with silently-failing log/trace queries.

The fix adds a bounded wait (30 × 4s) for the service-account claim to surface before patching, in both places that apply it (`deployments/quick-start/install.sh` and `deployments/setup/setup-openchoreo.sh`). It matches on `sub` (to patch) or `client_id` (already patched, e.g. a re-run) and ignores the always-present user `claim: groups`. `install.sh` keeps its warn-and-continue on timeout; `setup-openchoreo.sh` keeps its stricter `return 1`. No binding or role change is needed — those are already correct.

## User stories
As an operator, after a fresh install I can view agent logs and traces in the console instead of getting `502`/`500`.

## Release note
Fixed a race where the observer service-account auth-config patch could run before the config was populated and silently skip, leaving console log/trace views returning 403/502.

## Documentation
N/A — internal install-time configuration fix; no user-facing docs affected.

## Training
N/A — no training content covers this.

## Certification
N/A — no certification exam covers this.

## Marketing
N/A — a bug fix.

## Automation tests
 - Unit tests
   > N/A — the change is in the install shell scripts, which have no unit-test harness in this repo.
 - Integration tests
   > None automated. Verified manually on a live install; see Test environment.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell only, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
None.

## Migrations (if applicable)
N/A.

## Test environment
Reproduced and fixed on a fresh install (`amp/v0.0.0-dev-20260727`, OpenChoreo observability plane `1.1.1`). The original install log showed `observer-auth-config has no 'sub' claim to patch - skipping`, and console log/trace queries returned `403`→`502`/`500`. After the observability plane finished populating the configmap, the exact patch `sed` matched `claim: sub`; applying it and restarting the observer made log/trace queries return `200` with the shipped `amp-observer-reader-binding` (client_id) and `amp-observer-reader` role (`traces:view/logs:view/metrics:view`) unchanged, and the configmap stayed on `client_id` (not reconciled back) — confirming the only defect was the patch losing the race, which this wait closes. `bash -n` clean on both edited files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Observability Plane installation and setup reliability by waiting for service-account entitlement details before applying configuration updates.
  * Automatically updates the observer service and confirms its rollout after configuration changes.
  * Added a warning when required entitlement details are unavailable, helping identify potential authorization issues with log and trace queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->