### PR TITLE
fix: backfill LLM proxy handle in env-mapping repo to unblock model config deletion

### DIFF
--- a/agent-manager-service/repositories/agent_configuration_repository.go
+++ b/agent-manager-service/repositories/agent_configuration_repository.go
@@ -166,10 +166,15 @@ func backfillLLMProxyHandles(config *models.AgentConfiguration) {
 		return
 	}
 	for i := range config.EnvMappings {
-		proxy := config.EnvMappings[i].LLMProxy
-		if proxy != nil && proxy.Handle == "" {
-			proxy.Handle = proxy.Configuration.Name
-		}
+		backfillLLMProxyHandle(config.EnvMappings[i].LLMProxy)
+	}
+}
+
+// backfillLLMProxyHandle populates a single preloaded LLM proxy's Handle from
+// its Configuration.Name (see backfillLLMProxyHandles for why this is needed).
+func backfillLLMProxyHandle(proxy *models.LLMProxy) {
+	if proxy != nil && proxy.Handle == "" {
+		proxy.Handle = proxy.Configuration.Name
 	}
 }
 

--- a/agent-manager-service/repositories/env_agent_model_mapping_repository.go
+++ b/agent-manager-service/repositories/env_agent_model_mapping_repository.go
@@ -78,6 +78,9 @@ func (r *envAgentModelMappingRepository) GetByConfigAndEnv(ctx context.Context, 
 		Preload("LLMProxy").
 		Where("config_uuid = ? AND environment_uuid = ?", configUUID, envUUID).
 		First(&mapping).Error
+	if err == nil {
+		backfillLLMProxyHandle(mapping.LLMProxy)
+	}
 	return &mapping, err
 }
 
@@ -87,6 +90,11 @@ func (r *envAgentModelMappingRepository) ListByConfig(ctx context.Context, confi
 		Preload("LLMProxy").
 		Where("config_uuid = ?", configUUID).
 		Find(&mappings).Error
+	if err == nil {
+		for i := range mappings {
+			backfillLLMProxyHandle(mappings[i].LLMProxy)
+		}
+	}
 	return mappings, err
 }
 

--- a/agent-manager-service/repositories/env_agent_model_mapping_repository_test.go
+++ b/agent-manager-service/repositories/env_agent_model_mapping_repository_test.go
@@ -62,14 +62,17 @@ func TestEnvAgentModelMappingRepo_BackfillsLLMProxyHandle(t *testing.T) {
 		if err := tx.Exec("SET session_replication_role = 'replica'").Error; err != nil {
 			return err
 		}
-		if err := tx.Exec(
+		// Restore on every exit path (including an INSERT failure) so a pooled
+		// connection is never handed back to another test stuck in 'replica'
+		// mode, which would silently skip FK/trigger checks for it too.
+		defer func() {
+			_ = tx.Exec("SET session_replication_role = 'origin'").Error
+		}()
+		return tx.Exec(
 			`INSERT INTO llm_proxies (uuid, project_uuid, provider_uuid, status, configuration)
 			 VALUES (?, ?, ?, 'deployed', ?)`,
 			proxyUUID, uuid.New(), uuid.New(), `{"name":"`+proxyName+`"}`,
-		).Error; err != nil {
-			return err
-		}
-		return tx.Exec("SET session_replication_role = 'origin'").Error
+		).Error
 	}))
 
 	envUUID := uuid.New()

