### PR TITLE
Assert no chart renders a template zero value

### DIFF
--- a/.github/workflows/helm-charts-pr-check.yml
+++ b/.github/workflows/helm-charts-pr-check.yml
@@ -36,8 +36,10 @@ jobs:
           ALL_CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           CHANGED_FILES=$(echo "$ALL_CHANGED_FILES" | grep '^deployments/helm-charts/' || true)
 
-          # If shared helm tooling changed, test all charts
-          SHARED_CHANGES=$(echo "$ALL_CHANGED_FILES" | grep -E '^\.github/(actions/setup-helm-chart/|workflows/helm-charts-pr-check\.yml)' || true)
+          # If shared helm tooling changed, test all charts. deployments/helm-charts/tests/
+          # holds assertions applied to every chart, so a change there is shared tooling
+          # and not a change to one chart.
+          SHARED_CHANGES=$(echo "$ALL_CHANGED_FILES" | grep -E '^(\.github/(actions/setup-helm-chart/|workflows/helm-charts-pr-check\.yml)|deployments/helm-charts/tests/)' || true)
 
           if [ -n "$SHARED_CHANGES" ]; then
             echo "Shared Helm tooling changed, testing all charts"
@@ -55,8 +57,10 @@ jobs:
           DETECTED_CHARTS=""
 
           for chart in $CHART_NAMES; do
-            # CRITICAL: Only add if the directory exists in the current branch
-            if [ -d "deployments/helm-charts/$chart" ]; then
+            # CRITICAL: keying on Chart.yaml rather than the directory drops both charts
+            # deleted in this branch and sibling directories that are not charts at all
+            # (deployments/helm-charts/tests/). A non-chart in the matrix fails helm lint.
+            if [ -f "deployments/helm-charts/$chart/Chart.yaml" ]; then
               DETECTED_CHARTS+="$chart "
             fi
           done
@@ -146,6 +150,17 @@ jobs:
             --set resources.limits.cpu=200m > /tmp/templated-manifests-resources.yaml || true
 
           echo "Successfully templated common scenarios"
+        shell: bash
+
+      - name: Assert no template zero values are rendered
+        env:
+          CHART: ${{ matrix.chart }}
+        run: |
+          # Applies to every chart, unlike the per-chart assertions below: a manifest
+          # shipping "<nil>" instead of a value stays valid YAML and passes lint and
+          # kubeconform, so nothing else in this workflow can catch it.
+          env -i PATH="$PATH" HOME="$HOME" bash deployments/helm-charts/tests/no-nil-render.sh \
+            "deployments/helm-charts/$CHART"
         shell: bash
 
       - name: Run chart render assertions

