### PR TITLE
Align the gateway install with the shipped versions

### DIFF
--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -524,6 +524,7 @@ helm install api-platform-default-default \
   --set agentManager.orgName=default \
   --set gateway.environment=default \
   --set gateway.type=BOTH \
+  --set developmentMode=false \
   --set agentManager.idp.existingSecret=gateway-idp-credentials \
   --timeout 1800s
 
@@ -533,9 +534,7 @@ kubectl wait --for=condition=complete job/api-platform-default-default-bootstrap
 
 `gateway.type=BOTH` registers this gateway to serve both inbound and outbound traffic, which is what a single-gateway environment needs. It matches the chart default and is set explicitly here because the role is written once at registration and never rewritten — see [Gateway roles and topology](#gateway-roles-and-topology) for the split alternative and its constraints.
 
-:::warning Development mode is still on
-This release defaults to `developmentMode: true`, which relaxes gateway security checks. It no longer affects encryption keys — those are required either way and were created in [Step 1](#step-1-gateway-operator) — but the other relaxed checks remain. See [Gateway hardening](#gateway-hardening) before treating this gateway as production-ready.
-:::
+`developmentMode=false` turns off the relaxed security checks the chart enables by default. It depends on the encryption key from [Step 1](#step-1-gateway-operator): without one the install fails immediately with `encryptionKeys must be enabled: at-rest encryption is mandatory`. Set it here rather than hardening afterwards, so the gateway is never registered in a relaxed state.
 
 </Prod>
 

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -9,9 +9,9 @@
        - props.production         — (boolean, optional) if true, renders the production
          variants of the install commands (external database, generated client secrets,
          multiple replicas, non-debug logging) instead of the development-grade
-         defaults. Note the gateway still installs with developmentMode=true: turning
-         it off needs encryption keys the extension chart does not expose as a value,
-         so Step 7 flags it rather than setting it.
+         defaults. The gateway installs with developmentMode=true either way; the
+         encryption keys it needs are created in Step 1 and passed through the
+         operator, since the gateway requires them regardless of that setting.
 */}
 
 export const Prod = ({production, children}) => (production ? <>{children}</> : null);
@@ -36,16 +36,38 @@ Install these in order — each depends on the one before it.
 
 Manages API Gateway resources and enables secure, authenticated trace ingestion into the Observability Plane.
 
+The gateway controller encrypts stored credentials at rest and will not start without a key, so create one before installing the operator:
+
+```bash
+kubectl create namespace ${DATA_PLANE_NS} --dry-run=client -o yaml | kubectl apply -f -
+
+openssl rand 32 > gateway-aesgcm.key
+kubectl create secret generic gateway-encryption-keys \
+  --namespace ${DATA_PLANE_NS} \
+  --from-file=default-aesgcm256-v1.bin=gateway-aesgcm.key
+rm -f gateway-aesgcm.key
+```
+
+:::warning The key is required, and the file name is fixed
+The controller looks for a specific path, `/app/data/aesgcm-keys/default-aesgcm256-v1.bin`, so the Secret key must be exactly `default-aesgcm256-v1.bin`. Without it the controller crash-loops on `failed to initialize key manager: encryption key file not found for version aesgcm256-v1`, and the gateway never programs — the rest of the platform stays healthy, so the only symptom is that agents cannot be invoked.
+
+This applies whatever `developmentMode` is set to. Earlier gateway releases auto-generated a key in development mode; from `1.2.0-beta` they do not.
+
+Store the key with the rest of your platform secrets. It encrypts credentials the gateway holds, and losing it means those entries cannot be decrypted.
+:::
+
 <Dev production={props.production}>
 
 ```bash
 helm install gateway-operator \
   oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
-  --version 0.6.0 \
+  --version 0.10.1 \
   --namespace ${DATA_PLANE_NS} \
   --set logging.level=debug \
   --set gatewayApi.installStandardCRDs=false \
-  --set gateway.helm.chartVersion=1.1.1 \
+  --set gateway.helm.chartVersion=1.2.0-beta \
+  --set gateway.values.gateway.controller.encryptionKeys.enabled=true \
+  --set gateway.values.gateway.controller.encryptionKeys.secretName=gateway-encryption-keys \
   --timeout 600s
 ```
 
@@ -56,15 +78,23 @@ helm install gateway-operator \
 ```bash
 helm install gateway-operator \
   oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
-  --version 0.6.0 \
+  --version 0.10.1 \
   --namespace ${DATA_PLANE_NS} \
   --set logging.level=info \
   --set gatewayApi.installStandardCRDs=false \
-  --set gateway.helm.chartVersion=1.1.1 \
+  --set gateway.helm.chartVersion=1.2.0-beta \
+  --set gateway.values.gateway.controller.encryptionKeys.enabled=true \
+  --set gateway.values.gateway.controller.encryptionKeys.secretName=gateway-encryption-keys \
   --timeout 600s
 ```
 
 </Prod>
+
+:::note Pin the gateway chart, do not inherit it
+`gateway.helm.chartVersion` decides which gateway chart the operator deploys, and it is the only thing that decides it — the `APIGateway` resource carries no chart version. Operator `0.10.1` defaults to `1.2.0-alpha`, whose templates predate the controller reading its control-plane address from configuration while still shipping `1.2.0-beta` images. The result is a gateway that installs, programs, and serves traffic while never registering with Agent Manager, so it never appears in the gateway list. Pin `1.2.0-beta` as above so the chart and the images match.
+
+`gateway.values` is the operator's passthrough into that chart: anything set under it is merged into the values the gateway is deployed with, which is how the encryption keys above are wired.
+:::
 
 Wait for the operator to be ready:
 
@@ -504,7 +534,7 @@ kubectl wait --for=condition=complete job/api-platform-default-default-bootstrap
 `gateway.type=BOTH` registers this gateway to serve both inbound and outbound traffic, which is what a single-gateway environment needs. It matches the chart default and is set explicitly here because the role is written once at registration and never rewritten — see [Gateway roles and topology](#gateway-roles-and-topology) for the split alternative and its constraints.
 
 :::warning Development mode is still on
-This release defaults to `developmentMode: true`, which relaxes gateway security checks such as auto-generating encryption keys. Turning it off requires supplying encryption keys that the extension chart does not yet expose as a value — see [Gateway hardening](#gateway-hardening) for the procedure and its caveats.
+This release defaults to `developmentMode: true`, which relaxes gateway security checks. It no longer affects encryption keys — those are required either way and were created in [Step 1](#step-1-gateway-operator) — but the other relaxed checks remain. See [Gateway hardening](#gateway-hardening) before treating this gateway as production-ready.
 :::
 
 </Prod>

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -1468,7 +1468,7 @@ Work down this table against an existing install. The **When** column matters: t
 | Container registry is yours, with `tlsVerify=true` | [Phase 2](#phase-2-agent-manager-installation) | Any time — affects new builds |
 | Console `admin`/`admin` replaced by real users or a connected IdP | [Identity](#identity-and-access) | Any time |
 | JWT signature verification active on the API and the observer | [Identity](#identity-and-access) | Any time |
-| Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Not yet possible — chart gap |
+| Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Keys are set up during installation; development mode is turned off here |
 | Post-upgrade patches re-applied | [After a chart upgrade](#after-a-chart-upgrade) | After every relevant `helm upgrade` |
 | Build workloads bounded by a node pool or ResourceQuota | [Build workflows](#build-workflows) | Any time |
 | Stateless services running multiple replicas | [High availability](#high-availability-and-scaling) | Any time |
@@ -1537,17 +1537,44 @@ Metrics come from the in-cluster Prometheus deployed by the metrics module; for 
 
 ### Gateway Hardening
 
-The gateway extension provisions one gateway per environment and ships with `developmentMode: true`, which relaxes security checks such as auto-generating encryption keys. For production set `developmentMode=false`.
+The gateway extension provisions one gateway per environment and ships with `developmentMode: true`, which relaxes several security checks. For production set `developmentMode=false` on the extension:
 
-With development mode off the gateway requires explicit encryption keys (`gateway.controller.encryptionKeys`, key format per the [high-availability production guide](https://wso2.com/api-platform/docs/api-gateway/1.1.0/deployment/high-availability-production-deployment/)). The extension chart does not yet expose a value for that block.
+```bash
+helm upgrade api-platform-default-default \
+  oci://${HELM_CHART_REGISTRY}/wso2-amp-api-platform-gateway-extension \
+  --version ${VERSION} \
+  --namespace ${DATA_PLANE_NS} \
+  --reuse-values \
+  --set developmentMode=false \
+  --timeout 1800s
+```
 
-:::warning No working procedure today — leave development mode on
-Editing the rendered `<release>-config` ConfigMap looks like an escape hatch, but it does not work with gateway-operator 0.6.0 and makes things worse. Adding `encryptionKeys` under `gateway.controller` there is correctly formed — the gateway chart renders cleanly when given that same file directly — yet the operator does not pass the value through, and the APIGateway stays `Programmed=False` with `gateway.controller.encryptionKeys must be enabled when gateway.developmentMode is false`, through operator restarts and re-reconciles.
+Encryption keys are **not** part of that decision. The gateway requires them whichever way `developmentMode` is set, which is why [Step 1](#phase-2-agent-manager-installation) creates the `gateway-encryption-keys` Secret and passes it to the operator before anything is installed. Nothing further is needed here.
 
-Worse, patching that ConfigMap with `kubectl apply` transfers ownership of `.data.values.yaml` to `kubectl`, so the **next** `helm upgrade` of the extension fails with a field-manager conflict; recovery means deleting the ConfigMap so Helm can recreate it. And because the operator's retry budget is exhausted and persisted, reverting the values does not by itself return the CR to `Programmed=True`.
+:::note Configure the gateway through the operator, not the rendered ConfigMap
+Any gateway chart value can be set through the operator's `gateway.values` passthrough, which the operator merges into the values it deploys the gateway with:
 
-Until the extension exposes the value, keep `developmentMode: true` and treat this checklist row as outstanding. The data path is unaffected either way.
+```bash
+--set gateway.values.gateway.controller.<setting>=<value>
+```
+
+The extension also renders a `<release>-config` ConfigMap holding those values, and editing it directly looks like a shortcut. It is not: `kubectl apply` takes ownership of `.data.values.yaml`, so the next `helm upgrade` of the extension fails with a field-manager conflict, and recovery means deleting the ConfigMap so Helm can recreate it. Set values on the operator instead.
 :::
+
+:::warning A gateway that fails its first install stays failed
+If the gateway stack cannot start on first install — a missing encryption key is the usual cause — the operator exhausts its retry budget and **persists that state**. Correcting the values afterwards changes nothing on its own: the `APIGateway` stays `Programmed=False` with `Max retries (10) exceeded`, through operator restarts and re-reconciles, and its Helm sub-release is left in `pending-install`.
+
+Recovery is to clear both halves: `helm uninstall <release>-gw` to remove the wedged sub-release, then delete the `APIGateway` resource and `helm upgrade` the extension to re-render it. It reconciles to `Ready` within a minute once both are gone.
+:::
+
+Verify the gateway actually registered, rather than only that it is running:
+
+```bash
+kubectl get apigateway -n ${DATA_PLANE_NS}
+# expect PROGRAMMED=True
+```
+
+A gateway can be `Programmed=True` with both pods healthy and still not be registered with Agent Manager — it then never appears in the console's gateway list and cannot serve agent traffic. If that happens, check the controller's startup log for an empty control-plane address, which means the chart and image versions do not match: see the pinning note in [Step 1](#phase-2-agent-manager-installation).
 
 Rate-limiting policies default to an **in-memory** backend, which does not share counters across gateway replicas. When running more than one replica, switch to Redis through the extension's `apiGateway.config.policyConfigurations.ratelimit_v1` values (`backend: redis` plus the `redis` connection block).
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -1468,7 +1468,7 @@ Work down this table against an existing install. The **When** column matters: t
 | Container registry is yours, with `tlsVerify=true` | [Phase 2](#phase-2-agent-manager-installation) | Any time — affects new builds |
 | Console `admin`/`admin` replaced by real users or a connected IdP | [Identity](#identity-and-access) | Any time |
 | JWT signature verification active on the API and the observer | [Identity](#identity-and-access) | Any time |
-| Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Keys are set up during installation; development mode is turned off here |
+| Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Both are set during installation |
 | Post-upgrade patches re-applied | [After a chart upgrade](#after-a-chart-upgrade) | After every relevant `helm upgrade` |
 | Build workloads bounded by a node pool or ResourceQuota | [Build workflows](#build-workflows) | Any time |
 | Stateless services running multiple replicas | [High availability](#high-availability-and-scaling) | Any time |
@@ -1537,7 +1537,9 @@ Metrics come from the in-cluster Prometheus deployed by the metrics module; for 
 
 ### Gateway Hardening
 
-The gateway extension provisions one gateway per environment and ships with `developmentMode: true`, which relaxes several security checks. For production set `developmentMode=false` on the extension:
+The gateway extension provisions one gateway per environment and ships with `developmentMode: true`, which relaxes several security checks. The production install in [Phase 2](#phase-2-agent-manager-installation) already sets `developmentMode=false` and provisions the encryption key the gateway needs, so a gateway installed by following this guide starts hardened — there is nothing to turn off afterwards.
+
+If you inherited a gateway that was installed with development mode on, turn it off in place:
 
 ```bash
 helm upgrade api-platform-default-default \
@@ -1549,7 +1551,7 @@ helm upgrade api-platform-default-default \
   --timeout 1800s
 ```
 
-Encryption keys are **not** part of that decision. The gateway requires them whichever way `developmentMode` is set, which is why [Step 1](#phase-2-agent-manager-installation) creates the `gateway-encryption-keys` Secret and passes it to the operator before anything is installed. Nothing further is needed here.
+Encryption keys are **not** part of that decision. The gateway requires them whichever way `developmentMode` is set, which is why the key Secret is created before the operator is installed. If the upgrade above fails with `encryptionKeys must be enabled: at-rest encryption is mandatory`, the key is missing — create it and wire it through the operator as [Step 1](#phase-2-agent-manager-installation) describes, then retry.
 
 :::note Configure the gateway through the operator, not the rendered ConfigMap
 Any gateway chart value can be set through the operator's `gateway.values` passthrough, which the operator merges into the values it deploys the gateway with:


### PR DESCRIPTION
## Purpose
The installation guide's gateway steps no longer match what the platform ships. `deployments/setup/env.sh` now pins gateway-operator `0.10.1` with gateway chart and images `1.2.0-beta` and provisions an encryption key for the controller (#1429), while the guide still described operator `0.6.0` with chart `1.1.1` and told readers that no encryption-key procedure existed.

Following the guide against the next release would fail at the operator step. The extension emits its `APIGateway` and `RestApi` resources at `gateway.api-platform.wso2.com/v1`, and operator `0.6.0` serves only `v1alpha1`:

```
no matches for kind "APIGateway" in version "gateway.api-platform.wso2.com/v1"
```

Two further statements in the guide are now wrong: that encryption keys are only needed when `developmentMode=false`, and that there is no working procedure for configuring them.

Related https://github.com/wso2/agent-manager/issues/1058

## Goals
Bring the guide's gateway install in line with the shipped versions, and document the encryption key and gateway configuration in the places where they actually apply.

## Approach
**Create the encryption key before installing the operator.** The gateway controller requires a key regardless of `developmentMode` — earlier releases auto-generated one in development mode, `1.2.0-beta` does not — so this belongs in the install path, not in the hardening section. Without it the controller crash-loops on `encryption key file not found for version aesgcm256-v1` while the rest of the platform stays healthy, so the only symptom is that agents cannot be invoked. The Secret key must be exactly `default-aesgcm256-v1.bin`, which the guide now calls out.

**Pin `gateway.helm.chartVersion=1.2.0-beta` explicitly rather than inheriting the operator's default.** Operator `0.10.1` defaults to `1.2.0-alpha`, whose templates predate the controller reading its control-plane address from configuration while still shipping `1.2.0-beta` images. That combination produces a gateway which installs, reaches `Programmed=True`, serves traffic, and never registers with Agent Manager — so it never appears in the gateway list. Nothing about the failure points at a version mismatch, so the guide explains what to look for.

**Rewrite Gateway Hardening around what now works:**
- `developmentMode=false` can be set on its own, with a command.
- Gateway values are configured through the operator's `gateway.values` passthrough. The previous text described editing the rendered `<release>-config` ConfigMap and concluded there was no working procedure; that conclusion was wrong, and editing the ConfigMap is actively harmful because `kubectl apply` takes ownership of `.data.values.yaml` and breaks the next `helm upgrade`.
- Kept and sharpened the warning about a gateway that fails its first install: the operator persists its exhausted retry budget, so correcting the values afterwards does not recover it — both the wedged sub-release and the CR have to be cleared.
- Added a verification step, because a gateway can be `Programmed=True` with healthy pods and still be unregistered.

The checklist row that read `Not yet possible — chart gap` now describes the actual procedure.

## User stories
As a platform engineer following the installation guide, the gateway installs successfully against the shipped versions and registers with Agent Manager, and I can turn development mode off without hunting for an undocumented procedure.

## Release note
Updated the installation guide for gateway-operator 0.10.1 and gateway 1.2.0-beta, including the encryption key the gateway controller now requires.

## Documentation
This PR is the documentation change. Affects `documentation/docs/getting-started/on-your-environment.mdx` and the shared Phase 2 partial, which `on-k3d.mdx` also imports — the version pins and encryption key apply to both, matching what `make setup` and quick-start now do.

## Training
N/A

## Certification
N/A — documentation change with no impact on certification content.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — documentation only.
 - Integration tests
   > `npm run build` passes with `onBrokenLinks: 'throw'`, validating every internal link and anchor.

Rendered-HTML assertions on both affected pages confirm: `--version 0.10.1`, `gateway.helm.chartVersion=1.2.0-beta`, the `encryptionKeys` passthrough and `default-aesgcm256-v1.bin` all present; `--version 0.6.0`, `chartVersion=1.1.1`, `No working procedure today`, `does not yet expose` and `Not yet possible — chart gap` all absent. Production-only content (the hardening section, `developmentMode=false`) appears on `on-your-environment` and **not** on `on-k3d`.

The behaviours documented here were observed on a live GKE cluster: the `v1` / `v1alpha1` mismatch, the controller refusing to start without a key, the alpha-chart control-plane gap, and the persisted retry budget after a failed first install.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — documentation only.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the key is generated by the reader with `openssl rand`, and the guide notes it must be stored with their platform secrets.

## Samples
N/A

## Related PRs
Follows #1429, which moved the platform to operator 0.10.1 and gateway 1.2.0-beta.

## Migrations (if applicable)
N/A for the guide itself. Existing installations are unaffected until they upgrade the gateway; the encryption key must exist before moving to `1.2.0-beta`, which the Step 1 instructions cover.

## Test environment
- Docusaurus build, `onBrokenLinks: 'throw'`
- Behaviours verified on GKE 1.35.6-gke.1127000 with OpenChoreo 1.1.1 planes, gateway-operator 0.10.1, gateway chart 1.2.0-alpha and 1.2.0-beta

## Learning
The failure mode worth remembering is the chart/image mismatch: a gateway that installs cleanly, programs, and serves traffic while never registering, because the chart version rendering its configuration lagged the image reading that configuration. `helm list` showed the chart version and the running images plainly, and the mismatch between them was the whole answer — worth checking early whenever a component reports empty configuration it was clearly given.
