### PR TITLE
Fix amctl installer checksum check and print the API URL after quick-start

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1709,6 +1709,7 @@ log_info "Cluster: ${CLUSTER_CONTEXT}"
 # print their own reachable URLs instead.
 if [[ "${SHOW_LOCALHOST_URLS:-true}" == "true" ]]; then
   log_info "Agent Management Platform Console: http://console.amp.localhost:8080"
+  log_info "Agent Management Platform API: http://api.amp.localhost:8080"
   log_info "Observability Gateway (for traces): http://default-default.gateway.localhost:19080/otel"
 fi
 

--- a/scripts/install-amctl.sh
+++ b/scripts/install-amctl.sh
@@ -85,7 +85,8 @@ download_and_verify() {
     if command -v shasum >/dev/null 2>&1; then
         grep -F "  $ARCHIVE" checksums.txt | shasum -a 256 -c --quiet
     elif command -v sha256sum >/dev/null 2>&1; then
-        grep -F "  $ARCHIVE" checksums.txt | sha256sum -c --quiet
+        # No --quiet: BusyBox rejects it. Explicit "-": Apple's sha256sum won't read a bare stdin checklist.
+        grep -F "  $ARCHIVE" checksums.txt | sha256sum -c -
     else
         fail "Neither sha256sum nor shasum found. Cannot verify checksum."
     fi


### PR DESCRIPTION
## Purpose
Two defects in the install scripts:

1. **`scripts/install-amctl.sh` checksum verification fails outright on BusyBox.** The script passes `--quiet` to `sha256sum`, which is a GNU coreutils long option. BusyBox's `sha256sum` (Alpine and most slim container images, where a `curl | sh` install is common) rejects it and exits non-zero. Because the script runs under `set -eu`, the installer aborts at "Verifying checksum..." even when the download is perfectly valid — so `amctl` cannot be installed on those images at all.

2. **The quick-start success output never prints the Agent Manager API URL.** It prints the Console and the Observability Gateway, but not the API — which is the one URL a user needs for `amctl login --url ...` as their very next step. They had to go dig through the docs to find it.

## Goals
1. Make the `amctl` installer's checksum verification work on every `sha256sum` implementation it can realistically land on.
2. Print the API URL alongside the Console URL at the end of the quick-start so `amctl login` is an obvious next step.

## Approach

**1. `scripts/install-amctl.sh`**

Dropped `--quiet` and passed the checklist explicitly as `-` instead of relying on a bare stdin read:

```sh
grep -F "  $ARCHIVE" checksums.txt | sha256sum -c -
```

I verified the three `sha256sum` implementations this line can hit, and only this form works on all of them:

| Implementation | `-c --quiet` (before) | `-c` (bare stdin) | `-c -` (this PR) |
|---|---|---|---|
| BusyBox v1.38 | ❌ `unrecognized option '--quiet'` | ✅ | ✅ |
| GNU coreutils 9.11 | ✅ | ✅ | ✅ |
| Apple `/sbin/sha256sum` (Darwin 25) | ❌ no long options at all | ❌ usage error | ✅ |

Removing `--quiet` is what fixes the reported BusyBox breakage. The explicit `-` is a one-token addition covering the second row of failures: recent macOS ships its own `/sbin/sha256sum` that supports neither long options nor a bare stdin checklist. That branch is normally unreachable on macOS because `shasum` is probed first, but the `-` costs nothing and removes the latent trap.

The `shasum` branch above it is untouched — `shasum` is Perl-based and supports `--quiet` on every platform that ships it.

Verification is **not** weakened. `--quiet` only suppressed the per-file `OK` lines; it never affected exit codes. Confirmed a tampered archive still fails closed on both implementations:

```
BusyBox : amctl_v1.0.0_linux_amd64.tar.gz: FAILED
          sha256sum: WARNING: 1 of 1 computed checksums did NOT match   -> exit 1
GNU     : amctl_v1.0.0_linux_amd64.tar.gz: FAILED
          sha256sum: WARNING: 1 computed checksum did NOT match         -> exit 1
```

The script runs under `set -eu`, so that non-zero exit still aborts the install before the binary is unpacked. The only visible change on success is one extra `<archive>: OK` line, which sits fine next to the script's existing `==> Checksum verified.`

**2. `deployments/quick-start/install.sh`**

Added one line to the success block, inside the existing `SHOW_LOCALHOST_URLS` guard so wrappers that front the cluster with a reverse proxy (e.g. the VM installer) keep suppressing localhost URLs as before:

```
log_info "Agent Management Platform API: http://api.amp.localhost:8080"
```

I confirmed `http://api.amp.localhost:8080` is correct for the quick-start rather than assuming it:
- `deployments/helm-charts/wso2-agent-manager/values.yaml` sets `ocIngress.hostname: api.amp.localhost` and `serverPublicURL: "http://api.amp.localhost:8080"`.
- The quick-start does not override `ocIngress.hostname`, so the chart default applies.
- It matches what `install.sh` itself already prints at line 1619 (`AMP_API_URL=...http://api.amp.localhost:8080/api/v1`) and what `documentation/.../cli-installation.md` tells users to log in with.

## User stories
- As a user installing `amctl` on Alpine or a slim container image, the install completes instead of aborting at checksum verification.
- As a user who just finished the quick-start, I can see the API URL and run `amctl login` without going to the docs.

## Release note
Fixed `amctl` install script failing checksum verification on BusyBox-based systems, and the quick-start installer now prints the Agent Manager API URL on completion.

## Documentation
N/A — no doc changes needed. The API URL added to the output is the value already documented in `documentation/build/docs/next/getting-started/cli-installation.md`; this PR just surfaces it at the point of use. The installer fix restores documented behaviour rather than changing it.

## Training
N/A — install-script fixes, no training content impact.

## Certification
N/A — no functional or architectural change to certify against; these are portability and console-output fixes.

## Marketing
N/A — internal defect fixes.

## Automation tests
 - Unit tests
   > None added. The repo has no shell-script test harness, and these are single-line changes in two bash/sh scripts. Verified manually instead (see Test environment) — including the negative case, confirming a tampered archive still fails closed on both `sha256sum` implementations.
 - Integration tests
   > None added. Exercising the installer end-to-end would require publishing a real GitHub release artifact. The checksum-verification line was instead extracted and run against real BusyBox and GNU coreutils binaries in containers, in both the matching and mismatching case.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/Go code changed; FindSecurityBugs does not apply to shell scripts.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Worth an explicit note since this touches a supply-chain integrity check: the change is output-verbosity and stdin-plumbing only. Checksum comparison and its failure exit code are unchanged, and I verified the tampered-archive case still aborts under `set -eu`. No verification step was relaxed or skipped.

## Samples
N/A — no samples relate to these fixes.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data changes.

## Test environment
- Host: macOS (Darwin 25.0.0, arm64)
- `bash -n` and `sh -n` clean on both modified scripts; `shellcheck` reports no new findings (pre-existing warnings in `install.sh` untouched)
- `sha256sum` implementations exercised in the matching **and** mismatching case:
  - BusyBox v1.38.0 (`busybox:latest`)
  - GNU coreutils 9.11 (`alpine:latest` + `apk add coreutils`)
  - Apple `/sbin/sha256sum` (Darwin) 1.0, host
- `shasum` (Perl) 6.04 on host, confirming the untouched branch still verifies

Not run: a full `deployments/quick-start/install.sh` cluster install. The change there is a single `log_info` line in the terminal output block, with no control flow.

## Learning
The interesting part was that `--quiet` is a *GNU* long option, not a POSIX one — `sha256sum` is not one program but at least three with meaningfully different flag surfaces. Checking BusyBox and Apple's implementation directly (rather than just removing the flag and assuming GNU semantics elsewhere) is what surfaced the second, latent failure: Apple's `/sbin/sha256sum` also refuses a bare stdin checklist, so `-c` alone would have silently traded one broken platform for another. Passing the checklist as an explicit `-` is the portable intersection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation completion output now displays the Agent Management Platform API URL.

* **Bug Fixes**
  * Improved checksum verification compatibility for BusyBox-based environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->