### PR TITLE
Fix AgentID secret injection and multi-MCP scope handling for internal agents

### DIFF
--- a/agent-manager-service/app/app.go
+++ b/agent-manager-service/app/app.go
@@ -210,6 +210,13 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 		<-stopCh
 		slog.Info("Shutdown signal received, stopping services...")
 
+		// Abort any AgentID pod rollout still waiting or in flight first —
+		// this is a plain context.CancelFunc, so there is no reason to run
+		// it after any of the synchronous shutdown steps below, some of
+		// which could otherwise delay it long enough for a still-waiting
+		// rollout to fire in the meantime.
+		agentIdentityRolloutCancel()
+
 		// Single timeout context for the entire shutdown sequence
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer shutdownCancel()
@@ -219,10 +226,6 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 		if err := dependencies.MonitorScheduler.Stop(); err != nil {
 			slog.Error("error stopping monitor scheduler", "error", err)
 		}
-
-		// Abort any AgentID pod rollout still waiting or in flight rather
-		// than letting it fire after this point.
-		agentIdentityRolloutCancel()
 
 		agentThunderReconcilerCancel()
 		if agentThunderProvisioning != nil {

--- a/agent-manager-service/app/app.go
+++ b/agent-manager-service/app/app.go
@@ -70,7 +70,7 @@ type Options struct {
 	// credentials). encryptionKey is the platform ENCRYPTION_KEY, used to decrypt
 	// the env-Thunder system-client credential from AMS's own Postgres — that one
 	// is not read back from a key vault.
-	AgentThunderProvisioning func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, encryptionKey []byte) services.AgentThunderProvisioningService
+	AgentThunderProvisioning func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, ocClient occlient.OpenChoreoClient, encryptionKey []byte) services.AgentThunderProvisioningService
 }
 
 // Run starts the application with the provided providers and options.
@@ -133,7 +133,7 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 			slog.Error("failed to load encryption key for AgentID provisioning", "error", err)
 			os.Exit(1)
 		}
-		agentThunderProvisioning = opts.AgentThunderProvisioning(database, secretMgmtClientForProvisioning, encryptionKey)
+		agentThunderProvisioning = opts.AgentThunderProvisioning(database, secretMgmtClientForProvisioning, ocClientForProvisioning, encryptionKey)
 	}
 
 	dependencies, err := wiring.InitializeAppParams(cfg, database, authProvider, secretProvider, opts.GatewayConfigApplier, agentThunderProvisioning)

--- a/agent-manager-service/app/app.go
+++ b/agent-manager-service/app/app.go
@@ -155,6 +155,14 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 		setter.SetWorkloadInjector(dependencies.AgentIdentityInjectionService)
 	}
 
