### PR TITLE
Restore ingress coverage lost in the gateway role back-fill

### DIFF
--- a/agent-manager-service/db_migrations/041_promote_sole_egress_gateway.go
+++ b/agent-manager-service/db_migrations/041_promote_sole_egress_gateway.go
@@ -19,8 +19,10 @@ package dbmigrations
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -38,6 +40,7 @@ import (
 // gateway keeps carrying its existing LLM/MCP traffic. Environments that already hold an
 // 'ingress' or 'both' gateway are untouched, leaving the regular+ai pair and split
 // topology alone.
+
 var migration041 = migration{
 	ID: 41,
 	Migrate: func(db *gorm.DB) error {
@@ -50,8 +53,28 @@ var migration041 = migration{
 	},
 }
 
-// PromoteSoleEgressGateways promotes at most one gateway per environment that has no
-// ingress-capable gateway.
+// promotionCandidate is an egress gateway eligible for promotion, with the environments
+// it would cover as a comma-separated list.
+type promotionCandidate struct {
+	UUID uuid.UUID `gorm:"column:uuid"`
+	Envs string    `gorm:"column:envs"`
+}
+
+// PromoteSoleEgressGateways promotes egress gateways to 'both' so that every environment
+// currently without an ingress-capable gateway gets one.
+//
+// A gateway's role applies in every environment it is mapped to at once, so a candidate
+// must map only to uncovered environments — otherwise promoting it would breach the
+// one-ingress cap in an environment that already has coverage. Among those candidates,
+// the ones covering the most uncovered environments are taken first, so a gateway shared
+// by several uncovered environments covers them all in one promotion rather than being
+// passed over in favour of a single-environment gateway. created_at then uuid break ties.
+// Two promoted gateways may not share an environment, since that environment would then
+// hold two ingress-capable gateways.
+//
+// The greedy pick is not proven minimal for arbitrarily overlapping mappings; anything it
+// leaves uncovered is reported by AssertIngressCoveragePerEnvironment rather than passing
+// silently.
 //
 // deleted_at IS NULL because raw SQL bypasses GORM's soft-delete scope. is_active is
 // deliberately not filtered — it tracks WebSocket liveness and flaps, so a gateway that
@@ -75,40 +98,42 @@ func PromoteSoleEgressGateways(tx *gorm.DB) error {
 				WHERE l2.environment_uuid = l.environment_uuid
 				  AND l2.role IN ('ingress', 'both')
 			)
-		),
-		winners AS (
-			-- One candidate per environment, since the ingress slot holds exactly one.
-			-- Ordered so the pick is deterministic across runs.
-			SELECT uuid, environment_uuid
-			FROM (
-				SELECT l.uuid,
-				       l.environment_uuid,
-				       row_number() OVER (PARTITION BY l.environment_uuid
-				                          ORDER BY l.created_at, l.uuid) AS rn
-				FROM live l
-				JOIN uncovered u USING (environment_uuid)
-				WHERE l.role = 'egress'
-			) r
-			WHERE rn = 1
-		),
-		safe AS (
-			-- The role lives on the gateway row, so a promotion applies to every
-			-- environment the gateway serves. Promote only where it won in all of them,
-			-- else it would breach the one-ingress cap in the ones it lost.
-			SELECT wc.uuid
-			FROM (SELECT uuid, count(*) AS wins FROM winners GROUP BY uuid) wc
-			JOIN (SELECT gateway_uuid, count(*) AS total
-			      FROM gateway_environment_mappings
-			      GROUP BY gateway_uuid) mc ON mc.gateway_uuid = wc.uuid
-			WHERE wc.wins = mc.total
 		)
-		UPDATE gateways
-		SET gateway_functionality_type = 'both',
-		    updated_at = now()
-		WHERE uuid IN (SELECT uuid FROM safe);`
+		SELECT l.uuid,
+		       string_agg(l.environment_uuid::text, ',' ORDER BY l.environment_uuid) AS envs
+		FROM live l
+		LEFT JOIN uncovered u ON u.environment_uuid = l.environment_uuid
+		WHERE l.role = 'egress'
+		GROUP BY l.uuid, l.created_at
+		HAVING bool_and(u.environment_uuid IS NOT NULL)
+		ORDER BY count(*) DESC, l.created_at, l.uuid;`
 
-	if err := tx.Exec(q).Error; err != nil {
-		return fmt.Errorf("migration 041: promoting sole egress gateways failed: %w", err)
+	var candidates []promotionCandidate
+	if err := tx.Raw(q).Scan(&candidates).Error; err != nil {
+		return fmt.Errorf("migration 041: collecting promotion candidates failed: %w", err)
+	}
+
+	claimed := make(map[string]bool)
+	var promote []uuid.UUID
+	for _, c := range candidates {
+		envs := strings.Split(c.Envs, ",")
+		if slices.ContainsFunc(envs, func(env string) bool { return claimed[env] }) {
+			continue
+		}
+		for _, env := range envs {
+			claimed[env] = true
+		}
+		promote = append(promote, c.UUID)
+	}
+	if len(promote) == 0 {
+		return nil
+	}
+
+	if err := tx.Exec(
+		`UPDATE gateways SET gateway_functionality_type = 'both', updated_at = now()
+		 WHERE uuid IN ?`, promote,
+	).Error; err != nil {
+		return fmt.Errorf("migration 041: promoting egress gateways failed: %w", err)
 	}
 	return nil
 }

--- a/agent-manager-service/db_migrations/041_promote_sole_egress_gateway.go
+++ b/agent-manager-service/db_migrations/041_promote_sole_egress_gateway.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dbmigrations
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+// Restore ingress coverage that migration 037 removed.
+//
+// 037's ai -> egress arm assumed 'ai' was only ever a second gateway installed beside
+// a 'regular' one, which holds for the OSS paths but not for provisioners that register
+// an environment's ONLY gateway as 'ai'. Those environments came out of 037 with no
+// ingress-capable gateway, and resolveEnvGateways now filters on IngressGatewayRoles, so
+// they can no longer be issued an inbound agent API key at all.
+//
+// Promote one egress gateway to 'both' in each environment that has none — which is what
+// those environments effectively were before 037, whose resolver ignored the type column
+// and keyed every gateway mapped to the environment. 'both' rather than 'ingress' so the
+// gateway keeps carrying its existing LLM/MCP traffic. Environments that already hold an
+// 'ingress' or 'both' gateway are untouched, leaving the regular+ai pair and split
+// topology alone.
+var migration041 = migration{
+	ID: 41,
+	Migrate: func(db *gorm.DB) error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			if err := PromoteSoleEgressGateways(tx); err != nil {
+				return err
+			}
+			return AssertIngressCoveragePerEnvironment(tx)
+		})
+	},
+}
+
+// PromoteSoleEgressGateways promotes at most one gateway per environment that has no
+// ingress-capable gateway.
+//
+// deleted_at IS NULL because raw SQL bypasses GORM's soft-delete scope. is_active is
+// deliberately not filtered — it tracks WebSocket liveness and flaps, so a gateway that
+// happens to be disconnected during the upgrade must still be promoted.
+func PromoteSoleEgressGateways(tx *gorm.DB) error {
+	const q = `
+		WITH live AS (
+			SELECT g.uuid,
+			       g.created_at,
+			       g.gateway_functionality_type AS role,
+			       m.environment_uuid
+			FROM gateways g
+			JOIN gateway_environment_mappings m ON m.gateway_uuid = g.uuid
+			WHERE g.deleted_at IS NULL
+		),
+		uncovered AS (
+			SELECT DISTINCT l.environment_uuid
+			FROM live l
+			WHERE NOT EXISTS (
+				SELECT 1 FROM live l2
+				WHERE l2.environment_uuid = l.environment_uuid
+				  AND l2.role IN ('ingress', 'both')
+			)
+		),
+		winners AS (
+			-- One candidate per environment, since the ingress slot holds exactly one.
+			-- Ordered so the pick is deterministic across runs.
+			SELECT uuid, environment_uuid
+			FROM (
+				SELECT l.uuid,
+				       l.environment_uuid,
+				       row_number() OVER (PARTITION BY l.environment_uuid
+				                          ORDER BY l.created_at, l.uuid) AS rn
+				FROM live l
+				JOIN uncovered u USING (environment_uuid)
+				WHERE l.role = 'egress'
+			) r
+			WHERE rn = 1
+		),
+		safe AS (
+			-- The role lives on the gateway row, so a promotion applies to every
+			-- environment the gateway serves. Promote only where it won in all of them,
+			-- else it would breach the one-ingress cap in the ones it lost.
+			SELECT wc.uuid
+			FROM (SELECT uuid, count(*) AS wins FROM winners GROUP BY uuid) wc
+			JOIN (SELECT gateway_uuid, count(*) AS total
+			      FROM gateway_environment_mappings
+			      GROUP BY gateway_uuid) mc ON mc.gateway_uuid = wc.uuid
+			WHERE wc.wins = mc.total
+		)
+		UPDATE gateways
+		SET gateway_functionality_type = 'both',
+		    updated_at = now()
+		WHERE uuid IN (SELECT uuid FROM safe);`
+
+	if err := tx.Exec(q).Error; err != nil {
+		return fmt.Errorf("migration 041: promoting sole egress gateways failed: %w", err)
+	}
+	return nil
+}
+
+// uncoveredEnvRow is one environment left without an ingress-capable gateway.
+type uncoveredEnvRow struct {
+	EnvironmentUUID string `gorm:"column:environment_uuid"`
+	Gateways        string `gorm:"column:gateways"`
+}
+
+// AssertIngressCoveragePerEnvironment aborts the migration when an environment with
+// gateways mapped to it holds none that can serve ingress. It is the lower bound to
+// 037's AssertSingleIngressPerEnvironment upper bound, and the check whose absence let
+// 037 leave environments silently unable to issue an inbound API key.
+//
+// What reaches here is a gateway shared across environments that lost the pick in one of
+// them. The role is immutable once registered, so an operator has to resolve that in SQL
+// either way; failing the upgrade surfaces it while it is still cheap. Environments with
+// no gateways at all are not a regression and are not reported.
+func AssertIngressCoveragePerEnvironment(tx *gorm.DB) error {
+	const q = `
+		SELECT m.environment_uuid,
+		       string_agg(g.name || ' (' || g.gateway_functionality_type || ')', ', '
+		                  ORDER BY g.name) AS gateways
+		FROM gateway_environment_mappings m
+		JOIN gateways g ON g.uuid = m.gateway_uuid
+		WHERE g.deleted_at IS NULL
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM gateway_environment_mappings m2
+			JOIN gateways g2 ON g2.uuid = m2.gateway_uuid
+			WHERE m2.environment_uuid = m.environment_uuid
+			  AND g2.deleted_at IS NULL
+			  AND g2.gateway_functionality_type IN ('ingress', 'both')
+		  )
+		GROUP BY m.environment_uuid
+		ORDER BY m.environment_uuid;`
+
+	var rows []uncoveredEnvRow
+	if err := tx.Raw(q).Scan(&rows).Error; err != nil {
+		return fmt.Errorf("migration 041: ingress coverage check failed: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	var b strings.Builder
+	b.WriteString("migration 041 aborted: the environments below hold gateways but none that can " +
+		"serve ingress ('ingress' or 'both'), so no agent in them can be issued an inbound API " +
+		"key. The automatic promotion skipped these because the candidate gateway also serves an " +
+		"environment that already has an ingress-capable gateway, and the role applies to the " +
+		"gateway in every environment at once.\n\n" +
+		"Promote one gateway per environment below, or register a new ingress gateway there. " +
+		"This transaction has rolled back, so nothing has changed yet.\n")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "\n  environment %s: %s\n", r.EnvironmentUUID, r.Gateways)
+		fmt.Fprintf(&b, "      UPDATE gateways SET gateway_functionality_type = 'both' WHERE uuid = '<pick one>';\n")
+	}
+	return errors.New(b.String())
+}