--- a/agent-manager-service/repositories/env_agent_model_mapping_repository_test.go
+++ b/agent-manager-service/repositories/env_agent_model_mapping_repository_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+)
+
+// TestEnvAgentModelMappingRepo_BackfillsLLMProxyHandle guards against a
+// regression where deleting an agent's LLM model config failed with
+// "failed to get deployments for proxy \"\": failed to get proxy: record
+// not found". LLMProxy.Handle is gorm:"-" (derived, not a DB column), so
+// GORM's Preload("LLMProxy") always leaves it blank; the delete flow reads
+// mapping.LLMProxy.Handle straight off the ListByConfig/GetByConfigAndEnv
+// result to look up proxy deployments to clean up. Without backfilling it
+// from Configuration.Name (as agent_configuration_repository.go's
+// GetByUUID/GetByAgentID already do via backfillLLMProxyHandles), the
+// lookup always resolves an empty handle and the whole delete aborts.
+func TestEnvAgentModelMappingRepo_BackfillsLLMProxyHandle(t *testing.T) {
+	gdb := db.GetDB()
+	ctx := context.Background()
+
+	config := &models.AgentConfiguration{
+		Name:        "backfill-handle-agent-config",
+		AgentID:     "backfill-handle-agent",
+		OUID:        "test-ou-backfill-handle",
+		ProjectName: "test-proj-backfill-handle",
+	}
+	require.NoError(t, gdb.Create(config).Error)
+
+	// Seed an llm_proxies row directly, same as monitor_executor_test.go's
+	// TestExecuteMonitorRun_LLMCredentials: disable FK triggers so we don't
+	// need to also seed artifacts/llm_providers rows just to get a proxy with
+	// a Configuration.Name in place.
+	const proxyName = "backfill-handle-proxy-name"
+	proxyUUID := uuid.New()
+	require.NoError(t, gdb.Connection(func(tx *gorm.DB) error {
+		if err := tx.Exec("SET session_replication_role = 'replica'").Error; err != nil {
+			return err
+		}
+		if err := tx.Exec(
+			`INSERT INTO llm_proxies (uuid, project_uuid, provider_uuid, status, configuration)
+			 VALUES (?, ?, ?, 'deployed', ?)`,
+			proxyUUID, uuid.New(), uuid.New(), `{"name":"`+proxyName+`"}`,
+		).Error; err != nil {
+			return err
+		}
+		return tx.Exec("SET session_replication_role = 'origin'").Error
+	}))
+
+	envUUID := uuid.New()
+	mapping := &models.EnvAgentModelMapping{
+		ConfigUUID:      config.UUID,
+		EnvironmentUUID: envUUID,
+		LLMProxyUUID:    proxyUUID,
+	}
+	require.NoError(t, gdb.Create(mapping).Error)
+
+	t.Cleanup(func() {
+		gdb.Where("config_uuid = ?", config.UUID).Delete(&models.EnvAgentModelMapping{})
+		gdb.Exec("DELETE FROM llm_proxies WHERE uuid = ?", proxyUUID)
+		gdb.Delete(config)
+	})
+
+	repo := NewEnvAgentModelMappingRepository(gdb)
+
+	t.Run("ListByConfig backfills Handle", func(t *testing.T) {
+		mappings, err := repo.ListByConfig(ctx, config.UUID)
+		require.NoError(t, err)
+		require.Len(t, mappings, 1)
+		require.NotNil(t, mappings[0].LLMProxy)
+		require.Equal(t, proxyName, mappings[0].LLMProxy.Handle,
+			"ListByConfig must backfill LLMProxy.Handle so delete cleanup can resolve the proxy")
+	})
+
+	t.Run("GetByConfigAndEnv backfills Handle", func(t *testing.T) {
+		got, err := repo.GetByConfigAndEnv(ctx, config.UUID, envUUID)
+		require.NoError(t, err)
+		require.NotNil(t, got.LLMProxy)
+		require.Equal(t, proxyName, got.LLMProxy.Handle,
+			"GetByConfigAndEnv must backfill LLMProxy.Handle so delete cleanup can resolve the proxy")
+	})
+}


### PR DESCRIPTION
## Purpose
Deleting an LLM provider/model configuration attached to an agent fails with:
```
failed to get deployments for proxy "": failed to get proxy: record not found
```
This blocks a core config-management flow, users cannot remove an LLM provider config from an agent once it's been attached. Resolves the deletion failure reported against AMP v1.0.0-alpha1 (agent configuration / model config delete flow).

- Resolved : #1511 

## Goals
Make `DeleteAgentModelConfig` (and the equivalent agent-deletion cleanup path) correctly resolve the LLM proxy's handle before attempting to look up and clean up its proxy deployments, so deletion succeeds and orphaned proxy deployments are actually cleaned up instead of silently failing.