+	// So a rotated agent's deferred pod rollout (see RefreshAfterRotation)
+	// stops waiting, or aborts an in-flight roll, once shutdown starts below
+	// instead of firing an outbound update afterward.
+	agentIdentityRolloutCtx, agentIdentityRolloutCancel := context.WithCancel(context.Background())
+	if setter, ok := dependencies.AgentIdentityInjectionService.(services.AgentIdentityShutdownContextSetter); ok {
+		setter.SetShutdownContext(agentIdentityRolloutCtx)
+	}
+
 	// Start monitor scheduler with background context
 	schedulerCtx, schedulerCancel := context.WithCancel(context.Background())
 	if err := dependencies.MonitorScheduler.Start(schedulerCtx); err != nil {
@@ -211,6 +219,10 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 		if err := dependencies.MonitorScheduler.Stop(); err != nil {
 			slog.Error("error stopping monitor scheduler", "error", err)
 		}
+
+		// Abort any AgentID pod rollout still waiting or in flight rather
+		// than letting it fire after this point.
+		agentIdentityRolloutCancel()
 
 		agentThunderReconcilerCancel()
 		if agentThunderProvisioning != nil {

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -146,6 +146,10 @@ type SecretManagerConfig struct {
 	// RefreshInterval is how often SecretReference CRs should refresh from the
 	// secret store (default: "1h")
 	RefreshInterval string
+	// AgentIdentityRefreshInterval is the AgentID SecretReference's refresh
+	// cadence (default: "15s"), kept separate from RefreshInterval above so
+	// AgentID's fast rotation-to-pod requirement never depends on it.
+	AgentIdentityRefreshInterval string
 }
 
 // OpenBaoConfig holds OpenBao KV store configuration.

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -273,6 +274,7 @@ func loadEnvs() {
 	validateObserverURLs(config, r)
 	validateResourceLimitsConfig(config, r)
 	validatePostgresTLSConfig(config, r)
+	validateSecretManagerConfig(config, r)
 	validateAgentWorkloadCORSConfig(agentWorkloadConfig, r)
 
 	r.logAndExitIfErrorsFound()
@@ -290,6 +292,24 @@ var validPostgresSSLModes = map[string]struct{}{
 	"require":     {},
 	"verify-ca":   {},
 	"verify-full": {},
+}
+
+// validateSecretManagerConfig fails config load on a malformed or nonpositive
+// AGENT_IDENTITY_REFRESH_INTERVAL, instead of silently falling back to
+// agentIdentityInjectionService's own default at first use (see
+// secretSyncWaitDuration's doc comment).
+func validateSecretManagerConfig(cfg *Config, r *configReader) {
+	d, err := time.ParseDuration(cfg.SecretManager.AgentIdentityRefreshInterval)
+	switch {
+	case err != nil:
+		r.errors = append(r.errors, fmt.Errorf(
+			"AGENT_IDENTITY_REFRESH_INTERVAL %q is not a valid duration: %w", cfg.SecretManager.AgentIdentityRefreshInterval, err,
+		))
+	case d <= 0:
+		r.errors = append(r.errors, fmt.Errorf(
+			"AGENT_IDENTITY_REFRESH_INTERVAL must be a positive duration, got %q", cfg.SecretManager.AgentIdentityRefreshInterval,
+		))
+	}
 }
 
 func validatePostgresTLSConfig(cfg *Config, r *configReader) {

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -211,10 +211,11 @@ func loadEnvs() {
 	}
 
 	config.SecretManager = SecretManagerConfig{
-		Provider:        r.readOptionalString("SECRET_MANAGER_PROVIDER", "openchoreo"),
-		TargetPlaneKind: r.readOptionalString("SECRET_MANAGER_TARGET_PLANE_KIND", "ClusterDataPlane"),
-		TargetPlaneName: r.readOptionalString("SECRET_MANAGER_TARGET_PLANE_NAME", "default"),
-		RefreshInterval: r.readOptionalString("SECRET_MANAGER_REFRESH_INTERVAL", "1h"),
+		Provider:                     r.readOptionalString("SECRET_MANAGER_PROVIDER", "openchoreo"),
+		TargetPlaneKind:              r.readOptionalString("SECRET_MANAGER_TARGET_PLANE_KIND", "ClusterDataPlane"),
+		TargetPlaneName:              r.readOptionalString("SECRET_MANAGER_TARGET_PLANE_NAME", "default"),
+		RefreshInterval:              r.readOptionalString("SECRET_MANAGER_REFRESH_INTERVAL", "1h"),
+		AgentIdentityRefreshInterval: r.readOptionalString("AGENT_IDENTITY_REFRESH_INTERVAL", "15s"),
 	}
 
 	// OpenBao KV store configuration (data plane - for deployment secrets)

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -317,6 +317,68 @@ func TestValidatePostgresTLSConfig(t *testing.T) {
 	}
 }
 
+func TestValidateSecretManagerConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		interval    string
+		wantErrors  int
+		errContains string
+	}{
+		{
+			name:       "documented default accepted",
+			interval:   "15s",
+			wantErrors: 0,
+		},
+		{
+			name:       "other valid positive duration accepted",
+			interval:   "1h",
+			wantErrors: 0,
+		},
+		{
+			name:        "malformed duration rejected",
+			interval:    "not-a-duration",
+			wantErrors:  1,
+			errContains: "AGENT_IDENTITY_REFRESH_INTERVAL",
+		},
+		{
+			name:        "zero rejected",
+			interval:    "0s",
+			wantErrors:  1,
+			errContains: "must be a positive duration",
+		},
+		{
+			name:        "negative rejected",
+			interval:    "-15s",
+			wantErrors:  1,
+			errContains: "must be a positive duration",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{SecretManager: SecretManagerConfig{AgentIdentityRefreshInterval: tc.interval}}
+			r := &configReader{}
+			validateSecretManagerConfig(cfg, r)
+
+			if len(r.errors) != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tc.wantErrors, len(r.errors), r.errors)
+			}
+			if tc.errContains != "" {
+				found := false
+				for _, e := range r.errors {
+					if strings.Contains(e.Error(), tc.errContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected an error containing %q, got %v", tc.errContains, r.errors)
+				}
+			}
+		})
+	}
+}
+
 func TestLoadEnvs_ObserverConfig(t *testing.T) {
 	requiredEnv := map[string]string{
 		"OPEN_CHOREO_BASE_URL": "http://localhost/api/v1",

--- a/agent-manager-service/main.go
+++ b/agent-manager-service/main.go
@@ -47,8 +47,8 @@ func main() {
 	secretProvider := openchoreo.NewProvider()
 
 	// Open-source: DB-backed AgentID provisioning (env-Thunder credential read
-	// from Postgres, not a key vault — see NewDBBackedAgentThunderProvisioning)
-	agentThunderProvisioning := services.NewDBBackedAgentThunderProvisioning()
+	// from Postgres, not a key vault — see DBBackedAgentThunderProvisioning)
+	agentThunderProvisioning := services.DBBackedAgentThunderProvisioning()
 
 	app.Run(authProvider, secretProvider, app.Options{
 		Server:                   *serverFlag,

--- a/agent-manager-service/repositories/agent_configuration_repository.go
+++ b/agent-manager-service/repositories/agent_configuration_repository.go
@@ -38,8 +38,23 @@ type AgentConfigurationRepository interface {
 	// GetByUUID retrieves configuration by UUID
 	GetByUUID(ctx context.Context, configUUID uuid.UUID, ouID string) (*models.AgentConfiguration, error)
 
-	// GetByAgentID retrieves configuration by agent ID
+	// GetByAgentID retrieves configuration by agent ID. An agent can have
+	// several configuration rows of the same type (e.g. one per bound MCP
+	// proxy — see ListMCPConfigsByAgent's doc comment), so this returns an
+	// ARBITRARY single row when more than one exists; callers that need
+	// every row of a given type must use ListMCPConfigsByAgent (MCP) or
+	// ListByAgentAndType instead.
 	GetByAgentID(ctx context.Context, agentID, ouID string) (*models.AgentConfiguration, error)
+
+	// ListMCPConfigsByAgent returns every MCP-type AgentConfiguration row for
+	// one agent, each fully preloaded with its EnvMCPMappings (and their
+	// MCPProxy/Artifact) — one row per MCP proxy the agent is configured
+	// with (see createMCPConfig: each configured MCP proxy gets its own
+	// AgentConfiguration row, all sharing TypeID=AgentConfigTypeIDMCP).
+	// Callers that need the full set of MCP proxies an agent is bound to
+	// (e.g. resolving the union of every proxy's scopes) must use this
+	// instead of GetByAgentID, which only ever returns one arbitrary row.
+	ListMCPConfigsByAgent(ctx context.Context, ouID, projectName, agentID string) ([]models.AgentConfiguration, error)
 
 	// List retrieves configurations with pagination
 	List(ctx context.Context, ouID string, limit, offset int) ([]models.AgentConfiguration, error)
@@ -125,6 +140,18 @@ func (r *agentConfigurationRepository) GetByAgentID(ctx context.Context, agentID
 		backfillLLMProxyHandles(&config)
 	}
 	return &config, err
+}
+
+func (r *agentConfigurationRepository) ListMCPConfigsByAgent(ctx context.Context, ouID, projectName, agentID string) ([]models.AgentConfiguration, error) {
+	var configs []models.AgentConfiguration
+	err := r.db.WithContext(ctx).
+		Preload("EnvMCPMappings").
+		Preload("EnvMCPMappings.Artifact").
+		Preload("EnvMCPMappings.MCPProxy").
+		Preload("EnvMCPMappings.MCPProxy.Artifact").
+		Where("ou_id = ? AND project_name = ? AND agent_id = ? AND type_id = ?", ouID, projectName, agentID, models.AgentConfigTypeIDMCP).
+		Find(&configs).Error
+	return configs, err
 }
 
 // backfillLLMProxyHandles populates the Handle field of each preloaded LLM proxy

--- a/agent-manager-service/repositories/repomocks/agent_configuration_repository_mock.go
+++ b/agent-manager-service/repositories/repomocks/agent_configuration_repository_mock.go
@@ -51,6 +51,9 @@ import (
 //			ListByAgentAndTypeFunc: func(ctx context.Context, ouID string, projectName string, agentName string, typeID uint, limit int, offset int) ([]models.AgentConfiguration, error) {
 //				panic("mock out the ListByAgentAndType method")
 //			},
+//			ListMCPConfigsByAgentFunc: func(ctx context.Context, ouID string, projectName string, agentID string) ([]models.AgentConfiguration, error) {
+//				panic("mock out the ListMCPConfigsByAgent method")
+//			},
 //			UpdateFunc: func(ctx context.Context, tx *gorm.DB, config *models.AgentConfiguration) error {
 //				panic("mock out the Update method")
 //			},
@@ -93,6 +96,9 @@ type AgentConfigurationRepositoryMock struct {
 
 	// ListByAgentAndTypeFunc mocks the ListByAgentAndType method.
 	ListByAgentAndTypeFunc func(ctx context.Context, ouID string, projectName string, agentName string, typeID uint, limit int, offset int) ([]models.AgentConfiguration, error)
+
+	// ListMCPConfigsByAgentFunc mocks the ListMCPConfigsByAgent method.
+	ListMCPConfigsByAgentFunc func(ctx context.Context, ouID string, projectName string, agentID string) ([]models.AgentConfiguration, error)
 
 	// UpdateFunc mocks the Update method.
 	UpdateFunc func(ctx context.Context, tx *gorm.DB, config *models.AgentConfiguration) error
@@ -220,6 +226,17 @@ type AgentConfigurationRepositoryMock struct {
 			// Offset is the offset argument value.
 			Offset int
 		}
+		// ListMCPConfigsByAgent holds details about calls to the ListMCPConfigsByAgent method.
+		ListMCPConfigsByAgent []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OuID is the ouID argument value.
+			OuID string
+			// ProjectName is the projectName argument value.
+			ProjectName string
+			// AgentID is the agentID argument value.
+			AgentID string
+		}
 		// Update holds details about calls to the Update method.
 		Update []struct {
 			// Ctx is the ctx argument value.
@@ -230,18 +247,19 @@ type AgentConfigurationRepositoryMock struct {
 			Config *models.AgentConfiguration
 		}
 	}
-	lockCount               sync.RWMutex
-	lockCountByAgent        sync.RWMutex
-	lockCountByAgentAndType sync.RWMutex
-	lockCreate              sync.RWMutex
-	lockDelete              sync.RWMutex
-	lockExists              sync.RWMutex
-	lockGetByAgentID        sync.RWMutex
-	lockGetByUUID           sync.RWMutex
-	lockList                sync.RWMutex
-	lockListByAgent         sync.RWMutex
-	lockListByAgentAndType  sync.RWMutex
-	lockUpdate              sync.RWMutex
+	lockCount                 sync.RWMutex
+	lockCountByAgent          sync.RWMutex
+	lockCountByAgentAndType   sync.RWMutex
+	lockCreate                sync.RWMutex
+	lockDelete                sync.RWMutex
+	lockExists                sync.RWMutex
+	lockGetByAgentID          sync.RWMutex
+	lockGetByUUID             sync.RWMutex
+	lockList                  sync.RWMutex
+	lockListByAgent           sync.RWMutex
+	lockListByAgentAndType    sync.RWMutex
+	lockListMCPConfigsByAgent sync.RWMutex
+	lockUpdate                sync.RWMutex
 }
 
 // Count calls CountFunc.
@@ -725,6 +743,50 @@ func (mock *AgentConfigurationRepositoryMock) ListByAgentAndTypeCalls() []struct
 	mock.lockListByAgentAndType.RLock()
 	calls = mock.calls.ListByAgentAndType
 	mock.lockListByAgentAndType.RUnlock()
+	return calls
+}
+
+// ListMCPConfigsByAgent calls ListMCPConfigsByAgentFunc.
+func (mock *AgentConfigurationRepositoryMock) ListMCPConfigsByAgent(ctx context.Context, ouID string, projectName string, agentID string) ([]models.AgentConfiguration, error) {
+	if mock.ListMCPConfigsByAgentFunc == nil {
+		panic("AgentConfigurationRepositoryMock.ListMCPConfigsByAgentFunc: method is nil but AgentConfigurationRepository.ListMCPConfigsByAgent was just called")
+	}
+	callInfo := struct {
+		Ctx         context.Context
+		OuID        string
+		ProjectName string
+		AgentID     string
+	}{
+		Ctx:         ctx,
+		OuID:        ouID,
+		ProjectName: projectName,
+		AgentID:     agentID,
+	}
+	mock.lockListMCPConfigsByAgent.Lock()
+	mock.calls.ListMCPConfigsByAgent = append(mock.calls.ListMCPConfigsByAgent, callInfo)
+	mock.lockListMCPConfigsByAgent.Unlock()
+	return mock.ListMCPConfigsByAgentFunc(ctx, ouID, projectName, agentID)
+}
+
+// ListMCPConfigsByAgentCalls gets all the calls that were made to ListMCPConfigsByAgent.
+// Check the length with:
+//
+//	len(mockedAgentConfigurationRepository.ListMCPConfigsByAgentCalls())
+func (mock *AgentConfigurationRepositoryMock) ListMCPConfigsByAgentCalls() []struct {
+	Ctx         context.Context
+	OuID        string
+	ProjectName string
+	AgentID     string
+} {
+	var calls []struct {
+		Ctx         context.Context
+		OuID        string
+		ProjectName string
+		AgentID     string
+	}
+	mock.lockListMCPConfigsByAgent.RLock()
+	calls = mock.calls.ListMCPConfigsByAgent
+	mock.lockListMCPConfigsByAgent.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -1471,6 +1471,19 @@ func (s *agentConfigurationService) createMCPConfig(ctx context.Context, ouID, p
 		}
 	}
 
+	// A newly-created MCP config changes the agent's AgentID scope union just as
+	// much as editing an existing one does (see updateMCPConfig's identical call)
+	// — refresh every environment this config was just bound to so an
+	// already-running pod picks up the new scopes right away instead of waiting
+	// for its next deploy/promote/rotation. refreshTouchedMCPEnvironments already
+	// no-ops safely for external/unprovisioned agents, so this is safe to call
+	// unconditionally rather than duplicating the isExternalAgent branch here.
+	touchedEnvNames := make(map[string]struct{}, len(req.EnvMappings))
+	for envName := range req.EnvMappings {
+		touchedEnvNames[envName] = struct{}{}
+	}
+	go s.refreshTouchedMCPEnvironments(context.WithoutCancel(ctx), ouID, projectName, agentID, touchedEnvNames)
+
 	if isExternalAgent {
 		return s.buildExternalAgentConfigResponse(ctx, config, envCredentials)
 	}
@@ -3877,6 +3890,20 @@ func (s *agentConfigurationService) deleteMCPConfig(ctx context.Context, existin
 	}); err != nil {
 		return fmt.Errorf("failed to delete MCP configuration: %w", err)
 	}
+
+	// Removing this config drops its scopes from the agent's AgentID scope union
+	// just as much as adding one grows it (see createMCPConfig's identical call)
+	// — refresh every environment this config was bound to so an already-running
+	// pod stops requesting the now-removed MCP's scopes right away, instead of
+	// only on its next deploy/promote/rotation.
+	touchedEnvNames := make(map[string]struct{}, len(mappings))
+	for _, mapping := range mappings {
+		if envName := envIDNameMap[mapping.EnvironmentUUID.String()]; envName != "" {
+			touchedEnvNames[envName] = struct{}{}
+		}
+	}
+	go s.refreshTouchedMCPEnvironments(context.WithoutCancel(ctx), ouID, projectName, agentName, touchedEnvNames)
+
 	return nil
 }
 

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -1482,7 +1482,11 @@ func (s *agentConfigurationService) createMCPConfig(ctx context.Context, ouID, p
 	for envName := range req.EnvMappings {
 		touchedEnvNames[envName] = struct{}{}
 	}
-	go s.refreshTouchedMCPEnvironments(context.WithoutCancel(ctx), ouID, projectName, agentID, touchedEnvNames)
+	go func() {
+		refreshCtx, cancel := detachedRefreshContext(ctx)
+		defer cancel()
+		s.refreshTouchedMCPEnvironments(refreshCtx, ouID, projectName, agentID, touchedEnvNames)
+	}()
 
 	if isExternalAgent {
 		return s.buildExternalAgentConfigResponse(ctx, config, envCredentials)
@@ -2450,11 +2454,35 @@ func (s *agentConfigurationService) updateMCPConfig(ctx context.Context, existin
 
 	// Detached onto its own goroutine, off the request path — cost scales
 	// with the number of touched environments, and this is already a
-	// best-effort step. context.WithoutCancel keeps request-scoped values
-	// (e.g. a correlation ID) without tying it to this handler's cancellation.
-	go s.refreshTouchedMCPEnvironments(context.WithoutCancel(ctx), ouID, projectName, agentName, touchedEnvNames)
+	// best-effort step. See detachedRefreshContext for why it's built the way
+	// it is.
+	go func() {
+		refreshCtx, cancel := detachedRefreshContext(ctx)
+		defer cancel()
+		s.refreshTouchedMCPEnvironments(refreshCtx, ouID, projectName, agentName, touchedEnvNames)
+	}()
 
 	return s.GetMCP(ctx, existingConfig.UUID, ouID, projectName, agentName)
+}
+
+// mcpRefreshTimeout bounds how long a detached refreshTouchedMCPEnvironments
+// goroutine may run after its triggering request has already returned a
+// response. The OpenChoreo HTTP client it calls through has no timeout of
+// its own, so without this bound a single hung call would tie up the
+// goroutine indefinitely; 30s matches the timeout convention already used
+// elsewhere in this codebase for external-call bounds (Thunder's HTTP
+// client).
+const mcpRefreshTimeout = 30 * time.Second
+
+// detachedRefreshContext derives the context a refreshTouchedMCPEnvironments
+// goroutine runs with: WithoutCancel so the refresh survives the triggering
+// request's own cancellation (it's deliberately best-effort work that
+// outlives the response, not tied to the handler's lifecycle) while still
+// carrying request-scoped values like a correlation ID, and WithTimeout so a
+// hung external call can't run forever. Callers must defer the returned
+// cancel func to release the timer once the goroutine finishes.
+func detachedRefreshContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), mcpRefreshTimeout)
 }
 
 // refreshTouchedMCPEnvironments brings every given environment's live AgentID
@@ -2465,10 +2493,10 @@ func (s *agentConfigurationService) updateMCPConfig(ctx context.Context, existin
 // actually change (touchedEnvNames is the union of all existing and all
 // requested mappings, so this includes plenty of no-ops) never causes a
 // needless pod rollout. Best-effort: the caller runs this on a detached
-// goroutine after the MCP config change itself already succeeded, so a
-// refresh failure here must never turn that success into an error response —
-// it's logged and the agent simply picks up the change on its next
-// deploy/promote/rotation instead.
+// goroutine (see detachedRefreshContext) after the MCP config change itself
+// already succeeded, so a refresh failure here must never turn that success
+// into an error response — it's logged and the agent simply picks up the
+// change on its next deploy/promote/rotation instead.
 func (s *agentConfigurationService) refreshTouchedMCPEnvironments(ctx context.Context, ouID, projectName, agentName string, touchedEnvNames map[string]struct{}) {
 	for envName := range touchedEnvNames {
 		if err := s.agentIdentityInjection.ReconcileForEnvironment(ctx, ouID, projectName, agentName, envName); err != nil {
@@ -3902,7 +3930,11 @@ func (s *agentConfigurationService) deleteMCPConfig(ctx context.Context, existin
 			touchedEnvNames[envName] = struct{}{}
 		}
 	}
-	go s.refreshTouchedMCPEnvironments(context.WithoutCancel(ctx), ouID, projectName, agentName, touchedEnvNames)
+	go func() {
+		refreshCtx, cancel := detachedRefreshContext(ctx)
+		defer cancel()
+		s.refreshTouchedMCPEnvironments(refreshCtx, ouID, projectName, agentName, touchedEnvNames)
+	}()
 
 	return nil
 }

--- a/agent-manager-service/services/agent_identity_injection_service.go
+++ b/agent-manager-service/services/agent_identity_injection_service.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -193,6 +194,19 @@ type AgentIdentityInjectionService interface {
 	CleanupForEnvironment(ctx context.Context, ouID, agentName, envName string) error
 }
 
+// AgentIdentityShutdownContextSetter is an optional capability an
+// AgentIdentityInjectionService implementation MAY expose — deliberately not
+// part of the interface above, mirroring WorkloadInjectorSetter's pattern
+// (see its doc comment) for the same reason: an alternative implementation
+// with no deferred background work simply doesn't implement this. app.Run
+// type-asserts for it once at startup and provides the app's shutdown
+// context, so a RefreshAfterRotation rollout still waiting or in flight when
+// the app starts shutting down stops rather than firing an outbound update
+// afterward.
+type AgentIdentityShutdownContextSetter interface {
+	SetShutdownContext(ctx context.Context)
+}
+
 type agentIdentityInjectionService struct {
 	repo              repositories.AgentThunderClientRepository
 	agentConfigRepo   repositories.AgentConfigurationRepository
@@ -202,9 +216,19 @@ type agentIdentityInjectionService struct {
 	logger            *slog.Logger
 	// now is injectable for tests; defaults to time.Now.
 	now func() time.Time
-	// sleep is injectable for tests; defaults to time.Sleep. See
+	// after is injectable for tests; defaults to time.After. See
 	// RefreshAfterRotation's doc comment for why it waits at all.
-	sleep func(time.Duration)
+	after func(time.Duration) <-chan time.Time
+	// rolloutTokens/rolloutTokensMu let RefreshAfterRotation tell a stale
+	// deferred roll apart from the latest one, per binding — see
+	// RefreshAfterRotation's doc comment.
+	rolloutTokensMu sync.Mutex
+	rolloutTokens   map[string]uint64
+	// shutdownCtx/shutdownCtxMu are set via SetShutdownContext; default to
+	// context.Background() (never cancelled) so behavior is unchanged
+	// wherever that setter is never called, e.g. every existing test.
+	shutdownCtxMu sync.Mutex
+	shutdownCtx   context.Context
 }
 
 // NewAgentIdentityInjectionService creates a new AgentIdentityInjectionService.
@@ -226,8 +250,23 @@ func NewAgentIdentityInjectionService(
 		refreshInterval:   refreshInterval,
 		logger:            logger,
 		now:               time.Now,
-		sleep:             time.Sleep,
+		after:             time.After,
+		rolloutTokens:     make(map[string]uint64),
+		shutdownCtx:       context.Background(),
 	}
+}
+
+// SetShutdownContext implements AgentIdentityShutdownContextSetter.
+func (s *agentIdentityInjectionService) SetShutdownContext(ctx context.Context) {
+	s.shutdownCtxMu.Lock()
+	s.shutdownCtx = ctx
+	s.shutdownCtxMu.Unlock()
+}
+
+func (s *agentIdentityInjectionService) currentShutdownContext() context.Context {
+	s.shutdownCtxMu.Lock()
+	defer s.shutdownCtxMu.Unlock()
+	return s.shutdownCtx
 }
 
 // defaultSecretSyncWait is the fallback wait when refreshInterval is unset or
@@ -549,7 +588,15 @@ func identityEnvVarsInSync(desired []client.EnvVar, current []models.EnvVars) bo
 // kept the stale, already-invalidated secret for its whole lifetime
 // (secretKeyRef env vars resolve once at container start, never hot-reload).
 // The roll itself runs detached so a manual regenerate call never blocks on
-// the wait; a roll failure is only logged, not returned.
+// the wait; a roll failure is only logged, not returned. The wait, and the
+// roll itself once started, both stop early if the app starts shutting down
+// (see AgentIdentityShutdownContextSetter) instead of firing an outbound
+// update after the app has begun tearing down.
+//
+// Rotations for the same binding in quick succession each get their own
+// deferred roll, but only the latest one is allowed to actually run —
+// otherwise every rotation restarts the pod, even ones already superseded by
+// a later rotation before their own wait finished.
 func (s *agentIdentityInjectionService) RefreshAfterRotation(ctx context.Context, ouID, projectName, agentName, envName string) error {
 	annotations := map[string]string{
 		secretRotatedAtAnnotation: s.now().UTC().Format(secretRotatedAtFormat),
@@ -562,11 +609,46 @@ func (s *agentIdentityInjectionService) RefreshAfterRotation(ctx context.Context
 		return nil
 	}
 
+	key := bindingLockKey(ouID, projectName, agentName, envName)
+	s.rolloutTokensMu.Lock()
+	s.rolloutTokens[key]++
+	myToken := s.rolloutTokens[key]
+	s.rolloutTokensMu.Unlock()
+
 	wait := secretSyncWaitDuration(s.refreshInterval)
+	shutdownCtx := s.currentShutdownContext()
 	go func() {
-		s.sleep(wait)
+		select {
+		case <-s.after(wait):
+		case <-shutdownCtx.Done():
+			return // app is shutting down; abandon this deferred rollout
+		}
+
+		s.rolloutTokensMu.Lock()
+		isLatest := s.rolloutTokens[key] == myToken
+		s.rolloutTokensMu.Unlock()
+		if !isLatest {
+			return // a later rotation for this binding superseded this roll
+		}
+
+		// context.WithoutCancel keeps ctx's values (e.g. the request's
+		// correlation ID, for this call's own logging) without inheriting
+		// its cancellation — the roll must outlive the request that
+		// triggered it. shutdownCtx below is the only thing allowed to cut
+		// it short: a small bridge goroutine cancels refreshCtx if shutdown
+		// fires before the roll (including its retries) finishes.
 		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), releaseBindingUpdateRetries*releaseBindingUpdateRetryDelay+30*time.Second)
 		defer cancel()
+		bridgeDone := make(chan struct{})
+		defer close(bridgeDone)
+		go func() {
+			select {
+			case <-shutdownCtx.Done():
+				cancel()
+			case <-bridgeDone:
+			}
+		}()
+
 		// Re-merging identical env vars is a no-op content-wise, but the call
 		// also stamps restartedAt on the ReleaseBinding — the pod rollout that
 		// makes the workload actually pick up the refreshed Secret.

--- a/agent-manager-service/services/agent_identity_injection_service.go
+++ b/agent-manager-service/services/agent_identity_injection_service.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
@@ -34,23 +33,6 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
-
-// secretRotatedAtAnnotation is stamped (with a fresh timestamp) on the
-// SecretReference's Secret template after a credential rotation. The value
-// change is a real CR spec change, which forces the OpenChoreo controller to
-// re-sync the Kubernetes Secret from OpenBao immediately — without it, the
-// rotated value would only land at the next RefreshInterval tick, and the
-// rollout below would restart the pod onto the STALE secret.
-const secretRotatedAtAnnotation = "amp.wso2.com/secret-rotated-at"
-
-// secretRotatedAtFormat is nanosecond-precision (not time.RFC3339, which
-// only has second resolution) specifically so two rotations issued within
-// the same second still produce distinct annotation values — otherwise the
-// second rotation would write a byte-identical annotation, defeating the
-// whole point of stamping it (nothing for the controller to notice as a
-// spec change) and leaving the pod rolled out onto the FIRST rotation's
-// already-invalidated secret instead of the second, real one.
-const secretRotatedAtFormat = time.RFC3339Nano
 
 // releaseBindingUpdateRetries/releaseBindingUpdateRetryDelay bound the retry
 // of a ReleaseBinding/Workload env-var mutation. UpdateReleaseBindingEnvVars
@@ -133,32 +115,34 @@ func mergeAgentIdentityEnvVarKeys(dst map[string]bool) map[string]bool {
 // AgentIdentityInjectionService delivers an internal agent's AgentID
 // credentials (Thunder OAuth2 client) into its running workload — the
 // "Gateway Binding" phase of the AgentID feature. It never handles the secret
-// VALUE itself: the pod receives the client secret through a SecretKeyRef into
-// the Kubernetes Secret that OpenChoreo materializes from a SecretReference CR
-// pointing at wherever secretmanagersvc actually stored the credential.
+// VALUE itself: the pod receives the client secret through a SecretKeyRef
+// into a Kubernetes Secret that OpenChoreo materializes, in the agent's own
+// workload namespace, from a data-plane SecretReference this service owns
+// (ensureSecretReference) — pointed at the remote KV key
+// agentThunderProvisioningService.storeCredential resolved once, at
+// credential creation/rotation, and persisted in binding.SecretRefPath (see
+// its doc comment). This service never independently resolves or guesses
+// that KV key — it only ever reads binding.SecretRefPath, so it never repeats
+// a live OpenChoreo round trip on its own (much more frequent) injection
+// path.
 //
 // This service is wired unconditionally (see wiring.ProvideAgentIdentityInjectionService),
 // independent of which AgentThunderProvisioningService implementation a
-// deployment plugs in — but it stays consistent with whatever that
-// implementation stored by recomputing the same
-// secretmanagersvc.SecretLocation from binding fields (see
-// agentIdentitySecretLocation) rather than trusting
-// AgentThunderClient.SecretRefPath's content directly, so both services
-// always agree on where a binding's credential lives without either needing
-// to ask the other.
+// deployment plugs in.
 //
 // External agents are never injected — they run outside the platform and
 // generate their own credentials on demand instead. Every method here
 // silently no-ops for them.
 type AgentIdentityInjectionService interface {
 	// EnvVarsForEnvironment returns the identity env vars for one internal
-	// agent in one environment, ensuring the backing SecretReference CR exists
-	// first. Returns (nil, nil) when there is nothing to inject: no binding,
-	// provisioning not completed, an external agent, or a revoked credential.
-	// Callers treat nil as "skip identity injection" — a normal state, not an
-	// error. A non-nil error means the current state could not be determined
-	// (or the SecretReference could not be ensured) and the caller must NOT
-	// proceed with an env-var rewrite that would silently drop the vars.
+	// agent in one environment, ensuring the backing data-plane
+	// SecretReference exists first. Returns (nil, nil) when there is nothing
+	// to inject: no binding, provisioning not completed, an external agent,
+	// or a revoked credential. Callers treat nil as "skip identity
+	// injection" — a normal state, not an error. A non-nil error means the
+	// current state could not be determined (or the SecretReference could
+	// not be ensured) and the caller must NOT proceed with an env-var
+	// rewrite that would silently drop the vars.
 	EnvVarsForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) ([]client.EnvVar, error)
 
 	// InjectForEnvironment pushes the identity env vars into the agent's live
@@ -181,27 +165,32 @@ type AgentIdentityInjectionService interface {
 	// revoked bindings and for not-yet-deployed environments.
 	ReconcileForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) error
 
-	// RefreshAfterRotation re-asserts the SecretReference CR with a fresh
-	// rotated-at annotation (forcing OpenChoreo to re-read the rotated value
-	// from OpenBao) and rolls the pod so it starts with the new secret.
-	// No-op for external agents and unprovisioned bindings.
+	// RefreshAfterRotation re-asserts the data-plane SecretReference with a
+	// fresh rotated-at annotation (forcing OpenChoreo to re-read the rotated
+	// value immediately, rather than waiting for the SecretReference's own
+	// RefreshInterval to elapse) and rolls the pod. Rotation never changes
+	// the SecretReference's remote KV key (storeCredential's resolved
+	// location is stable — a rotation only updates the value in place), so
+	// this never touches binding.SecretRefPath itself. No-op for external
+	// agents and unprovisioned bindings.
 	RefreshAfterRotation(ctx context.Context, ouID, projectName, agentName, envName string) error
 
 	// RemoveForEnvironment removes the identity env vars from the agent's
-	// workload for one environment and deletes the backing SecretReference CR
-	// — used after a revoke, so the pod does not keep serving a credential
-	// that can no longer mint tokens. includeWorkloadLevel additionally
-	// removes the vars from the shared Workload CR; callers set it only when
-	// envName is the pipeline's lowest environment (the deploy flow writes
-	// that environment's vars at Workload level, shared by all environments —
-	// removing them while revoking a DIFFERENT environment's credential would
-	// break the lowest environment's pod).
+	// workload for one environment and deletes the backing data-plane
+	// SecretReference — used after a revoke, so the pod does not keep
+	// serving a credential that can no longer mint tokens.
+	// includeWorkloadLevel additionally removes the vars from the shared
+	// Workload CR; callers set it only when envName is the pipeline's lowest
+	// environment (the deploy flow writes that environment's vars at Workload
+	// level, shared by all environments — removing them while revoking a
+	// DIFFERENT environment's credential would break the lowest environment's
+	// pod).
 	RemoveForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string, includeWorkloadLevel bool) error
 
-	// CleanupForEnvironment deletes the AgentID SecretReference CR for one
-	// (agent, environment) — used on agent deletion, where the workload itself
-	// is being deleted so env var removal is pointless but the CR would leak.
-	// Best-effort: not-found is success.
+	// CleanupForEnvironment deletes the AgentID data-plane SecretReference
+	// for one (agent, environment) — used on agent deletion, where the
+	// workload itself is being deleted so env var removal is pointless but
+	// the SecretReference would leak. Best-effort: not-found is success.
 	CleanupForEnvironment(ctx context.Context, ouID, agentName, envName string) error
 }
 
@@ -217,8 +206,8 @@ type agentIdentityInjectionService struct {
 }
 
 // NewAgentIdentityInjectionService creates a new AgentIdentityInjectionService.
-// refreshInterval is the SecretReference refresh cadence (same value
-// secretmanagersvc uses, e.g. "1h").
+// refreshInterval is the data-plane SecretReference's refresh cadence (same
+// value secretmanagersvc uses elsewhere, e.g. "1h").
 func NewAgentIdentityInjectionService(
 	repo repositories.AgentThunderClientRepository,
 	agentConfigRepo repositories.AgentConfigurationRepository,
@@ -240,13 +229,21 @@ func NewAgentIdentityInjectionService(
 
 // resolveAgentIdentityScopes returns the full set of OAuth2 scopes the agent
 // should request when minting a token: the union of every scope defined on
-// any MCP proxy this agent is bound to in this environment (see
+// EVERY MCP proxy this agent is bound to in this environment (see
 // models.MCPProxyScope — a proxy-level action string, not tied to a specific
 // environment) — sourced entirely from AMS's own DB, no Thunder role/group
 // lookups. Requesting a scope the AgentID isn't actually authorized for is
 // safe: Thunder filters requested scopes down to what the agent's role
 // assignments actually grant at token-mint time, so this is a "what might I
 // need" list, not the enforcement point.
+//
+// Each MCP proxy an agent is configured with is stored as its OWN
+// AgentConfiguration row (see createMCPConfig) — an agent bound to two
+// proxies has two rows, both TypeID=AgentConfigTypeIDMCP. This reads ALL of
+// them via ListMCPConfigsByAgent and unions their EnvMCPMappings; it must
+// NOT use GetByAgentID, which returns a single arbitrary row and would
+// silently drop every proxy but one whenever an agent has more than one MCP
+// configuration.
 //
 // Returns an error on a genuine lookup failure (DB/OpenChoreo) instead of
 // silently falling back to no scopes: every caller of this service already
@@ -258,19 +255,14 @@ func NewAgentIdentityInjectionService(
 // a real scope change, causing one rollout to empty scopes and a second
 // rollout back once the blip cleared. Since a wrong-but-non-empty scope
 // request is no less safe than an empty one (Thunder still filters it at
-// mint time), swallowing the error here bought no real safety. A
-// gorm.ErrRecordNotFound, in contrast, is a legitimate "nothing configured
-// here" business state, not a failure — those still resolve to (nil, nil).
+// mint time), swallowing the error here bought no real safety.
 func (s *agentIdentityInjectionService) resolveAgentIdentityScopes(ctx context.Context, binding *models.AgentThunderClient) ([]string, error) {
-	config, err := s.agentConfigRepo.GetByAgentID(ctx, binding.AgentName, binding.OUID)
+	configs, err := s.agentConfigRepo.ListMCPConfigsByAgent(ctx, binding.OUID, binding.ProjectName, binding.AgentName)
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, nil // agent has no configuration yet — nothing to request
-		}
-		return nil, fmt.Errorf("resolve agent identity scopes: load agent configuration: %w", err)
+		return nil, fmt.Errorf("resolve agent identity scopes: list mcp configurations: %w", err)
 	}
-	if len(config.EnvMCPMappings) == 0 {
-		return nil, nil // no MCP bindings at all — skip resolving the environment UUID entirely
+	if len(configs) == 0 {
+		return nil, nil // no MCP configurations at all — skip resolving the environment UUID entirely
 	}
 
 	env, err := s.ocClient.GetEnvironment(ctx, binding.OUID, binding.EnvironmentName)
@@ -279,15 +271,18 @@ func (s *agentIdentityInjectionService) resolveAgentIdentityScopes(ctx context.C
 	}
 
 	// Proxy handles are needed to build each scope row's token string (see
-	// models.MCPProxyScope.ScopeString) — read from the mapping's own
-	// preloaded proxy (AgentConfigurationRepository.GetByAgentID preloads
-	// EnvMCPMappings.MCPProxy.Artifact) rather than a second lookup.
+	// models.MCPProxyScope.ScopeString) — read from each mapping's own
+	// preloaded proxy (ListMCPConfigsByAgent preloads EnvMCPMappings.MCPProxy.Artifact)
+	// rather than a second lookup. Aggregated across every MCP config row,
+	// not just the first one.
 	handleByProxy := map[uuid.UUID]string{}
-	for _, mapping := range config.EnvMCPMappings {
-		if mapping.EnvironmentUUID.String() != env.UUID || mapping.MCPProxy == nil {
-			continue
+	for _, config := range configs {
+		for _, mapping := range config.EnvMCPMappings {
+			if mapping.EnvironmentUUID.String() != env.UUID || mapping.MCPProxy == nil {
+				continue
+			}
+			handleByProxy[mapping.MCPProxyUUID] = proxyHandleOf(mapping.MCPProxy)
 		}
-		handleByProxy[mapping.MCPProxyUUID] = proxyHandleOf(mapping.MCPProxy)
 	}
 	if len(handleByProxy) == 0 {
 		return nil, nil
@@ -343,107 +338,64 @@ func (s *agentIdentityInjectionService) injectableBinding(ctx context.Context, o
 	return binding, nil
 }
 
-// ensureSecretReference creates or updates the SecretReference CR that lets
-// OpenChoreo materialize the stored credential as a Kubernetes Secret.
-// templateAnnotations may be nil; see secretRotatedAtAnnotation for when it
-// is not.
+// secretRotatedAtAnnotation/secretRotatedAtFormat stamp a fresh value on the
+// data-plane SecretReference's generated Secret template on every rotation —
+// changing an annotation is a real spec change, so it forces OpenChoreo to
+// re-sync the Secret from the KV store immediately instead of waiting for
+// the next RefreshInterval tick.
+const (
+	secretRotatedAtAnnotation = "amp.wso2.com/secret-rotated-at"
+	secretRotatedAtFormat     = time.RFC3339Nano
+)
+
+// ensureSecretReference creates or updates the data-plane SecretReference CR
+// that lets OpenChoreo materialize the stored credential as a Kubernetes
+// Secret in the agent's own workload namespace. templateAnnotations may be
+// nil; see secretRotatedAtAnnotation for when it is not.
 //
-// This service never has the secret VALUE (see the interface doc comment),
-// only a reference to it — so it can't go through
-// secretmanagersvc.SecretManagementClient.CreateSecret (which writes data);
-// it must still build the SecretReference CR fields directly. KVPath and the
-// CR name are computed from agentIdentitySecretLocation — the SAME
-// deterministic function agentThunderProvisioningService used to store the
-// credential — rather than trusting binding.SecretRefPath's content or using
-// a separately-maintained naming scheme, so a create-or-update here always
-// targets the exact CR the provisioning side already manages.
+// KVPath comes directly from binding.SecretRefPath — the remote key
+// agentThunderProvisioningService.storeCredential resolved once, at
+// credential creation/rotation, by reading the SecretReference CreateSecret
+// itself manages back from OpenChoreo (see storeCredential's doc comment).
+// This method never independently computes or re-resolves that value; it
+// only ever asserts the CR's spec from whatever's already in the DB, so it
+// carries no live-read dependency of its own — safe to call on every
+// deploy/promote/config-update, and from the reconciler on every tick.
 func (s *agentIdentityInjectionService) ensureSecretReference(ctx context.Context, binding *models.AgentThunderClient, templateAnnotations map[string]string) (string, error) {
 	location := agentIdentitySecretLocation(binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName)
-	kvPath, err := location.KVPath()
-	if err != nil {
-		return "", fmt.Errorf("derive kv path for agent identity SecretReference: %w", err)
-	}
 	refName := location.SecretRefName()
 	req := client.CreateSecretReferenceRequest{
 		Namespace:           binding.OUID,
 		Name:                refName,
 		ProjectName:         binding.ProjectName,
 		ComponentName:       binding.AgentName,
-		KVPath:              kvPath,
+		KVPath:              binding.SecretRefPath,
 		SecretKeys:          []string{thundersvc.AgentSecretKeyClientSecret},
 		RefreshInterval:     s.refreshInterval,
 		TemplateAnnotations: templateAnnotations,
 	}
-
-	existing, getErr := s.ocClient.GetSecretReference(ctx, binding.OUID, refName)
-	if getErr != nil {
-		if !errors.Is(getErr, utils.ErrNotFound) {
-			return "", fmt.Errorf("check agent identity SecretReference %q: %w", refName, getErr)
+	if _, err := s.ocClient.CreateSecretReference(ctx, binding.OUID, req); err != nil {
+		// A concurrent caller (another request for this same binding, or the
+		// reconciler) may have already created it — fall back to asserting
+		// the same spec via update rather than treating this as fatal.
+		if !errors.Is(err, utils.ErrConflict) {
+			return "", fmt.Errorf("create agent identity SecretReference %q: %w", refName, err)
 		}
-		if _, createErr := s.ocClient.CreateSecretReference(ctx, binding.OUID, req); createErr != nil {
-			// A concurrent caller may have created it between Get and Create.
-			if !errors.Is(createErr, utils.ErrConflict) {
-				return "", fmt.Errorf("create agent identity SecretReference %q: %w", refName, createErr)
-			}
-			if _, updateErr := s.ocClient.UpdateSecretReference(ctx, binding.OUID, refName, req); updateErr != nil {
-				return "", fmt.Errorf("update agent identity SecretReference %q after create conflict: %w", refName, updateErr)
-			}
+		if _, err := s.ocClient.UpdateSecretReference(ctx, binding.OUID, refName, req); err != nil {
+			return "", fmt.Errorf("update agent identity SecretReference %q after create conflict: %w", refName, err)
 		}
-		return refName, nil
-	}
-
-	// Skip the update when there's nothing new to assert. templateAnnotations is
-	// only ever non-empty on the rotation path (RefreshAfterRotation), where the
-	// value is a fresh timestamp every single call by design — never "unchanged",
-	// so that path always writes. Everywhere else (every plain
-	// EnvVarsForEnvironment call — one per deploy/promote/config-update, and one
-	// per reconciler tick per recently-completed binding), KVPath/SecretKeys are
-	// pure functions of the binding's own identity and never legitimately drift
-	// for an existing CR, so if the live CR's data sources already point at them,
-	// there's nothing to change.
-	//
-	// This also protects a previously-stamped rotation annotation: skipping here
-	// entirely (rather than sending an update with nil TemplateAnnotations) means
-	// this call never touches the CR at all, so it can't clobber whatever
-	// annotation a prior rotation set — this service has no way to read the CR's
-	// current annotations back to preserve them explicitly, since
-	// SecretReferenceInfo (GetSecretReference's return type) doesn't surface
-	// them, only Data (KVPath/SecretKeys). Note this also means a change to the
-	// platform-wide RefreshInterval config isn't pushed to an already-existing CR
-	// until something else (a rotation, or a delete+recreate) touches it — an
-	// accepted, narrow tradeoff given how much more often this path runs than
-	// that config would ever change.
-	if len(templateAnnotations) == 0 && secretReferenceAlreadyPointsAt(existing, kvPath, req.SecretKeys) {
-		return refName, nil
-	}
-
-	if _, updateErr := s.ocClient.UpdateSecretReference(ctx, binding.OUID, refName, req); updateErr != nil {
-		return "", fmt.Errorf("update agent identity SecretReference %q: %w", refName, updateErr)
 	}
 	return refName, nil
 }
 
-// secretReferenceAlreadyPointsAt reports whether existing's data sources
-// already carry exactly the given KV path for exactly the given secret keys —
-// the only fields SecretReferenceInfo exposes that can be compared against a
-// desired client.CreateSecretReferenceRequest.
-func secretReferenceAlreadyPointsAt(existing *client.SecretReferenceInfo, kvPath string, secretKeys []string) bool {
-	if existing == nil || len(existing.Data) != len(secretKeys) {
-		return false
+// deleteSecretReference deletes the data-plane SecretReference for one
+// binding. Best-effort by convention of every caller: not-found is success.
+func (s *agentIdentityInjectionService) deleteSecretReference(ctx context.Context, ouID, projectName, agentName, envName string) error {
+	refName := agentIdentitySecretLocation(ouID, projectName, agentName, envName).SecretRefName()
+	if err := s.ocClient.DeleteSecretReference(ctx, ouID, refName); err != nil && !errors.Is(err, utils.ErrNotFound) {
+		return fmt.Errorf("delete agent identity SecretReference %q: %w", refName, err)
 	}
-	want := make(map[string]struct{}, len(secretKeys))
-	for _, k := range secretKeys {
-		want[k] = struct{}{}
-	}
-	for _, ds := range existing.Data {
-		if ds.RemoteRef.Key != kvPath {
-			return false
-		}
-		if _, ok := want[ds.SecretKey]; !ok {
-			return false
-		}
-	}
-	return true
+	return nil
 }
 
 // buildEnvVars assembles the four identity env vars for one binding. The
@@ -629,27 +581,17 @@ func (s *agentIdentityInjectionService) RemoveForEnvironment(ctx context.Context
 		}
 	}
 
-	if err := s.deleteSecretReference(ctx, ouID, agentName, envName); err != nil {
-		return err
+	if err := s.deleteSecretReference(ctx, ouID, projectName, agentName, envName); err != nil {
+		return fmt.Errorf("delete agent identity SecretReference during removal: %w", err)
 	}
+
 	s.logger.Info("Removed agent identity env vars from workload", "agentName", agentName, "envName", envName, "includeWorkloadLevel", includeWorkloadLevel)
 	return nil
 }
 
 func (s *agentIdentityInjectionService) CleanupForEnvironment(ctx context.Context, ouID, agentName, envName string) error {
-	return s.deleteSecretReference(ctx, ouID, agentName, envName)
-}
-
-func (s *agentIdentityInjectionService) deleteSecretReference(ctx context.Context, ouID, agentName, envName string) error {
-	// SecretRefName() doesn't use ProjectName, so an empty one here is safe —
-	// this deletes only the CR (a K8s object, addressed by name), never the
-	// underlying stored secret (which agentThunderProvisioningService owns).
-	refName := agentIdentitySecretLocation(ouID, "", agentName, envName).SecretRefName()
-	if err := s.ocClient.DeleteSecretReference(ctx, ouID, refName); err != nil {
-		if errors.Is(err, utils.ErrNotFound) {
-			return nil
-		}
-		return fmt.Errorf("delete agent identity SecretReference %q: %w", refName, err)
-	}
-	return nil
+	// projectName is not part of SecretRefName's computation (see
+	// SecretLocation.SecretRefName) — this interface method doesn't carry
+	// one, matching agentThunderProvisioningService's call sites.
+	return s.deleteSecretReference(ctx, ouID, "", agentName, envName)
 }

--- a/agent-manager-service/services/agent_identity_injection_service.go
+++ b/agent-manager-service/services/agent_identity_injection_service.go
@@ -166,13 +166,12 @@ type AgentIdentityInjectionService interface {
 	ReconcileForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) error
 
 	// RefreshAfterRotation re-asserts the data-plane SecretReference with a
-	// fresh rotated-at annotation (forcing OpenChoreo to re-read the rotated
-	// value immediately, rather than waiting for the SecretReference's own
-	// RefreshInterval to elapse) and rolls the pod. Rotation never changes
-	// the SecretReference's remote KV key (storeCredential's resolved
-	// location is stable — a rotation only updates the value in place), so
-	// this never touches binding.SecretRefPath itself. No-op for external
-	// agents and unprovisioned bindings.
+	// fresh rotated-at annotation and rolls the pod once the secret-store sync
+	// has had time to catch up. Rotation never changes the SecretReference's
+	// remote KV key (storeCredential's resolved location is stable — a
+	// rotation only updates the value in place), so this never touches
+	// binding.SecretRefPath itself. No-op for external agents and
+	// unprovisioned bindings.
 	RefreshAfterRotation(ctx context.Context, ouID, projectName, agentName, envName string) error
 
 	// RemoveForEnvironment removes the identity env vars from the agent's
@@ -203,6 +202,9 @@ type agentIdentityInjectionService struct {
 	logger            *slog.Logger
 	// now is injectable for tests; defaults to time.Now.
 	now func() time.Time
+	// sleep is injectable for tests; defaults to time.Sleep. See
+	// RefreshAfterRotation's doc comment for why it waits at all.
+	sleep func(time.Duration)
 }
 
 // NewAgentIdentityInjectionService creates a new AgentIdentityInjectionService.
@@ -224,7 +226,22 @@ func NewAgentIdentityInjectionService(
 		refreshInterval:   refreshInterval,
 		logger:            logger,
 		now:               time.Now,
+		sleep:             time.Sleep,
 	}
+}
+
+// defaultSecretSyncWait is the fallback wait when refreshInterval is unset or
+// invalid — defensive only, should not normally trigger.
+const defaultSecretSyncWait = 30 * time.Second
+
+// secretSyncWaitDuration parses the SecretReference refresh cadence
+// (refreshInterval) into a wait duration for RefreshAfterRotation.
+func secretSyncWaitDuration(refreshInterval string) time.Duration {
+	d, err := time.ParseDuration(refreshInterval)
+	if err != nil || d <= 0 {
+		return defaultSecretSyncWait
+	}
+	return d
 }
 
 // resolveAgentIdentityScopes returns the full set of OAuth2 scopes the agent
@@ -339,10 +356,9 @@ func (s *agentIdentityInjectionService) injectableBinding(ctx context.Context, o
 }
 
 // secretRotatedAtAnnotation/secretRotatedAtFormat stamp a fresh value on the
-// data-plane SecretReference's generated Secret template on every rotation —
-// changing an annotation is a real spec change, so it forces OpenChoreo to
-// re-sync the Secret from the KV store immediately instead of waiting for
-// the next RefreshInterval tick.
+// SecretReference's Secret template on every rotation, marking its spec as
+// changed. This alone does not force the secret-store sync ahead of its own
+// refresh cadence — see RefreshAfterRotation for how the wait is handled.
 const (
 	secretRotatedAtAnnotation = "amp.wso2.com/secret-rotated-at"
 	secretRotatedAtFormat     = time.RFC3339Nano
@@ -522,6 +538,18 @@ func identityEnvVarsInSync(desired []client.EnvVar, current []models.EnvVars) bo
 	return true
 }
 
+// RefreshAfterRotation re-asserts a rotated internal agent's credential and
+// rolls its pod so it picks up the new value.
+//
+// The SecretReference update runs synchronously and its error is returned.
+// The pod roll is deferred: it waits out refreshInterval first, because the
+// secret-store sync only re-fetches a rotated value on its own cadence, not
+// immediately when the SecretReference's spec changes. Rolling immediately
+// used to lose that race — the new pod started before the sync caught up and
+// kept the stale, already-invalidated secret for its whole lifetime
+// (secretKeyRef env vars resolve once at container start, never hot-reload).
+// The roll itself runs detached so a manual regenerate call never blocks on
+// the wait; a roll failure is only logged, not returned.
 func (s *agentIdentityInjectionService) RefreshAfterRotation(ctx context.Context, ouID, projectName, agentName, envName string) error {
 	annotations := map[string]string{
 		secretRotatedAtAnnotation: s.now().UTC().Format(secretRotatedAtFormat),
@@ -533,15 +561,23 @@ func (s *agentIdentityInjectionService) RefreshAfterRotation(ctx context.Context
 	if len(envVars) == 0 {
 		return nil
 	}
-	// Re-merging identical env vars is a no-op content-wise, but the call also
-	// stamps restartedAt on the ReleaseBinding — the pod rollout that makes the
-	// workload actually pick up the refreshed Secret.
-	if err := withReleaseBindingRetry(ctx, func() error {
-		return s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, envVars)
-	}); err != nil {
-		return fmt.Errorf("roll out pod after agent identity secret rotation: %w", err)
-	}
-	s.logger.Info("Refreshed agent identity credentials in workload after rotation", "agentName", agentName, "envName", envName)
+
+	wait := secretSyncWaitDuration(s.refreshInterval)
+	go func() {
+		s.sleep(wait)
+		refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), releaseBindingUpdateRetries*releaseBindingUpdateRetryDelay+30*time.Second)
+		defer cancel()
+		// Re-merging identical env vars is a no-op content-wise, but the call
+		// also stamps restartedAt on the ReleaseBinding — the pod rollout that
+		// makes the workload actually pick up the refreshed Secret.
+		if err := withReleaseBindingRetry(refreshCtx, func() error {
+			return s.ocClient.UpdateReleaseBindingEnvVars(refreshCtx, ouID, projectName, agentName, envName, envVars)
+		}); err != nil {
+			s.logger.Warn("Failed to roll out pod after agent identity secret rotation", "agentName", agentName, "envName", envName, "error", err)
+			return
+		}
+		s.logger.Info("Refreshed agent identity credentials in workload after rotation", "agentName", agentName, "envName", envName)
+	}()
 	return nil
 }
 

--- a/agent-manager-service/services/agent_identity_injection_service_unit_test.go
+++ b/agent-manager-service/services/agent_identity_injection_service_unit_test.go
@@ -596,26 +596,23 @@ func TestAgentIdentityInjection_ReconcileForEnvironment_ConfigReadError_Propagat
 }
 
 // TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
-// guards rotation's contract: storeCredential's resolved location is
-// unchanged by a rotation (only the value at that location changes), but the
-// data-plane SecretReference must still be re-asserted with a fresh
-// rotated-at annotation so OpenChoreo re-syncs the Secret immediately rather
-// than waiting for its own RefreshInterval — and the pod must roll to pick it
-// up.
+// guards rotation's contract: the SecretReference gets a fresh rotated-at
+// annotation, and the pod rolls only after waiting out the refresh cadence
+// (see RefreshAfterRotation for why the roll is deferred and detached).
 func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 
 	fixedNow := time.Date(2026, 7, 8, 10, 30, 0, 0, time.UTC)
 	var createdReq client.CreateSecretReferenceRequest
-	rolled := false
+	rolled := make(chan struct{})
 	oc := injectableOCClient()
 	oc.CreateSecretReferenceFunc = func(_ context.Context, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
 		createdReq = req
 		return &client.SecretReferenceInfo{Name: req.Name}, nil
 	}
 	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
-		rolled = true
 		assert.Len(t, envVars, 4)
+		close(rolled)
 		return nil
 	}
 
@@ -623,13 +620,21 @@ func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
 	impl, ok := svc.(*agentIdentityInjectionService)
 	require.True(t, ok)
 	impl.now = func() time.Time { return fixedNow }
+	var slept time.Duration
+	impl.sleep = func(d time.Duration) { slept = d }
 
 	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
 	require.NotNil(t, createdReq.TemplateAnnotations)
 	assert.Equal(t, fixedNow.Format(secretRotatedAtFormat), createdReq.TemplateAnnotations[secretRotatedAtAnnotation],
-		"rotation must stamp a fresh annotation so the controller re-syncs the Secret immediately")
+		"rotation must stamp a fresh annotation marking the SecretReference spec as changed")
 	assert.Equal(t, testIdentityKVPath, createdReq.KVPath, "rotation must not change the resolved KV path")
-	assert.True(t, rolled, "rotation must roll the pod so it starts with the refreshed secret value")
+
+	select {
+	case <-rolled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("rotation must roll the pod (after the wait) so it starts with the refreshed secret value")
+	}
+	assert.Equal(t, secretSyncWaitDuration("1h"), slept, "the roll must wait out the configured refresh cadence before rolling")
 }
 
 func TestAgentIdentityInjection_RefreshAfterRotation_NoBinding_NoOp(t *testing.T) {

--- a/agent-manager-service/services/agent_identity_injection_service_unit_test.go
+++ b/agent-manager-service/services/agent_identity_injection_service_unit_test.go
@@ -19,6 +19,8 @@ package services
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -621,7 +623,12 @@ func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
 	require.True(t, ok)
 	impl.now = func() time.Time { return fixedNow }
 	var slept time.Duration
-	impl.sleep = func(d time.Duration) { slept = d }
+	impl.after = func(d time.Duration) <-chan time.Time {
+		slept = d
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
 
 	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
 	require.NotNil(t, createdReq.TemplateAnnotations)
@@ -635,6 +642,156 @@ func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
 		t.Fatal("rotation must roll the pod (after the wait) so it starts with the refreshed secret value")
 	}
 	assert.Equal(t, secretSyncWaitDuration("1h"), slept, "the roll must wait out the configured refresh cadence before rolling")
+}
+
+// TestAgentIdentityInjection_RefreshAfterRotation_CoalescesRapidRotations
+// guards against a second regenerate for the same binding, fired before the
+// first one's deferred roll runs, causing two pod rollouts instead of one:
+// only the latest rotation's roll must actually call UpdateReleaseBindingEnvVars.
+func TestAgentIdentityInjection_RefreshAfterRotation_CoalescesRapidRotations(t *testing.T) {
+	repo := identityRepoReturning(completedInternalBinding(), nil)
+	oc := injectableOCClient()
+
+	var rollCount int32
+	rolled := make(chan struct{}, 2)
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		atomic.AddInt32(&rollCount, 1)
+		rolled <- struct{}{}
+		return nil
+	}
+
+	svc := newTestIdentityInjectionService(repo, oc)
+	impl, ok := svc.(*agentIdentityInjectionService)
+	require.True(t, ok)
+
+	firstSleepStarted := make(chan struct{})
+	secondRotationDone := make(chan struct{})
+	var sleepMu sync.Mutex
+	sleepCalls := 0
+	impl.after = func(time.Duration) <-chan time.Time {
+		sleepMu.Lock()
+		sleepCalls++
+		isFirstCall := sleepCalls == 1
+		sleepMu.Unlock()
+		ch := make(chan time.Time, 1)
+		if isFirstCall {
+			close(firstSleepStarted)
+			go func() {
+				<-secondRotationDone // hold until the second rotation has superseded this one
+				ch <- time.Now()
+			}()
+		} else {
+			ch <- time.Now()
+		}
+		return ch
+	}
+
+	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
+	<-firstSleepStarted
+
+	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
+	close(secondRotationDone)
+
+	select {
+	case <-rolled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the latest rotation must still roll the pod")
+	}
+
+	// The superseded first rotation's goroutine has by now also run past its
+	// (already unblocked) sleep and taken its token check — give it a moment
+	// rather than asserting immediately after the one roll we expect.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&rollCount),
+		"a rotation superseded by a later one for the same binding must not also roll the pod")
+}
+
+// TestAgentIdentityInjection_RefreshAfterRotation_AbortsOnShutdown guards the
+// wait itself: once the app's shutdown context is done, a deferred rollout
+// must not roll the pod, even though its own wait timer never separately fires.
+func TestAgentIdentityInjection_RefreshAfterRotation_AbortsOnShutdown(t *testing.T) {
+	repo := identityRepoReturning(completedInternalBinding(), nil)
+	oc := injectableOCClient()
+
+	rolled := make(chan struct{})
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		close(rolled)
+		return nil
+	}
+
+	svc := newTestIdentityInjectionService(repo, oc)
+	impl, ok := svc.(*agentIdentityInjectionService)
+	require.True(t, ok)
+
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	impl.SetShutdownContext(shutdownCtx)
+	shutdownCancel() // app is already shutting down before the rotation starts
+
+	afterCalled := make(chan struct{})
+	impl.after = func(time.Duration) <-chan time.Time {
+		close(afterCalled)
+		return make(chan time.Time) // never fires; only shutdownCtx.Done() can win the select
+	}
+
+	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
+
+	select {
+	case <-afterCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the deferred goroutine must still start its wait")
+	}
+
+	select {
+	case <-rolled:
+		t.Fatal("a rotation must not roll out the pod once the app has started shutting down")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestAgentIdentityInjection_RefreshAfterRotation_CancelsInFlightRollOnShutdown
+// guards the roll itself, not just the wait before it: shutdown must cancel
+// an already-in-flight UpdateReleaseBindingEnvVars call rather than letting
+// it run to completion.
+func TestAgentIdentityInjection_RefreshAfterRotation_CancelsInFlightRollOnShutdown(t *testing.T) {
+	repo := identityRepoReturning(completedInternalBinding(), nil)
+	oc := injectableOCClient()
+
+	callStarted := make(chan struct{})
+	cancelled := make(chan struct{})
+	oc.UpdateReleaseBindingEnvVarsFunc = func(ctx context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		close(callStarted)
+		<-ctx.Done() // blocks until the shutdown bridge cancels this call's context
+		close(cancelled)
+		return ctx.Err()
+	}
+
+	svc := newTestIdentityInjectionService(repo, oc)
+	impl, ok := svc.(*agentIdentityInjectionService)
+	require.True(t, ok)
+
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
+	impl.SetShutdownContext(shutdownCtx)
+	impl.after = func(time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now() // wait completes immediately, moving straight into the roll
+		return ch
+	}
+
+	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
+
+	select {
+	case <-callStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the roll must start calling UpdateReleaseBindingEnvVars")
+	}
+
+	shutdownCancel() // app starts shutting down while the roll call is in flight
+
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown must cancel an in-flight roll's context, not let it run to completion")
+	}
 }
 
 func TestAgentIdentityInjection_RefreshAfterRotation_NoBinding_NoOp(t *testing.T) {

--- a/agent-manager-service/services/agent_identity_injection_service_unit_test.go
+++ b/agent-manager-service/services/agent_identity_injection_service_unit_test.go
@@ -55,6 +55,12 @@ func testIdentitySecretRefName() string {
 	return agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv).SecretRefName()
 }
 
+// testIdentityKVPath is a remote KV path distinct from
+// testIdentitySecretRefName(), so tests asserting createdReq.KVPath actually
+// exercise "value came from binding.SecretRefPath" rather than passing
+// vacuously because both happened to be the same string.
+const testIdentityKVPath = "openbao/agent-identities/test-agent/dev"
+
 func completedInternalBinding() *models.AgentThunderClient {
 	return &models.AgentThunderClient{
 		OUID:             testIdentityOrg,
@@ -65,7 +71,7 @@ func completedInternalBinding() *models.AgentThunderClient {
 		Status:           models.AgentThunderStatusCompleted,
 		ThunderAgentID:   "thunder-agent-1",
 		ThunderClientID:  "client-abc",
-		SecretRefPath:    testIdentitySecretRefName(),
+		SecretRefPath:    testIdentityKVPath,
 	}
 }
 
@@ -85,7 +91,7 @@ func identityRepoReturning(binding *models.AgentThunderClient, err error) *repom
 func noMCPConfigRepo() *repomocks.AgentConfigurationRepositoryMock {
 	return &repomocks.AgentConfigurationRepositoryMock{
 		ListMCPConfigsByAgentFunc: func(_ context.Context, _, _, _ string) ([]models.AgentConfiguration, error) {
-			return nil, nil
+			return []models.AgentConfiguration{}, nil
 		},
 	}
 }
@@ -140,7 +146,7 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecr
 	require.Len(t, envVars, 4)
 
 	expectedRefName := testIdentitySecretRefName()
-	assert.Equal(t, testIdentitySecretRefName(), createdReq.KVPath,
+	assert.Equal(t, testIdentityKVPath, createdReq.KVPath,
 		"KVPath must come from binding.SecretRefPath, never recomputed independently")
 	assert.Equal(t, []string{thundersvc.AgentSecretKeyClientSecret}, createdReq.SecretKeys)
 	assert.Empty(t, createdReq.TemplateAnnotations, "a plain read must not stamp a rotated-at annotation")
@@ -622,7 +628,7 @@ func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
 	require.NotNil(t, createdReq.TemplateAnnotations)
 	assert.Equal(t, fixedNow.Format(secretRotatedAtFormat), createdReq.TemplateAnnotations[secretRotatedAtAnnotation],
 		"rotation must stamp a fresh annotation so the controller re-syncs the Secret immediately")
-	assert.Equal(t, testIdentitySecretRefName(), createdReq.KVPath, "rotation must not change the resolved KV path")
+	assert.Equal(t, testIdentityKVPath, createdReq.KVPath, "rotation must not change the resolved KV path")
 	assert.True(t, rolled, "rotation must roll the pod so it starts with the refreshed secret value")
 }
 

--- a/agent-manager-service/services/agent_identity_injection_service_unit_test.go
+++ b/agent-manager-service/services/agent_identity_injection_service_unit_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
@@ -47,21 +46,11 @@ const (
 	testIdentityEnv     = "staging"
 )
 
-// testIdentityKVPath is the deterministic KV path agentIdentitySecretLocation
-// computes for the fixed (org, project, agent, env) tuple above — computed
-// via the real function, not hardcoded, so this fixture can't silently drift
-// out of sync with what ensureSecretReference actually derives.
-func testIdentityKVPath() string {
-	kvPath, err := agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv).KVPath()
-	if err != nil {
-		panic(err) // fixed, non-empty test constants — must never fail
-	}
-	return kvPath
-}
-
-// testIdentitySecretRefName is the deterministic SecretReference CR name
+// testIdentitySecretRefName is the deterministic SecretReference name
 // agentIdentitySecretLocation computes for the fixed (org, project, agent,
-// env) tuple above.
+// env) tuple above — the same value storeCredential now persists into
+// SecretRefPath (CreateSecret's own returned name, not a locally-computed
+// path; see storeCredential's doc comment).
 func testIdentitySecretRefName() string {
 	return agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv).SecretRefName()
 }
@@ -76,7 +65,7 @@ func completedInternalBinding() *models.AgentThunderClient {
 		Status:           models.AgentThunderStatusCompleted,
 		ThunderAgentID:   "thunder-agent-1",
 		ThunderClientID:  "client-abc",
-		SecretRefPath:    testIdentityKVPath(),
+		SecretRefPath:    testIdentitySecretRefName(),
 	}
 }
 
@@ -88,15 +77,15 @@ func identityRepoReturning(binding *models.AgentThunderClient, err error) *repom
 	}
 }
 
-// noMCPConfigRepo returns an AgentConfigurationRepository mock reporting "no
-// configuration found" for every agent — the default for tests that aren't
-// exercising scope resolution, so they don't also need to stub
+// noMCPConfigRepo returns an AgentConfigurationRepository mock reporting no
+// MCP configurations at all — the default for tests that aren't exercising
+// scope resolution, so they don't also need to stub
 // OpenChoreoClient.GetEnvironmentFunc (resolveAgentIdentityScopes short-
 // circuits before ever calling it when there's no agent configuration).
 func noMCPConfigRepo() *repomocks.AgentConfigurationRepositoryMock {
 	return &repomocks.AgentConfigurationRepositoryMock{
-		GetByAgentIDFunc: func(_ context.Context, _, _ string) (*models.AgentConfiguration, error) {
-			return nil, gorm.ErrRecordNotFound
+		ListMCPConfigsByAgentFunc: func(_ context.Context, _, _, _ string) ([]models.AgentConfiguration, error) {
+			return nil, nil
 		},
 	}
 }
@@ -116,19 +105,33 @@ func newTestIdentityInjectionService(
 	return NewAgentIdentityInjectionService(repo, noMCPConfigRepo(), noMCPProxyScopeRepo(), oc, "1h", discardLogger())
 }
 
-func TestAgentIdentityInjection_EnvVarsForEnvironment_CreatesSecretReferenceAndBuildsVars(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-
-	var createdReq client.CreateSecretReferenceRequest
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, _ string) (*client.SecretReferenceInfo, error) {
-			return nil, utils.ErrNotFound
-		},
-		CreateSecretReferenceFunc: func(_ context.Context, namespace string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			assert.Equal(t, testIdentityOrg, namespace)
-			createdReq = req
+// injectableOCClient returns an OpenChoreoClientMock with CreateSecretReferenceFunc
+// stubbed to succeed — the data-plane SecretReference write every injectable
+// binding now makes via ensureSecretReference on every EnvVarsForEnvironment
+// call. Tests that also exercise other OpenChoreo calls set their own funcs
+// on the returned mock before use.
+func injectableOCClient() *clientmocks.OpenChoreoClientMock {
+	return &clientmocks.OpenChoreoClientMock{
+		CreateSecretReferenceFunc: func(_ context.Context, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
 			return &client.SecretReferenceInfo{Name: req.Name}, nil
 		},
+	}
+}
+
+// TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecretReference
+// guards the core fix: the SecretKeyRef's Name comes from ensureSecretReference
+// asserting the data-plane SecretReference from binding.SecretRefPath — the
+// remote KV key agentThunderProvisioningService.storeCredential resolved
+// once, at creation/rotation (see its doc comment) — never independently
+// recomputed or guessed here.
+func TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecretReference(t *testing.T) {
+	repo := identityRepoReturning(completedInternalBinding(), nil)
+	oc := injectableOCClient()
+	var createdReq client.CreateSecretReferenceRequest
+	oc.CreateSecretReferenceFunc = func(_ context.Context, ouID string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
+		assert.Equal(t, testIdentityOrg, ouID)
+		createdReq = req
+		return &client.SecretReferenceInfo{Name: req.Name}, nil
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -137,13 +140,10 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_CreatesSecretReferenceAndB
 	require.Len(t, envVars, 4)
 
 	expectedRefName := testIdentitySecretRefName()
-	assert.Equal(t, expectedRefName, createdReq.Name)
-	assert.Equal(t, testIdentityKVPath(), createdReq.KVPath, "SecretReference must point at the EXISTING stored secret — no secret duplication")
+	assert.Equal(t, testIdentitySecretRefName(), createdReq.KVPath,
+		"KVPath must come from binding.SecretRefPath, never recomputed independently")
 	assert.Equal(t, []string{thundersvc.AgentSecretKeyClientSecret}, createdReq.SecretKeys)
-	assert.Equal(t, testIdentityProject, createdReq.ProjectName)
-	assert.Equal(t, testIdentityAgent, createdReq.ComponentName)
-	assert.Equal(t, "1h", createdReq.RefreshInterval)
-	assert.Empty(t, createdReq.TemplateAnnotations, "plain injection must not stamp a rotated-at annotation")
+	assert.Empty(t, createdReq.TemplateAnnotations, "a plain read must not stamp a rotated-at annotation")
 
 	byKey := map[string]client.EnvVar{}
 	for _, ev := range envVars {
@@ -163,6 +163,29 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_CreatesSecretReferenceAndB
 	assert.Empty(t, byKey[client.EnvVarAgentIDScopes].Value, "no agent configuration means no MCP bindings, so no scopes to request")
 }
 
+// TestAgentIdentityInjection_EnvVarsForEnvironment_CreateConflictFallsBackToUpdate
+// guards the concurrent-writer case: a create conflict (another request for
+// this same binding, or the reconciler, already created it) must fall back
+// to asserting the same spec via update rather than failing.
+func TestAgentIdentityInjection_EnvVarsForEnvironment_CreateConflictFallsBackToUpdate(t *testing.T) {
+	repo := identityRepoReturning(completedInternalBinding(), nil)
+	oc := injectableOCClient()
+	updated := false
+	oc.CreateSecretReferenceFunc = func(_ context.Context, _ string, _ client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
+		return nil, utils.ErrConflict
+	}
+	oc.UpdateSecretReferenceFunc = func(_ context.Context, _, _ string, _ client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
+		updated = true
+		return &client.SecretReferenceInfo{}, nil
+	}
+	svc := newTestIdentityInjectionService(repo, oc)
+
+	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
+	require.NoError(t, err)
+	assert.Len(t, envVars, 4)
+	assert.True(t, updated, "create conflict must fall back to update, not fail")
+}
+
 // mcpProxyBinding is one EnvAgentMCPMapping's worth of fixture data: a proxy
 // bound to an environment, carrying the given scope actions — the real chain
 // resolveAgentIdentityScopes now walks (proxy -> its own MCPProxyScope rows),
@@ -174,20 +197,30 @@ type mcpProxyBinding struct {
 }
 
 // mcpBoundAgentConfigRepo returns an AgentConfigurationRepository mock whose
-// GetByAgentID returns a config with one EnvAgentMCPMapping (preloaded
-// MCPProxy included, matching GetByAgentID's real preload chain) per given
-// binding, plus the MCPProxyScopeRepository mock that returns each proxy's
-// scope rows — together, what resolveAgentIdentityScopes needs to aggregate
-// scope strings.
+// ListMCPConfigsByAgent returns ONE AgentConfiguration row PER given binding
+// — matching real production shape exactly: each MCP proxy an agent is
+// configured with is stored as its OWN AgentConfiguration row (see
+// createMCPConfig), never bundled as multiple EnvAgentMCPMapping rows under
+// a single config. Getting this fixture shape right is what makes
+// TestResolveAgentIdentityScopes_MultipleProxies_ReturnsSortedUnion an actual
+// regression test for the "only one MCP's scopes survive" bug — a single
+// config with multiple mappings inside it (the old fixture shape) could
+// never occur in the real database (see uq_env_mcp_mapping) and would have
+// passed even with the bug that only ever loaded one config row.
 func mcpBoundAgentConfigRepo(bindings ...mcpProxyBinding) (*repomocks.AgentConfigurationRepositoryMock, *repomocks.MCPProxyScopeRepositoryMock) {
-	mappings := make([]models.EnvAgentMCPMapping, 0, len(bindings))
+	configs := make([]models.AgentConfiguration, 0, len(bindings))
 	scopesByProxy := map[uuid.UUID][]models.MCPProxyScope{}
 
 	for _, b := range bindings {
 		proxyUUID := uuid.New()
 		envUUID := uuid.MustParse(b.envUUID)
 		proxy := &models.MCPProxy{UUID: proxyUUID, Artifact: &models.Artifact{Handle: b.proxyHandle}}
-		mappings = append(mappings, models.EnvAgentMCPMapping{EnvironmentUUID: envUUID, MCPProxyUUID: proxyUUID, MCPProxy: proxy})
+		configs = append(configs, models.AgentConfiguration{
+			TypeID: models.AgentConfigTypeIDMCP,
+			EnvMCPMappings: []models.EnvAgentMCPMapping{
+				{EnvironmentUUID: envUUID, MCPProxyUUID: proxyUUID, MCPProxy: proxy},
+			},
+		})
 		scopes := make([]models.MCPProxyScope, 0, len(b.scopeActions))
 		for _, action := range b.scopeActions {
 			scopes = append(scopes, models.MCPProxyScope{MCPProxyUUID: proxyUUID, Action: action})
@@ -196,8 +229,8 @@ func mcpBoundAgentConfigRepo(bindings ...mcpProxyBinding) (*repomocks.AgentConfi
 	}
 
 	configRepo := &repomocks.AgentConfigurationRepositoryMock{
-		GetByAgentIDFunc: func(_ context.Context, _, _ string) (*models.AgentConfiguration, error) {
-			return &models.AgentConfiguration{EnvMCPMappings: mappings}, nil
+		ListMCPConfigsByAgentFunc: func(_ context.Context, _, _, _ string) ([]models.AgentConfiguration, error) {
+			return configs, nil
 		},
 	}
 	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
@@ -282,14 +315,14 @@ func TestResolveAgentIdentityScopes_MappingForDifferentEnvironment_Ignored(t *te
 	// are never even looked up.
 	proxyUUID := uuid.New()
 	configRepo := &repomocks.AgentConfigurationRepositoryMock{
-		GetByAgentIDFunc: func(_ context.Context, _, _ string) (*models.AgentConfiguration, error) {
-			return &models.AgentConfiguration{EnvMCPMappings: []models.EnvAgentMCPMapping{
+		ListMCPConfigsByAgentFunc: func(_ context.Context, _, _, _ string) ([]models.AgentConfiguration, error) {
+			return []models.AgentConfiguration{{EnvMCPMappings: []models.EnvAgentMCPMapping{
 				{
 					EnvironmentUUID: uuid.MustParse(otherEnvUUID),
 					MCPProxyUUID:    proxyUUID,
 					MCPProxy:        &models.MCPProxy{UUID: proxyUUID, Artifact: &models.Artifact{Handle: "tickets"}},
 				},
-			}}, nil
+			}}}, nil
 		},
 	}
 	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
@@ -322,7 +355,7 @@ func TestResolveAgentIdentityScopes_MappingForDifferentEnvironment_Ignored(t *te
 // blip cleared.
 func TestResolveAgentIdentityScopes_AgentConfigLoadError_PropagatesError(t *testing.T) {
 	failingRepo := &repomocks.AgentConfigurationRepositoryMock{
-		GetByAgentIDFunc: func(_ context.Context, _, _ string) (*models.AgentConfiguration, error) {
+		ListMCPConfigsByAgentFunc: func(_ context.Context, _, _, _ string) ([]models.AgentConfiguration, error) {
 			return nil, errors.New("db unavailable")
 		},
 	}
@@ -356,89 +389,6 @@ func TestResolveAgentIdentityScopes_EnvironmentResolveError_PropagatesError(t *t
 	assert.Empty(t, scopes)
 }
 
-// TestAgentIdentityInjection_EnvVarsForEnvironment_UpdatesExistingSecretReference
-// covers an existing CR whose data sources don't yet match the desired KV
-// path/keys (GetSecretReferenceFunc here returns no Data at all) — a genuine
-// drift that must still be corrected.
-func TestAgentIdentityInjection_EnvVarsForEnvironment_UpdatesExistingSecretReference(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-
-	updated := false
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			updated = true
-			assert.Equal(t, testIdentityKVPath(), req.KVPath)
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		// CreateSecretReferenceFunc deliberately nil — a Create call would panic the test.
-	}
-	svc := newTestIdentityInjectionService(repo, oc)
-
-	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
-	require.NoError(t, err)
-	assert.Len(t, envVars, 4)
-	assert.True(t, updated)
-}
-
-// TestAgentIdentityInjection_EnvVarsForEnvironment_ExistingSecretReferenceAlreadyCorrect_SkipsUpdate
-// guards against needless writes: an existing CR whose data sources already
-// point at the exact desired KV path/keys must not be rewritten on every
-// single call (one per deploy/promote/config-update, and one per reconciler
-// tick per recently-completed binding) — both for the needless K8s API
-// write, and because rewriting with nil TemplateAnnotations would otherwise
-// silently clobber whatever annotation a prior rotation set.
-func TestAgentIdentityInjection_EnvVarsForEnvironment_ExistingSecretReferenceAlreadyCorrect_SkipsUpdate(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{
-				Name: refName,
-				Data: []client.SecretDataSourceInfo{
-					{SecretKey: thundersvc.AgentSecretKeyClientSecret, RemoteRef: client.RemoteRefInfo{Key: testIdentityKVPath()}},
-				},
-			}, nil
-		},
-		UpdateSecretReferenceFunc: func(context.Context, string, string, client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			t.Fatal("must not update a SecretReference that already points at the desired KV path and keys")
-			return nil, nil //nolint:nilnil // unreachable — t.Fatal above halts the test
-		},
-		// CreateSecretReferenceFunc deliberately nil — a Create call would panic the test.
-	}
-	svc := newTestIdentityInjectionService(repo, oc)
-
-	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
-	require.NoError(t, err)
-	assert.Len(t, envVars, 4)
-}
-
-func TestAgentIdentityInjection_EnvVarsForEnvironment_CreateConflictFallsBackToUpdate(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-
-	updated := false
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, _ string) (*client.SecretReferenceInfo, error) {
-			return nil, utils.ErrNotFound
-		},
-		CreateSecretReferenceFunc: func(_ context.Context, _ string, _ client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return nil, utils.ErrConflict
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, _ client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			updated = true
-			return &client.SecretReferenceInfo{}, nil
-		},
-	}
-	svc := newTestIdentityInjectionService(repo, oc)
-
-	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
-	require.NoError(t, err)
-	assert.Len(t, envVars, 4)
-	assert.True(t, updated, "create conflict (concurrent creator) must fall back to update, not fail")
-}
-
 func TestAgentIdentityInjection_EnvVarsForEnvironment_SkipStates(t *testing.T) {
 	pending := completedInternalBinding()
 	pending.Status = models.AgentThunderStatusPending
@@ -470,8 +420,8 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_SkipStates(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := identityRepoReturning(tc.binding, tc.repoErr)
-			// All OpenChoreo funcs nil: any CR call would panic — proving
-			// skip states never touch OpenChoreo.
+			// OpenChoreoClientMock has every func nil: any OpenChoreo call would
+			// panic — proving skip states never touch OpenChoreo at all.
 			svc := newTestIdentityInjectionService(repo, &clientmocks.OpenChoreoClientMock{})
 
 			envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
@@ -492,39 +442,16 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_RepoErrorPropagates(t *tes
 	assert.Nil(t, envVars)
 }
 
-func TestAgentIdentityInjection_EnvVarsForEnvironment_SecretReferenceCheckErrorPropagates(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-	ocErr := errors.New("openchoreo unavailable")
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, _ string) (*client.SecretReferenceInfo, error) {
-			return nil, ocErr
-		},
-	}
-	svc := newTestIdentityInjectionService(repo, oc)
-
-	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ocErr)
-	assert.Nil(t, envVars)
-}
-
 func TestAgentIdentityInjection_InjectForEnvironment_PushesVarsIntoReleaseBinding(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 
 	var injectedEnv string
 	var injectedVars []client.EnvVar
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, envName string, envVars []client.EnvVar) error {
-			injectedEnv = envName
-			injectedVars = envVars
-			return nil
-		},
+	oc := injectableOCClient()
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, envName string, envVars []client.EnvVar) error {
+		injectedEnv = envName
+		injectedVars = envVars
+		return nil
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -544,16 +471,9 @@ func TestAgentIdentityInjection_InjectForEnvironment_NothingToInject_NoWorkloadC
 func TestAgentIdentityInjection_InjectForEnvironment_WorkloadUpdateErrorPropagates(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 	updateErr := errors.New("binding update failed")
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
-			return updateErr
-		},
+	oc := injectableOCClient()
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		return updateErr
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -578,19 +498,12 @@ func inSyncIdentityEnvVars() []models.EnvVars {
 
 func TestAgentIdentityInjection_ReconcileForEnvironment_InSync_DoesNotWrite(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		GetComponentConfigurationsFunc: func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
-			return inSyncIdentityEnvVars(), nil
-		},
-		// UpdateReleaseBindingEnvVarsFunc left nil — a call would panic, proving
-		// an already-in-sync workload is never re-written (no needless pod roll).
+	oc := injectableOCClient()
+	oc.GetComponentConfigurationsFunc = func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
+		return inSyncIdentityEnvVars(), nil
 	}
+	// UpdateReleaseBindingEnvVarsFunc left nil — a call would panic, proving
+	// an already-in-sync workload is never re-written (no needless pod roll).
 	svc := newTestIdentityInjectionService(repo, oc)
 
 	require.NoError(t, svc.ReconcileForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
@@ -599,21 +512,14 @@ func TestAgentIdentityInjection_ReconcileForEnvironment_InSync_DoesNotWrite(t *t
 func TestAgentIdentityInjection_ReconcileForEnvironment_MissingVars_Injects(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 	injectedVars := 0
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		GetComponentConfigurationsFunc: func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
-			// Workload just came up from a first build; only base vars present, no identity vars.
-			return []models.EnvVars{{Key: "AMP_OTEL_ENDPOINT", Value: "http://otel"}}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
-			injectedVars = len(envVars)
-			return nil
-		},
+	oc := injectableOCClient()
+	oc.GetComponentConfigurationsFunc = func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
+		// Workload just came up from a first build; only base vars present, no identity vars.
+		return []models.EnvVars{{Key: "AMP_OTEL_ENDPOINT", Value: "http://otel"}}, nil
+	}
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
+		injectedVars = len(envVars)
+		return nil
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -629,35 +535,28 @@ func TestAgentIdentityInjection_ReconcileForEnvironment_ScopeDrift_Reinjects(t *
 		scopeActions: []string{"read"},
 	})
 	var injectedScopes string
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetEnvironmentFunc: func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
-			return &models.EnvironmentResponse{UUID: envUUID}, nil
-		},
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		GetComponentConfigurationsFunc: func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
-			// All four keys present, but the live scopes are stale (empty) vs the
-			// now-desired "tickets:read".
-			refName := testIdentitySecretRefName()
-			return []models.EnvVars{
-				{Key: client.EnvVarAgentIDClientID, Value: "client-abc"},
-				{Key: client.EnvVarAgentIDClientSecret, IsSensitive: true, SecretRef: refName, SecretKey: thundersvc.AgentSecretKeyClientSecret},
-				{Key: client.EnvVarAgentIDTokenEndpoint, Value: thundersvc.ThunderTokenURL(ThunderOrgNamespace(), testIdentityEnv)},
-				{Key: client.EnvVarAgentIDScopes, Value: ""},
-			}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
-			for _, ev := range envVars {
-				if ev.Key == client.EnvVarAgentIDScopes {
-					injectedScopes = ev.Value
-				}
+	oc := injectableOCClient()
+	oc.GetEnvironmentFunc = func(_ context.Context, _, _ string) (*models.EnvironmentResponse, error) {
+		return &models.EnvironmentResponse{UUID: envUUID}, nil
+	}
+	oc.GetComponentConfigurationsFunc = func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
+		// All four keys present, but the live scopes are stale (empty) vs the
+		// now-desired "tickets:read".
+		refName := testIdentitySecretRefName()
+		return []models.EnvVars{
+			{Key: client.EnvVarAgentIDClientID, Value: "client-abc"},
+			{Key: client.EnvVarAgentIDClientSecret, IsSensitive: true, SecretRef: refName, SecretKey: thundersvc.AgentSecretKeyClientSecret},
+			{Key: client.EnvVarAgentIDTokenEndpoint, Value: thundersvc.ThunderTokenURL(ThunderOrgNamespace(), testIdentityEnv)},
+			{Key: client.EnvVarAgentIDScopes, Value: ""},
+		}, nil
+	}
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
+		for _, ev := range envVars {
+			if ev.Key == client.EnvVarAgentIDScopes {
+				injectedScopes = ev.Value
 			}
-			return nil
-		},
+		}
+		return nil
 	}
 	svc := NewAgentIdentityInjectionService(identityRepoReturning(completedInternalBinding(), nil),
 		configRepo, scopeRepo, oc, "1h", discardLogger())
@@ -678,87 +577,53 @@ func TestAgentIdentityInjection_ReconcileForEnvironment_NothingToInject_NoReadOr
 
 func TestAgentIdentityInjection_ReconcileForEnvironment_ConfigReadError_Propagates(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		GetComponentConfigurationsFunc: func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
-			return nil, errors.New("openchoreo unavailable")
-		},
-		// UpdateReleaseBindingEnvVarsFunc left nil — must not write when it can't
-		// determine the current state.
+	oc := injectableOCClient()
+	oc.GetComponentConfigurationsFunc = func(_ context.Context, _, _, _, _ string) ([]models.EnvVars, error) {
+		return nil, errors.New("openchoreo unavailable")
 	}
+	// UpdateReleaseBindingEnvVarsFunc left nil — must not write when it can't
+	// determine the current state.
 	svc := newTestIdentityInjectionService(repo, oc)
 
 	err := svc.ReconcileForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
 	assert.Error(t, err, "an unreadable current state must not silently proceed to a blind write")
 }
 
+// TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
+// guards rotation's contract: storeCredential's resolved location is
+// unchanged by a rotation (only the value at that location changes), but the
+// data-plane SecretReference must still be re-asserted with a fresh
+// rotated-at annotation so OpenChoreo re-syncs the Secret immediately rather
+// than waiting for its own RefreshInterval — and the pod must roll to pick it
+// up.
 func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 
 	fixedNow := time.Date(2026, 7, 8, 10, 30, 0, 0, time.UTC)
-	var updateReq client.CreateSecretReferenceRequest
+	var createdReq client.CreateSecretReferenceRequest
 	rolled := false
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			updateReq = req
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
-			rolled = true
-			return nil
-		},
+	oc := injectableOCClient()
+	oc.CreateSecretReferenceFunc = func(_ context.Context, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
+		createdReq = req
+		return &client.SecretReferenceInfo{Name: req.Name}, nil
+	}
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
+		rolled = true
+		assert.Len(t, envVars, 4)
+		return nil
 	}
 
-	svc := NewAgentIdentityInjectionService(repo, noMCPConfigRepo(), noMCPProxyScopeRepo(), oc, "1h", discardLogger())
+	svc := newTestIdentityInjectionService(repo, oc)
 	impl, ok := svc.(*agentIdentityInjectionService)
 	require.True(t, ok)
 	impl.now = func() time.Time { return fixedNow }
 
 	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
-	require.NotNil(t, updateReq.TemplateAnnotations)
-	assert.Equal(t, fixedNow.Format(secretRotatedAtFormat), updateReq.TemplateAnnotations[secretRotatedAtAnnotation],
+	require.NotNil(t, createdReq.TemplateAnnotations)
+	assert.Equal(t, fixedNow.Format(secretRotatedAtFormat), createdReq.TemplateAnnotations[secretRotatedAtAnnotation],
 		"rotation must stamp a fresh annotation so the controller re-syncs the Secret immediately")
-	assert.True(t, rolled, "rotation must roll the pod so it starts with the refreshed Secret")
-}
-
-// TestAgentIdentityInjection_RefreshAfterRotation_AlwaysUpdatesEvenWhenDataAlreadyMatches
-// guards the other half of the "skip when the CR already points at the
-// desired KV path/keys" optimization: it must never apply to the rotation
-// path, since rotation's whole point is to stamp a FRESH annotation value on
-// every single call (by design, never "unchanged") to force the controller
-// to re-sync immediately.
-func TestAgentIdentityInjection_RefreshAfterRotation_AlwaysUpdatesEvenWhenDataAlreadyMatches(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-
-	updated := false
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{
-				Name: refName,
-				Data: []client.SecretDataSourceInfo{
-					{SecretKey: thundersvc.AgentSecretKeyClientSecret, RemoteRef: client.RemoteRefInfo{Key: testIdentityKVPath()}},
-				},
-			}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			updated = true
-			require.NotEmpty(t, req.TemplateAnnotations, "rotation must always carry a fresh annotation")
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(context.Context, string, string, string, string, []client.EnvVar) error { return nil },
-	}
-	svc := NewAgentIdentityInjectionService(repo, noMCPConfigRepo(), noMCPProxyScopeRepo(), oc, "1h", discardLogger())
-
-	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
-	assert.True(t, updated, "rotation must always update the SecretReference, even when its data sources already match")
+	assert.Equal(t, testIdentitySecretRefName(), createdReq.KVPath, "rotation must not change the resolved KV path")
+	assert.True(t, rolled, "rotation must roll the pod so it starts with the refreshed secret value")
 }
 
 func TestAgentIdentityInjection_RefreshAfterRotation_NoBinding_NoOp(t *testing.T) {
@@ -768,25 +633,21 @@ func TestAgentIdentityInjection_RefreshAfterRotation_NoBinding_NoOp(t *testing.T
 	assert.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
 }
 
-func TestAgentIdentityInjection_RemoveForEnvironment_RemovesVarsAndSecretReference(t *testing.T) {
+func TestAgentIdentityInjection_RemoveForEnvironment_RemovesVars(t *testing.T) {
 	// Post-revoke state: still internal + completed, but no stored secret.
 	binding := completedInternalBinding()
 	binding.SecretRefPath = ""
 	repo := identityRepoReturning(binding, nil)
 
 	var removedKeys []string
-	deletedRef := ""
 	oc := &clientmocks.OpenChoreoClientMock{
 		RemoveReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, envName string, keys []string) error {
 			assert.Equal(t, testIdentityEnv, envName)
 			removedKeys = keys
 			return nil
 		},
-		DeleteSecretReferenceFunc: func(_ context.Context, _, refName string) error {
-			deletedRef = refName
-			return nil
-		},
 		// RemoveWorkloadEnvVarsFunc nil — includeWorkloadLevel=false must not touch the workload.
+		DeleteSecretReferenceFunc: func(_ context.Context, _, _ string) error { return nil },
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -797,7 +658,6 @@ func TestAgentIdentityInjection_RemoveForEnvironment_RemovesVarsAndSecretReferen
 		expectedKeys = append(expectedKeys, k)
 	}
 	assert.ElementsMatch(t, expectedKeys, removedKeys)
-	assert.Equal(t, testIdentitySecretRefName(), deletedRef)
 }
 
 func TestAgentIdentityInjection_RemoveForEnvironment_IncludeWorkloadLevel(t *testing.T) {
@@ -829,40 +689,12 @@ func TestAgentIdentityInjection_RemoveForEnvironment_ExternalAgent_NoOp(t *testi
 	assert.NoError(t, svc.RemoveForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv, true))
 }
 
-func TestAgentIdentityInjection_RemoveForEnvironment_SecretRefNotFound_Tolerated(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-	oc := &clientmocks.OpenChoreoClientMock{
-		RemoveReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []string) error { return nil },
-		DeleteSecretReferenceFunc: func(_ context.Context, _, _ string) error {
-			return utils.ErrNotFound
-		},
-	}
-	svc := newTestIdentityInjectionService(repo, oc)
-
-	assert.NoError(t, svc.RemoveForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv, false))
-}
-
-func TestAgentIdentityInjection_CleanupForEnvironment_DeletesSecretReference(t *testing.T) {
-	deletedRef := ""
-	oc := &clientmocks.OpenChoreoClientMock{
-		DeleteSecretReferenceFunc: func(_ context.Context, namespace, refName string) error {
-			assert.Equal(t, testIdentityOrg, namespace)
-			deletedRef = refName
-			return nil
-		},
-	}
-	svc := newTestIdentityInjectionService(&repomocks.AgentThunderClientRepositoryMock{}, oc)
-
-	require.NoError(t, svc.CleanupForEnvironment(context.Background(), testIdentityOrg, testIdentityAgent, testIdentityEnv))
-	assert.Equal(t, testIdentitySecretRefName(), deletedRef)
-}
-
 // TestAgentIdentitySecretLocation_EntityNameIsAgentScoped guards the specific
 // property agentIdentitySecretLocation must hold: EntityName includes the
 // agent name, not just a fixed "agent-identity" marker — secretmanagersvc's