--- a/agent-manager-service/db_migrations/migration_list.go
+++ b/agent-manager-service/db_migrations/migration_list.go
@@ -61,4 +61,5 @@ var migrations = []migration{
 	migration038,
 	migration039,
 	migration040,
+	migration041,
 }

--- a/agent-manager-service/db_migrations/migration_list.go
+++ b/agent-manager-service/db_migrations/migration_list.go
@@ -16,7 +16,7 @@
 
 package dbmigrations
 
-const latestVersion = 40
+const latestVersion = 41
 
 // migration list sorted by version.  Add new migrations to the end of the list.
 // Previous migrations should not be modified.

--- a/agent-manager-service/tests/gateway_roles_migration_test.go
+++ b/agent-manager-service/tests/gateway_roles_migration_test.go
@@ -200,3 +200,102 @@ func TestGatewayRolesMigration_InsertWithoutRoleFailsNotNull(t *testing.T) {
 		"expected not_null_violation (23502), got code %s: %s", pgErr.Code, pgErr.Message)
 	assert.Equal(t, "gateway_functionality_type", pgErr.ColumnName)
 }
+
+// roleOf reads a gateway's stored functionality type.
+func roleOf(t *testing.T, tx *gorm.DB, gatewayID uuid.UUID) string {
+	t.Helper()
+	var role string
+	require.NoError(t, tx.Raw(`SELECT gateway_functionality_type FROM gateways WHERE uuid = ?`, gatewayID).
+		Scan(&role).Error)
+	return role
+}
+
+// setGatewayCreatedAt pins created_at explicitly. CURRENT_TIMESTAMP is the transaction
+// start time in Postgres, so rows seeded in one test transaction otherwise share a
+// created_at and migration 041's tie-break falls through to the random uuid.
+func setGatewayCreatedAt(t *testing.T, tx *gorm.DB, gatewayID uuid.UUID, createdAt string) {
+	t.Helper()
+	require.NoError(t, tx.Exec(`UPDATE gateways SET created_at = ?::timestamp WHERE uuid = ?`,
+		createdAt, gatewayID).Error)
+}
+
+// Case 7: an environment whose only gateway was 'ai' comes out of 037 as egress-only,
+// which leaves it unable to issue an inbound API key. 041 promotes it to 'both'.
+func TestGatewayRolesMigration_PromotesSoleEgressGateway(t *testing.T) {
+	tx := gatewayRolesTestTx(t)
+	envID := uuid.New()
+	aiID := seedRoleGateway(t, tx, "ai")
+	mapGatewayToEnvironment(t, tx, aiID, envID)
+
+	runRoleBackfill(t, tx)
+	require.Equal(t, "egress", roleOf(t, tx, aiID), "037 should have demoted the sole gateway")
+
+	require.NoError(t, dbmigrations.PromoteSoleEgressGateways(tx))
+
+	assert.Equal(t, "both", roleOf(t, tx, aiID))
+	assert.NoError(t, dbmigrations.AssertIngressCoveragePerEnvironment(tx))
+}
+
+// Case 8: the regular+ai pair already has its ingress-capable gateway, so 041 must leave
+// the egress one alone — promoting it would breach the one-ingress cap.
+func TestGatewayRolesMigration_LeavesCoveredEnvironmentAlone(t *testing.T) {
+	tx := gatewayRolesTestTx(t)
+	envID := uuid.New()
+	regularID := seedRoleGateway(t, tx, "regular")
+	aiID := seedRoleGateway(t, tx, "ai")
+	mapGatewayToEnvironment(t, tx, regularID, envID)
+	mapGatewayToEnvironment(t, tx, aiID, envID)
+
+	runRoleBackfill(t, tx)
+	require.NoError(t, dbmigrations.PromoteSoleEgressGateways(tx))
+
+	assert.Equal(t, "both", roleOf(t, tx, regularID))
+	assert.Equal(t, "egress", roleOf(t, tx, aiID), "the egress gateway must not be promoted")
+	assert.NoError(t, dbmigrations.AssertSingleIngressPerEnvironment(tx))
+}
+
+// Case 9: several egress gateways and no ingress-capable one — exactly one is promoted,
+// the oldest, since the environment has a single ingress slot.
+func TestGatewayRolesMigration_PromotesOnlyOldestEgressGateway(t *testing.T) {
+	tx := gatewayRolesTestTx(t)
+	envID := uuid.New()
+	olderID := seedRoleGateway(t, tx, "ai")
+	newerID := seedRoleGateway(t, tx, "ai")
+	mapGatewayToEnvironment(t, tx, olderID, envID)
+	mapGatewayToEnvironment(t, tx, newerID, envID)
+	setGatewayCreatedAt(t, tx, olderID, "2026-07-03 10:15:39")
+	setGatewayCreatedAt(t, tx, newerID, "2026-07-22 08:54:05")
+
+	runRoleBackfill(t, tx)
+	require.NoError(t, dbmigrations.PromoteSoleEgressGateways(tx))
+
+	assert.Equal(t, "both", roleOf(t, tx, olderID))
+	assert.Equal(t, "egress", roleOf(t, tx, newerID))
+	assert.NoError(t, dbmigrations.AssertSingleIngressPerEnvironment(tx))
+	assert.NoError(t, dbmigrations.AssertIngressCoveragePerEnvironment(tx))
+}
+
+// Case 10: a gateway shared between an uncovered and an already-covered environment must
+// not be promoted — the role applies in both at once, so it would breach the cap in the
+// covered one. The uncovered environment therefore stays uncovered and 041 aborts.
+func TestGatewayRolesMigration_SharedGatewayAbortsInsteadOfBreachingCap(t *testing.T) {
+	tx := gatewayRolesTestTx(t)
+	coveredEnvID := uuid.New()
+	uncoveredEnvID := uuid.New()
+	regularID := seedRoleGateway(t, tx, "regular")
+	sharedID := seedRoleGateway(t, tx, "ai")
+	mapGatewayToEnvironment(t, tx, regularID, coveredEnvID)
+	mapGatewayToEnvironment(t, tx, sharedID, coveredEnvID)
+	mapGatewayToEnvironment(t, tx, sharedID, uncoveredEnvID)
+
+	runRoleBackfill(t, tx)
+	require.NoError(t, dbmigrations.PromoteSoleEgressGateways(tx))
+
+	assert.Equal(t, "egress", roleOf(t, tx, sharedID), "promotion would breach the cap in the covered env")
+	assert.NoError(t, dbmigrations.AssertSingleIngressPerEnvironment(tx))
+
+	err := dbmigrations.AssertIngressCoveragePerEnvironment(tx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), uncoveredEnvID.String())
+	assert.NotContains(t, err.Error(), coveredEnvID.String())
+}

