### PR TITLE
Make the gateway namespace configurable in traits

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-networkpolicy.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-networkpolicy.yaml
@@ -56,10 +56,19 @@ spec:
           protocol: TCP
 
     # LLM gateway for llm_judge evaluators — unconditional since NetworkPolicy can't scope by workflow.
+    # Two selectors, because the gateway's namespace is a deployment choice: the
+    # per-org-env namespaces created by setup-gateway.sh / add-environment.sh carry the
+    # label, while an install using the gateway chart's own apiGateway.namespace default
+    # does not, and would otherwise be denied.
     - to:
         - namespaceSelector:
             matchLabels:
               amp.wso2.com/api-platform-gateway: "true"
+        {{- with .Values.networkPolicy.evaluationJob.llmGateway.namespace }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
       ports:
         - port: {{ .Values.networkPolicy.evaluationJob.llmGateway.port }}
           protocol: TCP

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
@@ -82,6 +82,14 @@ networkPolicy:
 
     llmGateway:
       port: 22893
+      # -- Namespace holding the API Platform Gateway, allowed in addition to any
+      # namespace labelled amp.wso2.com/api-platform-gateway=true. That label is
+      # only applied by setup-gateway.sh and add-environment.sh, so an install
+      # that follows the gateway chart's own apiGateway.namespace default
+      # (openchoreo-data-plane) has no matching namespace and llm_judge
+      # evaluators are silently denied egress to the gateway. Empty = rely on
+      # the label alone.
+      namespace: ""
 
     # -- Local-dev only: ipBlock exception for agent-manager-service running outside the
     # cluster (docker-compose). Empty (no-op) elsewhere; setup-amp-extensions.sh sets it.

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/_helpers.tpl
@@ -90,3 +90,26 @@ Parameters:
   {{- fail (printf "Buildpack image with id '%s' not found in buildpackCache.images" $id) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Namespace-qualified DNS name of the per-environment gateway runtime Service.
+
+The Service name always follows the apiGatewayName convention
+("api-platform-<org>-<env>-gw-gateway-gateway-runtime"), but the namespace it
+lives in is a deployment choice: setup-gateway.sh and add-environment.sh install
+the gateway extension into "<org>-<env>", while the extension chart's own
+apiGateway.namespace default is openchoreo-data-plane. Callers set
+apiPlatformGateway.namespace to match wherever they installed it; empty keeps the
+per-org-env convention.
+
+Emits an OpenChoreo trait placeholder expression, so ${metadata.*} is resolved by
+the controller rather than by Helm.
+*/}}
+{{- define "amp.gatewayRuntimeHost" -}}
+{{- $svc := "api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gw-gateway-gateway-runtime" -}}
+{{- if .Values.apiPlatformGateway.namespace -}}
+{{- printf "%s.%s" $svc .Values.apiPlatformGateway.namespace -}}
+{{- else -}}
+{{- printf "%s.${metadata.componentNamespace}-${metadata.environmentName}" $svc -}}
+{{- end -}}
+{{- end -}}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/api-management-trait.yaml
@@ -110,7 +110,7 @@ spec:
           type: Static
           static:
             hosts:
-              - host: "api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gw-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}"
+              - host: "{{ include "amp.gatewayRuntimeHost" . }}"
                 port: 22893
 
     # Create RestApi resource (discovered by gateway via apiSelector scope: LabelSelector).

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-traits/instrumentation-trait-env-injection.yaml
@@ -105,7 +105,7 @@ spec:
             # install fronts a single public gateway host on :443, where the
             # per-env in-cluster Service does not apply). Leave empty for the
             # default in-cluster runtime endpoint.
-            value: {{ if .Values.apiPlatformGatewayVhost.otelEndpointOverride }}{{ .Values.apiPlatformGatewayVhost.otelEndpointOverride | quote }}{{ else }}"http://api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gw-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}:22893/otel"{{ end }}
+            value: {{ if .Values.apiPlatformGatewayVhost.otelEndpointOverride }}{{ .Values.apiPlatformGatewayVhost.otelEndpointOverride | quote }}{{ else }}"http://{{ include "amp.gatewayRuntimeHost" . }}:22893/otel"{{ end }}
         - op: add
           path: /spec/podTemplate/spec/containers/0/env/-
           value:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -149,6 +149,22 @@ apiPlatformGatewayVhost:
   # Kubernetes Service does not apply. Empty = derive the in-cluster Service.
   otelEndpointOverride: ""
 
+# Where the per-environment API Platform Gateway is installed. This must agree
+# with apiGateway.namespace in wso2-amp-api-platform-gateway-extension, because
+# the traits below address that release's gateway-runtime Service by DNS name.
+apiPlatformGateway:
+  # Empty = derive the per-org-env convention "<org>-<env>", which
+  # setup-gateway.sh and add-environment.sh create by passing
+  # --set apiGateway.namespace=<org>-<env>.
+  #
+  # Set this to a fixed namespace when the gateway extension is installed
+  # somewhere else — notably openchoreo-data-plane, which is the gateway
+  # chart's own default for apiGateway.namespace. Leaving it empty there
+  # makes the traits build a name that does not resolve, and the failure is
+  # silent: agents keep serving traffic while every span batch fails, and
+  # agent invocation has no route to the gateway runtime.
+  namespace: ""
+
 # Deployment Pipeline configuration
 deploymentPipeline:
   # Name of the default deployment pipeline

--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -341,6 +341,7 @@ helm install amp-platform-resources \
   oci://${HELM_CHART_REGISTRY}/wso2-amp-platform-resources-extension \
   --version ${VERSION} \
   --namespace ${DEFAULT_NS} \
+  --set apiPlatformGateway.namespace=${DATA_PLANE_NS} \
   --timeout 1800s
 ```
 
@@ -357,6 +358,7 @@ helm install amp-platform-resources \
   --set global.oauth.hostHeader="amp-thunder-extension-service.${THUNDER_NS}.svc.cluster.local" \
   --set global.apiServer.url="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --set global.apiServer.hostHeader="openchoreo-api.openchoreo-control-plane.svc.cluster.local" \
+  --set apiPlatformGateway.namespace=${DATA_PLANE_NS} \
   --timeout 1800s
 ```
 
@@ -367,6 +369,14 @@ Nothing earlier in the install touches these values, so a platform that installs
 :::
 
 </Prod>
+
+:::warning Point the traits at the namespace the gateway is actually in
+Deployed agents reach the gateway runtime by DNS name, and both the trace-export endpoint and the route agent traffic is forwarded through are built from `apiPlatformGateway.namespace`. Leaving it empty derives the per-org-env convention `<org>-<env>`, which is what `add-environment.sh` creates — but [Step 7](#step-7-api-platform-gateway-extension) installs the gateway extension into `${DATA_PLANE_NS}`, matching that chart's own `apiGateway.namespace` default. Set this to the same namespace, as above.
+
+Get it wrong and nothing reports an error. The agent starts and serves requests while every span batch fails inside it with `Failed to resolve '…-gw-gateway-gateway-runtime.default-default' ([Errno -2] Name or service not known)`, so the Traces view stays empty; and the backend agent routes forward to has no reachable host, so invocation never reaches the gateway. The only evidence is a `Transient error` warning in the agent's own log.
+
+If you install the gateway extension into `<org>-<env>` instead, leave this unset.
+:::
 
 export const RegistryConfig = ({expanded}) => {
   const content = (


### PR DESCRIPTION
## Purpose

Two charts in this repo disagree about which namespace the API Platform Gateway is installed into, and the disagreement is silent on any install that does not follow the setup scripts.

`wso2-amp-api-platform-gateway-extension` treats it as a value — `apiGateway.namespace`, defaulting to `openchoreo-data-plane`, with per-org-env isolation described as opt-in and applied by `setup-gateway.sh` / `add-environment.sh` via `--set apiGateway.namespace=<org>-<env>`.

`wso2-amp-platform-resources-extension` did not treat it as a value at all. Both agent traits built the gateway-runtime DNS name with `<org>-<env>` hardcoded:

```
api-platform-${metadata.componentNamespace}-${metadata.environmentName}-gw-gateway-gateway-runtime.${metadata.componentNamespace}-${metadata.environmentName}
```

An install that keeps the gateway chart's own default gets a name that never resolves. Nothing reports an error:

- the agent starts and serves requests normally, while every span batch fails inside it with `Failed to resolve '…-gw-gateway-gateway-runtime.default-default' ([Errno -2] Name or service not known)`, so the Traces view stays empty;
- the kgateway `Backend` that agent routes forward 100% of traffic to has no reachable host, so invocation never reaches the gateway runtime.

Only the scripted paths were unaffected, because they install exactly where the traits assume. Found on a multi-node cloud install, where an agent was deployed and invoked for the first time.

## Goals

Make the gateway's namespace a value in this chart too, so the traits address the gateway wherever it was actually installed, without changing behaviour for any existing installation.

## Approach

Both traits now resolve the runtime host through a single helper, `amp.gatewayRuntimeHost`, driven by a new `apiPlatformGateway.namespace` value:

- **empty (default)** — derive the per-org-env convention, exactly as before;
- **set** — qualify the Service with that namespace.

The helper emits an OpenChoreo trait placeholder expression, so `${metadata.*}` is still resolved by the controller rather than by Helm. Centralising it also means the next place that needs this address cannot drift from these two.

Worth noting why a value is needed rather than a post-install patch: editing the rendered `Backend` does not survive, because the controller re-renders it from the trait on the next reconcile. The instrumentation trait already had an escape hatch in `apiPlatformGatewayVhost.otelEndpointOverride`, but that is a *full-URL* override intended for installs fronting a single public gateway host (a VM install), and the api-management trait had no equivalent at all.

The evaluation job's egress policy carried the same shape of assumption and is fixed alongside: it allowed the LLM gateway **only** through a `amp.wso2.com/api-platform-gateway: "true"` namespaceSelector, and nothing but the setup scripts applies that label — so `llm_judge` evaluators are denied egress to the gateway on any other install. It now also accepts a configured namespace via `networkPolicy.evaluationJob.llmGateway.namespace`, defaulting to the label alone.

## User stories

As a platform engineer installing the gateway extension into its default namespace, deployed agents export traces and are reachable through the gateway, rather than failing silently in ways that only appear once an agent is invoked.

## Release note

Fixed the agent API-management and instrumentation traits hardcoding a per-org-env gateway namespace, which broke trace export and gateway-mediated invocation on installations that use the gateway extension's default namespace. The namespace is now configurable via `apiPlatformGateway.namespace`, and the evaluation job's LLM-gateway egress rule accepts a configured namespace in addition to the labelled one.

## Documentation

The production installation guide currently works around the trace half of this with `apiPlatformGatewayVhost.otelEndpointOverride` (#1465). Once this lands, that override should be replaced by `--set apiPlatformGateway.namespace=${DATA_PLANE_NS}`, which fixes both halves with one flag — left as a follow-up so the two changes stay reviewable separately.

The k3d guide needs the same flag: its Phase 2 Step 4 sets neither the namespace nor any override, so agents built by following that page have no trace export today, even though `make setup` is fine because it installs the gateway into `<org>-<env>`.

## Training

N/A — no training content covers chart values.

## Certification

N/A — a chart defect fix with no certification impact.

## Marketing

N/A — defect fix.

## Automation tests

 - Unit tests
   > N/A — Helm templates only.
 - Integration tests
   > Verified by rendering both charts and diffing the output:
   > - `wso2-amp-platform-resources-extension` with default values renders the runtime host **byte-identically** to `main` in both traits, confirming this is a no-op for every existing path;
   > - with `--set apiPlatformGateway.namespace=openchoreo-data-plane`, both traits render `…-gw-gateway-gateway-runtime.openchoreo-data-plane` (and the OTEL variant with `:22893/otel`);
   > - `wso2-amp-evaluation-extension` renders one `namespaceSelector` by default and two when `networkPolicy.evaluationJob.llmGateway.namespace` is set;
   > - `deployments/helm-charts/wso2-agent-manager/tests/render.sh` passes.

The underlying failure and its fix were both observed on a live multi-node cluster: pointing the trace endpoint at the real Service stopped the resolution errors and traces began flowing, and the gateway invocation path required the same correction.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/code changes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

The NetworkPolicy change widens an egress allowance, so it is worth reviewing deliberately. It adds a second `namespaceSelector` only when an operator names a namespace, and the policy still restricts egress to a single port. The alternative — telling operators to label the namespace — has the same effect with a less discoverable failure mode.

## Samples

N/A.

## Migrations (if applicable)

None. Both new values default to current behaviour, so upgrading changes nothing until an installer sets them.

## Test environment

Rendered with Helm 3 against the charts in this repo. The failure modes were reproduced on managed Kubernetes 1.35 (3 nodes), gateway operator 0.10.1 with gateway chart 1.2.0-beta, OpenChoreo planes 1.1.1.

## Learning

The general lesson is that when one chart models something as a value and another hardcodes the same fact, the mismatch surfaces only in the configuration neither author tested. The comment above the api-management trait's host records a deliberate simplification — the address is treated as a platform-wide constant because the service no longer injects it per environment — and that is what allowed the assumption to be written as a literal.

Also worth noting: `agent-manager-service` already stores the authoritative per-gateway runtime address, submitted by the gateway extension at registration and reconciled on upgrade. A longer-term simplification would be for the traits to consume that stored value rather than re-deriving it by convention, which would make this class of drift impossible.
