### PR TITLE
Align the agent-manager MCP resource identifier with its public URL

### DIFF
--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -194,11 +194,7 @@ agentManagerService:
     # Console and CLI logins carry no `resource`, so they resolve to the "amp"
     # resource server and arrive with aud=amp. MCP logins (am-mcp) DO send
     # `resource`, and get this service's serverPublicURL WITH a trailing slash
-    # as their audience, so that URL is listed. "am-mcp" is listed defensively;
-    # MCP tokens normally carry the resource URL, not the client ID.
-    # Keep the audience URL entry in sync with serverPublicURL below — an
-    # install that moves serverPublicURL must move this entry with it, or the
-    # service rejects every MCP token Thunder mints for it.
+    # as their audience, so that URL is listed too.
     keyManager:
       issuer: "http://thunder.amp.localhost:8080"
       audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp,http://api.amp.localhost:8080/"

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -188,14 +188,27 @@ agentManagerService:
       additionalInstrumentationVersions: []
 
     # Key Manager configuration
+    #
+    # Thunder (v0.45+) stamps the resource-server identifier named in the
+    # authorize request's RFC 8707 `resource` parameter as the token audience.
+    # Console and CLI logins carry no `resource`, so they resolve to the "amp"
+    # resource server and arrive with aud=amp. MCP logins (am-mcp) DO send
+    # `resource`, and get this service's serverPublicURL WITH a trailing slash
+    # as their audience, so that URL is listed. "am-mcp" is listed defensively;
+    # MCP tokens normally carry the resource URL, not the client ID.
+    # Keep the audience URL entry in sync with serverPublicURL below — an
+    # install that moves serverPublicURL must move this entry with it, or the
+    # service rejects every MCP token Thunder mints for it.
     keyManager:
       issuer: "http://thunder.amp.localhost:8080"
-      audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp"
+      audience: "amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp,http://api.amp.localhost:8080/"
       jwksUrl: "http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090/oauth2/jwks"
 
     # Externally reachable base URL of this service.
     # Used as the `resource` identifier in RFC 9728 protected resource metadata.
     # Routed through the OpenChoreo control-plane gateway (see ocIngress).