-// SecretRefName only derives the SecretReference CR name from EntityName (+
+// SecretRefName only derives the SecretReference name from EntityName (+
 // EnvironmentName), so two different agents in the same environment would
-// collide onto the identical CR name (one agent's credential silently
+// collide onto the identical name (one agent's credential silently
 // overwriting another's) if EntityName weren't agent-scoped. Collision
 // avoidance for very long names beyond that is secretmanagersvc's own
 // concern (SecretLocation.SecretRefName), not re-tested here.
@@ -875,79 +707,28 @@ func TestAgentIdentitySecretLocation_EntityNameIsAgentScoped(t *testing.T) {
 	assert.Contains(t, locA.EntityName, "agent-a")
 }
 
-// TestAgentIdentitySecretLocation_IsDeterministic guards the property both
-// agentThunderProvisioningService (storing) and agentIdentityInjectionService
-// (referencing) rely on: the same (org, project, agent, env) tuple must
-// always compute the exact same KV path and CR name, with no stored or
-// round-tripped state required to keep them in agreement.
+// TestAgentIdentitySecretLocation_IsDeterministic guards the property
+// agentThunderProvisioningService.HealSecretRef relies on: the same (org,
+// project, agent, env) tuple must always compute the exact same
+// SecretReference name, with no stored or round-tripped state required.
 func TestAgentIdentitySecretLocation_IsDeterministic(t *testing.T) {
 	loc1 := agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
 	loc2 := agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
 
-	kvPath1, err := loc1.KVPath()
-	require.NoError(t, err)
-	kvPath2, err := loc2.KVPath()
-	require.NoError(t, err)
-
-	assert.Equal(t, kvPath1, kvPath2)
 	assert.Equal(t, loc1.SecretRefName(), loc2.SecretRefName())
-}
-
-func TestAgentIdentityInjection_RefreshAfterRotation_TwoRotationsInSameSecondProduceDistinctAnnotations(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-
-	var annotations []string
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			annotations = append(annotations, req.TemplateAnnotations[secretRotatedAtAnnotation])
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error { return nil },
-	}
-
-	// Same wall-clock SECOND for both rotations — only nanoseconds differ,
-	// exactly the scenario time.RFC3339 (second precision) would collapse
-	// into an identical annotation value.
-	sameSecond := time.Date(2026, 7, 8, 10, 30, 0, 0, time.UTC)
-	callNum := 0
-	svc := NewAgentIdentityInjectionService(repo, noMCPConfigRepo(), noMCPProxyScopeRepo(), oc, "1h", discardLogger())
-	impl, ok := svc.(*agentIdentityInjectionService)
-	require.True(t, ok)
-	impl.now = func() time.Time {
-		callNum++
-		return sameSecond.Add(time.Duration(callNum) * time.Nanosecond)
-	}
-
-	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
-	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
-
-	require.Len(t, annotations, 2)
-	assert.NotEqual(t, annotations[0], annotations[1],
-		"two rotations within the same wall-clock second must still produce distinct annotation values, "+
-			"otherwise the second rotation's CR update is a no-op spec-wise and the controller never re-syncs the new secret")
 }
 
 func TestAgentIdentityInjection_InjectForEnvironment_RetriesOnTransientConflictThenSucceeds(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 
 	attempts := 0
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
-			attempts++
-			if attempts < 2 {
-				return utils.ErrConflict
-			}
-			return nil
-		},
+	oc := injectableOCClient()
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		attempts++
+		if attempts < 2 {
+			return utils.ErrConflict
+		}
+		return nil
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -966,20 +747,13 @@ func TestAgentIdentityInjection_InjectForEnvironment_RetriesOnInternalServerErro
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 
 	attempts := 0
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
-			attempts++
-			if attempts < 2 {
-				return utils.ErrInternalServerError
-			}
-			return nil
-		},
+	oc := injectableOCClient()
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		attempts++
+		if attempts < 2 {
+			return utils.ErrInternalServerError
+		}
+		return nil
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -992,17 +766,10 @@ func TestAgentIdentityInjection_InjectForEnvironment_GivesUpAfterRetriesExhauste
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 
 	attempts := 0
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
-			attempts++
-			return utils.ErrConflict
-		},
+	oc := injectableOCClient()
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		attempts++
+		return utils.ErrConflict
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -1017,17 +784,10 @@ func TestAgentIdentityInjection_InjectForEnvironment_DoesNotRetryPermanentError(
 
 	attempts := 0
 	permanentErr := errors.New("release binding validation failed")
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
-			attempts++
-			return permanentErr
-		},
+	oc := injectableOCClient()
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		attempts++
+		return permanentErr
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
@@ -1042,18 +802,11 @@ func TestAgentIdentityInjection_InjectForEnvironment_StopsRetryingOnContextCance
 
 	ctx, cancel := context.WithCancel(context.Background())
 	attempts := 0
