### PR TITLE
Capture workflow-plane state in heavy diagnostics

### DIFF
--- a/.github/workflows/instrumentation-matrix-manual.yaml
+++ b/.github/workflows/instrumentation-matrix-manual.yaml
@@ -268,6 +268,53 @@ jobs:
               | awk '/gateway-controller/{print $1}' \
               | while read -r p; do echo "----- $gwns/$p -----"; kubectl logs -n "$gwns" "$p" --tail=80 2>/dev/null; done
           done
+          echo "=== workflow-plane controller (Argo drives every agent build) ==="
+          # A build that never leaves WorkflowPending usually means this
+          # controller died mid-reconcile: its /healthz goes 500 once an
+          # incomplete workflow goes stale, the liveness probe kills it, and the
+          # same stale workflow fails the probe again — so one stall wedges every
+          # later cell. --previous is the only place the pre-kill reason survives.
+          kubectl get pods -n openchoreo-workflow-plane -o wide 2>/dev/null
+          kubectl get pods -n openchoreo-workflow-plane --no-headers 2>/dev/null \
+            | awk '/workflow-controller/{print $1}' \
+            | while read -r p; do
+                echo "----- $p: container state + restart count -----"
+                kubectl describe pod -n openchoreo-workflow-plane "$p" 2>/dev/null \
+                  | sed -n '/Containers:/,/Conditions:/p'
+                echo "----- $p: events -----"
+                kubectl describe pod -n openchoreo-workflow-plane "$p" 2>/dev/null \
+                  | sed -n '/Events:/,$p' | tail -25
+                echo "----- $p logs (current) -----"
+                kubectl logs -n openchoreo-workflow-plane "$p" --tail=200 2>/dev/null
+                echo "----- $p logs (previous container, if it restarted) -----"
+                kubectl logs -n openchoreo-workflow-plane "$p" --previous --tail=200 2>/dev/null \
+                  || echo "  (no previous container — never restarted)"
+              done
+          echo "=== Argo Workflow objects ==="
+          # The CR sweep above only greps openchoreo/api-platform/wso2 kinds, so
+          # Argo's own Workflows — where the per-step node statuses live — are
+          # invisible there.
+          kubectl get workflows.argoproj.io -A 2>/dev/null
+          while read -r ns name _; do
+            [ "$ns" = "NAMESPACE" ] && continue
+            echo "--- workflow $ns/$name ---"
+            kubectl get workflows.argoproj.io "$name" -n "$ns" -o yaml 2>/dev/null \
+              | sed -n '/^status:/,$p' | head -40
+          done < <(kubectl get workflows.argoproj.io -A 2>/dev/null)
+          echo "=== node conditions + resource pressure ==="
+          # A starved or disk-pressured node fails the controller's 1s liveness
+          # probe on its own, which looks identical to a controller bug.
+          kubectl describe node 2>/dev/null | sed -n '/Conditions:/,/Addresses:/p'
+          kubectl describe node 2>/dev/null | sed -n '/Allocated resources:/,/Events:/p'
+          kubectl top nodes 2>/dev/null || echo "  (metrics-server unavailable)"
+          kubectl top pods -A --sort-by=cpu 2>/dev/null | head -25
+          echo "--- runner disk ---"
+          df -h
+          echo "--- k3d node container disk (image layers land here, not on / ) ---"
+          for c in $(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^k3d-.*server'); do
+            echo "----- $c -----"
+            docker exec "$c" df -h / /var/lib/rancher 2>/dev/null
+          done
           echo "=== recent events ==="
           kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -80
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/instrumentation-matrix-nightly.yaml
+++ b/.github/workflows/instrumentation-matrix-nightly.yaml
@@ -122,6 +122,53 @@ jobs:
               | awk '/gateway-controller/{print $1}' \
               | while read -r p; do echo "----- $gwns/$p -----"; kubectl logs -n "$gwns" "$p" --tail=80 2>/dev/null; done
           done
+          echo "=== workflow-plane controller (Argo drives every agent build) ==="
+          # A build that never leaves WorkflowPending usually means this
+          # controller died mid-reconcile: its /healthz goes 500 once an
+          # incomplete workflow goes stale, the liveness probe kills it, and the
+          # same stale workflow fails the probe again — so one stall wedges every
+          # later cell. --previous is the only place the pre-kill reason survives.
+          kubectl get pods -n openchoreo-workflow-plane -o wide 2>/dev/null
+          kubectl get pods -n openchoreo-workflow-plane --no-headers 2>/dev/null \
+            | awk '/workflow-controller/{print $1}' \
+            | while read -r p; do
+                echo "----- $p: container state + restart count -----"
+                kubectl describe pod -n openchoreo-workflow-plane "$p" 2>/dev/null \
+                  | sed -n '/Containers:/,/Conditions:/p'
+                echo "----- $p: events -----"
+                kubectl describe pod -n openchoreo-workflow-plane "$p" 2>/dev/null \
+                  | sed -n '/Events:/,$p' | tail -25
+                echo "----- $p logs (current) -----"
+                kubectl logs -n openchoreo-workflow-plane "$p" --tail=200 2>/dev/null
+                echo "----- $p logs (previous container, if it restarted) -----"
+                kubectl logs -n openchoreo-workflow-plane "$p" --previous --tail=200 2>/dev/null \
+                  || echo "  (no previous container — never restarted)"
+              done
+          echo "=== Argo Workflow objects ==="
+          # The CR sweep above only greps openchoreo/api-platform/wso2 kinds, so
+          # Argo's own Workflows — where the per-step node statuses live — are
+          # invisible there.
+          kubectl get workflows.argoproj.io -A 2>/dev/null
+          while read -r ns name _; do
+            [ "$ns" = "NAMESPACE" ] && continue
+            echo "--- workflow $ns/$name ---"
+            kubectl get workflows.argoproj.io "$name" -n "$ns" -o yaml 2>/dev/null \
+              | sed -n '/^status:/,$p' | head -40
+          done < <(kubectl get workflows.argoproj.io -A 2>/dev/null)
+          echo "=== node conditions + resource pressure ==="
+          # A starved or disk-pressured node fails the controller's 1s liveness
+          # probe on its own, which looks identical to a controller bug.
+          kubectl describe node 2>/dev/null | sed -n '/Conditions:/,/Addresses:/p'
+          kubectl describe node 2>/dev/null | sed -n '/Allocated resources:/,/Events:/p'
+          kubectl top nodes 2>/dev/null || echo "  (metrics-server unavailable)"
+          kubectl top pods -A --sort-by=cpu 2>/dev/null | head -25
+          echo "--- runner disk ---"
+          df -h
+          echo "--- k3d node container disk (image layers land here, not on / ) ---"
+          for c in $(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^k3d-.*server'); do
+            echo "----- $c -----"
+            docker exec "$c" df -h / /var/lib/rancher 2>/dev/null
+          done
           echo "=== recent events ==="
           kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -80
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Purpose

The instrumentation-matrix heavy tier has started failing in a distinctive cliff shape: the first five or six cells pass normally at roughly four minutes each, then *every* remaining cell fails identically with `TimeoutError: build <name> did not complete within 600s`. The 08-03 nightly broke at cell 6 and hit the 90-minute job cap; a follow-up manual run (which has no `timeout-minutes`) ran the full subset and finished 6 passed / 10 failed.

The existing on-failure diagnostics dump narrows it down but cannot close it. It shows that the failed `WorkflowRun`s all sit at `reason: WorkflowPending`, that the first failing cell's build pods actually reached `Completed` (so the build itself succeeded and was simply never marked done), and that `argo-workflow-controller` has a high restart count with `Liveness probe failed: HTTP probe failed with statuscode: 500`, then `healthz: context deadline exceeded`, then `BackOff restarting failed container`.

What it does not show is *why* the controller died — the dump captures neither its pre-kill logs nor the node's resource state, and its CR sweep greps only `openchoreo|api-platform|wso2` kinds, so Argo's own Workflow objects (where the per-step node statuses live) are invisible. That leaves the trigger unproven and the next investigation blocked on another two-hour run.

## Goals

Make the next heavy-tier failure self-explanatory, so the cause can be identified from the uploaded diagnostics rather than by re-running the tier with ad-hoc `kubectl` added each time.

## Approach

Three sections are added to the "Dump cluster diagnostics on failure" step, before the existing events dump:

1. **Workflow-plane controller state** — pod listing, container state and restart count, events, and both current and `--previous` logs for `argo-workflow-controller`. The `--previous` logs are the only place the pre-kill reason survives a liveness restart.
2. **Argo Workflow objects** — `workflows.argoproj.io` across all namespaces plus each object's `status`, which carries the per-step node statuses the OpenChoreo-only CR sweep skips.
3. **Node conditions and resource pressure** — node conditions, allocated resources, `kubectl top nodes`/`pods`, `df -h` on the runner, and `df -h` inside the k3d node container, where pushed image layers actually land. A starved or disk-pressured node fails the controller's one-second liveness probe on its own, which is indistinguishable from a controller bug in the current output.

The step is duplicated verbatim between the manual and nightly workflows, so the same block was inserted into both and the two `run:` scripts are byte-identical after the change.

This is diagnostics only — no change to what the tier runs or how it passes and fails.

## User stories

N/A — CI-only change with no user-facing behaviour.

## Release note

N/A — internal CI diagnostics change, not user-facing.

## Documentation

N/A — no product behaviour changes, so there is no documentation impact.

## Training

N/A — no training content impact.

## Certification

N/A — CI diagnostics have no impact on certification exams.

## Marketing

N/A — internal change with nothing to promote.

## Automation tests

- Unit tests
  > N/A — the change is shell inside a GitHub Actions step, which carries no unit-testable code.
- Integration tests
  > Covered by the heavy tier itself: the next failing run exercises this step. Validated statically with `actionlint` on both workflows (the only finding is a pre-existing SC2162 in `revalidate-known-broken`, unrelated and merely shifted in line number), and both files were parsed to confirm the two diagnostics scripts are byte-identical.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

The added commands only read cluster and host state. No secret values are printed: no `kubectl get secret`, and the pod/workflow dumps are restricted to `status` and log tails.

## Samples

N/A — no samples relate to this change.

## Related PRs

N/A — standalone change.

## Migrations (if applicable)

N/A — no schema, config, or data migration.

## Test environment

GitHub-hosted `ubuntu-latest`, which is where the heavy job is pinned (the CodeBuild runners cannot host k3d). Cluster is k3d with the stack built from source via the `amp-dev-stack` action; Python 3.11 for the driver. Linted locally with `actionlint` 1.7.x on macOS.

## Learning

The cliff shape turned out to be the diagnostic clue rather than a coincidence. Argo's `/healthz` returns 500 once an incomplete workflow stops being reconciled, so a single wedged workflow gets the controller killed by its own liveness probe, and after the restart the same stale workflow fails the probe again. That makes the first stall self-reinforcing and explains why every later cell fails rather than just some — worth remembering when reading any "N passed then everything failed" matrix result.

Two signals in the current dump are red herrings worth recording so they are not chased again: the `OpenSearch index reset failed ... failed to start exec` warning also appears in a 16/16-green run, and the `registry-push-secret` `ExternalSecret` `UpdateFailed: Secret does not exist` errors line up with exactly the failed cells only because failed cells' resources linger and keep retrying on the refresh interval while cleaned-up cells stop emitting events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded diagnostics for heavy-tier workflow failures.
  * Failure reports now include controller state and logs, workflow statuses, node conditions, resource usage, and disk-space details.
  * Added equivalent diagnostics to both manual and nightly instrumentation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->