### PR TITLE
Skip git secret validation for an empty secret reference

### DIFF
--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -183,6 +183,15 @@ func translatePipelineError(err error) error {
 	return err
 }
 
+// requiresGitSecretValidation reports whether the repository names a git secret that
+// has to exist. Two different states both mean "no PAT-backed secret" and must not be
+// validated: an absent secretRef (public repository) and an explicitly empty one, which
+// prepareGitHubAppSource sets so the checkout workflow skips the ExternalSecret while
+// the build secret provisioner writes the per-run secret itself.
+func requiresGitSecretValidation(repository *spec.RepositoryConfig) bool {
+	return repository != nil && repository.GetSecretRef() != ""
+}
+
 // validateGitSecretExists checks if the specified git secret exists in the organization
 func (s *agentManagerService) validateGitSecretExists(ctx context.Context, ouID string, secretRef string) error {
 	if secretRef == "" {
@@ -1285,7 +1294,7 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 		return translateOrgError(err)
 	}
 
-	if req.Provisioning.Repository != nil && req.Provisioning.Repository.SecretRef.Get() != nil {
+	if requiresGitSecretValidation(req.Provisioning.Repository) {
 		if err := s.validateGitSecretExists(ctx, ouID, req.Provisioning.Repository.GetSecretRef()); err != nil {
 			return err
 		}
@@ -1901,8 +1910,8 @@ func (s *agentManagerService) UpdateAgentBuildParameters(ctx context.Context, ou
 		return nil, translateProjectError(err)
 	}
 
-	// Validate git secret exists if specified
-	if req.Provisioning.Repository != nil && req.Provisioning.Repository.SecretRef.Get() != nil {
+	// Validate git secret exists if specified.
+	if requiresGitSecretValidation(req.Provisioning.Repository) {
 		if err := s.validateGitSecretExists(ctx, ouID, req.Provisioning.Repository.GetSecretRef()); err != nil {
 			return nil, err
 		}

--- a/agent-manager-service/services/build_secret_provisioner_unit_test.go
+++ b/agent-manager-service/services/build_secret_provisioner_unit_test.go
@@ -182,3 +182,36 @@ func githubAppCreateRequest() *spec.CreateAgentRequest {
 		},
 	}
 }
+
+// A GitHub App source clears secretRef to an explicit empty string, which is a
+// non-nil pointer. Guarding git-secret validation on "not nil" therefore rejected
+// every GitHub App agent with "git secret reference is empty", while public repos
+// (nil ref) were unaffected. Each half was covered on its own; nothing pinned the
+// two together, so the contradiction survived.
+func TestRequiresGitSecretValidation_SkipsGitHubAppClearedSecretRef(t *testing.T) {
+	req := githubAppCreateRequest()
+	s := &agentManagerService{buildSecretProvisioner: &buildSecretProvisionerStub{}}
+
+	require.NoError(t, s.prepareGitHubAppSource(req))
+
+	// Precondition: the ref really is present-but-empty, not absent.
+	require.NotNil(t, req.Provisioning.Repository.SecretRef.Get())
+	require.Empty(t, *req.Provisioning.Repository.SecretRef.Get())
+
+	assert.False(t, requiresGitSecretValidation(req.Provisioning.Repository),
+		"an explicitly empty secretRef must not be validated as a git secret")
+}
+
+func TestRequiresGitSecretValidation_PublicAndPATRepositories(t *testing.T) {
+	assert.False(t, requiresGitSecretValidation(nil),
+		"no repository means nothing to validate")
+
+	public := &spec.RepositoryConfig{Url: "https://github.com/acme/demo"}
+	assert.False(t, requiresGitSecretValidation(public),
+		"a public repository leaves secretRef absent")
+
+	pat := &spec.RepositoryConfig{Url: "https://github.com/acme/demo"}
+	pat.SetSecretRef("my-git-secret")
+	assert.True(t, requiresGitSecretValidation(pat),
+		"a named git secret must still be validated")
+}


### PR DESCRIPTION
## Purpose

Creating an agent from a GitHub App repository source always fails with:

```
CreateAgent: failed to create agent  error="git secret reference is empty"
```

A GitHub App source has no PAT-backed git secret, so `prepareGitHubAppSource` clears the secret reference by setting it to an empty string. But git-secret validation is guarded on the reference being *present* rather than *non-empty*, and an explicitly empty value is still present. Validation therefore runs and rejects it immediately.

Public repositories leave the reference unset, so they were unaffected — only GitHub App sources fail.

## Approach

Guard validation on a non-empty secret reference instead of a present one, through a single shared helper used by both call sites (agent creation and build-parameter updates; the second would fail the same way).

Behaviour is unchanged for every case that previously worked: a named secret is still validated, and a public repository still skips validation. The only case that changes is an explicitly empty reference, which previously could never succeed — validation rejected it on the first line.

Adds a regression test that runs `prepareGitHubAppSource` and feeds its real output to the guard. The existing tests covered each half separately and both passed, which is why the contradiction between them shipped.