### PR TITLE
Add .env file upload and auto-split paste support for environment variables

### DIFF
--- a/console/workspaces/libs/views/src/component/EnvFileUpload/EnvFileUpload.tsx
+++ b/console/workspaces/libs/views/src/component/EnvFileUpload/EnvFileUpload.tsx
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useRef, useState } from 'react';
+import { Alert, Button } from '@wso2/oxygen-ui';
+import { Upload as UploadIcon } from '@wso2/oxygen-ui-icons-react';
+
+export interface ParsedEnvEntry {
+  key: string;
+  value: string;
+}
+
+/**
+ * Parses `.env`-style file content into key/value pairs. Skips blank lines
+ * and `#` comments, splits each line on the first `=`, and strips matching
+ * surrounding quotes from the value.
+ */
+export function parseEnvFileContent(text: string): ParsedEnvEntry[] {
+  const result: ParsedEnvEntry[] = [];
+  const lines = text.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const equalsIdx = trimmed.indexOf('=');
+    if (equalsIdx === -1) continue;
+
+    const key = trimmed.slice(0, equalsIdx).trim();
+    let value = trimmed.slice(equalsIdx + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (key) {
+      result.push({ key, value });
+    }
+  }
+
+  return result;
+}
+
+const MAX_FILE_SIZE = 1_000_000; // 1 MB — matches backend schema limit
+
+export interface EnvFileUploadButtonProps {
+  /**
+   * Called with the parsed key/value pairs once a valid file has been read.
+   */
+  onParsed: (entries: ParsedEnvEntry[]) => void;
+  disabled?: boolean;
+  label?: string;
+}
+
+/**
+ * A hidden-file-input upload button that reads a `.env`/text file with
+ * FileReader and hands the parsed entries to the caller to merge into its
+ * own env var state.
+ */
+export function EnvFileUploadButton({
+  onParsed,
+  disabled = false,
+  label = 'Upload .env file',
+}: EnvFileUploadButtonProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadError(null);
+
+    if (file.size > MAX_FILE_SIZE) {
+      setUploadError(`File exceeds 1 MB limit (${(file.size / 1_000_000).toFixed(1)} MB)`);
+      e.target.value = '';
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const entries = parseEnvFileContent(reader.result as string);
+      if (entries.length === 0) {
+        setUploadError('No key-value pairs found in the uploaded file');
+        return;
+      }
+      onParsed(entries);
+    };
+    reader.onerror = () => {
+      setUploadError('Failed to read file');
+    };
+    reader.readAsText(file, 'utf-8');
+    e.target.value = '';
+  };
+
+  return (
+    <>
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept=".env,.txt,text/plain"
+        onChange={handleFileUpload}
+        style={{ display: 'none' }}
+      />
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={<UploadIcon size={14} />}
+        onClick={() => fileInputRef.current?.click()}
+        disabled={disabled}
+      >
+        {label}
+      </Button>
+      {uploadError && (
+        <Alert severity="error" sx={{ mt: 1, py: 0.5 }} onClose={() => setUploadError(null)}>
+          {uploadError}
+        </Alert>
+      )}
+    </>
+  );
+}

--- a/console/workspaces/libs/views/src/component/EnvFileUpload/EnvFileUpload.tsx
+++ b/console/workspaces/libs/views/src/component/EnvFileUpload/EnvFileUpload.tsx
@@ -45,8 +45,9 @@ export function parseEnvFileContent(text: string): ParsedEnvEntry[] {
     let value = trimmed.slice(equalsIdx + 1).trim();
 
     if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
     ) {
       value = value.slice(1, -1);
     }

--- a/console/workspaces/libs/views/src/component/EnvFileUpload/index.ts
+++ b/console/workspaces/libs/views/src/component/EnvFileUpload/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from './EnvFileUpload';

