### PR TITLE
Fix eval-job egress to amp-api's container port

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-networkpolicy.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-networkpolicy.yaml
@@ -47,13 +47,23 @@ spec:
           protocol: TCP
 
     # agent-manager-service publisher endpoint (amp-api) — publish evaluation scores.
+    # Guarded: an egress rule whose ports list renders empty allows EVERY port, so a values
+    # file still carrying the pre-list `publisher.port` key would silently widen this pod's
+    # egress to the whole namespace. Omit the rule instead and fail closed — publishing
+    # breaks loudly, which is recoverable; a silent hole is not.
+    {{- with .Values.networkPolicy.evaluationJob.publisher }}
+    {{- if and .namespace .ports }}
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.evaluationJob.publisher.namespace }}
+              kubernetes.io/metadata.name: {{ .namespace }}
       ports:
-        - port: {{ .Values.networkPolicy.evaluationJob.publisher.port }}
+        {{- range .ports }}
+        - port: {{ . }}
           protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- end }}
 
     # LLM gateway for llm_judge evaluators — unconditional since NetworkPolicy can't scope by workflow.
     # Two selectors, because the gateway's namespace is a deployment choice: the

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
@@ -74,7 +74,14 @@ networkPolicy:
 
     publisher:
       namespace: "wso2-amp"
-      port: 9000
+      # -- 8080 is the port that carries the traffic: policy is matched after the Service port
+      # is translated, so the CNI sees amp-api's containerPort, never the 9000 its Service
+      # publishes. Both kube-router and Cilium document matching post-translation, so 9000 is
+      # a no-op here — it is kept only to record the Service port this rule corresponds to,
+      # and can be dropped without behavioural change.
+      ports:
+        - 9000
+        - 8080
 
     idp:
       namespace: "amp-thunder"


### PR DESCRIPTION
## Purpose

Monitor evaluation runs finished their work and then failed to persist it. The eval container computed every score, logged `Evaluation complete ... status=SUCCESS`, and then exited 1 after three attempts at:

```
Failed to publish scores (attempt 1/3): HTTPConnectionPool(host='amp-api.wso2-amp.svc.cluster.local', port=9000):
... [Errno 111] Connection refused
```

amp-api was healthy throughout — it was serving other requests during the exact seconds of the refusals, and never logged a single publish request arriving.

The cause is the evaluation-job NetworkPolicy. Its publisher rule allows egress to the `wso2-amp` namespace on port **9000**, the port amp-api's Service publishes. NetworkPolicy is enforced *after* kube-proxy DNAT, so the destination the CNI matches against is the backing pod on its containerPort, **8080**. The rule could never match a packet, and kube-router rejected it with `icmp-port-unreachable`, which the client sees as a refused connection.

The policy's other `namespaceSelector` rules escape this only by coincidence — each publishes a Service port identical to its containerPort, so naming either one happens to match. amp-api is the only destination where the two differ:

| Destination | Service port | containerPort | Rule allows | Result |
|---|---|---|---|---|
| amp-observer (traces) | 9098 | 9098 | 9098 | worked |
| amp-thunder (token) | 8090 | 8090 | 8090 | worked |
| LLM gateway | 22893 | 22893 | 22893 | worked |
| **amp-api (publish)** | 9000 | **8080** | 9000 | **refused** |

This is the same defect class as #1507, which corrects the API-server rule in the same policy. That PR concluded the ClusterIP `ipBlock` "was the only rule that could never match a packet" — that holds for the destination *address*, since `namespaceSelector` resolves to pod IPs, but not for the destination *port*, which is still the Service's on every rule.

Related to #1507

## Goals

Let monitor runs persist the scores they compute, by having the publisher egress rule name the port amp-api's pod actually listens on.

## Approach

Allow both ports on the publisher egress rule: `8080`, the containerPort amp-api actually listens on, and `9000`, the port its Service publishes. The value becomes a list, matching the shape #1507 gives the API-server rule.

8080 is the port that carries the traffic, and without it the rule matches nothing. 9000 is retained to record the Service port this rule corresponds to, but it is a **no-op**: both kube-router and Cilium document matching ports after service translation, so no known CNI matches on 9000 here. It can be dropped without behavioural change. Listing both is the configuration verified green below.

