### PR TITLE
Recreate the gateway controller on upgrade

### DIFF
--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-config.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-config.yaml
@@ -109,6 +109,25 @@ data:
         logging:
           level: info
         deployment:
+          # Recreate, not the Kubernetes default RollingUpdate. The controller is a
+          # single replica holding its SQLite store on a ReadWriteOnce PVC, and a
+          # rolling update starts the replacement before the old pod is evicted
+          # (maxSurge 1 / maxUnavailable 0 at one replica). On a multi-node cluster
+          # the scheduler prefers a different node for the new pod, which then cannot
+          # attach the volume — "Multi-Attach error for volume" — while the old pod
+          # cannot be evicted until the new one is Ready. That deadlock does not time
+          # out into a rollback; it holds the APIGateway at Programmed=False until an
+          # operator deletes the old pod by hand.
+          #
+          # Recreate terminates the old pod first, so the volume is free when the new
+          # one starts. The cost is a few seconds of controller downtime per upgrade,
+          # which this component already has: it cannot run more than one replica
+          # while storage.type is sqlite.
+          #
+          # Single-node clusters never hit the deadlock, because ReadWriteOnce allows
+          # multiple pods on the same node — which is why local installs are unaffected.
+          strategy:
+            type: Recreate
           podSecurityContext:
             fsGroup: 10001
             runAsUser: 10001


### PR DESCRIPTION
## Purpose

Upgrading the API Platform Gateway extension deadlocks the gateway controller on any multi-node cluster, leaving the `APIGateway` at `Programmed=False` until an operator intervenes by hand.

The gateway chart emits no update strategy for the controller Deployment, so Kubernetes applies `RollingUpdate`. The controller is a **single replica** mounting its SQLite store on a **ReadWriteOnce** PVC. At one replica the defaults give `maxSurge=1, maxUnavailable=0`, so the replacement pod must reach Ready before the old pod may be evicted — and on a multi-node cluster the scheduler's spread scoring prefers a node that does not already host a replica. The new pod therefore usually lands elsewhere and cannot attach the volume:

```
Warning  FailedAttachVolume  Multi-Attach error for volume "pvc-…"
  Volume is already used by pod(s) …-gw-gateway-controller-…
```

New pod waits for the detach; the detach waits for the old pod; the old pod waits for the new pod to be Ready. Nothing breaks the cycle — `progressDeadlineSeconds` only *marks* the rollout failed, it does not abort or roll back. Observed sitting in `ContainerCreating` for over ten minutes with `phase=Reconciling`, `Programmed=False`; deleting the old controller pod released the volume and the gateway went `Ready` immediately.

There is a second-order effect worth knowing: the operator installs the sub-release with wait enabled and a five-minute timeout, so this stall also fails the operator's Helm operation and feeds its retry path, which can leave the release in `pending-install` and the CR unrecoverable without deleting it.

**Single-node clusters never see any of this** — ReadWriteOnce permits multiple pods on the same node, so local installs complete the rolling update normally. That is why it took a multi-node cluster and an actual gateway upgrade to surface.

## Goals

Make gateway-extension upgrades complete unattended on multi-node clusters, without waiting on an upstream chart release.

## Approach

Set `strategy: {type: Recreate}` on the controller in the gateway values this chart already renders. `Recreate` terminates the old pod before starting the new one, so the volume is free when the replacement starts.

This ConfigMap is the values document the operator passes to the gateway release (`spec.configRef` on the `APIGateway` CR), so the default can be corrected here without an upstream change. The gateway chart does expose `gateway.controller.deployment.strategy` — it simply does not default it.

The trade-off is a few seconds of controller downtime per upgrade. That is already inherent to this component: it cannot run more than one replica while `storage.type` is `sqlite`, so there is no availability being given up. Verified that the chart's own comment agrees — its `strategy: {}` default is documented as "Empty = Kubernetes default (RollingUpdate, 25% maxSurge / 25% maxUnavailable)".

Alternatives considered and rejected:

- **`persistence.enabled=false`** — makes the volume an `emptyDir`, so the SQLite database is lost on every restart. Upstream issue [wso2/api-platform#2147](https://github.com/wso2/api-platform/issues/2147) documents the outcome: after the store is wiped, all `RestApi` routes return 404 while the CRs still report `Programmed=True`, with no self-healing. Strictly worse.
- **A StatefulSet** — the correct long-term shape, but the gateway chart offers no such option in any published version.
- **`podAntiAffinity` / pinning the controller to one node** — would keep the rolling update on a single node and avoid the attach conflict, but constrains scheduling for an unrelated reason and breaks if that node drains.

## User stories

As an operator upgrading the gateway extension on a multi-node cluster, the rollout completes on its own instead of stalling indefinitely and requiring me to identify and delete the previous controller pod.

## Release note

Fixed gateway-extension upgrades deadlocking on multi-node clusters. The gateway controller's Deployment now uses the `Recreate` update strategy, so its ReadWriteOnce volume is released before the replacement pod starts, instead of the two pods waiting on each other indefinitely.

## Documentation

The production installation guide currently documents the manual recovery (delete the old controller pod when two are listed and one is stuck). That note becomes unnecessary once this ships and can be removed in a follow-up; leaving it in place for now is harmless and still correct for anyone on an earlier chart.

## Training

N/A.

## Certification

N/A — defect fix.

## Marketing

N/A.

## Automation tests

 - Unit tests
   > N/A — Helm template values only.
 - Integration tests
   > Verified in both directions, since this value has to survive a hand-off between two charts:
   > 1. `helm template` of this chart renders `strategy: {type: Recreate}` into the gateway values ConfigMap;
   > 2. pulling the gateway chart at the pinned `1.2.0-beta` and templating it with that value produces `strategy: type: Recreate` on the controller Deployment — confirming the knob is honoured rather than silently ignored.
   >
   > Also confirmed against the upstream chart that no published version (`1.1.5`, `1.2.0-alpha`, `1.2.0-beta`, `1.2.0-rc`) defaults this, so the fix is still needed on the newest available gateway.

The failure and its manual recovery were both observed on a real multi-node cluster during an upgrade of this extension.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no code changes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A.

## Migrations (if applicable)

None. The new strategy applies from the next gateway upgrade onwards. An environment currently wedged by this deadlock still needs the old controller pod deleted once; after that, upgrades proceed cleanly.

## Related PRs

Reported upstream so the chart default can be corrected at the source, since every consumer of that chart is exposed, not only this platform.

## Test environment

Helm 3 rendering of both charts. The deadlock was observed on managed Kubernetes 1.35 with three nodes and a ReadWriteOnce default StorageClass, gateway operator 0.10.1, gateway chart 1.2.0-beta.

## Learning

The instructive part is how narrow the reproduction window is. Every ingredient is individually reasonable — one replica because SQLite cannot be shared, ReadWriteOnce because it is a local store, and RollingUpdate because that is simply the Kubernetes default nobody overrode. The failure needs all three plus more than one node, so it cannot appear on any single-node development install and only shows up the first time someone upgrades a gateway on a real cluster.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment behavior to prevent storage attachment conflicts when using SQLite-backed, single-node volumes.
  * Ensures the existing instance is stopped before its replacement starts, avoiding deployment deadlocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