+    # Must stay in sync with keyManager.audience's URL entry above and the
+    # thunder extension's thunder.bootstrap.agentManagerMcpBaseUrl.
     serverPublicURL: "http://api.amp.localhost:8080"
 
     # Comma-separated list of OAuth 2.0 authorization server URLs advertised

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1569,7 +1569,11 @@ data:
     # authorization checks expect.
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
-    {{- $base := index $.Values.thunder.bootstrap .baseUrlValue | required (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
+    {{- $base := index $.Values.thunder.bootstrap .baseUrlValue }}
+    {{- if and (not $base) (not .optional) }}
+    {{- fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
+    {{- end }}
+    {{- if $base }}
     {{- $identifier := printf "%s/" (trimSuffix "/" $base) }}
     MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")
     log_info "MCP resource server '{{ $identifier }}' ready (id: $MCP_RS_ID)"
@@ -1603,6 +1607,7 @@ data:
     MCP_AMP_ROOT=$(create_or_get_resource "$MCP_RS_ID" "Agent Manager" "amp" "Root of the amp permission tree")
     register_amp_permissions "$MCP_RS_ID" "{{ .permissionSet }}" "$MCP_AMP_ROOT"
     log_info "MCP resource server '{{ $identifier }}': '{{ .permissionSet }}' permission set registered."
+    {{- end }}
     {{- end }}
     log_success "MCP resource servers registered."
 

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1570,9 +1570,7 @@ data:
     log_info "Registering MCP resource servers..."
     {{- range .Values.thunder.bootstrap.mcpResourceServers }}
     {{- $base := index $.Values.thunder.bootstrap .baseUrlValue }}
-    {{- if and (not $base) (not .optional) }}
-    {{- fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}
-    {{- end }}
+    {{- if not (or $base .optional) }}{{ fail (printf "thunder.bootstrap.%s must be set (base URL for the %s resource server)" .baseUrlValue .name) }}{{ end }}
     {{- if $base }}
     {{- $identifier := printf "%s/" (trimSuffix "/" $base) }}
     MCP_RS_ID=$(create_or_get_rs "{{ .name }}" "{{ .handle }}" "{{ $identifier }}" "{{ .description }}" "$DEFAULT_OU_ID")

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -525,13 +525,30 @@ thunder:
     # extension's amObserver.publicUrl. Defaults suit a k3d/local install, where
     # amp-api is reached through the OpenChoreo control-plane gateway rather than
     # on its container port.
+    #
+    # An identifier is matched EXACTLY, so a service reachable on more than one
+    # origin needs one entry per origin. This single Thunder serves two amp-api
+    # front doors in a local setup: the k3d/quick-start install behind the
+    # control-plane gateway (agentManagerMcpBaseUrl), and the docker-compose dev
+    # stack published straight onto the host port (agentManagerMcpDevBaseUrl,
+    # matching SERVER_PUBLIC_URL in deployments/docker-compose.yml). Entries
+    # marked `optional: true` are skipped when their base URL is empty, so a
+    # deployment with no dev stack can drop that one with
+    # `--set thunder.bootstrap.agentManagerMcpDevBaseUrl=`.
     agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
+    agentManagerMcpDevBaseUrl: "http://localhost:9000"
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"
         handle: ""
         baseUrlValue: "agentManagerMcpBaseUrl"
         description: "Resource identifier for the agent-manager MCP endpoint"
+        permissionSet: "amp-minus-observability"
+      - name: "AMP Agent Manager MCP (dev)"
+        handle: ""
+        baseUrlValue: "agentManagerMcpDevBaseUrl"
+        optional: true
+        description: "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack"
         permissionSet: "amp-minus-observability"
       - name: "AMP Observer MCP"
         handle: ""

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -527,16 +527,13 @@ thunder:
     # on its container port.
     #
     # An identifier is matched EXACTLY, so a service reachable on more than one
-    # origin needs one entry per origin. This single Thunder serves two amp-api
-    # front doors in a local setup: the k3d/quick-start install behind the
-    # control-plane gateway (agentManagerMcpBaseUrl), and the docker-compose dev
-    # stack published straight onto the host port (agentManagerMcpDevBaseUrl,
-    # matching SERVER_PUBLIC_URL in deployments/docker-compose.yml). Entries
-    # marked `optional: true` are skipped when their base URL is empty, so a
-    # deployment with no dev stack can drop that one with
-    # `--set thunder.bootstrap.agentManagerMcpDevBaseUrl=`.
+    # origin needs one entry per origin. Entries marked `optional: true` are
+    # skipped when their base URL is empty. agentManagerMcpDevBaseUrl is the
+    # opt-in second origin for the docker-compose dev stack, which reaches
+    # amp-api on its published host port instead of through the gateway;
+    # setup-openchoreo.sh sets it.
     agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
-    agentManagerMcpDevBaseUrl: "http://localhost:9000"
+    agentManagerMcpDevBaseUrl: ""
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -522,8 +522,10 @@ thunder:
     # and silently drops name/handle/description/permissionSet. Point each base
     # URL at the externally reachable origin of its MCP endpoint's service — the
     # same value as agent-manager's serverPublicURL and the observability
-    # extension's amObserver.publicUrl. Defaults suit a k3d/local install.
-    agentManagerMcpBaseUrl: "http://localhost:9000"
+    # extension's amObserver.publicUrl. Defaults suit a k3d/local install, where
+    # amp-api is reached through the OpenChoreo control-plane gateway rather than
+    # on its container port.
+    agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -432,10 +432,23 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # handle, and the scope strings must come out identical to the amp resource
 # server's (amp:project:read etc.). The tree is rooted under a top-level
 # "amp" resource instead.
-AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://localhost:9000/}"
+# An identifier is matched EXACTLY, so a service reachable on more than one
+# origin needs one entry per origin. amp-api has two front doors against this
+# same Thunder: the k3d/quick-start install behind the control-plane gateway,
+# and the docker-compose dev stack on the published host port. Both are
+# registered; set either to the empty string to skip it.
+AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://api.amp.localhost:8080/}"
+AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE:-http://localhost:9000/}"
 OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE:-http://traces.amp.localhost:11080/}"
 
 log_info "Registering MCP resource servers..."
-register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
-register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
+if [[ -n "$AM_MCP_RESOURCE" ]]; then
+  register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
+fi
+if [[ -n "$AM_MCP_DEV_RESOURCE" ]]; then
+  register_mcp_resource_server "AMP Agent Manager MCP (dev)" "$AM_MCP_DEV_RESOURCE" "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack" "amp-minus-observability"
+fi
+if [[ -n "$OBSERVER_MCP_RESOURCE" ]]; then
+  register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
+fi
 log_success "MCP resource servers registered."

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -355,11 +355,18 @@ register_amp_permissions() {
 # permission (e.g. amp-am:amp:project:read), producing scope strings
 # agent-manager-service will never accept. MCP resource servers are pure
 # mirrors with no independent state, so delete and recreate is safe.
+# An empty identifier skips the resource server, mirroring the chart's
+# `optional: true` entries.
 # Usage: register_mcp_resource_server <name> <identifier> <description> <permission_set>
 # ---------------------------------------------------------------------------
 register_mcp_resource_server() {
   local name="$1" identifier="$2" description="$3" permission_set="$4"
   local rs_id response http_code body handle amp_root
+
+  if [[ -z "$identifier" ]]; then
+    log_info "Skipping MCP resource server '$name' (no identifier configured)"
+    return 0
+  fi
 
   rs_id=$(create_or_get_rs "$name" "" "$identifier" "$description" "$DEFAULT_OU_ID")
   log_info "MCP resource server '$identifier' ready (id: $rs_id)"
@@ -432,23 +439,15 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # handle, and the scope strings must come out identical to the amp resource
 # server's (amp:project:read etc.). The tree is rooted under a top-level
 # "amp" resource instead.
-# An identifier is matched EXACTLY, so a service reachable on more than one
-# origin needs one entry per origin. amp-api has two front doors against this
-# same Thunder: the k3d/quick-start install behind the control-plane gateway,
-# and the docker-compose dev stack on the published host port. Both are
-# registered; set either to the empty string to skip it.
+# Identifiers match exactly, so each origin amp-api is reachable on needs its
+# own entry; set one to "" to skip it. The dev origin is the docker-compose
+# stack's published host port.
 AM_MCP_RESOURCE="${AM_MCP_RESOURCE:-http://api.amp.localhost:8080/}"
 AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE:-http://localhost:9000/}"
 OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE:-http://traces.amp.localhost:11080/}"
 
 log_info "Registering MCP resource servers..."
-if [[ -n "$AM_MCP_RESOURCE" ]]; then
-  register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
-fi
-if [[ -n "$AM_MCP_DEV_RESOURCE" ]]; then
-  register_mcp_resource_server "AMP Agent Manager MCP (dev)" "$AM_MCP_DEV_RESOURCE" "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack" "amp-minus-observability"
-fi
-if [[ -n "$OBSERVER_MCP_RESOURCE" ]]; then
-  register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
-fi
+register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"
+register_mcp_resource_server "AMP Agent Manager MCP (dev)" "$AM_MCP_DEV_RESOURCE" "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack" "amp-minus-observability"
+register_mcp_resource_server "AMP Observer MCP" "$OBSERVER_MCP_RESOURCE" "Resource identifier for the observer MCP endpoint" "observability-only"
 log_success "MCP resource servers registered."

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -458,8 +458,12 @@ install_thunder_extension() {
         fi
     fi
 
+    # The dev stack runs amp-api on a published host port rather than behind the
+    # gateway, so register that origin as a second MCP resource identifier too —
+    # Thunder matches the authorize request's `resource` value exactly.
     helm upgrade --install amp-thunder-extension "${SCRIPT_DIR}/../helm-charts/wso2-amp-thunder-extension" \
-        --namespace amp-thunder --create-namespace
+        --namespace amp-thunder --create-namespace \
+        --set thunder.bootstrap.agentManagerMcpDevBaseUrl=http://localhost:9000
     echo "✅ AMP Thunder Extension installed/upgraded successfully"
 }
 

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -29,6 +29,16 @@ vm_host() {
 # own serving (that is internalServer.tlsEnabled) — it is purely the endpoint
 # scheme. The agent host is only reachable over TLS via Caddy's wildcard site, so
 # without this the console emits http:// and the browser blocks it as mixed content.
+#
+# keyManager.audience is restated rather than left at the chart default for the
+# same reason observability_helm_args restates amObserver.auth.audience: the
+# default's last entry is this service's own serverPublicURL, which the line
+# above has just moved. An MCP token carries the RFC 8707 resource identifier
+# (serverPublicURL plus a trailing slash) as its `aud`, so leaving the default
+# in place means amp-api rejects every MCP token Thunder mints for it. The
+# leading entries mirror the chart and must stay: console, amctl and publisher
+# tokens arrive with aud amp, amctl or amp-publisher-*. Commas are escaped
+# because helm's --set otherwise splits the value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
   local k
@@ -37,6 +47,7 @@ amp_helm_args() {
       "--set" "${k}.config.serverPublicURL=https://${AMP_HOST_API}" \
       "--set" "${k}.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
       "--set" "${k}.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
+      "--set" "${k}.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/" \
       "--set" "${k}.config.tlsEnabled=true" \
       "--set" "${k}.config.thunderHostBaseDomain=${AMP_HOST_THUNDER#thunder.}"
   done

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -268,8 +268,14 @@ thunder_helm_args() {
   # permissionSet, which makes Thunder reject the resource server (empty name)
   # and the bootstrap fail. Pass the base URL without a trailing slash — the
   # template adds it.
+  #
+  # agentManagerMcpDevBaseUrl is emptied: it exists so a local setup can also
+  # reach amp-api on the docker-compose host port, which no VM install has. The
+  # entry is marked optional in the chart, so an empty value skips it instead of
+  # registering a bogus localhost resource server.
   printf '%s\n' \
     "--set" "thunder.bootstrap.agentManagerMcpBaseUrl=https://${AMP_HOST_API}" \
+    "--set" "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
     "--set" "thunder.bootstrap.observerMcpBaseUrl=https://${AMP_HOST_OBSERVER}"
 
   # The console client's registered redirect URI lives under `setup` (<=main) and

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -30,15 +30,10 @@ vm_host() {
 # scheme. The agent host is only reachable over TLS via Caddy's wildcard site, so
 # without this the console emits http:// and the browser blocks it as mixed content.
 #
-# keyManager.audience is restated rather than left at the chart default for the
-# same reason observability_helm_args restates amObserver.auth.audience: the
-# default's last entry is this service's own serverPublicURL, which the line
-# above has just moved. An MCP token carries the RFC 8707 resource identifier
-# (serverPublicURL plus a trailing slash) as its `aud`, so leaving the default
-# in place means amp-api rejects every MCP token Thunder mints for it. The
-# leading entries mirror the chart and must stay: console, amctl and publisher
-# tokens arrive with aud amp, amctl or amp-publisher-*. Commas are escaped
-# because helm's --set otherwise splits the value into a list.
+# keyManager.audience is restated because the chart default's last entry is the
+# chart's own serverPublicURL, which the line below has just moved; an MCP
+# token's aud is serverPublicURL plus a trailing slash. Commas stay escaped or
+# helm's --set splits the value into a list.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
   local k
@@ -268,14 +263,8 @@ thunder_helm_args() {
   # permissionSet, which makes Thunder reject the resource server (empty name)
   # and the bootstrap fail. Pass the base URL without a trailing slash — the
   # template adds it.
-  #
-  # agentManagerMcpDevBaseUrl is emptied: it exists so a local setup can also
-  # reach amp-api on the docker-compose host port, which no VM install has. The
-  # entry is marked optional in the chart, so an empty value skips it instead of
-  # registering a bogus localhost resource server.
   printf '%s\n' \
     "--set" "thunder.bootstrap.agentManagerMcpBaseUrl=https://${AMP_HOST_API}" \
-    "--set" "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
     "--set" "thunder.bootstrap.observerMcpBaseUrl=https://${AMP_HOST_OBSERVER}"
 
   # The console client's registered redirect URI lives under `setup` (<=main) and

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -396,6 +396,11 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core thunder MCP base URL (observer)" \
     "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.example.com" \
     "$(grep -F 'observerMcpBaseUrl' <<<"$core_th")"
+  # No docker-compose stack on a VM, so the optional dev origin is skipped
+  # rather than registered as a bogus localhost resource server.
+  assert_eq "core thunder MCP dev base URL emptied" \
+    "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
+    "$(grep -F 'agentManagerMcpDevBaseUrl' <<<"$core_th")"
 
   core_obs="$(observability_helm_args)"
   assert_eq "core observability audience carries the public observer URL" \

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -55,15 +55,15 @@ assert_eq "amp oauthAuthorizationServers (service key)" \
 assert_eq "amp keyManager.issuer (service key)" \
   "agentManagerService.config.keyManager.issuer=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.keyManager.issuer' <<<"$amp")"
-# amp-api mints MCP tokens (am-mcp) whose aud is its own public URL plus a
-# trailing slash, so the audience list has to follow serverPublicURL off the
-# chart's localhost default. Commas stay escaped or helm splits it into a list.
-assert_eq "amp keyManager.audience carries the public API URL (service key)" \
-  'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
-  "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$amp")"
-assert_eq "amp keyManager.audience carries the public API URL (legacy key)" \
-  'agentManager.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
-  "$(grep -F 'agentManager.config.keyManager.audience' <<<"$amp")"
+# An MCP token's aud is serverPublicURL plus a trailing slash, so the audience
+# has to follow it off the chart's localhost default. Assert only that entry —
+# pinning the whole list would break on any unrelated audience change.
+assert_eq "amp keyManager.audience carries the public API URL (service key)" "yes" \
+  "$(has "$amp" 'agentManagerService.config.keyManager.audience=amp\,')"
+assert_eq "amp keyManager.audience ends with the public API URL (service key)" "yes" \
+  "$(has "$amp" 'am-mcp\,https://api.amp.203.0.113.10.sslip.io/')"
+assert_eq "amp keyManager.audience carries the public API URL (legacy key)" "yes" \
+  "$(has "$amp" 'agentManager.config.keyManager.audience=amp\,')"
 # tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
 # emitted under both keys (old agentManager + new agentManagerService).
 assert_eq "amp tlsEnabled (service key)" \
@@ -377,12 +377,10 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core amp cp url present" \
     "console.config.gatewayControlPlaneUrl=https://cp.amp.example.com" \
     "$(grep -F 'gatewayControlPlaneUrl' <<<"$core_amp")"
-  # The MCP resource identifier is serverPublicURL plus a trailing slash, so the
-  # audience must land on the same host as serverPublicURL above and as
+  # The audience must land on the same host as serverPublicURL above and as
   # thunder.bootstrap.agentManagerMcpBaseUrl below.
-  assert_eq "core amp keyManager.audience carries the public API URL" \
-    'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.example.com/' \
-    "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$core_amp")"
+  assert_eq "core amp keyManager.audience carries the public API URL" "yes" \
+    "$(has "$core_amp" 'am-mcp\,https://api.amp.example.com/')"
 
   core_th="$(thunder_helm_args)"
   assert_eq "core thunder jwt.issuer" \
@@ -396,10 +394,9 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core thunder MCP base URL (observer)" \
     "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.example.com" \
     "$(grep -F 'observerMcpBaseUrl' <<<"$core_th")"
-  # No docker-compose stack on a VM, so the optional dev origin is skipped
-  # rather than registered as a bogus localhost resource server.
-  assert_eq "core thunder MCP dev base URL emptied" \
-    "thunder.bootstrap.agentManagerMcpDevBaseUrl=" \
+  # The dev origin is opt-in (empty chart default), so a VM install must not
+  # register it at all.
+  assert_eq "core thunder leaves the dev MCP origin unset" "" \
     "$(grep -F 'agentManagerMcpDevBaseUrl' <<<"$core_th")"
 
   core_obs="$(observability_helm_args)"

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -55,6 +55,15 @@ assert_eq "amp oauthAuthorizationServers (service key)" \
 assert_eq "amp keyManager.issuer (service key)" \
   "agentManagerService.config.keyManager.issuer=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.keyManager.issuer' <<<"$amp")"
+# amp-api mints MCP tokens (am-mcp) whose aud is its own public URL plus a
+# trailing slash, so the audience list has to follow serverPublicURL off the
+# chart's localhost default. Commas stay escaped or helm splits it into a list.
+assert_eq "amp keyManager.audience carries the public API URL (service key)" \
+  'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
+  "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$amp")"
+assert_eq "amp keyManager.audience carries the public API URL (legacy key)" \
+  'agentManager.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.203.0.113.10.sslip.io/' \
+  "$(grep -F 'agentManager.config.keyManager.audience' <<<"$amp")"
 # tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
 # emitted under both keys (old agentManager + new agentManagerService).
 assert_eq "amp tlsEnabled (service key)" \
@@ -368,6 +377,12 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core amp cp url present" \
     "console.config.gatewayControlPlaneUrl=https://cp.amp.example.com" \
     "$(grep -F 'gatewayControlPlaneUrl' <<<"$core_amp")"
+  # The MCP resource identifier is serverPublicURL plus a trailing slash, so the
+  # audience must land on the same host as serverPublicURL above and as
+  # thunder.bootstrap.agentManagerMcpBaseUrl below.
+  assert_eq "core amp keyManager.audience carries the public API URL" \
+    'agentManagerService.config.keyManager.audience=amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://api.amp.example.com/' \
+    "$(grep -F 'agentManagerService.config.keyManager.audience' <<<"$core_amp")"
 
   core_th="$(thunder_helm_args)"
   assert_eq "core thunder jwt.issuer" \

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -101,6 +101,7 @@ helm install amp \
   --set agentManagerService.ocIngress.hostname="${API_PUBLIC_HOST}" \
   --set agentManagerService.config.serverPublicURL="${API_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.keyManager.audience="amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,${API_PUBLIC_URL}/" \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
@@ -243,6 +244,7 @@ helm install amp-observability-traces \
   --namespace ${OBSERVABILITY_NS} \
   --set amObserver.ocIngress.hostname="${OBS_API_PUBLIC_HOST}" \
   --set amObserver.publicUrl="${OBS_API_PUBLIC_URL}" \
+  --set amObserver.auth.audience="amp\,amp-api-client\,am-obs-mcp\,${OBS_API_PUBLIC_URL}/" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -360,6 +360,8 @@ For evaluation without a domain, the [nip.io appendix](#appendix-installing-with
 
 Thunder provides authentication and user management for the entire platform — login, API keys, and OAuth token exchange. It must be installed before the Control Plane because the Control Plane, Observability Plane, and Agent Manager all validate JWTs issued by Thunder. The browser reaches it at `https://${THUNDER_PUBLIC_HOST}` through the control-plane gateway.
 
+The `agentManagerMcpBaseUrl` / `observerMcpBaseUrl` settings below register the RFC 8707 resource identifiers that MCP clients send when logging in; they must match the public URLs of the two services, or MCP login fails with `invalid_target`. `agentManagerMcpDevBaseUrl` is emptied because this deployment has no docker-compose dev stack. These are seeded by a `pre-install` hook, so they must be set on the initial install — see the [MCP server reference](../reference/mcp-server.mdx).
+
 ```bash
 helm install amp-thunder-extension \
   oci://${HELM_CHART_REGISTRY}/wso2-amp-thunder-extension \
@@ -374,6 +376,9 @@ helm install amp-thunder-extension \
   --set thunder.configuration.gateClient.port=443 \
   --set "thunder.configuration.cors.allowedOrigins={${CONSOLE_PUBLIC_URL}}" \
   --set "thunder.bootstrap.ampConsoleClient.redirectUris={${CONSOLE_PUBLIC_URL}/login}" \
+  --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
+  --set thunder.bootstrap.agentManagerMcpDevBaseUrl= \
+  --set thunder.bootstrap.observerMcpBaseUrl="${OBS_API_PUBLIC_URL}" \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -360,7 +360,7 @@ For evaluation without a domain, the [nip.io appendix](#appendix-installing-with
 
 Thunder provides authentication and user management for the entire platform — login, API keys, and OAuth token exchange. It must be installed before the Control Plane because the Control Plane, Observability Plane, and Agent Manager all validate JWTs issued by Thunder. The browser reaches it at `https://${THUNDER_PUBLIC_HOST}` through the control-plane gateway.
 
-The `agentManagerMcpBaseUrl` / `observerMcpBaseUrl` settings below register the RFC 8707 resource identifiers that MCP clients send when logging in; they must match the public URLs of the two services, or MCP login fails with `invalid_target`. `agentManagerMcpDevBaseUrl` is emptied because this deployment has no docker-compose dev stack. These are seeded by a `pre-install` hook, so they must be set on the initial install — see the [MCP server reference](../reference/mcp-server.mdx).
+The `agentManagerMcpBaseUrl` / `observerMcpBaseUrl` settings below must match the public URLs of those two services, and are seeded by a `pre-install` hook — so they have to be right on the initial install. See the [MCP server reference](../reference/mcp-server.mdx).
 
 ```bash
 helm install amp-thunder-extension \
@@ -377,7 +377,6 @@ helm install amp-thunder-extension \
   --set "thunder.configuration.cors.allowedOrigins={${CONSOLE_PUBLIC_URL}}" \
   --set "thunder.bootstrap.ampConsoleClient.redirectUris={${CONSOLE_PUBLIC_URL}/login}" \
   --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
-  --set thunder.bootstrap.agentManagerMcpDevBaseUrl= \
   --set thunder.bootstrap.observerMcpBaseUrl="${OBS_API_PUBLIC_URL}" \
   --timeout 1800s
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -60,13 +60,19 @@ The MCP server URL follows the public URL of the `agent-manager-service`:
 <server-public-url>/mcp
 ```
 
-For a stock local installation (Quick Start, docker-compose, or k3d via the bundled Helm chart), the API is served through the OpenChoreo control-plane gateway at `api.amp.localhost:8080`, so the MCP server URL is:
+For a Quick Start or k3d install via the bundled Helm chart, the API is served through the OpenChoreo control-plane gateway, so the MCP server URL is:
 
 ```
 http://api.amp.localhost:8080/mcp
 ```
 
-If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value.
+The docker-compose dev stack publishes `agent-manager-service` straight onto a host port instead (`SERVER_PUBLIC_URL=http://localhost:9000`), so there the URL is:
+
+```
+http://localhost:9000/mcp
+```
+
+Both origins are registered as resource servers by the Thunder bootstrap, so either works out of the box. If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value — and see the warning below.
 
 :::warning Moving the public URL is a three-place change
 
@@ -86,6 +92,11 @@ Leaving `agentManagerMcpBaseUrl` behind makes the browser redirect fail with
 server`. Leaving the `audience` entry behind lets the login succeed but makes
 every tool call return 401.
 
+Identifiers are matched exactly, so a deployment reachable on more than one
+origin needs one resource server per origin. That is why the chart registers the
+docker-compose dev origin as well, via `thunder.bootstrap.agentManagerMcpDevBaseUrl`
+— set it to the empty string to drop it on a deployment that has no dev stack.
+
 :::
 
 ## Default OAuth Client
@@ -102,7 +113,7 @@ The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extens
 
 *Upgrading an existing install: the token scopes for MCP clients come from permissions registered on the MCP resource server in Thunder (script `60-amp-resource-server.sh`), which are seeded by the bootstrap job only. On existing installs, re-run the bootstrap job — it replaces legacy MCP resource servers automatically and seeds the permissions; a `helm upgrade` alone will not re-seed, and without the permissions MCP tokens are issued with an empty scope list and every tool call returns 403.*
 
-*Installs created before the `agentManagerMcpBaseUrl` default was corrected registered the agent-manager MCP resource server under `http://localhost:9000/` instead of the gateway URL, which fails the authorize request with `invalid_target`. Re-running the bootstrap job registers the correct identifier; the stale entry is inert and can be left in place.*
+*Installs created before the gateway origin was added registered the agent-manager MCP resource server only under `http://localhost:9000/`, so a Quick Start or k3d client pointed at `http://api.amp.localhost:8080/mcp` fails the authorize request with `invalid_target`. Note the bootstrap scripts live in a ConfigMap annotated `helm.sh/hook: pre-install`, which Helm does **not** re-apply on `helm upgrade` — so upgrading the chart alone leaves the old ConfigMap, and re-running the setup job would just re-register the old identifiers. Either reinstall the `amp-thunder-extension` release, or replace the `amp-thunder-bootstrap` ConfigMap and then re-run the job. Identifiers no longer in use are inert and can be left in place.*
 
 ## Configuring AI Assistants
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -68,6 +68,26 @@ http://api.amp.localhost:8080/mcp
 
 If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value.
 
+:::warning Moving the public URL is a three-place change
+
+MCP clients send the server's public URL — with a trailing slash — as the OAuth
+`resource` parameter (RFC 8707), and Thunder both validates that value against
+its registered resource servers and stamps it into the token's `aud`. Changing
+the public URL therefore means changing three settings together:
+
+| Setting                                        | Chart / file                     | Value                          |
+| ---------------------------------------------- | -------------------------------- | ------------------------------ |
+| `agentManagerService.config.serverPublicURL`   | `wso2-agent-manager`             | the public base URL            |
+| `thunder.bootstrap.agentManagerMcpBaseUrl`     | `wso2-amp-thunder-extension`     | the same base URL              |
+| `agentManagerService.config.keyManager.audience` | `wso2-agent-manager`           | must list the base URL **plus a trailing slash** |
+
+Leaving `agentManagerMcpBaseUrl` behind makes the browser redirect fail with
+`invalid_target: The resource parameter does not match any registered resource
+server`. Leaving the `audience` entry behind lets the login succeed but makes
+every tool call return 401.
+
+:::
+
 ## Default OAuth Client
 
 AMP ships a pre-registered OAuth application in Thunder for MCP clients:
@@ -81,6 +101,8 @@ The client is public (no secret), PKCE is required, and the callback port is pin
 The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extension` Helm chart (script `59-am-mcp-client.sh`) and is already wired into `KEY_MANAGER_AUDIENCE` on the docker-compose setup, so no manual registration is required for the default installations.
 
 *Upgrading an existing install: the token scopes for MCP clients come from permissions registered on the MCP resource server in Thunder (script `60-amp-resource-server.sh`), which are seeded by the bootstrap job only. On existing installs, re-run the bootstrap job — it replaces legacy MCP resource servers automatically and seeds the permissions; a `helm upgrade` alone will not re-seed, and without the permissions MCP tokens are issued with an empty scope list and every tool call returns 403.*
+
+*Installs created before the `agentManagerMcpBaseUrl` default was corrected registered the agent-manager MCP resource server under `http://localhost:9000/` instead of the gateway URL, which fails the authorize request with `invalid_target`. Re-running the bootstrap job registers the correct identifier; the stale entry is inert and can be left in place.*
 
 ## Configuring AI Assistants
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -93,9 +93,9 @@ server`. Leaving the `audience` entry behind lets the login succeed but makes
 every tool call return 401.
 
 Identifiers are matched exactly, so a deployment reachable on more than one
-origin needs one resource server per origin. That is why the chart registers the
-docker-compose dev origin as well, via `thunder.bootstrap.agentManagerMcpDevBaseUrl`
-— set it to the empty string to drop it on a deployment that has no dev stack.
+origin needs one resource server per origin. `thunder.bootstrap.agentManagerMcpDevBaseUrl`
+is the opt-in second origin for the docker-compose dev stack; `make setup-openchoreo`
+sets it, and other installs leave it empty.
 
 :::
 
@@ -111,9 +111,13 @@ The client is public (no secret), PKCE is required, and the callback port is pin
 
 The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extension` Helm chart (script `59-am-mcp-client.sh`) and is already wired into `KEY_MANAGER_AUDIENCE` on the docker-compose setup, so no manual registration is required for the default installations.
 
-*Upgrading an existing install: the token scopes for MCP clients come from permissions registered on the MCP resource server in Thunder (script `60-amp-resource-server.sh`), which are seeded by the bootstrap job only. On existing installs, re-run the bootstrap job — it replaces legacy MCP resource servers automatically and seeds the permissions; a `helm upgrade` alone will not re-seed, and without the permissions MCP tokens are issued with an empty scope list and every tool call returns 403.*
+:::note Upgrading an existing install
 
-*Installs created before the gateway origin was added registered the agent-manager MCP resource server only under `http://localhost:9000/`, so a Quick Start or k3d client pointed at `http://api.amp.localhost:8080/mcp` fails the authorize request with `invalid_target`. Note the bootstrap scripts live in a ConfigMap annotated `helm.sh/hook: pre-install`, which Helm does **not** re-apply on `helm upgrade` — so upgrading the chart alone leaves the old ConfigMap, and re-running the setup job would just re-register the old identifiers. Either reinstall the `amp-thunder-extension` release, or replace the `amp-thunder-bootstrap` ConfigMap and then re-run the job. Identifiers no longer in use are inert and can be left in place.*
+Both the MCP resource-server identifiers and the permissions that become MCP token scopes are seeded by `60-amp-resource-server.sh`, which lives in a ConfigMap annotated `helm.sh/hook: pre-install`. Helm does **not** re-apply that ConfigMap on `helm upgrade`, so upgrading the chart leaves the old scripts in place and re-running the setup job would just re-seed the old values.
+
+To pick up either, **reinstall the `amp-thunder-extension` release** (or replace the `amp-thunder-bootstrap` ConfigMap, then re-run the job). Symptoms if you skip it: an install seeded before the gateway origin was added registered only `http://localhost:9000/`, so a Quick Start or k3d client fails authorize with `invalid_target`; an install seeded without the permissions issues MCP tokens with an empty scope list and every tool call returns 403. Identifiers no longer in use are inert and can be left in place.
+
+:::
 
 ## Configuring AI Assistants
 


### PR DESCRIPTION
## Purpose

Fixes #1414 — the agent-manager MCP server's OAuth login fails with
`invalid_target: The resource parameter does not match any registered resource server`
for any RFC 8707-compliant MCP client (Claude Code included).

The root cause named in the issue — Thunder having no resource server registered
under the MCP endpoint's URL — was already addressed on main, which registers
`mcpResourceServers` from the Thunder bootstrap. **But the bug still reproduces**,
because that mechanism was wired to values that don't match what the services
advertise:

| Setting | Was | Now |
|---|---|---|
| `thunder.bootstrap.agentManagerMcpBaseUrl` | `http://localhost:9000` (amp-api's container port) | `http://api.amp.localhost:8080` (the gateway URL amp-api advertises) |
| `agentManagerService.config.keyManager.audience` | client IDs only | also lists `http://api.amp.localhost:8080/` |

Thunder stamps the resource identifier into the token's `aud`, so the audience
gap is a second, later-firing failure: a login that clears `/authorize` then
401s on every tool call.

## Goals

- A stock k3d / quick-start install completes MCP OAuth without manual patching.
- The docker-compose dev flow keeps working — it reaches amp-api on a published
  host port, not through the gateway, so it needs its own resource identifier.
- The documented production install path gets the settings it was missing.
- Identifiers and audiences are wired consistently per install path, not left to
  prose.

## Approach

amp-api is reachable on **two** origins against the same Thunder, and Thunder
matches a resource identifier exactly — so this is one identifier per origin, not
one identifier moved between them:

- **k3d / quick-start** — behind the OpenChoreo control-plane gateway at
  `api.amp.localhost:8080` (chart default).
- **docker-compose dev** — published straight onto host port 9000. Opt-in via
  `thunder.bootstrap.agentManagerMcpDevBaseUrl`, set by `setup-openchoreo.sh`,
  which is that path's only installer. Empty by default, so no other install
  registers a localhost identifier or pays the ~125 admin-API round-trips to
  seed its permission tree.

Alongside that: the audience entry is added to the chart default and restated by
the VM installer (which relocates `serverPublicURL` and previously left the
audience behind, mirroring what `observability_helm_args` already does for the
observer); the documented `on-your-environment` install gains the three `--set`s
it was missing; and the MCP reference gains a warning table naming the settings
that must move together.

## User stories

N/A — bug fix, no new user-facing capability.

## Release note

Fixed MCP OAuth login failing with `invalid_target` on default Helm/quick-start
installs. Existing installs must reinstall the `amp-thunder-extension` release to
pick up the corrected resource identifiers (a `helm upgrade` does not re-seed —
see below).

## Documentation

`documentation/docs/reference/mcp-server.mdx` — added the settings-that-track-each-other
warning, corrected the claim that docker-compose serves the API through the
gateway (it publishes port 9000, so its MCP URL differs), and merged two upgrade
notes whose remedies contradicted each other.
`documentation/docs/getting-started/` — added the missing `--set`s to the
documented install path.

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

- **Unit tests**: `deployments/vm/tests/run.sh` — added assertions that the VM
  installer's audience follows the public API host (both chart keys + the
  hostname-driven core) and that the dev origin stays unset on a VM install.
  Full suite passes: **176 assertions, `ALL TESTS PASSED`**.
- **Integration tests**: none added — there is no harness that drives a live
  browser OAuth flow against Thunder. See "Test environment" for the gap.

## Security checks

- **Are there any changes to the security model?** No. The audience list gains
  the resource identifier Thunder already mints for this service, so tokens that
  were being rejected are now accepted for the service they were issued for. It
  does not widen what any token can do — scopes and per-route authz are untouched.
- **Are there any changes to the authentication/authorization flows?** No flow
  changes; configuration values only, so the existing RFC 8707 flow resolves to
  the correct resource server.
- **Have you introduced any new dependencies?** No.

## Samples

N/A

## Related PRs

Builds on the MCP resource-server bootstrap work already on main (`66713235`,
`ff85c42e`, `3061db2e`, `0cfc16fe`), which registered the resource servers but
off base URLs that didn't match what the services advertise.

## Migrations

No DB migrations. **Operational step required on existing installs**: the
bootstrap scripts live in a ConfigMap annotated `helm.sh/hook: pre-install`,
which Helm does *not* re-apply on `helm upgrade` — so upgrading the chart leaves
the old scripts and re-running the setup job would re-seed the old identifiers.
Reinstall the `amp-thunder-extension` release, or replace the
`amp-thunder-bootstrap` ConfigMap and then re-run the job. Identifiers no longer
in use are inert and can be left in place.

## Test environment

Static verification only — **no live OAuth login was performed**, as no AMP
environment was available:

- `helm template` on `wso2-amp-thunder-extension` across three configurations:
  chart defaults (gateway origin only), the `setup-openchoreo.sh` override (both
  origins), and a blanked required base URL (still fails with its named error).
  Generated bootstrap script `bash -n` clean in each.
- yq check that the three-way invariant (`serverPublicURL` ==
  `agentManagerMcpBaseUrl`, and `audience` contains that URL plus a trailing
  slash) holds for agent-manager, matching the observer.
- `deployments/vm/tests/run.sh`: 176 assertions pass.
- `bash -n` clean on all four changed shell files; docs build verified.

**Not verified — worth doing before merge:** an end-to-end browser OAuth login
from Claude Code against a running install.

## Learning

MCP authorization (2025-06-18 spec) + RFC 8707 resource indicators, RFC 9728
protected resource metadata, Thunder's resource-server/downscoping model, and
Helm hook re-application semantics.

---

### Reviewer notes — known limitations

1. **The trailing slash is a client-side convention.** amp-api advertises
   `resource: http://host` (no slash) in its protected-resource metadata, while
   Thunder registers `http://host/`. This works because MCP clients canonicalize
   the origin via JS `new URL().href`, which appends the slash. There is no test
   or captured request in-repo proving it — only the observer precedent, which
   has shipped with the same split. A client that echoes the metadata value
   verbatim, or sends the full `/mcp` path, would still get `invalid_target`.
   Hardening `well_known_routes.go` to advertise the canonical slashed form
   (so advertised == registered == accepted) is the natural follow-up.
2. **The audience entry could be derived rather than configured.** "I accept
   tokens audienced at my own resource identifier" is a tautology in RFC 8707
   terms, and `config_loader.go` already reads `ServerPublicURL` and `Audience`
   a few lines apart — ~6 lines of Go there would delete nine hand-synced sites
   across both services and downgrade the new docs warning from three settings
   to two. Deliberately left out of a targeted fix for a released bug, since it
   changes auth configuration behavior; happy to do it here if preferred.
3. **Cross-chart drift is still convention-enforced.** The identifier lives in
   `wso2-amp-thunder-extension` and the public URL in `wso2-agent-manager`, with
   no umbrella chart and no shared values to hang the invariant off, and Thunder
   is bootstrapped by a `pre-install` hook so it cannot read the service's
   metadata. The one guardrail that would actually catch drift is an e2e
   assertion that the `resource` in `/.well-known/oauth-protected-resource`
   appears verbatim among Thunder's registered identifiers.
