### PR TITLE
Allow deployments to use the configured instrumentation URL

### DIFF
--- a/console/workspaces/libs/types/src/config/index.ts
+++ b/console/workspaces/libs/types/src/config/index.ts
@@ -41,6 +41,14 @@ export interface AppConfig {
   rbacEnabled: boolean;
   instrumentationUrl: string;
   /**
+   * When true, the OTEL endpoint shown in the Setup Agent panel is
+   * `instrumentationUrl` as-is. Enable this in deployments where one endpoint
+   * fronts every environment, or where the gateway vhost is not externally
+   * reachable. Defaults to false: the endpoint is derived per environment from
+   * the vhost of the gateway mapped to that environment.
+   */
+  useConfiguredInstrumentationUrl?: boolean;
+  /**
    * Base URL the API Platform Gateway uses to reach Agent Manager from inside
    * the cluster. The add-environment.sh script appends /api/v1 and
    * /auth/external/jwks.json to this as needed.

--- a/console/workspaces/pages/overview/src/AgentOverview/ExternalAgentOverview.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/ExternalAgentOverview.tsx
@@ -53,17 +53,22 @@ export const ExternalAgentOverview = () => {
     useSelectedEnvironmentParam(sortedEnvironmentList);
   const selectedEnvironmentId = selectedEnvironment?.id ?? "";
 
-  // Per-env OTEL endpoint. The gateway mapped to the selected environment carries
-  // the externally-reachable vhost; the OTEL RestApi is published at `<vhost>/otel`.
-  // Falls back to globalConfig only when the gateway lookup hasn't resolved yet
-  // (e.g. before an env is selected). useListGateways has no `enabled` option, so
-  // orgName is withheld until an environment is selected to avoid firing a
-  // throwaway `environment: ""` request that'd otherwise be discarded moments later.
+  // OTEL endpoint for the Setup Agent panel. By default it is derived per
+  // environment: the gateway mapped to the selected environment carries the
+  // externally-reachable vhost, and the OTEL RestApi is published at
+  // `<vhost>/otel`; the configured URL is the fallback until that lookup
+  // resolves. A deployment that sets useConfiguredInstrumentationUrl takes the
+  // configured URL as-is, so the gateway lookup is skipped entirely.
+  // useListGateways has no `enabled` option, so orgName is withheld until the
+  // lookup is actually needed to avoid firing a throwaway request.
+  const derivesUrlFromGateway = !globalConfig.useConfiguredInstrumentationUrl;
   const { data: envGatewayList } = useListGateways(
-    { orgName: selectedEnvironmentId ? (orgId ?? "") : "" },
+    { orgName: derivesUrlFromGateway && selectedEnvironmentId ? (orgId ?? "") : "" },
     { environment: selectedEnvironmentId },
   );
-  const envGatewayVhost = envGatewayList?.gateways?.[0]?.vhost;
+  const envGatewayVhost = derivesUrlFromGateway
+    ? envGatewayList?.gateways?.[0]?.vhost
+    : undefined;
   const agentInstrumentationUrl = envGatewayVhost
     ? `${envGatewayVhost.replace(/\/$/, "")}/otel`
     : (globalConfig.instrumentationUrl || "http://default-default.gateway.localhost:19080/otel");


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The Setup Agent panel derives the OTEL endpoint per environment from the vhost of the gateway mapped to that environment. Deployments where a single endpoint fronts every environment, or where the gateway vhost is not externally reachable, have no vhost to derive from.

Add the optional useConfiguredInstrumentationUrl config flag. When set, the panel uses instrumentationUrl as-is and the gateway lookup is skipped entirely. It defaults to false, so existing deployments keep deriving the endpoint per environment with no config change.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to use a configured instrumentation endpoint directly.
  * Instrumentation URLs now adapt based on the selected environment and organization when configured endpoints are not enabled.

* **Bug Fixes**
  * Improved instrumentation URL selection to avoid unnecessary gateway lookups and preserve fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->