### PR TITLE
Support Console/Agent "try it" page for SSE streaming

### DIFF
--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.test.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.test.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.test.tsx
@@ -254,7 +254,7 @@ describe("AgentChat", () => {
     controller.close();
 
     await waitFor(() =>
-      expect(screen.getByText(/Expected an SSE data: line/i)).toBeInTheDocument(),
+      expect(screen.getByText(/Expected an SSE data:/i)).toBeInTheDocument(),
     );
     expect(pushSnackBar).toHaveBeenCalledWith(
       expect.objectContaining({ type: "info", message: expect.stringContaining("Streamed response didn't match") }),

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.test.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  useGetAgent,
+  useGetAgentEndpoints,
+  useTestAgentAPIKey,
+} from "@agent-management-platform/api-client";
+import { AgentChat } from "./AgentChat";
+
+vi.mock("@agent-management-platform/api-client", () => ({
+  useGetAgent: vi.fn(),
+  useGetAgentEndpoints: vi.fn(),
+  useTestAgentAPIKey: vi.fn(),
+}));
+
+const pushSnackBar = vi.fn();
+
+vi.mock("@agent-management-platform/views", () => ({
+  FadeIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  MarkdownView: ({ content }: { content: string }) => <div>{content}</div>,
+  useSnackBar: () => ({ pushSnackBar }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useParams: () => ({
+      agentId: "agent-1",
+      orgId: "org-1",
+      projectId: "proj-1",
+      envId: "env-1",
+    }),
+  };
+});
+
+function mockHooks() {
+  vi.mocked(useGetAgentEndpoints).mockReturnValue({
+    data: { dev: { url: "https://agent.example.test" } },
+    isLoading: false,
+  } as unknown as ReturnType<typeof useGetAgentEndpoints>);
+
+  vi.mocked(useGetAgent).mockReturnValue({
+    data: {
+      displayName: "Test Agent",
+      configurations: {
+        enableApiKeySecurity: false,
+        enableOAuthSecurity: false,
+      },
+    },
+  } as ReturnType<typeof useGetAgent>);
+
+  vi.mocked(useTestAgentAPIKey).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useTestAgentAPIKey>);
+}
+
+async function sendMessage(text: string) {
+  const input = await screen.findByPlaceholderText("Type your message...");
+  fireEvent.change(input, { target: { value: text } });
+  const sendButton = screen.getByRole("button", { name: /send/i });
+  fireEvent.click(sendButton);
+}
+
+describe("AgentChat", () => {
+  beforeEach(() => {
+    mockHooks();
+    pushSnackBar.mockClear();
+  });
+
+  it("renders the assistant reply from a buffered JSON response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ response: "Hello from agent" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    render(<AgentChat />);
+    await sendMessage("Hi");
+
+    await waitFor(() =>
+      expect(screen.getByText("Hello from agent")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders and accumulates the assistant reply as SSE chunks stream in", async () => {
+    const encoder = new TextEncoder();
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+      ),
+    );
+
+    render(<AgentChat />);
+    await sendMessage("Hi");
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument(),
+    );
+
+    controller.enqueue(
+      encoder.encode(
+        'data: {"node":"answer","content":[{"type":"text","text":"Hel"}]}\n\n',
+      ),
+    );
+    await waitFor(() => expect(screen.getByText("Hel")).toBeInTheDocument());
+
+    controller.enqueue(
+      encoder.encode(
+        'data: {"node":"answer","content":[{"type":"text","text":"lo"}]}\n\n',
+      ),
+    );
+    await waitFor(() => expect(screen.getByText("Hello")).toBeInTheDocument());
+
+    controller.close();
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /stop/i })).not.toBeInTheDocument(),
+    );
+  });
+
+  it("aborts the stream and keeps the partial reply when Stop is clicked", async () => {
+    const encoder = new TextEncoder();
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        init?.signal?.addEventListener("abort", () => {
+          controller.error(new DOMException("Aborted", "AbortError"));
+        });
+        return Promise.resolve(
+          new Response(stream, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+        );
+      }),
+    );
+
+    render(<AgentChat />);
+    await sendMessage("Hi");
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument(),
+    );
+
+    controller.enqueue(
+      encoder.encode(
+        'data: {"node":"answer","content":[{"type":"text","text":"Partial"}]}\n\n',
+      ),
+    );
+    await waitFor(() => expect(screen.getByText("Partial")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /stop/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /stop/i })).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Partial")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows a hint and no crash when a buffered JSON response is missing `response`", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ unexpected: "shape" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+
+    render(<AgentChat />);
+    await sendMessage("Hi");
+
+    await waitFor(() =>
+      expect(screen.getByText(/Expected JSON body/i)).toBeInTheDocument(),
+    );
+    expect(pushSnackBar).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "info", message: expect.stringContaining("Response didn't match") }),
+    );
+  });
+
+  it("shows a hint when the stream ends without a recognized answer chunk", async () => {
+    const encoder = new TextEncoder();
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        controller = c;
+      },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        }),
+      ),
+    );
+
+    render(<AgentChat />);
+    await sendMessage("Hi");
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument(),
+    );
+
+    controller.enqueue(encoder.encode('data: {"unexpected":"shape"}\n\n'));
+    controller.close();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Expected an SSE data: line/i)).toBeInTheDocument(),
+    );
+    expect(pushSnackBar).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "info", message: expect.stringContaining("Streamed response didn't match") }),
+    );
+  });
+});

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
@@ -33,7 +33,8 @@ import {
 } from "@agent-management-platform/api-client";
 import { useParams } from "react-router-dom";
 import { ChatMessage } from "./subComponents/ChatMessage";