-	oc := &clientmocks.OpenChoreoClientMock{
-		GetSecretReferenceFunc: func(_ context.Context, _, refName string) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: refName}, nil
-		},
-		UpdateSecretReferenceFunc: func(_ context.Context, _, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
-		},
-		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
-			attempts++
-			cancel() // simulate the caller's context being cancelled mid-retry
-			return utils.ErrConflict
-		},
+	oc := injectableOCClient()
+	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, _ []client.EnvVar) error {
+		attempts++
+		cancel() // simulate the caller's context being cancelled mid-retry
+		return utils.ErrConflict
 	}
 	svc := newTestIdentityInjectionService(repo, oc)
 

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -79,6 +79,13 @@ func (s *stubAgentThunderProvisioning) GetIdentityViews(ctx context.Context, ouI
 	return s.GetIdentityViewsFunc(ctx, ouID, projectName, agentName)
 }
 
+// HealSecretRef is a no-op override: no test using this stub exercises the
+// reconciler's startup heal pass, but leaving it unimplemented would panic on
+// the nil embedded interface if that ever changes.
+func (s *stubAgentThunderProvisioning) HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error {
+	return nil
+}
+
 func TestValidateInstrumentationVersion_UsesCatalog(t *testing.T) {
 	instrumentation.SetCatalog(instrumentation.NewForTest(
 		[]instrumentation.Version{

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -309,6 +309,17 @@ func (s *agentThunderProvisioningService) resolveClientSecretKVPath(ctx context.
 // once per completed internal binding from the reconciler's unbounded
 // startup sweep; a no-op on every run after the first successful heal for a
 // given binding.
+//
+// The OpenChoreo resolve runs BEFORE the binding lock (never hold a lock
+// across I/O), but the write is gated on a fresh re-read taken INSIDE the
+// same bindingLocks key every other SecretRefPath writer (RegenerateSecret,
+// RevokeSecret, DeleteAllBindings) already holds. The sweep that calls this
+// runs concurrently with the HTTP server from process startup (Start()
+// backgrounds it and returns immediately) — without the re-read, a revoke or
+// delete landing on this binding between the sweep's initial snapshot and
+// this call's resolve would have its SecretRefPath="" clear silently
+// overwritten with a resolved-but-now-orphaned path, which the injection
+// reconciler would then treat as a live credential and re-inject.
 func (s *agentThunderProvisioningService) HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error {
 	if binding.ProvisioningType != models.AgentProvisioningTypeInternal || binding.SecretRefPath == "" {
 		return nil
@@ -321,7 +332,24 @@ func (s *agentThunderProvisioningService) HealSecretRef(ctx context.Context, bin
 	if binding.SecretRefPath == kvPath {
 		return nil
 	}
-	return s.repo.UpdateSecretRef(ctx, binding.ID, kvPath)
+
+	release, lockErr := s.bindingLocks.Lock(ctx, bindingLockKey(binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName))
+	if lockErr != nil {
+		return fmt.Errorf("heal secret ref for binding %s: %w", binding.ID, lockErr)
+	}
+	defer release()
+
+	current, err := s.repo.Get(ctx, binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName)
+	if err != nil {
+		if errors.Is(err, repositories.ErrAgentThunderClientNotFound) {
+			return nil // deleted while this heal was resolving — nothing left to heal
+		}
+		return fmt.Errorf("heal secret ref for binding %s: %w", binding.ID, err)
+	}
+	if current.SecretRefPath == "" || current.SecretRefPath == kvPath {
+		return nil // revoked/cleared for deletion since the snapshot, or already healed
+	}
+	return s.repo.UpdateSecretRef(ctx, current.ID, kvPath)
 }
 
 // deleteCredential permanently removes the stored credential (and its

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -64,7 +64,7 @@ const provisionRetryDelay = 3 * time.Minute
 // gateway) is a later phase and is deliberately not implemented here.
 //
 // Deployment-pluggable (see app.Options.AgentThunderProvisioning; the
-// open-source build injects NewDBBackedAgentThunderProvisioning). Credential
+// open-source build injects DBBackedAgentThunderProvisioning). Credential
 // storage goes through secretmanagersvc.SecretManagementClient — the same
 // deployment-pluggable seam LLM/MCP/publisher secrets already use (see
 // app.Options's secretProvider) — instead of talking to OpenBao directly, so
@@ -370,7 +370,7 @@ func (s *agentThunderProvisioningService) deleteCredential(ctx context.Context, 
 type WorkloadInjectorSetter interface {
 	// SetWorkloadInjector backfills the workload injector once the real
 	// AgentIdentityInjectionService exists (this service is constructed before
-	// the OpenChoreo client — see NewDBBackedAgentThunderProvisioning). app.Run
+	// the OpenChoreo client — see DBBackedAgentThunderProvisioning). app.Run
 	// calls it exactly once, before the reconciler or HTTP server start. No-op
 	// when injector is nil. If this backfill is ever skipped (a startup-order
 	// regression), the post-provisioning reconcile hook logs a warning rather
@@ -424,9 +424,10 @@ func reconcileWorkloadInjection(ctx context.Context, injector AgentIdentityInjec
 	}
 }
 
-// NewDBBackedAgentThunderProvisioning returns the deployment factory that builds
-// the provisioning service once the DB and secret management client are
-// available (see app.Options.AgentThunderProvisioning). Used by the
+// DBBackedAgentThunderProvisioning returns a constructor to be called
+// once the DB and secret management client are available (see
+// app.Options.AgentThunderProvisioning), rather than building the
+// provisioning service immediately. Used by the
 // open-source deployment, which provisions AgentIDs against per-environment
 // Thunder via env-Thunder. "DB-backed" (not "default") is the load-bearing
 // distinction: the env-Thunder system-client credential this service reads
@@ -451,7 +452,7 @@ func reconcileWorkloadInjection(ctx context.Context, injector AgentIdentityInjec
 // agent whose workload comes up outside AgentManagerService.DeployAgent (a
 // git/build-pipeline agent, or a kind-sourced one) would never get its AgentID
 // env vars — neither path calls InjectForEnvironment itself.
-func NewDBBackedAgentThunderProvisioning() func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, encryptionKey []byte) AgentThunderProvisioningService {
+func DBBackedAgentThunderProvisioning() func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, encryptionKey []byte) AgentThunderProvisioningService {
 	return func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, encryptionKey []byte) AgentThunderProvisioningService {
 		envThunderRepo := repositories.NewEnvThunderSystemClientRepo(db)
 		return NewAgentThunderProvisioningService(

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
@@ -68,13 +69,14 @@ const provisionRetryDelay = 3 * time.Minute
 // deployment-pluggable seam LLM/MCP/publisher secrets already use (see
 // app.Options's secretProvider) — instead of talking to OpenBao directly, so
 // a deployment can swap secret backends without any AgentID-specific code
-// change. AgentThunderClient.SecretRefPath stores whatever
-// secretmanagersvc.SecretLocation.KVPath() computes for one binding — an
-// opaque, backend-agnostic identifier (empty means "no credential currently
-// stored", e.g. revoked). AgentIdentityInjectionService recomputes the same
-// SecretLocation from binding fields rather than trusting this string's
-// content, so both services always agree on where a binding's credential
-// lives — see agentIdentitySecretLocation.
+// change. AgentThunderClient.SecretRefPath stores the SecretReference name
+// CreateSecret returns (empty means "no credential currently stored", e.g.
+// revoked) — never a locally-computed KV path. CreateSecret's own call
+// already creates a fully-configured SecretReference as a side effect of
+// storing the value (see CreateSecretRequest.Labels's doc comment: "Labels
+// applied to the underlying SecretReference"), so this stored name is the
+// only thing AgentIdentityInjectionService needs to point a pod's
+// SecretKeyRef at it — see storeCredential and agentIdentitySecretLocation.
 type AgentThunderProvisioningService interface {
 	// ProvisionForAgent writes a PENDING binding for every environment in
 	// envNames (write-ahead — Section 6.2), then attempts all of them
@@ -148,6 +150,15 @@ type AgentThunderProvisioningService interface {
 	// in one environment. Returns utils.ErrAgentIdentityNotProvisioned if the
 	// binding doesn't exist or hasn't completed yet.
 	GetAgentGroups(ctx context.Context, ouID, projectName, agentName, envName string) ([]thundersvc.ThunderGroup, error)
+
+	// HealSecretRef corrects binding.SecretRefPath when it doesn't match the
+	// credential's actual remote KV key, by re-resolving it via the same
+	// GetSecretReference lookup storeCredential itself uses (see its doc
+	// comment) — one bounded OpenChoreo read per call, no writes. No-op for
+	// external agents, unprovisioned bindings, and bindings already holding
+	// the correct value. Called once per completed internal binding from the
+	// reconciler's unbounded startup sweep.
+	HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error
 }
 
 // AgentThunderBindingState is a minimal, internal snapshot of one binding's
@@ -169,6 +180,13 @@ type agentThunderProvisioningService struct {
 	repo             repositories.AgentThunderClientRepository
 	envResolver      thundersvc.EnvThunderResolver
 	secretMgmtClient secretmanagersvc.SecretManagementClient
+	// ocClient resolves the REAL remote KV key for a stored credential — the
+	// SecretReference secretMgmtClient.CreateSecret manages internally is not
+	// itself reachable from the agent's own workload namespace, only whatever
+	// the secret provider decides as its physical location; storeCredential
+	// reads that back once, at credential creation/rotation, rather than
+	// guessing it locally. See storeCredential's doc comment.
+	ocClient client.OpenChoreoClient
 	// workloadInjector pushes an internal agent's credential into its live
 	// workload (Gateway Binding). Optional (nil skips injection). Used by the
 	// post-provisioning reconcile hook to cover agents whose workload comes up
@@ -202,40 +220,45 @@ func agentIdentitySecretLocation(ouID, projectName, agentName, envName string) s
 	}
 }
 
-// createSecretConflictRetryMarker is the exact substring
-// secretmanagersvc's OpenChoreo provider includes only when a create
-// conflict's own fallback update then also fails (PushSecret's "failed to
-// update secret after create conflict" wrap in
-// clients/secretmanagersvc/providers/openchoreo/client.go). The secret
-// manager doesn't expose a distinct sentinel for this exact shape, so this
-// is the only way to tell it apart from other, unrelated not-found errors
-// (e.g. a secret that existed and vanished before an update, or a create
-// that failed for an unrelated reason) without changing the secret manager
-// itself.
+// createSecretConflictRetryMarker is the exact substring secretmanagersvc's
+// OpenChoreo provider includes only when a create conflict's own fallback
+// update then also fails (PushSecret's "failed to update secret after create
+// conflict" wrap in clients/secretmanagersvc/providers/openchoreo/client.go).
+// The secret manager doesn't expose a distinct sentinel for this exact shape,
+// so this is the only way to tell it apart from other, unrelated not-found
+// errors without changing the secret manager itself.
 const createSecretConflictRetryMarker = "after create conflict"
 
 // storeCredential writes the client ID/secret pair for one binding via the
-// shared secret management client and returns the KV path to persist in
-// AgentThunderClient.SecretRefPath — computed directly from the location
-// rather than using CreateSecret's own return value, since that value is a
-// SecretReference CR name when an OpenChoreo client is configured (see
-// SecretManagementClient.CreateSecret's doc comment), not the raw KV path.
+// shared secret management client and returns the remote KV key to persist
+// in AgentThunderClient.SecretRefPath.
+//
+// CreateSecret's own return value is only the name of the tracking
+// SecretReference it manages internally (see
+// SecretManagementClient.CreateSecret's doc comment) — that resource is not
+// reachable from the agent's own workload namespace. The actual remote KV
+// location is decided by whichever secret provider is plugged in and is only
+// ever learned by reading it back via GetSecretReference, once, here — never
+// guessed locally, and never re-verified by AgentIdentityInjectionService on
+// its own (much more frequent) injection path. Same resolve-don't-guess
+// pattern as agentManagerService.storeAgentAPIKey.
 func (s *agentThunderProvisioningService) storeCredential(ctx context.Context, ouID, projectName, agentName, envName, clientID, clientSecret string) (string, error) {
 	location := agentIdentitySecretLocation(ouID, projectName, agentName, envName)
 	data := map[string]string{
 		thundersvc.AgentSecretKeyClientID:     clientID,
 		thundersvc.AgentSecretKeyClientSecret: clientSecret,
 	}
-	if _, err := s.secretMgmtClient.CreateSecret(ctx, location, data); err != nil {
+	refName, err := s.secretMgmtClient.CreateSecret(ctx, location, data)
+	if err != nil {
 		if !errors.Is(err, utils.ErrNotFound) || !strings.Contains(err.Error(), createSecretConflictRetryMarker) {
 			return "", err
 		}
-		// An already-provisioned internal agent already has a SecretReference
-		// for this name, owned by the identity injection reconciler rather
-		// than by this code, which is why the create above failed here.
-		// Delete it and create again: the retry succeeds because it's now a
-		// plain create with nothing in the way, same as a brand-new agent's
-		// first credential.
+		// An already-provisioned internal agent already has a data-plane
+		// SecretReference for this name, owned by the identity injection
+		// service rather than by this code, which is why the create above
+		// failed here. Delete it and create again: the retry succeeds
+		// because it's now a plain create with nothing in the way, same as
+		// a brand-new agent's first credential.
 		injector := s.getWorkloadInjector()
 		if injector == nil {
 			return "", err
@@ -243,15 +266,62 @@ func (s *agentThunderProvisioningService) storeCredential(ctx context.Context, o
 		if cleanupErr := injector.CleanupForEnvironment(ctx, ouID, agentName, envName); cleanupErr != nil {
 			return "", fmt.Errorf("clear existing SecretReference before retry: %w: %w", cleanupErr, err)
 		}
-		if _, retryErr := s.secretMgmtClient.CreateSecret(ctx, location, data); retryErr != nil {
-			return "", retryErr
+		refName, err = s.secretMgmtClient.CreateSecret(ctx, location, data)
+		if err != nil {
+			return "", err
 		}
 	}
-	kvPath, err := location.KVPath()
+
+	kvPath, err := s.resolveClientSecretKVPath(ctx, ouID, refName)
 	if err != nil {
-		return "", fmt.Errorf("derive kv path: %w", err)
+		return "", err
 	}
 	return kvPath, nil
+}
+
+// resolveClientSecretKVPath reads back the real remote KV key for refName's
+// AgentSecretKeyClientSecret data source. The one place both storeCredential
+// (at creation/rotation) and HealSecretRef (the one-time startup backfill)
+// learn where a credential actually lives — never guessed, never computed
+// from agentIdentitySecretLocation.
+func (s *agentThunderProvisioningService) resolveClientSecretKVPath(ctx context.Context, ouID, refName string) (string, error) {
+	if s.ocClient == nil {
+		return "", fmt.Errorf("resolve stored KV path for SecretReference %q: OpenChoreo client not configured", refName)
+	}
+	ref, err := s.ocClient.GetSecretReference(ctx, ouID, refName)
+	if err != nil {
+		return "", fmt.Errorf("resolve stored KV path for SecretReference %q: %w", refName, err)
+	}
+	for _, ds := range ref.Data {
+		if ds.SecretKey == thundersvc.AgentSecretKeyClientSecret {
+			return ds.RemoteRef.Key, nil
+		}
+	}
+	return "", fmt.Errorf("SecretReference %q has no %q data source", refName, thundersvc.AgentSecretKeyClientSecret)
+}
+
+// HealSecretRef corrects a binding's SecretRefPath if its stored value
+// doesn't match the credential's actual remote KV key. Re-resolves via the
+// same GetSecretReference lookup storeCredential itself uses — the binding's
+// deterministic SecretReference name is a pure function of (ouID,
+// projectName, agentName, envName), so re-deriving it locally and reading it
+// back is always safe regardless of how the stored value got stale. Called
+// once per completed internal binding from the reconciler's unbounded
+// startup sweep; a no-op on every run after the first successful heal for a
+// given binding.
+func (s *agentThunderProvisioningService) HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error {
+	if binding.ProvisioningType != models.AgentProvisioningTypeInternal || binding.SecretRefPath == "" {
+		return nil
+	}
+	refName := agentIdentitySecretLocation(binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName).SecretRefName()
+	kvPath, err := s.resolveClientSecretKVPath(ctx, binding.OUID, refName)
+	if err != nil {
+		return fmt.Errorf("heal secret ref for binding %s: %w", binding.ID, err)
+	}
+	if binding.SecretRefPath == kvPath {
+		return nil
+	}
+	return s.repo.UpdateSecretRef(ctx, binding.ID, kvPath)
 }
 
 // deleteCredential permanently removes the stored credential (and its
@@ -353,14 +423,15 @@ func reconcileWorkloadInjection(ctx context.Context, injector AgentIdentityInjec
 // agent whose workload comes up outside AgentManagerService.DeployAgent (a
 // git/build-pipeline agent, or a kind-sourced one) would never get its AgentID
 // env vars — neither path calls InjectForEnvironment itself.
-func NewDBBackedAgentThunderProvisioning() func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, encryptionKey []byte) AgentThunderProvisioningService {
-	return func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, encryptionKey []byte) AgentThunderProvisioningService {
+func NewDBBackedAgentThunderProvisioning() func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, encryptionKey []byte) AgentThunderProvisioningService {
+	return func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, encryptionKey []byte) AgentThunderProvisioningService {
 		envThunderRepo := repositories.NewEnvThunderSystemClientRepo(db)
 		return NewAgentThunderProvisioningService(
 			repositories.NewAgentThunderClientRepo(db),
 			thundersvc.NewEnvThunderResolver(NewEnvThunderSecretReader(envThunderRepo, encryptionKey)),
 			secretMgmtClient,
-			nil, // see doc comment above
+			ocClient,
+			nil, // workload injector — see doc comment above
 			slog.Default(),
 		)
 	}
@@ -372,6 +443,7 @@ func NewAgentThunderProvisioningService(
 	repo repositories.AgentThunderClientRepository,
 	envResolver thundersvc.EnvThunderResolver,
 	secretMgmtClient secretmanagersvc.SecretManagementClient,
+	ocClient client.OpenChoreoClient,
 	workloadInjector AgentIdentityInjectionService,
 	logger *slog.Logger,
 ) AgentThunderProvisioningService {
@@ -379,6 +451,7 @@ func NewAgentThunderProvisioningService(
 		repo:             repo,
 		envResolver:      envResolver,
 		secretMgmtClient: secretMgmtClient,
+		ocClient:         ocClient,
 		workloadInjector: workloadInjector,
 		logger:           logger,
 	}
@@ -984,13 +1057,16 @@ func (s *agentThunderProvisioningService) DeleteAllBindings(ctx context.Context,
 
 			// The AgentID SecretReference CR is independent of whether the identity
 			// ever landed in Thunder — clean it up for every internal binding, even
-			// ones that never completed.
+			// ones that never completed (a crash between storeCredential creating it
+			// and UpdateAfterAttempt persisting ThunderAgentID/SecretRefPath would
+			// otherwise leave it permanently orphaned, since it precedes the
+			// early-return below).
 			if b.ProvisioningType == models.AgentProvisioningTypeInternal {
 				if injector == nil {
 					s.logger.Warn("Skipping agent identity SecretReference cleanup: no workload injector configured",
 						"ouID", ouID, "bindingID", b.ID, "agentName", agentName, "env", b.EnvironmentName)
 				} else if err := injector.CleanupForEnvironment(ctx, ouID, agentName, b.EnvironmentName); err != nil {
-					s.logger.Warn("Failed to delete agent identity SecretReference during agent deletion", "ouID", ouID, "bindingID", b.ID, "agentName", agentName, "env", b.EnvironmentName, "error", err)
+					s.logger.Warn("Failed to clean up agent identity data-plane SecretReference", "ouID", ouID, "bindingID", b.ID, "agentName", agentName, "env", b.EnvironmentName, "error", err)
 				}
 			}
 			if b.ThunderAgentID == "" {

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -2173,12 +2173,18 @@ func TestAttemptProvision_RecordFailure_SkipsInjection(t *testing.T) {
 	})
 }
 
-// TestDeleteAllBindings_DeletesStoredSecretsForBindingsThatHaveOne guards
-// cleanup of the stored credential (secretMgmtClient.DeleteSecret, which also
-// deletes CreateSecret's auto-created SecretReference — there is no separate
-// AMS-owned SecretReference for this method to clean up on top of that).
-// External agents never have a stored secret to begin with (SecretRefPath is
-// always empty for them), so this is the only cleanup path that matters.
+// TestDeleteAllBindings_DeletesStoredSecretsForBindingsThatHaveOne guards two
+// separate cleanup paths at once: the stored credential
+// (secretMgmtClient.DeleteSecret, which also deletes CreateSecret's
+// auto-created SecretReference) for whichever binding actually has one, and
+// the AMS-owned data-plane SecretReference (injector.CleanupForEnvironment)
+// for every internal binding regardless of whether it has a stored secret —
+// DeleteAllBindings runs that cleanup for internal bindings that never
+// completed too, since a crash between storeCredential creating the
+// SecretReference and UpdateAfterAttempt persisting SecretRefPath would
+// otherwise leave it permanently orphaned. External bindings never have a
+// stored secret (SecretRefPath is always empty for them) and never get the
+// data-plane cleanup, since it's an internal-agent-only concept.
 func TestDeleteAllBindings_DeletesStoredSecretsForBindingsThatHaveOne(t *testing.T) {
 	internalBinding := models.AgentThunderClient{
 		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent",
@@ -2218,13 +2224,22 @@ func TestDeleteAllBindings_DeletesStoredSecretsForBindingsThatHaveOne(t *testing
 		DeleteByIDsFunc:     func(_ context.Context, _ []uuid.UUID) error { return nil },
 		UpdateSecretRefFunc: func(_ context.Context, _ uuid.UUID, _ string) error { return nil },
 	}
+	var cleanedUpEnvs []string
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(_ context.Context, _, _, envName string) error {
+			cleanedUpEnvs = append(cleanedUpEnvs, envName)
+			return nil
+		},
+	}
 
-	svc := newTestProvisioningService(repo, resolver, store)
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
 
 	svc.DeleteAllBindings(context.Background(), "acme", "proj1", "my-agent")
 
 	assert.Equal(t, []string{"dev"}, deletedEnvs,
 		"the stored secret is deleted only for the binding that actually has one")
+	assert.Equal(t, []string{"dev"}, cleanedUpEnvs,
+		"the data-plane SecretReference is cleaned up for the internal binding but not the external one")
 }
 
 func TestDeleteAllBindings_ContinuesExternalCleanupWhenDBRowDeleteFails(t *testing.T) {
@@ -2350,9 +2365,10 @@ func TestAttemptProvision_SerializesWithRegenerateSecret(t *testing.T) {
 
 // TestHealSecretRef_CorrectsStaleRow guards the one-time backfill: a binding
 // whose SecretRefPath still holds the old locally-computed KV-path guess
-// (from before storeCredential was fixed) gets corrected to the deterministic
-// SecretReference name — a pure local recomputation, no secret manager call
-// at all (the mock's every func is nil; a call would panic).
+// (from before storeCredential was fixed) gets corrected to the real remote
+// KV key, read back through GetSecretReference — never recomputed locally.
+// The secret management mock has every func nil, so a CreateSecret or
+// DeleteSecret call would panic: healing is a read plus one DB write.
 func TestHealSecretRef_CorrectsStaleRow(t *testing.T) {
 	svc := newTestProvisioningService(
 		&repomocks.AgentThunderClientRepositoryMock{},

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -2371,6 +2371,11 @@ func TestHealSecretRef_CorrectsStaleRow(t *testing.T) {
 	var updatedID uuid.UUID
 	var updatedPath string
 	impl.repo = &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			// The fresh re-read taken under the binding lock — still stale,
+			// matching the snapshot, so the write is expected to proceed.
+			return &binding, nil
+		},
 		UpdateSecretRefFunc: func(_ context.Context, id uuid.UUID, secretRefPath string) error {
 			updatedID = id
 			updatedPath = secretRefPath
@@ -2381,6 +2386,73 @@ func TestHealSecretRef_CorrectsStaleRow(t *testing.T) {
 	require.NoError(t, impl.HealSecretRef(context.Background(), binding))
 	assert.Equal(t, binding.ID, updatedID)
 	assert.Equal(t, "resolved/"+refName, updatedPath, "must heal to the value resolved via GetSecretReference, never a locally-computed name")
+}
+
+// TestHealSecretRef_RevokedAfterSnapshot_DoesNotResurrectCredential guards the
+// race a background startup sweep is exposed to: if a RevokeSecret or
+// DeleteAllBindings call clears SecretRefPath to "" for this binding between
+// the sweep's initial snapshot and this call's own GetSecretReference resolve
+// completing, the resolved (but now orphaned) path must never be written back
+// over the fresh, empty value — that would resurrect a revoked/deleted
+// credential for the injection reconciler to re-inject.
+func TestHealSecretRef_RevokedAfterSnapshot_DoesNotResurrectCredential(t *testing.T) {
+	svc := newTestProvisioningService(
+		&repomocks.AgentThunderClientRepositoryMock{},
+		&clientmocks.EnvThunderResolverMock{},
+		&clientmocks.SecretManagementClientMock{},
+	)
+	impl := svc.(*agentThunderProvisioningService)
+
+	staleBinding := models.AgentThunderClient{
+		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
+		ProvisioningType: models.AgentProvisioningTypeInternal,
+		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity", // the sweep's stale snapshot
+	}
+
+	impl.repo = &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			// A concurrent revoke/delete landed and cleared it since the snapshot.
+			revoked := staleBinding
+			revoked.SecretRefPath = ""
+			return &revoked, nil
+		},
+		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
+			t.Fatal("must not write a resolved path back over a binding that was revoked/cleared since the snapshot")
+			return nil
+		},
+	}
+
+	require.NoError(t, impl.HealSecretRef(context.Background(), staleBinding))
+}
+
+// TestHealSecretRef_DeletedAfterSnapshot_NoOp guards the sibling case: the
+// binding row was deleted entirely (agent deletion) between the sweep's
+// snapshot and this call's resolve completing.
+func TestHealSecretRef_DeletedAfterSnapshot_NoOp(t *testing.T) {
+	svc := newTestProvisioningService(
+		&repomocks.AgentThunderClientRepositoryMock{},
+		&clientmocks.EnvThunderResolverMock{},
+		&clientmocks.SecretManagementClientMock{},
+	)
+	impl := svc.(*agentThunderProvisioningService)
+
+	staleBinding := models.AgentThunderClient{
+		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
+		ProvisioningType: models.AgentProvisioningTypeInternal,
+		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity",
+	}
+
+	impl.repo = &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return nil, repositories.ErrAgentThunderClientNotFound
+		},
+		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
+			t.Fatal("must not write for a binding deleted since the snapshot")
+			return nil
+		},
+	}
+
+	require.NoError(t, impl.HealSecretRef(context.Background(), staleBinding))
 }
 
 // TestHealSecretRef_NoOpWhenAlreadyCorrect guards against a needless DB write

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -41,12 +41,37 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
+// testOCClientResolvingSecretRefs returns an OpenChoreoClientMock whose
+// GetSecretReference resolves ANY secret ref name to a "resolved/<name>" KV
+// key holding the agent-identity client-secret data source — standing in for
+// whatever path the real secret manager provider would have assigned when it
+// created the SecretReference (see storeCredential: that path is never
+// computed locally, only ever read back). Deliberately a different shape
+// than agentIdentitySecretLocation(...).KVPath() would produce, so a test
+// asserting a locally-guessed path would fail loudly instead of passing by
+// coincidence.
+func testOCClientResolvingSecretRefs() *clientmocks.OpenChoreoClientMock {
+	return &clientmocks.OpenChoreoClientMock{
+		GetSecretReferenceFunc: func(_ context.Context, _ string, secretRefName string) (*client.SecretReferenceInfo, error) {
+			return &client.SecretReferenceInfo{
+				Name: secretRefName,
+				Data: []client.SecretDataSourceInfo{
+					{
+						SecretKey: thundersvc.AgentSecretKeyClientSecret,
+						RemoteRef: client.RemoteRefInfo{Key: "resolved/" + secretRefName},
+					},
+				},
+			}, nil
+		},
+	}
+}
+
 func newTestProvisioningService(
 	repo *repomocks.AgentThunderClientRepositoryMock,
 	resolver *clientmocks.EnvThunderResolverMock,
 	store *clientmocks.SecretManagementClientMock,
 ) AgentThunderProvisioningService {
-	return NewAgentThunderProvisioningService(repo, resolver, store, nil, slog.Default())
+	return NewAgentThunderProvisioningService(repo, resolver, store, testOCClientResolvingSecretRefs(), nil, slog.Default())
 }
 
 // newTestProvisioningServiceWithInjector is newTestProvisioningService plus a
@@ -57,7 +82,7 @@ func newTestProvisioningServiceWithInjector(
 	store *clientmocks.SecretManagementClientMock,
 	injector AgentIdentityInjectionService,
 ) AgentThunderProvisioningService {
-	return NewAgentThunderProvisioningService(repo, resolver, store, injector, slog.Default())
+	return NewAgentThunderProvisioningService(repo, resolver, store, testOCClientResolvingSecretRefs(), injector, slog.Default())
 }
 
 func fakeThunderClientMock() *clientmocks.ThunderClientMock {
@@ -113,8 +138,8 @@ func TestAttemptProvision_Success_CreatesIdentityAndStoresSecret(t *testing.T) {
 	require.NotNil(t, recorded.ThunderClientID)
 	assert.Equal(t, "client-abc", *recorded.ThunderClientID)
 	require.NotNil(t, recorded.SecretRefPath)
-	assert.Equal(t, "acme/proj1/staging/my-agent/my-agent-agent-identity", *recorded.SecretRefPath,
-		"the persisted SecretRefPath is now the deterministic KV path derived from the binding's own fields, not CreateSecret's return value")
+	assert.Equal(t, "resolved/ref", *recorded.SecretRefPath,
+		"the persisted SecretRefPath is resolved by reading the SecretReference back from OpenChoreo, never CreateSecret's bare name or a locally-computed path")
 	assert.Empty(t, recorded.LastError)
 }
 
@@ -206,8 +231,8 @@ func TestAttemptProvision_AlreadyHasThunderAgentID_SkipsCreate(t *testing.T) {
 		"a binding with a Thunder identity but no stored secret must recover one before completing")
 	require.NotNil(t, recorded.SecretRefPath,
 		"the recovered secret's storage location must be persisted, not left empty")
-	assert.Equal(t, "acme/proj1/staging/my-agent/my-agent-agent-identity", *recorded.SecretRefPath,
-		"the persisted SecretRefPath is now the deterministic KV path derived from the binding's own fields, not CreateSecret's return value")
+	assert.Equal(t, "resolved/ref", *recorded.SecretRefPath,
+		"the persisted SecretRefPath is resolved by reading the SecretReference back from OpenChoreo, never CreateSecret's bare name or a locally-computed path")
 }
 
 // TestAttemptProvision_AlreadyHasSecretRef_SkipsRecovery guards the inverse of
@@ -617,18 +642,19 @@ func TestRegenerateSecret_Internal_StoresSecret(t *testing.T) {
 	assert.Equal(t, "client-abc", clientID)
 	assert.Equal(t, "new-secret", newSecret)
 	assert.Equal(t, "new-secret", storedSecret)
-	assert.Equal(t, "acme/proj1/staging/my-agent/my-agent-agent-identity", updatedPath,
-		"the persisted SecretRefPath is the deterministic KV path derived from the binding's own fields")
+	assert.Equal(t, "resolved/ref", updatedPath,
+		"the persisted SecretRefPath is resolved by reading the SecretReference back from OpenChoreo, never CreateSecret's bare name or a locally-computed path")
 }
 
-// TestRegenerateSecret_Internal_ExistingSecretReference_CleansUpAndRetries
-// covers an already-provisioned internal agent whose SecretReference was
-// created outside the secret manager's own bookkeeping (the shape the
-// identity injection reconciler produces): the first CreateSecret reports
-// not-found, storeCredential clears the stray SecretReference via the
-// workload injector and retries once, and that retry succeeding is enough
-// for the whole rotation to succeed.
-func TestRegenerateSecret_Internal_ExistingSecretReference_CleansUpAndRetries(t *testing.T) {
+// TestRegenerateSecret_Internal_CreateSecretErrorPropagatesDirectly_NoInjector
+// guards the no-workload-injector case: even when CreateSecret's error
+// matches the "after create conflict" marker storeCredential otherwise
+// retries on (see TestStoreCredential_ConflictMarker_CleansUpAndRetries),
+// there is nothing to clean up without an injector configured, so the
+// original error propagates on the first and only attempt instead of
+// panicking or retrying blind. newTestProvisioningService (used here) wires
+// no injector; newTestProvisioningServiceWithInjector is the variant that does.
+func TestRegenerateSecret_Internal_CreateSecretErrorPropagatesDirectly_NoInjector(t *testing.T) {
 	tc := fakeThunderClientMock()
 	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
 		return "new-secret", nil
@@ -636,62 +662,10 @@ func TestRegenerateSecret_Internal_ExistingSecretReference_CleansUpAndRetries(t 
 	resolver := &clientmocks.EnvThunderResolverMock{
 		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
 	}
-
 	var createCalls int
 	store := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(_ context.Context, _ secretmanagersvc.SecretLocation, data map[string]string) (string, error) {
-			createCalls++
-			if createCalls == 1 {
-				return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
-			}
-			assert.Equal(t, "new-secret", data[thundersvc.AgentSecretKeyClientSecret],
-				"the retry must persist the same rotated value as the failed first attempt")
-			return "ref", nil
-		},
-	}
-
-	var cleanedUpAgent string
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(_ context.Context, _, agentName, _ string) error {
-			cleanedUpAgent = agentName
-			return nil
-		},
-	}
-
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
-				ProvisioningType: models.AgentProvisioningTypeInternal,
-			}, nil
-		},
-		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error { return nil },
-	}
-
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
-	ownership, _, newSecret, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
-
-	require.NoError(t, err)
-	assert.Equal(t, models.AgentProvisioningTypeInternal, ownership)
-	assert.Equal(t, "new-secret", newSecret)
-	assert.Equal(t, 2, createCalls, "expected exactly one retry after the cleanup")
-	assert.Equal(t, "my-agent", cleanedUpAgent)
-}
-
-// TestRegenerateSecret_Internal_ExistingSecretReference_NoInjector_ReturnsOriginalError
-// guards against silently dropping the rotation when no workload injector is
-// configured to perform the cleanup — the caller must still see a failure
-// rather than a false success with the secret left unstored.
-func TestRegenerateSecret_Internal_ExistingSecretReference_NoInjector_ReturnsOriginalError(t *testing.T) {
-	tc := fakeThunderClientMock()
-	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
-		return "new-secret", nil
-	}
-	resolver := &clientmocks.EnvThunderResolverMock{
-		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
-	}
-	store := &clientmocks.SecretManagementClientMock{
 		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
+			createCalls++
 			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
 		},
 	}
@@ -709,13 +683,16 @@ func TestRegenerateSecret_Internal_ExistingSecretReference_NoInjector_ReturnsOri
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, utils.ErrNotFound)
+	assert.Equal(t, 1, createCalls, "no retry — the error propagates on the first and only attempt")
 }
 
-// TestRegenerateSecret_Internal_UnrelatedCreateSecretError_NotRetried guards
-// against over-broadening the recovery: a failure unrelated to an existing
-// SecretReference (no not-found in its chain) must surface immediately,
-// without ever invoking cleanup or a retry.
-func TestRegenerateSecret_Internal_UnrelatedCreateSecretError_NotRetried(t *testing.T) {
+// TestStoreCredential_ConflictMarker_CleansUpAndRetries guards the actual
+// recovery path the marker above exists for: an already-provisioned internal
+// agent's stray SecretReference (owned by AgentIdentityInjectionService, not
+// this code) collides with a fresh CreateSecret. With a workload injector
+// configured, storeCredential clears that stray reference and retries once,
+// succeeding on a now-unobstructed create.
+func TestStoreCredential_ConflictMarker_CleansUpAndRetries(t *testing.T) {
 	tc := fakeThunderClientMock()
 	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
 		return "new-secret", nil
@@ -727,229 +704,86 @@ func TestRegenerateSecret_Internal_UnrelatedCreateSecretError_NotRetried(t *test
 	store := &clientmocks.SecretManagementClientMock{
 		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
 			createCalls++
-			return "", errors.New("connection refused")
-		},
-	}
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
-			t.Fatal("must not clean up the SecretReference for an unrelated error")
-			return nil
-		},
-	}
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
-				ProvisioningType: models.AgentProvisioningTypeInternal,
-			}, nil
-		},
-	}
-
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
-	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
-
-	require.Error(t, err)
-	assert.Equal(t, 1, createCalls, "must not retry a failure that isn't the existing-SecretReference shape")
-}
-
-// TestRegenerateSecret_Internal_UnrelatedNotFoundError_NotRetried guards
-// against the narrower case: an error that does wrap utils.ErrNotFound, but
-// not from the create-conflict-then-fallback-update shape (for example, the
-// create itself failing for a reason unrelated to an existing
-// SecretReference), must not trigger cleanup or a retry either. Only the
-// exact shape carrying "after create conflict" should.
-func TestRegenerateSecret_Internal_UnrelatedNotFoundError_NotRetried(t *testing.T) {
-	tc := fakeThunderClientMock()
-	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
-		return "new-secret", nil
-	}
-	resolver := &clientmocks.EnvThunderResolverMock{
-		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
-	}
-	var createCalls int
-	store := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
-			createCalls++
-			return "", fmt.Errorf("failed to upsert secret: failed to create secret: %w", utils.ErrNotFound)
-		},
-	}
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
-			t.Fatal("must not clean up the SecretReference for a not-found that isn't the create-conflict shape")
-			return nil
-		},
-	}
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
-				ProvisioningType: models.AgentProvisioningTypeInternal,
-			}, nil
-		},
-	}
-
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
-	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, utils.ErrNotFound)
-	assert.Equal(t, 1, createCalls, "a not-found that isn't the create-conflict shape must not be retried")
-}
-
-// TestRegenerateSecret_Internal_CleanupItselfFails_ReturnsWrappedError guards
-// against attempting the retry on an unconfirmed cleanup: if clearing the
-// stray SecretReference itself errors, the original create failure must
-// still be visible to the caller rather than a confusing swallowed retry.
-func TestRegenerateSecret_Internal_CleanupItselfFails_ReturnsWrappedError(t *testing.T) {
-	tc := fakeThunderClientMock()
-	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
-		return "new-secret", nil
-	}
-	resolver := &clientmocks.EnvThunderResolverMock{
-		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
-	}
-	var createCalls int
-	store := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
-			createCalls++
-			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
-		},
-	}
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
-			return errors.New("openchoreo api unavailable")
-		},
-	}
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
-				ProvisioningType: models.AgentProvisioningTypeInternal,
-			}, nil
-		},
-	}
-
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
-	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, utils.ErrNotFound, "the original create failure stays visible alongside the cleanup failure")
-	assert.Contains(t, err.Error(), "openchoreo api unavailable", "the cleanup failure's own reason must not be discarded")
-	assert.Equal(t, 1, createCalls, "no retry without a confirmed cleanup")
-}
-
-// TestRegenerateSecret_Internal_RetryAlsoFails_ReturnsRetryErrorWithoutLooping
-// guards against an unbounded retry loop: if the SecretReference reappears
-// (or the underlying failure is persistent) even after cleanup, the second
-// attempt's own error must surface directly rather than retrying again.
-func TestRegenerateSecret_Internal_RetryAlsoFails_ReturnsRetryErrorWithoutLooping(t *testing.T) {
-	tc := fakeThunderClientMock()
-	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
-		return "new-secret", nil
-	}
-	resolver := &clientmocks.EnvThunderResolverMock{
-		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
-	}
-	var createCalls int
-	store := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
-			createCalls++
-			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
-		},
-	}
-	var cleanupCalls int
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
-			cleanupCalls++
-			return nil
-		},
-	}
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
-				ProvisioningType: models.AgentProvisioningTypeInternal,
-			}, nil
-		},
-	}
-
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
-	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, utils.ErrNotFound)
-	assert.Equal(t, 2, createCalls, "exactly one retry, never more")
-	assert.Equal(t, 1, cleanupCalls, "exactly one cleanup, never more")
-}
-
-// TestRegenerateSecret_Internal_ManyDifferentAgentsHittingRetryConcurrently
-// checks concurrency and performance of the create-conflict-and-retry path:
-// many DIFFERENT agents hitting it at the same time must all succeed
-// independently, with no shared state between them (bindingLocks is keyed
-// per-binding, so unrelated agents must never block each other) and no data
-// race (run with -race). Also checks the path scales linearly — no lock held
-// across all of them.
-func TestRegenerateSecret_Internal_ManyDifferentAgentsHittingRetryConcurrently(t *testing.T) {
-	const agentCount = 25
-
-	tc := fakeThunderClientMock()
-	tc.RegenerateAgentSecretFunc = func(_ context.Context, thunderAgentID string) (string, error) {
-		return "new-secret-for-" + thunderAgentID, nil
-	}
-	resolver := &clientmocks.EnvThunderResolverMock{
-		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
-	}
-
-	var createAttempts sync.Map // agentName -> *int32, first attempt per agent fails, second succeeds
-	store := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(_ context.Context, location secretmanagersvc.SecretLocation, _ map[string]string) (string, error) {
-			counter, _ := createAttempts.LoadOrStore(location.AgentName, new(int32))
-			if atomic.AddInt32(counter.(*int32), 1) == 1 {
+			if createCalls == 1 {
 				return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
 			}
 			return "ref", nil
 		},
 	}
-	var cleanupCount atomic.Int32
+	var cleanupCalls int
 	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error {
-			cleanupCount.Add(1)
+		CleanupForEnvironmentFunc: func(_ context.Context, orgName, agentName, envName string) error {
+			cleanupCalls++
+			assert.Equal(t, "acme", orgName)
+			assert.Equal(t, "my-agent", agentName)
+			assert.Equal(t, "staging", envName)
 			return nil
 		},
 	}
+	var updatedPath string
 	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(_ context.Context, _, _, agentName, _ string) (*models.AgentThunderClient, error) {
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
 			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-" + agentName, ThunderClientID: "client-" + agentName,
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
 				ProvisioningType: models.AgentProvisioningTypeInternal,
 			}, nil
 		},