## Approach
`LLMProxy.Handle` is a derived field (`gorm:"-"`) — it isn't a real column on `llm_proxies`, so it must be backfilled from `Configuration.Name` after every `Preload("LLMProxy")`. That backfill already existed (`backfillLLMProxyHandles`, in `agent_configuration_repository.go`), but was only wired into the read paths (`GetByUUID`, `GetByAgentID`). The delete flow (`deleteLLMConfig` in `agent_configuration_service.go`) fetches mappings via a different repository — `EnvAgentModelMappingRepository.ListByConfig` / `GetByConfigAndEnv` — which never got the same backfill. So `mapping.LLMProxy.Handle` was always empty on the delete path, and the proxy-deployment cleanup lookup failed with "record not found."

Fix: extracted the per-proxy backfill logic into a shared helper (`backfillLLMProxyHandle`) and applied it in `ListByConfig` and `GetByConfigAndEnv` in `env_agent_model_mapping_repository.go`, matching the existing pattern in `agent_configuration_repository.go`. No schema change, no new fields — just ensuring the derived value is computed on every read path that needs it.

<img width="370" height="88" alt="Screenshot 2026-08-06 at 17 10 39" src="https://github.com/user-attachments/assets/c5ee7870-3941-4168-8441-c3717fb09be4" />

Files changed:
- `agent-manager-service/repositories/agent_configuration_repository.go`
- `agent-manager-service/repositories/env_agent_model_mapping_repository.go`
- `agent-manager-service/repositories/env_agent_model_mapping_repository_test.go` (new)

## User stories
N/A

## Release note
Fixed a bug where deleting an LLM provider/model configuration from an agent failed with a "proxy record not found" error, leaving the configuration undeletable.

## Documentation
N/A — internal bug fix with no change to API contracts, request/response shapes, or user-facing behavior beyond "delete now works."

## Training
N/A — no training content impact.

## Certification
N/A — internal bug fix, no exam-relevant behavior change.

## Marketing
N/A — internal bug fix, not a feature.

## Automation tests
- **Unit tests:** N/A — the fix required real GORM/Postgres behavior (`Preload` join derivation), so it's covered at the integration level instead.
- **Integration tests:** Added `TestEnvAgentModelMappingRepo_BackfillsLLMProxyHandle` in `env_agent_model_mapping_repository_test.go` (`//go:build integration`). It seeds a real `llm_proxies` row (via FK-trigger bypass, matching the existing `monitor_executor_test.go` pattern) plus an `env_agent_model_mapping` row, then asserts both `ListByConfig` and `GetByConfigAndEnv` return a non-empty `LLMProxy.Handle`. Verified the test fails with the exact reported symptom (`Handle == ""`) when the fix is reverted, and passes with the fix applied. Also ran the full `repositories` and `services` integration suites — no regressions.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (Go codebase — not applicable to this static analysis tool)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no new sample apps or code required.

## Related PRs
None.

## Migrations
N/A — no schema or data migration required; this is a read-path bug fix only.

## Test environment
- Go 1.25
- PostgreSQL 16 (via `postgres:16-alpine` docker image, local `make setup` stack)
- macOS (Darwin 25.6.0)
- Tested against local AMP v1.0.0-alpha1 dev environment (Docker-based, `make setup`)

## Learning
Traced the failure from the reported log line back through `DeleteAgentModelConfig` → `deleteLLMConfig` → `EnvAgentModelMappingRepository.ListByConfig`, then compared against the sibling repository (`AgentConfigurationRepository`) to find the existing-but-incompletely-applied `backfillLLMProxyHandles` pattern via `git log`/`git blame` (introduced in commit `1c875ba1`). Classic "fixed in one place, missed the parallel path" gap — worth checking for other `gorm:"-"` derived fields with the same risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment agent-model mappings now correctly display the associated LLM proxy handle.
  * Proxy handles are consistently populated for both individual mapping lookups and list results.
  * Existing handles remain unchanged, and unavailable proxy records are handled safely.

* **Tests**
  * Added coverage validating proxy handle backfilling across supported mapping queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->