### PR TITLE
Rewrite install guide for production deployments and allow TLS on the database connection

### DIFF
--- a/agent-manager-service/.env.example
+++ b/agent-manager-service/.env.example
@@ -25,6 +25,15 @@ DB_USER=agentmanager
 DB_PASSWORD=agentmanager
 DB_NAME=agentmanager
 
+# Database TLS Configuration (Optional)
+# DB_SSL_MODE: disable|allow|prefer|require|verify-ca|verify-full.
+# Unset leaves the driver default ("prefer"), which negotiates TLS when the
+# server offers it and silently falls back to plaintext when it does not.
+# DB_SSL_MODE=
+# DB_SSL_ROOT_CERT: PEM CA bundle path for verify-ca/verify-full, or "system"
+# to validate against the container trust store.
+# DB_SSL_ROOT_CERT=
+
 # Database Pool Configuration (Optional)
 # GORM_SKIP_DEFAULT_TRANSACTION=true
 # GORM_SLOW_THRESHOLD_MILLISECONDS=200

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -245,6 +245,15 @@ type POSTGRESQL struct {
 	User     string
 	DBName   string
 	Password string `json:"-"`
+	// SSLMode is the libpq/pgx "sslmode" connection parameter
+	// (disable|allow|prefer|require|verify-ca|verify-full). Empty means the
+	// parameter is omitted from the connection string, which leaves the driver
+	// default ("prefer") — and any PGSSLMODE in the environment — in effect.
+	SSLMode string
+	// SSLRootCert is the libpq/pgx "sslrootcert" connection parameter: a path to
+	// a PEM CA bundle, or the literal "system" to use the image trust store.
+	// Empty omits the parameter, so verification falls back to the system pool.
+	SSLRootCert string
 	DbConfigs
 }
 

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -79,6 +80,11 @@ func loadEnvs() {
 		User:     r.readRequiredString("DB_USER"),
 		Password: r.readRequiredString("DB_PASSWORD"),
 		DBName:   r.readRequiredString("DB_NAME"),
+		// Left empty by default so the connection string stays byte-identical to
+		// pre-DB_SSL_MODE builds: pgx applies its libpq-compatible "prefer"
+		// default and still honours PGSSLMODE/PGSSLROOTCERT from the environment.
+		SSLMode:     strings.TrimSpace(r.readOptionalString("DB_SSL_MODE", "")),
+		SSLRootCert: strings.TrimSpace(r.readOptionalString("DB_SSL_ROOT_CERT", "")),
 	}
 	config.POSTGRESQL.DbConfigs = DbConfigs{
 		// gorm configs
@@ -265,11 +271,39 @@ func loadEnvs() {
 	validateInstrumentationURL(config, r)
 	validateObserverURLs(config, r)
 	validateResourceLimitsConfig(config, r)
+	validatePostgresTLSConfig(config, r)
 	validateAgentWorkloadCORSConfig(agentWorkloadConfig, r)
 
 	r.logAndExitIfErrorsFound()
 
 	slog.Info("configReader: configs loaded")
+}
+
+// validPostgresSSLModes is the set of libpq sslmode values pgx accepts. Kept as
+// an explicit allowlist so a typo fails config load with a clear message instead
+// of surfacing as an opaque driver parse error at first connect.
+var validPostgresSSLModes = map[string]struct{}{
+	"disable":     {},
+	"allow":       {},
+	"prefer":      {},
+	"require":     {},
+	"verify-ca":   {},
+	"verify-full": {},
+}
+
+func validatePostgresTLSConfig(cfg *Config, r *configReader) {
+	// loadEnvs already trims, so in the real flow this value is exactly what
+	// makeConnString puts in the DSN. Trimmed again here so the check holds for
+	// callers that build a Config directly rather than from the environment.
+	mode := strings.TrimSpace(cfg.POSTGRESQL.SSLMode)
+	if mode == "" {
+		return
+	}
+	if _, ok := validPostgresSSLModes[mode]; !ok {
+		r.errors = append(r.errors, fmt.Errorf(
+			"DB_SSL_MODE %q is not a valid PostgreSQL sslmode (disable, allow, prefer, require, verify-ca, verify-full)", mode,
+		))
+	}
 }
 
 func validateHTTPServerConfigs(cfg *Config, r *configReader) {

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -246,6 +246,77 @@ func TestValidateObserverURLs(t *testing.T) {
 	}
 }
 
+func TestValidatePostgresTLSConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		sslMode     string
+		wantErrors  int
+		errContains string
+	}{
+		{
+			name:       "empty is allowed and leaves the driver default in place",
+			sslMode:    "",
+			wantErrors: 0,
+		},
+		{
+			name:       "whitespace-only is treated as unset",
+			sslMode:    "   ",
+			wantErrors: 0,
+		},
+		{
+			name:       "require accepted",
+			sslMode:    "require",
+			wantErrors: 0,
+		},
+		{
+			name:       "disable accepted",
+			sslMode:    "disable",
+			wantErrors: 0,
+		},
+		{
+			name:       "verify-full accepted",
+			sslMode:    "verify-full",
+			wantErrors: 0,
+		},
+		{
+			name:        "typo rejected",
+			sslMode:     "requrie",
+			wantErrors:  1,
+			errContains: "DB_SSL_MODE",
+		},
+		{
+			name:        "uppercase rejected because libpq is case sensitive",
+			sslMode:     "REQUIRE",
+			wantErrors:  1,
+			errContains: "is not a valid PostgreSQL sslmode",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{POSTGRESQL: POSTGRESQL{SSLMode: tc.sslMode}}
+			r := &configReader{}
+			validatePostgresTLSConfig(cfg, r)
+
+			if len(r.errors) != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tc.wantErrors, len(r.errors), r.errors)
+			}
+			if tc.errContains != "" {
+				found := false
+				for _, e := range r.errors {
+					if strings.Contains(e.Error(), tc.errContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected an error containing %q, got %v", tc.errContains, r.errors)
+				}
+			}
+		})
+	}
+}
+
 func TestLoadEnvs_ObserverConfig(t *testing.T) {
 	requiredEnv := map[string]string{
 		"OPEN_CHOREO_BASE_URL": "http://localhost/api/v1",

--- a/agent-manager-service/db/db.go
+++ b/agent-manager-service/db/db.go
@@ -132,6 +132,15 @@ func GetDB() *gorm.DB {
 
 func makeConnString(p config.POSTGRESQL) string {
 	params := url.Values{}
+	// Only set the TLS parameters when configured. Omitting them keeps the DSN
+	// byte-identical to earlier builds, so pgx's libpq-compatible "prefer"
+	// default (and any PGSSLMODE/PGSSLROOTCERT in the environment) still apply.
+	if p.SSLMode != "" {
+		params.Set("sslmode", p.SSLMode)
+	}
+	if p.SSLRootCert != "" {
+		params.Set("sslrootcert", p.SSLRootCert)
+	}
 	conn := &url.URL{
 		Scheme:   "postgres",
 		User:     url.UserPassword(p.User, p.Password),

--- a/agent-manager-service/db/db_test.go
+++ b/agent-manager-service/db/db_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package db
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+)
+
+func basePostgresConfig() config.POSTGRESQL {
+	return config.POSTGRESQL{
+		Host:     "db.example.com",
+		Port:     5432,
+		User:     "agentmanager",
+		Password: "s3cr#t/pass",
+		DBName:   "agentmanager",
+	}
+}
+
+func TestMakeConnString(t *testing.T) {
+	tests := []struct {
+		name        string
+		sslMode     string
+		sslRootCert string
+		want        string
+	}{
+		{
+			name: "no TLS settings keeps the pre-existing DSN with no query string",
+			want: "postgres://agentmanager:s3cr%23t%2Fpass@db.example.com:5432/agentmanager",
+		},
+		{
+			name:    "sslmode is appended when set",
+			sslMode: "require",
+			want:    "postgres://agentmanager:s3cr%23t%2Fpass@db.example.com:5432/agentmanager?sslmode=require",
+		},
+		{
+			name:        "sslrootcert is appended alongside the mode",
+			sslMode:     "verify-full",
+			sslRootCert: "/etc/amp/db-ca/ca.crt",
+			want:        "postgres://agentmanager:s3cr%23t%2Fpass@db.example.com:5432/agentmanager?sslmode=verify-full&sslrootcert=%2Fetc%2Famp%2Fdb-ca%2Fca.crt",
+		},
+		{
+			name:        "sslrootcert alone is appended",
+			sslRootCert: "system",
+			want:        "postgres://agentmanager:s3cr%23t%2Fpass@db.example.com:5432/agentmanager?sslrootcert=system",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := basePostgresConfig()
+			cfg.SSLMode = tc.sslMode
+			cfg.SSLRootCert = tc.sslRootCert
+
+			if got := makeConnString(cfg); got != tc.want {
+				t.Errorf("makeConnString() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMakeConnStringIsParsedByDriver guards the contract that matters in
+// production: whatever makeConnString emits must survive the pgx parser with the
+// requested TLS mode intact. It also pins the fallback semantics that make the
+// empty default safe — "prefer" keeps a plaintext fallback, "require" does not.
+func TestMakeConnStringIsParsedByDriver(t *testing.T) {
+	tests := []struct {
+		name          string
+		sslMode       string
+		wantTLS       bool
+		wantFallbacks int
+	}{
+		{
+			name:          "empty mode yields the libpq prefer default with a plaintext fallback",
+			sslMode:       "",
+			wantTLS:       true,
+			wantFallbacks: 1,
+		},
+		{
+			name:          "require yields TLS with no plaintext fallback",
+			sslMode:       "require",
+			wantTLS:       true,
+			wantFallbacks: 0,
+		},
+		{
+			name:          "disable yields no TLS",
+			sslMode:       "disable",
+			wantTLS:       false,
+			wantFallbacks: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// PGSSLMODE in the ambient environment would override the empty case.
+			t.Setenv("PGSSLMODE", "")
+
+			cfg := basePostgresConfig()
+			cfg.SSLMode = tc.sslMode
+
+			parsed, err := pgx.ParseConfig(makeConnString(cfg))
+			if err != nil {
+				t.Fatalf("pgx.ParseConfig() returned an unexpected error: %v", err)
+			}
+			if gotTLS := parsed.TLSConfig != nil; gotTLS != tc.wantTLS {
+				t.Errorf("TLSConfig set = %t, want %t", gotTLS, tc.wantTLS)
+			}
+			if got := len(parsed.Fallbacks); got != tc.wantFallbacks {
+				t.Errorf("len(Fallbacks) = %d, want %d", got, tc.wantFallbacks)
+			}
+		})
+	}
+}

--- a/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
@@ -228,6 +228,49 @@ Uses simple naming: "amp-postgresql" instead of release-name-postgresql
 {{- end }}
 
 {{/*
+PostgreSQL SSL mode (libpq "sslmode": disable|allow|prefer|require|verify-ca|verify-full)
+Only meaningful for an external database — the in-cluster PostgreSQL this chart
+deploys serves plaintext, so the value stays empty there and the driver keeps its
+"prefer" default. Empty output means the DB_SSL_MODE env var is not rendered.
+*/}}
+{{- define "agent-management-platform.postgresql.sslMode" -}}
+{{- if .Values.postgresql.enabled }}
+{{- print "" }}
+{{- else }}
+{{- .Values.postgresql.external.sslMode | default "" }}
+{{- end }}
+{{- end }}
+
+{{/*
+PostgreSQL SSL root certificate (libpq "sslrootcert"): a path inside the
+container, or the literal "system" to validate against the image trust store.
+*/}}
+{{- define "agent-management-platform.postgresql.sslRootCert" -}}
+{{- if .Values.postgresql.enabled }}
+{{- print "" }}
+{{- else }}
+{{- .Values.postgresql.external.sslRootCert | default "" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Renders the optional DB TLS environment variables shared by the API deployment
+and the migration job. Emits nothing when no SSL mode is configured.
+*/}}
+{{- define "agent-management-platform.postgresql.tlsEnv" -}}
+{{- $sslMode := include "agent-management-platform.postgresql.sslMode" . }}
+{{- $sslRootCert := include "agent-management-platform.postgresql.sslRootCert" . }}
+{{- if $sslMode }}
+- name: DB_SSL_MODE
+  value: {{ $sslMode | quote }}
+{{- end }}
+{{- if $sslRootCert }}
+- name: DB_SSL_ROOT_CERT
+  value: {{ $sslRootCert | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
 PostgreSQL password secret key
 */}}
 {{- define "agent-management-platform.postgresql.secretPasswordKey" -}}

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/deployment.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/deployment.yaml
@@ -94,6 +94,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "agent-management-platform.postgresql.secretName" . }}
                   key: {{ include "agent-management-platform.postgresql.secretPasswordKey" . }}
+            {{- with (include "agent-management-platform.postgresql.tlsEnv" . | trim) }}
+            {{- . | nindent 12 }}
+            {{- end }}
             - name: API_KEY_VALUE
               valueFrom:
                 secretKeyRef:

--- a/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
@@ -73,6 +73,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "agent-management-platform.postgresql.secretName" . }}
                   key: {{ include "agent-management-platform.postgresql.secretPasswordKey" . }}
+            {{- with (include "agent-management-platform.postgresql.tlsEnv" . | trim) }}
+            {{- . | nindent 12 }}
+            {{- end }}
             - name: API_KEY_VALUE
               valueFrom:
                 secretKeyRef:

--- a/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
@@ -91,4 +91,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -164,8 +164,31 @@ assert_env "sslRootCert reaches the migration job" "$MIG_TMPL" DB_SSL_ROOT_CERT 
 assert_env "sslMode is ignored for the in-cluster database" \
   "$API_TMPL" DB_SSL_MODE "" --set postgresql.external.sslMode=require
 
-# mounts_ca <template-path> [helm --set args...] -> "yes" when the named volume
-# reaches both the pod spec and the container, else "no".
+# flatten_items <block-key> — reads YAML on stdin and prints one line per list
+# item in the first block with that key, fields joined by "; ". Flattening is
+# what lets a check require two fields on the SAME item, which independent greps
+# over the whole document cannot express.
+flatten_items() {
+  awk -v key="$1" '
+    function ind(s) { match(s, /^ */); return RLENGTH }
+    !inblk && $0 ~ "^ *"key":[ ]*$" { inblk = 1; bi = ind($0); next }
+    inblk {
+      if ($0 ~ /^[ ]*$/) { next }
+      if (ind($0) <= bi) { if (buf != "") print buf; exit }
+      if ($0 ~ /^ *- /) { if (buf != "") print buf; buf = "" }
+      line = $0
+      sub(/^ *-? */, "", line)
+      sub(/ +$/, "", line)
+      buf = (buf == "" ? line : buf "; " line)
+    }
+    END { if (buf != "") print buf }
+  '
+}
+
+# mounts_ca <template-path> [helm --set args...] -> "yes" only when the container
+# has a volumeMounts item carrying BOTH the volume name and the mount path, and
+# the pod spec declares a volume of that name. A template emitting one without
+# the other is broken, so both are required rather than matched independently.
 mounts_ca() {
   local tmpl="$1" rendered
   shift
@@ -174,7 +197,9 @@ mounts_ca() {
     printf 'helm template failed: %s\n' "$rendered" >&2
     return 1
   fi
-  if grep -q 'name: db-ca' <<<"$rendered" && grep -q 'mountPath: /etc/db-ca' <<<"$rendered"; then
+  if flatten_items volumeMounts <<<"$rendered" \
+       | grep 'name: db-ca' | grep -q 'mountPath: /etc/db-ca' \
+     && flatten_items volumes <<<"$rendered" | grep -q 'name: db-ca'; then
     printf 'yes\n'
   else
     printf 'no\n'

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -164,6 +164,51 @@ assert_env "sslRootCert reaches the migration job" "$MIG_TMPL" DB_SSL_ROOT_CERT 
 assert_env "sslMode is ignored for the in-cluster database" \
   "$API_TMPL" DB_SSL_MODE "" --set postgresql.external.sslMode=require
 
+# mounts_ca <template-path> [helm --set args...] -> "yes" when the named volume
+# reaches both the pod spec and the container, else "no".
+mounts_ca() {
+  local tmpl="$1" rendered
+  shift
+  if ! rendered="$(helm template test-release "$CHART_DIR" \
+    --show-only "$tmpl" "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$rendered" >&2
+    return 1
+  fi
+  if grep -q 'name: db-ca' <<<"$rendered" && grep -q 'mountPath: /etc/db-ca' <<<"$rendered"; then
+    printf 'yes\n'
+  else
+    printf 'no\n'
+  fi
+}
+
+assert_ca_mount() {
+  local label="$1" tmpl="$2" expected="$3"
+  shift 3
+  local actual
+  actual="$(mounts_ca "$tmpl" "$@")"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected %q, got %q\n' "$label" "$expected" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# verify-ca/verify-full against a private CA needs the PEM readable by every
+# process that opens a connection. The migration job runs as a post-install hook,
+# so a CA reaching only the API would fail the install with x509 "unknown
+# authority" rather than at request time.
+CA_VOLUME=(
+  --set 'volumes[0].name=db-ca'
+  --set 'volumes[0].secret.secretName=db-ca'
+  --set 'volumeMounts[0].name=db-ca'
+  --set 'volumeMounts[0].mountPath=/etc/db-ca'
+  --set 'volumeMounts[0].readOnly=true'
+)
+assert_ca_mount "a private CA volume reaches the API" "$API_TMPL" yes "${CA_VOLUME[@]}"
+assert_ca_mount "a private CA volume reaches the migration job" "$MIG_TMPL" yes "${CA_VOLUME[@]}"
+assert_ca_mount "no CA volume is invented for the migration job by default" "$MIG_TMPL" no
+
 if ((FAILURES > 0)); then
   printf '\n%d assertion(s) failed\n' "$FAILURES"
   exit 1

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -94,6 +94,76 @@ assert_cm "a stray comma in the audience does not produce an empty entry" \
   --set agentManagerService.config.serverPublicURL=https://api.example.com \
   --set 'agentManagerService.config.keyManager.audience=amp\,'
 
+# env_value <template-path> <env-name> [helm --set args...] -> value of that env var,
+# or empty when the variable is not rendered at all.
+env_value() {
+  local tmpl="$1" name="$2" rendered
+  shift 2
+  if ! rendered="$(helm template test-release "$CHART_DIR" \
+    --show-only "$tmpl" "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$rendered" >&2
+    return 1
+  fi
+  awk -v n="$name" '
+    $1 == "-" && $2 == "name:" { in_var = ($3 == n); next }
+    in_var && $1 == "value:" {
+      sub(/^[[:space:]]*value:[[:space:]]*/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^"|"$/, "")
+      print
+      exit
+    }
+  ' <<<"$rendered"
+}
+
+assert_env() {
+  local label="$1" tmpl="$2" key="$3" expected="$4"
+  shift 4
+  local actual
+  actual="$(env_value "$tmpl" "$key" "$@")"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected %s: %q\n      actual   %s: %q\n' \
+      "$label" "$key" "$expected" "$key" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+API_TMPL=templates/agent-manager-service/deployment.yaml
+MIG_TMPL=templates/jobs/db-migration-job.yaml
+EXTERNAL=(--set postgresql.enabled=false --set postgresql.external.host=db.example.com)
+
+# The database connection carries no TLS settings unless asked for, so the DSN
+# stays byte-identical to pre-DB_SSL_MODE builds and pgx keeps its "prefer"
+# default. Both workloads connect, so both must agree.
+assert_env "default renders no SSL mode for the API" "$API_TMPL" DB_SSL_MODE ""
+assert_env "default renders no SSL mode for the migration job" "$MIG_TMPL" DB_SSL_MODE ""
+assert_env "external without an SSL mode renders none for the API" \
+  "$API_TMPL" DB_SSL_MODE "" "${EXTERNAL[@]}"
+assert_env "external without an SSL mode renders none for the migration job" \
+  "$MIG_TMPL" DB_SSL_MODE "" "${EXTERNAL[@]}"
+
+# A configured mode has to reach the migration job too: it runs the same binary
+# against the same database, so a mode set only on the API would leave the
+# post-install migration hook connecting in plaintext.
+assert_env "sslMode reaches the API" "$API_TMPL" DB_SSL_MODE "require" \
+  "${EXTERNAL[@]}" --set postgresql.external.sslMode=require
+assert_env "sslMode reaches the migration job" "$MIG_TMPL" DB_SSL_MODE "require" \
+  "${EXTERNAL[@]}" --set postgresql.external.sslMode=require
+assert_env "sslRootCert reaches the API" "$API_TMPL" DB_SSL_ROOT_CERT "system" \
+  "${EXTERNAL[@]}" --set postgresql.external.sslMode=verify-full \
+  --set postgresql.external.sslRootCert=system
+assert_env "sslRootCert reaches the migration job" "$MIG_TMPL" DB_SSL_ROOT_CERT "system" \
+  "${EXTERNAL[@]}" --set postgresql.external.sslMode=verify-full \
+  --set postgresql.external.sslRootCert=system
+
+# The bundled PostgreSQL serves plaintext, so an sslMode left over from an
+# external configuration must not be applied to it — that would fail the API pod
+# and the migration hook on an otherwise working default install.
+assert_env "sslMode is ignored for the in-cluster database" \
+  "$API_TMPL" DB_SSL_MODE "" --set postgresql.external.sslMode=require
+
 if ((FAILURES > 0)); then
   printf '\n%d assertion(s) failed\n' "$FAILURES"
   exit 1

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -14,6 +14,18 @@ postgresql:
     password: ""
     existingSecret: ""
     existingSecretPasswordKey: "password"
+    # TLS for the client -> database hop (libpq "sslmode"). One of
+    # disable, allow, prefer, require, verify-ca, verify-full.
+    # Empty keeps the driver default ("prefer"), which negotiates TLS when the
+    # server offers it but silently falls back to plaintext when it does not.
+    # Set "require" to refuse an unencrypted connection; use verify-ca or
+    # verify-full to also validate the server certificate.
+    sslMode: ""
+    # Path to a PEM CA bundle inside the container for verify-ca/verify-full,
+    # or the literal "system" to validate against the image trust store
+    # (sufficient when the database certificate chains to a public CA).
+    # Mount a private CA through the top-level `volumes`/`volumeMounts` values.
+    sslRootCert: ""
   # Image configuration - use stable PostgreSQL 16 image
   auth:
     database: agentmanager

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -455,12 +455,15 @@ helm install api-platform-default-default \
   --namespace ${DATA_PLANE_NS} \
   --set agentManager.orgName=default \
   --set gateway.environment=default \
+  --set gateway.type=BOTH \
   --set agentManager.idp.existingSecret=gateway-idp-credentials \
   --timeout 1800s
 
 kubectl wait --for=condition=complete job/api-platform-default-default-bootstrap \
   -n ${DATA_PLANE_NS} --timeout=300s
 ```
+
+`gateway.type=BOTH` registers this gateway to serve both inbound and outbound traffic, which is what a single-gateway environment needs. It matches the chart default and is set explicitly here because the role is written once at registration and never rewritten — see [Gateway roles and topology](#gateway-roles-and-topology) for the split alternative and its constraints.
 
 :::warning Development mode is still on
 This release defaults to `developmentMode: true`, which relaxes gateway security checks such as auto-generating encryption keys. Turning it off requires supplying encryption keys that the extension chart does not yet expose as a value — see [Gateway hardening](#gateway-hardening) for the procedure and its caveats.

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -304,6 +304,8 @@ With this module, agents run sandboxed under the standard **runc** runtime. Opti
 
 Creates the default Organization, Project, Environment, DeploymentPipeline, and workflow template resources that the console needs on first login. This chart also configures the **container registry endpoint** used by build workflows to push agent images.
 
+<Dev production={props.production}>
+
 ```bash
 helm install amp-platform-resources \
   oci://${HELM_CHART_REGISTRY}/wso2-amp-platform-resources-extension \
@@ -311,6 +313,30 @@ helm install amp-platform-resources \
   --namespace ${DEFAULT_NS} \
   --timeout 1800s
 ```
+
+</Dev>
+
+<Prod production={props.production}>
+
+```bash
+helm install amp-platform-resources \
+  oci://${HELM_CHART_REGISTRY}/wso2-amp-platform-resources-extension \
+  --version ${VERSION} \
+  --namespace ${DEFAULT_NS} \
+  --set global.oauth.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
+  --set global.oauth.hostHeader="amp-thunder-extension-service.${THUNDER_NS}.svc.cluster.local" \
+  --set global.apiServer.url="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
+  --set global.apiServer.hostHeader="openchoreo-api.openchoreo-control-plane.svc.cluster.local" \
+  --timeout 1800s
+```
+
+:::warning These four values default to k3d addresses
+`global.oauth.tokenUrl` and `global.apiServer.url` default to `http://host.k3d.internal:8080`, which the single-cluster k3d layout reaches through the Docker host and routes by `Host` header. On any other cluster that name does not resolve, and the failure surfaces only when an agent is built: the workflow's `generate-workload` step prints `Failed to get access token:` with an empty body — a connection failure, not an authentication one — and the build ends with `cannot save parameter /mnt/vol/workload-cr.yaml`.
+
+Nothing earlier in the install touches these values, so a platform that installs and verifies cleanly still cannot complete a single build until they are set. Point them at the in-cluster services as above.
+:::
+
+</Prod>
 
 export const RegistryConfig = ({expanded}) => {
   const content = (

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -8,11 +8,14 @@
          expanded instead of collapsed (for non-k3d environments)
        - props.production         — (boolean, optional) if true, renders the production
          variants of the install commands (external database, generated client secrets,
-         gateway development mode off) instead of the development-grade defaults
+         multiple replicas, non-debug logging) instead of the development-grade
+         defaults. Note the gateway still installs with developmentMode=true: turning
+         it off needs encryption keys the extension chart does not expose as a value,
+         so Step 7 flags it rather than setting it.
 */}
 
-export const Prod = ({when, children}) => (when ? <>{children}</> : null);
-export const Dev = ({when, children}) => (when ? null : <>{children}</>);
+export const Prod = ({production, children}) => (production ? <>{children}</> : null);
+export const Dev = ({production, children}) => (production ? null : <>{children}</>);
 
 The Agent Manager installs as a set of Helm charts on top of OpenChoreo. The components fall into two groups based on install order:
 
@@ -33,7 +36,7 @@ Install these in order — each depends on the one before it.
 
 Manages API Gateway resources and enables secure, authenticated trace ingestion into the Observability Plane.
 
-<Dev when={props.production}>
+<Dev production={props.production}>
 
 ```bash
 helm install gateway-operator \
@@ -48,7 +51,7 @@ helm install gateway-operator \
 
 </Dev>
 
-<Prod when={props.production}>
+<Prod production={props.production}>
 
 ```bash
 helm install gateway-operator \
@@ -110,7 +113,7 @@ The API Platform Gateway is deployed as an extension after Agent Manager is runn
 
 The core platform: a Go API server, a React web console, and a database.
 
-<Dev when={props.production}>
+<Dev production={props.production}>
 
 ```bash
 helm install amp \
@@ -152,7 +155,7 @@ kubectl wait --for=condition=Available \
 
 </Dev>
 
-<Prod when={props.production}>
+<Prod production={props.production}>
 
 The chart deploys an in-cluster PostgreSQL with a default password unless you point it at an external database. Use a managed service — sizing, backups, failover, and patching then come from your database platform. Create the database and a credentials Secret first:
 
@@ -211,6 +214,12 @@ kubectl wait --for=condition=Available \
 ```
 
 `agentManagerService.config.thunder.clientSecret` can instead be supplied through `agentManagerService.config.thunder.existingSecret` (key `thunder-client-secret`) if you prefer to keep it out of Helm release history.
+
+:::warning Enforce TLS on the database server
+The chart passes the connection details as separate host, port, and credential values, and the service builds its connection string without an explicit SSL mode — so the driver's default of `prefer` applies. That negotiates TLS when the server offers it but **silently falls back to an unencrypted connection** when it does not, and there is currently no chart value to require it from the client side.
+
+Enforce it on the database instead, where it cannot be downgraded: *Require SSL* on Cloud SQL, `rds.force_ssl=1` on RDS, or *require secure transport* on Azure Database for PostgreSQL. Keep the database on a private network as well, so it is never reachable from outside the VPC.
+:::
 
 </Prod>
 
@@ -338,7 +347,7 @@ These can be installed in any order after Core is ready.
 
 Deploys the observer service that queries and serves trace, log, and metrics data to the console and CLI.
 
-<Dev when={props.production}>
+<Dev production={props.production}>
 
 ```bash
 helm install amp-observability-traces \
@@ -356,7 +365,7 @@ kubectl wait --for=condition=Available \
 
 </Dev>
 
-<Prod when={props.production}>
+<Prod production={props.production}>
 
 `amObserver.observer.idpClientSecret` is the observer's own outbound identity for calls to the OpenChoreo observer, and must match the `am-observer-client` secret seeded into Thunder:
 
@@ -410,7 +419,7 @@ Evaluation jobs publish scores using the `amp-publisher-client` OAuth2 credentia
 
 Registers the API Platform Gateway with the Agent Manager and deploys the gateway stack. **Install this last** — it requires the Agent Manager API to be healthy and Thunder to be ready for token exchange.
 
-<Dev when={props.production}>
+<Dev production={props.production}>
 
 ```bash
 helm install api-platform-default-default \
@@ -427,7 +436,7 @@ kubectl wait --for=condition=complete job/api-platform-default-default-bootstrap
 
 </Dev>
 
-<Prod when={props.production}>
+<Prod production={props.production}>
 
 The bootstrap job authenticates to the Agent Manager API as `amp-api-client`, so it needs the secret you seeded into Thunder. Keep it out of Helm release history with a Secret reference:
 

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -198,6 +198,7 @@ helm install amp \
   --set postgresql.external.username=agentmanager \
   --set postgresql.external.existingSecret=amp-db-credentials \
   --set postgresql.external.existingSecretPasswordKey=password \
+  --set postgresql.external.sslMode=require \
   --timeout 1800s
 ```
 
@@ -215,10 +216,12 @@ kubectl wait --for=condition=Available \
 
 `agentManagerService.config.thunder.clientSecret` can instead be supplied through `agentManagerService.config.thunder.existingSecret` (key `thunder-client-secret`) if you prefer to keep it out of Helm release history.
 
-:::warning Enforce TLS on the database server
-The chart passes the connection details as separate host, port, and credential values, and the service builds its connection string without an explicit SSL mode — so the driver's default of `prefer` applies. That negotiates TLS when the server offers it but **silently falls back to an unencrypted connection** when it does not, and there is currently no chart value to require it from the client side.
+:::warning Require TLS on the database connection
+`postgresql.external.sslMode=require` above makes the connection **fail closed**. Left unset, the driver's default of `prefer` applies: it negotiates TLS when the server offers it but silently falls back to an unencrypted connection when it does not, so a misconfigured or replaced instance downgrades without any error.
 
-Enforce it on the database instead, where it cannot be downgraded: *Require SSL* on Cloud SQL, `rds.force_ssl=1` on RDS, or *require secure transport* on Azure Database for PostgreSQL. Keep the database on a private network as well, so it is never reachable from outside the VPC.
+`require` encrypts but does **not** verify the server's identity. To also authenticate the database, use `sslMode=verify-full` with `postgresql.external.sslRootCert`. Set it to `system` when the certificate chains to a public CA — true for the managed services — which needs no CA mounted; for a private CA, mount the PEM through the chart's `volumes`/`volumeMounts` values and point `sslRootCert` at that path.
+
+Enforce it on the server as well, where the client cannot downgrade it: *Require SSL* on Cloud SQL, `rds.force_ssl=1` on RDS, or *require secure transport* on Azure Database for PostgreSQL. Keep the database on a private network so it is never reachable from outside the VPC.
 :::
 
 </Prod>

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -190,7 +190,11 @@ helm install amp \
   --set agentManagerService.config.thunder.clientSecret="${AMP_SYSTEM_CLIENT_SECRET}" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --set agentManagerService.replicaCount=2 \
+  --set agentManagerService.autoscaling.minReplicas=2 \
   --set console.replicaCount=2 \
+  --set agentManagerService.config.openbao.existingSecret=amp-openbao-token \
+  --set agentManagerService.config.workflowPlaneOpenbao.existingSecret=amp-openbao-token \
+  --set agentManagerService.config.workflowPlaneOpenbao.existingSecretKey=workflow-plane-openbao-token \
   --set postgresql.enabled=false \
   --set postgresql.external.host="your-db.example.com" \
   --set postgresql.external.port=5432 \
@@ -216,10 +220,18 @@ kubectl wait --for=condition=Available \
 
 `agentManagerService.config.thunder.clientSecret` can instead be supplied through `agentManagerService.config.thunder.existingSecret` (key `thunder-client-secret`) if you prefer to keep it out of Helm release history.
 
+:::warning Two values that look redundant but are not
+`agentManagerService.autoscaling.minReplicas=2` is what actually gives the API two replicas. Autoscaling is **on by default** for this component with `minReplicas: 1`, so the HPA takes ownership of the replica count and scales `replicaCount=2` straight back down to one — silently, within seconds. The console has autoscaling off by default, which is why `replicaCount` alone appears to work there.
+
+The two `openbao.existingSecret` values point at the Secret minted in [Step 2](#step-2-setup-secrets-store-openbao). Without them the chart falls back to the dev-mode token `root`, which a sealed OpenBao rejects, and **every agent creation fails** with a `500` while the platform otherwise looks healthy.
+:::
+
 :::warning Require TLS on the database connection
 `postgresql.external.sslMode=require` above makes the connection **fail closed**. Left unset, the driver's default of `prefer` applies: it negotiates TLS when the server offers it but silently falls back to an unencrypted connection when it does not, so a misconfigured or replaced instance downgrades without any error.
 
-`require` encrypts but does **not** verify the server's identity. To also authenticate the database, use `sslMode=verify-full` with `postgresql.external.sslRootCert`. Set it to `system` when the certificate chains to a public CA — true for the managed services — which needs no CA mounted; for a private CA, mount the PEM through the chart's `volumes`/`volumeMounts` values and point `sslRootCert` at that path.
+`require` encrypts but does **not** verify the server's identity. To also authenticate the database, use `sslMode=verify-full` with `postgresql.external.sslRootCert`. Set it to `system` only when the certificate chains to a **public** CA; otherwise mount the provider's CA PEM through the chart's `volumes`/`volumeMounts` values and point `sslRootCert` at that path. Managed services differ here — Cloud SQL, for example, issues its server certificate from a Google-managed private CA in either CA mode, so `system` fails with `certificate verify failed` and the CA must be mounted.
+
+Check the hostname too: `verify-full` matches the certificate's SAN exactly, so `postgresql.external.host` has to be a name the certificate actually covers rather than an IP. Cloud SQL's SAN carries a trailing dot, which means the host value needs one as well.
 
 Enforce it on the server as well, where the client cannot downgrade it: *Require SSL* on Cloud SQL, `rds.force_ssl=1` on RDS, or *require secure transport* on Azure Database for PostgreSQL. Keep the database on a private network so it is never reachable from outside the VPC.
 :::
@@ -471,7 +483,7 @@ This release defaults to `developmentMode: true`, which relaxes gateway security
 
 </Prod>
 
-After the gateway is running, apply the OTEL trace collection RestApi:
+The extension already renders an OTLP ingest route for its own gateway (`<release>-otel-restapi` in the data-plane namespace), so nothing further is needed for the default environment. The standalone manifest below targets the per-environment namespace `<org>-<env>`, which does not exist until the first agent is deployed there — apply it only if you need that variant, and only after a deployment has created the namespace:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/otel-collector-rest-api.yaml

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -6,7 +6,13 @@
          so the gateway reaches the AMP API via the Docker host network (k3d only)
        - props.expandRegistryConfig — (boolean, optional) if true, shows registry config
          expanded instead of collapsed (for non-k3d environments)
+       - props.production         — (boolean, optional) if true, renders the production
+         variants of the install commands (external database, generated client secrets,
+         gateway development mode off) instead of the development-grade defaults
 */}
+
+export const Prod = ({when, children}) => (when ? <>{children}</> : null);
+export const Dev = ({when, children}) => (when ? null : <>{children}</>);
 
 The Agent Manager installs as a set of Helm charts on top of OpenChoreo. The components fall into two groups based on install order:
 
@@ -27,6 +33,8 @@ Install these in order — each depends on the one before it.
 
 Manages API Gateway resources and enables secure, authenticated trace ingestion into the Observability Plane.
 
+<Dev when={props.production}>
+
 ```bash
 helm install gateway-operator \
   oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
@@ -37,6 +45,23 @@ helm install gateway-operator \
   --set gateway.helm.chartVersion=1.1.1 \
   --timeout 600s
 ```
+
+</Dev>
+
+<Prod when={props.production}>
+
+```bash
+helm install gateway-operator \
+  oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
+  --version 0.6.0 \
+  --namespace ${DATA_PLANE_NS} \
+  --set logging.level=info \
+  --set gatewayApi.installStandardCRDs=false \
+  --set gateway.helm.chartVersion=1.1.1 \
+  --timeout 600s
+```
+
+</Prod>
 
 Wait for the operator to be ready:
 
@@ -83,7 +108,9 @@ The API Platform Gateway is deployed as an extension after Agent Manager is runn
 
 #### Step 2: Agent Manager (API + Console + PostgreSQL)
 
-The core platform: a Go API server, a React web console, and a PostgreSQL database.
+The core platform: a Go API server, a React web console, and a database.
+
+<Dev when={props.production}>
 
 ```bash
 helm install amp \
@@ -107,16 +134,6 @@ helm install amp \
   --timeout 1800s
 ```
 
-:::info
-`keyManager.issuer` must be the public Thunder URL — the chart default is the k3d
-hostname. The authorization server the API advertises in its RFC 9728 protected
-resource metadata is derived from it, so
-`agentManagerService.config.oauthAuthorizationServers` only needs setting if it
-must differ. Likewise the MCP audience entry is derived from
-`serverPublicURL` above, so `keyManager.audience` only needs setting to change
-the accepted client IDs.
-:::
-
 Wait for all components:
 
 ```bash
@@ -133,10 +150,85 @@ kubectl wait --for=condition=Available \
   deployment/amp-console -n ${AMP_NS} --timeout=600s
 ```
 
+</Dev>
+
+<Prod when={props.production}>
+
+The chart deploys an in-cluster PostgreSQL with a default password unless you point it at an external database. Use a managed service — sizing, backups, failover, and patching then come from your database platform. Create the database and a credentials Secret first:
+
+```bash
+kubectl create namespace ${AMP_NS} --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic amp-db-credentials \
+  --namespace ${AMP_NS} \
+  --from-literal=password='<AMP_DB_PASSWORD>'
+```
+
+Then install, wiring the external database and the platform client secrets generated earlier:
+
+```bash
+helm install amp \
+  oci://${HELM_CHART_REGISTRY}/wso2-agent-manager \
+  --version ${VERSION} \
+  --namespace ${AMP_NS} \
+  --create-namespace \
+  --set console.config.instrumentationUrl="${INSTRUMENTATION_URL}" \
+  --set console.config.auth.baseUrl="${THUNDER_PUBLIC_URL}" \
+  --set console.config.auth.signInRedirectURL="${CONSOLE_PUBLIC_URL}/login" \
+  --set console.config.auth.signOutRedirectURL="${CONSOLE_PUBLIC_URL}/login" \
+  --set console.config.apiBaseUrl="${API_PUBLIC_URL}" \
+  --set agentManagerService.config.amObserverPublicURL="${OBS_API_PUBLIC_URL}" \
+  --set console.ocIngress.hostname="${CONSOLE_PUBLIC_HOST}" \
+  --set agentManagerService.ocIngress.hostname="${API_PUBLIC_HOST}" \
+  --set agentManagerService.config.serverPublicURL="${API_PUBLIC_URL}" \
+  --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
+  --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
+  --set agentManagerService.config.oidc.clientSecret="${AMP_API_CLIENT_SECRET}" \
+  --set agentManagerService.config.thunder.clientSecret="${AMP_SYSTEM_CLIENT_SECRET}" \
+  --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
+  --set agentManagerService.replicaCount=2 \
+  --set console.replicaCount=2 \
+  --set postgresql.enabled=false \
+  --set postgresql.external.host="your-db.example.com" \
+  --set postgresql.external.port=5432 \
+  --set postgresql.external.database=agentmanager \
+  --set postgresql.external.username=agentmanager \
+  --set postgresql.external.existingSecret=amp-db-credentials \
+  --set postgresql.external.existingSecretPasswordKey=password \
+  --timeout 1800s
+```
+
+Wait for all components — with an external database no PostgreSQL StatefulSet is deployed, so there is nothing to wait for there:
+
+```bash
+# API server
+kubectl wait --for=condition=Available \
+  deployment/amp-api -n ${AMP_NS} --timeout=600s
+
+# Console
+kubectl wait --for=condition=Available \
+  deployment/amp-console -n ${AMP_NS} --timeout=600s
+```
+
+`agentManagerService.config.thunder.clientSecret` can instead be supplied through `agentManagerService.config.thunder.existingSecret` (key `thunder-client-secret`) if you prefer to keep it out of Helm release history.
+
+</Prod>
+
+:::info
+`keyManager.issuer` must be the public Thunder URL — the chart default is the k3d
+hostname. The authorization server the API advertises in its RFC 9728 protected
+resource metadata is derived from it, so
+`agentManagerService.config.oauthAuthorizationServers` only needs setting if it
+must differ. Likewise the MCP audience entry is derived from
+`serverPublicURL` above, so `keyManager.audience` only needs setting to change
+the accepted client IDs.
+:::
+
 :::tip Verify
 ```bash
 kubectl get pods -n ${AMP_NS}
-# Expected: amp-postgresql-0 (Running), amp-api-xxx (Running), amp-console-xxx (Running)
+# Expected: amp-api-xxx (Running), amp-console-xxx (Running), plus
+# amp-postgresql-0 (Running) only when using the in-cluster database
 ```
 :::
 
@@ -246,6 +338,8 @@ These can be installed in any order after Core is ready.
 
 Deploys the observer service that queries and serves trace, log, and metrics data to the console and CLI.
 
+<Dev when={props.production}>
+
 ```bash
 helm install amp-observability-traces \
   oci://${HELM_CHART_REGISTRY}/wso2-amp-observability-extension \
@@ -259,6 +353,30 @@ helm install amp-observability-traces \
 kubectl wait --for=condition=Available \
   deployment/amp-observer -n ${OBSERVABILITY_NS} --timeout=600s
 ```
+
+</Dev>
+
+<Prod when={props.production}>
+
+`amObserver.observer.idpClientSecret` is the observer's own outbound identity for calls to the OpenChoreo observer, and must match the `am-observer-client` secret seeded into Thunder:
+
+```bash
+helm install amp-observability-traces \
+  oci://${HELM_CHART_REGISTRY}/wso2-amp-observability-extension \
+  --version ${VERSION} \
+  --namespace ${OBSERVABILITY_NS} \
+  --set amObserver.ocIngress.hostname="${OBS_API_PUBLIC_HOST}" \
+  --set amObserver.publicUrl="${OBS_API_PUBLIC_URL}" \
+  --set amObserver.auth.issuer="${THUNDER_PUBLIC_URL}" \
+  --set amObserver.observer.idpClientSecret="${AM_OBSERVER_CLIENT_SECRET}" \
+  --set amObserver.replicaCount=2 \
+  --timeout 1800s
+
+kubectl wait --for=condition=Available \
+  deployment/amp-observer -n ${OBSERVABILITY_NS} --timeout=600s
+```
+
+</Prod>
 
 :::warning
 `amObserver.auth.issuer` must be the **public** Thunder URL, not the in-cluster
@@ -285,12 +403,14 @@ helm install amp-evaluation-extension \
 ```
 
 :::info
-The default `publisher.apiKey` must match `publisherApiKey.value` in the Agent Manager chart. Both default to `amp-internal-api-key`.
+Evaluation jobs publish scores using the `amp-publisher-client` OAuth2 credentials bootstrapped by the Thunder extension. The client secret is fetched from OpenBao at workflow runtime (`secret/amp-publisher-client-secret`) and must match the value set on `thunder.bootstrap.ampPublisherClient.clientSecret`.
 :::
 
 #### Step 7: API Platform Gateway Extension
 
 Registers the API Platform Gateway with the Agent Manager and deploys the gateway stack. **Install this last** — it requires the Agent Manager API to be healthy and Thunder to be ready for token exchange.
+
+<Dev when={props.production}>
 
 ```bash
 helm install api-platform-default-default \
@@ -304,6 +424,37 @@ helm install api-platform-default-default \
 kubectl wait --for=condition=complete job/api-platform-default-default-bootstrap \
   -n ${DATA_PLANE_NS} --timeout=300s
 ```
+
+</Dev>
+
+<Prod when={props.production}>
+
+The bootstrap job authenticates to the Agent Manager API as `amp-api-client`, so it needs the secret you seeded into Thunder. Keep it out of Helm release history with a Secret reference:
+
+```bash
+kubectl create secret generic gateway-idp-credentials \
+  --namespace ${DATA_PLANE_NS} \
+  --from-literal=client-id=amp-api-client \
+  --from-literal=client-secret="${AMP_API_CLIENT_SECRET}"
+
+helm install api-platform-default-default \
+  oci://${HELM_CHART_REGISTRY}/wso2-amp-api-platform-gateway-extension \
+  --version ${VERSION} \
+  --namespace ${DATA_PLANE_NS} \
+  --set agentManager.orgName=default \
+  --set gateway.environment=default \
+  --set agentManager.idp.existingSecret=gateway-idp-credentials \
+  --timeout 1800s
+
+kubectl wait --for=condition=complete job/api-platform-default-default-bootstrap \
+  -n ${DATA_PLANE_NS} --timeout=300s
+```
+
+:::warning Development mode is still on
+This release defaults to `developmentMode: true`, which relaxes gateway security checks such as auto-generating encryption keys. Turning it off requires supplying encryption keys that the extension chart does not yet expose as a value — see [Gateway hardening](#gateway-hardening) for the procedure and its caveats.
+:::
+
+</Prod>
 
 After the gateway is running, apply the OTEL trace collection RestApi:
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -331,6 +331,25 @@ bao kv put secret/opensearch-password value='${OPENSEARCH_PASSWORD}'
 "
 ```
 
+Finally, mint the token the Agent Manager uses to store agent secrets, and put it in a Secret for [Phase 2](#phase-2-agent-manager-installation):
+
+```bash
+AMP_BAO_TOKEN=$(kubectl exec -n openbao openbao-0 -- sh -c "
+export BAO_ADDR=http://127.0.0.1:8200
+export BAO_TOKEN='<root-token>'
+bao token create -policy=openchoreo-secret-writer-policy -period=768h -format=json" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['auth']['client_token'])")
+
+kubectl create namespace ${AMP_NS} --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic amp-openbao-token -n ${AMP_NS} \
+  --from-literal=openbao-token="${AMP_BAO_TOKEN}" \
+  --from-literal=workflow-plane-openbao-token="${AMP_BAO_TOKEN}"
+```
+
+:::danger The chart defaults to the dev-mode token
+`agentManagerService.config.openbao.token` defaults to **`root`**, which only exists in dev mode. Against a sealed OpenBao that token is rejected, and the platform installs cleanly, passes every health check, and then fails **every agent creation** with a `500` — the underlying error being an OpenBao `permission denied` surfaced as `failed to store secrets in KV`. Phase 2 must reference the Secret created above; the periodic token also needs renewing before its period lapses, or agent creation starts failing again.
+:::
+
 :::tip Tighten the policies
 The writer policy above grants the whole `secret/*` tree to every service account in three namespaces, matching what the platform expects out of the box. If your security posture requires it, split the platform secrets onto dedicated mounts with per-service-account policies — the paths are referenced by the ExternalSecrets in [Step 8](#step-8-setup-observability-plane) and by the evaluation workflows.
 :::
@@ -467,12 +486,26 @@ Thunder provides authentication and user management for the entire platform — 
 Thunder writes its issuer URL, the console client's redirect URIs, and every platform OAuth client into its database on **first boot**, seeded by a `pre-install` hook that `helm upgrade` never re-runs. The database, the secrets, and the hostnames below are all effectively frozen once this command completes — getting any of them wrong means uninstalling, discarding Thunder's data, and reinstalling. Confirm your values against [Plan Your Deployment](#plan-your-deployment) before running it.
 :::
 
-**Database.** Production installations use an external PostgreSQL. Thunder keeps three logical databases — `configdb`, `runtimedb`, and `userdb` — which can live on one server; create them and a role that owns all three before installing.
+**Database.** Production installations use an external PostgreSQL. Thunder keeps three logical databases — `configdb`, `runtimedb`, and `userdb` — which can live on one server; create them and a role that owns all three before installing, then **load Thunder's schema into each one**. Nothing in the chart creates the tables for PostgreSQL: the init container only initialises the bundled SQLite files, so an empty database makes the pre-install hook fail.
 
 <Tabs groupId="deployment-mode">
   <TabItem value="production" label="External PostgreSQL" default>
 
-Store the database password in a Secret and reference it, so it never enters Helm release history:
+Load the schema first. The scripts ship inside the Thunder image, so copy them out of the version the chart pins and apply each to its database as the owning role:
+
+```bash
+THUNDER_IMAGE="ghcr.io/thunder-id/thunderid:0.45.0"
+docker create --name thunder-schema "${THUNDER_IMAGE}"
+for db in configdb runtimedb userdb; do
+  docker cp "thunder-schema:/opt/thunderid/dbscripts/${db}/postgres.sql" "./thunder-${db}.sql"
+  psql "postgresql://thunder@your-db.example.com:5432/${db}" -v ON_ERROR_STOP=1 -f "./thunder-${db}.sql"
+done
+docker rm thunder-schema
+```
+
+Expect 17 tables in `configdb`, 8 in `runtimedb`, and 5 in `userdb`. If the databases are empty when you install, the `amp-thunder-extension-setup` hook fails with `Server failed to start within 60 seconds` and its pod is deleted, so `kubectl logs` shows nothing — the real error, visible only by running the binary by hand, is `relation "INBOUND_CLIENT" does not exist`.
+
+Then store the database password in a Secret and reference it, so it never enters Helm release history:
 
 ```bash
 kubectl create namespace ${THUNDER_NS} --dry-run=client -o yaml | kubectl apply -f -
@@ -608,6 +641,7 @@ spec:
   dnsNames:
     - "*.${BASE_DOMAIN}"
     - "${BASE_DOMAIN}"
+    - "*.thunder.${BASE_DOMAIN}"
   privateKey:
     rotationPolicy: Always
 EOF
@@ -615,6 +649,10 @@ EOF
 kubectl wait --for=condition=Ready certificate/cp-gateway-tls \
   -n openchoreo-control-plane --timeout=300s
 ```
+
+:::note Why the third name
+A DNS wildcard matches exactly one label, so `*.${BASE_DOMAIN}` does **not** cover the per-environment Thunder hostnames that [Phase 2](#provision-thunder-identity-provider-for-the-default-environment) provisions at `<org>-<env>.thunder.${BASE_DOMAIN}`. Without `*.thunder.${BASE_DOMAIN}` the gateway serves a certificate that cannot validate for those names: routing succeeds, but every TLS-verifying client fails.
+:::
 
 Install the Control Plane with hostnames, TLS, and Thunder OIDC. The OpenChoreo API is deliberately **not** published on the gateway (`openchoreoApi.http.enabled=false`): Agent Manager and the observer call it over cluster DNS, so exposing it would only widen the platform's attack surface.
 
@@ -625,12 +663,17 @@ helm upgrade --install openchoreo-control-plane \
   --namespace openchoreo-control-plane \
   --create-namespace \
   --values - <<EOF
+features:
+  secretManagement:
+    enabled: true
 openchoreoApi:
   config:
     server:
       publicUrl: "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
   http:
     enabled: false
+    hostnames:
+      - "api.${BASE_DOMAIN}"
 backstage:
   enabled: false
   baseUrl: ""
@@ -697,7 +740,8 @@ Re-apply this patch after any `helm upgrade` of the Control Plane chart — the 
 - Backstage disabled (AMP provides its own console)
 - OIDC issuer set to `THUNDER_PUBLIC_URL` (matches the `iss` claim in Thunder-issued JWTs)
 - OIDC JWKS URL points to Thunder's in-cluster service (avoids external DNS dependency, and no TLS-verification overrides are needed since the in-cluster call is plain HTTP)
-- OpenChoreo API kept in-cluster only (`openchoreoApi.http.enabled=false`) — its `publicUrl` is set to the cluster-local service address, and no HTTPRoute is created on the gateway
+- OpenChoreo API kept in-cluster only (`openchoreoApi.http.enabled=false`) — its `publicUrl` is set to the cluster-local service address, and no HTTPRoute is created on the gateway. `openchoreoApi.http.hostnames` is still set to a real hostname even though the route is disabled: the chart validates that value for its `.invalid` placeholder regardless of `enabled`, and refuses to render otherwise. No route is created, so the name is never served — confirm with `kubectl get httproute -A | grep openchoreo-api`
+- Secret management enabled (`features.secretManagement.enabled=true`) — off by default, and required by Agent Manager to store an agent's environment variables. Without it every agent creation fails with a `500`, from an OpenChoreo `501 Secret API is disabled on this server`
 - TLS enabled on the gateway with the wildcard certificate — Thunder, the Console, the Agent Manager API, and the gateway control plane all serve HTTPS under it
 
 </details>
@@ -759,11 +803,24 @@ helm install openchoreo-data-plane \
   --set gateway.tls.enabled=true \
   --set "gateway.tls.hostname=*.${AGENTS_DOMAIN}" \
   --set "gateway.tls.certificateRefs[0].name=dp-gateway-tls" \
+  --set gateway.httpPort=80 \
+  --set gateway.httpsPort=443 \
   --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-dp.yaml
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-data-plane --timeout=600s
 ```
+
+:::warning Override the gateway ports
+`values-dp.yaml` and `values-op.yaml` come from the single-cluster **k3d** layout, where every plane shares one host load balancer and therefore cannot all own 443 — they pin the data plane to `19080`/`19443` and the observability plane to `11080`/`11085`. Here each plane has its **own** LoadBalancer address, so the standard ports apply and the `httpPort`/`httpsPort` overrides above are required.
+
+Without them the install still looks completely healthy — pods Running, certificates Ready, gateways `PROGRAMMED=True` — while every URL this guide publishes for those planes points at a port with nothing behind it. Agent invocation, OTLP trace ingest, and `${OBS_API_PUBLIC_URL}` all fail with connection timeouts rather than an error you can read. Verify after each plane install:
+
+```bash
+kubectl get svc gateway-default -n <plane-namespace> -o jsonpath='{.spec.ports[*].port}{"\n"}'
+# Expected: 80 443
+```
+:::
 
 Register the Data Plane:
 
@@ -993,6 +1050,8 @@ helm install openchoreo-observability-plane \
   --set "gateway.tls.hostname=*.${BASE_DOMAIN}" \
   --set "gateway.tls.certificateRefs[0].name=obs-gateway-tls" \
   --set clusterAgent.tls.generateCerts=true \
+  --set gateway.httpPort=80 \
+  --set gateway.httpsPort=443 \
   --set observer.controlPlaneApiUrl="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --set observer.extraEnv.AUTH_SERVER_BASE_URL="${THUNDER_PUBLIC_URL}" \
   --set security.oidc.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
@@ -1034,6 +1093,7 @@ helm upgrade --install observability-logs-opensearch \
   --timeout 10m
 
 # Enable Fluent Bit log collection
+# On GKE, disable the managed logging agent first — see the note below
 helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --namespace openchoreo-observability-plane \
@@ -1061,6 +1121,18 @@ helm upgrade --install observability-traces-opensearch \
   --set opentelemetry-collector.configMap.existingName="amp-opentelemetry-collector-config" \
   --timeout 10m
 ```
+
+:::warning GKE: free port 2020 before enabling Fluent Bit
+Fluent Bit runs with `hostNetwork: true` (its Kubernetes filter reads from the node-local kubelet) and binds its monitoring server to **port 2020** on every node. GKE's built-in `fluentbit-gke` logging agent already occupies that port, so all Fluent Bit pods stay in `CrashLoopBackOff` with `Cannot listen on 0.0.0.0:2020` — and the only visible symptom is that logs never reach OpenSearch.
+
+The platform ships its own log pipeline, so disable GKE's redundant one before the upgrade above:
+
+```bash
+gcloud container clusters update <cluster> --zone <zone> --logging=NONE
+```
+
+Turning off `hostNetwork` instead is not a workaround — the filter then cannot reach the kubelet and logs fail with `kubelet upstream connection error`.
+:::
 
 :::note Sizing and the admin password
 Two values above differ from the chart defaults. `openSearch.persistence.size` raises the volume from its 8Gi default — size it to your retention needs, since this single-node instance holds every trace, log, and metric the platform stores. The `OPENSEARCH_INITIAL_ADMIN_PASSWORD` override makes OpenSearch's own admin password match the one seeded into OpenBao in [Step 2](#step-2-setup-secrets-store-openbao); without it OpenSearch keeps the chart's published default while every client authenticates with yours, and all observability queries fail. Note the capital **S** in `openSearch` — it is the subchart alias, and lowercase `opensearch.*` values are silently ignored.
@@ -1134,8 +1206,11 @@ done
 | Record | Type | Points to |
 |---|---|---|
 | `console`, `api-amp`, `thunder`, `cp` `.${BASE_DOMAIN}` (or `*.${BASE_DOMAIN}`) | A / CNAME | control-plane gateway address |
+| `*.thunder.${BASE_DOMAIN}` | A / CNAME | control-plane gateway address |
 | `traces.${BASE_DOMAIN}` | A / CNAME | observability-plane gateway address |
 | `*.agents.${BASE_DOMAIN}` and `agents.${BASE_DOMAIN}` | A / CNAME | data-plane gateway address |
+
+The `*.thunder.${BASE_DOMAIN}` record covers the per-environment Thunder instances provisioned in Phase 2. A bare `*.${BASE_DOMAIN}` wildcard does not reach them — and note that once `*.thunder.${BASE_DOMAIN}` exists, [RFC 4592](https://www.rfc-editor.org/rfc/rfc4592) makes `thunder.${BASE_DOMAIN}` an empty non-terminal that the broader wildcard stops covering, so keep an explicit `thunder` record in that layout.
 
 Use A records for IPs (GKE, AKS) and CNAME records for hostnames (EKS). Verify resolution before continuing:
 
@@ -1193,7 +1268,11 @@ curl -fsSL "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}
   -o add-environment-thunder.sh
 ```
 
-Pick the tab matching your [Step 3](#step-3-setup-tls-issuer) issuer choice — the CA trust setting below only differs by that choice, nothing else changes. (Self-signed evaluation installs: see difference 5 in the [nip.io appendix](#appendix-installing-without-a-domain-nipio).)
+Pick the tab matching your [Step 3](#step-3-setup-tls-issuer) issuer choice — the CA trust setting below only differs by that choice, nothing else changes.
+
+:::note Pass the platform client secret
+`IDP_CLIENT_SECRET` defaults to the **shipped** `amp-api-client-secret`, so the script fails with `Could not obtain an access token to call agent-manager-service` on any install that generated real secrets in [Platform secrets](#4-platform-secrets). Passing `${AMP_API_CLIENT_SECRET}` as below is what makes the two steps consistent. The script stores its own generated system-client secret before that call, so a failure here leaves work half-done — rerun it once the credentials are right.
+::: (Self-signed evaluation installs: see difference 5 in the [nip.io appendix](#appendix-installing-without-a-domain-nipio).)
 
 <Tabs groupId="tls-issuer">
   <TabItem value="letsencrypt" label="Let's Encrypt (DNS-01)" default>
@@ -1207,6 +1286,8 @@ ORG_NAME=default \
 WAIT_TIMEOUT=300s \
 AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
 IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
+IDP_CLIENT_ID=amp-api-client \
+IDP_CLIENT_SECRET="${AMP_API_CLIENT_SECRET}" \
 PLATFORM_THUNDER_ISSUER="${THUNDER_PUBLIC_URL}" \
 PLATFORM_THUNDER_JWKS_URL="${THUNDER_PUBLIC_URL}/oauth2/jwks" \
 THUNDER_HOST_BASE_DOMAIN="${BASE_DOMAIN}" \
@@ -1252,6 +1333,8 @@ ORG_NAME=default \
 WAIT_TIMEOUT=300s \
 AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
 IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
+IDP_CLIENT_ID=amp-api-client \
+IDP_CLIENT_SECRET="${AMP_API_CLIENT_SECRET}" \
 PLATFORM_THUNDER_ISSUER="${THUNDER_PUBLIC_URL}" \
 PLATFORM_THUNDER_JWKS_URL="${THUNDER_PUBLIC_URL}/oauth2/jwks" \
 PLATFORM_THUNDER_CA_PEM="${PLATFORM_THUNDER_CA_PEM}" \
@@ -1372,11 +1455,24 @@ Work down this table against an existing install. The **When** column matters: t
 | Container registry is yours, with `tlsVerify=true` | [Phase 2](#phase-2-agent-manager-installation) | Any time — affects new builds |
 | Console `admin`/`admin` replaced by real users or a connected IdP | [Identity](#identity-and-access) | Any time |
 | JWT signature verification active on the API and the observer | [Identity](#identity-and-access) | Any time |
-| Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Any time |
+| Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Not yet possible — chart gap |
+| Post-upgrade patches re-applied | [After a chart upgrade](#after-a-chart-upgrade) | After every relevant `helm upgrade` |
 | Build workloads bounded by a node pool or ResourceQuota | [Build workflows](#build-workflows) | Any time |
 | Stateless services running multiple replicas | [High availability](#high-availability-and-scaling) | Any time |
 | NetworkPolicies, RBAC, and Pod Security Standards applied | [Cluster security](#certificates-and-cluster-security) | Any time |
 | Stronger isolation tier chosen where agents run untrusted code | [Agent isolation](#agent-isolation) | Any time, per environment |
+
+### After a chart upgrade
+
+Three settings in this guide are applied with `kubectl` on top of what Helm renders, and **any** `helm upgrade` of the owning chart reverts them — including upgrades that have nothing to do with authentication. The symptoms are quiet: `200` responses with empty lists, or a `403` on build logs, while every pod stays healthy. After upgrading the Control Plane or the Observability Plane, re-apply:
+
+| Patch | Owning chart | Symptom when missing |
+|---|---|---|
+| `openchoreo-api-config` entitlement claim ([Step 5](#patch-the-service-account-entitlement-claim-required-with-thunder--045)) | Control Plane | Service calls return `200` with empty lists; gateway bootstrap cannot find the environment |
+| `ClusterAuthzRoleBinding` entitlement claims ([Step 5](#patch-the-service-account-entitlement-claim-required-with-thunder--045)) | Control Plane | Same as above |
+| `observer-auth-config` entitlement claim ([Step 8](#step-8-setup-observability-plane)) | Observability Plane | Build-log queries return `403` |
+
+Two cautions learned the hard way. Because these use `kubectl patch`/`apply`, the field manager takes ownership of the patched fields, so the *next* `helm upgrade` of that chart can fail outright with a conflict such as `conflict with "kubectl-patch" using openchoreo.dev/v1alpha1: .spec.entitlement.claim`. And the obvious recovery — deleting the objects so Helm recreates them — is unsafe for the ClusterAuthzRoleBindings, because the set spans two charts: `amp-platform-resources` owns `amp-api-client-binding` and `amp-observer-reader-binding`, which the Control Plane chart will not recreate. Losing `amp-api-client-binding` silently empties every organization and agent list in the console. Re-create them from their own chart with `helm get manifest amp-platform-resources -n ${DEFAULT_NS}` rather than deleting blindly.
 
 ### Identity and Access
 
@@ -1430,7 +1526,15 @@ Metrics come from the in-cluster Prometheus deployed by the metrics module; for 
 
 The gateway extension provisions one gateway per environment and ships with `developmentMode: true`, which relaxes security checks such as auto-generating encryption keys. For production set `developmentMode=false`.
 
-With development mode off the gateway requires explicit encryption keys (`gateway.controller.encryptionKeys`, key format per the [high-availability production guide](https://wso2.com/api-platform/docs/api-gateway/1.1.0/deployment/high-availability-production-deployment/)). The extension chart does not yet expose a value for that block, so it has to be added to the values ConfigMap the extension renders — `<release>-config` in the data-plane namespace, under the `gateway.controller` section — and re-applied after every chart upgrade, since the upgrade rewrites the ConfigMap.
+With development mode off the gateway requires explicit encryption keys (`gateway.controller.encryptionKeys`, key format per the [high-availability production guide](https://wso2.com/api-platform/docs/api-gateway/1.1.0/deployment/high-availability-production-deployment/)). The extension chart does not yet expose a value for that block.
+
+:::warning No working procedure today — leave development mode on
+Editing the rendered `<release>-config` ConfigMap looks like an escape hatch, but it does not work with gateway-operator 0.6.0 and makes things worse. Adding `encryptionKeys` under `gateway.controller` there is correctly formed — the gateway chart renders cleanly when given that same file directly — yet the operator does not pass the value through, and the APIGateway stays `Programmed=False` with `gateway.controller.encryptionKeys must be enabled when gateway.developmentMode is false`, through operator restarts and re-reconciles.
+
+Worse, patching that ConfigMap with `kubectl apply` transfers ownership of `.data.values.yaml` to `kubectl`, so the **next** `helm upgrade` of the extension fails with a field-manager conflict; recovery means deleting the ConfigMap so Helm can recreate it. And because the operator's retry budget is exhausted and persisted, reverting the values does not by itself return the CR to `Programmed=True`.
+
+Until the extension exposes the value, keep `developmentMode: true` and treat this checklist row as outstanding. The data path is unaffected either way.
+:::
 
 Rate-limiting policies default to an **in-memory** backend, which does not share counters across gateway replicas. When running more than one replica, switch to Redis through the extension's `apiGateway.config.policyConfigurations.ratelimit_v1` values (`backend: redis` plus the `redis` connection block).
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -149,6 +149,7 @@ Each install step below carries its production configuration inline, so you can 
 | The MCP resource identifiers (`API_PUBLIC_URL`, `OBS_API_PUBLIC_URL`) | [Step 4](#step-4-install-thunder-extension-identity-provider) | Registered as OAuth resource servers by the same seeding job; an identifier is matched exactly, so a later change makes MCP logins fail with `invalid_target` |
 | Thunder replica count > 1 | [Step 4](#step-4-install-thunder-extension-identity-provider) | Requires external PostgreSQL **and** a shared Redis cache — the default in-pod SQLite cannot be shared across pods |
 | Agent Manager's database | [Phase 2](#phase-2-agent-manager-installation) | Switching later is a data migration, not a configuration change |
+| Each environment's gateway topology | [Phase 2](#phase-2-agent-manager-installation) | A gateway's ingress/egress role is written at first registration and never rewritten, so a single-gateway environment cannot be split later — the environment has to be deleted and recreated |
 
 Everything else — OpenSearch sizing, the container registry, gateway hardening, resource quotas, replica counts, isolation tiers — can be changed on a running platform. The [Production Reference](#production-reference) at the end summarises all of it.
 
@@ -1433,11 +1434,24 @@ With development mode off the gateway requires explicit encryption keys (`gatewa
 
 Rate-limiting policies default to an **in-memory** backend, which does not share counters across gateway replicas. When running more than one replica, switch to Redis through the extension's `apiGateway.config.policyConfigurations.ratelimit_v1` values (`backend: redis` plus the `redis` connection block).
 
-:::info Recommended architecture — separate API and AI gateways
-The production direction for this platform is **two gateways per environment**: an API Platform Gateway for agent ingress and a dedicated AI Gateway for LLM egress, scaled and configured independently (see the [AI Gateway Kubernetes deployment guide](https://wso2.com/api-platform/docs/ai-gateway/1.1.0/deployment-modes/kubernetes/gateway-operator/)). Today the default installation provisions a single gateway per environment that serves both roles; support for the split deployment is planned.
+:::warning Rolling back the gateway extension needs the API reachable
+The extension's bootstrap job runs as a `pre-install`, `pre-upgrade` **and `pre-rollback`** hook, so `helm rollback` executes it too and can fail — leaving the release stuck in `pending-rollback` — when the Agent Manager API is unreachable. If you are rolling back precisely because the platform is unhealthy, that is exactly when it will bite. Recovery is to re-run `helm rollback` once the API is back, or `helm rollback --no-hooks` to skip the job entirely.
 :::
 
-AI gateways can also run **outside** the cluster (for example, close to a private LLM endpoint), connecting back through the control-plane gateway at `https://${CP_GW_PUBLIC_HOST}` — see [Register an AI Gateway](../administration/register-ai-gateway.mdx).
+#### Gateway roles and topology
+
+Every gateway declares a role: **`INGRESS`** for traffic arriving at the agents in an environment, **`EGRESS`** for the calls those agents make out to LLMs and MCP servers, or **`BOTH`**. The install above registers the default environment's gateway as `BOTH`, which is what a single-gateway environment needs.
+
+Running the two directions on separate gateways lets you scale and harden them independently — an internet-facing ingress gateway and an egress gateway that reaches your model providers are rarely under the same load or the same threat model. That **split topology** is created per environment with `GATEWAY_TOPOLOGY=split`, which installs a second, egress-only release beside the ingress one. See [Gateway topology](../administration/environment-management.mdx#gateway-topology) for how to create an environment that way, including the shorter name limit it imposes.
+
+Two constraints are worth knowing before you choose:
+
+- An environment may hold **at most one** ingress-capable gateway (`INGRESS` or `BOTH`). Egress gateways are uncapped.
+- A gateway's role is fixed when it first registers. A later `helm upgrade` with a different `gateway.type` only logs a drift warning — it never rewrites the role — so an environment's topology cannot be switched in place. Moving an existing environment to a split topology means deleting and recreating it.
+
+`REGULAR` and `AI` are still accepted as input, mapping to `BOTH` and `EGRESS`, but they are deprecated; prefer the role names.
+
+AI gateways can also run **outside** the cluster (for example, close to a private LLM endpoint), connecting back through the control-plane gateway at `https://${CP_GW_PUBLIC_HOST}`. Register those as `EGRESS`, since they serve outbound traffic only — see [Register an AI Gateway](../administration/register-ai-gateway.mdx). The WSO2 [AI Gateway Kubernetes deployment guide](https://wso2.com/api-platform/docs/ai-gateway/1.1.0/deployment-modes/kubernetes/gateway-operator/) covers running one under the gateway operator.
 
 ### Build Workflows
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -174,7 +174,7 @@ export OPENSEARCH_PASSWORD="$(openssl rand -base64 24)"
 | `AMP_SYSTEM_CLIENT_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) | Agent Manager (Phase 2), OpenBao seed ([Step 2](#step-2-setup-secrets-store-openbao)) |
 | `AMP_PUBLISHER_CLIENT_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) | OpenBao seed — read by evaluation workflows at runtime |
 | `AM_OBSERVER_CLIENT_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) | Observability extension (Phase 2) |
-| `WORKFLOW_PUBLISHER_SECRET`, `OBSERVER_READER_SECRET` | OpenBao seed ([Step 2](#step-2-setup-secrets-store-openbao)) | OpenChoreo workflow plane and observer |
+| `WORKFLOW_PUBLISHER_SECRET`, `OBSERVER_READER_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) **and** OpenBao seed ([Step 2](#step-2-setup-secrets-store-openbao)) | OpenChoreo workflow plane and observer |
 | `OPENSEARCH_USERNAME` / `OPENSEARCH_PASSWORD` | OpenBao seed ([Step 2](#step-2-setup-secrets-store-openbao)) | Observability Plane and logs module ([Step 8](#step-8-setup-observability-plane)) |
 
 Keep this shell session for the whole install, and store the values in your secret manager — Thunder's are frozen after [Step 4](#step-4-install-thunder-extension-identity-provider).
@@ -591,6 +591,8 @@ helm install amp-thunder-extension \
   --set thunder.bootstrap.ampSystemClient.clientSecret="${AMP_SYSTEM_CLIENT_SECRET}" \
   --set thunder.bootstrap.ampPublisherClient.clientSecret="${AMP_PUBLISHER_CLIENT_SECRET}" \
   --set thunder.bootstrap.amObserverClient.clientSecret="${AM_OBSERVER_CLIENT_SECRET}" \
+  --set thunder.bootstrap.workloadPublisherClient.clientSecret="${WORKFLOW_PUBLISHER_SECRET}" \
+  --set thunder.bootstrap.observerResourceReaderClient.clientSecret="${OBSERVER_READER_SECRET}" \
   --values thunder-db-values.yaml \
   --timeout 1800s
 
@@ -598,6 +600,14 @@ kubectl wait --for=condition=Available \
   deployment -l app.kubernetes.io/instance=amp-thunder-extension \
   -n ${THUNDER_NS} --timeout=300s
 ```
+
+:::danger Override all six client secrets
+The chart bootstraps **six** OAuth clients, and every one it is not given keeps its shipped default. `workloadPublisherClient` and `observerResourceReaderClient` are easy to miss because their secrets are also seeded into OpenBao in [Step 2](#step-2-setup-secrets-store-openbao) — but seeding OpenBao only tells the *consumer*; Thunder still registers the default unless the two `--set` lines above are present.
+
+Leaving them out breaks the platform in two ways at once. The defaults stay valid, so an install that looks hardened still accepts `openchoreo-workload-publisher-secret` and `openchoreo-observer-resource-reader-client-secret`. And because the consumers read the *generated* values from OpenBao, they present a secret Thunder does not have: every agent build fails at the workload-publish step with `Failed to get access token`, from a `401 invalid_client` that never reaches the build log.
+
+When verifying, note the two client families use different token-endpoint auth methods — the four `amp*` clients use HTTP Basic, these two use POST-body credentials. Testing with the wrong method returns `400`, not `401`, which is easy to misread as a rejected credential.
+:::
 
 :::info MCP resource identifiers
 `agentManagerMcpBaseUrl` and `observerMcpBaseUrl` become the OAuth resource-server identifiers Thunder registers for the `/mcp` endpoints. Point them at the externally reachable origins of the API and observer — the same values as `agentManagerService.config.serverPublicURL` and `amObserver.publicUrl` in Phase 2 — because Thunder rejects an authorize request with `invalid_target` unless the `resource` an MCP client asks for matches a registered identifier exactly. See the [MCP server reference](../reference/mcp-server.mdx) for the full set of settings that must move together.
@@ -609,6 +619,10 @@ kubectl wait --for=condition=Available \
 
 :::warning Changing these values later
 A `helm upgrade` will not change the issuer in issued tokens, the registered redirect URIs, the MCP resource identifiers, or any client secret — those live in Thunder's database, seeded by the pre-install bootstrap job. To change them you must uninstall the chart and discard its data: **delete the PVC** if you used SQLite, or **drop and recreate the three databases** if you used PostgreSQL, then reinstall. Anything already issued against the old issuer stops validating.
+
+Discarding Thunder's data also **re-creates the organization**, and Agent Manager keys its own tenant data on that organization's identifier. Every organization-scoped row it holds — agents, deployments, API keys, gateways, monitors, the per-environment Thunder registration — is left pointing at the previous identifier and becomes invisible. The platform stays up and gives no error: the console reports deployment failures, agent identity resolution fails with `env-thunder not provisioned for this environment`, and the gateway cannot re-register because the environment still holds its ingress slot while the organization's gateway list reads empty.
+
+Treat a Thunder reinstall as a platform-data reset, not a component restart. On anything but a fresh install, discard Agent Manager's database in the same operation and re-run [env-Thunder provisioning](#provision-thunder-identity-provider-for-the-default-environment) and the gateway extension afterwards.
 :::
 
 :::tip Verify
@@ -1148,10 +1162,9 @@ OP_CA_CERT=$(kubectl get secret cluster-agent-tls \
 
 kubectl apply -f - <<EOF
 apiVersion: openchoreo.dev/v1alpha1
-kind: ObservabilityPlane
+kind: ClusterObservabilityPlane
 metadata:
   name: default
-  namespace: default
 spec:
   planeID: default
   clusterAgent:
@@ -1186,7 +1199,7 @@ kubectl get pods -n openchoreo-observability-plane
 echo "--- Thunder ---"
 kubectl get pods -n amp-thunder
 echo "--- Plane Registrations ---"
-kubectl get clusterdataplane,clusterworkflowplane,observabilityplane -n default
+kubectl get clusterdataplane,clusterworkflowplane,clusterobservabilityplane
 ```
 
 All pods should be in `Running` or `Completed` state.
@@ -1740,7 +1753,7 @@ Remove all Agent Manager and OpenChoreo resources:
 # 1. Delete plane registrations
 kubectl delete clusterdataplane default -n default
 kubectl delete clusterworkflowplane default -n default
-kubectl delete observabilityplane default -n default
+kubectl delete clusterobservabilityplane default
 
 # 2. Uninstall all Helm releases
 helm uninstall amp -n wso2-amp

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -8,10 +8,10 @@ import TabItem from '@theme/TabItem';
 
 # On Your Environment
 
-Install the Agent Manager on an existing Kubernetes cluster — AWS EKS, Google GKE, Azure AKS, or any distribution with LoadBalancer support.
+Set up a production-grade, single-cluster Agent Manager deployment on an existing Kubernetes cluster — AWS EKS, Google GKE, Azure AKS, or any distribution with LoadBalancer support. Each step carries its production configuration inline, so following the guide top to bottom produces a deployment you can put in front of real users. The [Production Reference](#production-reference) at the end is the checklist to audit against, plus the operational concerns that belong to no single step.
 
-:::tip Just want it running locally?
-The [Quick Start Guide](./quick-start.mdx) installs everything in a single command using a dev container with k3d. Use this page when you need to install on a managed cluster.
+:::tip Just want to evaluate?
+The [Quick Start Guide](./quick-start.mdx) installs everything in a single command using a dev container with k3d, the [k3d guide](./on-k3d.mdx) covers a local cluster install, and the [VM guide](./on-a-vm.mdx) covers a single-machine install. Use this page when you are deploying to a real cluster.
 :::
 
 :::info Stronger agent isolation tiers
@@ -26,7 +26,9 @@ Agent Manager is a two-layer system installed in two phases:
 
 - **Phase 2 — Agent Manager :** The AI agent management platform installed on top of OpenChoreo. It includes the **Console** (web UI), **AMP API** (backend), **AI Gateway**, **PostgreSQL** (database), **Secrets Extension** (OpenBao for runtime secret injection), **Agent Manager Observer** (traces, logs, and metrics), and **Evaluation Engine** (automated agent evaluations).
 
-This guide installs both layers on your existing Kubernetes cluster, production-first: a real domain, trusted TLS certificates issued automatically by cert-manager, and every management surface served through the three OpenChoreo plane gateways — the only LoadBalancers the platform needs.
+This guide installs both layers on your existing Kubernetes cluster, production-first: a real domain, trusted TLS certificates issued automatically by cert-manager, and every management surface served through the three OpenChoreo plane gateways — the only LoadBalancers the platform needs. The OpenChoreo API itself is not exposed outside the cluster; Agent Manager reaches it over cluster DNS.
+
+Where a step has a development-grade default and a production one — the databases, secret storage, observability retention — it offers both as tabs. Pick **Production** throughout unless you are deliberately evaluating, and pay attention to [the decisions you cannot change later](#3-decisions-you-cannot-change-later).
 
 :::tip No domain yet?
 The main flow assumes you control a DNS zone. If you are evaluating on a cluster without one, follow the [nip.io appendix](#appendix-installing-without-a-domain-nipio) instead — same steps, with hostnames derived from LoadBalancer IPs and self-signed certificates.
@@ -90,11 +92,10 @@ Pick a base domain you control (a delegated subdomain like `amp.yourdomain.com` 
 | `api-amp.<base>` | Agent Manager API (browser, `amctl`, MCP) | control-plane gateway LB |
 | `thunder.<base>` | Thunder OAuth login (+ per-environment `<org>-<env>.thunder.<base>`) | control-plane gateway LB |
 | `cp.<base>` | Gateway control plane (external AI gateways, optional) | control-plane gateway LB |
-| `api.<base>` | OpenChoreo API | control-plane gateway LB |
 | `traces.<base>` | Agent Manager Observer | observability-plane gateway LB |
 | `*.agents.<base>` | Deployed-agent invocation endpoints (wildcard) | data-plane gateway LB |
 
-Concretely: `console`/`api-amp`/`thunder`/`cp`/`api` all point at the control-plane gateway (five records, or a single `*.<base>` wildcard), `traces` points at the observability-plane gateway, and `*.agents.<base>` plus the `agents.<base>` apex point at the data-plane gateway. [Step 10](#step-10-publish-dns-records) lists the exact records once the LoadBalancer addresses exist.
+Concretely: `console`/`api-amp`/`thunder`/`cp` all point at the control-plane gateway (four records, or a single `*.<base>` wildcard), `traces` points at the observability-plane gateway, and `*.agents.<base>` plus the `agents.<base>` apex point at the data-plane gateway. [Step 10](#step-10-publish-dns-records) lists the exact records once the LoadBalancer addresses exist.
 
 ```bash
 export VERSION="0.0.0-dev"
@@ -128,17 +129,54 @@ export THUNDER_INTERNAL_URL="http://amp-thunder-extension-service.${THUNDER_NS}.
 export INSTRUMENTATION_URL="http://default-default.gateway.localhost:19080/otel"
 ```
 
-:::note Why `api-amp` and not `api`?
-The OpenChoreo API claims `api.<base>` on the same gateway, and the certificates below are single-level wildcards (`*.<base>`), so every hostname must sit directly under the base domain.
+:::note Hostname shape
+The certificates below are single-level wildcards (`*.<base>`), so every management hostname must sit directly under the base domain — no second-level names like `api.amp.<base>`.
 :::
 
 ### 2. TLS certificates
 
 The main flow uses **cert-manager with Let's Encrypt (DNS-01)**: publicly trusted certificates, automatic renewal, and wildcard support — you only need API credentials for the DNS provider hosting your zone. Step 3 also shows a corporate-CA alternative. Certificate issuance needs only the DNS zone, so it works before the DNS records for the gateways exist.
 
-### 3. Dependencies
+### 3. Decisions you cannot change later
 
-The default install runs PostgreSQL, OpenBao, and OpenSearch in-cluster with development settings. Each install step below carries a **Production** callout with the values to swap in a managed database, a hardened secrets backend, and persistent observability storage. Decide up front which you will use — moving PostgreSQL data or Thunder's identity database later is disruptive.
+Each install step below carries its production configuration inline, so you can follow the guide top to bottom and end up with a production deployment. Most of those settings can also be applied later against a running platform. **These cannot** — they are written to a database or a certificate on first boot, and changing them afterwards means an uninstall and reinstall of that component:
+
+| Decision | Fixed at | Why it is frozen |
+|---|---|---|
+| Thunder's database (in-pod SQLite vs external PostgreSQL) | [Step 4](#step-4-install-thunder-extension-identity-provider) | Thunder's OAuth clients are seeded into its database by a `pre-install` hook. Pointing Thunder at a different database later gives you an empty one — no clients, no logins — and `helm upgrade` does not re-seed it |
+| Thunder's platform client secrets | [Step 4](#step-4-install-thunder-extension-identity-provider) | Same seeding job; changing a secret afterwards means re-running the bootstrap and updating every consumer in one window |
+| `THUNDER_PUBLIC_URL` and `CONSOLE_PUBLIC_URL` | [Step 4](#step-4-install-thunder-extension-identity-provider) | The issuer URL and the console's OAuth redirect URIs are persisted on first boot |
+| The MCP resource identifiers (`API_PUBLIC_URL`, `OBS_API_PUBLIC_URL`) | [Step 4](#step-4-install-thunder-extension-identity-provider) | Registered as OAuth resource servers by the same seeding job; an identifier is matched exactly, so a later change makes MCP logins fail with `invalid_target` |
+| Thunder replica count > 1 | [Step 4](#step-4-install-thunder-extension-identity-provider) | Requires external PostgreSQL **and** a shared Redis cache — the default in-pod SQLite cannot be shared across pods |
+| Agent Manager's database | [Phase 2](#phase-2-agent-manager-installation) | Switching later is a data migration, not a configuration change |
+
+Everything else — OpenSearch sizing, the container registry, gateway hardening, resource quotas, replica counts, isolation tiers — can be changed on a running platform. The [Production Reference](#production-reference) at the end summarises all of it.
+
+### 4. Platform secrets
+
+The charts ship well-known placeholder secrets for the platform's internal OAuth clients and the OpenSearch admin user. Generate real ones now — several are consumed by more than one chart, and the steps below reference these variables by name:
+
+```bash
+export AMP_API_CLIENT_SECRET="$(openssl rand -hex 32)"
+export AMP_SYSTEM_CLIENT_SECRET="$(openssl rand -hex 32)"
+export AMP_PUBLISHER_CLIENT_SECRET="$(openssl rand -hex 32)"
+export AM_OBSERVER_CLIENT_SECRET="$(openssl rand -hex 32)"
+export WORKFLOW_PUBLISHER_SECRET="$(openssl rand -hex 32)"
+export OBSERVER_READER_SECRET="$(openssl rand -hex 32)"
+export OPENSEARCH_USERNAME="admin"
+export OPENSEARCH_PASSWORD="$(openssl rand -base64 24)"
+```
+
+| Variable | Set on | Also consumed by |
+|---|---|---|
+| `AMP_API_CLIENT_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) | Agent Manager, API Platform Gateway extension (Phase 2) |
+| `AMP_SYSTEM_CLIENT_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) | Agent Manager (Phase 2), OpenBao seed ([Step 2](#step-2-setup-secrets-store-openbao)) |
+| `AMP_PUBLISHER_CLIENT_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) | OpenBao seed — read by evaluation workflows at runtime |
+| `AM_OBSERVER_CLIENT_SECRET` | Thunder ([Step 4](#step-4-install-thunder-extension-identity-provider)) | Observability extension (Phase 2) |
+| `WORKFLOW_PUBLISHER_SECRET`, `OBSERVER_READER_SECRET` | OpenBao seed ([Step 2](#step-2-setup-secrets-store-openbao)) | OpenChoreo workflow plane and observer |
+| `OPENSEARCH_USERNAME` / `OPENSEARCH_PASSWORD` | OpenBao seed ([Step 2](#step-2-setup-secrets-store-openbao)) | Observability Plane and logs module ([Step 8](#step-8-setup-observability-plane)) |
+
+Keep this shell session for the whole install, and store the values in your secret manager — Thunder's are frozen after [Step 4](#step-4-install-thunder-extension-identity-provider).
 
 :::info OTLP trace ingest
 
@@ -216,28 +254,90 @@ helm upgrade --install kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgatew
   --set controller.extraEnv.KGW_ENABLE_GATEWAY_API_EXPERIMENTAL_FEATURES=true
 ```
 
-<details>
-<summary>Rancher Desktop / k3s users</summary>
-
-k3s ships with Traefik which binds to host ports 80/443 and conflicts with OpenChoreo's kgateway. Remove Traefik before proceeding:
-
-```bash
-helm uninstall traefik -n kube-system
-helm uninstall traefik-crd -n kube-system
-```
-
-After removing Traefik, re-apply the Gateway API CRDs (Traefik's CRD chart may have removed them):
-
-```bash
-kubectl apply --server-side --force-conflicts \
-  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
-```
-
-</details>
+:::note
+Evaluating on Rancher Desktop / k3s? See the [Rancher Desktop / k3s appendix](#appendix-rancher-desktop--k3s) — Traefik must be removed before this step.
+:::
 
 ### Step 2: Setup Secrets Store (OpenBao)
 
-OpenBao provides secret management for the Workflow Plane and deployed agents:
+OpenBao provides secret management for the Workflow Plane and deployed agents.
+
+<Tabs groupId="deployment-mode">
+  <TabItem value="production" label="Production" default>
+
+Install with the chart defaults — persistent file storage on a PVC, sealed at rest:
+
+```bash
+helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
+  --namespace openbao \
+  --create-namespace \
+  --version 0.25.6 \
+  --set server.dataStorage.size=10Gi \
+  --timeout 180s
+
+kubectl wait --for=condition=Ready=false pod/openbao-0 -n openbao --timeout=120s
+```
+
+Initialize and unseal. **Store the unseal keys and root token in your secret manager immediately** — they are displayed once, and without them the data on that PVC is unrecoverable:
+
+```bash
+kubectl exec -n openbao openbao-0 -- bao operator init -key-shares=5 -key-threshold=3
+# Record the 5 unseal keys and the initial root token, then unseal with any 3:
+kubectl exec -n openbao openbao-0 -- bao operator unseal <unseal-key-1>
+kubectl exec -n openbao openbao-0 -- bao operator unseal <unseal-key-2>
+kubectl exec -n openbao openbao-0 -- bao operator unseal <unseal-key-3>
+```
+
+A sealed OpenBao must be unsealed again after every pod restart. For unattended restarts, configure [auto-unseal](https://openbao.org/docs/concepts/seal/) against your cloud KMS through the `server.standalone.config` seal stanza.
+
+Create the KV v2 mount, the Kubernetes auth role the platform expects, and the seeded secrets (dev mode does this automatically; a sealed installation does not):
+
+```bash
+kubectl exec -n openbao openbao-0 -- sh -c "
+export BAO_ADDR=http://127.0.0.1:8200
+export BAO_TOKEN='<root-token>'
+
+bao secrets enable -path=secret -version=2 kv
+bao auth enable kubernetes
+bao write auth/kubernetes/config kubernetes_host=\"https://\$KUBERNETES_PORT_443_TCP_ADDR:443\"
+
+bao policy write openchoreo-secret-reader-policy - <<POLICY
+path \"secret/data/*\" { capabilities = [\"read\"] }
+path \"secret/metadata/*\" { capabilities = [\"list\", \"read\"] }
+POLICY
+
+bao policy write openchoreo-secret-writer-policy - <<POLICY
+path \"secret/data/*\" { capabilities = [\"create\", \"read\", \"update\", \"delete\"] }
+path \"secret/metadata/*\" { capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\"] }
+POLICY
+
+bao write auth/kubernetes/role/openchoreo-secret-reader-role \
+  bound_service_account_names=default \
+  bound_service_account_namespaces='dp*' \
+  policies=openchoreo-secret-reader-policy ttl=20m
+
+bao write auth/kubernetes/role/openchoreo-secret-writer-role \
+  bound_service_account_names='*' \
+  bound_service_account_namespaces='openbao,openchoreo-workflow-plane,wso2-amp' \
+  policies=openchoreo-secret-writer-policy ttl=20m
+
+bao kv put secret/workflow-plane-oauth-client-secret value='${WORKFLOW_PUBLISHER_SECRET}'
+bao kv put secret/amp-publisher-client-secret value='${AMP_PUBLISHER_CLIENT_SECRET}'
+bao kv put secret/amp-system-client-secret value='${AMP_SYSTEM_CLIENT_SECRET}'
+bao kv put secret/observer-oauth-client-secret value='${OBSERVER_READER_SECRET}'
+bao kv put secret/opensearch-username value='${OPENSEARCH_USERNAME}'
+bao kv put secret/opensearch-password value='${OPENSEARCH_PASSWORD}'
+"
+```
+
+:::tip Tighten the policies
+The writer policy above grants the whole `secret/*` tree to every service account in three namespaces, matching what the platform expects out of the box. If your security posture requires it, split the platform secrets onto dedicated mounts with per-service-account policies — the paths are referenced by the ExternalSecrets in [Step 8](#step-8-setup-observability-plane) and by the evaluation workflows.
+:::
+
+  </TabItem>
+  <TabItem value="evaluation" label="Evaluation only">
+
+The single-cluster values file runs OpenBao in **dev mode** — in-memory backend, auto-unseal, well-known root token — and seeds the placeholder secrets automatically:
 
 ```bash
 helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
@@ -250,7 +350,12 @@ helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
 kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=openbao -n openbao --timeout=120s
 ```
 
-Configure the External Secrets ClusterSecretStore:
+Every secret is lost when the pod restarts, including on node drains: already-running agents keep working, but new deployments fail with `Secret does not exist` until the values are re-entered. Do not use this beyond evaluation.
+
+  </TabItem>
+</Tabs>
+
+Configure the External Secrets ClusterSecretStore (identical either way):
 
 ```bash
 kubectl apply -f - <<'EOF'
@@ -280,15 +385,11 @@ spec:
 EOF
 ```
 
-:::warning Production
-The values file above runs OpenBao in **dev mode** (in-memory backend, auto-unseal, well-known root token) — secrets are lost on pod restart. For production, install OpenBao without the dev-mode values: set `server.dev.enabled=false`, enable `server.dataStorage` persistence (or an external storage backend), configure [auto-unseal](https://openbao.org/docs/concepts/seal/), and create the Kubernetes auth role (`openchoreo-secret-writer-role`) plus the KV v2 mount at `secret/` that the ClusterSecretStore below expects.
-:::
-
 ### Step 3: Setup TLS Issuer
 
 Every gateway certificate below references one ClusterIssuer named `openchoreo-ca`. Create it from your chosen certificate authority — the rest of the guide is identical regardless of which tab you pick.
 
-<Tabs>
+<Tabs groupId="tls-issuer">
   <TabItem value="letsencrypt" label="Let's Encrypt (DNS-01)" default>
 
 DNS-01 validation issues publicly trusted certificates (including the wildcards this guide needs) by writing a TXT record to your DNS zone — the CA never connects to your cluster. Create a credentials Secret for your DNS provider, then the issuer. The example below uses AWS Route 53; cert-manager supports [Cloudflare, Google Cloud DNS, Azure DNS, and others](https://cert-manager.io/docs/configuration/acme/dns01/) with the same structure.
@@ -361,6 +462,81 @@ For evaluation without a domain, the [nip.io appendix](#appendix-installing-with
 
 Thunder provides authentication and user management for the entire platform — login, API keys, and OAuth token exchange. It must be installed before the Control Plane because the Control Plane, Observability Plane, and Agent Manager all validate JWTs issued by Thunder. The browser reaches it at `https://${THUNDER_PUBLIC_HOST}` through the control-plane gateway.
 
+:::danger This step's settings are permanent
+Thunder writes its issuer URL, the console client's redirect URIs, and every platform OAuth client into its database on **first boot**, seeded by a `pre-install` hook that `helm upgrade` never re-runs. The database, the secrets, and the hostnames below are all effectively frozen once this command completes — getting any of them wrong means uninstalling, discarding Thunder's data, and reinstalling. Confirm your values against [Plan Your Deployment](#plan-your-deployment) before running it.
+:::
+
+**Database.** Production installations use an external PostgreSQL. Thunder keeps three logical databases — `configdb`, `runtimedb`, and `userdb` — which can live on one server; create them and a role that owns all three before installing.
+
+<Tabs groupId="deployment-mode">
+  <TabItem value="production" label="External PostgreSQL" default>
+
+Store the database password in a Secret and reference it, so it never enters Helm release history:
+
+```bash
+kubectl create namespace ${THUNDER_NS} --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic thunder-db-credentials \
+  --namespace ${THUNDER_NS} \
+  --from-literal=password='<THUNDER_DB_PASSWORD>'
+
+export THUNDER_DB_HOST="your-db.example.com"
+
+cat > thunder-db-values.yaml <<EOF
+thunder:
+  configuration:
+    database:
+      config:
+        type: postgres
+        postgres:
+          hostname: "${THUNDER_DB_HOST}"
+          port: "5432"
+          name: configdb
+          username: thunder
+          sslmode: require
+          passwordRef:
+            name: thunder-db-credentials
+            key: password
+      runtime:
+        type: postgres
+        postgres:
+          hostname: "${THUNDER_DB_HOST}"
+          port: "5432"
+          name: runtimedb
+          username: thunder
+          sslmode: require
+          passwordRef:
+            name: thunder-db-credentials
+            key: password
+      user:
+        type: postgres
+        postgres:
+          hostname: "${THUNDER_DB_HOST}"
+          port: "5432"
+          name: userdb
+          username: thunder
+          sslmode: require
+          passwordRef:
+            name: thunder-db-credentials
+            key: password
+EOF
+```
+
+Set `sslmode` to `verify-full` instead if your provider gives you a CA to pin.
+
+  </TabItem>
+  <TabItem value="evaluation" label="In-pod SQLite (evaluation only)">
+
+The chart's default keeps all three databases as SQLite files on a 1Gi PVC. It cannot be shared across pods, so Thunder is permanently limited to a single replica, and the data lives and dies with that volume. Write an empty overrides file so the install command below stays the same:
+
+```bash
+echo '{}' > thunder-db-values.yaml
+```
+
+  </TabItem>
+</Tabs>
+
+Install Thunder with the hostnames, the database, and the platform client secrets generated in [Platform secrets](#4-platform-secrets):
+
 ```bash
 helm install amp-thunder-extension \
   oci://${HELM_CHART_REGISTRY}/wso2-amp-thunder-extension \
@@ -377,6 +553,11 @@ helm install amp-thunder-extension \
   --set "thunder.bootstrap.ampConsoleClient.redirectUris={${CONSOLE_PUBLIC_URL}/login}" \
   --set thunder.bootstrap.agentManagerMcpBaseUrl="${API_PUBLIC_URL}" \
   --set thunder.bootstrap.observerMcpBaseUrl="${OBS_API_PUBLIC_URL}" \
+  --set thunder.bootstrap.ampApiClient.clientSecret="${AMP_API_CLIENT_SECRET}" \
+  --set thunder.bootstrap.ampSystemClient.clientSecret="${AMP_SYSTEM_CLIENT_SECRET}" \
+  --set thunder.bootstrap.ampPublisherClient.clientSecret="${AMP_PUBLISHER_CLIENT_SECRET}" \
+  --set thunder.bootstrap.amObserverClient.clientSecret="${AM_OBSERVER_CLIENT_SECRET}" \
+  --values thunder-db-values.yaml \
   --timeout 1800s
 
 kubectl wait --for=condition=Available \
@@ -384,10 +565,16 @@ kubectl wait --for=condition=Available \
   -n ${THUNDER_NS} --timeout=300s
 ```
 
-:::warning
-Thunder persists its configuration (including the issuer URL and the console client's OAuth redirect URIs) in a database on first boot. If you need to change `THUNDER_PUBLIC_URL` or `CONSOLE_PUBLIC_URL` after installation, you must **uninstall the chart, delete its PVC, and reinstall** — a `helm upgrade` alone will not change the issuer in issued tokens or the registered redirect URIs. This is why the hostnames are fixed in [Plan Your Deployment](#plan-your-deployment) before anything installs.
+:::info MCP resource identifiers
+`agentManagerMcpBaseUrl` and `observerMcpBaseUrl` become the OAuth resource-server identifiers Thunder registers for the `/mcp` endpoints. Point them at the externally reachable origins of the API and observer — the same values as `agentManagerService.config.serverPublicURL` and `amObserver.publicUrl` in Phase 2 — because Thunder rejects an authorize request with `invalid_target` unless the `resource` an MCP client asks for matches a registered identifier exactly. See the [MCP server reference](../reference/mcp-server.mdx) for the full set of settings that must move together.
+:::
 
-The same applies to the two MCP base URLs: they become the OAuth resource-server identifiers Thunder registers for the `/mcp` endpoints, and they are seeded by the pre-install bootstrap job only. Point them at the externally reachable origins of the API and observer — the same values as `agentManagerService.config.serverPublicURL` and `amObserver.publicUrl` in Phase 2 — because Thunder rejects an authorize request with `invalid_target` unless the `resource` an MCP client asks for matches a registered identifier exactly. See the [MCP server reference](../reference/mcp-server.mdx) for the full set of settings that must move together.
+:::note Scaling Thunder
+`thunder.deployment.replicaCount` can only exceed 1 when Thunder runs on external PostgreSQL **and** a shared cache — the default in-memory cache would leave each replica with its own session state. Configure Redis via `thunder.configuration.cache` per the [Thunder caching guide](https://thunderid.dev/docs/next/deployment/production-guidelines/#configure-caching), then raise the replica count on this same install.
+:::
+
+:::warning Changing these values later
+A `helm upgrade` will not change the issuer in issued tokens, the registered redirect URIs, the MCP resource identifiers, or any client secret — those live in Thunder's database, seeded by the pre-install bootstrap job. To change them you must uninstall the chart and discard its data: **delete the PVC** if you used SQLite, or **drop and recreate the three databases** if you used PostgreSQL, then reinstall. Anything already issued against the old issuer stops validating.
 :::
 
 :::tip Verify
@@ -428,7 +615,7 @@ kubectl wait --for=condition=Ready certificate/cp-gateway-tls \
   -n openchoreo-control-plane --timeout=300s
 ```
 
-Install the Control Plane with hostnames, TLS, and Thunder OIDC:
+Install the Control Plane with hostnames, TLS, and Thunder OIDC. The OpenChoreo API is deliberately **not** published on the gateway (`openchoreoApi.http.enabled=false`): Agent Manager and the observer call it over cluster DNS, so exposing it would only widen the platform's attack surface.
 
 ```bash
 helm upgrade --install openchoreo-control-plane \
@@ -440,10 +627,9 @@ helm upgrade --install openchoreo-control-plane \
 openchoreoApi:
   config:
     server:
-      publicUrl: "https://api.${BASE_DOMAIN}"
+      publicUrl: "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
   http:
-    hostnames:
-      - "api.${BASE_DOMAIN}"
+    enabled: false
 backstage:
   enabled: false
   baseUrl: ""
@@ -510,8 +696,8 @@ Re-apply this patch after any `helm upgrade` of the Control Plane chart — the 
 - Backstage disabled (AMP provides its own console)
 - OIDC issuer set to `THUNDER_PUBLIC_URL` (matches the `iss` claim in Thunder-issued JWTs)
 - OIDC JWKS URL points to Thunder's in-cluster service (avoids external DNS dependency, and no TLS-verification overrides are needed since the in-cluster call is plain HTTP)
-- OpenChoreo API at `api.${BASE_DOMAIN}`
-- TLS enabled on the gateway with the wildcard certificate — Thunder, the Console, the API, and the gateway control plane all serve HTTPS under it
+- OpenChoreo API kept in-cluster only (`openchoreoApi.http.enabled=false`) — its `publicUrl` is set to the cluster-local service address, and no HTTPRoute is created on the gateway
+- TLS enabled on the gateway with the wildcard certificate — Thunder, the Console, the Agent Manager API, and the gateway control plane all serve HTTPS under it
 
 </details>
 
@@ -639,7 +825,7 @@ kubectl create secret generic cluster-gateway-ca \
 ```
 
 :::info Container Registry
-The Workflow Plane needs a container registry to store built agent images. The registry endpoint is configured in **Phase 2 Step 3 (Platform Resources)** via the `global.registry.endpoint` or `global.baseDomain` Helm values. For local development, deploy an in-cluster `docker-registry` in this namespace — see the [k3d guide](./on-k3d.mdx) for an example.
+The Workflow Plane needs a container registry to store built agent images. The registry endpoint is configured in **Phase 2 Step 4 (Platform Resources)** via the `global.registry.endpoint` or `global.baseDomain` Helm values. Use a registry with access control — ECR, Artifact Registry, ACR, Harbor — and set `global.defaultResources.registry.tlsVerify=true`; [OpenChoreo's registry guide](https://openchoreo.dev/docs/platform-engineer-guide/container-registry-configuration/#registry-providers) covers provider-specific authentication.
 :::
 
 Install the Workflow Plane:
@@ -830,10 +1016,10 @@ kubectl rollout restart deployment/observer -n openchoreo-observability-plane
 kubectl rollout status deployment/observer -n openchoreo-observability-plane --timeout=120s
 ```
 
-Install observability modules (logs, metrics, tracing):
+Install observability modules (logs, metrics, tracing). The logs module is the chart that deploys OpenSearch itself, so its values decide how much history the platform can hold:
 
 ```bash
-# Logs module
+# Logs module — deploys OpenSearch
 helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
@@ -841,6 +1027,9 @@ helm upgrade --install observability-logs-opensearch \
   --version 0.4.1 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
+  --set openSearch.persistence.size=100Gi \
+  --set-string "openSearch.extraEnvs[0].name=OPENSEARCH_INITIAL_ADMIN_PASSWORD" \
+  --set-string "openSearch.extraEnvs[0].value=${OPENSEARCH_PASSWORD}" \
   --timeout 10m
 
 # Enable Fluent Bit log collection
@@ -872,8 +1061,10 @@ helm upgrade --install observability-traces-opensearch \
   --timeout 10m
 ```
 
-:::warning Production
-OpenSearch stores all traces, logs, and metrics. The default modules run it with ephemeral storage — set persistence before real use (`--set opensearch.persistence.enabled=true --set opensearch.persistence.size=100Gi` on the logs module that deploys OpenSearch, sized to your retention needs), or point the observability stack at a managed OpenSearch domain if your platform team operates one.
+:::note Sizing and the admin password
+Two values above differ from the chart defaults. `openSearch.persistence.size` raises the volume from its 8Gi default — size it to your retention needs, since this single-node instance holds every trace, log, and metric the platform stores. The `OPENSEARCH_INITIAL_ADMIN_PASSWORD` override makes OpenSearch's own admin password match the one seeded into OpenBao in [Step 2](#step-2-setup-secrets-store-openbao); without it OpenSearch keeps the chart's published default while every client authenticates with yours, and all observability queries fail. Note the capital **S** in `openSearch` — it is the subchart alias, and lowercase `opensearch.*` values are silently ignored.
+
+Both are storage-layer choices you can revisit later: growing the volume needs a storage class with expansion enabled, and moving to a managed OpenSearch is a reindex. See [Production Reference](#observability-storage) for the external-OpenSearch route.
 :::
 
 Register the Observability Plane and link it to other planes:
@@ -941,7 +1132,7 @@ done
 
 | Record | Type | Points to |
 |---|---|---|
-| `console`, `api-amp`, `thunder`, `cp`, `api` `.${BASE_DOMAIN}` (or `*.${BASE_DOMAIN}`) | A / CNAME | control-plane gateway address |
+| `console`, `api-amp`, `thunder`, `cp` `.${BASE_DOMAIN}` (or `*.${BASE_DOMAIN}`) | A / CNAME | control-plane gateway address |
 | `traces.${BASE_DOMAIN}` | A / CNAME | observability-plane gateway address |
 | `*.agents.${BASE_DOMAIN}` and `agents.${BASE_DOMAIN}` | A / CNAME | data-plane gateway address |
 
@@ -955,25 +1146,13 @@ dig +short thunder.${BASE_DOMAIN} traces.${BASE_DOMAIN} test.${AGENTS_DOMAIN}
 
 ## Phase 2: Agent Manager Installation
 
-With OpenChoreo and Thunder running, you can now install the Agent Manager components — the API, console, and extensions that provide the AI agent management capabilities.
+With OpenChoreo and Thunder running, you can now install the Agent Manager components — the API, console, and extensions that provide the AI agent management capabilities. The commands below are the production variants: an external database for the Agent Manager, the platform client secrets generated in [Platform secrets](#4-platform-secrets), and two replicas of each stateless service.
 
-:::warning Production — managed PostgreSQL
-The Agent Manager chart below deploys an in-cluster PostgreSQL with a default password by default. For production, use a managed database (RDS, Cloud SQL, Azure Database) and add these values to the `wso2-agent-manager` install in Step 2:
-
-```bash
-  --set postgresql.enabled=false \
-  --set postgresql.external.host="your-db.example.com" \
-  --set postgresql.external.port=5432 \
-  --set postgresql.external.database=agentmanager \
-  --set postgresql.external.username=agentmanager \
-  --set postgresql.external.existingSecret=amp-db-credentials \
-  --set postgresql.external.existingSecretPasswordKey=password
-```
-
-Create the `amp-db-credentials` Secret in `${AMP_NS}` beforehand. Sizing, backups, and HA then come from your database service.
+:::info Have the database ready
+Step 2 expects an existing PostgreSQL database and role for the Agent Manager. Create them before starting — switching afterwards is a data migration rather than a configuration change.
 :::
 
-<AmpInstallation version="${VERSION}" expandRegistryConfig={true} />
+<AmpInstallation version="${VERSION}" expandRegistryConfig={true} production={true} />
 
 ### Wire the Remaining Public Endpoints
 
@@ -1013,9 +1192,9 @@ curl -fsSL "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}
   -o add-environment-thunder.sh
 ```
 
-Pick the same tab you used in [Step 3](#step-3-setup-tls-issuer) — the CA trust setting below only differs by that choice, nothing else changes.
+Pick the tab matching your [Step 3](#step-3-setup-tls-issuer) issuer choice — the CA trust setting below only differs by that choice, nothing else changes. (Self-signed evaluation installs: see difference 5 in the [nip.io appendix](#appendix-installing-without-a-domain-nipio).)
 
-<Tabs>
+<Tabs groupId="tls-issuer">
   <TabItem value="letsencrypt" label="Let's Encrypt (DNS-01)" default>
 
 Platform Thunder's certificate comes from a real, publicly-trusted CA, so env-Thunder's container trust store already trusts it — no custom CA bundle needs to be fetched or mounted.
@@ -1081,53 +1260,10 @@ bash add-environment-thunder.sh
 ```
 
   </TabItem>
-  <TabItem value="selfsigned" label="Self-signed (evaluation only)">
-
-Same as the Corporate CA case — `SKIP_CA_BUNDLE_TRUST` doesn't mount anything, and the script's own auto-detect looks for a different, local-dev-specific secret name than the `openchoreo-ca-secret` this guide's [nip.io appendix](#appendix-installing-without-a-domain-nipio) creates. Extract the CA live instead:
-
-```bash
-PLATFORM_THUNDER_CA_PEM="$(echo | openssl s_client -connect "${THUNDER_PUBLIC_HOST}:443" \
-  -servername "${THUNDER_PUBLIC_HOST}" -showcerts 2>/dev/null \
-  | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/{print}')"
-```
-
-And just like the Corporate CA case, this only covers env-Thunder's own pod. The `curl` call this script makes from **your** machine to `IDP_TOKEN_URL` needs the same CA trusted locally, or it fails with "unable to get local issuer certificate":
-
-```bash
-CURL_CA_BUNDLE="$(mktemp)"
-if [ -f /etc/ssl/cert.pem ]; then
-  SYSTEM_CA_BUNDLE=/etc/ssl/cert.pem                        # macOS
-elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
-  SYSTEM_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt       # Debian/Ubuntu
-else
-  echo "Could not find a system CA bundle at /etc/ssl/cert.pem or /etc/ssl/certs/ca-certificates.crt. Find yours and set SYSTEM_CA_BUNDLE to it manually." >&2
-  exit 1
-fi
-cat "${SYSTEM_CA_BUNDLE}" > "${CURL_CA_BUNDLE}"
-echo "${PLATFORM_THUNDER_CA_PEM}" >> "${CURL_CA_BUNDLE}"
-export CURL_CA_BUNDLE
-```
-
-```bash
-ENV_NAME=default \
-DISPLAY_NAME="Default" \
-ORG_NAME=default \
-WAIT_TIMEOUT=300s \
-AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
-IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
-PLATFORM_THUNDER_ISSUER="${THUNDER_PUBLIC_URL}" \
-PLATFORM_THUNDER_JWKS_URL="${THUNDER_PUBLIC_URL}/oauth2/jwks" \
-PLATFORM_THUNDER_CA_PEM="${PLATFORM_THUNDER_CA_PEM}" \
-THUNDER_HOST_BASE_DOMAIN="${BASE_DOMAIN}" \
-TLS_ENABLED=true \
-bash add-environment-thunder.sh
-```
-
-  </TabItem>
 </Tabs>
 
 :::info
-Only the Let's Encrypt path can use `SKIP_CA_BUNDLE_TRUST=true` — it's specifically for a certificate that's already backed by a CA every trust store already knows. For a Corporate or self-signed CA, that flag doesn't help you: setting it to `true` skips the fetch outright, and simply omitting it falls back to the script's own auto-detect, which looks for a secret named `amp-local-root-ca-secret` — a name neither of those tabs in Step 3 ever creates. `PLATFORM_THUNDER_CA_PEM` sidesteps that entirely by pulling whatever certificate is actually being served, live, regardless of what you named things, but it only solves trust *inside the cluster*. The `CURL_CA_BUNDLE` step in each tab above is a separate fix for trust on **your own machine**, where this script's own `curl` calls run.
+Only the Let's Encrypt path can use `SKIP_CA_BUNDLE_TRUST=true` — it's specifically for a certificate that's already backed by a CA every trust store already knows. For a Corporate CA, that flag doesn't help you: setting it to `true` skips the fetch outright, and simply omitting it falls back to the script's own auto-detect, which looks for a secret named `amp-local-root-ca-secret` — a name the Corporate CA tab in Step 3 never creates. `PLATFORM_THUNDER_CA_PEM` sidesteps that entirely by pulling whatever certificate is actually being served, live, regardless of what you named things, but it only solves trust *inside the cluster*. The `CURL_CA_BUNDLE` step above is a separate fix for trust on **your own machine**, where this script's own `curl` calls run. (Running with the self-signed evaluation chain? See the [nip.io appendix](#appendix-installing-without-a-domain-nipio).)
 :::
 
 :::tip Verify
@@ -1172,20 +1308,196 @@ Everything is hostname-routed through the three plane gateway LoadBalancers, ove
 | **Agent Manager API** | `https://${API_PUBLIC_HOST}` |
 | **Thunder (OAuth login)** | `https://${THUNDER_PUBLIC_HOST}` |
 | **Agent Manager Observer** | `https://${OBS_API_PUBLIC_HOST}` |
-| **OpenChoreo API** | `https://api.${BASE_DOMAIN}` |
 | **Gateway control plane** | `https://${CP_GW_PUBLIC_HOST}` |
 
 Open the Console, log in, then create → build → deploy an agent; its invoke URL is published under `https://<org>-<project>.${AGENTS_DOMAIN}`.
 
 Port-forwarding remains available as a debugging fallback for any individual service (all Agent Manager services are ClusterIP), e.g. `kubectl port-forward -n wso2-amp svc/amp-console 3000:3000`.
 
-**Default credentials:** `admin` / `admin`
+**Default credentials:** `admin` / `admin` — bootstrap only; replace before exposing the platform (see [Identity and Access](#identity-and-access)).
+
+---
+
+## Cloud Provider Notes
+
+<details>
+<summary>AWS EKS</summary>
+
+- LoadBalancers return a **hostname** instead of an IP — use `dig` to resolve
+- For internet-facing access, annotate LoadBalancer services:
+  ```yaml
+  service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+  ```
+- Ensure security groups allow HTTP/HTTPS traffic
+
+</details>
+
+<details>
+<summary>Google Cloud Platform (GKE)</summary>
+
+- LoadBalancers return IPs directly — no special handling needed
+- Ensure firewall rules allow HTTP/HTTPS traffic to LoadBalancers
+
+</details>
+
+<details>
+<summary>Microsoft Azure (AKS)</summary>
+
+- LoadBalancers return IPs directly — no special handling needed
+- Ensure Network Security Groups allow HTTP/HTTPS traffic
+
+</details>
+
+---
+
+## Production Reference
+
+Following the steps above with the **Production** tab selected at each choice already gives you a production deployment: real hostnames, trusted wildcard TLS, every surface behind the three plane gateways, the OpenChoreo API kept in-cluster, generated platform secrets, external databases, and sealed secret storage.
+
+This section is the other half — the checklist to audit an install against, plus the operational concerns that belong to no single step. Agent Manager runs on [OpenChoreo](https://openchoreo.dev), and for the components OpenChoreo owns its documentation is the authoritative reference; its [production configuration index](https://openchoreo.dev/docs/getting-started/try-it-out/on-your-environment/#production-configuration) collects the relevant pages. This guide targets a **single-cluster** deployment — OpenChoreo's multi-cluster topology material is out of scope here.
+
+### Checklist
+
+Work down this table against an existing install. The **When** column matters: the first four rows cannot be corrected without reinstalling the component, so verify them before going live.
+
+| Item | Where | When it can be applied |
+|---|---|---|
+| Thunder on external PostgreSQL | [Step 4](#step-4-install-thunder-extension-identity-provider) | Install only |
+| Thunder platform client secrets are not the shipped defaults | [Step 4](#step-4-install-thunder-extension-identity-provider) | Install only |
+| Thunder issuer and console redirect URIs are the final hostnames | [Step 4](#step-4-install-thunder-extension-identity-provider) | Install only |
+| Agent Manager on external PostgreSQL | [Phase 2](#phase-2-agent-manager-installation) | Install (migration afterwards) |
+| OpenBao sealed, persistent, and unseal keys escrowed | [Step 2](#step-2-setup-secrets-store-openbao) | Any time — re-seeding required |
+| OpenSearch volume sized to retention, admin password matches OpenBao | [Step 8](#step-8-setup-observability-plane) | Any time |
+| Container registry is yours, with `tlsVerify=true` | [Phase 2](#phase-2-agent-manager-installation) | Any time — affects new builds |
+| Console `admin`/`admin` replaced by real users or a connected IdP | [Identity](#identity-and-access) | Any time |
+| JWT signature verification active on the API and the observer | [Identity](#identity-and-access) | Any time |
+| Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Any time |
+| Build workloads bounded by a node pool or ResourceQuota | [Build workflows](#build-workflows) | Any time |
+| Stateless services running multiple replicas | [High availability](#high-availability-and-scaling) | Any time |
+| NetworkPolicies, RBAC, and Pod Security Standards applied | [Cluster security](#certificates-and-cluster-security) | Any time |
+| Stronger isolation tier chosen where agents run untrusted code | [Agent isolation](#agent-isolation) | Any time, per environment |
+
+### Identity and Access
+
+The seeded `admin`/`admin` console login is for bootstrap only. Create real users in Thunder or connect your organization's identity provider before exposing the platform — see [Configure Identity Providers](../administration/configure-identity-providers.mdx).
+
+Each environment also gets its own Thunder instance, provisioned in Phase 2, which issues agents their OAuth credentials in that environment. Those are separate installations from the platform Thunder; its admin password is generated once at provisioning and shown only in the verify step, so capture it into your secret manager then. Apply the same database and credential hygiene per environment.
+
+There is no first-class rotation flow for the platform's internal client secrets yet: because Thunder seeds them through a `pre-install` hook, changing one means re-running the bootstrap and updating every consumer in the same maintenance window. Treat them as install-time values and protect them accordingly.
+
+#### Confirm JWT signature verification is active
+
+Both the Agent Manager API and the observer carry a **development-only** path that decodes a token's payload without verifying its signature. Leaving that active on an exposed deployment would let anyone forge a token, so it is worth confirming explicitly even though it is off by default.
+
+Neither service is at risk with the values this guide sets. The API takes the bypass only when its JWKS URL is empty **and** `IS_LOCAL_DEV_ENV` is `true`; that variable defaults to `false`, the chart does not set it on the API deployment, and the install above sets `agentManagerService.config.keyManager.jwksUrl` explicitly. With a JWKS URL configured it always verifies, and with neither configured it rejects the request outright rather than falling back. The observer is guarded in the chart: `amObserver.auth.isLocalDevEnv` defaults to `false`, and while it is false the chart refuses to render unless `auth.jwksUrl`, `auth.issuer`, and `auth.audience` are all set.
+
+The checks are therefore that nothing has switched the bypass on, and that the JWKS URLs point at your Thunder:
+
+```bash
+# Neither should report "true"
+kubectl get deploy amp-api -n ${AMP_NS} \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="IS_LOCAL_DEV_ENV")].value}{"\n"}'
+kubectl get deploy amp-observer -n ${OBSERVABILITY_NS} \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="IS_LOCAL_DEV_ENV")].value}{"\n"}'
+
+# The JWKS URL should be your Thunder instance
+kubectl get configmap -n ${AMP_NS} -o yaml | grep -i KEY_MANAGER_JWKS_URL
+```
+
+Empty output from the first two commands is the expected, secure result — the variable is simply not set. The `amp-db-migration` job does set `IS_LOCAL_DEV_ENV=true`, which is harmless: it runs the binary with `-migrate -server=false`, so it serves no requests and validates no tokens.
+
+### External Dependencies
+
+The install steps carry the values; these are the reference pages behind them.
+
+| Dependency | Reference |
+|---|---|
+| Thunder identity | [Thunder production guidelines](https://thunderid.dev/docs/next/deployment/production-guidelines/) — database, TLS, encryption keys, CORS, [caching](https://thunderid.dev/docs/next/deployment/production-guidelines/#configure-caching) |
+| Secret management | [OpenChoreo secret management](https://openchoreo.dev/docs/platform-engineer-guide/secret-management/), [OpenBao auto-unseal](https://openbao.org/docs/concepts/seal/) |
+| Observability storage | [OpenChoreo observability and alerting](https://openchoreo.dev/docs/platform-engineer-guide/observability-alerting/) |
+| Container registry | [OpenChoreo registry configuration](https://openchoreo.dev/docs/platform-engineer-guide/container-registry-configuration/#registry-providers) |
+| API Platform Gateway | [High-availability production deployment](https://wso2.com/api-platform/docs/api-gateway/1.1.0/deployment/high-availability-production-deployment/), [database configuration](https://wso2.com/api-platform/docs/api-gateway/1.1.0/deployment/production-deployment/database-configuration/) |
+| AI Gateway | [Kubernetes deployment with the gateway operator](https://wso2.com/api-platform/docs/ai-gateway/1.1.0/deployment-modes/kubernetes/gateway-operator/) |
+
+#### Observability storage
+
+To move off the in-cluster OpenSearch entirely, point the observability modules at a managed domain instead of letting the logs module deploy one: install it with `openSearch.enabled=false` and set the endpoint and credentials the modules and observer use through the `opensearch-admin-credentials` secret created in [Step 8](#step-8-setup-observability-plane). Existing data does not follow automatically — moving a running platform is a reindex, so prefer deciding this before trace volume accumulates.
+
+Metrics come from the in-cluster Prometheus deployed by the metrics module; for retention and alerting beyond its defaults, see the OpenChoreo observability guide above.
+
+### Gateway Hardening
+
+The gateway extension provisions one gateway per environment and ships with `developmentMode: true`, which relaxes security checks such as auto-generating encryption keys. For production set `developmentMode=false`.
+
+With development mode off the gateway requires explicit encryption keys (`gateway.controller.encryptionKeys`, key format per the [high-availability production guide](https://wso2.com/api-platform/docs/api-gateway/1.1.0/deployment/high-availability-production-deployment/)). The extension chart does not yet expose a value for that block, so it has to be added to the values ConfigMap the extension renders — `<release>-config` in the data-plane namespace, under the `gateway.controller` section — and re-applied after every chart upgrade, since the upgrade rewrites the ConfigMap.
+
+Rate-limiting policies default to an **in-memory** backend, which does not share counters across gateway replicas. When running more than one replica, switch to Redis through the extension's `apiGateway.config.policyConfigurations.ratelimit_v1` values (`backend: redis` plus the `redis` connection block).
+
+:::info Recommended architecture — separate API and AI gateways
+The production direction for this platform is **two gateways per environment**: an API Platform Gateway for agent ingress and a dedicated AI Gateway for LLM egress, scaled and configured independently (see the [AI Gateway Kubernetes deployment guide](https://wso2.com/api-platform/docs/ai-gateway/1.1.0/deployment-modes/kubernetes/gateway-operator/)). Today the default installation provisions a single gateway per environment that serves both roles; support for the split deployment is planned.
+:::
+
+AI gateways can also run **outside** the cluster (for example, close to a private LLM endpoint), connecting back through the control-plane gateway at `https://${CP_GW_PUBLIC_HOST}` — see [Register an AI Gateway](../administration/register-ai-gateway.mdx).
+
+### Build Workflows
+
+Agent builds run as Argo workflows in the Workflow Plane, and build pods have **no built-in resource ceiling** — a burst of builds can starve the platform and agent workloads on a shared node. Two mitigations, in order of preference:
+
+1. **Dedicated build nodes** — run the workflow plane's build workloads on a separate node pool so build spikes cannot affect serving workloads. Remember the build-node kernel requirement (Linux 6.3+ for user-namespaced builds, see [Prerequisites](#cluster-requirements)).
+2. **Namespace ResourceQuota** — cap total build resource consumption in the workflow-plane namespace:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: build-workloads
+  namespace: openchoreo-workflow-plane
+spec:
+  hard:
+    requests.cpu: "8"
+    requests.memory: 16Gi
+    limits.cpu: "16"
+    limits.memory: 32Gi
+EOF
+```
+
+Size the quota to your expected build concurrency; builds beyond the quota queue rather than fail.
+
+### High Availability and Scaling
+
+The production install already runs the Agent Manager API, console, and observer at two replicas. Spread them across availability zones with your cluster's default topology spreading, and adjust to load:
+
+- `agentManagerService.replicaCount` and `console.replicaCount` on `wso2-agent-manager`
+- `amObserver.replicaCount` on the observability extension
+- `thunder.deployment.replicaCount` on the Thunder extension — needs **both** external PostgreSQL (the default in-pod SQLite cannot be shared between pods) and a shared Redis cache. The database half is fixed at install; see [Step 4](#step-4-install-thunder-extension-identity-provider)
+
+The Agent Manager API runs a monitor scheduler that coordinates through a lock, so scheduled evaluations fire once regardless of replica count.
+
+Stateful dependencies get their availability from the platforms behind them: managed PostgreSQL, managed or clustered OpenSearch, and a sealed OpenBao with auto-unseal configured. Gateway replica guidance is in the gateway HA documentation linked above.
+
+### Certificates and Cluster Security
+
+With the Let's Encrypt DNS-01 issuer, certificate renewals are automatic — monitor cert-manager (its `Certificate` resources expose `Ready` and expiry conditions) and rotate the DNS-provider credentials Secret on your normal schedule. With a corporate CA, track the intermediate's expiry yourself.
+
+Apply your organization's standard cluster hardening around the platform: restrict namespace-to-namespace traffic with NetworkPolicies — in particular, only the gateways should reach the OTel collector and OpenSearch — scope RBAC for humans and CI to the namespaces they operate in, and enforce Pod Security Standards on the workload namespaces.
+
+Confirm your CNI actually **enforces** the `NetworkPolicy` objects the platform ships (the Observability and Evaluation extensions each include one — see [Cluster Requirements](#cluster-requirements)). A cluster without a policy engine selected — EKS's default VPC CNI, AKS, or legacy GKE — accepts those objects silently while blocking nothing, so the protection you think you have is not there.
+
+### Agent Isolation
+
+Agents run sandboxed under **runc** by default. Environments that execute untrusted or externally authored agent code can be moved to stronger isolation tiers — [gVisor](../administration/isolation-tiers/gvisor.mdx) (userspace kernel) or [Kata Containers](../administration/isolation-tiers/kata.mdx) (per-agent VM). Both have hardware/OS requirements and need dedicated nodes; plan the node pools alongside the build-node decision above.
 
 ---
 
 ## Appendix: Installing Without a Domain (nip.io)
 
-For evaluation on a cluster where you control no DNS zone, [nip.io](https://nip.io) turns LoadBalancer IPs into resolvable hostnames. The flow is the same as above with four differences.
+For evaluation on a cluster where you control no DNS zone, [nip.io](https://nip.io) turns LoadBalancer IPs into resolvable hostnames. This path is **not for production** — browsers warn on every hostname and the certificates are self-signed.
+
+<details>
+<summary>Full nip.io / self-signed flow differences</summary>
+
+The flow is the same as above with five differences.
 
 **1. Self-signed issuer.** In Step 3, create a self-signed chain under the same `openchoreo-ca` name instead of an ACME or corporate issuer:
 
@@ -1240,47 +1552,63 @@ Now export the [Plan Your Deployment](#plan-your-deployment) variables from this
 
 **4. Skip Step 10** (DNS records) — nip.io resolution is automatic.
 
+**5. Env-Thunder provisioning trusts the self-signed CA explicitly.** In the [Provision Thunder Identity Provider](#provision-thunder-identity-provider-for-the-default-environment) step, `SKIP_CA_BUNDLE_TRUST` doesn't mount anything, and the script's own auto-detect looks for a different, local-dev-specific secret name than the `openchoreo-ca-secret` this appendix creates. Extract the CA live instead:
+
+```bash
+PLATFORM_THUNDER_CA_PEM="$(echo | openssl s_client -connect "${THUNDER_PUBLIC_HOST}:443" \
+  -servername "${THUNDER_PUBLIC_HOST}" -showcerts 2>/dev/null \
+  | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/{print}')"
+```
+
+This only covers env-Thunder's own pod. The `curl` call the script makes from **your** machine to `IDP_TOKEN_URL` needs the same CA trusted locally, or it fails with "unable to get local issuer certificate":
+
+```bash
+CURL_CA_BUNDLE="$(mktemp)"
+if [ -f /etc/ssl/cert.pem ]; then
+  SYSTEM_CA_BUNDLE=/etc/ssl/cert.pem                        # macOS
+elif [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+  SYSTEM_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt       # Debian/Ubuntu
+else
+  echo "Could not find a system CA bundle at /etc/ssl/cert.pem or /etc/ssl/certs/ca-certificates.crt. Find yours and set SYSTEM_CA_BUNDLE to it manually." >&2
+  exit 1
+fi
+cat "${SYSTEM_CA_BUNDLE}" > "${CURL_CA_BUNDLE}"
+echo "${PLATFORM_THUNDER_CA_PEM}" >> "${CURL_CA_BUNDLE}"
+export CURL_CA_BUNDLE
+```
+
+Then run the script exactly as in the Corporate CA tab (with `PLATFORM_THUNDER_CA_PEM` set).
+
 The Thunder reinstall warning applies with full force here: if you tear down and recreate the cluster, the LoadBalancer IP — and therefore every hostname — changes, and Thunder must be reinstalled with the new values.
+
+</details>
 
 ---
 
-## Cloud Provider Notes
+## Appendix: Rancher Desktop / k3s
+
+For **evaluation** on Rancher Desktop or another k3s distribution — not a production target.
 
 <details>
-<summary>AWS EKS</summary>
+<summary>k3s-specific setup and workarounds</summary>
 
-- LoadBalancers return a **hostname** instead of an IP — use `dig` to resolve
-- For internet-facing access, annotate LoadBalancer services:
-  ```yaml
-  service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-  ```
-- Ensure security groups allow HTTP/HTTPS traffic
-
-</details>
-
-<details>
-<summary>Google Cloud Platform (GKE)</summary>
-
-- LoadBalancers return IPs directly — no special handling needed
-- Ensure firewall rules allow HTTP/HTTPS traffic to LoadBalancers
-
-</details>
-
-<details>
-<summary>Microsoft Azure (AKS)</summary>
-
-- LoadBalancers return IPs directly — no special handling needed
-- Ensure Network Security Groups allow HTTP/HTTPS traffic
-
-</details>
-
-<details>
-<summary>Rancher Desktop / k3s</summary>
-
-- Remove Traefik before installation (see [Step 1](#step-1-install-cluster-prerequisites))
 - Single-node clusters work for development but may run low on resources with all observability modules
 - LoadBalancer IPs are assigned via the built-in k3s servicelb
 - **cgroup `pids` controller issue** — see [Build workflow fails with cgroup pids error](#build-workflow-fails-with-cgroup-pids-error) in Troubleshooting
+
+k3s ships with Traefik which binds to host ports 80/443 and conflicts with OpenChoreo's kgateway. Remove Traefik before [Step 1](#step-1-install-cluster-prerequisites):
+
+```bash
+helm uninstall traefik -n kube-system
+helm uninstall traefik-crd -n kube-system
+```
+
+After removing Traefik, re-apply the Gateway API CRDs (Traefik's CRD chart may have removed them):
+
+```bash
+kubectl apply --server-side --force-conflicts \
+  -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml
+```
 
 </details>
 
@@ -1318,22 +1646,6 @@ kubectl delete namespace wso2-amp amp-thunder \
   openchoreo-data-plane openchoreo-control-plane \
   openbao external-secrets cert-manager
 ```
-
----
-
-## Production Considerations
-
-The main flow above already covers real domains, trusted wildcard TLS, and gateway-served endpoints. Beyond it, plan for:
-
-1. **Managed dependencies** — apply the **Production** callouts inline above: external PostgreSQL, OpenBao without dev mode, OpenSearch persistence
-2. **Identity provider** — the seeded `admin`/`admin` user is for bootstrap only; connect your organization's IdP or manage users in Thunder before exposing the platform
-3. **JWT authentication** — Set `IS_LOCAL_DEV_ENV=false` and configure `KEY_MANAGER_JWKS_URL` for `agent-manager-service` and `agent-manager-observer` before exposing either service; when unset, JWT signature verification is skipped and only the token payload is decoded
-4. **High availability** — deploy multiple replicas across availability zones and adjust resource requests/limits to workload
-5. **Security hardening** — scoped RBAC, pod security standards, and confirm your CNI actually
-   enforces the `NetworkPolicy` resources this platform ships (see the Cluster Requirements note
-   above) — an EKS/AKS/GKE cluster without a policy engine selected silently accepts these
-   objects without blocking anything
-6. **Certificate operations** — with Let's Encrypt, renewals are automatic; monitor cert-manager and keep the DNS-provider credentials Secret rotated
 
 ---
 


### PR DESCRIPTION
## Purpose

The **On Your Environment** guide is the entry point for deploying Agent Manager on a real cluster, but it was written as an install walkthrough with production advice gathered into a trailing section. That structure breaks down for settings that cannot be changed after installation.

Thunder seeds every platform OAuth client into its database through a `pre-install` hook that `helm upgrade` never re-runs. Its database, its client secrets, and its issuer/redirect hostnames are therefore frozen at first boot. A reader who followed the install steps and only then worked through the trailing "production" section would find that the guidance could not be applied without uninstalling Thunder and discarding its data — and, because pointing Thunder at a fresh database yields one with no OAuth clients in it, nothing on the platform would be able to authenticate.

Verifying the rest of the guide against the charts turned up several more instructions that could not work as written (detailed under Approach).

Review of this PR also surfaced a gap the documentation could only describe, not fix: the Agent Manager built its database connection string with no SSL mode, so pgx applied its libpq default of `prefer` — TLS when the server offers it, and a **silent** fall back to plaintext when it does not. No chart value could require it. Rather than ship a guide that documents that as unavoidable, this PR closes it.

Related https://github.com/wso2/agent-manager/issues/1058

## Goals

- Make the guide produce a production deployment when followed top to bottom, rather than requiring a second pass.
- Put every production setting at the step that applies it, so a setting is never described after the point where it had to be chosen.
- State plainly which decisions are irreversible, and front-load them.
- Correct the instructions that were factually wrong about the charts.
- Let an operator require TLS on the database connection, so it fails closed instead of downgrading silently.

## Approach

**Production configuration moved inline.** Each step that has a development/production split now offers both as tabs. The tab groups share a `groupId`, so choosing "Production" once carries through the page; the same mechanism syncs the Let's Encrypt/Corporate CA choice between the TLS issuer step and the per-environment Thunder step, which previously relied on the reader remembering their earlier choice.

**Two new planning subsections.** *Decisions you cannot change later* is a table of the five settings frozen at first boot, each linking to the step that fixes it. *Platform secrets* generates every internal credential up front with `openssl rand` and tabulates which chart sets each one and which other charts must match, so the steps reference variables instead of shipping well-known placeholder secrets.

**Thunder and OpenBao gained real production paths.** Thunder can now be installed against external PostgreSQL for all three of its logical databases, with the password supplied by `passwordRef` so it stays out of Helm release history. OpenBao's production tab covers the sealed install, `bao operator init`/unseal, and the KV mount, Kubernetes auth role, policies, and secret seeding that dev mode had been performing invisibly — a sealed installation does not create the `secret/` mount on its own, which the guide never mentioned.

**The trailing section became a reference.** It now leads with a checklist recording where each item is applied and whether it can still be applied to a running platform, followed only by concerns that belong to no single step: identity, gateway hardening, build workflows, high availability, cluster security, and agent isolation.

**Whole-page development/production tabs were considered and rejected.** Docusaurus emits headings from *every* tab into the table of contents regardless of which tab is selected (verified by building a test page and inspecting the output), so that approach would have listed every install step twice and left anchor links resolving into tabs that are not visible. It would also have duplicated content that the Quick Start, k3d, and VM guides already cover.

**Requiring TLS on the database connection (chart + service).** `DB_SSL_MODE` and `DB_SSL_ROOT_CERT` are threaded through the config loader and `makeConnString`, surfaced as `postgresql.external.sslMode` and `.sslRootCert`, and rendered for **both** workloads that open a connection — the API deployment and the migration job, which runs the same binary through the same DSN builder.

Both default to empty, which emits no query string at all: the DSN stays byte-identical to earlier builds, pgx keeps its `prefer` default, and `PGSSLMODE` still works. A full `helm template` diff against `main` for the default and external-without-`sslMode` cases is identical except the chart's own random secrets. The values are also ignored while `postgresql.enabled` is true, since the bundled PostgreSQL listens without TLS and `require` would otherwise fail the API pod and the post-install migration hook on a default install. An invalid mode is rejected at config load with the accepted values listed, rather than surfacing as an opaque driver error on first connect.

`verify-ca` and `verify-full` work as well: pgx falls back to the image trust store, so `verify-full` needs no mounted CA for a database whose certificate chains to a public one — `sslRootCert` accepts the literal `system` for that, or a path to a PEM mounted through the chart's existing `volumes`/`volumeMounts` values. Those two values were rendered only by the API deployment, so the migration job now renders them too; without that, a private CA reached the API but not the post-install migration hook, failing the install with `x509: unknown authority`. A dedicated, purpose-named CA value is still deferred as unnecessary now that the generic hook covers both workloads.

Note the value is `sslMode` (camelCase, matching every other key in this chart) where the `thunderid` subchart uses `sslmode`. That subchart's default of `require` is not usable precedent for defaulting the same way here: this platform forces all three Thunder databases to SQLite, so that block is dead config.

**Corrections made while verifying against the charts:**

| Issue | Correction |
|---|---|
| OpenChoreo API was published on the control-plane gateway | Disabled via `openchoreoApi.http.enabled=false`; the API is reached over cluster DNS, and its hostname, DNS record, and access-table row are removed |
| OpenSearch persistence values used the `opensearch` alias | The subchart alias is `openSearch`; the documented values were silently ignored. The guide also described the storage as ephemeral, when the chart renders a small persistent volume |
| Changing the OpenSearch password appeared to be a single change | The logs module also passes the password to OpenSearch through `openSearch.extraEnvs`; without a matching override the two sides disagree and all observability queries fail authentication |
| Per-environment Thunder hostnames had no TLS or DNS coverage | Added `*.thunder.<base>` to the control-plane gateway certificate and the DNS records, with a note that RFC 4592 makes an explicit `thunder.<base>` record mandatory once that wildcard exists |
| Gateway encryption keys were documented as a chart value | The extension does not expose one; the guide now describes the values-ConfigMap procedure and that it must be re-applied after chart upgrades |
| Evaluation publishing was described as a static API key | It authenticates with the `amp-publisher-client` OAuth2 credentials read from OpenBao at workflow runtime |
| `kubectl wait` on the PostgreSQL StatefulSet was unconditional | No StatefulSet exists with an external database; the wait is now part of the development variant only |
| The guide said TLS could not be required from the client | It can now; the production path sets `sslMode=require` and the warning explains what `require` does and does not verify |

The shared Phase 2 partial (`_amp-installation.mdx`) is used by the k3d guide as well, so its production content is behind a `production` prop. The k3d guide is unchanged in rendered output.

## User stories

- As a platform engineer deploying Agent Manager to a production cluster, I can follow the guide once and end up with a production-grade deployment, instead of installing and then discovering that some hardening steps required a reinstall.
- As a platform engineer, I can see before I start which decisions are permanent, so I can gather the databases and credentials I need in advance.
- As an evaluator, I can still follow the same page with development-grade defaults by choosing the evaluation tabs.
- As a platform engineer, I can require TLS on the database connection so a server that stops enforcing it causes a visible failure rather than a silent downgrade to plaintext.

## Release note

Rewrote the On Your Environment installation guide as a production deployment guide, with production configuration presented inline at each step, an explicit list of settings that cannot be changed after installation, and generated platform secrets replacing the shipped defaults.

Added `postgresql.external.sslMode` and `postgresql.external.sslRootCert` to the Agent Manager chart, allowing TLS to be required (and the server certificate verified) on the connection to an external PostgreSQL database. Defaults are unchanged: without these values the connection behaves exactly as before.

## Documentation

This PR is the documentation change. The affected page is `documentation/docs/getting-started/on-your-environment.mdx`, published at `/docs/next/getting-started/on-your-environment/`.

## Training

N/A — no training content covers platform installation.

## Certification

N/A — installation procedure changes are not covered by certification exams.

## Marketing

N/A — documentation correction and restructure, no new product capability to promote.

## Automation tests

- Unit tests
  > `config` and `db` gain coverage for the new settings — `config_loader_test.go` (+71) for the allowlist and whitespace handling, and a new `db_test.go` (~130) for DSN construction, in a package that previously had no tests. `make test-unit` passes: `ok config (77.7% coverage)`, `ok db (14.3%)`. `make codegenfmt-check` is clean, and `go mod tidy` produces no drift.
- Integration tests
  > The chart's render assertions (`deployments/helm-charts/wso2-agent-manager/tests/render.sh`, run by CI) gain 9 cases covering the backward-compatibility contract: no TLS env rendered by default or for an external database without `sslMode`; `sslMode` and `sslRootCert` reaching **both** the API deployment and the migration job; and `sslMode` being ignored for the in-cluster database. All 19 assertions pass, including the pre-existing ones.
  >
  > The service was additionally exercised against real PostgreSQL containers on the migration-job code path (`-migrate -server=false`): plaintext with no settings runs all 36 migrations; plaintext with `require` fails with `server refused TLS connection`; an invalid mode is rejected before connecting; a TLS server with `require` connects; `verify-full` without a CA fails with `x509: unknown authority` and succeeds once `sslRootCert` is supplied.
  >
  > For the documentation, the Docusaurus production build runs with `onBrokenLinks: 'throw'`, validating every internal link and anchor. Rendered output was asserted for both affected pages to confirm production content appears only on the production guide and the k3d guide keeps its development variants.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Java tooling; this is Go and Helm. The Go changes are covered by the repository's `golangci-lint` configuration in CI
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the guide generates credentials with `openssl rand` at install time and references them through shell variables and Kubernetes Secret references; no real credential values are committed. The database password continues to be read from a Kubernetes Secret, and the new TLS settings carry no secret material
- Note on the security posture of the change: `require` encrypts but does not authenticate the server, so `verify-full` with `sslRootCert` is documented as the stronger option, and server-side enforcement is still recommended alongside the client setting because the client cannot downgrade it

## Samples

N/A — no samples relate to this change.

## Related PRs

None.

## Migrations (if applicable)

No migration is required for existing installations, and no action is forced by the chart change: with `sslMode` unset the rendered manifests and the connection string are unchanged, which is asserted by both a full `helm template` diff against `main` and the chart render tests.

Operators who want to adopt it should confirm their database presents a TLS certificate before setting `require`, since the connection will then refuse to fall back. The guidance otherwise targets new deployments; existing installations remain supported, though operators may want to review the Production Reference checklist — in particular the OpenSearch admin password and the per-environment Thunder DNS and certificate coverage.

## Test environment

macOS. Documentation build via the repository's Docusaurus toolchain (`npm run build` in `documentation/`). Go build and unit tests via `make test-unit`; formatting and codegen via `make codegenfmt-check`. Chart rendering with Helm (local v4.0.5 — CI pins 3.19.4; only long-standing `with`/`trim`/`nindent`/`include` constructs are used) plus `helm lint --strict`. The TLS behaviour was exercised against PostgreSQL 16 containers, with and without a server certificate.

Not verified: a real RDS, Cloud SQL, or Azure Flexible Server instance; `golangci-lint` with the repository configuration (the local binary predates the config's schema version); and `verify-ca` separately from `verify-full`, which shares the same driver branch.

The install procedures themselves have not yet been executed end to end on a cloud cluster — the newly written Thunder external-PostgreSQL and sealed-OpenBao paths in particular have not been run, and remain the highest priority for a validation run before this guidance is relied upon.

## Learning

The structural question — inline production configuration versus development/production tabs spanning the page — was settled by looking at how comparable self-hosted products document the same split, and by testing the Docusaurus behaviour directly.

[Keycloak](https://www.keycloak.org/server/configuration-production) is the closest analogue, an identity product whose development mode is backed by an embedded database; it keeps a standalone production configuration guide and links to it from the getting-started pages rather than tabbing them together. [Temporal](https://docs.temporal.io/self-hosted-guide/deployment) organises by deployment method and embeds production guidance inline within each. [OpenChoreo](https://openchoreo.dev/docs/getting-started/try-it-out/on-your-environment/#production-configuration), which this platform builds on, keeps a lean install flow with a production section that links out per component. None of them tab an entire install page.

On the database TLS change, the alternative considered was a generic `extraEnv` hook to inject `PGSSLMODE`, which needs no Go change and was verified to work. It was rejected because the migration job has no `extraEnv` hook either, so both designs require editing `db-migration-job.yaml` — at which point the typed value costs about fourteen further lines of Go and buys load-time validation, a documented `values.yaml` entry, and parity with the `thunderid` subchart. Confirming that the migration job shares `makeConnString` (it runs the same binary with `-migrate`, over `gormigrate`, with no second DSN builder anywhere in the repository) was what made the change small enough to be worth doing properly.

The deciding technical detail was Docusaurus' [table of contents behaviour](https://docusaurus.io/docs/markdown-features/tabs): headings inside `<TabItem>` are collected into the page TOC regardless of the selected tab. A scratch page confirmed both variants of a heading appear, which rules out the whole-page tab approach for a guide whose structure is its ten numbered steps. Tabs are used only where a genuine either/or lives inside a single step, which is what they are designed for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added production-first installation guidance with separate Production and Evaluation paths across setup steps.
  - Enabled secure external PostgreSQL connections with configurable TLS settings, including CA certificate support, for runtime services and database migrations.
- **Documentation**
  - Expanded environment planning, TLS and issuer guidance, Thunder/PostgreSQL/Evaluation instructions, registry requirements, and troubleshooting.
  - Added warnings about settings requiring reinstallation and clarified secret, certificate, and OpenBao persistence expectations.
- **Bug Fixes**
  - Added validation for unsupported PostgreSQL TLS modes to prevent invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->