-		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error { return nil },
+		UpdateSecretRefFunc: func(_ context.Context, _ uuid.UUID, secretRefPath string) error {
+			updatedPath = secretRefPath
+			return nil
+		},
 	}
 
 	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	_, _, newSecret, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
 
-	var wg sync.WaitGroup
-	errs := make([]error, agentCount)
-	start := time.Now()
-	for i := 0; i < agentCount; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			agentName := fmt.Sprintf("agent-%d", i)
-			_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", agentName, "staging")
-			errs[i] = err
-		}(i)
-	}
-	wg.Wait()
-	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.Equal(t, "new-secret", newSecret)
+	assert.Equal(t, 2, createCalls, "the first create hits the stray reference; the retry succeeds")
+	assert.Equal(t, 1, cleanupCalls)
+	assert.Equal(t, "resolved/ref", updatedPath)
+}
 
-	for i, err := range errs {
-		assert.NoError(t, err, "agent-%d must succeed independently of every other agent's retry", i)
+// TestStoreCredential_ConflictMarker_CleanupFails_WrapsBothErrors guards the
+// double-failure case: if the stray SecretReference can't even be cleaned up,
+// the original CreateSecret error must not be silently dropped — both are
+// wrapped together so the real cause (the cleanup failure blocking recovery)
+// is visible alongside what triggered the recovery attempt in the first place.
+func TestStoreCredential_ConflictMarker_CleanupFails_WrapsBothErrors(t *testing.T) {
+	tc := fakeThunderClientMock()
+	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
+		return "new-secret", nil
 	}
-	assert.Equal(t, int32(agentCount), cleanupCount.Load(), "every agent hits the conflict exactly once, so exactly one cleanup each")
-	assert.Less(t, elapsed, 5*time.Second,
-		"unrelated agents' bindingLocks must not serialize this — %d concurrent retries took %s", agentCount, elapsed)
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
+	}
+	var createCalls int
+	store := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
+			createCalls++
+			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
+		},
+	}
+	cleanupErr := errors.New("cleanup boom")
+	injector := &agentIdentityInjectorStub{
+		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error { return cleanupErr },
+	}
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
+			return &models.AgentThunderClient{
+				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
+				ProvisioningType: models.AgentProvisioningTypeInternal,
+			}, nil
+		},
+	}
+
+	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, cleanupErr)
+	assert.ErrorIs(t, err, utils.ErrNotFound, "the original CreateSecret error must still be reachable, not replaced by the cleanup error")
+	assert.Equal(t, 1, createCalls, "no retry attempted once cleanup itself failed")
 }
 
 // TestRegenerateSecret_External_NeverStoresSecret guards the invariant that an