--- a/agent-manager-service/tests/gateway_roles_migration_test.go
+++ b/agent-manager-service/tests/gateway_roles_migration_test.go
@@ -299,3 +299,27 @@ func TestGatewayRolesMigration_SharedGatewayAbortsInsteadOfBreachingCap(t *testi
 	assert.Contains(t, err.Error(), uncoveredEnvID.String())
 	assert.NotContains(t, err.Error(), coveredEnvID.String())
 }
+
+// Case 11: gateway X is mapped to uncovered environments A and B, while older gateway Y
+// is mapped to B alone. Promoting Y would cover B and strand A, so X — which covers both
+// in one promotion — must win despite Y being older: coverage is ranked ahead of age.
+func TestGatewayRolesMigration_PrefersGatewayCoveringMoreEnvironments(t *testing.T) {
+	tx := gatewayRolesTestTx(t)
+	envA := uuid.New()
+	envB := uuid.New()
+	sharedX := seedRoleGateway(t, tx, "ai")
+	olderY := seedRoleGateway(t, tx, "ai")
+	mapGatewayToEnvironment(t, tx, sharedX, envA)
+	mapGatewayToEnvironment(t, tx, sharedX, envB)
+	mapGatewayToEnvironment(t, tx, olderY, envB)
+	setGatewayCreatedAt(t, tx, olderY, "2026-07-03 10:15:39")
+	setGatewayCreatedAt(t, tx, sharedX, "2026-07-22 08:54:05")
+
+	runRoleBackfill(t, tx)
+	require.NoError(t, dbmigrations.PromoteSoleEgressGateways(tx))
+
+	assert.Equal(t, "both", roleOf(t, tx, sharedX), "the gateway covering both environments must be promoted")
+	assert.Equal(t, "egress", roleOf(t, tx, olderY), "promoting it too would give env B two ingress gateways")
+	assert.NoError(t, dbmigrations.AssertSingleIngressPerEnvironment(tx))
+	assert.NoError(t, dbmigrations.AssertIngressCoveragePerEnvironment(tx))
+}


