### PR TITLE
Fix internal agent identity secret regeneration failing on internal agents

### DIFF
--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -209,11 +209,30 @@ func agentIdentitySecretLocation(ouID, projectName, agentName, envName string) s
 // SecretManagementClient.CreateSecret's doc comment), not the raw KV path.
 func (s *agentThunderProvisioningService) storeCredential(ctx context.Context, ouID, projectName, agentName, envName, clientID, clientSecret string) (string, error) {
 	location := agentIdentitySecretLocation(ouID, projectName, agentName, envName)
-	if _, err := s.secretMgmtClient.CreateSecret(ctx, location, map[string]string{
+	data := map[string]string{
 		thundersvc.AgentSecretKeyClientID:     clientID,
 		thundersvc.AgentSecretKeyClientSecret: clientSecret,
-	}); err != nil {
-		return "", err
+	}
+	if _, err := s.secretMgmtClient.CreateSecret(ctx, location, data); err != nil {
+		if !errors.Is(err, utils.ErrNotFound) {
+			return "", err
+		}
+		// An already-provisioned internal agent already has a SecretReference
+		// for this name, owned by the identity injection reconciler rather
+		// than by this code, which is why the create above failed here.
+		// Delete it and create again: the retry succeeds because it's now a
+		// plain create with nothing in the way, same as a brand-new agent's
+		// first credential.
+		injector := s.getWorkloadInjector()
+		if injector == nil {
+			return "", err
+		}
+		if cleanupErr := injector.CleanupForEnvironment(ctx, ouID, agentName, envName); cleanupErr != nil {
+			return "", fmt.Errorf("clear existing SecretReference before retry: %w", err)
+		}
+		if _, retryErr := s.secretMgmtClient.CreateSecret(ctx, location, data); retryErr != nil {
+			return "", retryErr
+		}
 	}
 	kvPath, err := location.KVPath()
 	if err != nil {

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -201,6 +202,18 @@ func agentIdentitySecretLocation(ouID, projectName, agentName, envName string) s
 	}
 }
 
+// createSecretConflictRetryMarker is the exact substring
+// secretmanagersvc's OpenChoreo provider includes only when a create
+// conflict's own fallback update then also fails (PushSecret's "failed to
+// update secret after create conflict" wrap in
+// clients/secretmanagersvc/providers/openchoreo/client.go). The secret
+// manager doesn't expose a distinct sentinel for this exact shape, so this
+// is the only way to tell it apart from other, unrelated not-found errors
+// (e.g. a secret that existed and vanished before an update, or a create
+// that failed for an unrelated reason) without changing the secret manager
+// itself.
+const createSecretConflictRetryMarker = "after create conflict"
+
 // storeCredential writes the client ID/secret pair for one binding via the
 // shared secret management client and returns the KV path to persist in
 // AgentThunderClient.SecretRefPath — computed directly from the location
@@ -214,7 +227,7 @@ func (s *agentThunderProvisioningService) storeCredential(ctx context.Context, o
 		thundersvc.AgentSecretKeyClientSecret: clientSecret,
 	}
 	if _, err := s.secretMgmtClient.CreateSecret(ctx, location, data); err != nil {
-		if !errors.Is(err, utils.ErrNotFound) {
+		if !errors.Is(err, utils.ErrNotFound) || !strings.Contains(err.Error(), createSecretConflictRetryMarker) {
 			return "", err
 		}
 		// An already-provisioned internal agent already has a SecretReference
@@ -228,7 +241,7 @@ func (s *agentThunderProvisioningService) storeCredential(ctx context.Context, o
 			return "", err
 		}
 		if cleanupErr := injector.CleanupForEnvironment(ctx, ouID, agentName, envName); cleanupErr != nil {
-			return "", fmt.Errorf("clear existing SecretReference before retry: %w", err)
+			return "", fmt.Errorf("clear existing SecretReference before retry: %w: %w", cleanupErr, err)
 		}
 		if _, retryErr := s.secretMgmtClient.CreateSecret(ctx, location, data); retryErr != nil {
 			return "", retryErr

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -621,6 +621,292 @@ func TestRegenerateSecret_Internal_StoresSecret(t *testing.T) {
 		"the persisted SecretRefPath is the deterministic KV path derived from the binding's own fields")
 }
 
+// TestRegenerateSecret_Internal_ExistingSecretReference_CleansUpAndRetries
+// covers an already-provisioned internal agent whose SecretReference was
+// created outside the secret manager's own bookkeeping (the shape the
+// identity injection reconciler produces): the first CreateSecret reports
+// not-found, storeCredential clears the stray SecretReference via the
+// workload injector and retries once, and that retry succeeding is enough
+// for the whole rotation to succeed.
+func TestRegenerateSecret_Internal_ExistingSecretReference_CleansUpAndRetries(t *testing.T) {
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
+		return "new-secret", nil
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+
+	var createCalls int
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(_ context.Context, _ secretmanagersvc.SecretLocation, data map[string]string) (string, error) {
+			createCalls++
+			if createCalls == 1 {
+				return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+			}
+			assert.Equal(t, "new-secret", data[thundersvc.AgentSecretKeyClientSecret],
+				"the retry must persist the same rotated value as the failed first attempt")
+			return "ref", nil
+		},
+	}
+
+	var cleanedUpAgent string
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(_ context.Context, _, agentName, _ string) error {
+			cleanedUpAgent = agentName
+			return nil
+		},
+	}
+
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error { return nil },
+	}
+
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	ownership, _, newSecret, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
+
+	require.NoError(t, err)
+	assert.Equal(t, models.AgentProvisioningTypeInternal, ownership)
+	assert.Equal(t, "new-secret", newSecret)
+	assert.Equal(t, 2, createCalls, "expected exactly one retry after the cleanup")
+	assert.Equal(t, "my-agent", cleanedUpAgent)
+}
+
+// TestRegenerateSecret_Internal_ExistingSecretReference_NoInjector_ReturnsOriginalError
+// guards against silently dropping the rotation when no workload injector is
+// configured to perform the cleanup — the caller must still see a failure
+// rather than a false success with the secret left unstored.
+func TestRegenerateSecret_Internal_ExistingSecretReference_NoInjector_ReturnsOriginalError(t *testing.T) {
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
+		return "new-secret", nil
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
+			return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+		},
+	}
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+	}
+
+	svc := newTestProvisioningService(repo, resolver, store)
+	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, utils.ErrNotFound)
+}
+
+// TestRegenerateSecret_Internal_UnrelatedCreateSecretError_NotRetried guards
+// against over-broadening the recovery: a failure unrelated to an existing
+// SecretReference (no not-found in its chain) must surface immediately,
+// without ever invoking cleanup or a retry.
+func TestRegenerateSecret_Internal_UnrelatedCreateSecretError_NotRetried(t *testing.T) {
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
+		return "new-secret", nil
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+	var createCalls int
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
+			createCalls++
+			return "", errors.New("connection refused")
+		},
+	}
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
+			t.Fatal("must not clean up the SecretReference for an unrelated error")
+			return nil
+		},
+	}
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+	}
+
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
+
+	require.Error(t, err)
+	assert.Equal(t, 1, createCalls, "must not retry a failure that isn't the existing-SecretReference shape")
+}
+
+// TestRegenerateSecret_Internal_CleanupItselfFails_ReturnsWrappedError guards
+// against attempting the retry on an unconfirmed cleanup: if clearing the
+// stray SecretReference itself errors, the original create failure must
+// still be visible to the caller rather than a confusing swallowed retry.
+func TestRegenerateSecret_Internal_CleanupItselfFails_ReturnsWrappedError(t *testing.T) {
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
+		return "new-secret", nil
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+	var createCalls int
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
+			createCalls++
+			return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+		},
+	}
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
+			return errors.New("openchoreo api unavailable")
+		},
+	}
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+	}
+
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, utils.ErrNotFound, "the original create failure stays visible alongside the cleanup failure")
+	assert.Equal(t, 1, createCalls, "no retry without a confirmed cleanup")
+}
+
+// TestRegenerateSecret_Internal_RetryAlsoFails_ReturnsRetryErrorWithoutLooping
+// guards against an unbounded retry loop: if the SecretReference reappears
+// (or the underlying failure is persistent) even after cleanup, the second
+// attempt's own error must surface directly rather than retrying again.
+func TestRegenerateSecret_Internal_RetryAlsoFails_ReturnsRetryErrorWithoutLooping(t *testing.T) {
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
+		return "new-secret", nil
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+	var createCalls int
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
+			createCalls++
+			return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+		},
+	}
+	var cleanupCalls int
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
+			cleanupCalls++
+			return nil
+		},
+	}
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+	}
+
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, utils.ErrNotFound)
+	assert.Equal(t, 2, createCalls, "exactly one retry, never more")
+	assert.Equal(t, 1, cleanupCalls, "exactly one cleanup, never more")
+}
+
+// TestRegenerateSecret_Internal_ManyDifferentAgentsHittingRetryConcurrently
+// checks concurrency and performance of the create-conflict-and-retry path:
+// many DIFFERENT agents hitting it at the same time must all succeed
+// independently, with no shared state between them (bindingLocks is keyed
+// per-binding, so unrelated agents must never block each other) and no data
+// race (run with -race). Also checks the path scales linearly — no lock held
+// across all of them.
+func TestRegenerateSecret_Internal_ManyDifferentAgentsHittingRetryConcurrently(t *testing.T) {
+	const agentCount = 25
+
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(_ context.Context, thunderAgentID string) (string, error) {
+		return "new-secret-for-" + thunderAgentID, nil
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+
+	var createAttempts sync.Map // agentName -> *int32, first attempt per agent fails, second succeeds
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(_ context.Context, location secretmanagersvc.SecretLocation, _ map[string]string) (string, error) {
+			counter, _ := createAttempts.LoadOrStore(location.AgentName, new(int32))
+			if atomic.AddInt32(counter.(*int32), 1) == 1 {
+				return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+			}
+			return "ref", nil
+		},
+	}
+	var cleanupCount atomic.Int32
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
+			cleanupCount.Add(1)
+			return nil
+		},
+	}
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(_ context.Context, _, _, agentName, _ string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-" + agentName, ThunderClientID: "client-" + agentName,
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error { return nil },
+	}
+
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+
+	var wg sync.WaitGroup
+	errs := make([]error, agentCount)
+	start := time.Now()
+	for i := 0; i < agentCount; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			agentName := fmt.Sprintf("agent-%d", i)
+			_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", agentName, "staging")
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	for i, err := range errs {
+		assert.NoError(t, err, "agent-%d must succeed independently of every other agent's retry", i)
+	}
+	assert.Equal(t, int32(agentCount), cleanupCount.Load(), "every agent hits the conflict exactly once, so exactly one cleanup each")
+	assert.Less(t, elapsed, 5*time.Second,
+		"unrelated agents' bindingLocks must not serialize this — %d concurrent retries took %s", agentCount, elapsed)
+}
+
 // TestRegenerateSecret_External_NeverStoresSecret guards the invariant that an
 // external agent's secret is minted by Thunder and handed straight back in
 // the response — it must never touch secretMgmtClient at all, first time or

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -642,7 +642,7 @@ func TestRegenerateSecret_Internal_ExistingSecretReference_CleansUpAndRetries(t 
 		CreateSecretFunc: func(_ context.Context, _ secretmanagersvc.SecretLocation, data map[string]string) (string, error) {
 			createCalls++
 			if createCalls == 1 {
-				return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+				return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
 			}
 			assert.Equal(t, "new-secret", data[thundersvc.AgentSecretKeyClientSecret],
 				"the retry must persist the same rotated value as the failed first attempt")
@@ -692,7 +692,7 @@ func TestRegenerateSecret_Internal_ExistingSecretReference_NoInjector_ReturnsOri
 	}
 	store := &clientmocks.SecretManagementClientMock{
 		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
-			return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
 		},
 	}
 	repo := &repomocks.AgentThunderClientRepositoryMock{
@@ -752,6 +752,50 @@ func TestRegenerateSecret_Internal_UnrelatedCreateSecretError_NotRetried(t *test
 	assert.Equal(t, 1, createCalls, "must not retry a failure that isn't the existing-SecretReference shape")
 }
 
+// TestRegenerateSecret_Internal_UnrelatedNotFoundError_NotRetried guards
+// against the narrower case: an error that does wrap utils.ErrNotFound, but
+// not from the create-conflict-then-fallback-update shape (for example, the
+// create itself failing for a reason unrelated to an existing
+// SecretReference), must not trigger cleanup or a retry either. Only the
+// exact shape carrying "after create conflict" should.
+func TestRegenerateSecret_Internal_UnrelatedNotFoundError_NotRetried(t *testing.T) {
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
+		return "new-secret", nil
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+	var createCalls int
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
+			createCalls++
+			return "", fmt.Errorf("failed to upsert secret: failed to create secret: %w", utils.ErrNotFound)
+		},
+	}
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
+			t.Fatal("must not clean up the SecretReference for a not-found that isn't the create-conflict shape")
+			return nil
+		},
+	}
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+	}
+
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, utils.ErrNotFound)
+	assert.Equal(t, 1, createCalls, "a not-found that isn't the create-conflict shape must not be retried")
+}
+
 // TestRegenerateSecret_Internal_CleanupItselfFails_ReturnsWrappedError guards
 // against attempting the retry on an unconfirmed cleanup: if clearing the
 // stray SecretReference itself errors, the original create failure must