@@ -2339,7 +2173,13 @@ func TestAttemptProvision_RecordFailure_SkipsInjection(t *testing.T) {
 	})
 }
 
-func TestDeleteAllBindings_CleansUpIdentitySecretReferences(t *testing.T) {
+// TestDeleteAllBindings_DeletesStoredSecretsForBindingsThatHaveOne guards
+// cleanup of the stored credential (secretMgmtClient.DeleteSecret, which also
+// deletes CreateSecret's auto-created SecretReference — there is no separate
+// AMS-owned SecretReference for this method to clean up on top of that).
+// External agents never have a stored secret to begin with (SecretRefPath is
+// always empty for them), so this is the only cleanup path that matters.
+func TestDeleteAllBindings_DeletesStoredSecretsForBindingsThatHaveOne(t *testing.T) {
 	internalBinding := models.AgentThunderClient{
 		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent",
 		EnvironmentName: "dev", ProvisioningType: models.AgentProvisioningTypeInternal,
@@ -2348,7 +2188,7 @@ func TestDeleteAllBindings_CleansUpIdentitySecretReferences(t *testing.T) {
 	externalBinding := models.AgentThunderClient{
 		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent",
 		EnvironmentName: "prod", ProvisioningType: models.AgentProvisioningTypeExternal,
-		ThunderAgentID: "t-2", SecretRefPath: "p2",
+		ThunderAgentID: "t-2", SecretRefPath: "", // external agents never have one stored
 	}
 
 	tc := fakeThunderClientMock()
@@ -2356,8 +2196,12 @@ func TestDeleteAllBindings_CleansUpIdentitySecretReferences(t *testing.T) {
 	resolver := &clientmocks.EnvThunderResolverMock{
 		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
 	}
+	var deletedEnvs []string
 	store := &clientmocks.SecretManagementClientMock{
-		DeleteSecretFunc: func(_ context.Context, _ secretmanagersvc.SecretLocation, _ string) error { return nil },
+		DeleteSecretFunc: func(_ context.Context, location secretmanagersvc.SecretLocation, _ string) error {
+			deletedEnvs = append(deletedEnvs, location.EnvironmentName)
+			return nil
+		},
 	}
 	repo := &repomocks.AgentThunderClientRepositoryMock{
 		FindByAgentFunc: func(_ context.Context, _, _, _ string) ([]models.AgentThunderClient, error) {
@@ -2375,21 +2219,12 @@ func TestDeleteAllBindings_CleansUpIdentitySecretReferences(t *testing.T) {
 		UpdateSecretRefFunc: func(_ context.Context, _ uuid.UUID, _ string) error { return nil },
 	}
 
-	var cleanedEnvs []string
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(_ context.Context, orgName, agentName, envName string) error {
-			assert.Equal(t, "acme", orgName)
-			assert.Equal(t, "my-agent", agentName)
-			cleanedEnvs = append(cleanedEnvs, envName)
-			return nil
-		},
-	}
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	svc := newTestProvisioningService(repo, resolver, store)
 
 	svc.DeleteAllBindings(context.Background(), "acme", "proj1", "my-agent")
 
-	assert.Equal(t, []string{"dev"}, cleanedEnvs,
-		"SecretReference cleanup must run for internal bindings only — external agents never had one")
+	assert.Equal(t, []string{"dev"}, deletedEnvs,
+		"the stored secret is deleted only for the binding that actually has one")
 }
 
 func TestDeleteAllBindings_ContinuesExternalCleanupWhenDBRowDeleteFails(t *testing.T) {
@@ -2427,20 +2262,12 @@ func TestDeleteAllBindings_ContinuesExternalCleanupWhenDBRowDeleteFails(t *testi
 		},
 		UpdateSecretRefFunc: func(_ context.Context, _ uuid.UUID, _ string) error { return nil },
 	}
-	secretRefCleaned := false
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(_ context.Context, _, _, _ string) error {
-			secretRefCleaned = true
-			return nil
-		},
-	}
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
+	svc := newTestProvisioningService(repo, resolver, store)
 
 	svc.DeleteAllBindings(context.Background(), "acme", "proj1", "my-agent")
 
 	assert.True(t, thunderDeleted, "a failed local DB row delete must not block deleting the live Thunder identity")
-	assert.True(t, secretDeleted, "a failed local DB row delete must not block deleting the OpenBao secret")
-	assert.True(t, secretRefCleaned, "a failed local DB row delete must not block deleting the SecretReference CR")
+	assert.True(t, secretDeleted, "a failed local DB row delete must not block deleting the stored secret")
 }
 
 func TestAttemptProvision_SerializesWithRegenerateSecret(t *testing.T) {
@@ -2519,4 +2346,91 @@ func TestAttemptProvision_SerializesWithRegenerateSecret(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("RegenerateSecret never unblocked after AttemptProvision released the binding lock")
 	}
+}
+
+// TestHealSecretRef_CorrectsStaleRow guards the one-time backfill: a binding
+// whose SecretRefPath still holds the old locally-computed KV-path guess
+// (from before storeCredential was fixed) gets corrected to the deterministic
+// SecretReference name — a pure local recomputation, no secret manager call
+// at all (the mock's every func is nil; a call would panic).
+func TestHealSecretRef_CorrectsStaleRow(t *testing.T) {
+	svc := newTestProvisioningService(
+		&repomocks.AgentThunderClientRepositoryMock{},
+		&clientmocks.EnvThunderResolverMock{},
+		&clientmocks.SecretManagementClientMock{},
+	)
+	impl := svc.(*agentThunderProvisioningService)
+
+	refName := agentIdentitySecretLocation("acme", "proj1", "my-agent", "staging").SecretRefName()
+	binding := models.AgentThunderClient{
+		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
+		ProvisioningType: models.AgentProvisioningTypeInternal,
+		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity", // the old, wrong KV-path-shaped guess
+	}
+
+	var updatedID uuid.UUID
+	var updatedPath string
+	impl.repo = &repomocks.AgentThunderClientRepositoryMock{
+		UpdateSecretRefFunc: func(_ context.Context, id uuid.UUID, secretRefPath string) error {
+			updatedID = id
+			updatedPath = secretRefPath
+			return nil
+		},
+	}
+
+	require.NoError(t, impl.HealSecretRef(context.Background(), binding))
+	assert.Equal(t, binding.ID, updatedID)
+	assert.Equal(t, "resolved/"+refName, updatedPath, "must heal to the value resolved via GetSecretReference, never a locally-computed name")
+}
+
+// TestHealSecretRef_NoOpWhenAlreadyCorrect guards against a needless DB write
+// on every restart once a binding has already been healed (or was always
+// correct, e.g. provisioned after the fix shipped).
+func TestHealSecretRef_NoOpWhenAlreadyCorrect(t *testing.T) {
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
+			t.Fatal("must not write when the stored ref is already correct")
+			return nil
+		},
+	}
+	svc := newTestProvisioningService(repo, &clientmocks.EnvThunderResolverMock{}, &clientmocks.SecretManagementClientMock{})
+	impl := svc.(*agentThunderProvisioningService)
+
+	refName := agentIdentitySecretLocation("acme", "proj1", "my-agent", "staging").SecretRefName()
+	binding := models.AgentThunderClient{
+		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
+		ProvisioningType: models.AgentProvisioningTypeInternal,
+		SecretRefPath:    "resolved/" + refName, // already the resolved value HealSecretRef would derive
+	}
+
+	require.NoError(t, impl.HealSecretRef(context.Background(), binding))
+}
+
+// TestHealSecretRef_SkipsExternalAndRevoked guards the two states that must
+// never be touched: external agents never have a stored secret at all, and a
+// revoked binding's empty SecretRefPath must stay empty, not be "healed"
+// into a name pointing at a secret that no longer exists.
+func TestHealSecretRef_SkipsExternalAndRevoked(t *testing.T) {
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
+			t.Fatal("must not write for an external agent or a revoked (empty SecretRefPath) binding")
+			return nil
+		},
+	}
+	svc := newTestProvisioningService(repo, &clientmocks.EnvThunderResolverMock{}, &clientmocks.SecretManagementClientMock{})
+	impl := svc.(*agentThunderProvisioningService)
+
+	external := models.AgentThunderClient{
+		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
+		ProvisioningType: models.AgentProvisioningTypeExternal,
+		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity",
+	}
+	revoked := models.AgentThunderClient{
+		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
+		ProvisioningType: models.AgentProvisioningTypeInternal,
+		SecretRefPath:    "",
+	}
+
+	require.NoError(t, impl.HealSecretRef(context.Background(), external))
+	require.NoError(t, impl.HealSecretRef(context.Background(), revoked))
 }

