### PR TITLE
Fix production install guide for cloud clusters

### DIFF
--- a/deployments/values/oc-collector-configmap.yaml
+++ b/deployments/values/oc-collector-configmap.yaml
@@ -28,9 +28,18 @@ data:
 
     extensions:
       basicauth/opensearch:
-        client_auth: 
-          username: admin
-          password: ThisIsTheOpenSearchPassword1
+        client_auth:
+          # Injected by the observability-tracing-opensearch chart's default
+          # opentelemetry-collector.extraEnvs, which source them from the
+          # opensearch-admin-credentials Secret — the same Secret the observer,
+          # the Fluent Bit adapter and openSearchSetup already read. Never
+          # inline the credentials here: a literal keeps working on a local
+          # install (where the seeded password happens to match the chart
+          # default) while silently failing anywhere the password was changed,
+          # and the collector then drops every trace with
+          # "failed to json unmarshal body: invalid character 'U'".
+          username: ${env:OPENSEARCH_USERNAME}
+          password: ${env:OPENSEARCH_PASSWORD}
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
   

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -23,7 +23,7 @@ The Agent Manager installs as a set of Helm charts on top of OpenChoreo. The com
 2. **Extensions :** Secret Management, Observability, Evaluation extensions and the API Platform Gateway Extension.
 
 :::info Prerequisites
-Thunder (identity provider) must be installed before proceeding — see the Thunder installation step in Phase 1. The variables `THUNDER_PUBLIC_URL`, `THUNDER_INTERNAL_URL`, `CONSOLE_PUBLIC_URL`, `API_PUBLIC_URL`, `OBS_API_PUBLIC_URL`, `CONSOLE_PUBLIC_HOST`, `API_PUBLIC_HOST`, `OBS_API_PUBLIC_HOST`, and `INSTRUMENTATION_URL` must be set from the Configuration Variables section. The `*_PUBLIC_HOST` variables carry the bare hostname (no scheme or port) and become the HTTPRoute hostnames on the plane gateways.
+Thunder (identity provider) must be installed before proceeding — see the Thunder installation step in Phase 1. The variables `THUNDER_PUBLIC_URL`, `THUNDER_INTERNAL_URL`, `CONSOLE_PUBLIC_URL`, `API_PUBLIC_URL`, `OBS_API_PUBLIC_URL`, `CONSOLE_PUBLIC_HOST`, `API_PUBLIC_HOST`, `OBS_API_PUBLIC_HOST`, and `INSTRUMENTATION_URL` must be set from the Configuration Variables section. The production steps below additionally use `AGENTS_DOMAIN` — the domain deployed agents are served on, `agents.<your base domain>` — to build the gateway's hostname and virtual host. The `*_PUBLIC_HOST` variables carry the bare hostname (no scheme or port) and become the HTTPRoute hostnames on the plane gateways.
 :::
 
 ---
@@ -219,6 +219,7 @@ helm install amp \
   --set agentManagerService.config.oidc.clientSecret="${AMP_API_CLIENT_SECRET}" \
   --set agentManagerService.config.thunder.clientSecret="${AMP_SYSTEM_CLIENT_SECRET}" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
+  --set agentManagerService.config.tlsEnabled=true \
   --set agentManagerService.replicaCount=2 \
   --set agentManagerService.autoscaling.minReplicas=2 \
   --set console.replicaCount=2 \
@@ -249,6 +250,10 @@ kubectl wait --for=condition=Available \
 ```
 
 `agentManagerService.config.thunder.clientSecret` can instead be supplied through `agentManagerService.config.thunder.existingSecret` (key `thunder-client-secret`) if you prefer to keep it out of Helm release history.
+
+:::warning `tlsEnabled` decides which agent invoke URL the console publishes
+`agentManagerService.config.tlsEnabled` defaults to `false`, and it is what selects between an Environment's `http` and `https` endpoint variants when the API builds an agent's invoke URL. Left at the default on an HTTPS platform, the console publishes an `http://` URL — which the browser then refuses to call from an HTTPS page, showing the request as `blocked:mixed-content` with no error anywhere in the platform. The agent itself is healthy and reachable; only the published URL is wrong.
+:::
 
 :::warning Two values that look redundant but are not
 `agentManagerService.autoscaling.minReplicas=2` is what actually gives the API two replicas. Autoscaling is **on by default** for this component with `minReplicas: 1`, so the HPA takes ownership of the replica count and scales `replicaCount=2` straight back down to one — silently, within seconds. The console has autoscaling off by default, which is why `replicaCount` alone appears to work there.
