### PR TITLE
Reject mismatched project path in agent token generation with 400

### DIFF
--- a/agent-manager-service/services/agent_token_manager.go
+++ b/agent-manager-service/services/agent_token_manager.go
@@ -29,6 +29,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -255,11 +256,21 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 		return nil, fmt.Errorf("org id is required: %w", utils.ErrInvalidInput)
 	}
 
-	// Fetch component UID from OpenChoreo
+	// Fetch component UID from OpenChoreo. Agent names are unique organization-wide,
+	// not per-project, so this resolves by name alone regardless of req.ProjectName.
 	component, err := s.ocClient.GetComponent(ctx, req.OrgName, req.ProjectName, req.AgentName)
 	if err != nil {
 		s.logger.Error("Failed to get agent component", "agentName", req.AgentName, "error", err)
-		return nil, fmt.Errorf("failed to get agent component: %w", err)
+		return nil, translateAgentError(err)
+	}
+
+	// The request path names both a project and an agent; reject the request if
+	// they don't actually belong together rather than silently using the agent's
+	// real project. This isn't an access-control check — org membership already
+	// grants access to every project and every agent in it — it's input validation:
+	// a path that names an agent under a project it doesn't belong to is malformed.
+	if !strings.EqualFold(component.ProjectName, req.ProjectName) {
+		return nil, fmt.Errorf("agent %q does not belong to project %q: %w", req.AgentName, req.ProjectName, utils.ErrInvalidInput)
 	}
 
 	// Determine which environment to use

--- a/agent-manager-service/services/agent_token_manager_unit_test.go
+++ b/agent-manager-service/services/agent_token_manager_unit_test.go
@@ -148,7 +148,7 @@ func TestAgentTokenManager_GenerateToken_ValidationGates(t *testing.T) {
 		// before GetEnvironment, so GetEnvironment must stay unconfigured.
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
-				return &models.AgentResponse{UUID: "comp-uuid"}, nil
+				return &models.AgentResponse{UUID: "comp-uuid", ProjectName: "proj"}, nil
 			},
 		}
 		svc := newTokenManager(t, oc)
@@ -193,7 +193,7 @@ func TestAgentTokenManager_GenerateToken_ClientErrors(t *testing.T) {
 		boom := errors.New("environment lookup failed")
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
-				return &models.AgentResponse{UUID: "comp-uuid"}, nil
+				return &models.AgentResponse{UUID: "comp-uuid", ProjectName: base.ProjectName}, nil
 			},
 			GetEnvironmentFunc: func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
 				return nil, boom
@@ -207,11 +207,64 @@ func TestAgentTokenManager_GenerateToken_ClientErrors(t *testing.T) {
 		assert.ErrorIs(t, err, boom)
 	})
 
