### PR TITLE
Escape the registry secret template placeholder

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
@@ -270,7 +270,7 @@ spec:
             template:
               type: kubernetes.io/dockerconfigjson
               data:
-                .dockerconfigjson: "{{ .registrysecret | toString }}"
+                .dockerconfigjson: "{{ "{{" }} .registrysecret | toString {{ "}}" }}"
           data:
             - secretKey: registrysecret
               remoteRef:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
@@ -305,7 +305,7 @@ spec:
             template:
               type: kubernetes.io/dockerconfigjson
               data:
-                .dockerconfigjson: "{{ .registrysecret | toString }}"
+                .dockerconfigjson: "{{ "{{" }} .registrysecret | toString {{ "}}" }}"
           data:
             - secretKey: registrysecret
               remoteRef:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
@@ -270,7 +270,7 @@ spec:
             template:
               type: kubernetes.io/dockerconfigjson
               data:
-                .dockerconfigjson: "{{ .registrysecret | toString }}"
+                .dockerconfigjson: "{{ "{{" }} .registrysecret | toString {{ "}}" }}"
           data:
             - secretKey: registrysecret
               remoteRef:


### PR DESCRIPTION
## Purpose
Agent builds cannot push images to any container registry that requires authentication. The publish-image step fails with:

```
Error: trying to reuse blob sha256:... at destination: Requesting bearer token:
  invalid status code from registry 403 (Forbidden)
time=... level=error msg="cannot save parameter /tmp/image.txt"
```

The root cause is an External Secrets template placeholder left unescaped inside a Helm template. In the three builder workflows:

```yaml
.dockerconfigjson: "{{ .registrysecret | toString }}"
```

`{{ }}` is Helm's delimiter and these files live under `templates/`, so Helm evaluates the expression at packaging time instead of passing it through to External Secrets. `.registrysecret` does not exist in Helm's context, and sprig's `toString` of nil renders the literal string `<nil>`. The published chart therefore ships a `ClusterWorkflow` whose ExternalSecret template is already collapsed to a constant.

This is invisible on the single-cluster k3d layout, whose in-cluster registry at `host.k3d.internal:10082` accepts unauthenticated pushes — the missing credential simply does not matter there. It only appears against a registry that enforces authentication (Artifact Registry, ECR, ACR, Harbor), which is what every production install uses.

## Goals
Make the registry push credential reach the build workflow, so agent builds can push to an authenticated registry.

## Approach
Escape the braces using the same idiom already used in `publish-image.yaml`, so the placeholder survives Helm rendering and reaches External Secrets intact:

```yaml
.dockerconfigjson: "{{ "{{" }} .registrysecret | toString {{ "}}" }}"
```

Applied to all three builder workflows, which carry identical copies of the line:

- `amp-gcp-buildpack-builder.yaml`
- `amp-dockerfile-builder.yaml`
- `amp-ballerina-buildpack-builder.yaml`

The full failure chain, for reviewers: Helm collapses the placeholder to `<nil>` → each build's generated ExternalSecret inherits it → External Secrets rejects it as invalid content for a `kubernetes.io/dockerconfigjson` Secret and reports `SecretSyncedError: could not update secret` → the Secret is never created → the mounted auth file is absent → podman falls back to an anonymous push → the registry answers `403`. The error surfaces as a registry token problem, which points away from the actual cause.

## User stories
As a platform engineer installing Agent Manager against my own container registry, I can build an agent and have its image pushed successfully.

## Release note
Fixed agent builds failing to push images with `403 Forbidden` when using a container registry that requires authentication.

## Documentation
N/A — no documented behaviour changes. The registry configuration steps in the installation guide are already correct; they were simply not being honoured at runtime.

## Training
N/A

## Certification
N/A — this is a defect fix with no impact on certification content.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — the change is a Helm template escaping fix with no Go code involved.
 - Integration tests
   > Verified manually against a real cluster (see Test environment). No automated coverage exists for chart rendering of the builder workflows; a render assertion that the shipped `ClusterWorkflow` contains no literal `<nil>` would be a reasonable follow-up.

Verification performed:

- `helm template` on the chart before the fix renders `.dockerconfigjson: "<nil>"` three times; after the fix it renders the correct placeholder three times and zero `<nil>`.
- `helm lint` passes.
- On a live GKE cluster with Artifact Registry: before the fix the build failed at publish-image with `403`, and the generated ExternalSecret was `Ready=False / SecretSyncedError`. After patching the three `ClusterWorkflow` resources, a rebuild produced `Ready=True / SecretSynced` and pushed the image successfully.
- Confirmed the credential itself was never at fault — the same registry bearer-token request with the stored service-account key returns `200` with a token.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java or Go code changed; this is a Helm template fix.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
No migration required. Existing installations pick up the corrected template on the next chart upgrade. Builds that failed with `403` succeed on retry once the upgrade is applied; no cleanup of the previously generated ExternalSecrets is needed, as a new one is created per build.

## Test environment
- GKE 1.35.6-gke.1127000, Container-Optimized OS, kernel 6.12.85
- OpenChoreo 1.1.1 planes, Agent Manager chart `0.0.0-dev-20260801`
- Google Artifact Registry (`us-central1-docker.pkg.dev`), authenticated push with a `_json_key` service-account credential stored in OpenBao and delivered via External Secrets
- Helm 3, External Secrets Operator 1.3.2

## Learning
The failing line is a cross-templating-system hazard: an External Secrets `{{ }}` expression embedded in a Helm `{{ }}` template. The repository already handles the same hazard correctly for Argo Workflows expressions in `publish-image.yaml`, which escapes them as `{{ "{{" }}...{{ "}}" }}`; this one line had simply been missed. The failure is easy to misdiagnose because sprig's `toString` renders nil as the plausible-looking string `<nil>` rather than failing, and because the resulting error appears at the registry as a `403` rather than anywhere near the template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed registry secret rendering across build workflows.
  * Ensured embedded registry credentials are correctly preserved and evaluated during deployment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->