--- a/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
+++ b/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
@@ -122,6 +122,28 @@ export function EnvVariableEditor({
   const isSecretField = isValueSecret || isSensitive;
   const isSecretLocked = isExistingSecret && isSensitive && !isEditing;
 
+  // Lets users paste a full "KEY=VALUE" line into the Key field and have it
+  // split automatically, instead of forcing a manual copy into each field.
+  const handleKeyPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    if (keyDisabled) return;
+    const pasted = e.clipboardData.getData('text');
+    const equalsIdx = pasted.indexOf('=');
+    if (equalsIdx === -1) return;
+
+    e.preventDefault();
+    const pastedKey = pasted.slice(0, equalsIdx).trim();
+    let pastedValue = pasted.slice(equalsIdx + 1).trim();
+    if (
+      (pastedValue.startsWith('"') && pastedValue.endsWith('"')) ||
+      (pastedValue.startsWith("'") && pastedValue.endsWith("'"))
+    ) {
+      pastedValue = pastedValue.slice(1, -1);
+    }
+
+    onKeyChange(pastedKey.replace(/\s/g, '_'));
+    onValueChange(pastedValue);
+  };
+
   const handleStartEdit = () => {
     setValueBeforeEdit(valueValue);
     setIsEditing(true);
@@ -162,6 +184,7 @@ export function EnvVariableEditor({
             size="small"
             value={keyValue}
             onChange={(e) => onKeyChange(e.target.value.replace(/\s/g, '_'))}
+            onPaste={handleKeyPaste}
             error={!!keyError}
             helperText={keyError}
             disabled={keyDisabled}

--- a/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
+++ b/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
@@ -125,7 +125,7 @@ export function EnvVariableEditor({
   // Lets users paste a full "KEY=VALUE" line into the Key field and have it
   // split automatically, instead of forcing a manual copy into each field.
   const handleKeyPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
-    if (keyDisabled) return;
+    if (keyDisabled || isSecretLocked) return;
     const pasted = e.clipboardData.getData('text');
     const equalsIdx = pasted.indexOf('=');
     if (equalsIdx === -1) return;
@@ -134,8 +134,9 @@ export function EnvVariableEditor({
     const pastedKey = pasted.slice(0, equalsIdx).trim();
     let pastedValue = pasted.slice(equalsIdx + 1).trim();
     if (
-      (pastedValue.startsWith('"') && pastedValue.endsWith('"')) ||
-      (pastedValue.startsWith("'") && pastedValue.endsWith("'"))
+      pastedValue.length >= 2 &&
+      ((pastedValue.startsWith('"') && pastedValue.endsWith('"')) ||
+        (pastedValue.startsWith("'") && pastedValue.endsWith("'")))
     ) {
       pastedValue = pastedValue.slice(1, -1);
     }

--- a/console/workspaces/libs/views/src/component/index.ts
+++ b/console/workspaces/libs/views/src/component/index.ts
@@ -24,6 +24,7 @@ export * from './PageLayout';
 export * from './FadeIn';
 export * from "./Loader";
 export * from './EnvVariableEditor';
+export * from './EnvFileUpload';
 export * from './FileMountEditor';
 export * from './TraceExplorer';
 export * from './FormElements';

--- a/console/workspaces/pages/add-new-agent/src/components/EnvironmentVariable.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/EnvironmentVariable.tsx
@@ -18,7 +18,7 @@
 
 import { Box, Button, Card, CardContent, Typography } from "@wso2/oxygen-ui";
 import { Plus as Add } from "@wso2/oxygen-ui-icons-react";
-import { EnvVariableEditor } from "@agent-management-platform/views";
+import { EnvFileUploadButton, EnvVariableEditor } from "@agent-management-platform/views";
 import { CreateAgentFormValues } from "../form/schema";
 
 interface EnvironmentVariableProps {
@@ -64,6 +64,22 @@ export const EnvironmentVariable = ({
     }));
   };
 
+  const handleEnvFileParsed = (entries: { key: string; value: string }[]) => {
+    setFormData((prev) => {
+      const nextEnv = [...(prev.env || [])].filter((e) => e.key || e.value);
+      for (const { key, value } of entries) {
+        if (lockedKeys.has(key)) continue;
+        const existingIndex = nextEnv.findIndex((e) => e.key === key);
+        if (existingIndex !== -1) {
+          nextEnv[existingIndex] = { ...nextEnv[existingIndex], key, value };
+        } else {
+          nextEnv.push({ key, value, isSensitive: false });
+        }
+      }
+      return { ...prev, env: nextEnv };
+    });
+  };
+
   const handleInitialEdit = (field: 'key' | 'value' | 'isSensitive', value: string | boolean) => {
     setFormData((prev) => {
       const envList = prev.env || [];
@@ -92,10 +108,11 @@ export const EnvironmentVariable = ({
   return (
     <Card variant="outlined">
       <CardContent>
-        <Box display="flex" flexDirection="row" alignItems="center" gap={1}>
+        <Box display="flex" flexDirection="row" alignItems="center" justifyContent="space-between" gap={1}>
           <Typography variant="h5">
             {hideAdd ? "Environment Variables" : "Environment Variables (Optional)"}
           </Typography>
+          {!hideAdd && <EnvFileUploadButton onParsed={handleEnvFileParsed} />}
         </Box>
         <Box display="flex" flexDirection="column" py={2} gap={2}>
           {envVariables.length ? envVariables.map((item, index) => {

--- a/console/workspaces/pages/deploy/src/subComponent/EditDeployConfigDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/EditDeployConfigDrawer.tsx
@@ -434,13 +434,16 @@ export function EditDeployConfigDrawer({
             <Stack direction="row" justifyContent="space-between" alignItems="center">
               <Form.Header>Environment Variables</Form.Header>
               <Stack direction="row" gap={1}>
-                <EnvFileUploadButton onParsed={handleEnvFileParsed} disabled={isPending} />
+                <EnvFileUploadButton
+                  onParsed={handleEnvFileParsed}
+                  disabled={isPending || !seededRef.current}
+                />
                 <Button
                   size="small"
                   variant="outlined"
                   startIcon={<Plus size={14} />}
                   onClick={handleAddEnv}
-                  disabled={isPending}
+                  disabled={isPending || !seededRef.current}
                 >
                   Add
                 </Button>

--- a/console/workspaces/pages/deploy/src/subComponent/EditDeployConfigDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/EditDeployConfigDrawer.tsx
@@ -33,6 +33,7 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerWrapper,
+  EnvFileUploadButton,
   EnvVariableEditor,
   FileMountEditor,
   TokenExpirySelector,
@@ -304,6 +305,21 @@ export function EditDeployConfigDrawer({
     setEnv((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
+  const handleEnvFileParsed = useCallback((entries: { key: string; value: string }[]) => {
+    setEnv((prev) => {
+      const next = [...prev];
+      for (const { key, value } of entries) {
+        const existingIndex = next.findIndex((e) => e.key === key);
+        if (existingIndex !== -1) {
+          next[existingIndex] = { ...next[existingIndex], key, value, secretRef: undefined };
+        } else {
+          next.push({ key, value, isSensitive: false });
+        }
+      }
+      return next;
+    });
+  }, []);
+
   // ── File handlers ─────────────────────────────────────────────────────────
   const handleAddFile = useCallback(() => {
     setFiles((prev) => [...prev, { key: "", mountPath: "", value: "" }]);
@@ -417,15 +433,18 @@ export function EditDeployConfigDrawer({
           <Form.Section>
             <Stack direction="row" justifyContent="space-between" alignItems="center">
               <Form.Header>Environment Variables</Form.Header>
-              <Button
-                size="small"
-                variant="outlined"
-                startIcon={<Plus size={14} />}
-                onClick={handleAddEnv}
-                disabled={isPending}
-              >
-                Add
-              </Button>
+              <Stack direction="row" gap={1}>
+                <EnvFileUploadButton onParsed={handleEnvFileParsed} disabled={isPending} />
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<Plus size={14} />}
+                  onClick={handleAddEnv}
+                  disabled={isPending}
+                >
+                  Add
+                </Button>
+              </Stack>
             </Stack>
             {env.length === 0 ? (
               <Typography variant="body2" color="text.secondary">

--- a/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
@@ -179,6 +179,13 @@ export function PromoteAgentDrawer({
   // once per target rather than on every background refetch.
   const [filledForTarget, setFilledForTarget] = useState<string | null>(null);
 
+  // True once the target's config has loaded AND been seeded into formState.
+  // Gates Add/Upload so a user can't add/merge entries into the editor while
+  // it's still holding the previous target's (or blank) state, which the
+  // seed effect below would otherwise clobber once it fires.
+  const targetConfigReady =
+    targetConfigLoaded && filledForTarget === formState.targetEnvironment;
+
   // Pick a default target environment when the drawer opens, and clear state on close.
   useEffect(() => {
     if (!open) {
@@ -291,10 +298,23 @@ export function PromoteAgentDrawer({
     }));
   }, []);
 
+  // Same system-key exclusion as the prefill effect above: uploaded entries
+  // must not shadow platform-injected keys, which are never part of formState.env.
+  const targetSystemKeys = useMemo(
+    () =>
+      new Set(
+        (targetConfigs?.configurations?.env ?? [])
+          .filter((e) => e.isSystem)
+          .map((e) => e.key),
+      ),
+    [targetConfigs],
+  );
+
   const handleEnvFileParsed = useCallback((entries: { key: string; value: string }[]) => {
     setFormState((prev) => {
       const nextEnv = [...prev.env];
       for (const { key, value } of entries) {
+        if (targetSystemKeys.has(key)) continue;
         const existingIndex = nextEnv.findIndex((e) => e.key === key);
         if (existingIndex !== -1) {
           nextEnv[existingIndex] = { ...nextEnv[existingIndex], key, value, secretRef: undefined };
@@ -304,7 +324,7 @@ export function PromoteAgentDrawer({
       }
       return { ...prev, env: nextEnv };
     });
-  }, []);
+  }, [targetSystemKeys]);
 
   const handleAddFile = useCallback(() => {
     setFormState((prev) => ({
@@ -509,14 +529,14 @@ export function PromoteAgentDrawer({
                             <Stack direction="row" gap={1}>
                               <EnvFileUploadButton
                                 onParsed={handleEnvFileParsed}
-                                disabled={isPending}
+                                disabled={isPending || !targetConfigReady}
                               />
                               <Button
                                 size="small"
                                 variant="outlined"
                                 startIcon={<Plus size={14} />}
                                 onClick={handleAddEnv}
-                                disabled={isPending}
+                                disabled={isPending || !targetConfigReady}
                               >
                                 Add
                               </Button>

--- a/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
@@ -38,6 +38,7 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerWrapper,
+  EnvFileUploadButton,
   EnvVariableEditor,
   FileMountEditor,
 } from "@agent-management-platform/views";
@@ -290,6 +291,21 @@ export function PromoteAgentDrawer({
     }));
   }, []);
 
+  const handleEnvFileParsed = useCallback((entries: { key: string; value: string }[]) => {
+    setFormState((prev) => {
+      const nextEnv = [...prev.env];
+      for (const { key, value } of entries) {
+        const existingIndex = nextEnv.findIndex((e) => e.key === key);
+        if (existingIndex !== -1) {
+          nextEnv[existingIndex] = { ...nextEnv[existingIndex], key, value, secretRef: undefined };
+        } else {
+          nextEnv.push({ key, value, isSensitive: false });
+        }
+      }
+      return { ...prev, env: nextEnv };
+    });
+  }, []);
+
   const handleAddFile = useCallback(() => {
     setFormState((prev) => ({
       ...prev,
@@ -490,15 +506,21 @@ export function PromoteAgentDrawer({
                             <Typography variant="h6">
                               Environment Variables
                             </Typography>
-                            <Button
-                              size="small"
-                              variant="outlined"
-                              startIcon={<Plus size={14} />}
-                              onClick={handleAddEnv}
-                              disabled={isPending}
-                            >
-                              Add
-                            </Button>
+                            <Stack direction="row" gap={1}>
+                              <EnvFileUploadButton
+                                onParsed={handleEnvFileParsed}
+                                disabled={isPending}
+                              />
+                              <Button
+                                size="small"
+                                variant="outlined"
+                                startIcon={<Plus size={14} />}
+                                onClick={handleAddEnv}
+                                disabled={isPending}
+                              >
+                                Add
+                              </Button>
+                            </Stack>
                           </Stack>
                           {formState.env.length === 0 ? (
                             <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
## Purpose
Configuring environment variables one field at a time is tedious, especially
when a user already has a `.env` file, or is copying `KEY=VALUE` pairs from a
terminal, doc, or another tool. This PR streamlines both entry paths across
every place environment variables are edited in the console.

Resolves issue  https://github.com/wso2/agent-manager/issues/1453

## Goals
1. Let users paste a full `KEY=VALUE` line (optionally quoted, e.g.
   `API_KEY="12345"`) directly into the **Key** field and have it
   auto-split into the Key and Value fields.
2. Let users upload a `.env` (or plain text) file to bulk-populate /
   merge environment variables into the existing list, instead of adding
   them one at a time.

## Approach
- Added an `onPaste` handler on the Key `TextInput` in the shared
  `EnvVariableEditor` component (`libs/views/src/component/EnvVariableEditor`).
  It detects `=` in the pasted text, splits on the first occurrence, trims
  whitespace and strips matching surrounding quotes from the value, then
  populates both the Key and Value fields. Falls back to normal paste
  behavior when there's no `=` or the field is disabled.
- Added a new shared component, `EnvFileUpload`
  (`libs/views/src/component/EnvFileUpload`), exposing:
  - `parseEnvFileContent(text)` — parses `.env` syntax: skips blank lines
    and `#` comments, splits each line on the first `=`, strips matching
    surrounding quotes from the value.
  - `EnvFileUploadButton` — a button + hidden file input read via
    `FileReader`, following the existing upload pattern already used by
    `FileMountEditor`.
- Wired the upload button into the three places environment variables are
  edited:
  - Deploy config drawer (`pages/deploy/src/subComponent/EditDeployConfigDrawer.tsx`)
  - Promote agent drawer (`pages/deploy/src/subComponent/PromoteAgentDrawer.tsx`)
  - Create-agent environment variable step
    (`pages/add-new-agent/src/components/EnvironmentVariable.tsx`)
- Uploaded/pasted entries are merged into existing state by key (update the
  existing row if the key already exists, append otherwise); the
  create-agent flow additionally skips overwriting keys that are locked /
  pre-defined by the Agent Kind schema.

| Before | After |
|---|---|
| <img width="1109" height="220" alt="Screenshot 2026-07-31 at 14 42 49" src="https://github.com/user-attachments/assets/9c9dc99d-47a0-4596-a772-c2e2f195999c" /> | <img width="1108" height="227" alt="Screenshot 2026-08-03 at 21 24 30" src="https://github.com/user-attachments/assets/1d47169d-f3ab-4103-b80a-b9d0b8d9f9dc" /> |


## User stories
- As a user configuring an agent's environment variables, I want to paste a
  `KEY=VALUE` line and have both fields fill in automatically, so I don't
  have to manually split and retype it.
- As a user with an existing `.env` file, I want to upload it directly
  instead of re-entering each variable by hand.

## Release note
You can now paste `KEY=VALUE` lines directly into an environment variable's
Key field to auto-fill both fields, and upload a `.env` file to
bulk-populate environment variables when creating, deploying, or promoting
an agent.

## Documentation
N/A — this is a self-explanatory UI affordance (standard paste/upload
interaction) on an existing form; there is no dedicated doc page for the
environment variable editor to update.

## Training
N/A — no training content covers this UI flow today.

## Certification
N/A — no certification exam content covers this UI flow today.

## Marketing
N/A — minor UX improvement to an existing feature, not a new marketable
capability.

## Automation tests
 - Unit tests
     N/A
 - Integration tests
     N/A
## Security checks
 - Followed secure coding standards in
   http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens,
   usernames, or other secrets? yes

## Samples
N/A — no new sample apps or configs; existing `.env` files can be used
directly with the new upload button.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no data model, schema, or config migration involved; this is a
console-only UI change.

## Test environment
Verified locally by rebuilding and running the console via the
`docker-compose` dev setup (`make dev-rebuild`) on macOS; the shared
`EnvFileUpload` component and the `EnvVariableEditor` paste handler compiled
cleanly through the console's Vite watch build.

## Learning
Followed the existing `FileMountEditor` file-upload pattern already in the
codebase (`libs/views/src/component/FileMountEditor/FileMountEditor.tsx`)
for consistency — same `FileReader`-based read, same 1 MB size guard — rather
than introducing a new upload mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `.env` file upload support for environment variable editors.
  - Automatically parses valid key-value entries, handles quoted values, and reports invalid or oversized files.
  - Merges uploaded variables with existing entries while preserving locked variables.
  - Added support across agent creation, deployment configuration, and agent promotion workflows.
  - Users can paste `KEY=VALUE` content directly into environment variable fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->