### PR TITLE
Fall back to is_active for gateway connectivity

### DIFF
--- a/agent-manager-service/services/agent_apikey_service.go
+++ b/agent-manager-service/services/agent_apikey_service.go
@@ -102,10 +102,23 @@ func NewAgentAPIKeyService(
 // least one live websocket connection to this control plane. Key events for
 // a disconnected gateway are queued and only apply after it reconnects, so
 // callers surface this to warn that a fresh key is not yet usable.
+//
+// A gateway holds its websocket with exactly one replica, and the connection
+// registry is per-process, so the local registry alone cannot answer this for
+// the whole deployment: a replica that does not hold the socket would report a
+// live gateway as disconnected. is_active is the cross-replica view of the same
+// fact — the holding replica writes it on connect and clears it on disconnect —
+// so it is consulted as a fallback.
+//
+// The two are OR'd rather than the DB replacing the registry. The local
+// registry is the fresher signal when this replica does hold the socket, and
+// is_active can go stale as true if a holding pod dies without running its
+// disconnect path. OR keeps the accurate answer in the common case and can only
+// turn a false negative into a true, never the reverse.
 func (s *AgentAPIKeyService) gatewaysConnected(gateways []*models.Gateway) *bool {
 	connected := true
 	for _, gw := range gateways {
-		if len(s.connChecker.GetConnections(gw.UUID.String())) == 0 {
+		if len(s.connChecker.GetConnections(gw.UUID.String())) == 0 && !gw.IsActive {
 			connected = false
 			break
 		}

--- a/agent-manager-service/services/agent_apikey_service_unit_test.go
+++ b/agent-manager-service/services/agent_apikey_service_unit_test.go
@@ -80,6 +80,7 @@ type apiKeyServiceFixture struct {
 	upsertedKeys *[]*models.StoredAPIKey
 	lookedUpName *string
 	connChecker  *stubConnChecker
+	gateway      *models.Gateway
 }
 
 // newAPIKeyServiceFixture wires an AgentAPIKeyService whose artifact/env/gateway
@@ -130,6 +131,7 @@ func newAPIKeyServiceFixture(t *testing.T, existing *models.StoredAPIKey) *apiKe
 		upsertedKeys: upserted,
 		lookedUpName: lookedUp,
 		connChecker:  connChecker,
+		gateway:      gateway,
 	}
 }
 
@@ -199,11 +201,29 @@ func TestAgentAPIKeyService_IssueTestAPIKey_PerUser(t *testing.T) {
 		require.NotNil(t, resp.GatewayConnected)
 		assert.True(t, *resp.GatewayConnected)
 
+		// Only when both the local registry and is_active say otherwise is the
+		// gateway reported disconnected.
 		fx.connChecker.connected = false
+		fx.gateway.IsActive = false
 		resp, err = fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
 		require.NoError(t, err)
 		require.NotNil(t, resp.GatewayConnected)
 		assert.False(t, *resp.GatewayConnected)
+	})
+
+	t.Run("falls back to is_active when this replica does not hold the websocket", func(t *testing.T) {
+		// A gateway holds its websocket with exactly one replica, so a replica
+		// without the socket sees an empty local registry for a live gateway.
+		// Reporting disconnected there is a false negative that the console acts
+		// on, so is_active — written by the holding replica — decides instead.
+		fx := newAPIKeyServiceFixture(t, nil)
+		fx.connChecker.connected = false
+		fx.gateway.IsActive = true
+
+		resp, err := fx.svc.IssueTestAPIKey(context.Background(), org, proj, agent, env, "user-a-sub")
+		require.NoError(t, err)
+		require.NotNil(t, resp.GatewayConnected)
+		assert.True(t, *resp.GatewayConnected)
 	})
 
 	t.Run("rejects reissue when the existing row is not a test key", func(t *testing.T) {
@@ -273,6 +293,7 @@ func TestAgentAPIKeyService_CreateAPIKey_ReservedTestKeyPrefix(t *testing.T) {
 	t.Run("reports gateway websocket connectivity in the response", func(t *testing.T) {
 		fx := newAPIKeyServiceFixture(t, nil)
 		fx.connChecker.connected = false
+		fx.gateway.IsActive = false
 
 		resp, err := fx.svc.CreateAPIKey(context.Background(), org, proj, agent, env,
 			&models.CreateAPIKeyRequest{Name: "my-key"})
@@ -280,5 +301,18 @@ func TestAgentAPIKeyService_CreateAPIKey_ReservedTestKeyPrefix(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.GatewayConnected)
 		assert.False(t, *resp.GatewayConnected)
+	})
+
+	t.Run("falls back to is_active when this replica does not hold the websocket", func(t *testing.T) {
+		fx := newAPIKeyServiceFixture(t, nil)
+		fx.connChecker.connected = false
+		fx.gateway.IsActive = true
+
+		resp, err := fx.svc.CreateAPIKey(context.Background(), org, proj, agent, env,
+			&models.CreateAPIKeyRequest{Name: "my-key"})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp.GatewayConnected)
+		assert.True(t, *resp.GatewayConnected)
 	})
 }


### PR DESCRIPTION
## Purpose

The gateway-connectivity flag returned with an API key is computed from a **process-local** connection registry, so it is wrong on any replica that does not happen to hold the gateway's websocket.

A gateway opens exactly one websocket, balanced to one `amp-api` pod. `gatewaysConnected()` answers from `websocket.Manager.GetConnections()`, backed by a `sync.Map` that only that pod populates. Nothing pins a console session to the holding pod — neither the `amp-api` nor `amp-api-gateway-manager` Service sets `sessionAffinity`, and neither HTTPRoute sets `sessionPersistence` — so with the API at two replicas roughly half of requests get a false `gatewayConnected: false` for a perfectly healthy gateway.

This is reachable on default settings, not only in a tuned deployment: `autoscaling.enabled` is `true` with `maxReplicas: 10`, and the deployment omits `replicas` when autoscaling is on, so `replicaCount: 1` is a no-op. The production guide additionally sets `minReplicas=2` explicitly.

**The impact is functional, not just a misleading banner.** Try-It installs a fetch wrapper that retries once on 401 after a propagation delay, and installs it *only while the gateway is believed connected*. That retry is what absorbs the few seconds between issuing a key and the holding replica delivering it. A false negative removes the recovery and surfaces a hard 401 instead. The same state also suppresses the alert offering to refresh the key, so a genuine auth failure is left with no remedy.

Observed on a multi-node cluster at two replicas: the console reported the gateway as not connected while the gateway demonstrably received and processed the key event seconds later, and invocation through it returned `200`.

## Goals

Report connectivity for the deployment rather than for whichever replica served the request, without weakening the signal where it is currently accurate.

## Approach

Event *delivery* was already designed to cross pods — the manager subscribes to the event hub so any instance can reach a gateway attached elsewhere. The status *read* never got the same treatment.

`gateways.is_active` is the cross-replica view of the same fact: the holding replica writes it on connect and clears it on disconnect. `gatewaysConnected()` now treats a gateway as connected when the local registry has a connection **or** the row is active. The service already receives fully hydrated `*models.Gateway` rows, so this needs no new table, query, or repository method.

`OR` rather than replacing the registry, deliberately:

- the local registry is the fresher signal when this replica *does* hold the socket;
- `is_active` is known-imperfect — it is described in-code as flapping, and it can stay `true` if a holding pod dies without running its disconnect path;
- `OR` can only turn a false negative into a true, never the reverse. The worst remaining case is a banner that fails to appear when a gateway is genuinely down, which is strictly better than today's banner appearing when it is up — and it matches the semantics the gateway-status UI already exposes elsewhere.

A durable alternative would be a `last_seen_at` lease refreshed by the holding pod's heartbeat and read with a staleness window. That is a larger change and not needed to fix this symptom; worth considering if the stale-`true` case ever matters.

## User stories

As an operator running the Agent Manager API with more than one replica, Try-It works on the first attempt and the console does not tell me a healthy gateway is disconnected.

## Release note

Fixed the gateway connectivity indicator returned with agent API keys being computed per-replica, which caused the console to intermittently report a connected gateway as offline when the Agent Manager API runs with multiple replicas, and disabled the Try-It retry that masks key-propagation delay.

## Documentation

N/A — no documented behaviour changes; this makes the existing behaviour correct under HA.

## Training

N/A.

## Certification

N/A — defect fix.

## Marketing

N/A.

## Automation tests

 - Unit tests
   > Two cases added to `agent_apikey_service_unit_test.go`, one per entry point (`IssueTestAPIKey` and `CreateAPIKey`): with the local registry empty and `is_active` true, the response now reports connected; with both false, it still reports disconnected.
   >
   > Note the two pre-existing "reports gateway websocket connectivity" cases encoded the old behaviour — the fixture builds an **active** gateway, so they asserted `false` while relying on the registry alone. They now clear `IsActive` explicitly to test the genuinely-disconnected path, which is what they were actually asserting. This is a deliberate test change, not a weakened assertion.
   >
   > `services` package coverage 30.5%. Full suite via `scripts/run_unit_tests.sh` passes (exit 0), and `make codegenfmt-check` is clean.
 - Integration tests
   > Not added — reproducing this needs two API replicas and a connected gateway, which the unit tier cannot express. The scenario was verified manually on a live two-replica cluster.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go, not Java
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Worth stating explicitly: this flag is advisory and does not gate key distribution. Key fan-out already ignores connectivity by design — the code notes `is_active` flaps and filtering on it would starve a live gateway — so this change does not alter who receives a key, only what the response reports.

## Samples

N/A.

## Migrations (if applicable)

None.

## Test environment

Go unit tests on macOS via `scripts/run_unit_tests.sh` (the config package requires env vars exported by that script). Behaviour reproduced on managed Kubernetes 1.35, Agent Manager API at 2 replicas with an HPA minimum of 2, gateway operator 0.10.1 with gateway chart 1.2.0-beta.

## Learning

The instructive part is that the codebase had already solved the harder half of this problem. `websocket/manager.go` documents that event delivery deliberately works across pods, and `gateways.is_active` was already being maintained as a cross-replica presence signal by the websocket controller. The bug was a single-replica assumption surviving in one read path after the rest of the design had moved on — and it stayed invisible because the local map is correct exactly half the time.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway connection detection for API key operations.
  * Gateways now remain recognized as connected when their active status is available, even if a local websocket connection is not present.
  * Prevented valid API key creation and issuance from being incorrectly blocked in multi-instance environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
