### PR TITLE
Keep git credentials out of the build workspace

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/checkout-source.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/checkout-source.yaml
@@ -37,7 +37,6 @@ spec:
 
                     if [ -f "$GIT_SECRET_PATH/username" ]; then
                         USERNAME=$(cat "$GIT_SECRET_PATH/username")
-                        echo "Username found: $USERNAME"
                     else
                         USERNAME="git"
                     fi
@@ -45,16 +44,24 @@ spec:
                     if echo "$REPO" | grep -q "^https://"; then
                         PROTOCOL=$(echo "$REPO" | cut -d: -f1)
                         DOMAIN_PATH=$(echo "$REPO" | cut -d/ -f3-)
+                        HOST=$(echo "$DOMAIN_PATH" | cut -d/ -f1)
 
                         USERNAME_ENCODED=$(echo -n "$USERNAME" | sed 's/%/%25/g; s/ /%20/g; s/!/%21/g; s/"/%22/g; s/#/%23/g; s/\$/%24/g; s/&/%26/g; s/'\''/%27/g; s/(/%28/g; s/)/%29/g; s/\*/%2A/g; s/+/%2B/g; s/,/%2C/g; s/\//%2F/g; s/:/%3A/g; s/;/%3B/g; s/=/%3D/g; s/?/%3F/g; s/@/%40/g; s/\[/%5B/g; s/\]/%5D/g')
                         PASSWORD_ENCODED=$(echo -n "$PASSWORD" | sed 's/%/%25/g; s/ /%20/g; s/!/%21/g; s/"/%22/g; s/#/%23/g; s/\$/%24/g; s/&/%26/g; s/'\''/%27/g; s/(/%28/g; s/)/%29/g; s/\*/%2A/g; s/+/%2B/g; s/,/%2C/g; s/\//%2F/g; s/:/%3A/g; s/;/%3B/g; s/=/%3D/g; s/?/%3F/g; s/@/%40/g; s/\[/%5B/g; s/\]/%5D/g')
 
-                        REPO="$PROTOCOL://${USERNAME_ENCODED}:${PASSWORD_ENCODED}@${DOMAIN_PATH}"
+                        # Keep the credential out of the clone URL: git would
+                        # persist it into .git/config under /mnt/vol, which the
+                        # build step can read. The store helper supplies it per-host
+                        # instead, leaving the recorded remote URL credential-free.
+                        # Store entries are URL-formatted, so encoding is still needed.
+                        : > /tmp/.git-credentials
+                        chmod 600 /tmp/.git-credentials
+                        printf '%s://%s:%s@%s\n' "$PROTOCOL" "$USERNAME_ENCODED" "$PASSWORD_ENCODED" "$HOST" >> /tmp/.git-credentials
+
+                        git config --global credential.helper "store --file=/tmp/.git-credentials"
                     else
                         echo "Warning: REPO is not an HTTPS URL, basic auth may not work"
                     fi
-
-                    git config --global credential.helper store
                 else
                     echo "Warning: Git secret exists but no recognized credentials found"
                 fi
@@ -77,6 +84,11 @@ spec:
                 COMMIT_SHA=$(git rev-parse HEAD)
                 echo -n "$COMMIT_SHA" | cut -c1-8 > /tmp/git-revision.txt
             fi
+
+            # Drop git metadata before the build step mounts the workspace: keeps
+            # any credential state out of the build context and out of "COPY . ."
+            # images. Nothing downstream needs it (revision is a workflow output).
+            rm -rf /mnt/vol/source/.git
 
             echo "Repository cloned successfully"
         volumeMounts:


### PR DESCRIPTION
## Purpose
> Git credentials for private agent repos were embedded in the clone URL, which `git clone` persists into `.git/config`. That file sits in the workspace shared with the build step, so a user-supplied Dockerfile could read the credential or bake it into the image.
Resolves: https://github.com/wso2-enterprise/agent-manager-internal/issues/8 


## Goals
> Keep git credentials out of the build workspace, without changing how private repos are cloned.

## Approach
In `checkout-source.yaml`:
- Pass the credential to git via a credentials file on the checkout container (`/tmp`) using the `store` helper, instead of putting it in the clone URL — so `.git/config` stays credential-free.
- Delete `.git` after checkout, before the build step runs. Nothing downstream needs it (revision is a workflow output).

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
>  N/A

## Automation tests
 - Unit tests 
   > N/A - Helm template update
 - Integration tests
   > Verified on local k3d: with a canary secret attached, `.git` is absent from the build context and the canary never reaches the build log or image, normal build + deploy still succeeds

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Local K3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Improved HTTPS repository authentication by using temporary, restricted credential storage during source checkout.
  - Repository credentials are no longer embedded directly in checkout configuration or exposed in logs.

- **Bug Fixes**
  - Removed Git metadata after checkout to prevent repository details from being carried into subsequent build steps.
  - Preserved compatibility with repositories that rely on the default Git username.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->