### PR TITLE
Key monitor LLM-proxy name on the monitor UUID (fixes cross-agent 'LLM proxy already exists')

### DIFF
--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -1370,6 +1370,26 @@ func (s *monitorManagerService) resolveMonitorSecretRef(ctx context.Context, ouI
 	return "", "", fmt.Errorf("SecretReference %s has no \"LLM_API_KEY\" data source (found %d sources)", secretRefName, len(ref.Data))
 }
 
+// monitorProxyName derives the LLM proxy name (and handle) for a monitor's
+// provider. Monitor names are unique only per agent
+// (UNIQUE(name, ou_id, project_name, agent_name)), so a handle built from just
+// name+provider collides when two agents have a monitor of the same name and
+// provider, and provisioning fails with "LLM proxy already exists". Including the
+// monitor UUID makes the handle unique to the monitor. The name is capped at 52
+// chars so that appending "-deployment" (11 chars) never exceeds the Kubernetes
+// 63-char name limit; when capping, the unique suffix is kept and the readable
+// prefix is trimmed.
+func monitorProxyName(monitorID uuid.UUID, monitorName, providerName string) string {
+	const monitorSuffixLen = 8
+	monitorSuffix := strings.ReplaceAll(monitorID.String(), "-", "")[:monitorSuffixLen]
+	readable := fmt.Sprintf("%s-%s", sanitizeForK8sName(monitorName), sanitizeForK8sName(providerName))
+	// Reserve room for "-<suffix>-proxy".
+	if maxReadable := 52 - 1 - monitorSuffixLen - len("-proxy"); len(readable) > maxReadable {
+		readable = strings.TrimRight(readable[:maxReadable], "-")
+	}
+	return fmt.Sprintf("%s-%s-proxy", readable, monitorSuffix)
+}
+
 func (s *monitorManagerService) provisionLLMProxy(
 	ctx context.Context,
 	ouID string,
@@ -1378,17 +1398,7 @@ func (s *monitorManagerService) provisionLLMProxy(
 	gateway *models.Gateway,
 	projectUUID uuid.UUID,
 ) (*models.MonitorLLMMapping, ProxyRollbackState, string, error) {
-	// Cap the full proxy name to 52 chars so that appending "-deployment" (11 chars)
-	// never exceeds the Kubernetes 63-char name limit. When truncation is needed,
-	// append the first 8 hex chars of the monitor UUID to avoid collisions between
-	// monitors whose names share a long common prefix.
-	rawProxyName := fmt.Sprintf("%s-%s-proxy", sanitizeForK8sName(monitor.Name), sanitizeForK8sName(provRef.ProviderName))
-	proxyName := rawProxyName
-	if len(proxyName) > 52 {
-		const suffixLen = 8
-		monitorSuffix := strings.ReplaceAll(monitor.ID.String(), "-", "")[:suffixLen]
-		proxyName = strings.TrimRight(rawProxyName[:52-1-suffixLen], "-") + "-" + monitorSuffix
-	}
+	proxyName := monitorProxyName(monitor.ID, monitor.Name, provRef.ProviderName)
 
 	provisioned, err := s.llmProvisioner.ProvisionProxy(ctx, ProvisionProxyParams{
 		OrgName:        ouID,

--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -1380,11 +1380,12 @@ func (s *monitorManagerService) resolveMonitorSecretRef(ctx context.Context, ouI
 // 63-char name limit; when capping, the unique suffix is kept and the readable
 // prefix is trimmed.
 func monitorProxyName(monitorID uuid.UUID, monitorName, providerName string) string {
-	const monitorSuffixLen = 8
-	monitorSuffix := strings.ReplaceAll(monitorID.String(), "-", "")[:monitorSuffixLen]
+	// Use the full dashless UUID (not a truncated prefix): a shortened suffix
+	// could still collide when two monitor UUIDs share their leading hex digits.
+	monitorSuffix := strings.ReplaceAll(monitorID.String(), "-", "")
 	readable := fmt.Sprintf("%s-%s", sanitizeForK8sName(monitorName), sanitizeForK8sName(providerName))
 	// Reserve room for "-<suffix>-proxy".
-	if maxReadable := 52 - 1 - monitorSuffixLen - len("-proxy"); len(readable) > maxReadable {
+	if maxReadable := 52 - 1 - len(monitorSuffix) - len("-proxy"); len(readable) > maxReadable {
 		readable = strings.TrimRight(readable[:maxReadable], "-")
 	}
 	return fmt.Sprintf("%s-%s-proxy", readable, monitorSuffix)

--- a/agent-manager-service/services/monitor_proxy_name_test.go
+++ b/agent-manager-service/services/monitor_proxy_name_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestMonitorProxyName guards the collision fix: the derived proxy name must be
+// unique per monitor (via the monitor UUID) so two monitors with the same name
+// and provider — e.g. a "monitor-1"/"openai" on two different agents — do not
+// derive the same handle and fail provisioning with "LLM proxy already exists".
+// It also stays within the Kubernetes name budget (<=52 so "-deployment" keeps
+// it <=63).
+func TestMonitorProxyName(t *testing.T) {
+	id1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	id2 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	t.Run("includes the monitor uuid, ends in -proxy, within budget", func(t *testing.T) {
+		name := monitorProxyName(id1, "monitor-1", "openai")
+		if !strings.HasSuffix(name, "-proxy") {
+			t.Errorf("expected -proxy suffix, got %q", name)
+		}
+		if !strings.Contains(name, "11111111") {
+			t.Errorf("expected monitor uuid prefix in %q", name)
+		}
+		if len(name) > 52 {
+			t.Errorf("proxy name too long: %q (len=%d, max=52)", name, len(name))
+		}
+	})
+
+	t.Run("same name and provider but different monitors do not collide", func(t *testing.T) {
+		a := monitorProxyName(id1, "monitor-1", "openai")
+		b := monitorProxyName(id2, "monitor-1", "openai")
+		if a == b {
+			t.Errorf("expected distinct proxy names for different monitors, both were %q", a)
+		}
+	})
+
+	t.Run("long names truncate but keep the uuid, suffix, budget, and distinctness", func(t *testing.T) {
+		longName := strings.Repeat("a", 60)
+		longProvider := "some-very-long-provider-name"
+
+		name := monitorProxyName(id1, longName, longProvider)
+		if len(name) > 52 {
+			t.Errorf("proxy name too long: %q (len=%d, max=52)", name, len(name))
+		}
+		if !strings.HasSuffix(name, "-proxy") {
+			t.Errorf("expected -proxy suffix, got %q", name)
+		}
+		if !strings.Contains(name, "11111111") {
+			t.Errorf("expected monitor uuid prefix in %q", name)
+		}
+
+		other := monitorProxyName(id2, longName, longProvider)
+		if name == other {
+			t.Errorf("expected distinct truncated names for different monitors, both were %q", name)
+		}
+	})
+}

--- a/agent-manager-service/services/monitor_proxy_name_test.go
+++ b/agent-manager-service/services/monitor_proxy_name_test.go
@@ -31,7 +31,9 @@ import (
 // it <=63).
 func TestMonitorProxyName(t *testing.T) {
 	id1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	id2 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	// id2 deliberately shares id1's first eight hex digits and differs only
+	// afterwards, so a suffix built from a truncated UUID prefix would collide.
+	id2 := uuid.MustParse("11111111-1111-1111-1111-111111111112")
 
 	t.Run("includes the monitor uuid, ends in -proxy, within budget", func(t *testing.T) {
 		name := monitorProxyName(id1, "monitor-1", "openai")


### PR DESCRIPTION
## Purpose
Creating a monitor can fail with `500` and `failed to create proxy: LLM proxy already exists`. The LLM proxy name was derived from only the monitor name and provider (`<name>-<provider>-proxy`), and the existence check is org-scoped, but monitor names are unique only per agent (`UNIQUE(name, ou_id, project_name, agent_name)`). So two agents that each create a `monitor-1` with the same provider derive the same org-global proxy handle and the second collides.

Resolves #1420

## Goals
Make the monitor LLM proxy handle unique to the monitor so provisioning cannot collide across agents.

## Approach
Include the monitor UUID in the proxy name so the derived handle is unique to the monitor and no longer collides across agents. The existing 52-char cap (so `-deployment` stays under the Kubernetes 63-char name limit) is preserved, and the unique suffix is kept when the readable prefix is trimmed. The derivation is extracted into `monitorProxyName` so it can be unit-tested.

Cleanup is unaffected: `cleanupLLMProxies` tears proxies down by the stored mapping UUID (`monitorLLMMappingRepo`), not by re-deriving the name, so changing the name format does not orphan existing proxies at delete time.

This is a naming change, so proxies created before this change keep their old-format handles; that is acceptable pre-GA.

## User stories
As an operator, I can create a monitor named `monitor-1` on more than one agent without a 500 "LLM proxy already exists".

## Release note
Fixed monitor creation failing with "LLM proxy already exists" when another agent already had a monitor of the same name and provider.

## Documentation
N/A — internal naming/provisioning fix; no user-facing docs affected.

## Training
N/A — no training content covers this.

## Certification
N/A — no certification exam covers this.

## Marketing
N/A — a bug fix.

## Automation tests
 - Unit tests
   > Added `TestMonitorProxyName` (`services/monitor_proxy_name_test.go`): the derived name includes the monitor UUID, ends in `-proxy`, and stays within the 52-char budget; two monitors with the same name and provider but different UUIDs get distinct names (the collision guard), including after truncation of long names. Runs in the existing unit tier (`make test-unit`), no database required.
 - Integration tests
   > None added; the unit test pins the collision-free naming contract directly.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go, not Java; `go vet` clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Related PRs
None.

## Migrations (if applicable)
No schema migration. Existing monitor proxies keep their previously-derived handles; new/re-created monitors use the UUID-keyed name.

## Test environment
Reproduced on a fresh install (`amp/v0.0.0-dev-20260727`): creating a monitor on an agent whose `(name, provider)` pair was already taken org-wide returned `500` `failed to create proxy: LLM proxy already exists`, while a fresh agent succeeded. Locally: `make test-unit` passes with the new test; `TestMonitorProxyName` passes (all three subtests); `gofumpt -l` clean and `go vet ./services/` clean on the changed files (built with `GOFLAGS=-mod=mod`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM proxy naming to ensure unique, Kubernetes-compatible names.
  * Preserved monitor identifiers in generated names to prevent collisions.
  * Limited long names to remain within platform naming constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->