-import { FadeIn } from "@agent-management-platform/views";
+import { FadeIn, useSnackBar } from "@agent-management-platform/views";
+import { readSSEStream, parseStreamChunk } from "./utils/sse";
 
 interface ChatMessage {
   id: string;
@@ -47,7 +48,23 @@ interface ChatMessage {
 // so a single delayed retry with the same key rides out that window.
 const TEST_KEY_PROPAGATION_RETRY_DELAY_MS = 2000;
 
+const FORMAT_MISMATCH_SNACKBAR_DURATION_MS = 15000;
+
+const FORMAT_MISMATCH_SNACKBAR_TEXT: Record<"streaming" | "http", string> = {
+  streaming:
+    "Streamed response didn't match the expected format",
+  http: "Response didn't match the expected format ",
+};
+
+
+const FORMAT_HINT_DETAIL: Record<"streaming" | "http", string> = {
+  streaming:
+    "Expected an SSE data:{node: string, content: [{type: string, text?: string}]}",
+  http: "Expected JSON body: {response: string}",
+};
+
 export function AgentChat() {
+  const { pushSnackBar } = useSnackBar();
   const [endpoint, setEndpoint] = useState("");
   const [message, setMessage] = useState("");
   const defaultBody = useMemo(() => {
@@ -65,6 +82,8 @@ export function AgentChat() {
     null,
   );
   const [isRefreshingKey, setIsRefreshingKey] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const { agentId, orgId, projectId, envId } = useParams();
   const { data: endpoints, isLoading: isEndpointsLoading } =
@@ -114,6 +133,74 @@ export function AgentChat() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
+  const handleStreamingResponse = async (body: ReadableStream<Uint8Array>) => {
+    const assistantMessageId = (Date.now() + 1).toString();
+    let started = false;
+
+    try {
+      for await (const raw of readSSEStream(body)) {
+        const chunk = parseStreamChunk(raw);
+        if (!chunk || chunk.node !== "answer") continue;
+
+        const text = chunk.content
+          .filter((part) => part.type === "text" && typeof part.text === "string")
+          .map((part) => part.text as string)
+          .join("");
+        if (!text) continue;
+
+        if (!started) {
+          started = true;
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: assistantMessageId,
+              role: "assistant",
+              content: text,
+              timestamp: new Date(),
+            },
+          ]);
+        } else {
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === assistantMessageId ? { ...m, content: m.content + text } : m,
+            ),
+          );
+        }
+      }
+
+      // Surface a hint instead of leaving the reply blank.
+      if (!started) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: assistantMessageId,
+            role: "assistant",
+            content: `${FORMAT_HINT_DETAIL.streaming}`,
+            timestamp: new Date(),
+          },
+        ]);
+        pushSnackBar({
+          message: FORMAT_MISMATCH_SNACKBAR_TEXT.streaming,
+          type: "info",
+          duration: FORMAT_MISMATCH_SNACKBAR_DURATION_MS,
+        });
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        return;
+      }
+      const errorMsg =
+        err instanceof Error
+          ? err.message
+          : "An error occurred while streaming the response";
+      setError(errorMsg);
+    }
+  };
+
+  const handleStopStreaming = () => {
+    abortControllerRef.current?.abort();
+  };
+
   const handleSendMessage = async () => {
     if (!message.trim() || isLoading || oauthOnly) return;
     if (securityEnabled && !testKey?.apiKey) {
@@ -133,6 +220,10 @@ export function AgentChat() {
     setError(null);
     setKeyAlert(null);
     setIsLoading(true);
+    setIsStreaming(false);
+
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
 
     try {
       const requestBody = {
@@ -152,6 +243,7 @@ export function AgentChat() {
           headers,
           body: JSON.stringify(requestBody),
           referrerPolicy: "",
+          signal: abortController.signal,
         });
       };
       // The gateway strips CORS headers from auth-rejected responses, so a
@@ -202,8 +294,15 @@ export function AgentChat() {
         return;
       }
 
-      let responseData: any;
       const contentType = apiResponse.headers.get("content-type");
+
+      if (apiResponse.ok && contentType?.includes("text/event-stream") && apiResponse.body) {
+        setIsStreaming(true);
+        await handleStreamingResponse(apiResponse.body);
+        return;
+      }
+
+      let responseData: any;
       if (contentType && contentType.includes("application/json")) {
         responseData = await apiResponse.json();
       } else {
@@ -227,10 +326,10 @@ export function AgentChat() {
         };
         setMessages((prev) => [...prev, errorMessageObj]);
       } else {
-        const responseText =
-          typeof responseData?.response === "string"
-            ? (responseData.response as string)
-            : JSON.stringify(responseData?.result, null, 4);
+        const hasExpectedShape = typeof responseData?.response === "string";
+        const responseText = hasExpectedShape
+          ? (responseData.response as string)
+          : `${JSON.stringify(responseData?.result, null, 4)}\n\n${FORMAT_HINT_DETAIL.http}`;
 
         const assistantMessage: ChatMessage = {
           id: (Date.now() + 1).toString(),
@@ -239,6 +338,13 @@ export function AgentChat() {
           timestamp: new Date(),
         };
         setMessages((prev) => [...prev, assistantMessage]);
+        if (!hasExpectedShape) {
+          pushSnackBar({
+            message: FORMAT_MISMATCH_SNACKBAR_TEXT.http,
+            type: "info",
+            duration: FORMAT_MISMATCH_SNACKBAR_DURATION_MS,
+          });
+        }
       }
     } catch (err) {
       const errorMsg =
@@ -256,6 +362,7 @@ export function AgentChat() {
       setMessages((prev) => [...prev, errorMessageObj]);
     } finally {
       setIsLoading(false);
+      setIsStreaming(false);
     }
   };
 
@@ -482,21 +589,27 @@ export function AgentChat() {
             size="small"
             disabled={inputDisabled}
           />
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={handleSendMessage}
-            disabled={sendDisabled}
-            startIcon={
-              isLoading || isEndpointsLoading ? (
-                <CircularProgress size={16} />
-              ) : (
-                <Send size={16} />
-              )
-            }
-          >
-            {isLoading || isEndpointsLoading ? "Sending" : "Send"}
-          </Button>
+          {isStreaming ? (
+            <Button variant="outlined" color="primary" onClick={handleStopStreaming}>
+              Stop
+            </Button>
+          ) : (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSendMessage}
+              disabled={sendDisabled}
+              startIcon={
+                isLoading || isEndpointsLoading ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <Send size={16} />
+                )
+              }
+            >
+              {isLoading || isEndpointsLoading ? "Sending" : "Send"}
+            </Button>
+          )}
         </Box>
       </Box>
     </FadeIn>

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
@@ -329,7 +329,7 @@ export function AgentChat() {
         const hasExpectedShape = typeof responseData?.response === "string";
         const responseText = hasExpectedShape
           ? (responseData.response as string)
-          : `${JSON.stringify(responseData?.result, null, 4)}\n\n${FORMAT_HINT_DETAIL.http}`;
+          : `${JSON.stringify(responseData, null, 4)}\n\n${FORMAT_HINT_DETAIL.http}`;
 
         const assistantMessage: ChatMessage = {
           id: (Date.now() + 1).toString(),

--- a/console/workspaces/pages/test/src/AgentTest/utils/sse.test.ts
+++ b/console/workspaces/pages/test/src/AgentTest/utils/sse.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/console/workspaces/pages/test/src/AgentTest/utils/sse.test.ts
+++ b/console/workspaces/pages/test/src/AgentTest/utils/sse.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readSSEStream, parseStreamChunk, type StreamChunk } from "./sse";
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string[]> {
+  const results: string[] = [];
+  for await (const data of readSSEStream(stream)) {
+    results.push(data);
+  }
+  return results;
+}
+
+describe("readSSEStream", () => {
+  it("yields the data payload for a single complete event", async () => {
+    const stream = streamFromChunks(['data: {"node":"answer"}\n\n']);
+    await expect(collect(stream)).resolves.toEqual(['{"node":"answer"}']);
+  });
+
+  it("reassembles an event split across multiple network reads", async () => {
+    const stream = streamFromChunks(['data: {"no', 'de":"answer"}\n\n']);
+    await expect(collect(stream)).resolves.toEqual(['{"node":"answer"}']);
+  });
+
+  it("joins multi-line data fields with a newline", async () => {
+    const stream = streamFromChunks(["data: line one\ndata: line two\n\n"]);
+    await expect(collect(stream)).resolves.toEqual(["line one\nline two"]);
+  });
+
+  it("ignores comment lines and unrelated SSE fields", async () => {
+    const stream = streamFromChunks([
+      ": this is a comment\nevent: answer\nid: 1\ndata: hello\nretry: 3000\n\n",
+    ]);
+    await expect(collect(stream)).resolves.toEqual(["hello"]);
+  });
+
+  it("yields multiple events found in a single network read", async () => {
+    const stream = streamFromChunks(["data: first\n\ndata: second\n\n"]);
+    await expect(collect(stream)).resolves.toEqual(["first", "second"]);
+  });
+
+  it("flushes a trailing event that arrives without a final blank line", async () => {
+    const stream = streamFromChunks(["data: no trailing newline"]);
+    await expect(collect(stream)).resolves.toEqual(["no trailing newline"]);
+  });
+});
+
+describe("parseStreamChunk", () => {
+  it("parses a valid chunk payload", () => {
+    const chunk = parseStreamChunk(
+      '{"node":"answer","content":[{"type":"text","text":" including"}]}',
+    );
+    const expected: StreamChunk = {
+      node: "answer",
+      content: [{ type: "text", text: " including" }],
+    };
+    expect(chunk).toEqual(expected);
+  });
+
+  it("returns null for the [DONE] sentinel", () => {
+    expect(parseStreamChunk("[DONE]")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseStreamChunk("{not json")).toBeNull();
+  });
+
+  it("returns null when required fields are missing", () => {
+    expect(parseStreamChunk('{"content":[]}')).toBeNull();
+    expect(parseStreamChunk('{"node":"answer"}')).toBeNull();
+  });
+});

--- a/console/workspaces/pages/test/src/AgentTest/utils/sse.ts
+++ b/console/workspaces/pages/test/src/AgentTest/utils/sse.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/console/workspaces/pages/test/src/AgentTest/utils/sse.ts
+++ b/console/workspaces/pages/test/src/AgentTest/utils/sse.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface StreamContentPart {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+export interface StreamChunk {
+  node: string;
+  content: StreamContentPart[];
+}
+
+/**
+ * Reads a `text/event-stream` body and yields each event's joined `data:`
+ * payload as a raw string, in arrival order. Buffers partial lines across
+ * network chunk boundaries, since those don't align with SSE event
+ * boundaries (blank-line-delimited, per the SSE spec).
+ */
+export async function* readSSEStream(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      let boundary = buffer.indexOf("\n\n");
+      while (boundary !== -1) {
+        const rawEvent = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        const data = extractDataField(rawEvent);
+        if (data !== null) {
+          yield data;
+        }
+        boundary = buffer.indexOf("\n\n");
+      }
+    }
+
+    const trailing = buffer.trim();
+    if (trailing) {
+      const data = extractDataField(trailing);
+      if (data !== null) {
+        yield data;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function extractDataField(rawEvent: string): string | null {
+  const dataLines: string[] = [];
+  for (const line of rawEvent.split("\n")) {
+    if (line.startsWith(":")) continue;
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).replace(/^ /, ""));
+    }
+  }
+  return dataLines.length > 0 ? dataLines.join("\n") : null;
+}
+
+/**
+ * Parses a raw SSE `data:` payload into a StreamChunk. Returns null for
+ * the "[DONE]" sentinel, malformed JSON, or a payload missing the fields
+ * this UI relies on — callers should skip (not crash) on null.
+ */
+export function parseStreamChunk(raw: string): StreamChunk | null {
+  if (raw === "[DONE]") return null;
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.node === "string" &&
+      Array.isArray(parsed.content)
+    ) {
+      return parsed as StreamChunk;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Purpose
The current console "Try it" page does not support interaction with SSE streaming agents. Although the response content is received successfully by the frontend the UI does not display or render the streaming output correctly. This PR tries to resolve that issue

## Goals

## Approach

https://github.com/user-attachments/assets/2eca635a-a7a1-4d7c-882b-22d244b90c15


# when recieved response is different from the expected one
<img width="1223" height="788" alt="image" src="https://github.com/user-attachments/assets/5612e236-5c93-4e28-a094-9c80ea6a315a" />


## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

Fixes #1446 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent Chat now displays responses as they stream in real time.
  * Added a Stop button to cancel an in-progress response while preserving partial output.
  * Added clearer handling for incomplete, malformed, or unsupported responses, including helpful hints and notifications.

* **Bug Fixes**
  * Improved chat behavior for interrupted streams and invalid response formats.
  * Enhanced loading and message display states during streamed replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->