@@ -525,12 +530,20 @@ helm install api-platform-default-default \
   --set gateway.environment=default \
   --set gateway.type=BOTH \
   --set developmentMode=false \
+  --set gateway.vhost="https://default-default.${AGENTS_DOMAIN}" \
+  --set gateway.hostname="default-default.${AGENTS_DOMAIN}" \
   --set agentManager.idp.existingSecret=gateway-idp-credentials \
   --timeout 1800s
 
 kubectl wait --for=condition=complete job/api-platform-default-default-bootstrap \
   -n ${DATA_PLANE_NS} --timeout=300s
 ```
+
+:::warning Set the vhost now — it cannot be changed later
+`gateway.vhost` and `gateway.hostname` default to the local k3d addresses (`http://default-default.gateway.localhost:19080`). The bootstrap job writes them into Agent Manager at **first registration only**: on every later run it finds the gateway already present, logs `already exists`, and exits without reconciling the record. A `helm upgrade` with corrected values changes nothing, and there is no error to notice — the console simply keeps showing the `.localhost:19080` virtual host, which is what an operator would copy when wiring an external caller.
+
+Correcting it after the fact means deleting the gateway registration and re-registering, so get these right on the first install.
+:::
 
 `gateway.type=BOTH` registers this gateway to serve both inbound and outbound traffic, which is what a single-gateway environment needs. It matches the chart default and is set explicitly here because the role is written once at registration and never rewritten — see [Gateway roles and topology](#gateway-roles-and-topology) for the split alternative and its constraints.
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -1031,6 +1031,8 @@ kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VER
   -n openchoreo-observability-plane
 ```
 
+The collector reads its OpenSearch credentials from the `opensearch-admin-credentials` Secret through environment variables the tracing module injects, so the generated password flows through without any substitution here.
+
 Create the gateway certificate, then install the Observability Plane:
 
 ```bash
@@ -1267,10 +1269,16 @@ helm upgrade amp-platform-resources oci://${HELM_CHART_REGISTRY}/wso2-amp-platfo
   --reuse-values \
   --set global.oauth.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set environment.gateway.http.host="${AGENTS_DOMAIN}" \
-  --set environment.gateway.http.port=443 \
+  --set environment.gateway.http.port=80 \
   --set environment.gateway.https.host="${AGENTS_DOMAIN}" \
   --set environment.gateway.https.port=443
 ```
+
+:::warning Both variants, each on its own port
+The Environment's gateway binding **wholly replaces** the data plane's, so a partial override silently discards what [Step 6](#step-6-setup-data-plane) wrote rather than merging with it. Set both variants, and give each the port its listener actually serves — `80` for `http`, `443` for `https`, matching the plane gateway.
+
+Putting `443` on the `http` variant is the trap: the console then publishes `http://<host>:443`, an HTTP scheme on the TLS port, and a browser refuses to call it from the HTTPS console as mixed content. Nothing in the platform reports an error, because the gateway and the agent are both fine.
+:::
 
 ### Provision Thunder Identity Provider for the Default Environment
 
@@ -1376,6 +1384,51 @@ kubectl get secret amp-thunder-default-default-admin-credentials \
 :::
 
 Safe to re-run: the system-client secret and admin password are reused, never rotated.
+
+### Point the Gateway at the Environment's Thunder
+
+The gateway extension was installed before this Environment's Thunder existed, so it has no way to validate the tokens that Thunder issues. Wire it now that the issuer is known — this registers Thunder both as a gateway key manager (JWT validation for deployed agents) and as an identity provider visible in the console:
+
+```bash
+export ENV_THUNDER_RELEASE="amp-thunder-default-default"
+export ENV_THUNDER_ISSUER="https://default-default.thunder.${BASE_DOMAIN}"
+export ENV_THUNDER_JWKS="http://${ENV_THUNDER_RELEASE}-service.${ENV_THUNDER_RELEASE}.svc.cluster.local:8090/oauth2/jwks"
+
+helm upgrade api-platform-default-default \
+  oci://${HELM_CHART_REGISTRY}/wso2-amp-api-platform-gateway-extension \
+  --version ${VERSION} \
+  --namespace ${DATA_PLANE_NS} \
+  --reuse-values \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].name=agent-manager-service" \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].issuer=agent-manager-service" \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].jwks.remote.uri=http://amp-api.${AMP_NS}.svc.cluster.local:9000/auth/external/jwks.json" \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[0].jwks.remote.skipTlsVerify=true" \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].name=ThunderKeyManager" \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].issuer=${ENV_THUNDER_ISSUER}" \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.uri=${ENV_THUNDER_JWKS}" \
+  --set "apiGateway.config.policyConfigurations.jwtauth_v1.keymanagers[1].jwks.remote.skipTlsVerify=false" \
+  --set "bootstrap.identityProviders[0].name=ThunderKeyManager" \
+  --set "bootstrap.identityProviders[0].issuer=${ENV_THUNDER_ISSUER}" \
+  --set "bootstrap.identityProviders[0].jwksUri=${ENV_THUNDER_JWKS}" \
+  --set "bootstrap.identityProviders[0].skipTlsVerify=false" \
+  --timeout 900s
+```
+
+Both key managers must be listed. Helm's `--set` on an indexed array replaces the whole list, so re-stating `keymanagers[0]` is what keeps the internal `agent-manager-service` entry that API-key authentication relies on.
+
+:::warning Without this, agents cannot accept OAuth tokens
+Skipping this step leaves the gateway with only its internal key manager. Agents still work with API keys, so the platform looks complete — but no agent endpoint can validate a Thunder-issued OAuth token, and the console's gateway page shows *No identity providers configured* with nothing to explain why.
+:::
+
+:::note The controller restarts, and its volume is single-attach
+This upgrade rolls the gateway controller. Its data volume is `ReadWriteOnce`, so on a multi-node cluster the replacement pod may be scheduled to a different node and block with `Multi-Attach error for volume`, leaving the `APIGateway` at `Programmed=False` indefinitely. Delete the old controller pod to release the volume; the new one then starts and the gateway returns to `Ready`.
+
+```bash
+kubectl get pods -n ${DATA_PLANE_NS} | grep gateway-controller
+# If two are listed and one is stuck ContainerCreating, delete the older Running pod
+kubectl delete pod <old-gateway-controller-pod> -n ${DATA_PLANE_NS}
+```
+:::
 
 ---
 
@@ -1603,16 +1656,44 @@ AI gateways can also run **outside** the cluster (for example, close to a privat
 
 Agent builds run as Argo workflows in the Workflow Plane, and build pods have **no built-in resource ceiling** — a burst of builds can starve the platform and agent workloads on a shared node. Two mitigations, in order of preference:
 
-1. **Dedicated build nodes** — run the workflow plane's build workloads on a separate node pool so build spikes cannot affect serving workloads. Remember the build-node kernel requirement (Linux 6.3+ for user-namespaced builds, see [Prerequisites](#cluster-requirements)).
-2. **Namespace ResourceQuota** — cap total build resource consumption in the workflow-plane namespace:
+1. **Dedicated build nodes** — run the workflow plane's build workloads on a separate node pool so build spikes cannot affect serving workloads. Remember the build-node kernel requirement (Linux 6.3+ for user-namespaced builds, see [Prerequisites](#cluster-requirements)). This is the preferred mitigation: it needs no per-pod resource declarations and cannot reject a build.
+
+2. **Namespace ResourceQuota plus a LimitRange** — cap total build resource consumption. Both objects go in the namespace where builds actually run, which is **`workflows-<environment>`** (`workflows-default` for the default environment), not the workflow-plane namespace — that one holds the Argo controller and cluster agent, not the build pods.
+
+   The `LimitRange` is not optional, and it has to come before the quota. Build pods declare no requests or limits of their own, and a ResourceQuota that tracks `requests.*`/`limits.*` **rejects** every pod that omits them. Applying the quota alone fails each build within seconds at its first step with `must specify limits.cpu for: init,main,wait` — a hard failure, not a queued build. Note all three containers in that message: `main` is the build step, while `init` and `wait` are injected by Argo, so a `LimitRange` is what covers them all from one object you control.
+
+   **Measure before you set these.** The values below are placeholders, not recommendations — the right numbers depend on what your agents build. Run one build with the `LimitRange` absent and watch what a step actually uses:
+
+```bash
+# While a build is running, in another shell:
+kubectl top pod -n workflows-default --containers
+```
+
+   Set `defaultRequest` near the steady-state usage you observe and `default` (the limit) above the peak, with headroom. Then apply both objects:
 
 ```bash
 kubectl apply -f - <<EOF
 apiVersion: v1
+kind: LimitRange
+metadata:
+  name: build-workload-defaults
+  namespace: workflows-default
+spec:
+  limits:
+    - type: Container
+      # Replace with your measured values.
+      defaultRequest:
+        cpu: 500m
+        memory: 1Gi
+      default:
+        cpu: "2"
+        memory: 4Gi
+---
+apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: build-workloads
-  namespace: openchoreo-workflow-plane
+  namespace: workflows-default
 spec:
   hard:
     requests.cpu: "8"
@@ -1622,7 +1703,15 @@ spec:
 EOF
 ```
 
-Size the quota to your expected build concurrency; builds beyond the quota queue rather than fail.
+Size the quota to your expected build concurrency: the quota divided by the per-container defaults is what decides how many build steps run at once. With the defaults in place, builds beyond that cap stay Pending until capacity frees up instead of failing.
+
+:::warning Defaults set too low fail builds in a way that looks unrelated
+A memory limit under what a build needs gets the step OOMKilled, and a low CPU limit throttles it into a timeout. Either reads as a broken build rather than a resource cap, and the build log rarely says which. If builds start failing after you apply these, raise the limits before looking anywhere else — and prefer generous limits with a smaller quota, since the quota is what actually bounds total consumption.
+:::
+
+:::note The namespace appears when the environment first runs a workflow
+`workflows-<environment>` is created by OpenChoreo the first time a workflow runs there, so apply these after the first successful build rather than during the install. Repeat them for each environment you add.
+:::
 
 ### High Availability and Scaling
 


### PR DESCRIPTION
## Purpose

A validation run of the production install guide on a multi-node managed Kubernetes cluster reached the agent lifecycle — build, deploy, invoke, traces, evaluation — for the first time, and surfaced seven defects in the guide.

Every one of them is silent. The platform installs, all pods report healthy, `helm list` shows every release deployed, and yet a user-visible capability does not work. Most trace back to a single-node local default that the guide inherits without overriding, so they cannot reproduce on a k3d or Rancher Desktop install.

Related https://github.com/wso2/agent-manager/issues/1058

## Goals

Make the guide produce a working platform on a real cloud cluster: traces reaching storage, agents exporting spans, a usable invoke URL in the console, a correctly advertised gateway virtual host, OAuth token validation on deployed agents, and resource-quota guidance that does not fail builds.

## Approach

Seven fixes, each with a warning admonition explaining the failure mode so the next reader recognises the symptom rather than rediscovering the cause.

**Traces never reach storage.** The OpenTelemetry collector manifest hardcodes the placeholder OpenSearch password. Applied verbatim beside the generated-password override in the same step, the collector authenticates with the placeholder against an OpenSearch holding the real one. Logs are unaffected — their adapter reads the credential from a Secret — so the only symptom is a permanently empty Traces view, with `failed to json unmarshal body: invalid character 'U'` (the start of `Unauthorized`) buried in collector logs. Now substituted as the manifest is applied.

**Deployed agents cannot export spans.** `AMP_OTEL_ENDPOINT` is derived from a convention assuming the gateway runtime lives in an `<org>-<env>` namespace, but Step 7 installs the extension into the data-plane namespace. The name does not resolve and every span batch fails inside the agent, which otherwise keeps serving traffic normally. Now set via `otelEndpointOverride`.

**The console publishes an invoke URL the browser refuses.** Two independent causes combine: `agentManagerService.config.tlsEnabled` defaults to `false` and selects the Environment's `http` variant, and the endpoint-wiring step assigned port `443` to that plaintext variant. The result is `http://<host>:443`, blocked as mixed content from the HTTPS console. Both corrected, with a note that the Environment binding wholly replaces the data plane's rather than merging.

**The gateway advertises a local virtual host.** `gateway.vhost`/`gateway.hostname` default to k3d addresses, and the bootstrap job writes the registration only at first install — later runs log `already exists` and exit without reconciling, so a `helm upgrade` cannot fix it. Now set on the initial install, with that constraint documented.

**Deployed agents cannot validate OAuth tokens.** The gateway extension is installed before the environment's Thunder exists, so its issuer is unknown at that point and nothing registers Thunder as a key manager or identity provider. API-key auth still works, so the platform looks complete while the console shows *No identity providers configured*. Adds a step after Thunder provisioning that wires both, including the detail that Helm's indexed-array `--set` replaces the whole list and the internal key manager must be re-stated. Also documents the `ReadWriteOnce` controller volume that makes the resulting rolling restart deadlock with `Multi-Attach error` on a multi-node cluster.

**The documented ResourceQuota has no effect, and breaks builds where it would.** It targets the workflow-plane namespace, which holds the Argo controller rather than build pods; builds run in the per-environment `workflows-<env>` namespace. Applied there, it rejects every build at admission with `must specify limits.cpu for: init,main,wait`, because build pods declare no requests or limits — terminally failed in seconds, not the queueing the guide promised. The section now names the right namespace, requires a `LimitRange` alongside the quota, drops the incorrect claim, and notes the namespace only exists after the environment's first workflow run.

## User stories

As an operator following the production install guide on a cloud cluster, I get a platform whose traces, agent invocation, gateway registration and build quotas all work as documented, without having to diagnose silent failures myself.

## Release note

Fixed seven issues in the production installation guide that produced a platform which installed cleanly but had broken trace ingestion, agent span export, console invoke URLs, gateway virtual host registration, OAuth token validation, and build resource quotas on multi-node cloud clusters.

## Documentation

This PR *is* the documentation change: `documentation/docs/getting-started/on-your-environment.mdx` and its shared Phase 2 partial `documentation/docs/getting-started/_partials/_amp-installation.mdx`.

## Training

N/A — no training content covers the production install guide.

## Certification

N/A — installation-guide corrections, no impact on certification exams.

## Marketing

N/A — a documentation defect fix, not a promotable feature.

## Automation tests

 - Unit tests
   > N/A — documentation only, no code paths changed.
 - Integration tests
   > Verified by `npm run build` in `documentation/` (the site sets `onBrokenLinks: 'throw'`, so every internal link and anchor is validated) plus assertions over the rendered HTML of `on-your-environment/index.html` and `on-k3d/index.html`: 11 expected strings present, 3 removed strings absent, and 4 production-only strings confirmed absent from the k3d page, since the Phase 2 partial is shared between the two.

Each individual fix was also applied to a live cluster during the validation run and confirmed to resolve its symptom — traces began flowing, the identity provider registered, invoke succeeded over HTTPS — and the quota behaviour was verified in both directions: unconstrained in the documented namespace, and terminally failing a real build in the correct one.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code changes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

One change is security-relevant in the other direction: the collector previously authenticated with a well-known placeholder password taken from a shipped manifest, and the guide now substitutes the operator's generated credential.

## Samples

N/A — no sample changes.

## Migrations (if applicable)

N/A for new installs. Existing installs that followed the previous guide can apply the trace-collector password substitution, the `tlsEnabled` and endpoint-port corrections, and the Thunder key-manager wiring as `helm upgrade`s. The gateway virtual host is the exception: it is written at first registration only, so correcting it requires deleting and re-registering the gateway.

## Test environment

Managed Kubernetes 1.35 (3 nodes, 4 vCPU / 16 GB, Container-Optimized OS, kernel 6.12), managed PostgreSQL 16 over a private address with TLS required, a managed container registry with authenticated push, Let's Encrypt production certificates via DNS-01, OpenChoreo planes 1.1.1, gateway operator 0.10.1 with gateway chart 1.2.0-beta, Thunder 0.45.0, and all Agent Manager charts at a single nightly version. Docs build verified on Node 20, macOS.

## Learning

The common thread is that a value which is correct for the single-cluster local layout becomes wrong on a cloud cluster, and the platform reports success either way. Five of the seven cannot reproduce on a single-node, single-replica, non-TLS install at all — one needs a multi-node cluster, one needs two API replicas, one needs HTTPS, one needs a real registry, and one needs an agent to actually be invoked.

Two process lessons worth recording. First, the repo's own install scripts already set most of these values correctly, with comments explaining why — the guide had drifted from them, so diffing the guide against `deployments/setup/setup-gateway.sh` and `deployments/scripts/add-environment.sh` is a cheap way to find this class of gap. Second, the mixed-content URL was invisible to command-line testing with hand-constructed URLs and obvious the moment the console's own Try It panel was used; at least one check should exercise the UI rather than reconstructing what it would do.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified production installation requirements, including domain, TLS, HTTPS, gateway, and telemetry settings.
  * Documented secure OpenSearch credential injection for telemetry collection.
  * Added troubleshooting guidance for OpenSearch authentication and trace exports.
  * Documented connecting Thunder to the API gateway for identity and key management while preserving API-key authentication.
  * Expanded workflow resource guidance with dedicated build nodes, quotas, limits, and default resource behavior.
  * Added warnings about incorrect settings, first registration, and recovery from partial configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
