### PR TITLE
Remove leftover conflict marker in setup-openchoreo.sh

### DIFF
--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -408,23 +408,6 @@ echo "All core OpenChoreo planes are installed and registered!"
 # setup-default-env-thunder target: it needs AMS up (store_via_ams).
 # ============================================================================
 echo ""
-# Step 6: Install Observability Extension (Agent Manager Observer)
-# ============================================================================
-echo "6️⃣  Observability Extension (Agent Manager Observer)"
-if ! helm status wso2-amp-observability-extension -n openchoreo-observability-plane &>/dev/null; then
-    echo "Building and loading Agent Manager Observer Docker image into k3d cluster..."
-    make -C ${PROJECT_ROOT}/agent-manager-observer docker-load-k3d
-    sleep 10
-fi
-echo "   Installing/upgrading Agent Manager Observer (local dev: JWKS disabled, unverified JWT parse)..."
-helm upgrade --install wso2-amp-observability-extension ${PROJECT_ROOT}/deployments/helm-charts/wso2-amp-observability-extension \
-    --create-namespace \
-    --namespace openchoreo-observability-plane \
-    --timeout=10m \
-    --set amObserver.developmentMode=true \
-    --set amObserver.auth.isLocalDevEnv=true \
-    --set-string amObserver.auth.jwksUrl=""
-=======
 echo "5️⃣ +6️⃣  AMP Extensions"
 "${SCRIPT_DIR}/setup-amp-extensions.sh" "${PROJECT_ROOT}" || exit 1
 echo ""


### PR DESCRIPTION
## Purpose
A bad merge resolution in #1440 left a bare `=======` conflict marker at `deployments/setup/setup-openchoreo.sh:427`, together with the old inline Step 6 observability-extension install block that the new `setup-amp-extensions.sh` was meant to replace. Bash executes the marker as a command and exits 127, so every `make setup-openchoreo` run on `main` fails at the end of the script. This broke the nightly instrumentation-matrix run (https://github.com/wso2/agent-manager/actions/runs/30584098912/job/91018087395), which dies in the `amp-dev-stack` setup step before any test cells run, and equally breaks fresh local `make setup`.

## Goals
Make `make setup-openchoreo` (and everything layered on it: `make setup`, the `amp-dev-stack` CI action, the nightly matrix) run to completion again on `main`.

## Approach
Delete the stray `=======` marker and the duplicated old Step 6 block. `setup-amp-extensions.sh` already builds/loads the observer image and performs the identical `wso2-amp-observability-extension` helm upgrade, so the extracted script remains the sole owner of that step, as #1440 intended. The change is a pure 17-line deletion; `bash -n` passes and a repo-wide sweep confirms no other conflict markers remain.

## User stories
N/A — developer/CI tooling fix, no user-facing behavior change.

## Release note
N/A — fixes a broken merge in an internal setup script; no released functionality affected.

## Documentation
N/A — no doc impact; the script's documented behavior is unchanged.

## Training
N/A

## Certification
N/A — internal dev/CI setup script fix, no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — shell setup script; no unit-test harness covers it.
 - Integration tests
   > Verified with `bash -n deployments/setup/setup-openchoreo.sh` (syntax OK) and `git grep` confirming no conflict markers remain repo-wide. The nightly instrumentation-matrix workflow exercises this script end-to-end and will validate the fix on its next run.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell script change, no Java code.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
Introduced by #1440.

## Migrations (if applicable)
N/A

## Test environment
macOS 15 (Darwin 25.5.0), verified with `bash -n`; the script itself targets the k3d-based dev/CI stack.

## Learning
N/A — straightforward merge-conflict cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment setup by delegating AMP extension installation to a dedicated setup process.
  * Deployment setup now stops immediately if AMP extension installation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->