### PR TITLE
Fall back to configured default environment for agent tokens

### DIFF
--- a/agent-manager-service/keys/README.md
+++ b/agent-manager-service/keys/README.md
@@ -45,7 +45,9 @@ JWT_SIGNING_PUBLIC_KEYS_CONFIG=./keys/public-keys-config.json
 # Other settings
 JWT_SIGNING_DEFAULT_EXPIRY=8760h
 JWT_SIGNING_ISSUER=agent-manager-service
-JWT_SIGNING_DEFAULT_ENVIRONMENT=development
+# Environment used for token claims when the caller does not name one. It must be an
+# environment that actually exists in this install — the shipped charts create "default".
+JWT_SIGNING_DEFAULT_ENVIRONMENT=default
 ```
 
 Create `public-keys-config.json`:

--- a/agent-manager-service/mcp/tools/agents.go
+++ b/agent-manager-service/mcp/tools/agents.go
@@ -377,7 +377,10 @@ func createExternalAgent(handler AgentToolsetHandler) func(context.Context, *gom
 			return nil, nil, wrapToolError("create_external_agent", err)
 		}
 
-		// generate a token for the agent that allows instrumentation
+		// generate a token for the agent that allows instrumentation. External agents
+		// run outside the platform, so there is no deployment environment to derive
+		// here: the empty environment routes through the token service's configured
+		// default (JWT_SIGNING_DEFAULT_ENVIRONMENT).
 		expiresIn := "8760h"
 		tokenResp, err := handler.GenerateToken(ctx, ouID, input.ProjectName, agentName, "", expiresIn)
 		if err != nil {

--- a/agent-manager-service/mcp/tools/helpers.go
+++ b/agent-manager-service/mcp/tools/helpers.go
@@ -41,16 +41,6 @@ func resolveOUID(ctx context.Context) string {
 	return ""
 }
 
-// helper function for resolving the environment of the agent
-const defaultEnvName = "default"
-
-func resolveEnv(value string) string {
-	if trimmed := strings.TrimSpace(value); trimmed != "" {
-		return trimmed
-	}
-	return defaultEnvName
-}
-
 // helper functions  that build JSON Schema snippets
 
 func createSchema(properties map[string]any, required []string) map[string]any {

--- a/agent-manager-service/services/agent_apikey_secret_ref_test.go
+++ b/agent-manager-service/services/agent_apikey_secret_ref_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func TestInjectAgentAPIKeySecretRef_AddsEntry(t *testing.T) {
@@ -84,4 +85,24 @@ func TestResolveAgentAPIKeySecretRef_ReturnsPerEnvRemoteRef(t *testing.T) {
 	require.Len(t, ocClient.GetSecretReferenceCalls(), 1)
 	expectedName := agentAPIKeySecretLocation("org", "proj", "agent", "production").SecretRefName()
 	assert.Equal(t, expectedName, ocClient.GetSecretReferenceCalls()[0].SecretRefName)
+}
+
+// generateAgentAPIKey must refuse an empty environment. The token service itself treats
+// GenerateTokenRequest.Environment as optional (falling back to the configured default for
+// external agents and the token REST endpoint), so this guard is what keeps a deploy-shaped
+// caller that lost its environment — e.g. agent creation swallowing a
+// GetProjectDeploymentPipeline error, leaving findLowestEnvironment empty — from silently
+// minting a token scoped to the wrong environment and writing its API key to the org-level
+// KV path instead of the per-environment one.
+func TestGenerateAgentAPIKey_RequiresEnvironment(t *testing.T) {
+	for _, envName := range []string{"", "   "} {
+		// Every collaborator is nil: the guard must fire before any of them is touched,
+		// so a regression shows up as a panic rather than a passing test.
+		s := &agentManagerService{logger: discardLogger()}
+
+		_, err := s.generateAgentAPIKey(context.Background(), "org", "proj", "agent", envName)
+
+		require.Error(t, err, "empty environment %q must be rejected", envName)
+		assert.ErrorIs(t, err, utils.ErrInvalidInput)
+	}
 }

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -758,6 +758,19 @@ func (s *agentManagerService) persistInstrumentationConfig(ctx context.Context, 
 // generateAgentAPIKey generates an agent API key (JWT token) for the agent
 // This is a common utility used by both buildpack and docker agent instrumentation
 func (s *agentManagerService) generateAgentAPIKey(ctx context.Context, ouID, projectName, agentName, envName string) (string, error) {
+	// An environment is mandatory here, unlike on GenerateTokenRequest itself. The key is
+	// minted per environment and stored at an env-scoped KV path, so an empty name would
+	// both mis-scope the token's environment_uid claim and collapse the secret to the
+	// org-level path (SecretLocation skips the segment when EnvironmentName is empty).
+	// The token service's fallback to the configured default environment exists for
+	// callers that genuinely have none — external agents, the token REST endpoint. A
+	// deploy-shaped caller reaching here without one is an upstream bug (e.g. a swallowed
+	// GetProjectDeploymentPipeline error) and must fail loudly rather than be papered over.
+	if strings.TrimSpace(envName) == "" {
+		s.logger.Error("Cannot generate agent API key without an environment", "agentName", agentName, "projectName", projectName)
+		return "", fmt.Errorf("%w: environment name is required to generate an agent API key", utils.ErrInvalidInput)
+	}
+
 	// Extract OrgId from the caller's JWT claims
 	callerClaims := jwtassertion.GetTokenClaims(ctx)
 	if callerClaims == nil || callerClaims.OuId == "" {

--- a/agent-manager-service/services/agent_token_manager.go
+++ b/agent-manager-service/services/agent_token_manager.go
@@ -29,6 +29,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -262,10 +263,21 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 		return nil, fmt.Errorf("failed to get agent component: %w", err)
 	}
 
-	// Determine which environment to use
-	environmentName := req.Environment
+	// Determine which environment to use. Environment is optional on the request:
+	// the token REST endpoint's ?environment= query parameter and the MCP
+	// create_external_agent tool both leave it unset, so an omitted value falls
+	// back to the configured default (JWT_SIGNING_DEFAULT_ENVIRONMENT, "default"
+	// unless overridden) rather than failing the call.
+	environmentName := strings.TrimSpace(req.Environment)
 	if environmentName == "" {
-		return nil, fmt.Errorf("environment name cannot be empty")
+		environmentName = strings.TrimSpace(s.config.DefaultEnvironment)
+		if environmentName == "" {
+			// Server-side misconfiguration, not bad caller input: the config loader
+			// defaults this to "default", so it is only empty if explicitly blanked.
+			return nil, fmt.Errorf("environment name cannot be empty and no default " +
+				"environment is configured (set JWT_SIGNING_DEFAULT_ENVIRONMENT)")
+		}
+		s.logger.Debug("No environment supplied; using configured default", "environment", environmentName)
 	}
 
 	// Fetch environment UID from OpenChoreo

--- a/agent-manager-service/services/agent_token_manager.go
+++ b/agent-manager-service/services/agent_token_manager.go
@@ -264,6 +264,12 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 	// OpenChoreo call so a purely local failure costs no remote round trips.
 	environmentName := strings.TrimSpace(req.Environment)
 	if environmentName == "" {
+		if req.Environment != "" {
+			// Supplied but blank (e.g. ?environment=%20) is caller error, not an omitted
+			// field: silently substituting the default would scope the token to an
+			// environment other than the one the caller named.
+			return nil, fmt.Errorf("%w: environment name is blank", utils.ErrInvalidInput)
+		}
 		environmentName = strings.TrimSpace(s.config.DefaultEnvironment)
 		if environmentName == "" {
 			// Server-side misconfiguration, not bad caller input: the config loader
@@ -281,11 +287,15 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 		return nil, fmt.Errorf("failed to get agent component: %w", err)
 	}
 
-	// Fetch environment UID from OpenChoreo
+	// Fetch environment UID from OpenChoreo. The client reports a 404 as the generic
+	// utils.ErrNotFound, which is a different sentinel from the utils.ErrEnvironmentNotFound
+	// the token controller maps to 404 — translate so a missing environment (now the
+	// common case, since an omitted environment resolves to a configured default that
+	// may not exist in this install) surfaces as 404 rather than an opaque 500.
 	environment, err := s.ocClient.GetEnvironment(ctx, req.OrgName, environmentName)
 	if err != nil {
 		s.logger.Error("Failed to get environment", "environment", environmentName, "error", err)
-		return nil, fmt.Errorf("failed to get environment: %w", err)
+		return nil, fmt.Errorf("failed to get environment %q: %w", environmentName, translateEnvironmentError(err))
 	}
 
 	// Fetch project UID

--- a/agent-manager-service/services/agent_token_manager.go
+++ b/agent-manager-service/services/agent_token_manager.go
@@ -256,18 +256,12 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 		return nil, fmt.Errorf("org id is required: %w", utils.ErrInvalidInput)
 	}
 
-	// Fetch component UID from OpenChoreo
-	component, err := s.ocClient.GetComponent(ctx, req.OrgName, req.ProjectName, req.AgentName)
-	if err != nil {
-		s.logger.Error("Failed to get agent component", "agentName", req.AgentName, "error", err)
-		return nil, fmt.Errorf("failed to get agent component: %w", err)
-	}
-
 	// Determine which environment to use. Environment is optional on the request:
 	// the token REST endpoint's ?environment= query parameter and the MCP
 	// create_external_agent tool both leave it unset, so an omitted value falls
 	// back to the configured default (JWT_SIGNING_DEFAULT_ENVIRONMENT, "default"
-	// unless overridden) rather than failing the call.
+	// unless overridden) rather than failing the call. Resolved before any
+	// OpenChoreo call so a purely local failure costs no remote round trips.
 	environmentName := strings.TrimSpace(req.Environment)
 	if environmentName == "" {
 		environmentName = strings.TrimSpace(s.config.DefaultEnvironment)
@@ -278,6 +272,13 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 				"environment is configured (set JWT_SIGNING_DEFAULT_ENVIRONMENT)")
 		}
 		s.logger.Debug("No environment supplied; using configured default", "environment", environmentName)
+	}
+
+	// Fetch component UID from OpenChoreo
+	component, err := s.ocClient.GetComponent(ctx, req.OrgName, req.ProjectName, req.AgentName)
+	if err != nil {
+		s.logger.Error("Failed to get agent component", "agentName", req.AgentName, "error", err)
+		return nil, fmt.Errorf("failed to get agent component: %w", err)
 	}
 
 	// Fetch environment UID from OpenChoreo

--- a/agent-manager-service/services/agent_token_manager_unit_test.go
+++ b/agent-manager-service/services/agent_token_manager_unit_test.go
@@ -33,6 +33,7 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -419,6 +420,40 @@ func TestAgentTokenManager_GenerateToken_DefaultEnvironment(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "staging", lookedUp)
+	})
+
+	t.Run("blank-but-supplied environment is rejected, not defaulted", func(t *testing.T) {
+		// A caller that names an environment gets that environment or an error — never a
+		// silent substitution. Guards ?environment=%20 on the token REST endpoint, which
+		// passes the raw query value through.
+		oc := &clientmocks.OpenChoreoClientMock{}
+		svc := newTokenManagerWithConfig(t, oc, cfg)
+		req := base
+		req.Environment = "   "
+
+		_, err := svc.GenerateToken(context.Background(), req)
+
+		assert.ErrorIs(t, err, utils.ErrInvalidInput)
+		assert.Empty(t, oc.GetEnvironmentCalls(), "a blank environment must not be resolved against the default")
+	})
+
+	t.Run("missing environment maps to ErrEnvironmentNotFound", func(t *testing.T) {
+		// The OpenChoreo client reports a 404 as the generic utils.ErrNotFound; the token
+		// controller only maps utils.ErrEnvironmentNotFound to a 404 response. Without the
+		// translation a configured default that does not exist in this install would
+		// surface as an opaque 500.
+		oc := fullClientMock("comp-uuid", "env-uuid", "proj-uuid")
+		oc.GetEnvironmentFunc = func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
+			return nil, fmt.Errorf("%w: environment not found", utils.ErrNotFound)
+		}
+		svc := newTokenManagerWithConfig(t, oc, cfg)
+
+		_, err := svc.GenerateToken(context.Background(), base)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrEnvironmentNotFound,
+			"a 404 from GetEnvironment must reach the controller as ErrEnvironmentNotFound")
+		assert.Contains(t, err.Error(), "default", "the error must name the environment that was not found")
 	})
 }
 

--- a/agent-manager-service/services/agent_token_manager_unit_test.go
+++ b/agent-manager-service/services/agent_token_manager_unit_test.go
@@ -156,15 +156,13 @@ func TestAgentTokenManager_GenerateToken_ValidationGates(t *testing.T) {
 	})
 
 	t.Run("rejects empty environment name when no default is configured", func(t *testing.T) {
-		// Org id passes; GetComponent succeeds; the empty-environment guard fires
-		// before GetEnvironment, so GetEnvironment must stay unconfigured. This is
-		// the only case where an omitted environment is fatal — testJWTConfig
-		// leaves DefaultEnvironment empty, so there is nothing to fall back to.
-		oc := &clientmocks.OpenChoreoClientMock{
-			GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
-				return &models.AgentResponse{UUID: "comp-uuid"}, nil
-			},
-		}
+		// This is the only case where an omitted environment is fatal — testJWTConfig
+		// leaves DefaultEnvironment empty, so there is nothing to fall back to. The
+		// environment resolves entirely from the request and local config, so it must
+		// fail before any OpenChoreo I/O: leaving every mock func nil asserts that
+		// (a call on an unconfigured moq func panics), and the call recorders below
+		// state it explicitly.
+		oc := &clientmocks.OpenChoreoClientMock{}
 		svc := newTokenManager(t, oc)
 
 		_, err := svc.GenerateToken(context.Background(), GenerateTokenRequest{
@@ -176,6 +174,12 @@ func TestAgentTokenManager_GenerateToken_ValidationGates(t *testing.T) {
 		})
 
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "JWT_SIGNING_DEFAULT_ENVIRONMENT",
+			"the error must name the config knob the operator has to set")
+		assert.Empty(t, oc.GetComponentCalls(), "no component lookup before the environment is resolved")
+		assert.Empty(t, oc.GetEnvironmentCalls(), "no environment lookup without a resolved name")
+		assert.Empty(t, oc.GetProjectCalls(), "no project lookup before the environment is resolved")
+		assert.Empty(t, oc.ListOrganizationsCalls(), "no namespace resolution before the environment is resolved")
 	})
 }
 

--- a/agent-manager-service/services/agent_token_manager_unit_test.go
+++ b/agent-manager-service/services/agent_token_manager_unit_test.go
@@ -66,9 +66,21 @@ func testJWTConfig() config.JWTSigningConfig {
 // signing config. It skips the test if the signing keys are not present (the
 // unit-test runner generates them; a bare `go test` without gen_keys.sh would
 // otherwise fail with an unrelated file-not-found).
+//
+// testJWTConfig leaves DefaultEnvironment empty, so services built here have no
+// configured fallback environment — use newTokenManagerWithConfig to exercise
+// that fallback.
 func newTokenManager(t *testing.T, oc *clientmocks.OpenChoreoClientMock) AgentTokenManagerService {
 	t.Helper()
-	cfg := testJWTConfig()
+	return newTokenManagerWithConfig(t, oc, testJWTConfig())
+}
+
+// newTokenManagerWithConfig is newTokenManager with a caller-supplied signing
+// config, for asserting config-driven defaults.
+func newTokenManagerWithConfig(
+	t *testing.T, oc *clientmocks.OpenChoreoClientMock, cfg config.JWTSigningConfig,
+) AgentTokenManagerService {
+	t.Helper()
 	if _, err := os.Stat(cfg.PrivateKeyPath); err != nil {
 		t.Skipf("signing keys not present (%v); run scripts/gen_keys.sh", err)
 	}
@@ -143,9 +155,11 @@ func TestAgentTokenManager_GenerateToken_ValidationGates(t *testing.T) {
 		assert.ErrorIs(t, err, utils.ErrInvalidInput)
 	})
 
-	t.Run("rejects empty environment name", func(t *testing.T) {
+	t.Run("rejects empty environment name when no default is configured", func(t *testing.T) {
 		// Org id passes; GetComponent succeeds; the empty-environment guard fires
-		// before GetEnvironment, so GetEnvironment must stay unconfigured.
+		// before GetEnvironment, so GetEnvironment must stay unconfigured. This is
+		// the only case where an omitted environment is fatal — testJWTConfig
+		// leaves DefaultEnvironment empty, so there is nothing to fall back to.
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
 				return &models.AgentResponse{UUID: "comp-uuid"}, nil
@@ -346,6 +360,62 @@ func TestAgentTokenManager_GenerateToken_DefaultExpiry(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.NotEmpty(t, resp.Token)
+}
+
+func TestAgentTokenManager_GenerateToken_DefaultEnvironment(t *testing.T) {
+	// GenerateTokenRequest.Environment is documented as optional, falling back to
+	// the configured default (JWT_SIGNING_DEFAULT_ENVIRONMENT). Callers rely on
+	// that: the MCP create_external_agent tool always passes an empty
+	// environment, and the token REST endpoint's ?environment= query parameter is
+	// optional. Regression test for #1415, where an omitted environment failed
+	// outright with "environment name cannot be empty".
+	newMock := func(seen *string) *clientmocks.OpenChoreoClientMock {
+		oc := fullClientMock("comp-uuid", "env-uuid", "proj-uuid")
+		oc.GetEnvironmentFunc = func(_ context.Context, _, environmentName string) (*models.EnvironmentResponse, error) {
+			*seen = environmentName
+			return &models.EnvironmentResponse{UUID: "env-uuid"}, nil
+		}
+		return oc
+	}
+
+	base := GenerateTokenRequest{
+		OrgName:     "acme",
+		ProjectName: "proj",
+		AgentName:   "agent",
+		OrgId:       "org-123",
+		ExpiresIn:   "1h",
+	}
+
+	cfg := testJWTConfig()
+	cfg.DefaultEnvironment = "default"
+
+	t.Run("omitted environment falls back to the configured default", func(t *testing.T) {
+		var lookedUp string
+		svc := newTokenManagerWithConfig(t, newMock(&lookedUp), cfg)
+
+		resp, err := svc.GenerateToken(context.Background(), base)
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, "default", lookedUp, "the configured default environment must be the one looked up")
+
+		claims := &AgentTokenClaims{}
+		_, _, err = jwt.NewParser().ParseUnverified(resp.Token, claims)
+		require.NoError(t, err)
+		assert.Equal(t, "env-uuid", claims.EnvironmentUid, "the resolved environment's UUID must reach the claims")
+	})
+
+	t.Run("request environment wins over the configured default", func(t *testing.T) {
+		var lookedUp string
+		svc := newTokenManagerWithConfig(t, newMock(&lookedUp), cfg)
+		req := base
+		req.Environment = "  staging  " // surrounding whitespace must not defeat the explicit value
+
+		_, err := svc.GenerateToken(context.Background(), req)
+
+		require.NoError(t, err)
+		assert.Equal(t, "staging", lookedUp)
+	})
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose
Resolves #1415

`create_external_agent` (MCP) always failed with `environment name cannot be empty`, so the tool could never register an agent. The same defect breaks `POST /orgs/{org}/projects/{project}/agents/{agent}/token` whenever the optional `?environment=` query parameter is omitted.

The issue attributes this to a field-mapping mismatch (`environmentName` vs `metadata.name`) when decoding the OpenChoreo Environments API. That is **no longer** the cause — the generated OpenChoreo client (`clients/openchoreosvc/gen/types.gen.go`) models `Environment` with `Metadata ObjectMeta`, and `convertEnvironmentToResponse` reads `env.Metadata.Name`. There is no `environmentName` field on the type any more, and no environment-name cache.

The real cause is one layer up, in `agentTokenManagerService.GenerateToken`:

```go
environmentName := req.Environment
if environmentName == "" {
    return nil, fmt.Errorf("environment name cannot be empty")
}
```

`GenerateTokenRequest.Environment` is documented as *"Optional, defaults to config default if not provided"*, and the config for that fallback exists and is plumbed all the way through (`JWTSigningConfig.DefaultEnvironment` ← `JWT_SIGNING_DEFAULT_ENVIRONMENT`, default `"default"`, also set in the Helm configmap). The fallback was simply never implemented — `config.JWTSigningConfig.DefaultEnvironment` had zero readers in the codebase. Two callers then hit the guard unconditionally:

- `mcp/tools/agents.go` — `createExternalAgent` passes `""`; external agents have no deployment environment to derive.
- `controllers/agent_token_controller.go` — `environment` comes from an optional query parameter.

A dead `resolveEnv()` helper + `defaultEnvName = "default"` const in `mcp/tools/helpers.go` (never called from anywhere) is the vestige of the missing defaulting.

## Goals
Honour the documented contract: an omitted environment resolves to the configured default instead of failing the request. Fix it once, at the layer that owns the config, so both the MCP tool and the REST endpoint are fixed together.

## Approach
- `services/agent_token_manager.go`: trim `req.Environment`; when empty, fall back to `s.config.DefaultEnvironment`. Only error if *both* are empty — a server-side misconfiguration (the config loader defaults it to `"default"`, so it is empty only if explicitly blanked), with an error message that names the env var to set. Deliberately left unwrapped by `utils.ErrInvalidInput` so it maps to 500 rather than mis-reporting a config problem as bad caller input.
- `mcp/tools/agents.go`: comment at the `GenerateToken` call site explaining why the environment is empty and where the value comes from.
- `mcp/tools/helpers.go`: delete the dead `resolveEnv`/`defaultEnvName`. Resolving the default lives in one place (config) — a second hardcoded `"default"` in the tools layer would defeat the `JWT_SIGNING_DEFAULT_ENVIRONMENT` override that deployments with differently-named environments rely on.

No behaviour change for callers that pass an explicit environment.

## User stories
As a developer, I can register an external agent through `create_external_agent` and receive a working instrumentation token, without having to know or supply an environment name.

## Release note
Fixed `create_external_agent` and the agent token endpoint failing with "environment name cannot be empty" when no environment was supplied; the configured default environment (`JWT_SIGNING_DEFAULT_ENVIRONMENT`) is now used.

## Documentation
N/A — no user-facing API or config surface changes. `JWT_SIGNING_DEFAULT_ENVIRONMENT` is already documented in `agent-manager-service/README.md` and `.env.example`; this change makes it actually take effect.

## Training
N/A — bug fix with no conceptual change.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — internal bug fix.

## Automation tests
 - Unit tests
   > Added `TestAgentTokenManager_GenerateToken_DefaultEnvironment` in `services/agent_token_manager_unit_test.go` with two subtests: an omitted environment resolves to the configured default and its UUID reaches the `environment_uid` claim; an explicitly supplied environment still wins (and is trimmed). Both subtests were confirmed to fail against the unfixed code with the exact reported error before the fix was applied. Existing `rejects empty environment name` case retained, retitled to `rejects empty environment name when no default is configured`, which is the branch it now covers. Added `newTokenManagerWithConfig` helper so tests can vary the signing config. Full unit tier passes (`bash scripts/run_unit_tests.sh`).
 - Integration tests
   > None added — the change is pure service-layer branching over a config value with the OpenChoreo client mocked; a DB-backed test would add no coverage.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Go codebase; `golangci-lint` with `.github/linters/.golangci.yaml` reports 0 issues on the touched packages
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema or data changes.

## Test environment
macOS 15 (darwin/arm64), Go toolchain per `agent-manager-service/go.mod`. `go build ./...`, `go build -tags=integration ./...`, `gofmt -l`, `golangci-lint run --config .github/linters/.golangci.yaml ./services/... ./mcp/...`, and `bash scripts/run_unit_tests.sh` all clean.

## Learning
Traced the failure backwards from the reported error string rather than starting from the issue's diagnosis, which turned out to describe an already-fixed problem. Two pieces of dead code — the unread `JWTSigningConfig.DefaultEnvironment` and the uncalled `resolveEnv()` helper — pinpointed both the intended design and the exact place the implementation was missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token generation now supports using a configured default environment when none is provided.
  * Environment values are automatically trimmed, while explicitly supplied values take precedence.

* **Bug Fixes**
  * Improved error messaging when no environment is available for token generation.
  * External agent token routing now works correctly with the default signing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->