The rule is also now guarded on a non-empty port list. An egress rule whose `ports` renders empty allows **every** port, so a values file still carrying the pre-list `publisher.port` key would have silently granted the eval pod — which runs untrusted, user-submitted code — egress to the whole namespace on all ports. It now omits the rule and fails closed, matching the `{{- if and $cidrs .ports }}` guard #1507 uses for the same class of change.

The original value was copied from `ampEvaluation.publisher.endpoint` (`http://amp-api.wso2-amp.svc.cluster.local:9000`), where 9000 is correct — the URL is resolved before DNAT, the policy is matched after it.

## User stories

N/A — this is a defect fix with no new user-facing capability.

## Release note

Fixed monitor evaluation runs failing to publish their scores, caused by the evaluation-job NetworkPolicy allowing egress to the agent-manager API on its Service port rather than its container port.

## Documentation

N/A — no documented behaviour changes. The value is an internal chart default that operators are not expected to set.

## Training

N/A — no training-content impact.

## Certification

N/A — no certification impact; this is an internal chart default with no user-facing surface.

## Marketing

N/A — defect fix.

## Automation tests

 - Unit tests
   > N/A — the change is a chart value plus the template line that renders it, with no unit-testable code path. #1507 adds `tests/render.sh` to this chart to keep its API-server egress rule from silently regressing; once that lands, the publisher rule deserves an assertion in the same harness, since this defect would have been caught by one.
 - Integration tests
   > Verified manually end to end on a live install (below). No automated integration coverage exercises a monitor run against an enforcing CNI today, which is why this survived.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

No new namespace, CIDR, or protocol is allowed, and the rule now fails closed rather than open if its port list is empty (see Approach).

Stated plainly, though: this **is** a real widening. The rule previously matched nothing at all, so it granted no reachable egress; it now grants 8080 across the whole `wso2-amp` namespace, and 8080 is a far more collision-prone port than 9000. That is the traffic the rule always intended to allow, but the namespace-wide scope is worth a reviewer's attention — `wso2-amp` also holds the console, gateway-mgt and postgres. Adding a `podSelector` alongside the `namespaceSelector` (the `agentManagerService.selectorLabels` helper already exists) would turn this into a net tightening. I have left that out to keep the fix minimal and would rather do it as a follow-up.

## Samples

N/A — no sample impact.

## Related PRs

#1507 — fixes the API-server egress rule in this same NetworkPolicy, which is the other half of a fully green monitor run. Both are needed: without this PR the eval container exits 1 and no scores persist; without #1507 Argo's `wait` sidecar exits 64 and the run is reported failed even though the scores did persist.

## Migrations (if applicable)

None. Applied by a chart upgrade, which replaces the NetworkPolicy in place. Existing installs are broken until upgraded and need no other action.

## Test environment

k3s v1.32.9 on k3d, Ubuntu 26.04, 4 vCPU. NetworkPolicy enforced by k3s's built-in kube-router controller.

Confirmed by the exit codes across consecutive runs of the same monitor on one cluster, isolating each fix:

| Run | Rules in effect | `main` | `wait` | Run status |
|---|---|---|---|---|
| before | publisher rule on 9000 only | **1** | 64 | failed, no scores |
| after this fix | publisher rule on 9000 + 8080 | **0** | 64 | failed, scores persisted |
| after both | plus #1507's rule | **0** | **0** | **success** |

With this change amp-api logs `Published evaluation scores` for the run, where it had previously logged nothing at all. A probe pod carrying the eval-job labels still cannot reach anything outside the policy's allowed set.

Worth noting for anyone reproducing: kube-router programs a pod's rules asynchronously, so short-lived probe pods can connect freely before the policy lands and appear to disprove the bug. A probe has to stay up (~100s here) before its egress is actually filtered.

## Learning

The general rule is that Kubernetes NetworkPolicy is matched against the post-DNAT destination, so egress rules aimed at a Service must name the backing pods' `targetPort`, not the port the Service publishes. Documented upstream in the Kubernetes NetworkPolicy guide, and the same trap #1507 hit from the address side.
