### PR TITLE
Fix MCP proxy upstream URL losing its /mcp suffix on deploy

### DIFF
--- a/agent-manager-service/services/mcp_proxy_deployment.go
+++ b/agent-manager-service/services/mcp_proxy_deployment.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -422,7 +421,7 @@ func (s *MCPProxyService) buildMCPProxyDeploymentYAML(proxy *models.MCPProxy, pr
 	upstream := MCPProxyUpstream{}
 	var upstreamAuth *models.UpstreamAuth
 	if proxy.Configuration.Upstream.Main != nil {
-		upstream.URL = normalizeMCPUpstreamURLForDeployment(proxy.Configuration.Upstream.Main.URL)
+		upstream.URL = strings.TrimSpace(proxy.Configuration.Upstream.Main.URL)
 		upstreamAuth = proxy.Configuration.Upstream.Main.Auth
 	}
 	if strings.TrimSpace(upstream.URL) == "" {
@@ -751,31 +750,6 @@ func cloneStringInterfaceMap(in map[string]interface{}) map[string]interface{} {
 		out[key] = value
 	}
 	return out
-}
-
-func normalizeMCPUpstreamURLForDeployment(rawURL string) string {
-	trimmed := strings.TrimSpace(rawURL)
-	parsed, err := url.Parse(trimmed)
-	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-		return trimmed
-	}
-
-	path := strings.TrimRight(parsed.Path, "/")
-	if path == "" {
-		return trimmed
-	}
-	segments := strings.Split(path, "/")
-	if len(segments) == 0 || segments[len(segments)-1] != "mcp" {
-		return trimmed
-	}
-
-	segments = segments[:len(segments)-1]
-	parsed.Path = strings.Join(segments, "/")
-	if parsed.Path == "" {
-		parsed.Path = "/"
-	}
-	parsed.RawPath = ""
-	return parsed.String()
 }
 
 func deploymentName(proxy *models.MCPProxy) string {

--- a/agent-manager-service/services/mcp_proxy_deployment_test.go
+++ b/agent-manager-service/services/mcp_proxy_deployment_test.go
@@ -135,8 +135,9 @@ func TestGenerateMCPProxyDeploymentYAML_WithContextAndVhost(t *testing.T) {
 	}
 }
 
