### PR TITLE
Add readiness probes to agent pods and reflect them in deployment status

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/constants.go
+++ b/agent-manager-service/clients/openchoreosvc/client/constants.go
@@ -149,6 +149,10 @@ const (
 	DeploymentStatusSuspended   = "suspended"
 )
 
+// resourceKindSandboxWarmPool is the kind of the dataplane resource that owns agent pods.
+// Its status carries the replica counts used to tell whether an agent can serve traffic.
+const resourceKindSandboxWarmPool = "SandboxWarmPool"
+
 // -----------------------------------------------------------------------------
 // OpenChoreo binding status values
 // -----------------------------------------------------------------------------

--- a/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
@@ -51,6 +51,35 @@ func warmPoolTree(status map[string]interface{}) *gen.K8sResourceTreeResponse {
 	}
 }
 
+// externalSecretNode builds an ExternalSecret node whose own status reports the given Ready
+// condition. Its health field is deliberately Healthy: that is what OpenChoreo reports even
+// for a secret that is failing to sync, which is why the object status is what gets read.
+func externalSecretNode(name, condStatus, reason, message string) gen.ResourceNode {
+	healthy := gen.HealthInfo{}
+	return gen.ResourceNode{
+		Kind:   "ExternalSecret",
+		Name:   name,
+		Uid:    "es-" + name,
+		Health: &healthy,
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type": "Ready", "status": condStatus, "reason": reason, "message": message,
+					},
+				},
+			},
+		},
+	}
+}
+
+// treeWith builds a tree from a warm pool status plus any extra nodes.
+func treeWith(poolStatus map[string]interface{}, extra ...gen.ResourceNode) *gen.K8sResourceTreeResponse {
+	tree := warmPoolTree(poolStatus)
+	tree.RenderedReleases[0].Nodes = append(tree.RenderedReleases[0].Nodes, extra...)
+	return tree
+}
+
 func readyBinding() *gen.ReleaseBinding {
 	return &gen.ReleaseBinding{
 		Metadata: gen.ObjectMeta{Name: "it-helpdesk-agent-default"},
@@ -145,5 +174,88 @@ func TestDetermineDeploymentStatusWithRuntimeReadiness(t *testing.T) {
 
 	t.Run("nil binding is not deployed", func(t *testing.T) {
 		assert.Equal(t, DeploymentStatusNotDeployed, determineDeploymentStatus(nil, runtimeReplicaState{}))
+	})
+}
+
+// A resource reporting itself not ready, with nothing serving, must report failed rather
+// than sitting at in-progress forever. Reproduces the observed case: an ExternalSecret that
+// will not sync leaves the container in CreateContainerConfigError ("secret ... not found")
+// indefinitely.
+func TestNotReadyResourceIsReportedAsFailed(t *testing.T) {
+	const syncErr = "could not get secret data from provider"
+
+	t.Run("unsyncable secret with nothing ready is failed", func(t *testing.T) {
+		tree := treeWith(
+			map[string]interface{}{"replicas": float64(1)},
+			externalSecretNode("env-secrets", "False", "SecretSyncedError", syncErr),
+		)
+		state := runtimeReplicaStateFromTree(tree)
+
+		assert.True(t, state.isFailed())
+		assert.False(t, state.isBooting(), "a pod that cannot start is not starting")
+		assert.Contains(t, state.notReadyResource, "SecretSyncedError")
+		assert.Equal(t, DeploymentStatusFailed, determineDeploymentStatus(readyBinding(), state))
+	})
+
+	t.Run("unsyncable secret while a replica still serves stays active", func(t *testing.T) {
+		// Observed live: the ExternalSecret was failing for ~30 minutes while the pod ran on
+		// a previously synced Secret. The agent was serving, so it is not failed.
+		tree := treeWith(
+			map[string]interface{}{"replicas": float64(1), "readyReplicas": float64(1)},
+			externalSecretNode("env-secrets", "False", "SecretSyncedError", syncErr),
+		)
+		state := runtimeReplicaStateFromTree(tree)
+
+		assert.False(t, state.isFailed())
+		assert.Equal(t, DeploymentStatusActive, determineDeploymentStatus(readyBinding(), state))
+	})
+
+	t.Run("synced secrets with nothing ready is still in progress", func(t *testing.T) {
+		tree := treeWith(
+			map[string]interface{}{"replicas": float64(1)},
+			externalSecretNode("env-secrets", "True", "SecretSynced", "secret synced"),
+		)
+		state := runtimeReplicaStateFromTree(tree)
+
+		assert.Empty(t, state.notReadyResource)
+		assert.Equal(t, DeploymentStatusInProgress, determineDeploymentStatus(readyBinding(), state))
+	})
+
+	t.Run("secret with no conditions is not treated as a failure", func(t *testing.T) {
+		node := gen.ResourceNode{
+			Kind: "ExternalSecret", Name: "fresh", Uid: "u",
+			Object: map[string]interface{}{},
+		}
+		state := runtimeReplicaStateFromTree(treeWith(map[string]interface{}{"replicas": float64(1)}, node))
+
+		assert.Empty(t, state.notReadyResource)
+		assert.True(t, state.isBooting())
+	})
+
+	t.Run("any kind reporting Ready=False counts, not just ExternalSecret", func(t *testing.T) {
+		// No kind is special-cased. ExternalSecret is merely the only kind in the tree today
+		// that publishes a Ready condition; Backend and RestApi use Accepted/Programmed and
+		// so are ignored whatever they report.
+		blocked := externalSecretNode("x", "False", "Blocked", "nope")
+		blocked.Kind = "SomeFutureKind"
+		accepted := externalSecretNode("gw", "False", "NotAccepted", "ignored")
+		accepted.Kind = "Backend"
+		accepted.Object["status"].(map[string]interface{})["conditions"] = []interface{}{
+			map[string]interface{}{"type": "Accepted", "status": "False", "reason": "NotAccepted"},
+		}
+
+		state := runtimeReplicaStateFromTree(
+			treeWith(map[string]interface{}{"replicas": float64(1)}, accepted, blocked))
+
+		assert.Contains(t, state.notReadyResource, "SomeFutureKind")
+		assert.NotContains(t, state.notReadyResource, "Backend", "a non-Ready condition type is ignored")
+	})
+
+	t.Run("scaled to zero with a failing secret is not failed", func(t *testing.T) {
+		tree := treeWith(
+			map[string]interface{}{"replicas": float64(0), "readyReplicas": float64(0)},
+			externalSecretNode("env-secrets", "False", "SecretSyncedError", syncErr),
+		)
+		assert.False(t, runtimeReplicaStateFromTree(tree).isFailed())
 	})
 }

--- a/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
@@ -1,0 +1,149 @@
+//
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+)
+
+// warmPoolTree builds a resource tree containing a SandboxWarmPool node with the given
+// status, mirroring the shape returned by the OpenChoreo k8sresources/tree endpoint.
+func warmPoolTree(status map[string]interface{}) *gen.K8sResourceTreeResponse {
+	pool := gen.ResourceNode{
+		Kind: resourceKindSandboxWarmPool,
+		Name: "it-helpdesk-agent",
+		Uid:  "pool-uid",
+		Object: map[string]interface{}{
+			"kind": resourceKindSandboxWarmPool,
+		},
+	}
+	if status != nil {
+		pool.Object["status"] = status
+	}
+
+	return &gen.K8sResourceTreeResponse{
+		RenderedReleases: []gen.ReleaseResourceTree{{
+			Name: "it-helpdesk-agent-default",
+			Nodes: []gen.ResourceNode{
+				{Kind: "Service", Name: "it-helpdesk-agent", Uid: "svc-uid", Object: map[string]interface{}{}},
+				pool,
+			},
+		}},
+	}
+}
+
+func readyBinding() *gen.ReleaseBinding {
+	return &gen.ReleaseBinding{
+		Metadata: gen.ObjectMeta{Name: "it-helpdesk-agent-default"},
+		Spec:     &gen.ReleaseBindingSpec{Environment: "default"},
+		Status: &gen.ReleaseBindingStatus{
+			Conditions: &[]gen.Condition{{Type: "Ready", Status: "True", Reason: "Ready"}},
+		},
+	}
+}
+
+func TestRuntimeReplicaStateFromTree(t *testing.T) {
+	t.Run("nil tree is unknown", func(t *testing.T) {
+		assert.Equal(t, runtimeReplicaState{}, runtimeReplicaStateFromTree(nil))
+	})
+
+	t.Run("no warm pool node is unknown", func(t *testing.T) {
+		tree := &gen.K8sResourceTreeResponse{
+			RenderedReleases: []gen.ReleaseResourceTree{{
+				Name:  "r",
+				Nodes: []gen.ResourceNode{{Kind: "Service", Name: "svc", Uid: "u", Object: map[string]interface{}{}}},
+			}},
+		}
+		assert.False(t, runtimeReplicaStateFromTree(tree).found)
+	})
+
+	t.Run("all replicas ready", func(t *testing.T) {
+		// JSON numbers decode as float64, which is how the counts actually arrive.
+		got := runtimeReplicaStateFromTree(warmPoolTree(map[string]interface{}{
+			"replicas": float64(1), "readyReplicas": float64(1),
+		}))
+		assert.Equal(t, runtimeReplicaState{found: true, desired: 1, ready: 1}, got)
+		assert.False(t, got.isBooting())
+	})
+
+	t.Run("no replica ready yet", func(t *testing.T) {
+		// The warm pool omits readyReplicas entirely while the pod boots.
+		got := runtimeReplicaStateFromTree(warmPoolTree(map[string]interface{}{"replicas": float64(1)}))
+		assert.Equal(t, runtimeReplicaState{found: true, desired: 1, ready: 0}, got)
+		assert.True(t, got.isBooting())
+	})
+
+	t.Run("pool without status is not ready", func(t *testing.T) {
+		got := runtimeReplicaStateFromTree(warmPoolTree(nil))
+		assert.True(t, got.found)
+		assert.False(t, got.isBooting(), "desired is unknown, so nothing is claimed about readiness")
+	})
+
+	t.Run("scaled to zero is not booting", func(t *testing.T) {
+		got := runtimeReplicaStateFromTree(warmPoolTree(map[string]interface{}{
+			"replicas": float64(0), "readyReplicas": float64(0),
+		}))
+		assert.False(t, got.isBooting(), "an agent scaled to zero is not mid-startup")
+	})
+
+	t.Run("partially ready pool counts as ready", func(t *testing.T) {
+		got := runtimeReplicaStateFromTree(warmPoolTree(map[string]interface{}{
+			"replicas": float64(3), "readyReplicas": float64(1),
+		}))
+		assert.False(t, got.isBooting(), "one ready replica can already serve traffic")
+	})
+}
+
+func TestDetermineDeploymentStatusWithRuntimeReadiness(t *testing.T) {
+	t.Run("ready binding with no ready replica is in progress", func(t *testing.T) {
+		booting := runtimeReplicaState{found: true, desired: 1, ready: 0}
+		assert.Equal(t, DeploymentStatusInProgress, determineDeploymentStatus(readyBinding(), booting))
+	})
+
+	t.Run("ready binding with a ready replica is active", func(t *testing.T) {
+		serving := runtimeReplicaState{found: true, desired: 1, ready: 1}
+		assert.Equal(t, DeploymentStatusActive, determineDeploymentStatus(readyBinding(), serving))
+	})
+
+	t.Run("unknown readiness falls back to the binding", func(t *testing.T) {
+		assert.Equal(t, DeploymentStatusActive, determineDeploymentStatus(readyBinding(), runtimeReplicaState{}))
+	})
+
+	t.Run("readiness does not override suspended", func(t *testing.T) {
+		binding := readyBinding()
+		state := gen.ReleaseBindingSpecStateUndeploy
+		binding.Spec.State = &state
+		booting := runtimeReplicaState{found: true, desired: 1, ready: 0}
+		assert.Equal(t, DeploymentStatusSuspended, determineDeploymentStatus(binding, booting))
+	})
+
+	t.Run("readiness does not override failed", func(t *testing.T) {
+		binding := readyBinding()
+		binding.Status.Conditions = &[]gen.Condition{{Type: "Ready", Status: "False", Reason: "Failed"}}
+		booting := runtimeReplicaState{found: true, desired: 1, ready: 0}
+		assert.Equal(t, DeploymentStatusFailed, determineDeploymentStatus(binding, booting))
+	})
+
+	t.Run("nil binding is not deployed", func(t *testing.T) {
+		assert.Equal(t, DeploymentStatusNotDeployed, determineDeploymentStatus(nil, runtimeReplicaState{}))
+	})
+}

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -870,7 +870,14 @@ func (c *openChoreoClient) GetDeployments(ctx context.Context, ouID, pipelineNam
 				componentRelease = componentReleaseMap[*releaseBinding.Spec.ReleaseName]
 			}
 
-			deploymentDetail, err := toDeploymentDetailsResponse(releaseBinding, componentRelease, environmentMap, promotionTargetEnv, workloadEndpoints, liveWorkloadContainerImage)
+			// Only bindings that would otherwise report "active" need the extra
+			// resource-tree lookup; every other status is already accurate without it.
+			var runtime runtimeReplicaState
+			if determineDeploymentStatus(releaseBinding, runtimeReplicaState{}) == DeploymentStatusActive {
+				runtime = c.fetchRuntimeReplicaState(ctx, namespaceName, releaseBinding.Metadata.Name)
+			}
+
+			deploymentDetail, err := toDeploymentDetailsResponse(releaseBinding, componentRelease, environmentMap, promotionTargetEnv, workloadEndpoints, liveWorkloadContainerImage, runtime)
 			if err != nil {
 				return nil, fmt.Errorf("failed to build deployment details for environment %s: %w", envName, err)
 			}
@@ -975,7 +982,11 @@ func (c *openChoreoClient) IsDeploymentInProgress(ctx context.Context, ouID, com
 	for i := range resp.JSON200.Items {
 		binding := &resp.JSON200.Items[i]
 		if binding.Spec != nil && binding.Spec.Environment == environment {
-			status := determineDeploymentStatus(binding)
+			// Deliberately binding-only: this guards against concurrent *rollouts*, and
+			// callers abort the deploy when it reports true. Counting a booting pod as
+			// in-progress here would block redeploys for the whole startup window — and
+			// forever for an agent whose pods never become ready.
+			status := determineDeploymentStatus(binding, runtimeReplicaState{})
 			return status == DeploymentStatusInProgress, nil
 		}
 	}
@@ -983,8 +994,104 @@ func (c *openChoreoClient) IsDeploymentInProgress(ctx context.Context, ouID, com
 	return false, nil
 }
 
-// determineDeploymentStatus determines deployment status from release binding conditions
-func determineDeploymentStatus(binding *gen.ReleaseBinding) string {
+// runtimeReplicaState is the agent's live pod readiness, read from the SandboxWarmPool
+// in the release binding's Kubernetes resource tree.
+//
+// A ReleaseBinding reports Ready=True (and ResourcesReady=True, "All N resources ready")
+// as soon as the dataplane resources are applied — it never observes whether a pod passed
+// its readiness probe. An agent whose container is still booting therefore shows as Ready
+// on the binding while its Service has zero ready endpoints, which is what made the console
+// report "active" while invocations still failed with 503. The warm pool's replica counts
+// are the only readiness signal available, so they are consulted separately.
+//
+// found is false when the state could not be determined (no warm pool node in the tree, or
+// the tree fetch failed); callers then fall back to the binding conditions alone rather than
+// reporting a worse status than they can prove.
+type runtimeReplicaState struct {
+	found   bool
+	desired int32
+	ready   int32
+}
+
+// isBooting reports whether the agent is expected to be serving but no replica is ready yet.
+func (r runtimeReplicaState) isBooting() bool {
+	return r.found && r.desired > 0 && r.ready == 0
+}
+
+// runtimeReplicaStateFromTree extracts the warm pool replica counts from a resource tree.
+// The node's full object is used rather than its health field: OpenChoreo reports the
+// SandboxWarmPool as Healthy regardless of how many replicas are ready.
+func runtimeReplicaStateFromTree(tree *gen.K8sResourceTreeResponse) runtimeReplicaState {
+	if tree == nil {
+		return runtimeReplicaState{}
+	}
+
+	for _, rendered := range tree.RenderedReleases {
+		for i := range rendered.Nodes {
+			node := &rendered.Nodes[i]
+			if node.Kind != resourceKindSandboxWarmPool {
+				continue
+			}
+
+			status, ok := node.Object["status"].(map[string]interface{})
+			if !ok {
+				// The pool exists but has not reported status yet: nothing is ready.
+				return runtimeReplicaState{found: true, desired: 0, ready: 0}
+			}
+
+			return runtimeReplicaState{
+				found:   true,
+				desired: replicaCount(status, "replicas"),
+				ready:   replicaCount(status, "readyReplicas"),
+			}
+		}
+	}
+
+	return runtimeReplicaState{}
+}
+
+// replicaCount reads an integral replica field out of an unstructured status map. JSON
+// numbers decode as float64, so the concrete numeric types are handled explicitly.
+func replicaCount(status map[string]interface{}, key string) int32 {
+	switch v := status[key].(type) {
+	case float64:
+		return int32(v)
+	case int64:
+		return int32(v)
+	case int:
+		return int32(v)
+	default:
+		return 0
+	}
+}
+
+// fetchRuntimeReplicaState looks up the live warm pool replica counts for a release binding.
+// It is best effort: any failure yields an unknown state so deployment listings degrade to
+// binding-only status instead of erroring.
+func (c *openChoreoClient) fetchRuntimeReplicaState(ctx context.Context, namespaceName, bindingName string) runtimeReplicaState {
+	if bindingName == "" {
+		return runtimeReplicaState{}
+	}
+
+	resp, err := c.ocClient.GetReleaseBindingK8sResourceTreeWithResponse(ctx, namespaceName, bindingName)
+	if err != nil {
+		slog.Warn("failed to fetch resource tree for deployment readiness",
+			"binding", bindingName, "namespace", namespaceName, "error", err)
+		return runtimeReplicaState{}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		slog.Warn("resource tree request returned non-OK for deployment readiness",
+			"binding", bindingName, "namespace", namespaceName, "status", resp.StatusCode())
+		return runtimeReplicaState{}
+	}
+
+	return runtimeReplicaStateFromTree(resp.JSON200)
+}
+
+// determineDeploymentStatus determines deployment status from release binding conditions,
+// downgrading "active" to "in-progress" while the agent's pods are still starting.
+// Pass an unknown runtimeReplicaState to derive the status from the binding alone.
+func determineDeploymentStatus(binding *gen.ReleaseBinding, runtime runtimeReplicaState) string {
 	if binding == nil {
 		return DeploymentStatusNotDeployed
 	}
@@ -1004,6 +1111,12 @@ func determineDeploymentStatus(binding *gen.ReleaseBinding) string {
 		if condition.Type == "Ready" {
 			switch condition.Status {
 			case "True":
+				// The binding is applied, but the agent cannot serve traffic until a pod
+				// passes its readiness probe. Reporting "active" here is what let callers
+				// invoke an agent whose container was still booting and get a 503.
+				if runtime.isBooting() {
+					return DeploymentStatusInProgress
+				}
 				return DeploymentStatusActive
 			case "False":
 				// Check reason for more specific status
@@ -1045,12 +1158,12 @@ func findPromotionTargetEnvironment(sourceEnvName string, promotionPaths []model
 	return nil
 }
 
-func toDeploymentDetailsResponse(binding *gen.ReleaseBinding, componentRelease *gen.ComponentRelease, environmentMap map[string]*models.EnvironmentResponse, promotionTargetEnv *models.PromotionTargetEnvironment, workloadEndpoints map[string]*gen.WorkloadEndpoint, liveWorkloadContainerImage string) (*models.DeploymentResponse, error) {
+func toDeploymentDetailsResponse(binding *gen.ReleaseBinding, componentRelease *gen.ComponentRelease, environmentMap map[string]*models.EnvironmentResponse, promotionTargetEnv *models.PromotionTargetEnvironment, workloadEndpoints map[string]*gen.WorkloadEndpoint, liveWorkloadContainerImage string, runtime runtimeReplicaState) (*models.DeploymentResponse, error) {
 	if binding == nil || binding.Spec == nil {
 		return nil, fmt.Errorf("release binding is nil or has no spec")
 	}
 
-	status := determineDeploymentStatus(binding)
+	status := determineDeploymentStatus(binding, runtime)
 
 	// Extract endpoints from release binding status, enriched with workload endpoint info
 	endpoints := extractEndpointsFromBinding(binding, workloadEndpoints)

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -1011,43 +1012,97 @@ type runtimeReplicaState struct {
 	found   bool
 	desired int32
 	ready   int32
+
+	// notReadyResource describes a resource the deployment depends on that reports itself not
+	// ready — in practice an ExternalSecret that will not sync, which leaves the container
+	// in CreateContainerConfigError ("secret ... not found") indefinitely. It separates
+	// "cannot start" from "still starting" so a broken deployment is not reported as
+	// in-progress forever. Empty when nothing reported itself unready.
+	notReadyResource string
 }
 
-// isBooting reports whether the agent is expected to be serving but no replica is ready yet.
+// isBooting reports whether the agent is expected to be serving but no replica is ready
+// yet, and nothing is known to be preventing it from starting.
 func (r runtimeReplicaState) isBooting() bool {
-	return r.found && r.desired > 0 && r.ready == 0
+	return r.found && r.desired > 0 && r.ready == 0 && r.notReadyResource == ""
 }
 
-// runtimeReplicaStateFromTree extracts the warm pool replica counts from a resource tree.
-// The node's full object is used rather than its health field: OpenChoreo reports the
-// SandboxWarmPool as Healthy regardless of how many replicas are ready.
+// isFailed reports whether the agent cannot serve and a dependency explains why.
+// Requires ready == 0: a pool still serving on a previously synced Secret is working,
+// whatever that Secret's ExternalSecret currently reports.
+func (r runtimeReplicaState) isFailed() bool {
+	return r.found && r.desired > 0 && r.ready == 0 && r.notReadyResource != ""
+}
+
+// runtimeReplicaStateFromTree extracts warm pool replica counts and any blocking
+// dependency failure from a resource tree.
+//
+// Node objects are inspected rather than the nodes' health field, which cannot be used
+// for either signal: OpenChoreo reports the SandboxWarmPool as Healthy regardless of how
+// many replicas are ready, and reports an ExternalSecret as Healthy while its own status
+// says Ready=False/SecretSyncedError. Pods are not in the tree at all (and the OpenChoreo
+// API exposes no pod endpoint), so container-level failures such as ImagePullBackOff or
+// CrashLoopBackOff cannot be detected here.
 func runtimeReplicaStateFromTree(tree *gen.K8sResourceTreeResponse) runtimeReplicaState {
 	if tree == nil {
 		return runtimeReplicaState{}
 	}
 
+	state := runtimeReplicaState{}
 	for _, rendered := range tree.RenderedReleases {
 		for i := range rendered.Nodes {
 			node := &rendered.Nodes[i]
-			if node.Kind != resourceKindSandboxWarmPool {
-				continue
+
+			if node.Kind == resourceKindSandboxWarmPool {
+				state.found = true
+				// A pool with no status yet has nothing ready; the zero counts already say so.
+				if status, ok := node.Object["status"].(map[string]interface{}); ok {
+					state.desired = replicaCount(status, "replicas")
+					state.ready = replicaCount(status, "readyReplicas")
+				}
 			}
 
-			status, ok := node.Object["status"].(map[string]interface{})
-			if !ok {
-				// The pool exists but has not reported status yet: nothing is ready.
-				return runtimeReplicaState{found: true, desired: 0, ready: 0}
-			}
-
-			return runtimeReplicaState{
-				found:   true,
-				desired: replicaCount(status, "replicas"),
-				ready:   replicaCount(status, "readyReplicas"),
+			// Any resource that reports itself not ready is a candidate explanation. No kind
+			// is singled out: ExternalSecret happens to be the only kind in the tree today
+			// that publishes a Ready condition (Backend and RestApi use Accepted/Programmed,
+			// the rest publish none), so naming it would add a rule without changing what is
+			// matched, and would need editing whenever another kind starts reporting Ready.
+			if state.notReadyResource == "" {
+				state.notReadyResource = notReadyCondition(node)
 			}
 		}
 	}
 
-	return runtimeReplicaState{}
+	return state
+}
+
+// notReadyCondition returns a description of a node's Ready=False condition, or "" when
+// the node is ready or reports no Ready condition.
+func notReadyCondition(node *gen.ResourceNode) string {
+	status, ok := node.Object["status"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	conditions, ok := status["conditions"].([]interface{})
+	if !ok {
+		return ""
+	}
+
+	for _, raw := range conditions {
+		condition, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if condition["type"] != "Ready" || condition["status"] != "False" {
+			continue
+		}
+
+		reason, _ := condition["reason"].(string)
+		message, _ := condition["message"].(string)
+		return strings.TrimSpace(fmt.Sprintf("%s %s: %s %s", node.Kind, node.Name, reason, message))
+	}
+
+	return ""
 }
 
 // replicaCount reads an integral replica field out of an unstructured status map. JSON
@@ -1085,7 +1140,12 @@ func (c *openChoreoClient) fetchRuntimeReplicaState(ctx context.Context, namespa
 		return runtimeReplicaState{}
 	}
 
-	return runtimeReplicaStateFromTree(resp.JSON200)
+	state := runtimeReplicaStateFromTree(resp.JSON200)
+	slog.Debug("resolved agent runtime state",
+		"binding", bindingName, "namespace", namespaceName,
+		"desired", state.desired, "ready", state.ready, "cause", state.notReadyResource)
+
+	return state
 }
 
 // determineDeploymentStatus determines deployment status from release binding conditions,
@@ -1114,6 +1174,9 @@ func determineDeploymentStatus(binding *gen.ReleaseBinding, runtime runtimeRepli
 				// The binding is applied, but the agent cannot serve traffic until a pod
 				// passes its readiness probe. Reporting "active" here is what let callers
 				// invoke an agent whose container was still booting and get a 503.
+				if runtime.isFailed() {
+					return DeploymentStatusFailed
+				}
 				if runtime.isBooting() {
 					return DeploymentStatusInProgress
 				}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
@@ -168,6 +168,17 @@ spec:
                     limits:
                       cpu: ${environmentConfigs.resources.limits.?cpu.orValue(parameters.resources.limits.cpu)}
                       memory: ${environmentConfigs.resources.limits.?memory.orValue(parameters.resources.limits.memory)}
+                  startupProbe:
+                    tcpSocket:
+                      port: ${workload.endpoints.transformList(name, ep, [ep.port]).flatten()[0]}
+                    periodSeconds: 5
+                    failureThreshold: 60
+                    initialDelaySeconds: 10
+                  readinessProbe:
+                    tcpSocket:
+                      port: ${workload.endpoints.transformList(name, ep, [ep.port]).flatten()[0]}
+                    periodSeconds: 5
+                    failureThreshold: 6
                   env: ${dependencies.toContainerEnvs()}
                   envFrom: ${configurations.toContainerEnvFrom()}
                   volumeMounts: |


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Agent pods had no probes, so Kubernetes considered them ready the moment the container started and routed traffic before the app had bound its port. The first requests after a deploy failed with 503 for as long as the agent took to
boot — 98s for the it-helpdesk sample. Add a startup and readiness probe so the pod only joins the Service once it is listening. The check is TCP because agents are not required to expose a health endpoint.

Deployment status had the same blind spot: it came from the ReleaseBinding, which reports Ready as soon as the resources are applied and never looks at the pods, so the console said "active" while nothing could serve. Derive it from the SandboxWarmPool's ready replicas instead — "in-progress" while the agent is
starting, "failed" when a resource it depends on cannot become ready.

Implementation notes:
- Replica counts and conditions are read from the node objects in the binding's resource tree, not the nodes' health field, which reports both a pool with zero ready replicas and a failing ExternalSecret as Healthy.
- The tree is fetched only for bindings that would otherwise report "active",  and a failed lookup falls back to binding-only status.
- No kind is special-cased when looking for a blocking resource: ExternalSecret is simply the only kind in the tree that publishes a Ready condition today.
- A pool that is scaled to zero, or still serving on a previously synced Secret, stays "active" — neither is a deployment that cannot start.
- IsDeploymentInProgress stays binding-only: it aborts deploys, so counting a booting pod would block redeploys until the pod is ready.

Resolves #936 

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.