@@ -768,7 +812,7 @@ func TestRegenerateSecret_Internal_CleanupItselfFails_ReturnsWrappedError(t *tes
 	store := &clientmocks.SecretManagementClientMock{
 		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
 			createCalls++
-			return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
 		},
 	}
 	injector := &agentIdentityInjectorStub{
@@ -790,6 +834,7 @@ func TestRegenerateSecret_Internal_CleanupItselfFails_ReturnsWrappedError(t *tes
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, utils.ErrNotFound, "the original create failure stays visible alongside the cleanup failure")
+	assert.Contains(t, err.Error(), "openchoreo api unavailable", "the cleanup failure's own reason must not be discarded")
 	assert.Equal(t, 1, createCalls, "no retry without a confirmed cleanup")
 }
 
@@ -809,7 +854,7 @@ func TestRegenerateSecret_Internal_RetryAlsoFails_ReturnsRetryErrorWithoutLoopin
 	store := &clientmocks.SecretManagementClientMock{
 		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
 			createCalls++
-			return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
 		},
 	}
 	var cleanupCalls int
@@ -860,7 +905,7 @@ func TestRegenerateSecret_Internal_ManyDifferentAgentsHittingRetryConcurrently(t
 		CreateSecretFunc: func(_ context.Context, location secretmanagersvc.SecretLocation, _ map[string]string) (string, error) {
 			counter, _ := createAttempts.LoadOrStore(location.AgentName, new(int32))
 			if atomic.AddInt32(counter.(*int32), 1) == 1 {
-				return "", fmt.Errorf("failed to upsert secret: %w", utils.ErrNotFound)
+				return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
 			}
 			return "ref", nil
 		},


### PR DESCRIPTION
## Purpose
Regenerating (or first provisioning) an internal agent's identity secret returns a 500 once the agent already exists. `storeCredential` in `agent_thunder_provisioning_service.go` writes the secret through the secret manager's `CreateSecret`, but the identity injection reconciler independently manages that same agent's `SecretReference` and gets there first. The secret manager's own create-conflict fallback then can't find it under its own bookkeeping, fails with not-found, and the whole rotation errors out.
- FIxed : https://github.com/wso2/agent-manager/issues/1419

## Goals
- Let `RegenerateAgentIdentitySecret` (and initial provisioning, which shares the same `storeCredential` call) succeed for an already-provisioned internal agent.
- Fix it entirely in `agent_thunder_provisioning_service.go`, without changing `secretmanagersvc` or `agent_identity_injection_service.go`.
- Reuse only already-exported functions, no new abstractions.

## Approach
- `storeCredential` now checks if `CreateSecret`'s error chain contains `utils.ErrNotFound`, the exact shape this conflict produces.
- On that shape, it fetches the workload injector via the existing `getWorkloadInjector()` accessor and calls its existing `CleanupForEnvironment` to delete the stray `SecretReference`.
- Retries `CreateSecret` once against the now-free name, the same path a brand-new agent's first credential already goes through.
- No injector configured, or the cleanup itself failing, surfaces the original error instead of attempting an unconfirmed retry.
- A second failed retry surfaces that error directly, no further retries.
- External agents are unaffected: `RegenerateSecret` never calls `storeCredential` for them.

## User stories
As a platform operator, regenerating or re-provisioning an internal agent's identity secret succeeds instead of a 500, with no change to external agent behavior.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   `agent_thunder_provisioning_service_test.go` adds: successful cleanup-and-retry recovery, no-injector-configured returns the original error, an unrelated create error never triggers cleanup or a retry, cleanup itself failing surfaces the original error, a second failed retry surfaces that error without looping, and 25 different agents hitting the path concurrently all succeed independently with no data race (`-race`). `make test-unit`: all packages pass.
 - Integration tests
   No new integration test, this path is fully exercised through mocked collaborators at the unit level. `make test-integration`: all tests pass, unaffected by this change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
> List any other related PRs

## Migrations (if applicable)
N/A

## Test environment
- macOS (Darwin), Go 1.25 (module) built with go1.26.4, local Postgres test database via `make test-integration`, Docker build verified against the repo's `Dockerfile`.
- Live k3d cluster on a GCP VM (WSO2 Agent Manager `0.0.0-dev-20260801` nightly build): confirmed the built image runs and stays healthy under the real cluster, gateway, and Thunder stack, not just local mocks. Full live scenario coverage (agent creation, regenerate flow end to end)

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret regeneration when an existing secret reference causes creation to fail.
  * Automatically cleans up the stale reference and retries creation once.
  * Preserves meaningful errors when cleanup is unavailable or fails.
  * Prevents unnecessary retries for unrelated errors and avoids retry loops.

* **Tests**
  * Added coverage for successful retries, failure handling, retry limits, and concurrent secret regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->