### PR TITLE
Recover a gateway whose tokens no longer exist

### DIFF
--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-bootstrap-job.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-bootstrap-job.yaml
@@ -251,6 +251,22 @@ spec:
                 return 0
               }
 
+              warn_vhost_drift() {
+                # _vh_ prefix: POSIX sh has no portable `local`, so these leak as globals.
+                _vh_want="$1"; _vh_have="$2"
+                if [ -z "${_vh_want}" ] || [ "${_vh_want}" = "${_vh_have}" ]; then
+                  return 0
+                fi
+                # Unlike runtimeUrl there is no PUT for vhost: it is not part of the
+                # gateway update API, so registration is the only chance to set it and a
+                # supplied value that differs is silently discarded. Say so, rather than
+                # leaving the operator to notice the console still shows the old host.
+                log_info "WARNING: gateway.vhost is '${_vh_want}' but this gateway is registered with '${_vh_have}'."
+                log_info "WARNING: vhost is written at first registration only and cannot be updated, so the registered value stays in effect."
+                log_info "WARNING: Applying it means deleting this gateway registration and re-registering."
+                return 0
+              }
+
               # ----------------------------------------------------------------
               # Step 1: Wait for Agent Manager API to be healthy
               # ----------------------------------------------------------------
@@ -327,6 +343,13 @@ spec:
                   grep -o '"name":"'"${GATEWAY_NAME}"'"[^}]*"runtimeUrl":"[^"]*"' | \
                   grep -o '"runtimeUrl":"[^"]*"' | cut -d'"' -f4 | head -1)
                 sync_runtime_url "${GATEWAY_RUNTIME_URL}" "${REGISTERED_RUNTIME_URL}"
+
+                # Same window reasoning as runtimeUrl above: vhost sorts after name and
+                # everything between them is scalar.
+                REGISTERED_VHOST=$(echo "${LIST_RESPONSE}" | \
+                  grep -o '"name":"'"${GATEWAY_NAME}"'"[^}]*"vhost":"[^"]*"' | \
+                  grep -o '"vhost":"[^"]*"' | cut -d'"' -f4 | head -1)
+                warn_vhost_drift "${GATEWAY_VHOST}" "${REGISTERED_VHOST}"
               else
                 # ----------------------------------------------------------------
                 # Step 4: Find the environment by name
@@ -393,6 +416,22 @@ spec:
               EXISTING_TOKEN=$(kubectl get secret "${TOKEN_SECRET_NAME}" \
                 --namespace="${TOKEN_SECRET_NAMESPACE}" \
                 -o jsonpath="{.data.${TOKEN_SECRET_KEY}}" 2>/dev/null | base64 -d 2>/dev/null || true)
+
+              # The Secret is created with kubectl below, so Helm does not own it and
+              # `helm uninstall` leaves it behind. Reusing it unconditionally would then
+              # hand the controller a credential the control plane has no record of —
+              # which is what happens on a reinstall after the gateway's tokens are gone,
+              # and it authenticates nowhere while looking correctly configured. Only
+              # reuse the Secret when this gateway still has at least one token.
+              if [ -n "${EXISTING_TOKEN}" ]; then
+                TOKEN_LIST=$(http_get \
+                  "${AMP_API_URL}/orgs/${ORG_NAME}/gateways/${GATEWAY_ID}/tokens" \
+                  "${ACCESS_TOKEN}" || true)
+                if ! echo "${TOKEN_LIST}" | grep -q '"id"'; then
+                  log_info "Token Secret '${TOKEN_SECRET_NAME}' exists but gateway '${GATEWAY_ID}' has no registered tokens — minting a new one."
+                  EXISTING_TOKEN=""
+                fi
+              fi
 
               if [ -n "${EXISTING_TOKEN}" ]; then
                 log_info "Token Secret '${TOKEN_SECRET_NAME}' already exists — skipping token rotation."


### PR DESCRIPTION
## Purpose

Two gaps in the gateway bootstrap job, both found while recovering a gateway on a real cluster.

**1. A gateway whose tokens no longer exist can never authenticate again.**

The job reuses an existing registration-token Secret instead of rotating. That is correct in the normal case — rotating on every upgrade would cut off a running gateway-controller, and the control plane caps a gateway at two active tokens, so repeated rotation would eventually fail outright.

But the reuse was unconditional, and the Secret is created with `kubectl` inside the Job rather than by Helm, so **`helm uninstall` leaves it behind**. Reinstalling after the gateway's tokens are gone therefore: registers a new gateway, finds the stale Secret, skips minting, and hands the controller a credential the control plane has no record of. Nothing detects it — the job logs success, the Secret looks right, and the controller authenticates nowhere.

That is exactly the state the documented recovery for a platform data reset produces, which is why following the documented steps did not recover. `VerifyToken` returns `invalid token` for an unknown prefix and every consumer simply 401s; nothing re-registers or re-mints.