### PR DESCRIPTION
Migration 037 mapped ai -> egress on the premise that 'ai' was only ever a second gateway installed beside a 'regular' one. That holds for the OSS paths, but a provisioner that registers an environment's only gateway as 'ai' leaves that environment egress-only after the upgrade. Since resolveEnvGateways filters on IngressGatewayRoles, those environments can no longer be issued an inbound agent API key at all: create, rotate, revoke and the console Try-It flow fail with ErrGatewayNotFound, surfaced as 503 "No gateway connections available".

Add migration 041, promoting one egress gateway to 'both' in each environment that holds none that can serve ingress — which is what those environments effectively were before 037, whose resolver ignored the type column and keyed every gateway mapped to the environment. Environments that already hold an 'ingress' or 'both' gateway are untouched, leaving the regular+ai pair and split topology alone.

Pair it with AssertIngressCoveragePerEnvironment, the lower bound to 037's AssertSingleIngressPerEnvironment. Its absence is why 037 could leave an environment silently unable to issue a key; a case the promotion cannot safely resolve — a gateway shared with an already-covered environment, where promoting it would breach the one-ingress cap — now fails the upgrade with the offending environments and the remediation SQL.

Cover the back-fill shapes with four cases: sole egress promoted, covered environment left alone, only the oldest of several egress gateways promoted, and the shared-gateway conflict aborting rather than breaching the cap.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored ingress coverage for environments that previously had only egress gateways.
  * Automatically promotes a suitable gateway when safe while preserving existing coverage and role limits.
  * Validates ingress coverage and reports affected environments when coverage cannot be restored.
  * Applies changes transactionally to prevent partial updates.

* **Tests**
  * Added coverage for gateway promotion, existing coverage preservation, deterministic selection, and safe abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->