### PR TITLE
Derive the OAuth metadata and MCP resource audiences that installs had to hand-sync

### DIFF
--- a/.github/workflows/helm-charts-pr-check.yml
+++ b/.github/workflows/helm-charts-pr-check.yml
@@ -7,6 +7,11 @@ on:
       - ".github/actions/setup-helm-chart/**"
       - ".github/workflows/helm-charts-pr-check.yml"
 
+# These jobs render and lint PR-authored charts, so the token they run with is
+# read-only. No job here calls the API or pushes.
+permissions:
+  contents: read
+
 env:
   HELM_VERSION: "3.19.4"
   KUBECONFORM_VERSION: "0.7.0"
@@ -144,13 +149,18 @@ jobs:
         shell: bash
 
       - name: Run chart render assertions
+        env:
+          CHART: ${{ matrix.chart }}
         run: |
-          CHART_PATH="deployments/helm-charts/${{ matrix.chart }}"
+          CHART_PATH="deployments/helm-charts/$CHART"
           # Charts that derive values from other values carry their own assertions.
           if [ -f "$CHART_PATH/tests/render.sh" ]; then
-            bash "$CHART_PATH/tests/render.sh"
+            # render.sh is PR-authored. Run it with a scrubbed environment so it
+            # inherits no token or other credential, and only the PATH/HOME helm
+            # needs. env -i also stops a chart name from reaching it as $CHART.
+            env -i PATH="$PATH" HOME="$HOME" bash "$CHART_PATH/tests/render.sh"
           else
-            echo "No tests/render.sh for ${{ matrix.chart }}, skipping"
+            echo "No tests/render.sh for $CHART, skipping"
           fi
         shell: bash
 

--- a/.github/workflows/helm-charts-pr-check.yml
+++ b/.github/workflows/helm-charts-pr-check.yml
@@ -143,6 +143,17 @@ jobs:
           echo "Successfully templated common scenarios"
         shell: bash
 
+      - name: Run chart render assertions
+        run: |
+          CHART_PATH="deployments/helm-charts/${{ matrix.chart }}"
+          # Charts that derive values from other values carry their own assertions.
+          if [ -f "$CHART_PATH/tests/render.sh" ]; then
+            bash "$CHART_PATH/tests/render.sh"
+          else
+            echo "No tests/render.sh for ${{ matrix.chart }}, skipping"
+          fi
+        shell: bash
+
   kubeconform:
     name: Kubeconform Validation
     needs: detect-changes

--- a/agent-manager-observer/mcp/README.md
+++ b/agent-manager-observer/mcp/README.md
@@ -80,7 +80,9 @@ complete OAuth discovery.
 
 In the Helm deployment these come from
 `wso2-amp-observability-extension/values.yaml` under `amObserver.publicUrl`
-and `amObserver.oauth.*`. The `am-obs-mcp` OAuth client itself is registered
+and `amObserver.oauth.*`; `amObserver.oauth.authorizationServers` is empty by
+default and falls back to `amObserver.auth.issuer`, so overriding the issuer for
+a custom domain moves both. The `am-obs-mcp` OAuth client itself is registered
 by `wso2-amp-thunder-extension` (script `64-am-obs-mcp-client.sh`; see
 `amObsMcpClient` in its `values.yaml`).
 

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       # Accepts Thunder-issued tokens (client_credentials for publisher)
       - KEY_MANAGER_JWKS_URL=http://thunder.amp.localhost:8080/oauth2/jwks
       - KEY_MANAGER_ISSUER=Agent Management Platform Local,http://thunder.amp.localhost:8080
+      # Last entry is SERVER_PUBLIC_URL above plus a trailing slash — an MCP
+      # token's `aud`. The Helm charts derive this; here it moves by hand.
       - KEY_MANAGER_AUDIENCE=amp,localhost,amp-publisher-*,amp-api-client,amp-console-client,amctl,am-mcp,http://localhost:9000/
       - AMP_VERSION=v0.8.0
       # In-cluster API Platform gateway runtime Service URL convention.

--- a/deployments/helm-charts/wso2-agent-manager/.helmignore
+++ b/deployments/helm-charts/wso2-agent-manager/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Chart render assertions: dev/CI only, not shipped to users.
+tests/

--- a/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
@@ -114,6 +114,21 @@ app.kubernetes.io/component: agent-manager-service
 {{- end }}
 
 {{/*
+Accepted token audiences. serverPublicURL — with the trailing slash Thunder
+stamps on RFC 8707 resource identifiers — is appended so tokens minted for this
+service's own MCP client stay valid when serverPublicURL is overridden, without
+the operator having to restate the whole audience list. nospace keeps a spaced-out
+list from defeating the uniq.
+*/}}
+{{- define "agent-management-platform.agentManagerService.audience" -}}
+{{- $audiences := .Values.agentManagerService.config.keyManager.audience | nospace | splitList "," | compact -}}
+{{- with .Values.agentManagerService.config.serverPublicURL -}}
+{{- $audiences = append $audiences (printf "%s/" (trimSuffix "/" .)) -}}
+{{- end -}}
+{{- join "," (uniq $audiences) -}}
+{{- end }}
+
+{{/*
 ==============================================
 Console Helpers
 ==============================================

--- a/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
@@ -114,11 +114,9 @@ app.kubernetes.io/component: agent-manager-service
 {{- end }}
 
 {{/*
-Accepted token audiences. serverPublicURL — with the trailing slash Thunder
-stamps on RFC 8707 resource identifiers — is appended so tokens minted for this
-service's own MCP client stay valid when serverPublicURL is overridden, without
-the operator having to restate the whole audience list. nospace keeps a spaced-out
-list from defeating the uniq.
+Accepted token audiences: keyManager.audience plus serverPublicURL with the
+trailing slash Thunder stamps on RFC 8707 resource identifiers. nospace keeps a
+spaced-out list from defeating the uniq. See values.yaml for why it is derived.
 */}}
 {{- define "agent-management-platform.agentManagerService.audience" -}}
 {{- $audiences := .Values.agentManagerService.config.keyManager.audience | nospace | splitList "," | compact -}}

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -36,7 +36,7 @@ data:
   KEY_MANAGER_AUDIENCE: {{ include "agent-management-platform.agentManagerService.audience" . | quote }}
   KEY_MANAGER_JWKS_URL: {{ .Values.agentManagerService.config.keyManager.jwksUrl | quote }}                                         
   SERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.serverPublicURL | default "" | quote }}
-  OAUTH_AUTHORIZATION_SERVERS: {{ .Values.agentManagerService.config.oauthAuthorizationServers | default .Values.agentManagerService.config.keyManager.issuer | default "" | quote }}
+  OAUTH_AUTHORIZATION_SERVERS: {{ .Values.agentManagerService.config.oauthAuthorizationServers | default .Values.agentManagerService.config.keyManager.issuer | quote }}
   # Domain suffix env-Thunder's developer-facing hostnames are built from:
   # "<org>-<env>.thunder.<THUNDER_HOST_BASE_DOMAIN>". Must match the value the
   # deployment-wide provisioning uses, or the identity-provider endpoints the API

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -36,7 +36,7 @@ data:
   KEY_MANAGER_AUDIENCE: {{ .Values.agentManagerService.config.keyManager.audience | quote }}                                   
   KEY_MANAGER_JWKS_URL: {{ .Values.agentManagerService.config.keyManager.jwksUrl | quote }}                                         
   SERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.serverPublicURL | default "" | quote }}
-  OAUTH_AUTHORIZATION_SERVERS: {{ .Values.agentManagerService.config.oauthAuthorizationServers | default "" | quote }}
+  OAUTH_AUTHORIZATION_SERVERS: {{ .Values.agentManagerService.config.oauthAuthorizationServers | default .Values.agentManagerService.config.keyManager.issuer | default "" | quote }}
   # Domain suffix env-Thunder's developer-facing hostnames are built from:
   # "<org>-<env>.thunder.<THUNDER_HOST_BASE_DOMAIN>". Must match the value the
   # deployment-wide provisioning uses, or the identity-provider endpoints the API

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -33,7 +33,7 @@ data:
   OTEL_DEFAULT_INSTRUMENTATION_VERSION: {{ .Values.agentManagerService.config.otel.defaultInstrumentationVersion | quote }}
   INSTRUMENTATION_EXTENSION_PATH: "/etc/amp/instrumentation-extension.yaml"
   KEY_MANAGER_ISSUER: {{ .Values.agentManagerService.config.keyManager.issuer | quote }}                                         