+	t.Run("rejects a project path that doesn't match the agent's real project", func(t *testing.T) {
+		// Agent names are unique organization-wide, not per-project, so GetComponent
+		// resolves by name regardless of what req.ProjectName says. This isn't an
+		// access-control gate — org membership already grants access to every project
+		// and agent in it — it's input validation: a request path naming a project
+		// the agent doesn't belong to is malformed and must be rejected with 400,
+		// not silently corrected to the agent's real project.
+		oc := &clientmocks.OpenChoreoClientMock{
+			GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+				return &models.AgentResponse{UUID: "comp-uuid", ProjectName: "actual-project"}, nil
+			},
+		}
+		svc := newTokenManager(t, oc)
+
+		req := base
+		req.ProjectName = "requested-project" // deliberately different from the agent's real project
+
+		resp, err := svc.GenerateToken(context.Background(), req)
+
+		require.Error(t, err)
+		assert.Nil(t, resp)
+		assert.ErrorIs(t, err, utils.ErrInvalidInput)
+	})
+
+	t.Run("accepts a project path that matches the agent's real project (case-insensitive)", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{
+			GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+				return &models.AgentResponse{UUID: "comp-uuid", ProjectName: "Proj"}, nil
+			},
+			GetEnvironmentFunc: func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
+				return &models.EnvironmentResponse{UUID: "env-uuid"}, nil
+			},
+			GetProjectFunc: func(_ context.Context, _, _ string) (*models.ProjectResponse, error) {
+				return &models.ProjectResponse{UUID: "proj-uuid"}, nil
+			},
+			ListOrganizationsFunc: func(_ context.Context) ([]*models.OrganizationResponse, error) {
+				return []*models.OrganizationResponse{{Namespace: "acme-namespace"}}, nil
+			},
+		}
+		svc := newTokenManager(t, oc)
+
+		resp, err := svc.GenerateToken(context.Background(), base) // base.ProjectName == "proj"
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		parser := jwt.NewParser()
+		claims := &AgentTokenClaims{}
+		_, _, err = parser.ParseUnverified(resp.Token, claims)
+		require.NoError(t, err)
+		assert.Equal(t, "proj-uuid", claims.ProjectUid)
+	})
+
 	t.Run("propagates GetProject error", func(t *testing.T) {
 		boom := errors.New("project lookup failed")
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
-				return &models.AgentResponse{UUID: "comp-uuid"}, nil
+				return &models.AgentResponse{UUID: "comp-uuid", ProjectName: base.ProjectName}, nil
 			},
 			GetEnvironmentFunc: func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
 				return &models.EnvironmentResponse{UUID: "env-uuid"}, nil
@@ -233,8 +286,11 @@ func TestAgentTokenManager_GenerateToken_ClientErrors(t *testing.T) {
 // UUIDs, used to drive the happy path and expiry-validation branches.
 func fullClientMock(compUID, envUID, projUID string) *clientmocks.OpenChoreoClientMock {
 	return &clientmocks.OpenChoreoClientMock{
-		GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
-			return &models.AgentResponse{UUID: compUID}, nil
+		// Echoes back the requested projectName so the real-project validation in
+		// GenerateToken always passes here — this helper drives the happy-path and
+		// expiry tests, not project-mismatch behavior (see the dedicated tests for that).
+		GetComponentFunc: func(_ context.Context, _, projectName, _ string) (*models.AgentResponse, error) {
+			return &models.AgentResponse{UUID: compUID, ProjectName: projectName}, nil
 		},
 		GetEnvironmentFunc: func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
 			return &models.EnvironmentResponse{UUID: envUID}, nil


### PR DESCRIPTION
## Purpose
External Agent API key (token) generation resolved an agent purely by name, since agent names are unique per organization and not per project, but never checked that the project named in the URL actually matches the agent's real project. A request naming the wrong project for a real agent still succeeded and returned a valid token labeled with the wrong project's ID.
- Resolved : https://github.com/wso2/agent-manager/issues/1441

## Goals
- Reject an agent token generation request with a 400 error when the project in the path does not own the named agent.
- Keep correct, matching-project requests working exactly as before.

## Approach
- `agent_token_manager.go`: after resolving the agent by name, compare `component.ProjectName` to `req.ProjectName` case-insensitively using `strings.EqualFold`.
- On mismatch, return an error wrapped in `utils.ErrInvalidInput`, which the existing controller error handling already maps to a 400 response.
- On a match, behavior is unchanged, the rest of token generation proceeds exactly as before.
- Routed the agent-lookup failure through the existing `translateAgentError` helper, so a genuinely nonexistent agent now correctly returns 404 instead of falling through to a generic 500.
- Updated `agent_token_manager_unit_test.go` with a test for the mismatch case, a case-insensitive match test that checks the resulting token's `project_uid` claim, and adjusted the mocks in three existing tests so they still exercise their original intent under the new check.

## User stories
As an org member calling the agent-token endpoint, if I put the wrong project in the URL for an agent, I get a clear 400 error immediately instead of a token that is silently generated and mislabeled with the wrong project.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   `agent_token_manager_unit_test.go` covers the mismatch case (asserts `utils.ErrInvalidInput`), the case-insensitive match case (asserts the token's `project_uid` claim), and three pre-existing tests whose mocks were adjusted to keep exercising their original branch under the new check. `make test-unit`: all packages pass.
 - Integration tests
   Not run this session. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
macOS (Darwin), local Docker Compose and k3d dev stack (agent-manager-service, OpenChoreo, ThunderID) for live verification, Go 1.25.7. `golangci-lint` run with the repo's own CI config (`.github/linters/.golangci.yaml`), 0 issues.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token generation validation by ensuring the requested project matches the agent’s actual project, regardless of letter case.
  * Prevented token issuance for invalid project paths.
  * Improved error messages when agent or project retrieval fails.
  * Added coverage for project validation, matching behavior, and related error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->