-// TestGenerateMCPProxyDeploymentYAML_StripsMCPSuffix verifies the trailing
-// "/mcp" path segment is stripped from the upstream URL during deployment.
+// TestGenerateMCPProxyDeploymentYAML_PreservesUpstreamPath verifies the
+// trailing "/mcp" path segment survives to the deployed upstream URL
+// unchanged, since the gateway no longer re-appends it itself.
 func TestGenerateMCPProxyDeploymentYAML_PreservesUpstreamPath(t *testing.T) {
 	service := &MCPProxyService{}
 
@@ -658,6 +659,7 @@ func TestGenerateMCPProxyDeploymentYAML_UpstreamURLPassthrough(t *testing.T) {
 		{name: "trailing slash after /mcp is kept as-is", in: "https://host.example.com/api/mcp/", want: "https://host.example.com/api/mcp/"},
 		{name: "non-mcp path untouched", in: "https://host.example.com/api/v1", want: "https://host.example.com/api/v1"},
 		{name: "bare host with /mcp kept as-is", in: "https://host.example.com/mcp", want: "https://host.example.com/mcp"},
+		{name: "non-url passthrough", in: "not a url", want: "not a url"},
 		{name: "trims whitespace", in: "  https://host.example.com/x  ", want: "https://host.example.com/x"},
 	}
 

--- a/agent-manager-service/services/mcp_proxy_deployment_test.go
+++ b/agent-manager-service/services/mcp_proxy_deployment_test.go
@@ -137,13 +137,13 @@ func TestGenerateMCPProxyDeploymentYAML_WithContextAndVhost(t *testing.T) {
 
 // TestGenerateMCPProxyDeploymentYAML_StripsMCPSuffix verifies the trailing
 // "/mcp" path segment is stripped from the upstream URL during deployment.
-func TestGenerateMCPProxyDeploymentYAML_StripsMCPSuffix(t *testing.T) {
+func TestGenerateMCPProxyDeploymentYAML_PreservesUpstreamPath(t *testing.T) {
 	service := &MCPProxyService{}
 
 	proxy := &models.MCPProxy{
-		Handle: "strip-proxy",
+		Handle: "preserve-proxy",
 		Configuration: models.MCPProxyConfig{
-			Name:    "Strip Proxy",
+			Name:    "Preserve Proxy",
 			Version: "v1",
 			Upstream: models.UpstreamConfig{
 				Main: &models.UpstreamEndpoint{URL: "https://host.example.com/godzilla/server/v1.0/mcp"},
@@ -161,9 +161,11 @@ func TestGenerateMCPProxyDeploymentYAML_StripsMCPSuffix(t *testing.T) {
 		t.Fatalf("failed to unmarshal YAML: %v", err)
 	}
 
-	want := "https://host.example.com/godzilla/server/v1.0"
+	// The gateway no longer re-appends "/mcp" itself, so the full upstream URL,
+	// including the "/mcp" suffix, must reach it unchanged.
+	want := "https://host.example.com/godzilla/server/v1.0/mcp"
 	if deployment.Spec.Upstream.URL != want {
-		t.Errorf("expected upstream url %q (\"/mcp\" stripped), got %q", want, deployment.Spec.Upstream.URL)
+		t.Errorf("expected upstream url %q unchanged, got %q", want, deployment.Spec.Upstream.URL)
 	}
 }
 
@@ -643,25 +645,47 @@ func TestMergeMCPPoliciesForDeployment(t *testing.T) {
 	})
 }
 
-// TestNormalizeMCPUpstreamURLForDeployment covers URL normalization edge cases.
-func TestNormalizeMCPUpstreamURLForDeployment(t *testing.T) {
+// TestGenerateMCPProxyDeploymentYAML_UpstreamURLPassthrough covers the URL edge
+// cases the old normalizer used to special-case: none of them should be
+// altered now, only whitespace-trimmed.
+func TestGenerateMCPProxyDeploymentYAML_UpstreamURLPassthrough(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
 		want string
 	}{
-		{name: "strips trailing /mcp", in: "https://host.example.com/api/mcp", want: "https://host.example.com/api"},
-		{name: "strips trailing /mcp with trailing slash", in: "https://host.example.com/api/mcp/", want: "https://host.example.com/api"},
-		{name: "leaves non-mcp path untouched", in: "https://host.example.com/api/v1", want: "https://host.example.com/api/v1"},
-		{name: "root mcp collapses to root", in: "https://host.example.com/mcp", want: "https://host.example.com/"},
-		{name: "non-url passthrough", in: "not a url", want: "not a url"},
+		{name: "url ending in /mcp is kept as-is", in: "https://host.example.com/api/mcp", want: "https://host.example.com/api/mcp"},
+		{name: "trailing slash after /mcp is kept as-is", in: "https://host.example.com/api/mcp/", want: "https://host.example.com/api/mcp/"},
+		{name: "non-mcp path untouched", in: "https://host.example.com/api/v1", want: "https://host.example.com/api/v1"},
+		{name: "bare host with /mcp kept as-is", in: "https://host.example.com/mcp", want: "https://host.example.com/mcp"},
 		{name: "trims whitespace", in: "  https://host.example.com/x  ", want: "https://host.example.com/x"},
 	}
 
+	service := &MCPProxyService{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := normalizeMCPUpstreamURLForDeployment(tt.in); got != tt.want {
-				t.Errorf("normalizeMCPUpstreamURLForDeployment(%q) = %q, want %q", tt.in, got, tt.want)
+			proxy := &models.MCPProxy{
+				Handle: "passthrough-proxy",
+				Configuration: models.MCPProxyConfig{
+					Name:    "Passthrough Proxy",
+					Version: "v1",
+					Upstream: models.UpstreamConfig{
+						Main: &models.UpstreamEndpoint{URL: tt.in},
+					},
+				},
+			}
+
+			yamlStr, err := service.generateMCPProxyDeploymentYAML(proxy, "x", nil)
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+
+			var deployment MCPProxyDeploymentYAML
+			if err := yaml.Unmarshal([]byte(yamlStr), &deployment); err != nil {
+				t.Fatalf("failed to unmarshal YAML: %v", err)
+			}
+			if deployment.Spec.Upstream.URL != tt.want {
+				t.Errorf("upstream url = %q, want %q", deployment.Spec.Upstream.URL, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

`normalizeMCPUpstreamURLForDeployment` strips a trailing `/mcp` segment from an MCP proxy's upstream URL before deploying it to the gateway, on the assumption that the gateway would re-append `/mcp` itself. That's no longer how the gateway behaves — it now forwards to exactly the upstream URL it's given, with no re-appending. The result: every MCP proxy call gets routed to the upstream's root path instead of `/mcp`, and the upstream 404s, even though the correct full URL (including `/mcp`) was entered when registering the proxy. 
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment configurations now preserve the complete upstream URL path, including trailing `/mcp` segments.
  * Surrounding whitespace is still removed from configured upstream URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->