-  KEY_MANAGER_AUDIENCE: {{ .Values.agentManagerService.config.keyManager.audience | quote }}                                   
+  KEY_MANAGER_AUDIENCE: {{ include "agent-management-platform.agentManagerService.audience" . | quote }}
   KEY_MANAGER_JWKS_URL: {{ .Values.agentManagerService.config.keyManager.jwksUrl | quote }}                                         
   SERVER_PUBLIC_URL: {{ .Values.agentManagerService.config.serverPublicURL | default "" | quote }}
   OAUTH_AUTHORIZATION_SERVERS: {{ .Values.agentManagerService.config.oauthAuthorizationServers | default .Values.agentManagerService.config.keyManager.issuer | default "" | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Render assertions for wso2-agent-manager.
+# Run: bash deployments/helm-charts/wso2-agent-manager/tests/render.sh
+#
+# Covers the derived auth values that plain `helm template` with default values
+# cannot distinguish from hardcoded ones: OAUTH_AUTHORIZATION_SERVERS falling
+# back to keyManager.issuer, and serverPublicURL being appended to
+# keyManager.audience. Both are invisible at install time and surface only as a
+# broken MCP login — `invalid_target` on authorize if the advertised
+# authorization server is wrong, or 401 on every tool call if the audience is
+# (see issues #1414 and #1424).
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=0
+
+# cm_value <key> [helm --set args...] -> the rendered value of ConfigMap data key <key>
+# A render failure is reported rather than silently becoming an empty value, so a
+# crash cannot look like a wrong value.
+cm_value() {
+  local key="$1" rendered
+  shift
+  if ! rendered="$(helm template test-release "$CHART_DIR" \
+    --show-only templates/agent-manager-service/configmap.yaml "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$rendered" >&2
+    return 1
+  fi
+  awk -v k="$key" '
+    $1 == k":" {
+      sub(/^[[:space:]]*[^:]+:[[:space:]]*/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^"|"$/, "")
+      print
+      exit
+    }
+  ' <<<"$rendered"
+}
+
+assert_cm() {
+  local label="$1" key="$2" expected="$3"
+  shift 3
+  local actual
+  actual="$(cm_value "$key" "$@")"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected %s: %q\n      actual   %s: %q\n' \
+      "$label" "$key" "$expected" "$key" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+CLIENTS="amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp"
+
+# Defaults must stay byte-identical to the pre-derivation literals, so existing
+# installs and quick-start (which passes no overrides) are unaffected.
+assert_cm "default audience keeps the gateway resource entry" \
+  KEY_MANAGER_AUDIENCE "${CLIENTS},http://api.amp.localhost:8080/"
+assert_cm "default authorization servers fall back to the default issuer" \
+  OAUTH_AUTHORIZATION_SERVERS "http://thunder.amp.localhost:8080"
+
+# Issue #1424: one issuer override has to move the advertised authorization
+# server too, or MCP clients discover an authorization server whose tokens this
+# service then rejects.
+assert_cm "issuer override moves the advertised authorization server" \
+  OAUTH_AUTHORIZATION_SERVERS "https://thunder.example.com" \
+  --set agentManagerService.config.keyManager.issuer=https://thunder.example.com
+assert_cm "explicit authorization servers win over the issuer" \
+  OAUTH_AUTHORIZATION_SERVERS "https://as.example.com" \
+  --set agentManagerService.config.keyManager.issuer=https://thunder.example.com \
+  --set agentManagerService.config.oauthAuthorizationServers=https://as.example.com
+
+# Issue #1414: serverPublicURL is the RFC 8707 resource identifier MCP tokens are
+# minted with, so it must reach the audience list with exactly one trailing slash.
+assert_cm "serverPublicURL override is appended to the audience" \
+  KEY_MANAGER_AUDIENCE "${CLIENTS},https://api.example.com/" \
+  --set agentManagerService.config.serverPublicURL=https://api.example.com
+assert_cm "a serverPublicURL that already ends in a slash is not doubled" \
+  KEY_MANAGER_AUDIENCE "${CLIENTS},https://api.example.com/" \
+  --set agentManagerService.config.serverPublicURL=https://api.example.com/
+assert_cm "an audience that already lists the resource gains no duplicate" \
+  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/" \
+  --set agentManagerService.config.serverPublicURL=https://api.example.com \
+  --set 'agentManagerService.config.keyManager.audience=amp\,https://api.example.com/'
+assert_cm "whitespace in the audience does not defeat the duplicate check" \
+  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/" \
+  --set agentManagerService.config.serverPublicURL=https://api.example.com \
+  --set 'agentManagerService.config.keyManager.audience=amp\, https://api.example.com/'
+assert_cm "an empty serverPublicURL appends nothing and leaves no trailing comma" \
+  KEY_MANAGER_AUDIENCE "$CLIENTS" \
+  --set-string agentManagerService.config.serverPublicURL=
+assert_cm "a stray comma in the audience does not produce an empty entry" \
+  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/" \
+  --set agentManagerService.config.serverPublicURL=https://api.example.com \
+  --set 'agentManagerService.config.keyManager.audience=amp\,'
+
+if ((FAILURES > 0)); then
+  printf '\n%d assertion(s) failed\n' "$FAILURES"
+  exit 1
+fi
+printf '\nAll render assertions passed\n'

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -194,11 +194,7 @@ agentManagerService:
     # Console and CLI logins carry no `resource`, so they resolve to the "amp"
     # resource server and arrive with aud=amp. MCP logins (am-mcp) DO send
     # `resource`, and get this service's serverPublicURL WITH a trailing slash
-    # as their audience, so that URL is listed. "am-mcp" is listed defensively;
-    # MCP tokens normally carry the resource URL, not the client ID.
-    # Keep the audience URL entry in sync with serverPublicURL below — an
-    # install that moves serverPublicURL must move this entry with it, or the
-    # service rejects every MCP token Thunder mints for it.
+    # as their audience, so that URL is listed too.
     keyManager:
       issuer: "http://thunder.amp.localhost:8080"
       audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp,http://api.amp.localhost:8080/"

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -201,8 +201,12 @@ agentManagerService:
     # Comma-separated list of OAuth 2.0 authorization server URLs advertised
     # in RFC 9728 protected resource metadata. Each entry must be an absolute
     # http/https URL. Validated at startup. Required for the well-known
-    # endpoint to serve.
-    oauthAuthorizationServers: "http://thunder.amp.localhost:8080"
+    # endpoint to serve. Left empty on purpose: it defaults to
+    # keyManager.issuer above, which is the same authorization server — startup
+    # validation only checks the URLs are well-formed, so a stale value here
+    # would silently advertise the wrong issuer. Set it only when the advertised
+    # URL must differ from the one tokens are validated against.
+    oauthAuthorizationServers: ""
 
     # Domain suffix env-Thunder developer-facing hostnames are built from:
     # "<org>-<env>.thunder.<thunderHostBaseDomain>". Override on custom-domain /

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -188,6 +188,15 @@ agentManagerService:
       additionalInstrumentationVersions: []
 
     # Key Manager configuration
+    #
+    # Thunder (v0.45+) stamps the resource-server identifier named in the
+    # authorize request's RFC 8707 `resource` parameter as the token audience.
+    # Console and CLI logins carry no `resource`, so they resolve to the "amp"
+    # resource server and arrive with aud=amp. MCP logins (am-mcp) DO send
+    # `resource`, and get this service's serverPublicURL WITH a trailing slash
+    # as their audience — the chart appends that entry automatically, so
+    # overriding serverPublicURL below is enough and this list only needs the
+    # client IDs.
     keyManager:
       issuer: "http://thunder.amp.localhost:8080"
       audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp"
@@ -196,6 +205,9 @@ agentManagerService:
     # Externally reachable base URL of this service.
     # Used as the `resource` identifier in RFC 9728 protected resource metadata.
     # Routed through the OpenChoreo control-plane gateway (see ocIngress).
+    # Must stay in sync with the thunder extension's
+    # thunder.bootstrap.agentManagerMcpBaseUrl; keyManager.audience above picks
+    # this up on its own.
     serverPublicURL: "http://api.amp.localhost:8080"
 
     # Comma-separated list of OAuth 2.0 authorization server URLs advertised

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -188,14 +188,27 @@ agentManagerService:
       additionalInstrumentationVersions: []
 
     # Key Manager configuration
+    #
+    # Thunder (v0.45+) stamps the resource-server identifier named in the
+    # authorize request's RFC 8707 `resource` parameter as the token audience.
+    # Console and CLI logins carry no `resource`, so they resolve to the "amp"
+    # resource server and arrive with aud=amp. MCP logins (am-mcp) DO send
+    # `resource`, and get this service's serverPublicURL WITH a trailing slash
+    # as their audience, so that URL is listed. "am-mcp" is listed defensively;
+    # MCP tokens normally carry the resource URL, not the client ID.
+    # Keep the audience URL entry in sync with serverPublicURL below — an
+    # install that moves serverPublicURL must move this entry with it, or the
+    # service rejects every MCP token Thunder mints for it.
     keyManager:
       issuer: "http://thunder.amp.localhost:8080"
-      audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp"
+      audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp,http://api.amp.localhost:8080/"
       jwksUrl: "http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/jwks"
 
     # Externally reachable base URL of this service.
     # Used as the `resource` identifier in RFC 9728 protected resource metadata.
     # Routed through the OpenChoreo control-plane gateway (see ocIngress).
+    # Must stay in sync with keyManager.audience's URL entry above and the
+    # thunder extension's thunder.bootstrap.agentManagerMcpBaseUrl.
     serverPublicURL: "http://api.amp.localhost:8080"
 
     # Comma-separated list of OAuth 2.0 authorization server URLs advertised

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -189,14 +189,9 @@ agentManagerService:
 
     # Key Manager configuration
     #
-    # Thunder (v0.45+) stamps the resource-server identifier named in the
-    # authorize request's RFC 8707 `resource` parameter as the token audience.
-    # Console and CLI logins carry no `resource`, so they resolve to the "amp"
-    # resource server and arrive with aud=amp. MCP logins (am-mcp) DO send
-    # `resource`, and get this service's serverPublicURL WITH a trailing slash
-    # as their audience — the chart appends that entry automatically, so
-    # overriding serverPublicURL below is enough and this list only needs the
-    # client IDs.
+    # Token audiences accepted by this service. Console/CLI logins arrive with
+    # aud=amp; MCP logins arrive with serverPublicURL plus a trailing slash,
+    # which the chart appends automatically — list only client IDs here.
     keyManager:
       issuer: "http://thunder.amp.localhost:8080"
       audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp"
@@ -210,14 +205,10 @@ agentManagerService:
     # this up on its own.
     serverPublicURL: "http://api.amp.localhost:8080"
 
-    # Comma-separated list of OAuth 2.0 authorization server URLs advertised
-    # in RFC 9728 protected resource metadata. Each entry must be an absolute
-    # http/https URL. Validated at startup. Required for the well-known
-    # endpoint to serve. Left empty on purpose: it defaults to
-    # keyManager.issuer above, which is the same authorization server — startup
-    # validation only checks the URLs are well-formed, so a stale value here
-    # would silently advertise the wrong issuer. Set it only when the advertised
-    # URL must differ from the one tokens are validated against.
+    # Comma-separated absolute http/https URLs advertised in RFC 9728 protected
+    # resource metadata. Empty by design: falls back to keyManager.issuer above.
+    # Startup validation only checks the URLs are well-formed, so a stale value
+    # here silently advertises the wrong issuer. Set only if it must differ.
     oauthAuthorizationServers: ""
 
     # Domain suffix env-Thunder developer-facing hostnames are built from:

--- a/deployments/helm-charts/wso2-amp-observability-extension/.helmignore
+++ b/deployments/helm-charts/wso2-amp-observability-extension/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Chart render assertions: dev/CI only, not shipped to users.
+tests/

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
@@ -51,10 +51,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-OAuth 2.0 authorization servers advertised in RFC 9728 protected resource
-metadata. Defaults to the token issuer: both name the same Thunder deployment,
-and advertising a different URL than the one tokens are validated against sends
-MCP clients to an authorization server whose tokens this service then rejects.
+Authorization servers advertised in RFC 9728 metadata; see values.yaml for why
+this falls back to the token issuer.
 */}}
 {{- define "amp-observability-extension.authorizationServers" -}}
 {{- .Values.amObserver.oauth.authorizationServers | default .Values.amObserver.auth.issuer -}}
@@ -64,17 +62,15 @@ MCP clients to an authorization server whose tokens this service then rejects.
 Accepted token audiences. publicUrl — with the trailing slash Thunder stamps on
 RFC 8707 resource identifiers — is appended so tokens minted for this service's
 own MCP client stay valid when publicUrl is overridden, without the operator
-having to restate the whole audience list.
+having to restate the whole audience list. nospace keeps a spaced-out list from
+defeating the uniq.
 */}}
 {{- define "amp-observability-extension.audience" -}}
-{{- $audiences := .Values.amObserver.auth.audience | splitList "," | compact -}}
-{{- if .Values.amObserver.publicUrl -}}
-{{- $resource := printf "%s/" (trimSuffix "/" .Values.amObserver.publicUrl) -}}
-{{- if not (has $resource $audiences) -}}
-{{- $audiences = append $audiences $resource -}}
+{{- $audiences := .Values.amObserver.auth.audience | nospace | splitList "," | compact -}}
+{{- with .Values.amObserver.publicUrl -}}
+{{- $audiences = append $audiences (printf "%s/" (trimSuffix "/" .)) -}}
 {{- end -}}
-{{- end -}}
-{{- join "," $audiences -}}
+{{- join "," (uniq $audiences) -}}
 {{- end }}
 
 {{/*

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
@@ -51,19 +51,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Authorization servers advertised in RFC 9728 metadata; see values.yaml for why
-this falls back to the token issuer.
-*/}}
-{{- define "amp-observability-extension.authorizationServers" -}}
-{{- .Values.amObserver.oauth.authorizationServers | default .Values.amObserver.auth.issuer -}}
-{{- end }}
-
-{{/*
-Accepted token audiences. publicUrl — with the trailing slash Thunder stamps on
-RFC 8707 resource identifiers — is appended so tokens minted for this service's
-own MCP client stay valid when publicUrl is overridden, without the operator
-having to restate the whole audience list. nospace keeps a spaced-out list from
-defeating the uniq.
+Accepted token audiences: auth.audience plus publicUrl with the trailing slash
+Thunder stamps on RFC 8707 resource identifiers. nospace keeps a spaced-out list
+from defeating the uniq. See values.yaml for why it is derived.
 */}}
 {{- define "amp-observability-extension.audience" -}}
 {{- $audiences := .Values.amObserver.auth.audience | nospace | splitList "," | compact -}}

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
@@ -51,6 +51,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+OAuth 2.0 authorization servers advertised in RFC 9728 protected resource
+metadata. Defaults to the token issuer: both name the same Thunder deployment,
+and advertising a different URL than the one tokens are validated against sends
+MCP clients to an authorization server whose tokens this service then rejects.
+*/}}
+{{- define "amp-observability-extension.authorizationServers" -}}
+{{- .Values.amObserver.oauth.authorizationServers | default .Values.amObserver.auth.issuer -}}
+{{- end }}
+
+{{/*
+Accepted token audiences. publicUrl — with the trailing slash Thunder stamps on
+RFC 8707 resource identifiers — is appended so tokens minted for this service's
+own MCP client stay valid when publicUrl is overridden, without the operator
+having to restate the whole audience list.
+*/}}
+{{- define "amp-observability-extension.audience" -}}
+{{- $audiences := .Values.amObserver.auth.audience | splitList "," | compact -}}
+{{- if .Values.amObserver.publicUrl -}}
+{{- $resource := printf "%s/" (trimSuffix "/" .Values.amObserver.publicUrl) -}}
+{{- if not (has $resource $audiences) -}}
+{{- $audiences = append $audiences $resource -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $audiences -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "amp-observability-extension.serviceAccountName" -}}

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
@@ -71,14 +71,14 @@ spec:
             - name: KEY_MANAGER_ISSUER
               value: "{{ .Values.amObserver.auth.issuer }}"
             - name: KEY_MANAGER_AUDIENCE
-              value: "{{ .Values.amObserver.auth.audience }}"
+              value: "{{ include "amp-observability-extension.audience" . }}"
             - name: RBAC_ENABLED
               value: {{ .Values.amObserver.auth.rbacEnabled | default "true" | quote }}
             # OAuth 2.0 protected-resource metadata (RFC 9728) for MCP clients
             - name: SERVER_PUBLIC_URL
               value: "{{ .Values.amObserver.publicUrl }}"
             - name: OAUTH_AUTHORIZATION_SERVERS
-              value: "{{ .Values.amObserver.oauth.authorizationServers }}"
+              value: "{{ include "amp-observability-extension.authorizationServers" . }}"
             - name: OAUTH_SCOPES_SUPPORTED
               value: "{{ .Values.amObserver.oauth.scopesSupported }}"
           resources:

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - name: SERVER_PUBLIC_URL
               value: "{{ .Values.amObserver.publicUrl }}"
             - name: OAUTH_AUTHORIZATION_SERVERS
-              value: "{{ include "amp-observability-extension.authorizationServers" . }}"
+              value: "{{ .Values.amObserver.oauth.authorizationServers | default .Values.amObserver.auth.issuer }}"
             - name: OAUTH_SCOPES_SUPPORTED
               value: "{{ .Values.amObserver.oauth.scopesSupported }}"
           resources:

--- a/deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Render assertions for wso2-amp-observability-extension.
+# Run: bash deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh
+#
+# Covers the derived auth values that plain `helm template` with default values
+# cannot distinguish from hardcoded ones: oauth.authorizationServers falling back
+# to auth.issuer, and publicUrl being appended to auth.audience. A wrong issuer
+# or audience here is invisible at install time and surfaces only as the observer
+# 401ing every traces request with "invalid issuer" (see issue #1424).
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=0
+
+# env_value <name> [helm --set args...] -> the rendered value of container env var <name>
+# A render failure is reported rather than silently becoming an empty value: this
+# chart deliberately `fail`s on some inputs, so a crash must not look like a
+# wrong value.
+env_value() {
+  local name="$1" rendered
+  shift
+  if ! rendered="$(helm template test-release "$CHART_DIR" "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$rendered" >&2
+    return 1
+  fi
+  awk -v n="$name" '
+    $1 == "-" && $2 == "name:" && $3 == n { found = 1; next }
+    found && $1 == "value:" {
+      sub(/^[[:space:]]*value:[[:space:]]*/, "")
+      gsub(/^"|"$/, "")
+      print
+      exit
+    }
+  ' <<<"$rendered"
+}
+
+assert_env() {
+  local label="$1" name="$2" expected="$3"
+  shift 3
+  local actual
+  actual="$(env_value "$name" "$@")"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected %s: %q\n      actual   %s: %q\n' \
+      "$label" "$name" "$expected" "$name" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# Defaults must stay byte-identical to the pre-derivation literals, so that
+# existing installs and quick-start (which passes no overrides) are unaffected.
+assert_env "default audience keeps the k3d resource entry" \
+  KEY_MANAGER_AUDIENCE "amp,amp-api-client,am-obs-mcp,http://traces.amp.localhost:11080/"
+assert_env "default authorization servers fall back to the default issuer" \
+  OAUTH_AUTHORIZATION_SERVERS "http://thunder.amp.localhost:8080"
+
+# The issue #1424 fix: one issuer override has to move the advertised
+# authorization server too, or MCP clients discover an authorization server whose
+# tokens this service then rejects.
+assert_env "issuer override moves the advertised authorization server" \
+  OAUTH_AUTHORIZATION_SERVERS "https://thunder.example.com" \
+  --set amObserver.auth.issuer=https://thunder.example.com
+assert_env "explicit authorization servers win over the issuer" \
+  OAUTH_AUTHORIZATION_SERVERS "https://as.example.com" \
+  --set amObserver.auth.issuer=https://thunder.example.com \
+  --set amObserver.oauth.authorizationServers=https://as.example.com
+
+# publicUrl carries the RFC 8707 resource identifier MCP tokens are minted with,
+# so it must reach the audience list with exactly one trailing slash.
+assert_env "publicUrl override is appended to the audience" \
+  KEY_MANAGER_AUDIENCE "amp,amp-api-client,am-obs-mcp,https://traces.example.com/" \
+  --set amObserver.publicUrl=https://traces.example.com
+assert_env "a publicUrl that already ends in a slash is not doubled" \
+  KEY_MANAGER_AUDIENCE "amp,amp-api-client,am-obs-mcp,https://traces.example.com/" \
+  --set amObserver.publicUrl=https://traces.example.com/
+assert_env "an audience that already lists the resource gains no duplicate" \
+  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/" \
+  --set amObserver.publicUrl=https://traces.example.com \
+  --set 'amObserver.auth.audience=amp\,https://traces.example.com/'
+assert_env "whitespace in the audience does not defeat the duplicate check" \
+  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/" \
+  --set amObserver.publicUrl=https://traces.example.com \
+  --set 'amObserver.auth.audience=amp\, https://traces.example.com/'
+assert_env "an empty publicUrl appends nothing and leaves no trailing comma" \
+  KEY_MANAGER_AUDIENCE "amp,amp-api-client,am-obs-mcp" \
+  --set-string amObserver.publicUrl=
+assert_env "a stray comma in the audience does not produce an empty entry" \
+  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/" \
+  --set amObserver.publicUrl=https://traces.example.com \
+  --set 'amObserver.auth.audience=amp\,'
+
+if ((FAILURES > 0)); then
+  printf '\n%d assertion(s) failed\n' "$FAILURES"
+  exit 1
+fi
+printf '\nAll render assertions passed\n'

--- a/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
@@ -91,8 +91,8 @@ amObserver:
     # in RFC 9728 protected resource metadata. Left empty on purpose: it
     # defaults to auth.issuer above, which is the same authorization server.
     # Only set it when the advertised URL must differ from the token issuer.
-    # Since empty means "fall back", suppressing the metadata endpoint entirely
-    # now takes an empty auth.issuer as well.
+    # To suppress the metadata endpoint instead, empty publicUrl — the handler
+    # checks that first, and an empty auth.issuer fails startup validation.
     authorizationServers: ""
     # Comma-separated list of OAuth 2.0 scopes supported by this resource,
     # advertised in RFC 9728 protected resource metadata.

--- a/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
@@ -53,17 +53,24 @@ amObserver:
   # the observer's auth middleware and do not need to be listed here.
   # MCP tokens minted for the observer MCP client (am-obs-mcp) carry the
   # RFC 8707 resource identifier — this service's publicUrl WITH a trailing
-  # slash — as their audience, so that URL is listed. "am-obs-mcp" is listed
-  # defensively; MCP logins normally carry the resource URL above as the
+  # slash — as their audience. That URL is NOT listed here: the chart appends
+  # publicUrl (slash included) to this list automatically, so overriding
+  # publicUrl alone keeps MCP tokens valid. "am-obs-mcp" is listed
+  # defensively; MCP logins normally carry that resource URL as the
   # audience, not the client ID (unlike amp-api-client's client-credentials
   # fallback, this can't occur for am-obs-mcp, a public client restricted to
   # authorization_code).
-  # Keep the audience URL entry in sync with publicUrl below.
   auth:
     isLocalDevEnv: false
     jwksUrl: "http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/jwks"
+    # MUST be the PUBLIC Thunder URL the platform issues tokens from (the `iss`
+    # claim), not the in-cluster service URL used for jwksUrl above. The console
+    # and amctl send the same user token here that they send to
+    # agent-manager-service, so this has to match that chart's
+    # agentManagerService.config.keyManager.issuer — otherwise every traces
+    # request 401s with "invalid issuer".
     issuer: "http://thunder.amp.localhost:8080"
-    audience: "amp,amp-api-client,am-obs-mcp,http://traces.amp.localhost:11080/"
+    audience: "amp,amp-api-client,am-obs-mcp"
     # Enables scope-based authorization on the observer REST data routes.
     # Mirrors agent-manager-service's rbacEnabled. MUST stay a quoted string:
     # Helm's `default` treats boolean false as unset, which would make the
@@ -81,8 +88,10 @@ amObserver:
   # enforcement on the REST data routes is governed by auth.rbacEnabled above.
   oauth:
     # Comma-separated list of OAuth 2.0 authorization server URLs advertised
-    # in RFC 9728 protected resource metadata. Must match auth.issuer above.
-    authorizationServers: "http://thunder.amp.localhost:8080"
+    # in RFC 9728 protected resource metadata. Left empty on purpose: it
+    # defaults to auth.issuer above, which is the same authorization server.
+    # Only set it when the advertised URL must differ from the token issuer.
+    authorizationServers: ""
     # Comma-separated list of OAuth 2.0 scopes supported by this resource,
     # advertised in RFC 9728 protected resource metadata.
     scopesSupported: "amp:observability:log-read,amp:observability:trace-read,amp:observability:metric-read,amp:observability:build-log-read"

--- a/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
@@ -91,6 +91,8 @@ amObserver:
     # in RFC 9728 protected resource metadata. Left empty on purpose: it
     # defaults to auth.issuer above, which is the same authorization server.
     # Only set it when the advertised URL must differ from the token issuer.
+    # Since empty means "fall back", suppressing the metadata endpoint entirely
+    # now takes an empty auth.issuer as well.
     authorizationServers: ""
     # Comma-separated list of OAuth 2.0 scopes supported by this resource,
     # advertised in RFC 9728 protected resource metadata.

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1569,7 +1569,11 @@ data:
     # authorization checks expect.
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
-    {{- $base := index $.Values.thunder.bootstrap .baseUrlValue | required (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
+    {{- $base := index $.Values.thunder.bootstrap .baseUrlValue }}
+    {{- if and (not $base) (not .optional) }}
+    {{- fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
+    {{- end }}
+    {{- if $base }}
     {{- $identifier := printf "%s/" (trimSuffix "/" $base) }}
     MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
     log_info "MCP resource server '{{ $identifier }}' ready (id: $MCP_RS_ID)"
@@ -1603,6 +1607,7 @@ data:
     MCP_AMP_ROOT=$(create_or_get_resource "$MCP_RS_ID" "Agent Manager" "amp" "Root of the amp permission tree")
     register_amp_permissions "$MCP_RS_ID" "{{ .permissionSet }}" "$MCP_AMP_ROOT"
     log_info "MCP resource server '{{ $identifier }}': '{{ .permissionSet }}' permission set registered."
+    {{- end }}
     {{- end }}
     log_success "MCP resource servers registered."
 

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1569,7 +1569,9 @@ data:
     # authorization checks expect.
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
-    {{- $base := index $.Values.thunder.bootstrap .baseUrlValue | required (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
+    {{- $base := index $.Values.thunder.bootstrap .baseUrlValue }}
+    {{- if not (or $base .optional) }}{{ fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}{{ end }}
+    {{- if $base }}
     {{- $identifier := printf "%s/" (trimSuffix "/" $base) }}
     MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
     log_info "MCP resource server '{{ $identifier }}' ready (id: $MCP_RS_ID)"
@@ -1603,6 +1605,7 @@ data:
     MCP_AMP_ROOT=$(create_or_get_resource "$MCP_RS_ID" "Agent Manager" "amp" "Root of the amp permission tree")
     register_amp_permissions "$MCP_RS_ID" "{{ .permissionSet }}" "$MCP_AMP_ROOT"
     log_info "MCP resource server '{{ $identifier }}': '{{ .permissionSet }}' permission set registered."
+    {{- end }}
     {{- end }}
     log_success "MCP resource servers registered."
 

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1570,9 +1570,7 @@ data:
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
     {{- $base := index $.Values.thunder.bootstrap .baseUrlValue }}
-    {{- if and (not $base) (not .optional) }}
-    {{- fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
-    {{- end }}
+    {{- if not (or $base .optional) }}{{ fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}{{ end }}
     {{- if $base }}
     {{- $identifier := printf "%s/" (trimSuffix "/" $base) }}
     MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1570,7 +1570,6 @@ data:
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
     {{- $base := index $.Values.thunder.bootstrap .baseUrlValue }}
-    {{- if not (or $base .optional) }}{{ fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}{{ end }}
     {{- if $base }}
     {{- $identifier := printf "%s/" (trimSuffix "/" $base) }}
     MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
@@ -1605,6 +1604,8 @@ data:
     MCP_AMP_ROOT=$(create_or_get_resource "$MCP_RS_ID" "Agent Manager" "amp" "Root of the amp permission tree")
     register_amp_permissions "$MCP_RS_ID" "{{ .permissionSet }}" "$MCP_AMP_ROOT"
     log_info "MCP resource server '{{ $identifier }}': '{{ .permissionSet }}' permission set registered."
+    {{- else if not .optional }}
+    {{- fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
     {{- end }}
     {{- end }}
     log_success "MCP resource servers registered."

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -523,7 +523,11 @@ thunder:
     # URL at the externally reachable origin of its MCP endpoint's service — the
     # same value as agent-manager's serverPublicURL and the observability
     # extension's amObserver.publicUrl. Defaults suit a k3d/local install.
-    agentManagerMcpBaseUrl: "http://localhost:9000"
+    # Not http://localhost:9000 — that is the docker-compose dev API, which
+    # reaches Thunder through the non-Helm path in
+    # deployments/setup/register-amp-resources.sh; a chart install always reaches
+    # the API through the control-plane gateway.
+    agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -522,23 +522,32 @@ thunder:
     # and silently drops name/handle/description/permissionSet. Point each base
     # URL at the externally reachable origin of its MCP endpoint's service — the
     # same value as agent-manager's serverPublicURL and the observability
-    # extension's amObserver.publicUrl. Defaults suit a k3d/local install.
-    # agentManagerMcpBaseUrl intentionally stays on the local-dev API origin:
-    # `make setup` (deployments/setup/setup-openchoreo.sh) installs this chart
-    # with no overrides and runs agent-manager-service as a host process on
-    # :9000, so an MCP client there asks for resource http://localhost:9000/ and
-    # Thunder answers invalid_target if the registered identifier is anything
-    # else. Installs that front the API with a gateway must override it —
-    # quick-start and the getting-started guides pass their API origin. Unlike
-    # observerMcpBaseUrl below, whose k3d default the dev setup also happens to
-    # use, this one cannot suit both.
-    agentManagerMcpBaseUrl: "http://localhost:9000"
+    # extension's amObserver.publicUrl. Defaults suit a k3d/local install, where
+    # amp-api is reached through the OpenChoreo control-plane gateway rather than
+    # on its container port.
+    #
+    # An identifier is matched EXACTLY, so a service reachable on more than one
+    # origin needs one entry per origin. Entries marked `optional: true` are
+    # skipped when their base URL is empty. agentManagerMcpDevBaseUrl is the
+    # opt-in second origin for the dev stack, where `make setup`
+    # (deployments/setup/setup-openchoreo.sh, this chart's only installer on that
+    # path) runs agent-manager-service as a host process on :9000 — an MCP client
+    # there asks for resource http://localhost:9000/, so without that entry
+    # Thunder answers invalid_target. setup-openchoreo.sh sets it.
+    agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
+    agentManagerMcpDevBaseUrl: ""
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"
         handle: ""
         baseUrlValue: "agentManagerMcpBaseUrl"
         description: "Resource identifier for the agent-manager MCP endpoint"
+        permissionSet: "amp-minus-observability"
+      - name: "AMP Agent Manager MCP (dev)"
+        handle: ""
+        baseUrlValue: "agentManagerMcpDevBaseUrl"
+        optional: true
+        description: "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack"
         permissionSet: "amp-minus-observability"
       - name: "AMP Observer MCP"
         handle: ""

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -525,13 +525,30 @@ thunder:
     # extension's amObserver.publicUrl. Defaults suit a k3d/local install, where
     # amp-api is reached through the OpenChoreo control-plane gateway rather than
     # on its container port.
+    #
+    # An identifier is matched EXACTLY, so a service reachable on more than one
+    # origin needs one entry per origin. This single Thunder serves two amp-api
+    # front doors in a local setup: the k3d/quick-start install behind the
+    # control-plane gateway (agentManagerMcpBaseUrl), and the docker-compose dev
+    # stack published straight onto the host port (agentManagerMcpDevBaseUrl,
+    # matching SERVER_PUBLIC_URL in deployments/docker-compose.yml). Entries
+    # marked `optional: true` are skipped when their base URL is empty, so a
+    # deployment with no dev stack can drop that one with
+    # `--set thunder.bootstrap.agentManagerMcpDevBaseUrl=`.
     agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
+    agentManagerMcpDevBaseUrl: "http://localhost:9000"
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"
         handle: ""
         baseUrlValue: "agentManagerMcpBaseUrl"
         description: "Resource identifier for the agent-manager MCP endpoint"
+        permissionSet: "amp-minus-observability"
+      - name: "AMP Agent Manager MCP (dev)"
+        handle: ""
+        baseUrlValue: "agentManagerMcpDevBaseUrl"
+        optional: true
+        description: "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack"
         permissionSet: "amp-minus-observability"
       - name: "AMP Observer MCP"
         handle: ""

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -527,16 +527,13 @@ thunder:
     # on its container port.
     #
     # An identifier is matched EXACTLY, so a service reachable on more than one
-    # origin needs one entry per origin. This single Thunder serves two amp-api
-    # front doors in a local setup: the k3d/quick-start install behind the
-    # control-plane gateway (agentManagerMcpBaseUrl), and the docker-compose dev
-    # stack published straight onto the host port (agentManagerMcpDevBaseUrl,
-    # matching SERVER_PUBLIC_URL in deployments/docker-compose.yml). Entries
-    # marked `optional: true` are skipped when their base URL is empty, so a
-    # deployment with no dev stack can drop that one with
-    # `--set thunder.bootstrap.agentManagerMcpDevBaseUrl=`.
+    # origin needs one entry per origin. Entries marked `optional: true` are
+    # skipped when their base URL is empty. agentManagerMcpDevBaseUrl is the
+    # opt-in second origin for the docker-compose dev stack, which reaches
+    # amp-api on its published host port instead of through the gateway;
+    # setup-openchoreo.sh sets it.
     agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
-    agentManagerMcpDevBaseUrl: "http://localhost:9000"
+    agentManagerMcpDevBaseUrl: ""
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -522,8 +522,10 @@ thunder:
     # and silently drops name/handle/description/permissionSet. Point each base
     # URL at the externally reachable origin of its MCP endpoint's service — the
     # same value as agent-manager's serverPublicURL and the observability
-    # extension's amObserver.publicUrl. Defaults suit a k3d/local install.
-    agentManagerMcpBaseUrl: "http://localhost:9000"
+    # extension's amObserver.publicUrl. Defaults suit a k3d/local install, where
+    # amp-api is reached through the OpenChoreo control-plane gateway rather than
+    # on its container port.
+    agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -523,11 +523,16 @@ thunder:
     # URL at the externally reachable origin of its MCP endpoint's service — the
     # same value as agent-manager's serverPublicURL and the observability
     # extension's amObserver.publicUrl. Defaults suit a k3d/local install.
-    # Not http://localhost:9000 — that is the docker-compose dev API, which
-    # reaches Thunder through the non-Helm path in
-    # deployments/setup/register-amp-resources.sh; a chart install always reaches
-    # the API through the control-plane gateway.
-    agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
+    # agentManagerMcpBaseUrl intentionally stays on the local-dev API origin:
+    # `make setup` (deployments/setup/setup-openchoreo.sh) installs this chart
+    # with no overrides and runs agent-manager-service as a host process on
+    # :9000, so an MCP client there asks for resource http://localhost:9000/ and
+    # Thunder answers invalid_target if the registered identifier is anything
+    # else. Installs that front the API with a gateway must override it —
+    # quick-start and the getting-started guides pass their API origin. Unlike
+    # observerMcpBaseUrl below, whose k3d default the dev setup also happens to
+    # use, this one cannot suit both.
+    agentManagerMcpBaseUrl: "http://localhost:9000"
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -299,15 +299,11 @@ install_amp_thunder_extension() {
     local chart_version="${VERSION}"
     local release_name="amp-thunder-extension"
 
-    # Install Helm chart.
-    # The chart's agentManagerMcpBaseUrl default is the local-dev API origin
-    # (host process on :9000, see that chart's values.yaml); here the API is
-    # behind the control-plane gateway, and Thunder answers invalid_target unless
-    # the registered MCP resource identifier matches what a client requests.
-    # Set before THUNDER_HELM_ARGS so a custom-domain caller still overrides it.
+    # Install Helm chart. The chart's agentManagerMcpBaseUrl/observerMcpBaseUrl
+    # defaults are already this install's gateway origins, so no MCP resource
+    # identifier override is needed here.
     if ! install_amp_helm_chart "${release_name}" "${chart_ref}" "${THUNDER_NS}" "${TIMEOUT_AMP_INSTALL}" \
         --version "${chart_version}" \
-        --set thunder.bootstrap.agentManagerMcpBaseUrl="http://api.amp.localhost:8080" \
         "${THUNDER_HELM_ARGS[@]}"; then
         return 1
     fi

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -299,9 +299,15 @@ install_amp_thunder_extension() {
     local chart_version="${VERSION}"
     local release_name="amp-thunder-extension"
 
-    # Install Helm chart
+    # Install Helm chart.
+    # The chart's agentManagerMcpBaseUrl default is the local-dev API origin
+    # (host process on :9000, see that chart's values.yaml); here the API is
+    # behind the control-plane gateway, and Thunder answers invalid_target unless
+    # the registered MCP resource identifier matches what a client requests.
+    # Set before THUNDER_HELM_ARGS so a custom-domain caller still overrides it.
     if ! install_amp_helm_chart "${release_name}" "${chart_ref}" "${THUNDER_NS}" "${TIMEOUT_AMP_INSTALL}" \
         --version "${chart_version}" \
+        --set thunder.bootstrap.agentManagerMcpBaseUrl="http://api.amp.localhost:8080" \
         "${THUNDER_HELM_ARGS[@]}"; then
         return 1
     fi

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -432,10 +432,23 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # handle, and the scope strings must come out identical to the amp resource
 # server's (amp:project:read etc.). The tree is rooted under a top-level
 # "amp" resource instead.
-AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://localhost:9000/}"
+# An identifier is matched EXACTLY, so a service reachable on more than one
+# origin needs one entry per origin. amp-api has two front doors against this
+# same Thunder: the k3d/quick-start install behind the control-plane gateway,
+# and the docker-compose dev stack on the published host port. Both are
+# registered; set either to the empty string to skip it.
+AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://api.amp.localhost:8080/}"
+AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE:-http://localhost:9000/}"
 OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE:-http://traces.amp.localhost:11080/}"
 
 log_info "Registering MCP resource servers..."
-register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
-register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
+if [[ -n "$AM_MCP_RESOURCE" ]]; then
+  register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
+fi
+if [[ -n "$AM_MCP_DEV_RESOURCE" ]]; then
+  register_mcp_resource_server "AMP Agent Manager MCP (dev)" "$AM_MCP_DEV_RESOURCE" "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack" "amp-minus-observability"
+fi
+if [[ -n "$OBSERVER_MCP_RESOURCE" ]]; then
+  register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
+fi
 log_success "MCP resource servers registered."

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -446,9 +446,10 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # Identifiers match exactly, so each origin amp-api is reachable on needs its
 # own entry; set one to "" to skip it. The dev origin is the docker-compose
 # stack's published host port.
-AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://api.amp.localhost:8080/}"
-AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE:-http://localhost:9000/}"
-OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE:-http://traces.amp.localhost:11080/}"
+# Unset-only defaults, so an explicit "" survives to the skip above.
+AM_MCP_RESOURCE="${AM_MCP_RESOURCE-http://api.amp.localhost:8080/}"
+AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE-http://localhost:9000/}"
+OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE-http://traces.amp.localhost:11080/}"
 
 log_info "Registering MCP resource servers..."
 register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 # Registers the Agent Manager (amp) resource server with its full permission
-# tree in Thunder, plus the two MCP resource servers (RFC 8707 resource
-# indicators) with the permission slices their MCP clients are allowed —
-# mirroring the helm bootstrap (60-amp-resource-server.sh).
+# tree in Thunder, plus the MCP resource servers (RFC 8707 resource indicators)
+# with the permission slices their MCP clients are allowed.
 # Runs against the external Thunder endpoint using amp-system-client credentials.
+#
+# This mirrors the helm bootstrap's 60-amp-resource-server.sh
+# (wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml), which is
+# authoritative — nothing invokes this script automatically, so a change to the
+# identifiers or the permission tree has to land in both.
 #
 # Usage:
 #   ./register-amp-resources.sh

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -355,11 +355,18 @@ register_amp_permissions() {
 # permission (e.g. amp-am:amp:project:read), producing scope strings
 # agent-manager-service will never accept. MCP resource servers are pure
 # mirrors with no independent state, so delete and recreate is safe.
+# An empty identifier skips the resource server, mirroring the chart's
+# `optional: true` entries.
 # Usage: register_mcp_resource_server <name> <identifier> <description> <permission_set>
 # ---------------------------------------------------------------------------
 register_mcp_resource_server() {
   local name="$1" identifier="$2" description="$3" permission_set="$4"
   local rs_id response http_code body handle amp_root
+
+  if [[ -z "$identifier" ]]; then
+    log_info "Skipping MCP resource server '$name' (no identifier configured)"
+    return 0
+  fi
 
   rs_id=$(create_or_get_rs "$name" "" "$identifier" "$description" "$DEFAULT_OU_ID")
   log_info "MCP resource server '$identifier' ready (id: $rs_id)"
@@ -432,10 +439,15 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # handle, and the scope strings must come out identical to the amp resource
 # server's (amp:project:read etc.). The tree is rooted under a top-level
 # "amp" resource instead.
-AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://localhost:9000/}"
+# Identifiers match exactly, so each origin amp-api is reachable on needs its
+# own entry; set one to "" to skip it. The dev origin is the docker-compose
+# stack's published host port.
+AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://api.amp.localhost:8080/}"
+AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE:-http://localhost:9000/}"
 OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE:-http://traces.amp.localhost:11080/}"
 
 log_info "Registering MCP resource servers..."
 register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
+register_mcp_resource_server "AMP Agent Manager MCP (dev)" "$AM_MCP_DEV_RESOURCE" "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack" "amp-minus-observability"
 register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
 log_success "MCP resource servers registered."

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -355,11 +355,18 @@ register_amp_permissions() {
 # permission (e.g. amp-am:amp:project:read), producing scope strings
 # agent-manager-service will never accept. MCP resource servers are pure
 # mirrors with no independent state, so delete and recreate is safe.
+# An empty identifier skips the resource server, mirroring the chart's
+# `optional: true` entries.
 # Usage: register_mcp_resource_server <name> <identifier> <description> <permission_set>
 # ---------------------------------------------------------------------------
 register_mcp_resource_server() {
   local name="$1" identifier="$2" description="$3" permission_set="$4"
   local rs_id response http_code body handle amp_root
+
+  if [[ -z "$identifier" ]]; then
+    log_info "Skipping MCP resource server '$name' (no identifier configured)"
+    return 0
+  fi
 
   rs_id=$(create_or_get_rs "$name" "" "$identifier" "$description" "$DEFAULT_OU_ID")
   log_info "MCP resource server '$identifier' ready (id: $rs_id)"
@@ -432,23 +439,15 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # handle, and the scope strings must come out identical to the amp resource
 # server's (amp:project:read etc.). The tree is rooted under a top-level
 # "amp" resource instead.
-# An identifier is matched EXACTLY, so a service reachable on more than one
-# origin needs one entry per origin. amp-api has two front doors against this
-# same Thunder: the k3d/quick-start install behind the control-plane gateway,
-# and the docker-compose dev stack on the published host port. Both are
-# registered; set either to the empty string to skip it.
+# Identifiers match exactly, so each origin amp-api is reachable on needs its
+# own entry; set one to "" to skip it. The dev origin is the docker-compose
+# stack's published host port.
 AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://api.amp.localhost:8080/}"
 AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE:-http://localhost:9000/}"
 OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE:-http://traces.amp.localhost:11080/}"
 
 log_info "Registering MCP resource servers..."
-if [[ -n "$AM_MCP_RESOURCE" ]]; then
-  register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
-fi
-if [[ -n "$AM_MCP_DEV_RESOURCE" ]]; then
-  register_mcp_resource_server "AMP Agent Manager MCP (dev)" "$AM_MCP_DEV_RESOURCE" "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack" "amp-minus-observability"
-fi
-if [[ -n "$OBSERVER_MCP_RESOURCE" ]]; then
-  register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
-fi
+register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
+register_mcp_resource_server "AMP Agent Manager MCP (dev)" "$AM_MCP_DEV_RESOURCE" "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack" "amp-minus-observability"
+register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
 log_success "MCP resource servers registered."

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -458,8 +458,12 @@ install_thunder_extension() {
         fi
     fi
 
+    # The dev stack runs amp-api on a published host port rather than behind the
+    # gateway, so register that origin as a second MCP resource identifier too —
+    # Thunder matches the authorize request's `resource` value exactly.
     helm upgrade --install amp-thunder-extension "${SCRIPT_DIR}/../helm-charts/wso2-amp-thunder-extension" \
-        --namespace amp-thunder --create-namespace
+        --namespace amp-thunder --create-namespace \
+        --set thunder.bootstrap.agentManagerMcpDevBaseUrl=http://localhost:9000
     echo "✅ AMP Thunder Extension installed/upgraded successfully"
 }
 

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -29,6 +29,16 @@ vm_host() {
 # own serving (that is internalServer.tlsEnabled) — it is purely the endpoint
 # scheme. The agent host is only reachable over TLS via Caddy's wildcard site, so
 # without this the console emits http:// and the browser blocks it as mixed content.
+#
+# keyManager.audience is restated rather than left at the chart default for the
+# same reason observability_helm_args restates amObserver.auth.audience: the
+# default's last entry is this service's own serverPublicURL, which the line
+# above has just moved. An MCP token carries the RFC 8707 resource identifier
+# (serverPublicURL plus a trailing slash) as its `aud`, so leaving the default
+# in place means amp-api rejects every MCP token Thunder mints for it. The
+# leading entries mirror the chart and must stay: console, amctl and publisher
+# tokens arrive with aud amp, amctl or amp-publisher-*. Commas are escaped
+# because helm's --set otherwise splits the value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
   local k
@@ -37,6 +47,7 @@ amp_helm_args() {
       "--set" "${k}.config.serverPublicURL=https://${AMP_HOST_API}" \
       "--set" "${k}.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
       "--set" "${k}.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
+      "--set" "${k}.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/" \
       "--set" "${k}.config.tlsEnabled=true" \
       "--set" "${k}.config.thunderHostBaseDomain=${AMP_HOST_THUNDER#thunder.}"
   done

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -30,13 +30,13 @@ vm_host() {
 # scheme. The agent host is only reachable over TLS via Caddy's wildcard site, so
 # without this the console emits http:// and the browser blocks it as mixed content.
 #
-# keyManager.audience is restated even though current charts derive its URL entry
-# (serverPublicURL plus a trailing slash, which is an MCP token's aud): this
+# VERSION SKEW: current charts derive the advertised authorization server from
+# the issuer, and append publicURL plus a trailing slash to the audience. This
 # installer targets whatever published AMP_VERSION the caller asks for, including
-# releases predating that derivation, where the default pins the k3d hostname
-# that serverPublicURL above has just moved. Same reason as
-# observability_helm_args below. Commas stay escaped or helm's --set splits the
-# value into a list.
+# releases predating that derivation, where the defaults pin the k3d hostnames
+# these functions have just moved. So both this function and
+# observability_helm_args below restate the derived values explicitly. Commas
+# stay escaped or helm's --set splits the value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
   local k
@@ -135,15 +135,9 @@ build_gateway_helm_args() {
 # observability_helm_args — hostname-driven core. Reads AMP_HOST_THUNDER and
 # AMP_HOST_OBSERVER.
 #
-# oauth.authorizationServers and auth.audience are restated even though current
-# charts derive both (authorizationServers falls back to auth.issuer, and
-# publicUrl plus a trailing slash is appended to the audience automatically):
-# this installer targets whatever published AMP_VERSION the caller asks for,
-# including releases predating that derivation, where the chart defaults pin the
-# k3d hostnames. An observer MCP token carries the RFC 8707 resource identifier (publicUrl
-# plus a trailing slash) as its `aud`, hence the last entry; console and amctl
-# tokens arrive with aud amp or amp-api-client, hence the first three. Commas are
-# escaped because helm's --set otherwise splits the value into a list.
+# authorizationServers/audience are restated for the version-skew reason noted
+# above amp_helm_args. The last audience entry is the observer MCP token's `aud`
+# (publicUrl plus a trailing slash); the first three cover console/amctl tokens.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 observability_helm_args() {
   printf '%s\n' \

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -268,8 +268,14 @@ thunder_helm_args() {
   # permissionSet, which makes Thunder reject the resource server (empty name)
   # and the bootstrap fail. Pass the base URL without a trailing slash — the
   # template adds it.
+  #
+  # agentManagerMcpDevBaseUrl is emptied: it exists so a local setup can also
+  # reach amp-api on the docker-compose host port, which no VM install has. The
+  # entry is marked optional in the chart, so an empty value skips it instead of
+  # registering a bogus localhost resource server.
   printf '%s\n' \
     "--set" "thunder.bootstrap.agentManagerMcpBaseUrl=https://${AMP_HOST_API}" \
+    "--set" "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
     "--set" "thunder.bootstrap.observerMcpBaseUrl=https://${AMP_HOST_OBSERVER}"
 
   # The console client's registered redirect URI lives under `setup` (<=main) and

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -126,14 +126,15 @@ build_gateway_helm_args() {
 # observability_helm_args — hostname-driven core. Reads AMP_HOST_THUNDER and
 # AMP_HOST_OBSERVER.
 #
-# auth.audience is restated rather than left at the chart default because the
-# default's last entry is this service's own publicUrl, which publicUrl above
-# has just moved. An observer MCP token carries the RFC 8707 resource
-# identifier (publicUrl plus a trailing slash) as its `aud`, so leaving the
-# default in place means the observer rejects every token it mints for itself.
-# The first three entries mirror the chart and must stay: console and amctl
-# tokens arrive with aud amp or amp-api-client. Commas are escaped because
-# helm's --set otherwise splits the value into a list.
+# oauth.authorizationServers and auth.audience are restated even though current
+# charts derive both (authorizationServers falls back to auth.issuer, and
+# publicUrl plus a trailing slash is appended to the audience automatically):
+# this installer targets whatever published AMP_VERSION the caller asks for,
+# including releases predating that derivation, where the chart defaults pin the
+# k3d hostnames. An observer MCP token carries the RFC 8707 resource identifier (publicUrl
+# plus a trailing slash) as its `aud`, hence the last entry; console and amctl
+# tokens arrive with aud amp or amp-api-client, hence the first three. Commas are
+# escaped because helm's --set otherwise splits the value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 observability_helm_args() {
   printf '%s\n' \

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -30,15 +30,10 @@ vm_host() {
 # scheme. The agent host is only reachable over TLS via Caddy's wildcard site, so
 # without this the console emits http:// and the browser blocks it as mixed content.
 #
-# keyManager.audience is restated rather than left at the chart default for the
-# same reason observability_helm_args restates amObserver.auth.audience: the
-# default's last entry is this service's own serverPublicURL, which the line
-# above has just moved. An MCP token carries the RFC 8707 resource identifier
-# (serverPublicURL plus a trailing slash) as its `aud`, so leaving the default
-# in place means amp-api rejects every MCP token Thunder mints for it. The
-# leading entries mirror the chart and must stay: console, amctl and publisher
-# tokens arrive with aud amp, amctl or amp-publisher-*. Commas are escaped
-# because helm's --set otherwise splits the value into a list.
+# keyManager.audience is restated because the chart default's last entry is the
+# chart's own serverPublicURL, which the line below has just moved; an MCP
+# token's aud is serverPublicURL plus a trailing slash. Commas stay escaped or
+# helm's --set splits the value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
   local k
@@ -268,14 +263,8 @@ thunder_helm_args() {
   # permissionSet, which makes Thunder reject the resource server (empty name)
   # and the bootstrap fail. Pass the base URL without a trailing slash — the
   # template adds it.
-  #
-  # agentManagerMcpDevBaseUrl is emptied: it exists so a local setup can also
-  # reach amp-api on the docker-compose host port, which no VM install has. The
-  # entry is marked optional in the chart, so an empty value skips it instead of
-  # registering a bogus localhost resource server.
   printf '%s\n' \
     "--set" "thunder.bootstrap.agentManagerMcpBaseUrl=https://${AMP_HOST_API}" \
-    "--set" "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
     "--set" "thunder.bootstrap.observerMcpBaseUrl=https://${AMP_HOST_OBSERVER}"
 
   # The console client's registered redirect URI lives under `setup` (<=main) and

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -29,6 +29,14 @@ vm_host() {
 # own serving (that is internalServer.tlsEnabled) — it is purely the endpoint
 # scheme. The agent host is only reachable over TLS via Caddy's wildcard site, so
 # without this the console emits http:// and the browser blocks it as mixed content.
+#
+# keyManager.audience is restated even though current charts derive its URL entry
+# (serverPublicURL plus a trailing slash, which is an MCP token's aud): this
+# installer targets whatever published AMP_VERSION the caller asks for, including
+# releases predating that derivation, where the default pins the k3d hostname
+# that serverPublicURL above has just moved. Same reason as
+# observability_helm_args below. Commas stay escaped or helm's --set splits the
+# value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
   local k
@@ -37,6 +45,7 @@ amp_helm_args() {
       "--set" "${k}.config.serverPublicURL=https://${AMP_HOST_API}" \
       "--set" "${k}.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
       "--set" "${k}.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
+      "--set" "${k}.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/" \
       "--set" "${k}.config.tlsEnabled=true" \
       "--set" "${k}.config.thunderHostBaseDomain=${AMP_HOST_THUNDER#thunder.}"
   done

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -396,6 +396,11 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core thunder MCP base URL (observer)" \
     "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.example.com" \
     "$(grep -F 'observerMcpBaseUrl' <<<"$core_th")"
+  # No docker-compose stack on a VM, so the optional dev origin is skipped
+  # rather than registered as a bogus localhost resource server.
+  assert_eq "core thunder MCP dev base URL emptied" \
+    "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
+    "$(grep -F 'agentManagerMcpDevBaseUrl' <<<"$core_th")"
 
   core_obs="$(observability_helm_args)"
   assert_eq "core observability audience carries the public observer URL" \

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -55,15 +55,15 @@ assert_eq "amp oauthAuthorizationServers (service key)" \
 assert_eq "amp keyManager.issuer (service key)" \
   "agentManagerService.config.keyManager.issuer=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.keyManager.issuer' <<<"$amp")"
-# amp-api mints MCP tokens (am-mcp) whose aud is its own public URL plus a
-# trailing slash, so the audience list has to follow serverPublicURL off the
-# chart's localhost default. Commas stay escaped or helm splits it into a list.
-assert_eq "amp keyManager.audience carries the public API URL (service key)" \
-  'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
-  "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$amp")"
-assert_eq "amp keyManager.audience carries the public API URL (legacy key)" \
-  'agentManager.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
-  "$(grep -F 'agentManager.config.keyManager.audience' <<<"$amp")"
+# An MCP token's aud is serverPublicURL plus a trailing slash, so the audience
+# has to follow it off the chart's localhost default. Assert only that entry —
+# pinning the whole list would break on any unrelated audience change.
+assert_eq "amp keyManager.audience carries the public API URL (service key)" "yes" \
+  "$(has "$amp" 'agentManagerService.config.keyManager.audience=amp\,')"
+assert_eq "amp keyManager.audience ends with the public API URL (service key)" "yes" \
+  "$(has "$amp" 'am-mcp\,https://api.amp.203.0.113.10.sslip.io/')"
+assert_eq "amp keyManager.audience carries the public API URL (legacy key)" "yes" \
+  "$(has "$amp" 'agentManager.config.keyManager.audience=amp\,')"
 # tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
 # emitted under both keys (old agentManager + new agentManagerService).
 assert_eq "amp tlsEnabled (service key)" \
@@ -377,12 +377,10 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core amp cp url present" \
     "console.config.gatewayControlPlaneUrl=https://cp.amp.example.com" \
     "$(grep -F 'gatewayControlPlaneUrl' <<<"$core_amp")"
-  # The MCP resource identifier is serverPublicURL plus a trailing slash, so the
-  # audience must land on the same host as serverPublicURL above and as
+  # The audience must land on the same host as serverPublicURL above and as
   # thunder.bootstrap.agentManagerMcpBaseUrl below.
-  assert_eq "core amp keyManager.audience carries the public API URL" \
-    'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.example.com/' \
-    "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$core_amp")"
+  assert_eq "core amp keyManager.audience carries the public API URL" "yes" \
+    "$(has "$core_amp" 'am-mcp\,https://api.amp.example.com/')"
 
   core_th="$(thunder_helm_args)"
   assert_eq "core thunder jwt.issuer" \
@@ -396,10 +394,9 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core thunder MCP base URL (observer)" \
     "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.example.com" \
     "$(grep -F 'observerMcpBaseUrl' <<<"$core_th")"
-  # No docker-compose stack on a VM, so the optional dev origin is skipped
-  # rather than registered as a bogus localhost resource server.
-  assert_eq "core thunder MCP dev base URL emptied" \
-    "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
+  # The dev origin is opt-in (empty chart default), so a VM install must not
+  # register it at all.
+  assert_eq "core thunder leaves the dev MCP origin unset" "" \
     "$(grep -F 'agentManagerMcpDevBaseUrl' <<<"$core_th")"
 
   core_obs="$(observability_helm_args)"

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -55,6 +55,15 @@ assert_eq "amp oauthAuthorizationServers (service key)" \
 assert_eq "amp keyManager.issuer (service key)" \
   "agentManagerService.config.keyManager.issuer=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.keyManager.issuer' <<<"$amp")"
+# amp-api mints MCP tokens (am-mcp) whose aud is its own public URL plus a
+# trailing slash, so the audience list has to follow serverPublicURL off the
+# chart's localhost default. Commas stay escaped or helm splits it into a list.
+assert_eq "amp keyManager.audience carries the public API URL (service key)" \
+  'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
+  "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$amp")"
+assert_eq "amp keyManager.audience carries the public API URL (legacy key)" \
+  'agentManager.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
+  "$(grep -F 'agentManager.config.keyManager.audience' <<<"$amp")"
 # tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
 # emitted under both keys (old agentManager + new agentManagerService).
 assert_eq "amp tlsEnabled (service key)" \
@@ -368,6 +377,12 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core amp cp url present" \
     "console.config.gatewayControlPlaneUrl=https://cp.amp.example.com" \
     "$(grep -F 'gatewayControlPlaneUrl' <<<"$core_amp")"
+  # The MCP resource identifier is serverPublicURL plus a trailing slash, so the
+  # audience must land on the same host as serverPublicURL above and as
+  # thunder.bootstrap.agentManagerMcpBaseUrl below.
+  assert_eq "core amp keyManager.audience carries the public API URL" \
+    'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.example.com/' \
+    "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$core_amp")"
 
   core_th="$(thunder_helm_args)"
   assert_eq "core thunder jwt.issuer" \

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -55,6 +55,15 @@ assert_eq "amp oauthAuthorizationServers (service key)" \
 assert_eq "amp keyManager.issuer (service key)" \
   "agentManagerService.config.keyManager.issuer=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.keyManager.issuer' <<<"$amp")"
+# An MCP token's aud is serverPublicURL plus a trailing slash, so the audience
+# has to follow it off the chart's localhost default. Assert only that entry —
+# pinning the whole list would break on any unrelated audience change.
+assert_eq "amp keyManager.audience carries the public API URL (service key)" "yes" \
+  "$(has "$amp" 'agentManagerService.config.keyManager.audience=amp\,')"
+assert_eq "amp keyManager.audience ends with the public API URL (service key)" "yes" \
+  "$(has "$amp" 'am-mcp\,https://api.amp.203.0.113.10.sslip.io/')"
+assert_eq "amp keyManager.audience carries the public API URL (legacy key)" "yes" \
+  "$(has "$amp" 'agentManager.config.keyManager.audience=amp\,')"
 # tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
 # emitted under both keys (old agentManager + new agentManagerService).
 assert_eq "amp tlsEnabled (service key)" \
@@ -368,6 +377,10 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core amp cp url present" \
     "console.config.gatewayControlPlaneUrl=https://cp.amp.example.com" \
     "$(grep -F 'gatewayControlPlaneUrl' <<<"$core_amp")"
+  # The audience must land on the same host as serverPublicURL above and as
+  # thunder.bootstrap.agentManagerMcpBaseUrl below.
+  assert_eq "core amp keyManager.audience carries the public API URL" "yes" \
+    "$(has "$core_amp" 'am-mcp\,https://api.amp.example.com/')"
 
   core_th="$(thunder_helm_args)"
   assert_eq "core thunder jwt.issuer" \
@@ -381,6 +394,10 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core thunder MCP base URL (observer)" \
     "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.example.com" \
     "$(grep -F 'observerMcpBaseUrl' <<<"$core_th")"
+  # The dev origin is opt-in (empty chart default), so a VM install must not
+  # register it at all.
+  assert_eq "core thunder leaves the dev MCP origin unset" "" \
+    "$(grep -F 'agentManagerMcpDevBaseUrl' <<<"$core_th")"
 
   core_obs="$(observability_helm_args)"
   assert_eq "core observability audience carries the public observer URL" \

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -101,6 +101,7 @@ helm install amp \
   --set agentManagerService.ocIngress.hostname="${API_PUBLIC_HOST}" \
   --set agentManagerService.config.serverPublicURL="${API_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.oauthAuthorizationServers="${THUNDER_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
@@ -243,11 +244,27 @@ helm install amp-observability-traces \
   --namespace ${OBSERVABILITY_NS} \
   --set amObserver.ocIngress.hostname="${OBS_API_PUBLIC_HOST}" \
   --set amObserver.publicUrl="${OBS_API_PUBLIC_URL}" \
+  --set amObserver.auth.issuer="${THUNDER_PUBLIC_URL}" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \
   deployment/amp-observer -n ${OBSERVABILITY_NS} --timeout=600s
 ```
+
+:::warning
+`amObserver.auth.issuer` must be the **public** Thunder URL, not the in-cluster
+service URL. The observer validates the same user token the console and `amctl`
+send to the Agent Manager API, so its issuer has to match
+`agentManagerService.config.keyManager.issuer` from Step 2. Leave it at the
+chart default on a custom-domain install and the traces page stays empty while
+the observer logs `JWT validation failed ... invalid issuer`.
+
+The chart derives the two related values from what you set above:
+`amObserver.oauth.authorizationServers` defaults to `amObserver.auth.issuer`,
+and `amObserver.publicUrl` (with a trailing slash) is appended to
+`amObserver.auth.audience` so observer MCP tokens validate. Set them explicitly
+only if your setup needs them to differ.
+:::
 
 #### Step 6: Evaluation Extension
 

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -101,6 +101,7 @@ helm install amp \
   --set agentManagerService.ocIngress.hostname="${API_PUBLIC_HOST}" \
   --set agentManagerService.config.serverPublicURL="${API_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.keyManager.audience="amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,${API_PUBLIC_URL}/" \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
@@ -243,6 +244,7 @@ helm install amp-observability-traces \
   --namespace ${OBSERVABILITY_NS} \
   --set amObserver.ocIngress.hostname="${OBS_API_PUBLIC_HOST}" \
   --set amObserver.publicUrl="${OBS_API_PUBLIC_URL}" \
+  --set amObserver.auth.audience="amp\,amp-api-client\,am-obs-mcp\,${OBS_API_PUBLIC_URL}/" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -101,12 +101,19 @@ helm install amp \
   --set agentManagerService.ocIngress.hostname="${API_PUBLIC_HOST}" \
   --set agentManagerService.config.serverPublicURL="${API_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
-  --set agentManagerService.config.oauthAuthorizationServers="${THUNDER_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --timeout 1800s
 ```
+
+:::info
+`keyManager.issuer` must be the public Thunder URL — the chart default is the k3d
+hostname. The authorization server the API advertises in its RFC 9728 protected
+resource metadata is derived from it, so
+`agentManagerService.config.oauthAuthorizationServers` only needs setting if it
+must differ.
+:::
 
 Wait for all components:
 
@@ -259,11 +266,8 @@ send to the Agent Manager API, so its issuer has to match
 chart default on a custom-domain install and the traces page stays empty while
 the observer logs `JWT validation failed ... invalid issuer`.
 
-The chart derives the two related values from what you set above:
-`amObserver.oauth.authorizationServers` defaults to `amObserver.auth.issuer`,
-and `amObserver.publicUrl` (with a trailing slash) is appended to
-`amObserver.auth.audience` so observer MCP tokens validate. Set them explicitly
-only if your setup needs them to differ.
+The chart derives `amObserver.oauth.authorizationServers` and the MCP audience
+entry from the values above; set them explicitly only if they must differ.
 :::
 
 #### Step 6: Evaluation Extension

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -112,7 +112,9 @@ helm install amp \
 hostname. The authorization server the API advertises in its RFC 9728 protected
 resource metadata is derived from it, so
 `agentManagerService.config.oauthAuthorizationServers` only needs setting if it
-must differ.
+must differ. Likewise the MCP audience entry is derived from
+`serverPublicURL` above, so `keyManager.audience` only needs setting to change
+the accepted client IDs.
 :::
 
 Wait for all components:

--- a/documentation/docs/getting-started/on-k3d.mdx
+++ b/documentation/docs/getting-started/on-k3d.mdx
@@ -268,12 +268,25 @@ helm install amp-thunder-extension \
   --version ${VERSION} \
   --namespace ${THUNDER_NS} \
   --create-namespace \
+  --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \
   deployment -l app.kubernetes.io/instance=amp-thunder-extension \
   -n ${THUNDER_NS} --timeout=300s
 ```
+
+:::info
+`agentManagerMcpBaseUrl` becomes the OAuth resource-server identifier Thunder
+registers for the API's `/mcp` endpoint, and Thunder answers `invalid_target`
+unless an MCP client's requested `resource` matches it exactly. Its chart default
+is the local-dev API origin (a host process on `:9000`), so a chart install has
+to point it at the gateway-fronted API — the same value as
+`agentManagerService.config.serverPublicURL` in the next step. The observer's
+equivalent, `observerMcpBaseUrl`, already defaults to the k3d URL and needs no
+override here. Both are seeded by the pre-install bootstrap job only, so a
+`helm upgrade` will not re-seed them.
+:::
 
 :::warning
 Thunder persists its configuration (including the issuer URL) in a database on first boot. If you need to change `THUNDER_PUBLIC_URL` after installation, you must **uninstall the chart, delete its PVC, and reinstall** — a `helm upgrade` alone will not change the issuer in issued tokens.

--- a/documentation/docs/getting-started/on-k3d.mdx
+++ b/documentation/docs/getting-started/on-k3d.mdx
@@ -268,7 +268,6 @@ helm install amp-thunder-extension \
   --version ${VERSION} \
   --namespace ${THUNDER_NS} \
   --create-namespace \
-  --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \
@@ -277,15 +276,14 @@ kubectl wait --for=condition=Available \
 ```
 
 :::info
-`agentManagerMcpBaseUrl` becomes the OAuth resource-server identifier Thunder
-registers for the API's `/mcp` endpoint, and Thunder answers `invalid_target`
-unless an MCP client's requested `resource` matches it exactly. Its chart default
-is the local-dev API origin (a host process on `:9000`), so a chart install has
-to point it at the gateway-fronted API — the same value as
-`agentManagerService.config.serverPublicURL` in the next step. The observer's
-equivalent, `observerMcpBaseUrl`, already defaults to the k3d URL and needs no
-override here. Both are seeded by the pre-install bootstrap job only, so a
-`helm upgrade` will not re-seed them.
+No MCP overrides are needed here: `thunder.bootstrap.agentManagerMcpBaseUrl` and
+`observerMcpBaseUrl` become the OAuth resource-server identifiers Thunder
+registers for the `/mcp` endpoints, and their chart defaults are already the k3d
+gateway URLs used throughout this guide. If you deviate from those hostnames,
+override both to match `agentManagerService.config.serverPublicURL` and
+`amObserver.publicUrl` — Thunder answers `invalid_target` unless an MCP client's
+requested `resource` matches a registered identifier exactly. Both are seeded by
+the pre-install bootstrap job only, so a `helm upgrade` will not re-seed them.
 :::
 
 :::warning

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -360,6 +360,8 @@ For evaluation without a domain, the [nip.io appendix](#appendix-installing-with
 
 Thunder provides authentication and user management for the entire platform — login, API keys, and OAuth token exchange. It must be installed before the Control Plane because the Control Plane, Observability Plane, and Agent Manager all validate JWTs issued by Thunder. The browser reaches it at `https://${THUNDER_PUBLIC_HOST}` through the control-plane gateway.
 
+The `agentManagerMcpBaseUrl` / `observerMcpBaseUrl` settings below register the RFC 8707 resource identifiers that MCP clients send when logging in; they must match the public URLs of the two services, or MCP login fails with `invalid_target`. `agentManagerMcpDevBaseUrl` is emptied because this deployment has no docker-compose dev stack. These are seeded by a `pre-install` hook, so they must be set on the initial install — see the [MCP server reference](../reference/mcp-server.mdx).
+
 ```bash
 helm install amp-thunder-extension \
   oci://${HELM_CHART_REGISTRY}/wso2-amp-thunder-extension \
@@ -374,6 +376,9 @@ helm install amp-thunder-extension \
   --set thunder.configuration.gateClient.port=443 \
   --set "thunder.configuration.cors.allowedOrigins={${CONSOLE_PUBLIC_URL}}" \
   --set "thunder.bootstrap.ampConsoleClient.redirectUris={${CONSOLE_PUBLIC_URL}/login}" \
+  --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
+  --set thunder.bootstrap.agentManagerMcpDevBaseUrl= \
+  --set thunder.bootstrap.observerMcpBaseUrl="${OBS_API_PUBLIC_URL}" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -374,6 +374,8 @@ helm install amp-thunder-extension \
   --set thunder.configuration.gateClient.port=443 \
   --set "thunder.configuration.cors.allowedOrigins={${CONSOLE_PUBLIC_URL}}" \
   --set "thunder.bootstrap.ampConsoleClient.redirectUris={${CONSOLE_PUBLIC_URL}/login}" \
+  --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
+  --set thunder.bootstrap.observerMcpBaseUrl="${OBS_API_PUBLIC_URL}" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \
@@ -383,6 +385,8 @@ kubectl wait --for=condition=Available \
 
 :::warning
 Thunder persists its configuration (including the issuer URL and the console client's OAuth redirect URIs) in a database on first boot. If you need to change `THUNDER_PUBLIC_URL` or `CONSOLE_PUBLIC_URL` after installation, you must **uninstall the chart, delete its PVC, and reinstall** — a `helm upgrade` alone will not change the issuer in issued tokens or the registered redirect URIs. This is why the hostnames are fixed in [Plan Your Deployment](#plan-your-deployment) before anything installs.
+
+The same applies to the two MCP base URLs: they become the OAuth resource-server identifiers Thunder registers for the `/mcp` endpoints, and they are seeded by the pre-install bootstrap job only. Point them at the externally reachable origins of the API and observer — the same values as `agentManagerService.config.serverPublicURL` and `amObserver.publicUrl` in Phase 2 — because Thunder rejects an authorize request with `invalid_target` unless the `resource` an MCP client asks for matches a registered identifier exactly.
 :::
 
 :::tip Verify

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -386,7 +386,7 @@ kubectl wait --for=condition=Available \
 :::warning
 Thunder persists its configuration (including the issuer URL and the console client's OAuth redirect URIs) in a database on first boot. If you need to change `THUNDER_PUBLIC_URL` or `CONSOLE_PUBLIC_URL` after installation, you must **uninstall the chart, delete its PVC, and reinstall** — a `helm upgrade` alone will not change the issuer in issued tokens or the registered redirect URIs. This is why the hostnames are fixed in [Plan Your Deployment](#plan-your-deployment) before anything installs.
 
-The same applies to the two MCP base URLs: they become the OAuth resource-server identifiers Thunder registers for the `/mcp` endpoints, and they are seeded by the pre-install bootstrap job only. Point them at the externally reachable origins of the API and observer — the same values as `agentManagerService.config.serverPublicURL` and `amObserver.publicUrl` in Phase 2 — because Thunder rejects an authorize request with `invalid_target` unless the `resource` an MCP client asks for matches a registered identifier exactly.
+The same applies to the two MCP base URLs: they become the OAuth resource-server identifiers Thunder registers for the `/mcp` endpoints, and they are seeded by the pre-install bootstrap job only. Point them at the externally reachable origins of the API and observer — the same values as `agentManagerService.config.serverPublicURL` and `amObserver.publicUrl` in Phase 2 — because Thunder rejects an authorize request with `invalid_target` unless the `resource` an MCP client asks for matches a registered identifier exactly. See the [MCP server reference](../reference/mcp-server.mdx) for the full set of settings that must move together.
 :::
 
 :::tip Verify

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -360,7 +360,7 @@ For evaluation without a domain, the [nip.io appendix](#appendix-installing-with
 
 Thunder provides authentication and user management for the entire platform — login, API keys, and OAuth token exchange. It must be installed before the Control Plane because the Control Plane, Observability Plane, and Agent Manager all validate JWTs issued by Thunder. The browser reaches it at `https://${THUNDER_PUBLIC_HOST}` through the control-plane gateway.
 
-The `agentManagerMcpBaseUrl` / `observerMcpBaseUrl` settings below register the RFC 8707 resource identifiers that MCP clients send when logging in; they must match the public URLs of the two services, or MCP login fails with `invalid_target`. `agentManagerMcpDevBaseUrl` is emptied because this deployment has no docker-compose dev stack. These are seeded by a `pre-install` hook, so they must be set on the initial install — see the [MCP server reference](../reference/mcp-server.mdx).
+The `agentManagerMcpBaseUrl` / `observerMcpBaseUrl` settings below must match the public URLs of those two services, and are seeded by a `pre-install` hook — so they have to be right on the initial install. See the [MCP server reference](../reference/mcp-server.mdx).
 
 ```bash
 helm install amp-thunder-extension \
@@ -377,7 +377,6 @@ helm install amp-thunder-extension \
   --set "thunder.configuration.cors.allowedOrigins={${CONSOLE_PUBLIC_URL}}" \
   --set "thunder.bootstrap.ampConsoleClient.redirectUris={${CONSOLE_PUBLIC_URL}/login}" \
   --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
-  --set thunder.bootstrap.agentManagerMcpDevBaseUrl= \
   --set thunder.bootstrap.observerMcpBaseUrl="${OBS_API_PUBLIC_URL}" \
   --timeout 1800s
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -60,13 +60,19 @@ The MCP server URL follows the public URL of the `agent-manager-service`:
 <server-public-url>/mcp
 ```
 
-For a stock local installation (Quick Start, docker-compose, or k3d via the bundled Helm chart), the API is served through the OpenChoreo control-plane gateway at `api.amp.localhost:8080`, so the MCP server URL is:
+For a Quick Start or k3d install via the bundled Helm chart, the API is served through the OpenChoreo control-plane gateway, so the MCP server URL is:
 
 ```
 http://api.amp.localhost:8080/mcp
 ```
 
-If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value.
+The docker-compose dev stack publishes `agent-manager-service` straight onto a host port instead (`SERVER_PUBLIC_URL=http://localhost:9000`), so there the URL is:
+
+```
+http://localhost:9000/mcp
+```
+
+Both origins are registered as resource servers by the Thunder bootstrap, so either works out of the box. If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value — and see the warning below.
 
 :::warning Moving the public URL is a three-place change
 
@@ -86,6 +92,11 @@ Leaving `agentManagerMcpBaseUrl` behind makes the browser redirect fail with
 server`. Leaving the `audience` entry behind lets the login succeed but makes
 every tool call return 401.
 
+Identifiers are matched exactly, so a deployment reachable on more than one
+origin needs one resource server per origin. That is why the chart registers the
+docker-compose dev origin as well, via `thunder.bootstrap.agentManagerMcpDevBaseUrl`
+— set it to the empty string to drop it on a deployment that has no dev stack.
+
 :::
 
 ## Default OAuth Client
@@ -102,7 +113,7 @@ The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extens
 
 *Upgrading an existing install: the token scopes for MCP clients come from permissions registered on the MCP resource server in Thunder (script `60-amp-resource-server.sh`), which are seeded by the bootstrap job only. On existing installs, re-run the bootstrap job — it replaces legacy MCP resource servers automatically and seeds the permissions; a `helm upgrade` alone will not re-seed, and without the permissions MCP tokens are issued with an empty scope list and every tool call returns 403.*
 
-*Installs created before the `agentManagerMcpBaseUrl` default was corrected registered the agent-manager MCP resource server under `http://localhost:9000/` instead of the gateway URL, which fails the authorize request with `invalid_target`. Re-running the bootstrap job registers the correct identifier; the stale entry is inert and can be left in place.*
+*Installs created before the gateway origin was added registered the agent-manager MCP resource server only under `http://localhost:9000/`, so a Quick Start or k3d client pointed at `http://api.amp.localhost:8080/mcp` fails the authorize request with `invalid_target`. Note the bootstrap scripts live in a ConfigMap annotated `helm.sh/hook: pre-install`, which Helm does **not** re-apply on `helm upgrade` — so upgrading the chart alone leaves the old ConfigMap, and re-running the setup job would just re-register the old identifiers. Either reinstall the `amp-thunder-extension` release, or replace the `amp-thunder-bootstrap` ConfigMap and then re-run the job. Identifiers no longer in use are inert and can be left in place.*
 
 ## Configuring AI Assistants
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -68,6 +68,26 @@ http://api.amp.localhost:8080/mcp
 
 If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value.
 
+:::warning Moving the public URL is a three-place change
+
+MCP clients send the server's public URL — with a trailing slash — as the OAuth
+`resource` parameter (RFC 8707), and Thunder both validates that value against
+its registered resource servers and stamps it into the token's `aud`. Changing
+the public URL therefore means changing three settings together:
+
+| Setting                                        | Chart / file                     | Value                          |
+| ---------------------------------------------- | -------------------------------- | ------------------------------ |
+| `agentManagerService.config.serverPublicURL`   | `wso2-agent-manager`             | the public base URL            |
+| `thunder.bootstrap.agentManagerMcpBaseUrl`     | `wso2-amp-thunder-extension`     | the same base URL              |
+| `agentManagerService.config.keyManager.audience` | `wso2-agent-manager`           | must list the base URL **plus a trailing slash** |
+
+Leaving `agentManagerMcpBaseUrl` behind makes the browser redirect fail with
+`invalid_target: The resource parameter does not match any registered resource
+server`. Leaving the `audience` entry behind lets the login succeed but makes
+every tool call return 401.
+
+:::
+
 ## Default OAuth Client
 
 AMP ships a pre-registered OAuth application in Thunder for MCP clients:
@@ -81,6 +101,8 @@ The client is public (no secret), PKCE is required, and the callback port is pin
 The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extension` Helm chart (script `59-am-mcp-client.sh`) and is already wired into `KEY_MANAGER_AUDIENCE` on the docker-compose setup, so no manual registration is required for the default installations.
 
 *Upgrading an existing install: the token scopes for MCP clients come from permissions registered on the MCP resource server in Thunder (script `60-amp-resource-server.sh`), which are seeded by the bootstrap job only. On existing installs, re-run the bootstrap job — it replaces legacy MCP resource servers automatically and seeds the permissions; a `helm upgrade` alone will not re-seed, and without the permissions MCP tokens are issued with an empty scope list and every tool call returns 403.*
+
+*Installs created before the `agentManagerMcpBaseUrl` default was corrected registered the agent-manager MCP resource server under `http://localhost:9000/` instead of the gateway URL, which fails the authorize request with `invalid_target`. Re-running the bootstrap job registers the correct identifier; the stale entry is inert and can be left in place.*
 
 ## Configuring AI Assistants
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -60,13 +60,47 @@ The MCP server URL follows the public URL of the `agent-manager-service`:
 <server-public-url>/mcp
 ```
 
-For a stock local installation (Quick Start, docker-compose, or k3d via the bundled Helm chart), the API is served through the OpenChoreo control-plane gateway at `api.amp.localhost:8080`, so the MCP server URL is:
+For a Quick Start or k3d install via the bundled Helm chart, the API is served through the OpenChoreo control-plane gateway, so the MCP server URL is:
 
 ```
 http://api.amp.localhost:8080/mcp
 ```
 
-If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value.
+The docker-compose dev stack publishes `agent-manager-service` straight onto a host port instead (`SERVER_PUBLIC_URL=http://localhost:9000`), so there the URL is:
+
+```
+http://localhost:9000/mcp
+```
+
+Both origins are registered as resource servers by the Thunder bootstrap, so either works out of the box. If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value — and see the warning below.
+
+:::warning Moving the public URL is a two-place change
+
+MCP clients send the server's public URL — with a trailing slash — as the OAuth
+`resource` parameter (RFC 8707), and Thunder both validates that value against
+its registered resource servers and stamps it into the token's `aud`. Changing
+the public URL therefore means changing two settings together, in two charts:
+
+| Setting                                      | Chart                        | Value               |
+| -------------------------------------------- | ---------------------------- | ------------------- |
+| `agentManagerService.config.serverPublicURL` | `wso2-agent-manager`         | the public base URL |
+| `thunder.bootstrap.agentManagerMcpBaseUrl`   | `wso2-amp-thunder-extension` | the same base URL   |
+
+Leaving `agentManagerMcpBaseUrl` behind makes the browser redirect fail with
+`invalid_target: The resource parameter does not match any registered resource
+server`.
+
+The matching `aud` entry needs no separate setting: `wso2-agent-manager` appends
+`serverPublicURL` plus a trailing slash to `keyManager.audience` when it renders,
+so that list only carries client IDs. (Charts released before that derivation
+list the URL literally — there, moving the public URL is a three-place change.)
+
+Identifiers are matched exactly, so a deployment reachable on more than one
+origin needs one resource server per origin. `thunder.bootstrap.agentManagerMcpDevBaseUrl`
+is the opt-in second origin for the docker-compose dev stack; `make setup-openchoreo`
+sets it, and other installs leave it empty.
+
+:::
 
 ## Default OAuth Client
 
@@ -80,7 +114,13 @@ The client is public (no secret), PKCE is required, and the callback port is pin
 
 The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extension` Helm chart (script `59-am-mcp-client.sh`) and is already wired into `KEY_MANAGER_AUDIENCE` on the docker-compose setup, so no manual registration is required for the default installations.
 
-*Upgrading an existing install: the token scopes for MCP clients come from permissions registered on the MCP resource server in Thunder (script `60-amp-resource-server.sh`), which are seeded by the bootstrap job only. On existing installs, re-run the bootstrap job — it replaces legacy MCP resource servers automatically and seeds the permissions; a `helm upgrade` alone will not re-seed, and without the permissions MCP tokens are issued with an empty scope list and every tool call returns 403.*
+:::note Upgrading an existing install
+
+Both the MCP resource-server identifiers and the permissions that become MCP token scopes are seeded by `60-amp-resource-server.sh`, which lives in a ConfigMap annotated `helm.sh/hook: pre-install`. Helm does **not** re-apply that ConfigMap on `helm upgrade`, so upgrading the chart leaves the old scripts in place and re-running the setup job would just re-seed the old values.
+
+To pick up either, **reinstall the `amp-thunder-extension` release** (or replace the `amp-thunder-bootstrap` ConfigMap, then re-run the job). Symptoms if you skip it: an install seeded before the gateway origin was added registered only `http://localhost:9000/`, so a Quick Start or k3d client fails authorize with `invalid_target`; an install seeded without the permissions issues MCP tokens with an empty scope list and every tool call returns 403. Identifiers no longer in use are inert and can be left in place.
+
+:::
 
 ## Configuring AI Assistants
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -93,9 +93,9 @@ server`. Leaving the `audience` entry behind lets the login succeed but makes
 every tool call return 401.
 
 Identifiers are matched exactly, so a deployment reachable on more than one
-origin needs one resource server per origin. That is why the chart registers the
-docker-compose dev origin as well, via `thunder.bootstrap.agentManagerMcpDevBaseUrl`
-— set it to the empty string to drop it on a deployment that has no dev stack.
+origin needs one resource server per origin. `thunder.bootstrap.agentManagerMcpDevBaseUrl`
+is the opt-in second origin for the docker-compose dev stack; `make setup-openchoreo`
+sets it, and other installs leave it empty.
 
 :::
 
@@ -111,9 +111,13 @@ The client is public (no secret), PKCE is required, and the callback port is pin
 
 The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extension` Helm chart (script `59-am-mcp-client.sh`) and is already wired into `KEY_MANAGER_AUDIENCE` on the docker-compose setup, so no manual registration is required for the default installations.
 
-*Upgrading an existing install: the token scopes for MCP clients come from permissions registered on the MCP resource server in Thunder (script `60-amp-resource-server.sh`), which are seeded by the bootstrap job only. On existing installs, re-run the bootstrap job — it replaces legacy MCP resource servers automatically and seeds the permissions; a `helm upgrade` alone will not re-seed, and without the permissions MCP tokens are issued with an empty scope list and every tool call returns 403.*
+:::note Upgrading an existing install
 
-*Installs created before the gateway origin was added registered the agent-manager MCP resource server only under `http://localhost:9000/`, so a Quick Start or k3d client pointed at `http://api.amp.localhost:8080/mcp` fails the authorize request with `invalid_target`. Note the bootstrap scripts live in a ConfigMap annotated `helm.sh/hook: pre-install`, which Helm does **not** re-apply on `helm upgrade` — so upgrading the chart alone leaves the old ConfigMap, and re-running the setup job would just re-register the old identifiers. Either reinstall the `amp-thunder-extension` release, or replace the `amp-thunder-bootstrap` ConfigMap and then re-run the job. Identifiers no longer in use are inert and can be left in place.*
+Both the MCP resource-server identifiers and the permissions that become MCP token scopes are seeded by `60-amp-resource-server.sh`, which lives in a ConfigMap annotated `helm.sh/hook: pre-install`. Helm does **not** re-apply that ConfigMap on `helm upgrade`, so upgrading the chart leaves the old scripts in place and re-running the setup job would just re-seed the old values.
+
+To pick up either, **reinstall the `amp-thunder-extension` release** (or replace the `amp-thunder-bootstrap` ConfigMap, then re-run the job). Symptoms if you skip it: an install seeded before the gateway origin was added registered only `http://localhost:9000/`, so a Quick Start or k3d client fails authorize with `invalid_target`; an install seeded without the permissions issues MCP tokens with an empty scope list and every tool call returns 403. Identifiers no longer in use are inert and can be left in place.
+
+:::
 
 ## Configuring AI Assistants
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -72,7 +72,7 @@ The docker-compose dev stack publishes `agent-manager-service` straight onto a h
 http://localhost:9000/mcp
 ```
 
-Both origins are registered as resource servers by the Thunder bootstrap, so either works out of the box. If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value — and see the warning below.
+Each install registers only the origins it actually serves: `make setup` registers both (the gateway origin and the dev host port), while a Quick Start or k3d install registers the gateway origin alone. If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value — and see the warning below.
 
 :::warning Moving the public URL is a two-place change
 
@@ -85,6 +85,11 @@ the public URL therefore means changing two settings together, in two charts:
 | -------------------------------------------- | ---------------------------- | ------------------- |
 | `agentManagerService.config.serverPublicURL` | `wso2-agent-manager`         | the public base URL |
 | `thunder.bootstrap.agentManagerMcpBaseUrl`   | `wso2-amp-thunder-extension` | the same base URL   |
+
+On docker-compose there is no chart to derive anything, so all three move together
+by hand in `deployments/docker-compose.yml`: `SERVER_PUBLIC_URL`, the matching
+`KEY_MANAGER_AUDIENCE` entry (the same URL **plus a trailing slash**), and the
+identifier registered in Thunder.
 
 Leaving `agentManagerMcpBaseUrl` behind makes the browser redirect fail with
 `invalid_target: The resource parameter does not match any registered resource

--- a/documentation/versioned_docs/version-v1.0.0-alpha1/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-alpha1/getting-started/_partials/_amp-installation.mdx
@@ -108,6 +108,14 @@ helm install amp \
   --timeout 1800s
 ```
 
+:::info
+Both are the public Thunder URL, and the chart defaults are the k3d hostname:
+`keyManager.issuer` is what the API validates user tokens against, and
+`oauthAuthorizationServers` is the authorization server it advertises in its RFC
+9728 protected resource metadata. Startup validation only checks that the
+advertised URLs are well-formed, so a stale value here fails silently.
+:::
+
 Wait for all components:
 
 ```bash
@@ -246,7 +254,6 @@ helm install amp-observability-traces \
   --set amObserver.publicUrl="${OBS_API_PUBLIC_URL}" \
   --set amObserver.auth.issuer="${THUNDER_PUBLIC_URL}" \
   --set amObserver.oauth.authorizationServers="${THUNDER_PUBLIC_URL}" \
-  --set amObserver.auth.audience="amp\,amp-api-client\,am-obs-mcp\,${OBS_API_PUBLIC_URL}/" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \
@@ -254,16 +261,16 @@ kubectl wait --for=condition=Available \
 ```
 
 :::warning
-All three auth values must be overridden together; the chart defaults point at
-the k3d hostnames. `amObserver.auth.issuer` is the **public** Thunder URL (not
-the in-cluster service URL) and must match
-`agentManagerService.config.keyManager.issuer` from Step 2 — the observer
+Both values must be set, and both are the **public** Thunder URL — not the
+in-cluster service URL used for `jwksUrl`. `amObserver.auth.issuer` has to match
+`agentManagerService.config.keyManager.issuer` from Step 2, because the observer
 validates the same user token the console and `amctl` send to the Agent Manager
-API. Miss it and the traces page stays empty while the observer logs
-`JWT validation failed ... invalid issuer`. The last audience entry is this
-service's own `publicUrl` **with a trailing slash**: observer MCP tokens carry
-that URL as their audience. The commas are backslash-escaped because `helm --set`
-otherwise splits the value into a list.
+API. Leave it at the chart default on a custom-domain install and the traces
+page stays empty while the observer logs
+`JWT validation failed ... invalid issuer`.
+`amObserver.oauth.authorizationServers` is the authorization server advertised in
+this service's RFC 9728 protected resource metadata and must name the same
+Thunder deployment as the issuer.
 :::
 
 #### Step 6: Evaluation Extension

--- a/documentation/versioned_docs/version-v1.0.0-alpha1/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-alpha1/getting-started/_partials/_amp-installation.mdx
@@ -101,6 +101,7 @@ helm install amp \
   --set agentManagerService.ocIngress.hostname="${API_PUBLIC_HOST}" \
   --set agentManagerService.config.serverPublicURL="${API_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.oauthAuthorizationServers="${THUNDER_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
@@ -243,11 +244,27 @@ helm install amp-observability-traces \
   --namespace ${OBSERVABILITY_NS} \
   --set amObserver.ocIngress.hostname="${OBS_API_PUBLIC_HOST}" \
   --set amObserver.publicUrl="${OBS_API_PUBLIC_URL}" \
+  --set amObserver.auth.issuer="${THUNDER_PUBLIC_URL}" \
+  --set amObserver.oauth.authorizationServers="${THUNDER_PUBLIC_URL}" \
+  --set amObserver.auth.audience="amp\,amp-api-client\,am-obs-mcp\,${OBS_API_PUBLIC_URL}/" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \
   deployment/amp-observer -n ${OBSERVABILITY_NS} --timeout=600s
 ```
+
+:::warning
+All three auth values must be overridden together; the chart defaults point at
+the k3d hostnames. `amObserver.auth.issuer` is the **public** Thunder URL (not
+the in-cluster service URL) and must match
+`agentManagerService.config.keyManager.issuer` from Step 2 — the observer
+validates the same user token the console and `amctl` send to the Agent Manager
+API. Miss it and the traces page stays empty while the observer logs
+`JWT validation failed ... invalid issuer`. The last audience entry is this
+service's own `publicUrl` **with a trailing slash**: observer MCP tokens carry
+that URL as their audience. The commas are backslash-escaped because `helm --set`
+otherwise splits the value into a list.
+:::
 
 #### Step 6: Evaluation Extension
 


### PR DESCRIPTION
## Purpose

Fixes #1424 and #1414. **This branch merges #1437 into #1435** — both fix the same
class of bug, so they are easier to review and safer to land as one change.

The shared defect: an auth value that must be kept in sync with *another* value by
hand, where a mismatch is invisible at install time and only surfaces later as a
401 or a failed login.

**#1424** — the observability extension's install steps never overrode
`amObserver.auth.issuer`, so any install whose Thunder issuer differs from the k3d
chart default had the observer reject every token the console and `amctl` sent it:

```
{"level":"ERROR","msg":"JWT validation failed","error":"invalid issuer: http://localhost:8090"}
{"level":"INFO","msg":"Request completed","path":"/api/v1/traces","status":401}
```

The traces page just renders empty — the 401 is only visible in the observer's logs.
Three chart values had to be hand-synced for this to work (`auth.issuer`,
`oauth.authorizationServers`, and the `publicUrl` entry in `auth.audience`).
`deployments/vm/lib-vm.sh` already set all three, with a long comment explaining
why; the manual install docs set none.

**#1414** — the agent-manager MCP server's OAuth login failed with
`invalid_target: The resource parameter does not match any registered resource
server` for any RFC 8707-compliant MCP client. Thunder's resource-server bootstrap
was already on main, but wired to values that didn't match what the services
advertise.

## Goals

- A custom-domain install needs one Thunder override, not three.
- A stock k3d / quick-start install completes MCP OAuth without manual patching.
- The `make setup` dev flow keeps working — it reaches amp-api on a published host
  port, not through the gateway, so it needs its own resource identifier.
- The published install docs actually set what they must.
- The same relationship is expressed the same way in every chart that has it.

## Approach

Rather than document a fourth sync rule, the charts derive the dependent values.

**`wso2-amp-observability-extension`**

- `oauth.authorizationServers` now defaults to `auth.issuer` (new
  `amp-observability-extension.authorizationServers` helper). Both always name the
  same Thunder deployment, and advertising one URL while validating against another
  sends MCP clients to an authorization server whose tokens the observer rejects.
- `auth.audience` no longer hardcodes `publicUrl`. The new
  `amp-observability-extension.audience` helper appends `publicUrl` plus the
  trailing slash Thunder stamps on RFC 8707 resource identifiers, de-duplicating so
  an explicit list is never doubled.

**`wso2-agent-manager`** — had the identical hand-synced pair
(`config.oauthAuthorizationServers` vs `config.keyManager.issuer`), and after
merging, the identical audience problem. Both now derive: the advertised
authorization server falls back to the issuer, and `keyManager.audience` appends
`serverPublicURL` plus its trailing slash, mirroring the observer helper.

Rendered output with default values is byte-identical to `main` for the
observability chart and to #1437's hand-written literal for agent-manager, so no
existing install changes behaviour.

**MCP resource identifiers** — these become the identifiers Thunder registers for
the `/mcp` endpoints, and Thunder matches a requested `resource` **exactly**.
amp-api is reachable on two origins against the same Thunder, so this is one
identifier per origin, not one identifier moved between them:

- **k3d / quick-start** — behind the control-plane gateway at
  `api.amp.localhost:8080`, now the chart default.
- **`make setup` dev** — amp-api runs as a host process on `:9000`. Opt-in via the
  new `thunder.bootstrap.agentManagerMcpDevBaseUrl`, set by `setup-openchoreo.sh`,
  that path's only installer. Empty by default, so no other install registers a
  localhost identifier or pays the ~125 admin-API round-trips to seed its
  permission tree. Entries marked `optional: true` are skipped when blank; the
  required ones still `fail` the render.

**Docs** — the getting-started steps gain the overrides they were missing;
`mcp-server.mdx` gains a warning naming the settings that must move together,
corrects the claim that docker-compose serves the API through the gateway, and
merges two upgrade notes whose remedies contradicted each other. The
`version-v1.0.0-alpha1` docs stay explicit: that release ships neither the
derivation nor any `mcpResourceServers` keys, so it needs the flags spelled out and
no MCP guidance.

**Tests** — `tests/render.sh` in both charts (10 assertions each), wired into the
helm PR check by a generic per-chart hook. `helm template` with default values
cannot distinguish a derived value from a hardcoded one, which is exactly the blind
spot that let #1424 ship.

## Merge resolutions

Beyond the textual conflicts, three decisions where the two branches disagreed:

1. **MCP base URL default.** #1435 had *reverted* the default to the dev origin,
   because with a single identifier only one install can own the default and dev is
   the path that passes no arguments. #1437's dual-origin model removes that
   constraint entirely, so it wins: default is the gateway URL, dev opts in. The
   revert's concrete reason survives as the comment explaining why the dev entry
   exists.
2. **Audience: derived, not restated.** #1437 hand-listed the URL entry in
   `wso2-agent-manager` while #1435 derives it in the observability chart. Shipping
   both would put two conventions on sibling services, so agent-manager now derives
   too — which is what #1437's own reviewer note #2 proposed. That deletes the
   hand-synced sites #1437 added (the chart default's URL entry and the `--set` in
   both install guides), and downgrades the `mcp-server.mdx` warning from a
   three-place to a two-place change. The VM installer keeps its restatement: it
   targets published `AMP_VERSION` releases that predate the derivation.
3. **Quick-start's `agentManagerMcpBaseUrl` override** (added by #1435) is dropped —
   with the gateway URL as the chart default it only restated it.

## User stories

N/A — operator-facing install fix, no product behaviour change.

## Release note

Fixed traces returning 401 (`invalid issuer`) on installs where Thunder's public
URL differs from the chart default, and fixed MCP OAuth login failing with
`invalid_target` on default Helm/quick-start installs. The advertised OAuth
authorization server and the MCP audience entry are now derived from the token
issuer and the service's public URL in both the observability and agent-manager
charts. **Existing installs must reinstall the `amp-thunder-extension` release** to
pick up the corrected resource identifiers — a `helm upgrade` does not re-seed (see
Migrations).

## Documentation

Included — getting-started install steps (next and `v1.0.0-alpha1`),
`documentation/docs/reference/mcp-server.mdx`, values.yaml comments, and
`agent-manager-observer/mcp/README.md`.

## Training

N/A — no new concepts.

## Certification

N/A

## Marketing

N/A

## Automation tests

- **Unit tests**:
  - `deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh` — 10 render assertions.
  - `deployments/helm-charts/wso2-agent-manager/tests/render.sh` — 10 render assertions (new in the merge).
  - Both run in CI via the new "Run chart render assertions" step, which discovers
    `tests/render.sh` per chart.
  - `deployments/vm/tests/run.sh` — **176 assertions, ALL TESTS PASSED**, including
    #1437's additions that the VM installer's audience follows the public API host
    and that the dev origin stays unset on a VM install.
- **Integration tests**: none added — no harness drives a live browser OAuth flow
  against Thunder. See Test environment.

Also verified manually on the merge commit:

- `helm lint --strict` clean on all three changed charts. (`wso2-amp-thunder-extension`
  fails lint identically on `main` without `helm dependency build`; clean with
  dependencies present.)
- Thunder chart renders the gateway origin only by default, both origins under
  `setup-openchoreo.sh`'s override, and still `fail`s when a *required* base URL is
  blanked. Generated bootstrap script is `bash -n` clean.
- `wso2-agent-manager`'s derived audience default renders byte-identical to the
  literal #1437 hand-wrote; override, trailing-slash, empty, duplicate, whitespace
  and stray-comma cases all verified.
- Both render suites mutation-tested — dropping the trailing slash fails 6
  assertions, `uniq` 2, `compact` 1, `nospace` 1. Every pipeline stage is pinned.
- `bash -n` clean on all changed shell files; `make -C documentation build` succeeds.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **Yes**
- Ran FindSecurityBugs plugin and verified report? **No** — no Java/Go code changed;
  the diff is Helm templates, values, docs, and bash tests.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or
  other secrets? **Yes**
- **Changes to the security model?** No. The audience list gains the resource
  identifier Thunder already mints for this service, so tokens that were being
  rejected are now accepted for the service they were issued for. It does not widen
  what any token can do — scopes and per-route authz are untouched.
- **Changes to the authentication/authorization flows?** No flow changes;
  configuration values only, so the existing RFC 8707 flow resolves to the correct
  resource server.
- **New dependencies?** No.

## Samples

N/A

## Migrations

No DB migrations. **Operational step required on existing installs**: the bootstrap
scripts live in a ConfigMap annotated `helm.sh/hook: pre-install`, which Helm does
*not* re-apply on `helm upgrade` — so upgrading leaves the old scripts in place and
re-running the setup job would re-seed the old identifiers. Reinstall the
`amp-thunder-extension` release, or replace the `amp-thunder-bootstrap` ConfigMap
and then re-run the job. Identifiers no longer in use are inert and can be left in
place.

## Related PRs

- Supersedes and includes #1437 (merged into this branch).
- Builds on the MCP resource-server bootstrap work already on main (`66713235`,
  `ff85c42e`, `3061db2e`, `0cfc16fe`), which registered the resource servers but off
  base URLs that didn't match what the services advertise.

## Test environment

Static verification only — **no live OAuth login was performed**, as no AMP
environment was available. macOS; `helm v4.1.0` for rendering/lint, cross-checked on
`v3.19.4` (the version CI pins) for the sprig functions used; Docusaurus via
`make -C documentation build`.

**Not verified — worth doing before merge:** an end-to-end browser OAuth login from
an MCP client against a running install, on both the k3d and `make setup` paths.

## Learning

MCP authorization (2025-06-18 spec) + RFC 8707 resource indicators, RFC 9728
protected-resource metadata, Thunder's resource-server/downscoping model, and Helm
hook re-application semantics.

---

## Reviewer notes — known limitations

1. **The trailing slash is a client-side convention.** amp-api advertises
   `resource: http://host` (no slash) in its protected-resource metadata, while
   Thunder registers `http://host/`. This works because MCP clients canonicalize the
   origin via JS `new URL().href`, which appends the slash. Nothing in-repo proves
   it — only the observer precedent, which has shipped with the same split. A client
   that echoes the metadata value verbatim, or sends the full `/mcp` path, would
   still get `invalid_target`. Hardening `well_known_routes.go` to advertise the
   canonical slashed form is the natural follow-up.
2. **Cross-chart drift is still convention-enforced.** The identifier lives in
   `wso2-amp-thunder-extension` and the public URL in `wso2-agent-manager`, with no
   umbrella chart and no shared values to hang the invariant off, and Thunder is
   bootstrapped by a `pre-install` hook so it cannot read the service's metadata.
   The one guardrail that would actually catch drift is an e2e assertion that the
   `resource` in `/.well-known/oauth-protected-resource` appears verbatim among
   Thunder's registered identifiers. This PR removes the *within-chart* drift; the
   cross-chart pair remains.

## Deliberately out of scope

- Moving the audience append into the services' `config.go`. It would reach chart
  releases that predate the derivation, but it couples a new chart default (audience
  without the URL) to a new image, and the invariant is deployment topology, which
  the chart owns.
- Wiring `deployments/vm/tests/run.sh` into CI. It is the only place asserting the
  *cross-chart* issuer equality that actually broke here, needs no cluster, and
  currently runs in no workflow — worth its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Helm configuration for OAuth issuers, authorization servers, and token audiences, including automatic public URL handling and fallback behavior.
  - Added support for separate production and development MCP endpoints.
  - Optional MCP endpoints can now be omitted without blocking installation.

- **Bug Fixes**
  - Prevented mismatched issuers, duplicate audiences, malformed URLs, and invalid MCP resource identifiers.

- **Documentation**
  - Expanded installation and MCP guidance for public URLs, k3d, Docker Compose, upgrades, and issuer alignment.

- **Tests**
  - Added automated chart-rendering checks covering authentication and MCP configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->