--- a/deployments/helm-charts/tests/no-nil-render.sh
+++ b/deployments/helm-charts/tests/no-nil-render.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Asserts that a chart never renders a Go-template zero value into a shipped
+# manifest. Run: bash deployments/helm-charts/tests/no-nil-render.sh <chart-dir>
+#
+# This exists because of a defect that shipped. An External Secrets placeholder
+# was written into three builder templates unescaped, so Helm evaluated
+# `.registrysecret` — a key that exists only in the ExternalSecret's own
+# templating context, not in the chart's — and emitted
+#
+#     .dockerconfigjson: <nil>
+#
+# The manifests stayed valid YAML, the charts linted, kubeconform passed, and
+# every agent image push against an authenticated registry failed. It was
+# invisible on k3d, whose registry needs no auth, so three runs of scripted
+# local testing never hit it and it reached a cloud cluster instead.
+#
+# The bug rendered at default values, which is why a plain default render is the
+# assertion. Unlike the per-chart tests/render.sh files, this runs for EVERY
+# chart: the point is to catch a template nobody thought to write a case for.
+set -uo pipefail
+
+if [[ $# -ne 1 ]]; then
+  printf 'usage: %s <chart-dir>\n' "${0##*/}" >&2
+  exit 2
+fi
+
+CHART_DIR="${1%/}"
+CHART_NAME="${CHART_DIR##*/}"
+
+if [[ ! -f "$CHART_DIR/Chart.yaml" ]]; then
+  printf 'not a chart directory (no Chart.yaml): %s\n' "$CHART_DIR" >&2
+  exit 2
+fi
+
+FAILURES=0
+
+# The three ways Helm surfaces a template value that resolved to nothing.
+# `<nil>` comes from printing a nil interface, `<no value>` from a missing map
+# key under text/template, and `%!s(` from a Printf verb applied to the wrong
+# type — all of them mean a manifest shipped a placeholder instead of a value.
+MARKERS=('<nil>' '<no value>' '%!s(')
+
+# scan <label> — reads a rendered manifest stream on stdin and reports every line
+# carrying a marker, attributed to the template that produced it. helm emits a
+# `# Source: <path>` comment ahead of each document, so tracking the most recent
+# one names the offending file without re-rendering per template.
+scan() {
+  awk -v label="$1" -v m1="${MARKERS[0]}" -v m2="${MARKERS[1]}" -v m3="${MARKERS[2]}" '
+    /^# Source: / { src = $3; next }
+    {
+      hit = ""
+      if (index($0, m1)) hit = m1
+      else if (index($0, m2)) hit = m2
+      else if (index($0, m3)) hit = m3
+      if (hit == "") next
+      bad++
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      printf "     %s in %s\n       %s\n", hit, (src == "" ? "(no Source comment)" : src), line
+    }
+    END { exit (bad > 0) }
+  '
+}
+
+# render_case <label> [helm --set args...]
+# A render that fails to execute is reported as a failure of its own rather than
+# becoming an empty stream — otherwise a broken template would read as "no
+# placeholder found", which is the opposite of the truth.
+render_case() {
+  local label="$1" rendered
+  shift
+  if ! rendered="$(helm template test-release "$CHART_DIR" "$@" 2>&1)"; then
+    printf 'FAIL - %s: helm template failed\n%s\n' "$label" "$rendered"
+    if [[ "$rendered" == *"found in Chart.yaml, but missing in charts/"* ]]; then
+      printf '     hint: helm dependency build %s\n' "$CHART_DIR"
+    fi
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  if printf '%s\n' "$rendered" | scan "$label"; then
+    printf 'ok   - %s renders no template zero values\n' "$label"
+  else
+    printf 'FAIL - %s renders a template zero value\n' "$label"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+render_case "$CHART_NAME (default values)"
+
+# Optional per-chart extra renders, one line of `helm --set` arguments each, for
+# charts whose templates are gated behind a value and so are absent from the
+# default render. Blank lines and # comments are ignored.
+CASES_FILE="$CHART_DIR/tests/render-cases.txt"
+if [[ -f "$CASES_FILE" ]]; then
+  case_no=0
+  while IFS= read -r case_args || [[ -n "$case_args" ]]; do
+    [[ -z "${case_args// /}" || "${case_args#\#}" != "$case_args" ]] && continue
+    case_no=$((case_no + 1))
+    # Word-split deliberately: the file holds shell-style argument lists.
+    # shellcheck disable=SC2086
+    render_case "$CHART_NAME (case $case_no: $case_args)" $case_args
+  done <"$CASES_FILE"
+fi
+
+if ((FAILURES > 0)); then
+  printf '\n%d of %s render check(s) failed\n' "$FAILURES" "$CHART_NAME"
+  exit 1
+fi
+printf '\n%s: no template zero values rendered\n' "$CHART_NAME"


### PR DESCRIPTION
## Purpose
An unescaped External Secrets placeholder was once written into the three builder templates, so Helm evaluated `.registrysecret` — a key that exists only in the ExternalSecret's own templating context, not the chart's — and shipped `.dockerconfigjson: <nil>`.

The manifests stayed valid YAML, `helm lint --strict` passed, and kubeconform passed. Every agent image push against an authenticated registry failed. It was invisible on k3d, whose registry needs no auth, so scripted local testing never reached it and the defect got as far as a cloud cluster.

Nothing in the existing PR checks can catch this class of defect.

## Goals
Fail the Helm PR check when any shipped chart renders a Go-template zero value into a manifest.

## Approach
New `deployments/helm-charts/tests/no-nil-render.sh <chart-dir>`, wired into the existing `helm-template` job.

It runs for **every** chart, not only those carrying a `tests/render.sh` — the point is to catch a template nobody thought to write a case for. The original defect rendered at default values, so a plain default render is the assertion.

Three markers are flagged: `<nil>` (printing a nil interface), `<no value>` (a missing map key under text/template), and `%!s(` (a Printf verb applied to the wrong type). A failure reports the chart, the template path from helm's `# Source:` comment, and the offending line, so it is actionable without a re-run. A render that fails to execute is reported as its own failure rather than becoming an empty stream, so a broken template cannot read as "no placeholder found".

An optional per-chart `tests/render-cases.txt` allows extra `--set` permutations for charts whose templates are gated behind a value. None are shipped; the default render is what closes the original defect.

One supporting change: chart detection in the workflow now keys on `Chart.yaml` rather than on the directory existing. `deployments/helm-charts/tests/` is a sibling of the charts, and a non-chart entry in the matrix fails `helm lint`. Changes under it count as shared tooling and re-test every chart.

## User stories
N/A — internal CI hardening, no user-facing behaviour.

## Release note
N/A — CI-only change, no shipped artifact is modified.

## Documentation
N/A — no user-facing behaviour changes. The script carries a comment block explaining the defect it guards against and why the assertion is shaped this way.

## Training
N/A — no training impact.

## Certification
N/A — internal CI check with no product surface.

## Marketing
N/A — internal CI check.

## Automation tests
 - Unit tests
   > N/A — the change *is* a test. It was verified by reintroducing the original defect verbatim (dropping the escaping so Helm evaluates `.registrysecret`) and confirming the assertion reports `<nil> in .../amp-gcp-buildpack-builder.yaml` with the offending line and exits 1, then reverting.
 - Integration tests
   > Ran against all six charts on a clean tree: all pass, and the baseline is clean for all three markers. The existing `wso2-agent-manager/tests/render.sh` assertions still pass. Also run against the **published** `wso2-amp-platform-resources-extension` chart at `0.0.0-dev-20260804` pulled from `ghcr.io`, confirming 0 occurrences in a shipped artifact. Missing-dependency behaviour verified: the script reports the failure and emits a `helm dependency build` hint rather than silently passing.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell script, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

The script is PR-authored, so the workflow runs it with `env -i PATH HOME`, matching how the existing per-chart assertions are invoked — it inherits no token or other credential.

## Samples
N/A — no samples.

## Related PRs
N/A.

## Migrations (if applicable)
N/A — no state, no shipped manifest changes.

## Test environment
Helm 3.19.4 (matching the workflow's pinned version), macOS 15 / darwin-arm64, bash 3.2 and shellcheck clean. `actionlint` reports no new findings versus `main` (byte-identical counts). Chart detection logic re-verified under bash, since zsh does not word-split and produced a misleading empty result locally.

## Learning
The interesting part was where to put the assertion. Adding cases to the existing per-chart `render.sh` files would have covered only charts someone had already thought about, which is precisely the wrong set — the defect reached production because nobody had written a case for those templates. A chart-agnostic default render, applied unconditionally, is cheap and catches the whole class.

Attributing a failure to a template needed no extra rendering: `helm template` already emits a `# Source:` comment ahead of each document, so tracking the most recent one while scanning is enough.
