### PR TITLE
Create the namespace the eval NetworkPolicy targets

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-namespace.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-namespace.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.networkPolicy.evaluationJob.enabled }}
 {{- $evalJobNamespace := .Values.networkPolicy.evaluationJob.namespace | default (printf "workflows-%s" (.Values.ampEvaluation.workflowNamespace | default "default")) }}
 {{- if ne $evalJobNamespace .Release.Namespace }}
+{{- if not (lookup "v1" "Namespace" "" $evalJobNamespace) }}
 # The evaluation-job NetworkPolicy lives in the namespace where OpenChoreo runs this
 # environment's Argo workflows, which OpenChoreo does not create until a workflow first
 # runs there. On a fresh install that namespace does not exist yet, so rendering only the
@@ -9,8 +10,17 @@
 # Create it here so the chart is self-sufficient. Helm orders Namespace ahead of
 # NetworkPolicy, so this is always applied first.
 #
+# Only when it is absent: Helm refuses to adopt a resource that lacks its ownership
+# metadata, so rendering this unconditionally fails with `invalid ownership metadata`
+# wherever OpenChoreo created the namespace first — and on any reinstall, since the keep
+# policy below deliberately leaves it behind. The lookup needs a live cluster; a rendering
+# path without one (helm template, GitOps dry-run) emits the Namespace, which is correct
+# for a first install and the safe direction to be wrong in.
+#
 # resource-policy: keep — OpenChoreo owns this namespace's lifecycle and it holds running
 # workflows. Uninstalling this chart must never delete it; only the NetworkPolicy goes.
+# It also keeps the namespace when a later upgrade stops rendering it, the lookup having
+# found it by then.
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,5 +29,6 @@ metadata:
     helm.sh/resource-policy: keep
   labels:
 {{- include "amp-evaluation-extension.labels" . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-namespace.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-namespace.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkPolicy.evaluationJob.enabled }}
+{{- $evalJobNamespace := .Values.networkPolicy.evaluationJob.namespace | default (printf "workflows-%s" (.Values.ampEvaluation.workflowNamespace | default "default")) }}
+{{- if ne $evalJobNamespace .Release.Namespace }}
+# The evaluation-job NetworkPolicy lives in the namespace where OpenChoreo runs this
+# environment's Argo workflows, which OpenChoreo does not create until a workflow first
+# runs there. On a fresh install that namespace does not exist yet, so rendering only the
+# NetworkPolicy fails the install outright with `namespaces "<name>" not found`.
+#
+# Create it here so the chart is self-sufficient. Helm orders Namespace ahead of
+# NetworkPolicy, so this is always applied first.
+#
+# resource-policy: keep — OpenChoreo owns this namespace's lifecycle and it holds running
+# workflows. Uninstalling this chart must never delete it; only the NetworkPolicy goes.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $evalJobNamespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+{{- include "amp-evaluation-extension.labels" . | nindent 4 }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Purpose
The evaluation extension cannot be installed on a fresh cluster. Following the installation guide, the step fails outright:

```
Error: INSTALLATION FAILED: namespaces "workflows-default" not found
```

`templates/evaluation-job-networkpolicy.yaml` renders the evaluation-job NetworkPolicy into the namespace where OpenChoreo runs an environment's Argo workflows — derived as `workflows-<ampEvaluation.workflowNamespace>` — rather than into the chart's own release namespace. OpenChoreo does not create that namespace until a workflow first runs there, so on a fresh install it cannot exist yet.

The failure is also awkward to recover from: the aborted install claims the release name, so an immediate retry reports `cannot reuse a name that is still in use`, which points away from the real cause. Recovery needs a `helm uninstall` first.

This affects every fresh install. The NetworkPolicy template is recent, so installs predating it were unaffected.

## Goals
Make the evaluation extension installable on a fresh cluster without weakening the egress restriction it exists to apply.

## Approach
Create the target namespace alongside the policy, in a new `evaluation-job-namespace.yaml` template guarded by the same `networkPolicy.evaluationJob.enabled` condition and using the same namespace derivation. Helm orders `Namespace` ahead of `NetworkPolicy`, so it is always applied first.

Two details worth calling out for review:

- **The namespace is annotated `helm.sh/resource-policy: keep`.** OpenChoreo owns this namespace's lifecycle and it holds running workflows, so uninstalling this chart must remove only the NetworkPolicy, never the namespace.
- **It is skipped when the target resolves to the release namespace**, which Helm already creates and manages, so no duplicate ownership.

**Alternative considered and rejected:** guarding the policy on a `lookup` of the namespace, so it renders only when the namespace already exists. That would make the install succeed, but on a fresh cluster it silently omits the policy — and this policy restricts egress for the evaluation job's untrusted, user-submitted code. Failing open on a security control is the wrong default, and the omission would be invisible.

## User stories
As a platform engineer installing Agent Manager on a new cluster, the evaluation extension installs successfully on the first attempt, with the evaluation-job egress restriction in place.

## Release note
Fixed the evaluation extension failing to install on a fresh cluster with `namespaces "workflows-<environment>" not found`.

## Documentation
N/A — no documented behaviour changes. The installation guide's step is already correct; it simply could not succeed.

## Training
N/A

## Certification
N/A — defect fix with no impact on certification content.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — Helm template change, no application code.
 - Integration tests
   > No automated coverage exists for this chart's rendering. Verified by rendering the chart across the relevant cases:

| Case | Result |
|---|---|
| Defaults | `Namespace/workflows-default` rendered before `NetworkPolicy` in `workflows-default` |
| `networkPolicy.evaluationJob.enabled=false` | neither resource rendered |
| `networkPolicy.evaluationJob.namespace=my-workflows` | namespace and policy both `my-workflows` |
| `ampEvaluation.workflowNamespace=prod` | namespace and policy both `workflows-prod` |
| target equals release namespace | `Namespace` skipped, `NetworkPolicy` still rendered |

`helm lint` passes.

The original failure was reproduced on a live GKE cluster during a production-install validation run, and creating the namespace first allowed the extension to install with the policy correctly in place, including the API-server egress CIDR resolved via `lookup`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java or Go code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
None. On existing installations the namespace already exists, so the added resource is adopted as a no-op; `resource-policy: keep` ensures it is never removed by a later uninstall.

## Test environment
- GKE 1.35.6-gke.1127000, Container-Optimized OS
- OpenChoreo 1.1.1 planes, evaluation extension chart `0.0.0-dev-20260801`
- Helm 3

## Learning
The chart reaches into a namespace owned by another component, which makes install ordering a cross-component concern rather than a local one. Where a chart must place a resource in someone else's namespace, it needs either to create that namespace or to state the dependency explicitly — and when the resource is a security control, failing closed (create it) is preferable to rendering conditionally on the namespace's presence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic creation of a dedicated evaluation-job namespace when network policy support is enabled and a separate target namespace is configured.
  * Applies standard chart labels and preserves the namespace during Helm release removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->