### PR TITLE
Scope the ingress-gateway cap to one organization

### DIFF
--- a/agent-manager-service/repositories/gateway_repository.go
+++ b/agent-manager-service/repositories/gateway_repository.go
@@ -76,7 +76,7 @@ type GatewayRepository interface {
 	AcquireEnvironmentLock(tx *gorm.DB, environmentID string) error
 	CreateTx(tx *gorm.DB, gateway *models.Gateway) error
 	CreateEnvironmentMappingTx(tx *gorm.DB, mapping *models.GatewayEnvironmentMapping) error
-	CountIngressCapableInEnvironment(tx *gorm.DB, environmentID string) (int64, error)
+	ListIngressCapableInEnvironment(tx *gorm.DB, environmentID string) ([]*models.Gateway, error)
 
 	// Gateway association checking operations
 	HasGatewayDeployments(gatewayID, ouID string) (bool, error)
@@ -602,19 +602,27 @@ func (r *GatewayRepo) CreateEnvironmentMappingTx(tx *gorm.DB, mapping *models.Ga
 	return tx.Create(mapping).Error
 }
 
-// CountIngressCapableInEnvironment counts non-deleted ingress-capable gateways mapped
+// ListIngressCapableInEnvironment returns the non-deleted ingress-capable gateways mapped
 // to the environment. Deliberately omits is_active: the cap is a membership rule, and
 // is_active is WebSocket liveness that flaps.
-func (r *GatewayRepo) CountIngressCapableInEnvironment(tx *gorm.DB, environmentID string) (int64, error) {
-	var count int64
-	err := tx.Table("gateway_environment_mappings AS m").
-		Joins("JOIN gateways g ON g.uuid = m.gateway_uuid").
-		Where("m.environment_uuid = ?", environmentID).
-		Where("g.deleted_at IS NULL").
-		Where("g.gateway_functionality_type IN ?", models.IngressGatewayRoles).
-		Count(&count).Error
+//
+// Returns rows rather than a count, and does not filter by organization, because the
+// caller needs both halves of the picture. A row owned by the caller's organization
+// blocks registration and has to be named in the rejection; a row owned by a different
+// organization is corrupt data on a per-organization environment, and reporting it
+// without blocking is what stops it holding a slot no tenant can see or delete.
+func (r *GatewayRepo) ListIngressCapableInEnvironment(tx *gorm.DB, environmentID string) ([]*models.Gateway, error) {
+	var gateways []*models.Gateway
+	// Model() rather than Table() so GORM applies the soft-delete predicate itself and
+	// projects gateways' own columns explicitly — both tables carry created_at, and the
+	// raw-table form would have to disambiguate by hand.
+	err := tx.Model(&models.Gateway{}).
+		Joins("JOIN gateway_environment_mappings ON gateway_environment_mappings.gateway_uuid = gateways.uuid").
+		Where("gateway_environment_mappings.environment_uuid = ?", environmentID).
+		Where("gateways.gateway_functionality_type IN ?", models.IngressGatewayRoles).
+		Find(&gateways).Error
 	if err != nil {
-		return 0, fmt.Errorf("failed to count ingress-capable gateways in environment %s: %w", environmentID, err)
+		return nil, fmt.Errorf("failed to list ingress-capable gateways in environment %s: %w", environmentID, err)
 	}
-	return count, nil
+	return gateways, nil
 }

--- a/agent-manager-service/repositories/repomocks/gateway_repository_mock.go
+++ b/agent-manager-service/repositories/repomocks/gateway_repository_mock.go
@@ -24,9 +24,6 @@ import (
 //			CountActiveTokensFunc: func(gatewayId string) (int, error) {
 //				panic("mock out the CountActiveTokens method")
 //			},
-//			CountIngressCapableInEnvironmentFunc: func(tx *gorm.DB, environmentID string) (int64, error) {
-//				panic("mock out the CountIngressCapableInEnvironment method")
-//			},
 //			CountWithFiltersFunc: func(filters repositories.GatewayFilterOptions) (int64, error) {
 //				panic("mock out the CountWithFilters method")
 //			},
@@ -108,6 +105,9 @@ import (
 //			ListIdentityProvidersByOrgFunc: func(ouID string) ([]repositories.IdentityProviderWithContext, error) {
 //				panic("mock out the ListIdentityProvidersByOrg method")
 //			},
+//			ListIngressCapableInEnvironmentFunc: func(tx *gorm.DB, environmentID string) ([]*models.Gateway, error) {
+//				panic("mock out the ListIngressCapableInEnvironment method")
+//			},
 //			ListWithFiltersFunc: func(filters repositories.GatewayFilterOptions) ([]*models.Gateway, error) {
 //				panic("mock out the ListWithFilters method")
 //			},
@@ -138,9 +138,6 @@ type GatewayRepositoryMock struct {
 
 	// CountActiveTokensFunc mocks the CountActiveTokens method.
 	CountActiveTokensFunc func(gatewayId string) (int, error)
-
-	// CountIngressCapableInEnvironmentFunc mocks the CountIngressCapableInEnvironment method.
-	CountIngressCapableInEnvironmentFunc func(tx *gorm.DB, environmentID string) (int64, error)
 
 	// CountWithFiltersFunc mocks the CountWithFilters method.
 	CountWithFiltersFunc func(filters repositories.GatewayFilterOptions) (int64, error)
@@ -223,6 +220,9 @@ type GatewayRepositoryMock struct {
 	// ListIdentityProvidersByOrgFunc mocks the ListIdentityProvidersByOrg method.
 	ListIdentityProvidersByOrgFunc func(ouID string) ([]repositories.IdentityProviderWithContext, error)
 
+	// ListIngressCapableInEnvironmentFunc mocks the ListIngressCapableInEnvironment method.
+	ListIngressCapableInEnvironmentFunc func(tx *gorm.DB, environmentID string) ([]*models.Gateway, error)
+
 	// ListWithFiltersFunc mocks the ListWithFilters method.
 	ListWithFiltersFunc func(filters repositories.GatewayFilterOptions) ([]*models.Gateway, error)
 
@@ -254,13 +254,6 @@ type GatewayRepositoryMock struct {
 		CountActiveTokens []struct {
 			// GatewayId is the gatewayId argument value.
 			GatewayId string
-		}
-		// CountIngressCapableInEnvironment holds details about calls to the CountIngressCapableInEnvironment method.
-		CountIngressCapableInEnvironment []struct {
-			// Tx is the tx argument value.
-			Tx *gorm.DB
-			// EnvironmentID is the environmentID argument value.
-			EnvironmentID string
 		}
 		// CountWithFilters holds details about calls to the CountWithFilters method.
 		CountWithFilters []struct {
@@ -417,6 +410,13 @@ type GatewayRepositoryMock struct {
 			// OuID is the ouID argument value.
 			OuID string
 		}
+		// ListIngressCapableInEnvironment holds details about calls to the ListIngressCapableInEnvironment method.
+		ListIngressCapableInEnvironment []struct {
+			// Tx is the tx argument value.
+			Tx *gorm.DB
+			// EnvironmentID is the environmentID argument value.
+			EnvironmentID string
+		}
 		// ListWithFilters holds details about calls to the ListWithFilters method.
 		ListWithFilters []struct {
 			// Filters is the filters argument value.
@@ -452,7 +452,6 @@ type GatewayRepositoryMock struct {
 	}
 	lockAcquireEnvironmentLock                   sync.RWMutex
 	lockCountActiveTokens                        sync.RWMutex
-	lockCountIngressCapableInEnvironment         sync.RWMutex
 	lockCountWithFilters                         sync.RWMutex
 	lockCreate                                   sync.RWMutex
 	lockCreateEnvironmentMapping                 sync.RWMutex
@@ -480,6 +479,7 @@ type GatewayRepositoryMock struct {
 	lockListIdentityProvidersByEnvironment       sync.RWMutex
 	lockListIdentityProvidersByGateway           sync.RWMutex
 	lockListIdentityProvidersByOrg               sync.RWMutex
+	lockListIngressCapableInEnvironment          sync.RWMutex
 	lockListWithFilters                          sync.RWMutex
 	lockRevokeToken                              sync.RWMutex
 	lockTransaction                              sync.RWMutex
@@ -553,42 +553,6 @@ func (mock *GatewayRepositoryMock) CountActiveTokensCalls() []struct {
 	mock.lockCountActiveTokens.RLock()
 	calls = mock.calls.CountActiveTokens
 	mock.lockCountActiveTokens.RUnlock()
-	return calls
-}
-
-// CountIngressCapableInEnvironment calls CountIngressCapableInEnvironmentFunc.
-func (mock *GatewayRepositoryMock) CountIngressCapableInEnvironment(tx *gorm.DB, environmentID string) (int64, error) {
-	if mock.CountIngressCapableInEnvironmentFunc == nil {
-		panic("GatewayRepositoryMock.CountIngressCapableInEnvironmentFunc: method is nil but GatewayRepository.CountIngressCapableInEnvironment was just called")
-	}
-	callInfo := struct {
-		Tx            *gorm.DB
-		EnvironmentID string
-	}{
-		Tx:            tx,
-		EnvironmentID: environmentID,
-	}
-	mock.lockCountIngressCapableInEnvironment.Lock()
-	mock.calls.CountIngressCapableInEnvironment = append(mock.calls.CountIngressCapableInEnvironment, callInfo)
-	mock.lockCountIngressCapableInEnvironment.Unlock()
-	return mock.CountIngressCapableInEnvironmentFunc(tx, environmentID)
-}
-
-// CountIngressCapableInEnvironmentCalls gets all the calls that were made to CountIngressCapableInEnvironment.
-// Check the length with:
-//
-//	len(mockedGatewayRepository.CountIngressCapableInEnvironmentCalls())
-func (mock *GatewayRepositoryMock) CountIngressCapableInEnvironmentCalls() []struct {
-	Tx            *gorm.DB
-	EnvironmentID string
-} {
-	var calls []struct {
-		Tx            *gorm.DB
-		EnvironmentID string
-	}
-	mock.lockCountIngressCapableInEnvironment.RLock()
-	calls = mock.calls.CountIngressCapableInEnvironment
-	mock.lockCountIngressCapableInEnvironment.RUnlock()
 	return calls
 }
 
@@ -1492,6 +1456,42 @@ func (mock *GatewayRepositoryMock) ListIdentityProvidersByOrgCalls() []struct {
 	mock.lockListIdentityProvidersByOrg.RLock()
 	calls = mock.calls.ListIdentityProvidersByOrg
 	mock.lockListIdentityProvidersByOrg.RUnlock()
+	return calls
+}
+
+// ListIngressCapableInEnvironment calls ListIngressCapableInEnvironmentFunc.
+func (mock *GatewayRepositoryMock) ListIngressCapableInEnvironment(tx *gorm.DB, environmentID string) ([]*models.Gateway, error) {
+	if mock.ListIngressCapableInEnvironmentFunc == nil {
+		panic("GatewayRepositoryMock.ListIngressCapableInEnvironmentFunc: method is nil but GatewayRepository.ListIngressCapableInEnvironment was just called")
+	}
+	callInfo := struct {
+		Tx            *gorm.DB
+		EnvironmentID string
+	}{
+		Tx:            tx,
+		EnvironmentID: environmentID,
+	}
+	mock.lockListIngressCapableInEnvironment.Lock()
+	mock.calls.ListIngressCapableInEnvironment = append(mock.calls.ListIngressCapableInEnvironment, callInfo)
+	mock.lockListIngressCapableInEnvironment.Unlock()
+	return mock.ListIngressCapableInEnvironmentFunc(tx, environmentID)
+}
+
+// ListIngressCapableInEnvironmentCalls gets all the calls that were made to ListIngressCapableInEnvironment.
+// Check the length with:
+//
+//	len(mockedGatewayRepository.ListIngressCapableInEnvironmentCalls())
+func (mock *GatewayRepositoryMock) ListIngressCapableInEnvironmentCalls() []struct {
+	Tx            *gorm.DB
+	EnvironmentID string
+} {
+	var calls []struct {
+		Tx            *gorm.DB
+		EnvironmentID string
+	}
+	mock.lockListIngressCapableInEnvironment.RLock()
+	calls = mock.calls.ListIngressCapableInEnvironment
+	mock.lockListIngressCapableInEnvironment.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/services/platform_gateway_cap_unit_test.go
+++ b/agent-manager-service/services/platform_gateway_cap_unit_test.go
@@ -62,22 +62,118 @@ func TestNormalizeGatewayRole(t *testing.T) {
 	}
 }
 
-// A second ingress-capable gateway in one environment is rejected.
+// A second ingress-capable gateway in one environment is rejected when it belongs to the
+// same organization, and the rejection names the gateway holding the slot. The name is
+// asserted because the message is the only place an operator learns which row to remove —
+// "environment already has an ingress gateway" on its own sends them looking.
 func TestAssignGatewayToEnvironment_SecondIngressRejected(t *testing.T) {
 	envID := uuid.New().String()
-	gw := &models.Gateway{UUID: uuid.New(), GatewayFunctionalityType: models.GatewayRoleBoth}
+	gw := &models.Gateway{UUID: uuid.New(), OUID: "org-a", GatewayFunctionalityType: models.GatewayRoleBoth}
+	blocker := &models.Gateway{
+		UUID: uuid.New(), OUID: "org-a", Name: "api-platform-default-default",
+		GatewayFunctionalityType: models.GatewayRoleIngress,
+	}
 	repo := &repomocks.GatewayRepositoryMock{
-		GetByUUIDFunc:                        func(string) (*models.Gateway, error) { return gw, nil },
-		TransactionFunc:                      func(fn func(tx *gorm.DB) error) error { return fn(nil) },
-		AcquireEnvironmentLockFunc:           func(*gorm.DB, string) error { return nil },
-		EnvironmentMappingExistsFunc:         func(string, string) (bool, error) { return false, nil },
-		CountIngressCapableInEnvironmentFunc: func(*gorm.DB, string) (int64, error) { return 1, nil },
+		GetByUUIDFunc:                func(string) (*models.Gateway, error) { return gw, nil },
+		TransactionFunc:              func(fn func(tx *gorm.DB) error) error { return fn(nil) },
+		AcquireEnvironmentLockFunc:   func(*gorm.DB, string) error { return nil },
+		EnvironmentMappingExistsFunc: func(string, string) (bool, error) { return false, nil },
+		ListIngressCapableInEnvironmentFunc: func(*gorm.DB, string) ([]*models.Gateway, error) {
+			return []*models.Gateway{blocker}, nil
+		},
 	}
 	svc := NewPlatformGatewayService(repo, nil)
 
 	err := svc.AssignGatewayToEnvironment(gw.UUID.String(), envID)
 
 	require.ErrorIs(t, err, utils.ErrGatewayIngressCapExceeded)
+	require.Contains(t, err.Error(), blocker.Name)
+	require.Contains(t, err.Error(), blocker.UUID.String())
+}
+
+// An ingress-capable gateway owned by a different organization does not block, and the
+// mapping is created. This is the bug being fixed: environments are per-organization, so
+// a foreign row is corrupt data, and an unscoped count let it hold the slot while staying
+// invisible to every organization-scoped read — a 409 against a tenant whose gateway list
+// came back empty, with nothing it could find or delete.
+func TestAssignGatewayToEnvironment_ForeignOrgIngressDoesNotBlock(t *testing.T) {
+	envID := uuid.New().String()
+	gw := &models.Gateway{UUID: uuid.New(), OUID: "org-a", GatewayFunctionalityType: models.GatewayRoleBoth}
+	orphan := &models.Gateway{
+		UUID: uuid.New(), OUID: "org-defunct", Name: "stale-gateway",
+		GatewayFunctionalityType: models.GatewayRoleBoth,
+	}
+	created := false
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByUUIDFunc:                func(string) (*models.Gateway, error) { return gw, nil },
+		TransactionFunc:              func(fn func(tx *gorm.DB) error) error { return fn(nil) },
+		AcquireEnvironmentLockFunc:   func(*gorm.DB, string) error { return nil },
+		EnvironmentMappingExistsFunc: func(string, string) (bool, error) { return false, nil },
+		ListIngressCapableInEnvironmentFunc: func(*gorm.DB, string) ([]*models.Gateway, error) {
+			return []*models.Gateway{orphan}, nil
+		},
+		CreateEnvironmentMappingTxFunc: func(*gorm.DB, *models.GatewayEnvironmentMapping) error {
+			created = true
+			return nil
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	require.NoError(t, svc.AssignGatewayToEnvironment(gw.UUID.String(), envID))
+	require.True(t, created, "a foreign-organization row must not hold this organization's ingress slot")
+}
+
+// A same-organization blocker still wins when a foreign row is present alongside it, so
+// scoping the cap cannot be mistaken for removing it.
+func TestAssignGatewayToEnvironment_SameOrgBlockerWinsOverForeignRow(t *testing.T) {
+	envID := uuid.New().String()
+	gw := &models.Gateway{UUID: uuid.New(), OUID: "org-a", GatewayFunctionalityType: models.GatewayRoleBoth}
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByUUIDFunc:                func(string) (*models.Gateway, error) { return gw, nil },
+		TransactionFunc:              func(fn func(tx *gorm.DB) error) error { return fn(nil) },
+		AcquireEnvironmentLockFunc:   func(*gorm.DB, string) error { return nil },
+		EnvironmentMappingExistsFunc: func(string, string) (bool, error) { return false, nil },
+		ListIngressCapableInEnvironmentFunc: func(*gorm.DB, string) ([]*models.Gateway, error) {
+			return []*models.Gateway{
+				{UUID: uuid.New(), OUID: "org-defunct", Name: "stale-gateway", GatewayFunctionalityType: models.GatewayRoleBoth},
+				{UUID: uuid.New(), OUID: "org-a", Name: "ours", GatewayFunctionalityType: models.GatewayRoleIngress},
+			}, nil
+		},
+		CreateEnvironmentMappingTxFunc: func(*gorm.DB, *models.GatewayEnvironmentMapping) error {
+			t.Fatal("a same-organization ingress gateway must still block")
+			return nil
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	err := svc.AssignGatewayToEnvironment(gw.UUID.String(), envID)
+
+	require.ErrorIs(t, err, utils.ErrGatewayIngressCapExceeded)
+	require.Contains(t, err.Error(), "ours")
+}
+
+// An empty result frees the slot.
+func TestAssignGatewayToEnvironment_FirstIngressAllowed(t *testing.T) {
+	envID := uuid.New().String()
+	gw := &models.Gateway{UUID: uuid.New(), OUID: "org-a", GatewayFunctionalityType: models.GatewayRoleIngress}
+	created := false
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByUUIDFunc:                func(string) (*models.Gateway, error) { return gw, nil },
+		TransactionFunc:              func(fn func(tx *gorm.DB) error) error { return fn(nil) },
+		AcquireEnvironmentLockFunc:   func(*gorm.DB, string) error { return nil },
+		EnvironmentMappingExistsFunc: func(string, string) (bool, error) { return false, nil },
+		ListIngressCapableInEnvironmentFunc: func(*gorm.DB, string) ([]*models.Gateway, error) {
+			return nil, nil
+		},
+		CreateEnvironmentMappingTxFunc: func(*gorm.DB, *models.GatewayEnvironmentMapping) error {
+			created = true
+			return nil
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	require.NoError(t, svc.AssignGatewayToEnvironment(gw.UUID.String(), envID))
+	require.True(t, created)
 }
 
 // A second EGRESS gateway is allowed. This is the supported both+egress shape and the
@@ -92,9 +188,9 @@ func TestAssignGatewayToEnvironment_SecondEgressAllowed(t *testing.T) {
 		TransactionFunc:              func(fn func(tx *gorm.DB) error) error { return fn(nil) },
 		AcquireEnvironmentLockFunc:   func(*gorm.DB, string) error { return nil },
 		EnvironmentMappingExistsFunc: func(string, string) (bool, error) { return false, nil },
-		CountIngressCapableInEnvironmentFunc: func(*gorm.DB, string) (int64, error) {
+		ListIngressCapableInEnvironmentFunc: func(*gorm.DB, string) ([]*models.Gateway, error) {
 			t.Fatal("egress gateways must not be counted against the ingress cap")
-			return 0, nil
+			return nil, nil
 		},
 		CreateEnvironmentMappingTxFunc: func(*gorm.DB, *models.GatewayEnvironmentMapping) error {
 			created = true
@@ -128,9 +224,9 @@ func TestAssignGatewayToEnvironment_IdempotentWhenAlreadyMapped(t *testing.T) {
 			require.True(t, lockAcquired, "expected environment lock to be acquired before the existence check")
 			return true, nil
 		},
-		CountIngressCapableInEnvironmentFunc: func(*gorm.DB, string) (int64, error) {
+		ListIngressCapableInEnvironmentFunc: func(*gorm.DB, string) ([]*models.Gateway, error) {
 			t.Fatal("an already-mapped gateway must not be counted against the ingress cap")
-			return 0, nil
+			return nil, nil
 		},
 		CreateEnvironmentMappingTxFunc: func(*gorm.DB, *models.GatewayEnvironmentMapping) error {
 			t.Fatal("an already-mapped gateway must not be re-inserted")
@@ -160,11 +256,17 @@ func TestRegisterGateway_CapRejectionRollsBackGatewayRow(t *testing.T) {
 		},
 		CreateTxFunc: func(*gorm.DB, *models.Gateway) error { createdInTx = true; return nil },
 		GetByUUIDFunc: func(string) (*models.Gateway, error) {
-			return &models.Gateway{UUID: uuid.New(), GatewayFunctionalityType: models.GatewayRoleBoth}, nil
+			return &models.Gateway{UUID: uuid.New(), OUID: "org", GatewayFunctionalityType: models.GatewayRoleBoth}, nil
 		},
-		AcquireEnvironmentLockFunc:           func(*gorm.DB, string) error { return nil },
-		EnvironmentMappingExistsFunc:         func(string, string) (bool, error) { return false, nil },
-		CountIngressCapableInEnvironmentFunc: func(*gorm.DB, string) (int64, error) { return 1, nil },
+		AcquireEnvironmentLockFunc:   func(*gorm.DB, string) error { return nil },
+		EnvironmentMappingExistsFunc: func(string, string) (bool, error) { return false, nil },
+		// RegisterGateway passes the row it just built, whose OUID is the "org" argument
+		// below, so the blocker has to share it to exercise the cap.
+		ListIngressCapableInEnvironmentFunc: func(*gorm.DB, string) ([]*models.Gateway, error) {
+			return []*models.Gateway{
+				{UUID: uuid.New(), OUID: "org", Name: "incumbent", GatewayFunctionalityType: models.GatewayRoleIngress},
+			}, nil
+		},
 	}
 	svc := NewPlatformGatewayService(repo, nil)
 

--- a/agent-manager-service/services/platform_gateway_service.go
+++ b/agent-manager-service/services/platform_gateway_service.go
@@ -975,13 +975,8 @@ func (s *PlatformGatewayService) assignGatewayToEnvironmentTx(
 	}
 
 	if gateway.IsIngressCapable() {
-		count, err := s.gatewayRepo.CountIngressCapableInEnvironment(tx, envIDStr)
-		if err != nil {
+		if err := s.enforceIngressCap(tx, gateway, envIDStr); err != nil {
 			return err
-		}
-		if count > 0 {
-			return fmt.Errorf("%w: environment %s already has an ingress gateway; "+
-				"register this gateway with gatewayType EGRESS instead", utils.ErrGatewayIngressCapExceeded, envIDStr)
 		}
 	}
 
@@ -991,6 +986,55 @@ func (s *PlatformGatewayService) assignGatewayToEnvironmentTx(
 	}
 	if err := s.gatewayRepo.CreateEnvironmentMappingTx(tx, mapping); err != nil {
 		return fmt.Errorf("failed to create gateway-environment mapping: %w", err)
+	}
+	return nil
+}
+
+// enforceIngressCap rejects the mapping when the gateway's own organization already holds
+// the environment's ingress slot.
+//
+// The cap is scoped to the organization on purpose. Environments are per-organization, so
+// an ingress-capable row owned by a different organization is corrupt data — yet an
+// unscoped count let such a row hold the slot while staying invisible to every
+// organization-scoped read. That asymmetry is what produced "environment already has an
+// ingress gateway" against an organization whose gateway list came back empty, with no
+// row the tenant could find or delete. Scoping removes the phantom block; the foreign row
+// is logged instead, so the corruption stays observable.
+//
+// The trade-off: a foreign row that still corresponds to a live gateway no longer blocks
+// here, and the conflict resurfaces further down as duplicate routing for the same
+// hostname. That is the better failure — this counter cannot see routing, and refusing
+// a tenant on account of a row it cannot reach is not enforcement, it is a dead end.
+func (s *PlatformGatewayService) enforceIngressCap(tx *gorm.DB, gateway *models.Gateway, envIDStr string) error {
+	existing, err := s.gatewayRepo.ListIngressCapableInEnvironment(tx, envIDStr)
+	if err != nil {
+		return err
+	}
+
+	// Partition before deciding, so a foreign row is reported even when a same-org row
+	// is also present and short-circuits the request.
+	var blocking *models.Gateway
+	foreign := make([]string, 0, len(existing))
+	for _, gw := range existing {
+		if gw.OUID == gateway.OUID {
+			if blocking == nil {
+				blocking = gw
+			}
+			continue
+		}
+		foreign = append(foreign, fmt.Sprintf("%s (%s, org %s)", gw.Name, gw.UUID, gw.OUID))
+	}
+
+	if len(foreign) > 0 {
+		slog.Warn("environment has ingress-capable gateways owned by another organization; "+
+			"these are not counted against this organization's ingress cap",
+			"environmentID", envIDStr, "ouID", gateway.OUID, "foreignGateways", strings.Join(foreign, ", "))
+	}
+
+	if blocking != nil {
+		return fmt.Errorf("%w: environment %s already has an ingress gateway %q (%s); "+
+			"register this gateway with gatewayType EGRESS instead",
+			utils.ErrGatewayIngressCapExceeded, envIDStr, blocking.Name, blocking.UUID)
 	}
 	return nil
 }


### PR DESCRIPTION
## Purpose
An environment's single ingress-gateway slot was counted across every organization. An ingress-capable row owned by a defunct organization identifier therefore held the slot while remaining invisible to every organization-scoped read.

The result was `409 environment already has an ingress gateway` returned to a tenant whose own gateway list came back empty, naming no row it could find or delete. There was no way for that tenant to make progress and nothing in the message to escalate with.

## Goals
1. Stop a foreign-organization row from blocking a tenant that cannot see or delete it.
2. Make the rejection self-explanatory when the cap legitimately applies, by naming the gateway holding the slot.

## Approach
`CountIngressCapableInEnvironment` becomes `ListIngressCapableInEnvironment`, returning the matching rows rather than a bare count. The query deliberately stays unfiltered by organization, because the caller needs both halves of the picture.

`PlatformGatewayService` gains `enforceIngressCap`, which partitions those rows before deciding:

- A row owned by the registering organization blocks, and its name and UUID go into the error.
- A row owned by a different organization is logged at warn level and does not block.

Environments are per-organization, so an ingress-capable row belonging to another organization is corrupt data rather than a legitimate incumbent. Logging it keeps the corruption observable instead of silently dropping it.

The partition happens before the decision so a foreign row is still reported when a same-organization row is also present and short-circuits the request.

**Trade-off, stated explicitly:** a foreign row that still corresponds to a live gateway no longer fails here. The conflict resurfaces further down as duplicate routing for one hostname. That is the better failure — this counter cannot see routing at all, and refusing a tenant on account of a row it cannot reach is not enforcement, it is a dead end.

The cap semantics are otherwise unchanged: egress is still uncapped, the advisory lock still serialises check-then-insert per environment, and an already-mapped gateway still returns before the count runs so it can never count itself.

## User stories
As a platform tenant, when I register an ingress gateway for an environment and the request is rejected, the error names the gateway already holding that slot so I can act on it — and I am not blocked by a row belonging to an organization I have no visibility into.

## Release note
Fixed the one-ingress-gateway-per-environment cap counting gateways across organizations, which could reject a registration on account of a row invisible to the requesting organization. The rejection message now names the gateway holding the slot.

## Documentation
N/A — no documented behaviour changes. The cap itself and the `gatewayType EGRESS` guidance in the error are unchanged; only its scope and the message detail differ.

## Training
N/A — no training impact.

## Certification
N/A — internal enforcement detail with no exam surface.

## Marketing
N/A — bug fix.

## Automation tests
 - Unit tests
   > `services/platform_gateway_cap_unit_test.go` extended from 3 to 7 cap tests, all passing. Four are new:
   > - a same-organization blocker is rejected **and** the error contains the blocking gateway's name and UUID
   > - a foreign-organization row does not block and the mapping is created
   > - a same-organization blocker still wins when a foreign row is present alongside it
   > - an empty result frees the slot
   >
   > The regression test was confirmed to fail against the old behaviour: forcing the ownership comparison to match unconditionally makes `ForeignOrgIngressDoesNotBlock` fail, and it passes with the fix.
 - Integration tests
   > The new query was exercised against a real PostgreSQL 16 instance with all 40 migrations applied, seeded with five rows covering same-org, foreign-org, egress-role, soft-deleted and other-environment cases. It returned exactly the two expected ingress-capable rows, with the soft-delete predicate and role filter applied and `created_at` scanned from `gateways` despite the join. Full unit suite passes via `scripts/run_unit_tests.sh`; `make codegenfmt-check` exits 0.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go, not Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Note on the change's security direction: it narrows enforcement, so it is worth being explicit that nothing cross-tenant is newly permitted. Environment UUIDs are per-organization, the mapping insert is unchanged, and every other read on this path was already organization-scoped — this brings the cap into line with them rather than relaxing an intended boundary.

## Samples
N/A.

## Related PRs
N/A.

## Migrations (if applicable)
N/A — no schema change. The repository method signature changes, and its generated mock is regenerated in the same commit.

## Test environment
Go toolchain per `go.mod`, PostgreSQL 16.14 (containerised) for the query verification, macOS 15 / darwin-arm64. `GOFLAGS=-mod=mod` throughout, since the vendor directory is inconsistent with `go.mod` on `main`.

## Learning
Two things worth recording.

The repository returns rows rather than a count specifically so one query can serve both the enforcement decision and the diagnostic message. An earlier shape used a second query for the blocking row, which meant the cap and the message could disagree under concurrent writes.

The real-database check earned its keep in an unexpected way. I had added an explicit `Select("gateways.*")` on the theory that both joined tables carry `created_at` and an unqualified projection would be ambiguous. Testing showed GORM already emits a fully qualified column list when the model is known, so the `Select` was redundant and the theory wrong — it was removed. The first test that appeared to confirm the theory was itself invalid: it failed on a unique-name collision from the previous run's rows, not on the projection.