--- a/agent-manager-service/services/agent_thunder_reconciler.go
+++ b/agent-manager-service/services/agent_thunder_reconciler.go
@@ -246,7 +246,7 @@ func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx conte
 		for _, binding := range recent {
 			if healSecretRefs {
 				if err := s.provisioning.HealSecretRef(ctx, binding); err != nil {
-					s.logger.Warn("Failed to heal agent thunder binding secret ref", "bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName, "error", err)
+					s.logger.Warn("Failed to heal agent thunder binding secret ref", "ouID", binding.OUID, "bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName, "error", err)
 				}
 			}
 			reconcileWorkloadInjection(ctx, s.injector, binding, s.logger)

--- a/agent-manager-service/services/agent_thunder_reconciler.go
+++ b/agent-manager-service/services/agent_thunder_reconciler.go
@@ -194,7 +194,7 @@ const identityInjectionReconcileWindow = 2 * time.Hour
 // lock; concurrent instances converge on the same desired state, so the worst
 // case is a duplicate content-identical write.
 func (s *agentThunderReconcilerService) runIdentityInjectionReconcile(ctx context.Context) {
-	s.pageIdentityInjectionReconcile(ctx, time.Now().Add(-identityInjectionReconcileWindow))
+	s.pageIdentityInjectionReconcile(ctx, time.Now().Add(-identityInjectionReconcileWindow), false)
 }
 
 // runInitialIdentityInjectionBackfill runs once per process start (see Start)
@@ -217,7 +217,7 @@ func (s *agentThunderReconcilerService) runIdentityInjectionReconcile(ctx contex
 // on every one-minute tick forever, not just once (or a few times) per
 // restart.
 func (s *agentThunderReconcilerService) runInitialIdentityInjectionBackfill(ctx context.Context) {
-	s.pageIdentityInjectionReconcile(ctx, time.Time{})
+	s.pageIdentityInjectionReconcile(ctx, time.Time{}, true)
 }
 
 // pageIdentityInjectionReconcile reconciles every COMPLETED internal binding
@@ -229,7 +229,13 @@ func (s *agentThunderReconcilerService) runInitialIdentityInjectionBackfill(ctx 
 // newest ones — the same oldest page would be reselected every call until
 // enough of them aged out of the (periodic caller's) window, and a newer
 // binding could miss its entire window without ever being reconciled.
-func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx context.Context, createdAfter time.Time) {
+//
+// healSecretRefs is true only for the unbounded startup pass
+// (runInitialIdentityInjectionBackfill): HealSecretRef is cheap (one bounded
+// OpenChoreo read) and idempotent (a no-op once a binding's SecretRefPath
+// already matches), but there is no reason to re-run it against every
+// already-healed row on every one-minute periodic tick too.
+func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx context.Context, createdAfter time.Time, healSecretRefs bool) {
 	var cursor *repositories.ReconcileCursor
 	for {
 		recent, err := s.repo.FindRecentlyCompletedInternal(ctx, createdAfter, cursor, reconcilerBatchSize)
@@ -238,6 +244,11 @@ func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx conte
 			return
 		}
 		for _, binding := range recent {
+			if healSecretRefs {
+				if err := s.provisioning.HealSecretRef(ctx, binding); err != nil {
+					s.logger.Warn("Failed to heal agent thunder binding secret ref", "bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName, "error", err)
+				}
+			}
 			reconcileWorkloadInjection(ctx, s.injector, binding, s.logger)
 		}
 		if len(recent) < reconcilerBatchSize {

--- a/agent-manager-service/services/agent_thunder_reconciler_test.go
+++ b/agent-manager-service/services/agent_thunder_reconciler_test.go
@@ -338,7 +338,11 @@ func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_CoversBindin
 			return nil
 		},
 	}
-	s := &agentThunderReconcilerService{injector: injector, repo: repo, logger: slog.Default(), stopCh: make(chan struct{})}
+	// provisioning must be set (even with no healFunc) because
+	// runInitialIdentityInjectionBackfill below calls HealSecretRef on every
+	// binding it reconciles — unset would panic on the nil interface, not
+	// silently skip it.
+	s := &agentThunderReconcilerService{injector: injector, provisioning: &fakeProvisioningService{}, repo: repo, logger: slog.Default(), stopCh: make(chan struct{})}
 
 	s.runIdentityInjectionReconcile(ctx)
 	mu.Lock()
@@ -351,11 +355,111 @@ func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_CoversBindin
 	assert.True(t, reconciled, "the one-time backfill must reconcile a binding regardless of age")
 }
 
+// TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealsEveryBinding
+// verifies the startup pass actually invokes HealSecretRef for each binding it
+// covers, and that a periodic (non-startup) sweep does not.
+func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealsEveryBinding(t *testing.T) {
+	ctx := context.Background()
+	repo := repositories.NewAgentThunderClientRepo(db.GetDB())
+	const org, project, agent, env = "test-org", "test-proj", "reconcile-heal-agent", "production"
+	t.Cleanup(func() { _ = repo.DeleteByAgent(ctx, org, project, agent) })
+
+	require.NoError(t, repo.Upsert(ctx, &models.AgentThunderClient{
+		OUID: org, ProjectName: project, AgentName: agent, EnvironmentName: env,
+		ProvisioningType: models.AgentProvisioningTypeInternal, Status: models.AgentThunderStatusCompleted,
+		ThunderAgentID: "thunder-heal", ThunderClientID: "client-heal", SecretRefPath: "path/heal",
+	}))
+
+	var mu sync.Mutex
+	var healed, reconciled int
+	provisioning := &fakeProvisioningService{
+		healFunc: func(_ context.Context, binding models.AgentThunderClient) error {
+			if binding.OUID != org || binding.ProjectName != project || binding.AgentName != agent {
+				return nil // a stray binding from an unrelated concurrent test
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			healed++
+			return nil
+		},
+	}
+	injector := &agentIdentityInjectorStub{
+		ReconcileForEnvironmentFunc: func(_ context.Context, ouID, projectName, agentName, envName string) error {
+			if ouID != org || projectName != project || agentName != agent {
+				return nil
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			reconciled++
+			return nil
+		},
+	}
+	s := &agentThunderReconcilerService{injector: injector, provisioning: provisioning, repo: repo, logger: slog.Default(), stopCh: make(chan struct{})}
+
+	s.runIdentityInjectionReconcile(ctx)
+	mu.Lock()
+	assert.Equal(t, 0, healed, "the periodic sweep must not call HealSecretRef — only the startup backfill does")
+	assert.Equal(t, 1, reconciled, "the periodic sweep must still reconcile the workload")
+	mu.Unlock()
+
+	s.runInitialIdentityInjectionBackfill(ctx)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, healed, "the startup backfill must call HealSecretRef for the binding it covers")
+	assert.Equal(t, 2, reconciled, "the startup backfill must still reconcile the workload after healing")
+}
+
+// TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealFailureDoesNotBlockReconcile
+// verifies a HealSecretRef failure is logged and swallowed rather than
+// aborting the binding's workload reconcile — matching HealSecretRef's own
+// doc comment ("best-effort... a failed heal on one binding just means that
+// binding's pod keeps failing exactly as it does today until the next sweep
+// retries it; no regression versus current behavior").
+func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealFailureDoesNotBlockReconcile(t *testing.T) {
+	ctx := context.Background()
+	repo := repositories.NewAgentThunderClientRepo(db.GetDB())
+	const org, project, agent, env = "test-org", "test-proj", "reconcile-heal-fail-agent", "production"
+	t.Cleanup(func() { _ = repo.DeleteByAgent(ctx, org, project, agent) })
+
+	require.NoError(t, repo.Upsert(ctx, &models.AgentThunderClient{
+		OUID: org, ProjectName: project, AgentName: agent, EnvironmentName: env,
+		ProvisioningType: models.AgentProvisioningTypeInternal, Status: models.AgentThunderStatusCompleted,
+		ThunderAgentID: "thunder-heal-fail", ThunderClientID: "client-heal-fail", SecretRefPath: "path/heal-fail",
+	}))
+
+	provisioning := &fakeProvisioningService{
+		healFunc: func(context.Context, models.AgentThunderClient) error {
+			return fmt.Errorf("simulated heal failure")
+		},
+	}
+	var mu sync.Mutex
+	var reconciled bool
+	injector := &agentIdentityInjectorStub{
+		ReconcileForEnvironmentFunc: func(_ context.Context, ouID, projectName, agentName, envName string) error {
+			if ouID != org || projectName != project || agentName != agent {
+				return nil
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			reconciled = true
+			return nil
+		},
+	}
+	s := &agentThunderReconcilerService{injector: injector, provisioning: provisioning, repo: repo, logger: slog.Default(), stopCh: make(chan struct{})}
+
+	require.NotPanics(t, func() { s.runInitialIdentityInjectionBackfill(ctx) })
+	mu.Lock()
+	defer mu.Unlock()
+	assert.True(t, reconciled, "a HealSecretRef failure must not prevent the binding's workload from still being reconciled")
+}
+
 // fakeProvisioningService is a minimal hand-written test double for
-// AgentThunderProvisioningService — only AttemptProvision is exercised by the
-// reconciler, so that is the only method given a real implementation.
+// AgentThunderProvisioningService — only AttemptProvision and HealSecretRef
+// are exercised by the reconciler, so those are the only methods given a
+// real implementation.
 type fakeProvisioningService struct {
 	attemptFunc func(ctx context.Context, binding models.AgentThunderClient)
+	healFunc    func(ctx context.Context, binding models.AgentThunderClient) error
 }
 
 func (f *fakeProvisioningService) ProvisionForAgent(context.Context, string, string, string, models.AgentProvisioningType, []string, string) {
@@ -400,6 +504,13 @@ func (f *fakeProvisioningService) GetAgentRoles(context.Context, string, string,
 
 func (f *fakeProvisioningService) GetAgentGroups(context.Context, string, string, string, string) ([]thundersvc.ThunderGroup, error) {
 	return nil, nil
+}
+
+func (f *fakeProvisioningService) HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error {
+	if f.healFunc == nil {
+		return nil
+	}
+	return f.healFunc(ctx, binding)
 }
 
 // compile-time interface check

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -509,7 +509,7 @@ func ProvideAgentIdentityInjectionService(
 	cfg config.Config,
 	logger *slog.Logger,
 ) services.AgentIdentityInjectionService {
-	return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.RefreshInterval, logger)
+	return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger)
 }
 
 func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -8,6 +8,9 @@ package wiring
 
 import (
 	"fmt"
+	"log/slog"
+	"time"
+
 	"github.com/google/wire"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/observersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
@@ -24,8 +27,6 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 	"gorm.io/gorm"
-	"log/slog"
-	"time"
 )
 
 // Injectors from wire.go:

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -774,7 +774,7 @@ func ProvideAgentIdentityInjectionService(
 	cfg config.Config,
 	logger *slog.Logger,
 ) services.AgentIdentityInjectionService {
-	return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.RefreshInterval, logger)
+	return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger)
 }
 
 func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -8,9 +8,6 @@ package wiring
 
 import (
 	"fmt"
-	"log/slog"
-	"time"
-
 	"github.com/google/wire"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/observersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
@@ -27,6 +24,8 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 	"gorm.io/gorm"
+	"log/slog"
+	"time"
 )
 
 // Injectors from wire.go:
@@ -275,7 +274,7 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	agentKindRepository := ProvideAgentKindRepository(db)
 	agentKindService := services.NewAgentKindService(agentKindRepository, openChoreoClient)
 	artifactRepository := ProvideArtifactRepository(db)
-	agentThunderProvisioningService := services.NewAgentThunderProvisioningService(agentThunderClientRepository, envThunderResolver, secretManagementClient, agentIdentityInjectionService, logger)
+	agentThunderProvisioningService := services.NewAgentThunderProvisioningService(agentThunderClientRepository, envThunderResolver, secretManagementClient, openChoreoClient, agentIdentityInjectionService, logger)
 	observerSvcClient := ProvideTestObserverClient(testClients)
 	monitorRepository := ProvideMonitorRepository(db)
 	customEvaluatorRepository := ProvideCustomEvaluatorRepository(db)

--- a/console/workspaces/libs/api-client/src/hooks/agent-mcp-configs.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agent-mcp-configs.ts
@@ -104,6 +104,13 @@ export function useCreateAgentMCPConfig() {
       queryClient.invalidateQueries({
         queryKey: ["agent-mcp-proxies", toAgentPathParams(variables.params)],
       });
+      // A new MCP config changes the agent's AgentID scope union (see
+      // agent_configuration_service.go's refreshTouchedMCPEnvironments) — the
+      // deploy cards' displayed AMP_AGENTID_SCOPES value comes from this query,
+      // so it must invalidate too or it keeps showing the pre-change scope list.
+      queryClient.invalidateQueries({
+        queryKey: ["agent-configurations", toAgentPathParams(variables.params)],
+      });
     },
   });
 }
@@ -127,6 +134,10 @@ export function useUpdateAgentMCPConfig() {
       queryClient.invalidateQueries({
         queryKey: ["agent-mcp-proxies", toAgentPathParams(variables.params)],
       });
+      // See useCreateAgentMCPConfig's identical invalidation for why.
+      queryClient.invalidateQueries({
+        queryKey: ["agent-configurations", toAgentPathParams(variables.params)],
+      });
     },
   });
 }