**2. `gateway.vhost` is silently discarded on upgrade.**

`runtimeUrl` is reconciled on every run via `sync_runtime_url`, which PUTs when the registered value differs — the address is a fact about placement, so a stale one is simply wrong. `vhost` gets no such treatment and is not part of the gateway update API at all, so a corrected value in `values.yaml` has no effect and produces no message. The console keeps showing the old host, which is what an operator would copy when wiring an external caller.

## Goals

Make a token-less gateway recoverable by reinstalling, and make vhost drift visible instead of silent.

## Approach

**Token reuse is now conditional.** Before reusing the Secret, the job lists the gateway's tokens and only reuses when at least one exists; otherwise it mints. The job already requests `amp:gateway:token-manage`, so no scope change is needed, and the normal upgrade path is unchanged — a gateway with a live token still skips rotation exactly as before.

**Vhost drift is reported.** A `warn_vhost_drift` helper mirrors the shape of the existing role-drift warning: it compares the supplied value against the registered one and, when they differ, states that vhost is written at first registration only, that the registered value stays in effect, and that applying a change means re-registering.

Deliberately *not* included: making vhost mutable. It appears safe to reconcile — it never reaches Kubernetes (routing comes from `gateway.hostname` → `HTTPRoute.spec.hostnames`), the environment's ingress-slot check keys on environment and role only, and API-key fan-out resolves gateways by environment and role rather than by vhost. Everything that reads it builds a display or config URL at request time, structurally the same as `runtimeUrl`. So adding `vhost` to `UpdateGatewayRequest` and a `sync_vhost` mirroring `sync_runtime_url` looks like the right end state — but it widens a public API surface, which deserves its own review rather than riding along in a defect fix. Happy to follow up with it if reviewers agree.

## User stories

As an operator who has reset Agent Manager's data, reinstalling the gateway extension gives me a gateway that can actually authenticate, instead of one that looks correctly configured and silently cannot.

As an operator who set the wrong gateway virtual host, the install tells me the value was not applied and what to do about it, instead of leaving me to spot it in the console.

## Release note

Fixed the gateway bootstrap job reusing a stale registration-token Secret when the gateway has no registered tokens, which left the gateway unable to authenticate after a reinstall — the token is now regenerated in that case. The job also now warns when the configured gateway virtual host differs from the registered one, which cannot be changed after first registration.

## Documentation

The production installation guide already states that the virtual host must be set on the first install because it cannot be corrected later (#1465). This change makes the platform say the same thing at the point it happens. No further documentation change needed.

## Training

N/A.

## Certification

N/A — defect fix.

## Marketing

N/A.

## Automation tests

 - Unit tests
   > N/A — the change is shell inside a Helm-templated Job; there is no unit tier for it.
 - Integration tests
   > Verified by rendering the chart and testing the logic directly:
   > - the rendered Job script passes `sh -n` (POSIX syntax check);
   > - the token gate was exercised against three payload shapes — `{"tokens":[]}` → mint, `{"tokens":[{"id":…}]}` → reuse, empty/failed response → mint (fail-safe: an API error mints rather than reusing a possibly-dead credential);
   > - the vhost extraction was run against a **real list payload captured from a live cluster** and returns the registered vhost correctly;
   > - the existing `runtimeUrl` extraction was re-run against the same payload as a regression check, since both rely on the same alphabetical-key window, and still returns the right value.
   >
   > The failure mode itself was observed on that cluster: `helm upgrade` with a corrected `gateway.vhost` logged `already exists` and left the old value in the database, and recovery from the token-less state required manually deleting the Secret.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/code changes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

The token change mints a credential in one additional case. It is gated on the gateway having no valid token, so it cannot rotate a credential a live controller is using — which is the risk the original unconditional skip existed to avoid.

## Samples

N/A.

## Migrations (if applicable)

None. Existing installs are unaffected: a gateway with at least one registered token follows exactly the previous path.

## Test environment

Helm 3 rendering plus POSIX shell execution of the extracted script on macOS. The underlying failures were observed on managed Kubernetes 1.35, gateway operator 0.10.1 with gateway chart 1.2.0-beta, Agent Manager charts at a single nightly version.

## Learning

The interesting part is that the job already had the right pattern for half of this. `sync_runtime_url` exists, with a comment explaining precisely when a registered value should be reconciled and when it should not — and vhost, which is the external counterpart of the same fact, simply never got the same treatment. The role, by contrast, is immutable for a stated technical reason. So the field-by-field behaviour is a mix of deliberate design and omission, and the omission was indistinguishable from the design because neither said anything at runtime.

The token issue is a reminder that a resource created with `kubectl` inside a Job sits outside the release lifecycle: `helm uninstall` removes what Helm owns, and anything else silently outlives it and is then treated as valid state by the next install.
