### PR TITLE
Fix install-guide traps found in a from-scratch EKS run

### DIFF
--- a/documentation/docs/getting-started/_partials/_amp-installation.mdx
+++ b/documentation/docs/getting-started/_partials/_amp-installation.mdx
@@ -427,6 +427,15 @@ helm install amp-platform-resources \\
 
 <RegistryConfig expanded={props.expandRegistryConfig} />
 
+:::warning Not every registry can back build workflows
+Two properties are required, and the failure surfaces only on the first agent build, long after the platform installs and verifies cleanly:
+
+- **Push-to-create.** Each build pushes its image as `<workflow-run-name>-image` — a repository name that is different on every run, so repositories cannot be pre-created. The registry must create them on push. **Amazon ECR does not** and fails every build with `repository ... not found`; the same applies to any registry that requires repositories to be provisioned first.
+- **Static credentials.** The push step reads a fixed `.dockerconfigjson` from the `registry-push-secret` Secret (or pushes unauthenticated if it is absent). Registries whose credentials expire — ECR again, with its 12-hour tokens — cannot be refreshed by anything in the build pipeline.
+
+[CNCF Distribution](https://distribution.github.io/distribution/), Harbor (with a project set to auto-create), and GitLab's registry satisfy both. If you have no registry yet, running Distribution in-cluster behind an internal LoadBalancer with a cert-manager certificate is a few resources — but it ships with **no authentication**; put htpasswd in front of it before it carries anything real.
+:::
+
 ---
 
 ### Extensions

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -45,7 +45,7 @@ The main flow assumes you control a DNS zone. If you are evaluating on a cluster
 | CPU per node | 4 cores |
 | RAM per node | 8 GB |
 | LoadBalancer support | Required |
-| Default StorageClass | Required |
+| Default StorageClass | Required, and it must actually provision volumes. Stock EKS ships a default `gp2` class bound to the **removed** in-tree provisioner: PVCs are accepted and stay `Pending` forever. Install the EBS CSI driver and make a CSI-backed class (e.g. `gp3`) the default |
 | Node kernel (build nodes) | Linux **6.3+** for user-namespaced agent builds (idmapped-mount support). On older kernels (Ubuntu 22.04's 5.15, Amazon Linux 2's 5.10) set `buildWorkflows.userNamespaces=false` on the Platform Resources chart — see [Troubleshooting](#build-pods-fail-with-mount_attr_idmap--idmap-mounts-errors) |
 | NetworkPolicy-enforcing CNI | Recommended. The Observability and Evaluation extension charts each ship a `NetworkPolicy` (collector ingress, evaluation-job egress) — inert on a CNI that doesn't implement the NetworkPolicy API. EKS's default VPC CNI, AKS, and legacy GKE don't enforce it out of the box; enable your provider's policy add-on (or install Calico/Cilium) if you want these to actually take effect. k3s (local/CI) enforces it by default. |
 
@@ -61,11 +61,23 @@ The main flow assumes you control a DNS zone. If you are evaluating on a cluster
 | Tool | Version | Purpose |
 |------|---------|---------|
 | [kubectl](https://kubernetes.io/docs/tasks/tools/) | v1.32+ | Kubernetes CLI |
-| [Helm](https://helm.sh/docs/intro/install/) | v3.12+ | Kubernetes package manager |
+| [Helm](https://helm.sh/docs/intro/install/) | v3.12+, **v3 only** | Kubernetes package manager |
 | curl / dig | — | DNS resolution of LoadBalancer hostnames |
 
 ```bash
 kubectl version --client && helm version
+```
+
+:::caution Helm 4 is not supported by this guide
+Helm 4 applies charts with Kubernetes server-side apply, where every field has an owner. Several charts below (OpenBao, cert-manager) have controllers that rewrite their own webhook `caBundle` at runtime under a different field manager, so any **re-run** of an install command — including the retries this guide's own troubleshooting recommends — fails with `Apply failed with 1 conflict`. Use Helm 3, or append `--server-side=false` to every `helm install`/`helm upgrade` in this guide.
+:::
+
+Verify LoadBalancer provisioning works before starting — the alternative is discovering it an hour into the install, when the first plane gateway hangs `<pending>`:
+
+```bash
+kubectl create deploy lbtest --image=nginx && kubectl expose deploy lbtest --port=80 --type=LoadBalancer
+kubectl wait --for=jsonpath='{.status.loadBalancer.ingress}' svc/lbtest --timeout=5m && echo "LoadBalancer OK"
+kubectl delete svc/lbtest deploy/lbtest
 ```
 
 ### Permissions
@@ -131,6 +143,14 @@ export INSTRUMENTATION_URL="http://default-default.gateway.localhost:19080/otel"
 
 :::note Hostname shape
 The certificates below are single-level wildcards (`*.<base>`), so every management hostname must sit directly under the base domain — no second-level names like `api.amp.<base>`.
+:::
+
+:::caution Reading the unreleased (next) version of this guide?
+`0.0.0-dev` is a placeholder that is swapped for the real tag at release — it is **not itself a published tag**, so every `helm pull` and values-file download below will fail with it. Use the latest nightly instead, tagged `0.0.0-dev-<YYYYMMDD>`:
+
+```bash
+git ls-remote --tags https://github.com/wso2/agent-manager 'refs/tags/amp/v0.0.0-dev-*' | tail -1
+```
 :::
 
 ### 2. TLS certificates
@@ -292,7 +312,15 @@ helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
   --set server.dataStorage.size=10Gi \
   --timeout 180s
 
-kubectl wait --for=condition=Ready=false pod/openbao-0 -n openbao --timeout=120s
+# A sealed OpenBao never reports Ready, and there is no pod condition that
+# means "running but sealed" — conditions are set before the container starts,
+# so waiting on one races the exec below ('container not found ("openbao")').
+# Poll bao itself: exit 2 = sealed but responding (the state we want here);
+# exit 0 = already unsealed (a re-run); anything else = not up yet.
+until kubectl exec -n openbao openbao-0 -- bao status >/dev/null 2>&1; do
+  [ $? -eq 2 ] && break
+  sleep 5
+done
 ```
 
 Initialize and unseal. **Store the unseal keys and root token in your secret manager immediately** — they are displayed once, and without them the data on that PVC is unrecoverable:
@@ -471,6 +499,12 @@ Every gateway certificate below references one ClusterIssuer named `openchoreo-c
 
 DNS-01 validation issues publicly trusted certificates (including the wildcards this guide needs) by writing a TXT record to your DNS zone — the CA never connects to your cluster. Create a credentials Secret for your DNS provider, then the issuer. The example below uses AWS Route 53; cert-manager supports [Cloudflare, Google Cloud DNS, Azure DNS, and others](https://cert-manager.io/docs/configuration/acme/dns01/) with the same structure.
 
+First confirm the zone is actually **delegated** — that the public DNS tree hands queries for it to your provider's nameservers. If it is not (a freshly created zone, or nameservers not yet changed at the registrar or parent zone), cert-manager writes its challenge records into a zone no resolver consults, and every certificate below hangs unissued with no obvious error. Query a public resolver, never the zone's own nameservers — those are authoritative the moment the zone exists, delegated or not:
+
+```bash
+dig +short NS <your-zone> @1.1.1.1   # must return your DNS provider's nameservers
+```
+
 ```bash
 kubectl create secret generic route53-credentials \
   --namespace cert-manager \
@@ -503,6 +537,10 @@ EOF
 
 :::tip
 Test with the Let's Encrypt staging server (`https://acme-staging-v02.api.letsencrypt.org/directory`) first if you expect to iterate — the production server rate-limits duplicate certificates to 5 per week.
+:::
+
+:::note Prefer ambient credentials over a static access key
+On EKS, cert-manager picks up IAM Roles for Service Accounts or Pod Identity credentials automatically — no long-lived access key in a cluster Secret. Bind a role scoped to `route53:ChangeResourceRecordSets`/`ListResourceRecordSets` on your one hosted zone (plus `route53:GetChange` and `ListHostedZonesByName`) to the cert-manager ServiceAccount, and reduce the solver to just `region` and `hostedZoneID`. See [cert-manager's Route 53 documentation](https://cert-manager.io/docs/configuration/acme/dns01/route53/) for the equivalent on other setups.
 :::
 
   </TabItem>
@@ -544,6 +582,16 @@ Thunder writes its issuer URL, the console client's redirect URIs, and every pla
 :::
 
 **Database.** Production installations use an external PostgreSQL. Thunder keeps three logical databases — `configdb`, `runtimedb`, and `userdb` — which can live on one server; create them and a role that owns all three before installing, then **load Thunder's schema into each one**. Nothing in the chart creates the tables for PostgreSQL: the init container only initialises the bundled SQLite files, so an empty database makes the pre-install hook fail.
+
+On a managed service (RDS, Cloud SQL, Azure Database) the admin user is **not a superuser**, and PostgreSQL 16+ only lets it create a database *owned by another role* if it holds membership in that role. Grant it first, or `CREATE DATABASE ... OWNER thunder` fails with `must be able to SET ROLE "thunder"`:
+
+```sql
+CREATE ROLE thunder LOGIN PASSWORD '...';
+GRANT thunder TO CURRENT_USER;  -- required on managed PostgreSQL; harmless elsewhere
+CREATE DATABASE configdb OWNER thunder;  -- likewise runtimedb, userdb
+```
+
+The same applies to the Agent Manager database role in [Phase 2](#phase-2-agent-manager-installation).
 
 <Tabs groupId="deployment-mode">
   <TabItem value="production" label="External PostgreSQL" default>

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -45,7 +45,7 @@ The main flow assumes you control a DNS zone. If you are evaluating on a cluster
 | CPU per node | 4 cores |
 | RAM per node | 8 GB |
 | LoadBalancer support | Required |
-| Default StorageClass | Required, and it must actually provision volumes. Stock EKS ships a default `gp2` class bound to the **removed** in-tree provisioner: PVCs are accepted and stay `Pending` forever. Install the EBS CSI driver and make a CSI-backed class (e.g. `gp3`) the default |
+| Default StorageClass | Required, and it must actually provision volumes. On EKS check both halves: clusters created at 1.30+ ship **no default class at all**, and the stock `gp2` class (default on upgraded clusters) references the in-tree provisioner removed in Kubernetes 1.27, so without the EBS CSI driver its PVCs are accepted and stay `Pending` forever. Install the EBS CSI driver and mark a CSI-backed class (e.g. `gp3`) as default |
 | Node kernel (build nodes) | Linux **6.3+** for user-namespaced agent builds (idmapped-mount support). On older kernels (Ubuntu 22.04's 5.15, Amazon Linux 2's 5.10) set `buildWorkflows.userNamespaces=false` on the Platform Resources chart — see [Troubleshooting](#build-pods-fail-with-mount_attr_idmap--idmap-mounts-errors) |
 | NetworkPolicy-enforcing CNI | Recommended. The Observability and Evaluation extension charts each ship a `NetworkPolicy` (collector ingress, evaluation-job egress) — inert on a CNI that doesn't implement the NetworkPolicy API. EKS's default VPC CNI, AKS, and legacy GKE don't enforce it out of the box; enable your provider's policy add-on (or install Calico/Cilium) if you want these to actually take effect. k3s (local/CI) enforces it by default. |
 
@@ -146,10 +146,12 @@ The certificates below are single-level wildcards (`*.<base>`), so every managem
 :::
 
 :::caution Reading the unreleased (next) version of this guide?
-`0.0.0-dev` is a placeholder that is swapped for the real tag at release — it is **not itself a published tag**, so every `helm pull` and values-file download below will fail with it. Use the latest nightly instead, tagged `0.0.0-dev-<YYYYMMDD>`:
+`0.0.0-dev` is a placeholder that is swapped for the real tag at release — it is **not itself a published tag**, so every `helm pull` and values-file download below will fail with it. Point `VERSION` at the latest nightly instead, tagged `0.0.0-dev-<YYYYMMDD>` (run this **after** the export block above, so it overrides the placeholder):
 
 ```bash
-git ls-remote --tags https://github.com/wso2/agent-manager 'refs/tags/amp/v0.0.0-dev-*' | tail -1
+export VERSION="$(git ls-remote --refs --tags https://github.com/wso2/agent-manager 'refs/tags/amp/v0.0.0-dev-*' \
+  | awk -F/ '{print $NF}' | sed 's/^v//' | sort | tail -n 1)"
+echo "VERSION=${VERSION:?no nightly tag found}"
 ```
 :::
 

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -145,16 +145,6 @@ export INSTRUMENTATION_URL="http://default-default.gateway.localhost:19080/otel"
 The certificates below are single-level wildcards (`*.<base>`), so every management hostname must sit directly under the base domain — no second-level names like `api.amp.<base>`.
 :::
 
-:::caution Reading the unreleased (next) version of this guide?
-`0.0.0-dev` is a placeholder that is swapped for the real tag at release — it is **not itself a published tag**, so every `helm pull` and values-file download below will fail with it. Point `VERSION` at the latest nightly instead, tagged `0.0.0-dev-<YYYYMMDD>` (run this **after** the export block above, so it overrides the placeholder):
-
-```bash
-export VERSION="$(git ls-remote --refs --tags https://github.com/wso2/agent-manager 'refs/tags/amp/v0.0.0-dev-*' \
-  | awk -F/ '{print $NF}' | sed 's/^v//' | sort | tail -n 1)"
-echo "VERSION=${VERSION:?no nightly tag found}"
-```
-:::
-
 ### 2. TLS certificates
 
 The main flow uses **cert-manager with Let's Encrypt (DNS-01)**: publicly trusted certificates, automatic renewal, and wildcard support — you only need API credentials for the DNS provider hosting your zone. Step 3 also shows a corporate-CA alternative. Certificate issuance needs only the DNS zone, so it works before the DNS records for the gateways exist.


### PR DESCRIPTION
## Purpose

A from-scratch install on EKS (external PostgreSQL on RDS, Let's Encrypt DNS-01 via Route 53) following the `next` on-your-environment guide verbatim hit several failures the guide doesn't cover. Each change below corresponds to a failure actually reproduced during that run — three break the guide's own commands, the rest are environment traps the production path steers readers into.

## Changes

**Guide commands that fail as written**

- **`VERSION="0.0.0-dev"` admonition** — the placeholder is swapped for a real tag at release, but readers of the `next` docs hit it live, and it exists as neither a GHCR chart tag nor an `amp/v*` git tag, so the very first `helm pull` fails. Added a caution with a one-liner to find the latest nightly tag.
- **OpenBao readiness wait** — `kubectl wait --for=condition=Ready=false pod/openbao-0` is satisfied before the container starts (and a sealed OpenBao never goes Ready), so the `bao operator init` exec races it and dies with `container not found ("openbao")`. Replaced with a poll on `bao status` exit codes (0 = unsealed, 2 = sealed but responding).
- **Helm 4** — satisfies the documented "v3.12+" but its server-side apply conflicts with charts whose controllers rewrite their own webhook `caBundle` (OpenBao's injector, cert-manager's cainjector) on any re-run: `Apply failed with 1 conflict ... "vault-k8s" ... clientConfig.caBundle`. Since the guide's own troubleshooting recommends re-running installs, pinned the prerequisite to v3 and documented the `--server-side=false` escape hatch.

**Environment traps on the production path**

- **Managed PostgreSQL** — RDS/Cloud SQL/Azure admin users are not superusers, and PostgreSQL 16+ rejects `CREATE DATABASE ... OWNER thunder` with `must be able to SET ROLE "thunder"` until the role is granted to the admin. Added the `GRANT ... TO CURRENT_USER` step.
- **Registry requirements** — build workflows push `<workflow-run-name>-image` (a new repository per run, so push-to-create is mandatory) using a static `.dockerconfigjson` (so expiring credentials can't work). ECR fails both, and the failure only surfaces on the first build. Documented the two requirements, which registries satisfy them, and the no-auth caveat of a quick in-cluster Distribution deploy.
- **Default StorageClass prerequisite** — stock EKS satisfies "Required" with a `gp2` class bound to the removed in-tree provisioner; PVCs accept and never bind. Qualified the prerequisite.

**Fail-fast additions**

- DNS delegation pre-check (via a public resolver, not the zone's own NS) before the DNS-01 issuer — an undelegated zone otherwise leaves every certificate hanging unissued with no error.
- LoadBalancer smoke test in the prerequisites, so a missing LB controller surfaces before the install rather than at Step 6.
- Note that cert-manager picks up ambient credentials (IRSA/Pod Identity) on EKS as the safer alternative to a static access key.

## Verification

- `npm run build` in `documentation/` passes on the branch.
- Every runtime failure above was reproduced and its fix validated during the EKS install run (2026-08-05, EKS 1.34 / Helm 4.2.0 / RDS PostgreSQL 17.10 / OpenBao chart 0.25.6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added registry requirements for build workflows, including repository creation on push and static, non-expiring credentials.
  * Clarified supported registry options and authentication requirements for Distribution deployments.
  * Expanded environment setup guidance for storage, Helm 3, load balancers, DNS delegation, credentials, and PostgreSQL permissions.
  * Updated OpenBao readiness guidance to use status checks.
  * Added guidance for validating LoadBalancer provisioning and DNS configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->