@@ -141,6 +152,10 @@ export function useDeleteAgentMCPConfig() {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
       queryClient.invalidateQueries({
         queryKey: ["agent-mcp-proxies", toAgentPathParams(variables)],
+      });
+      // See useCreateAgentMCPConfig's identical invalidation for why.
+      queryClient.invalidateQueries({
+        queryKey: ["agent-configurations", toAgentPathParams(variables)],
       });
     },
   });

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
@@ -192,6 +192,16 @@ spec:
                     protocol: UDP
                   - port: 53
                     protocol: TCP
+              # AgentID's per-env Thunder instance (amp-thunder-<org>-<env>) issues
+              # OAuth2 tokens on this port. Agents attach an AgentID bearer-token auth
+              # step to every MCP/LLM proxy call, so this egress is needed even though
+              # the proxy traffic itself goes out via the gateway rule below. Thunder
+              # namespaces carry no distinguishing label today (unlike the gateway rule's
+              # amp.wso2.com/api-platform-gateway), so this is scoped by port only, not
+              # by namespace.
+              - ports:
+                  - port: 8090
+                    protocol: TCP
               - to:
                   - namespaceSelector:
                       matchLabels:


### PR DESCRIPTION
## Purpose
- Internal agents got permanently stuck at `CreateContainerConfigError`: `storeCredential` computed a guessed OpenBao KV path for the AgentID client secret locally instead of resolving the real one, so the pod's `SecretKeyRef` pointed at a location that never synced.
- An agent configured with more than one MCP proxy only ever got one proxy's scopes in its AgentID token request, since `resolveAgentIdentityScopes` read an arbitrary single `AgentConfiguration` row (`GetByAgentID`) instead of every MCP config the agent has.
- Adding or removing an MCP tool on an already-deployed agent never refreshed its injected `AMP_AGENTID_SCOPES`, so the running pod kept requesting the old scope list until an unrelated deploy, promote, or rotation happened to touch it.
- The console's Configure page kept showing that stale scope list even after a fix landed server-side, because MCP config mutations never invalidated the `agent-configurations` query the deploy cards read from.
- Sandboxed agent pods configured with any MCP proxy could not mint an AgentID token at all: the sandbox NetworkPolicy had no egress rule for the environment's Thunder instance on port 8090.
- Resolved : https://github.com/wso2/agent-manager/issues/1473

## Goals
- Resolve and persist the AgentID client secret's real SecretReference KV path instead of guessing it, and heal existing bindings that already have the wrong value.
- Aggregate AgentID scopes across every MCP proxy an agent is bound to, not just one.
- Refresh an already-running agent's scopes immediately when an MCP tool is added or removed.
- Keep the console's displayed scope list in sync with what the backend actually injects.
- Allow sandboxed pods to reach their environment's Thunder instance so AgentID token requests succeed.

## Approach
- `agentThunderProvisioningService.storeCredential` now reads back the real KV path via `resolveClientSecretKVPath` (`GetSecretReference`) after `CreateSecret`, instead of computing one with `agentIdentitySecretLocation(...).KVPath()`.
- Added `HealSecretRef`, a one-time, per-binding correction that re-resolves and overwrites a stale `SecretRefPath`, hooked into the reconciler's existing unbounded startup sweep in `agent_thunder_reconciler.go`.
- `agentIdentityInjectionService.ensureSecretReference` now builds its `SecretReference` request from the binding's own stored `SecretRefPath`, removing the second, independently-guessing writer that used to race the first.
- Fixed a related ordering bug in `DeleteAllBindings`: SecretReference cleanup now runs before the `ThunderAgentID == ""` early return again, so a binding that crashed mid-provisioning doesn't leak its SecretReference on agent deletion.
- Added `AgentConfigurationRepository.ListMCPConfigsByAgent` and switched `resolveAgentIdentityScopes` to use it, unioning `EnvMCPMappings` across every returned MCP config instead of trusting `GetByAgentID`'s single arbitrary row.
- `agentConfigurationService.createMCPConfig` and `deleteMCPConfig` now call the existing `refreshTouchedMCPEnvironments` helper (already used by `updateMCPConfig`) so a scope change from adding or removing a tool rolls the pod right away.
- The console's `useCreateAgentMCPConfig`, `useUpdateAgentMCPConfig`, and `useDeleteAgentMCPConfig` hooks now also invalidate the `agent-configurations` query key on success, alongside the `agent-mcp-configs`/`agent-mcp-proxies` invalidations they already did.
- Added a port-8090 egress rule (scoped by port, no destination selector, since env-Thunder namespaces carry no distinguishing label) to the sandbox `NetworkPolicy` in `agent-api.yaml`'s `SandboxTemplate`.

## User stories
As a platform operator, an internal agent's AgentID credential and scopes now inject correctly on first deploy, stay correct across MCP tool changes without a manual redeploy, and the console shows the same scope list the running pod actually has.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   `agent_identity_injection_service_unit_test.go` covers scope aggregation across multiple MCP configs (`TestResolveAgentIdentityScopes_MultipleProxies_ReturnsSortedUnion` and siblings) and SecretReference create/update/conflict paths. `agent_thunder_provisioning_service_test.go` adds `TestStoreCredential_ConflictMarker_CleansUpAndRetries` and `TestStoreCredential_ConflictMarker_CleanupFails_WrapsBothErrors` to cover the create-conflict recovery path that previously had no real coverage, plus `TestHealSecretRef_CorrectsStaleRow`, `TestHealSecretRef_NoOpWhenAlreadyCorrect`, and `TestHealSecretRef_SkipsExternalAndRevoked`. `make test-unit`: all packages pass.
 - Integration tests
   `agent_thunder_reconciler_test.go` adds `TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealsEveryBinding` and `_HealFailureDoesNotBlockReconcile`, proving the startup sweep calls `HealSecretRef` for every binding it covers, the periodic sweep does not, and a heal failure doesn't block the workload reconcile. `make test-integration`: 769 passed, 0 failed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
macOS (Darwin), Docker Compose for the local database and agent-manager-service, k3d for the Kubernetes-based parts (OpenChoreo, ThunderID). Go 1.25, Postgres (agentmanager container), Node/pnpm via Rush for the console, `tsc --noEmit` and `golangci-lint` both clean on every changed file.

## Learning
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and managing all MCP configurations associated with an agent.
  * Added automatic healing of outdated credential references during startup reconciliation.
  * Enabled environment connectivity to Thunder instances on port 8090.
  * Added a dedicated, configurable refresh interval for agent identity synchronization.

* **Bug Fixes**
  * Improved credential creation, rotation, cleanup, and retry handling.
  * Ensured configuration data refreshes after MCP configuration changes.
  * Improved identity synchronization across environments.
  * Added validation for invalid or non-positive refresh intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->