### PR TITLE
Add LLM provider Deployment tab with per-environment gateway selection

### DIFF
--- a/console/workspaces/libs/api-client/src/hooks/llm-providers.ts
+++ b/console/workspaces/libs/api-client/src/hooks/llm-providers.ts
@@ -240,6 +240,9 @@ export function useUpdateLLMProvider() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
       queryClient.invalidateQueries({ queryKey: ["llm-provider"] });
+      // An update can change `gateways`, which deploys/undeploys; invoke URLs
+      // derived from ["llm-deployments"] must refetch or they go stale.
+      queryClient.invalidateQueries({ queryKey: ["llm-deployments"] });
     },
   });
 }

--- a/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.test.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.test.tsx
@@ -47,9 +47,10 @@ const makeEnvironment = (id: string, name: string): Environment => ({
   createdAt: "2026-01-01T00:00:00Z",
 });
 
+// A gateway belongs to exactly one environment; the wire shape is an array.
 const makeGateway = (
   uuid: string,
-  envIds: string[],
+  envId: string,
   gatewayType: GatewayType = "EGRESS",
 ): GatewayResponse => ({
   uuid,
@@ -62,17 +63,19 @@ const makeGateway = (
   status: "ACTIVE",
   createdAt: "2026-01-01T00:00:00Z",
   updatedAt: "2026-01-01T00:00:00Z",
-  environments: envIds.map((envId) => ({
-    id: envId,
-    organizationName: "org",
-    name: envId,
-    displayName: envId,
-    dataplaneRef: "dp-1",
-    dnsPrefix: envId,
-    isProduction: false,
-    createdAt: "2026-01-01T00:00:00Z",
-    updatedAt: "2026-01-01T00:00:00Z",
-  })),
+  environments: [
+    {
+      id: envId,
+      organizationName: "org",
+      name: envId,
+      displayName: envId,
+      dataplaneRef: "dp-1",
+      dnsPrefix: envId,
+      isProduction: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    },
+  ],
 });
 
 // Controlled wrapper so onChange results flow back into value, mirroring how
@@ -134,7 +137,7 @@ describe("EnvironmentGatewaySelectorView", () => {
     renderWithTheme(
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
-        gateways={[makeGateway("gw-1", ["env-a"])]}
+        gateways={[makeGateway("gw-1", "env-a")]}
         onChangeSpy={onChangeSpy}
       />,
     );
@@ -150,7 +153,7 @@ describe("EnvironmentGatewaySelectorView", () => {
     renderWithTheme(
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
-        gateways={[makeGateway("gw-1", ["env-a"])]}
+        gateways={[makeGateway("gw-1", "env-a")]}
         onChangeSpy={onChangeSpy}
       />,
     );
@@ -165,8 +168,8 @@ describe("EnvironmentGatewaySelectorView", () => {
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
         gateways={[
-          makeGateway("gw-1", ["env-a"]),
-          makeGateway("gw-2", ["env-a"]),
+          makeGateway("gw-1", "env-a"),
+          makeGateway("gw-2", "env-a"),
         ]}
         onChangeSpy={onChangeSpy}
         onValidityChange={onValidityChange}
@@ -190,8 +193,8 @@ describe("EnvironmentGatewaySelectorView", () => {
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
         gateways={[
-          makeGateway("gw-1", ["env-a"]),
-          makeGateway("gw-2", ["env-a"]),
+          makeGateway("gw-1", "env-a"),
+          makeGateway("gw-2", "env-a"),
         ]}
         onValidityChange={onValidityChange}
       />,
@@ -223,8 +226,8 @@ describe("EnvironmentGatewaySelectorView", () => {
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
         gateways={[
-          makeGateway("gw-1", ["env-a"]),
-          makeGateway("gw-2", ["env-a"]),
+          makeGateway("gw-1", "env-a"),
+          makeGateway("gw-2", "env-a"),
         ]}
         initialValue={["gw-1"]}
         lockedGatewayIds={["gw-1"]}
@@ -246,8 +249,8 @@ describe("EnvironmentGatewaySelectorView", () => {
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
         gateways={[
-          makeGateway("gw-1", ["env-a"]),
-          makeGateway("gw-2", ["env-a"]),
+          makeGateway("gw-1", "env-a"),
+          makeGateway("gw-2", "env-a"),
         ]}
         initialValue={["gw-1"]}
         lockedGatewayIds={["gw-1"]}
@@ -260,7 +263,7 @@ describe("EnvironmentGatewaySelectorView", () => {
     expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-1"]);
   });
 
-  it("renders every environment a multi-env gateway covers as checked and never pairs it with an overlapping gateway", () => {
+  it("evicts the previously selected gateway when a different candidate is chosen in the same environment", () => {
     const onChangeSpy = vi.fn();
     renderWithTheme(
       <ControlledSelector
@@ -269,27 +272,24 @@ describe("EnvironmentGatewaySelectorView", () => {
           makeEnvironment("env-b", "Beta"),
         ]}
         gateways={[
-          makeGateway("gw-shared", ["env-a", "env-b"]),
-          makeGateway("gw-solo", ["env-a"]),
+          makeGateway("gw-1", "env-a"),
+          makeGateway("gw-2", "env-a"),
+          makeGateway("gw-3", "env-b"),
         ]}
         onChangeSpy={onChangeSpy}
       />,
     );
     fireEvent.click(getCheckbox("Alpha"));
-    chooseOption("Egress gateway for Alpha", "Gateway gw-shared");
-    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-shared"]);
-    expect(getCheckbox("Beta")).toBeChecked();
+    chooseOption("Egress gateway for Alpha", "Gateway gw-1");
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-1"]);
 
-    // Replacing the shared gateway in Alpha evicts it everywhere it deploys.
-    chooseOption("Egress gateway for Alpha", "Gateway gw-solo");
-    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-solo"]);
-    expect(getCheckbox("Beta")).not.toBeChecked();
-
-    // Re-selecting the shared gateway evicts the solo one from Alpha.
-    chooseOption("Egress gateway for Alpha", "Gateway gw-shared");
-    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-shared"]);
+    // A gateway in a different environment coexists.
     fireEvent.click(getCheckbox("Beta"));
-    expect(onChangeSpy).toHaveBeenLastCalledWith([]);
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-1", "gw-3"]);
+
+    // Switching Alpha's candidate replaces gw-1 rather than joining it.
+    chooseOption("Egress gateway for Alpha", "Gateway gw-2");
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-3", "gw-2"]);
   });
 
   it("renders an unmapped selected gateway as a removable locked row", () => {
@@ -297,7 +297,7 @@ describe("EnvironmentGatewaySelectorView", () => {
     renderWithTheme(
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
-        gateways={[makeGateway("gw-1", ["env-a"])]}
+        gateways={[makeGateway("gw-1", "env-a")]}
         initialValue={["ghost-gw"]}
         onChangeSpy={onChangeSpy}
       />,
@@ -318,8 +318,8 @@ describe("EnvironmentGatewaySelectorView", () => {
           makeEnvironment("env-b", "Beta"),
         ]}
         gateways={[
-          makeGateway("gw-1", ["env-a"]),
-          makeGateway("gw-2", ["env-b"]),
+          makeGateway("gw-1", "env-a"),
+          makeGateway("gw-2", "env-b"),
         ]}
         initialValue={["gw-1"]}
       />,
@@ -332,7 +332,7 @@ describe("EnvironmentGatewaySelectorView", () => {
     renderWithTheme(
       <ControlledSelector
         environments={[makeEnvironment("env-a", "Alpha")]}
-        gateways={[makeGateway("gw-1", ["env-a"])]}
+        gateways={[makeGateway("gw-1", "env-a")]}
         initialValue={["gw-1"]}
       />,
     );
@@ -354,7 +354,7 @@ interface Fixture {
   gateways: GatewayResponse[];
   lockedGatewayIds: string[];
   initialValue: string[];
-  envIdsByUuid: Record<string, string[]>;
+  envIdByUuid: Record<string, string | undefined>;
 }
 
 const generateFixture = (rand: () => number): Fixture => {
@@ -363,40 +363,35 @@ const generateFixture = (rand: () => number): Fixture => {
     makeEnvironment(`env-${i}`, `Env ${i}`),
   );
   const gatewayCount = 2 + Math.floor(rand() * 5);
-  const gateways = Array.from({ length: gatewayCount }, (_, i) => {
-    const covered = environments
-      .filter(() => rand() < 0.4)
-      .map((env) => env.id as string);
-    if (covered.length === 0) {
-      covered.push(environments[Math.floor(rand() * envCount)].id as string);
-    }
-    return makeGateway(`gw-${i}`, covered);
-  });
+  const gateways = Array.from({ length: gatewayCount }, (_, i) =>
+    makeGateway(
+      `gw-${i}`,
+      environments[Math.floor(rand() * envCount)].id as string,
+    ),
+  );
 
-  const envIdsByUuid: Record<string, string[]> = {};
+  const envIdByUuid: Record<string, string | undefined> = {};
   gateways.forEach((gateway) => {
-    envIdsByUuid[gateway.uuid] = (gateway.environments ?? []).map(
-      (env) => env.id,
-    );
+    envIdByUuid[gateway.uuid] = gateway.environments?.[0]?.id;
   });
 
   const lockedGatewayIds: string[] = [];
   const lockedEnvIds = new Set<string>();
   gateways.forEach((gateway) => {
     if (rand() >= 0.35) return;
-    const envIds = envIdsByUuid[gateway.uuid];
-    if (envIds.some((envId) => lockedEnvIds.has(envId))) return;
+    const envId = envIdByUuid[gateway.uuid];
+    if (!envId || lockedEnvIds.has(envId)) return;
     lockedGatewayIds.push(gateway.uuid);
-    envIds.forEach((envId) => lockedEnvIds.add(envId));
+    lockedEnvIds.add(envId);
   });
 
   const initialValue = [...lockedGatewayIds];
   if (rand() < 0.3) {
     initialValue.push("ghost-gw");
-    envIdsByUuid["ghost-gw"] = [];
+    envIdByUuid["ghost-gw"] = undefined;
   }
 
-  return { environments, gateways, lockedGatewayIds, initialValue, envIdsByUuid };
+  return { environments, gateways, lockedGatewayIds, initialValue, envIdByUuid };
 };
 
 const performRandomAction = (rand: () => number) => {
@@ -425,7 +420,7 @@ const performRandomAction = (rand: () => number) => {
 
 describe("EnvironmentGatewaySelectorView placement invariant", () => {
   it.each([7, 42, 1337, 20260807])(
-    "never emits two gateways with intersecting environment sets (seed %i)",
+    "never emits two gateways in the same environment (seed %i)",
     (seed) => {
       const rand = makeLcg(seed);
       const fixture = generateFixture(rand);
@@ -446,15 +441,15 @@ describe("EnvironmentGatewaySelectorView placement invariant", () => {
           const emitted = emissions[verified];
           const coveredEnvIds = new Set<string>();
           emitted.forEach((uuid) => {
-            (fixture.envIdsByUuid[uuid] ?? []).forEach((envId) => {
-              if (coveredEnvIds.has(envId)) {
-                throw new Error(
-                  `seed ${seed}, emission ${verified}: env ${envId} covered ` +
-                    `twice in [${emitted.join(", ")}]`,
-                );
-              }
-              coveredEnvIds.add(envId);
-            });
+            const envId = fixture.envIdByUuid[uuid];
+            if (!envId) return;
+            if (coveredEnvIds.has(envId)) {
+              throw new Error(
+                `seed ${seed}, emission ${verified}: env ${envId} covered ` +
+                  `twice in [${emitted.join(", ")}]`,
+              );
+            }
+            coveredEnvIds.add(envId);
           });
         }
       };

--- a/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.test.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.test.tsx
@@ -310,7 +310,7 @@ describe("EnvironmentGatewaySelectorView", () => {
     expect(screen.queryByText("Unmapped")).not.toBeInTheDocument();
   });
 
-  it("shows the deployment footer only when there is more than one environment", () => {
+  it("shows the selection footer only when there is more than one environment", () => {
     const { unmount } = renderWithTheme(
       <ControlledSelector
         environments={[
@@ -325,7 +325,7 @@ describe("EnvironmentGatewaySelectorView", () => {
       />,
     );
     expect(
-      screen.getByText("1 of 2 environments deployed."),
+      screen.getByText("1 of 2 environments selected."),
     ).toBeInTheDocument();
     unmount();
 
@@ -336,7 +336,7 @@ describe("EnvironmentGatewaySelectorView", () => {
         initialValue={["gw-1"]}
       />,
     );
-    expect(screen.queryByText(/environments deployed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/environments selected/)).not.toBeInTheDocument();
   });
 });
 

--- a/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.test.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.test.tsx
@@ -1,0 +1,469 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
+import type {
+  Environment,
+  GatewayResponse,
+  GatewayType,
+} from "@agent-management-platform/types";
+// Only EnvironmentGatewaySelectorView is under test, but importing the module
+// drags in api-client, whose auth dependency crashes at import time outside a
+// configured app shell. Stub the module boundary; no hook behavior is mocked.
+vi.mock("@agent-management-platform/api-client", () => ({
+  useListEnvironments: vi.fn(() => ({ data: [], isLoading: false })),
+  useListGateways: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+
+import { EnvironmentGatewaySelectorView } from "./EnvironmentGatewaySelector";
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider theme={createTheme()}>{component}</ThemeProvider>);
+
+const makeEnvironment = (id: string, name: string): Environment => ({
+  id,
+  name,
+  displayName: name,
+  dataplaneRef: "dp-1",
+  isProduction: false,
+  createdAt: "2026-01-01T00:00:00Z",
+});
+
+const makeGateway = (
+  uuid: string,
+  envIds: string[],
+  gatewayType: GatewayType = "EGRESS",
+): GatewayResponse => ({
+  uuid,
+  organizationName: "org",
+  name: uuid,
+  displayName: `Gateway ${uuid}`,
+  gatewayType,
+  vhost: "example.com",
+  isCritical: false,
+  status: "ACTIVE",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  environments: envIds.map((envId) => ({
+    id: envId,
+    organizationName: "org",
+    name: envId,
+    displayName: envId,
+    dataplaneRef: "dp-1",
+    dnsPrefix: envId,
+    isProduction: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  })),
+});
+
+// Controlled wrapper so onChange results flow back into value, mirroring how
+// the create form and Deployment tab own the selection state.
+const ControlledSelector: React.FC<{
+  environments: Environment[];
+  gateways: GatewayResponse[];
+  initialValue?: string[];
+  lockedGatewayIds?: string[];
+  disabled?: boolean;
+  onChangeSpy?: (ids: string[]) => void;
+  onValidityChange?: (isValid: boolean) => void;
+}> = ({
+  environments,
+  gateways,
+  initialValue = [],
+  lockedGatewayIds,
+  disabled,
+  onChangeSpy,
+  onValidityChange,
+}) => {
+  const [value, setValue] = useState<string[]>(initialValue);
+  return (
+    <EnvironmentGatewaySelectorView
+      environments={environments}
+      gateways={gateways}
+      value={value}
+      onChange={(ids) => {
+        setValue(ids);
+        onChangeSpy?.(ids);
+      }}
+      lockedGatewayIds={lockedGatewayIds}
+      onValidityChange={onValidityChange}
+      disabled={disabled}
+    />
+  );
+};
+
+// `hidden: true` throughout: while an MUI Select menu is open (or still
+// unmounting), the Modal marks the rest of the app aria-hidden, which would
+// otherwise make every row invisible to role queries.
+const getCheckbox = (name: string) =>
+  screen.getByRole("checkbox", { name, hidden: true }) as HTMLInputElement;
+
+const chooseOption = (selectName: string, optionName: string) => {
+  fireEvent.mouseDown(
+    screen.getByRole("combobox", { name: selectName, hidden: true }),
+  );
+  const listboxes = screen.getAllByRole("listbox", { hidden: true });
+  const listbox = listboxes[listboxes.length - 1];
+  fireEvent.click(
+    within(listbox).getByRole("option", { name: optionName, hidden: true }),
+  );
+};
+
+describe("EnvironmentGatewaySelectorView", () => {
+  it("emits the sole candidate without rendering a Select when a 1-candidate row is checked", () => {
+    const onChangeSpy = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[makeGateway("gw-1", ["env-a"])]}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+    expect(
+      screen.queryByRole("combobox", { hidden: true }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(getCheckbox("Alpha"));
+    expect(onChangeSpy).toHaveBeenCalledWith(["gw-1"]);
+  });
+
+  it("contributes nothing while a 1-candidate row stays unchecked", () => {
+    const onChangeSpy = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[makeGateway("gw-1", ["env-a"])]}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+    expect(getCheckbox("Alpha")).not.toBeChecked();
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders a Select for 2 candidates and reports invalid until one is chosen", () => {
+    const onChangeSpy = vi.fn();
+    const onValidityChange = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[
+          makeGateway("gw-1", ["env-a"]),
+          makeGateway("gw-2", ["env-a"]),
+        ]}
+        onChangeSpy={onChangeSpy}
+        onValidityChange={onValidityChange}
+      />,
+    );
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+    fireEvent.click(getCheckbox("Alpha"));
+    expect(onChangeSpy).not.toHaveBeenCalled();
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    expect(
+      screen.getByText("Select an egress gateway for this environment."),
+    ).toBeInTheDocument();
+    chooseOption("Egress gateway for Alpha", "Gateway gw-2");
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-2"]);
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("does not block validity while a 2-candidate row is unchecked and unresolved", () => {
+    const onValidityChange = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[
+          makeGateway("gw-1", ["env-a"]),
+          makeGateway("gw-2", ["env-a"]),
+        ]}
+        onValidityChange={onValidityChange}
+      />,
+    );
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+    expect(onValidityChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("disables the checkbox of a 0-candidate row and explains why", () => {
+    const onChangeSpy = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[]}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+    expect(getCheckbox("Alpha")).toBeDisabled();
+    expect(
+      screen.getByText(
+        "No egress-capable gateway is attached to this environment.",
+      ),
+    ).toBeInTheDocument();
+    expect(onChangeSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders a locked row checked with a disabled Select and a Deployed chip", () => {
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[
+          makeGateway("gw-1", ["env-a"]),
+          makeGateway("gw-2", ["env-a"]),
+        ]}
+        initialValue={["gw-1"]}
+        lockedGatewayIds={["gw-1"]}
+      />,
+    );
+    expect(getCheckbox("Alpha")).toBeChecked();
+    expect(
+      screen.getByRole("combobox", {
+        name: "Egress gateway for Alpha",
+        hidden: true,
+      }),
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByText("Deployed")).toBeInTheDocument();
+  });
+
+  it("drops a locked gateway from the emission when its row is unchecked, and re-adds it on re-check", () => {
+    const onChangeSpy = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[
+          makeGateway("gw-1", ["env-a"]),
+          makeGateway("gw-2", ["env-a"]),
+        ]}
+        initialValue={["gw-1"]}
+        lockedGatewayIds={["gw-1"]}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+    fireEvent.click(getCheckbox("Alpha"));
+    expect(onChangeSpy).toHaveBeenLastCalledWith([]);
+    fireEvent.click(getCheckbox("Alpha"));
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-1"]);
+  });
+
+  it("renders every environment a multi-env gateway covers as checked and never pairs it with an overlapping gateway", () => {
+    const onChangeSpy = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[
+          makeEnvironment("env-a", "Alpha"),
+          makeEnvironment("env-b", "Beta"),
+        ]}
+        gateways={[
+          makeGateway("gw-shared", ["env-a", "env-b"]),
+          makeGateway("gw-solo", ["env-a"]),
+        ]}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+    fireEvent.click(getCheckbox("Alpha"));
+    chooseOption("Egress gateway for Alpha", "Gateway gw-shared");
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-shared"]);
+    expect(getCheckbox("Beta")).toBeChecked();
+
+    // Replacing the shared gateway in Alpha evicts it everywhere it deploys.
+    chooseOption("Egress gateway for Alpha", "Gateway gw-solo");
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-solo"]);
+    expect(getCheckbox("Beta")).not.toBeChecked();
+
+    // Re-selecting the shared gateway evicts the solo one from Alpha.
+    chooseOption("Egress gateway for Alpha", "Gateway gw-shared");
+    expect(onChangeSpy).toHaveBeenLastCalledWith(["gw-shared"]);
+    fireEvent.click(getCheckbox("Beta"));
+    expect(onChangeSpy).toHaveBeenLastCalledWith([]);
+  });
+
+  it("renders an unmapped selected gateway as a removable locked row", () => {
+    const onChangeSpy = vi.fn();
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[makeGateway("gw-1", ["env-a"])]}
+        initialValue={["ghost-gw"]}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+    expect(screen.getByText("Unmapped")).toBeInTheDocument();
+    const ghostCheckbox = getCheckbox("ghost-gw");
+    expect(ghostCheckbox).toBeChecked();
+    fireEvent.click(ghostCheckbox);
+    expect(onChangeSpy).toHaveBeenLastCalledWith([]);
+    expect(screen.queryByText("Unmapped")).not.toBeInTheDocument();
+  });
+
+  it("shows the deployment footer only when there is more than one environment", () => {
+    const { unmount } = renderWithTheme(
+      <ControlledSelector
+        environments={[
+          makeEnvironment("env-a", "Alpha"),
+          makeEnvironment("env-b", "Beta"),
+        ]}
+        gateways={[
+          makeGateway("gw-1", ["env-a"]),
+          makeGateway("gw-2", ["env-b"]),
+        ]}
+        initialValue={["gw-1"]}
+      />,
+    );
+    expect(
+      screen.getByText("1 of 2 environments deployed."),
+    ).toBeInTheDocument();
+    unmount();
+
+    renderWithTheme(
+      <ControlledSelector
+        environments={[makeEnvironment("env-a", "Alpha")]}
+        gateways={[makeGateway("gw-1", ["env-a"])]}
+        initialValue={["gw-1"]}
+      />,
+    );
+    expect(screen.queryByText(/environments deployed/)).not.toBeInTheDocument();
+  });
+});
+
+// Deterministic LCG so any failure reproduces from its seed.
+const makeLcg = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 2 ** 32;
+  };
+};
+
+interface Fixture {
+  environments: Environment[];
+  gateways: GatewayResponse[];
+  lockedGatewayIds: string[];
+  initialValue: string[];
+  envIdsByUuid: Record<string, string[]>;
+}
+
+const generateFixture = (rand: () => number): Fixture => {
+  const envCount = 2 + Math.floor(rand() * 4);
+  const environments = Array.from({ length: envCount }, (_, i) =>
+    makeEnvironment(`env-${i}`, `Env ${i}`),
+  );
+  const gatewayCount = 2 + Math.floor(rand() * 5);
+  const gateways = Array.from({ length: gatewayCount }, (_, i) => {
+    const covered = environments
+      .filter(() => rand() < 0.4)
+      .map((env) => env.id as string);
+    if (covered.length === 0) {
+      covered.push(environments[Math.floor(rand() * envCount)].id as string);
+    }
+    return makeGateway(`gw-${i}`, covered);
+  });
+
+  const envIdsByUuid: Record<string, string[]> = {};
+  gateways.forEach((gateway) => {
+    envIdsByUuid[gateway.uuid] = (gateway.environments ?? []).map(
+      (env) => env.id,
+    );
+  });
+
+  const lockedGatewayIds: string[] = [];
+  const lockedEnvIds = new Set<string>();
+  gateways.forEach((gateway) => {
+    if (rand() >= 0.35) return;
+    const envIds = envIdsByUuid[gateway.uuid];
+    if (envIds.some((envId) => lockedEnvIds.has(envId))) return;
+    lockedGatewayIds.push(gateway.uuid);
+    envIds.forEach((envId) => lockedEnvIds.add(envId));
+  });
+
+  const initialValue = [...lockedGatewayIds];
+  if (rand() < 0.3) {
+    initialValue.push("ghost-gw");
+    envIdsByUuid["ghost-gw"] = [];
+  }
+
+  return { environments, gateways, lockedGatewayIds, initialValue, envIdsByUuid };
+};
+
+const performRandomAction = (rand: () => number) => {
+  const checkboxes = screen
+    .queryAllByRole("checkbox", { hidden: true })
+    .filter((checkbox) => !(checkbox as HTMLInputElement).disabled);
+  const combos = screen
+    .queryAllByRole("combobox", { hidden: true })
+    .filter((combo) => combo.getAttribute("aria-disabled") !== "true");
+  const total = checkboxes.length + combos.length;
+  if (total === 0) return;
+  const pick = Math.floor(rand() * total);
+  if (pick < checkboxes.length) {
+    fireEvent.click(checkboxes[pick]);
+    return;
+  }
+  fireEvent.mouseDown(combos[pick - checkboxes.length]);
+  const listboxes = screen.getAllByRole("listbox", { hidden: true });
+  const options = within(listboxes[listboxes.length - 1])
+    .getAllByRole("option", { hidden: true })
+    .filter((option) => option.getAttribute("aria-disabled") !== "true");
+  if (options.length > 0) {
+    fireEvent.click(options[Math.floor(rand() * options.length)]);
+  }
+};
+
+describe("EnvironmentGatewaySelectorView placement invariant", () => {
+  it.each([7, 42, 1337, 20260807])(
+    "never emits two gateways with intersecting environment sets (seed %i)",
+    (seed) => {
+      const rand = makeLcg(seed);
+      const fixture = generateFixture(rand);
+      const emissions: string[][] = [];
+      renderWithTheme(
+        <ControlledSelector
+          environments={fixture.environments}
+          gateways={fixture.gateways}
+          initialValue={fixture.initialValue}
+          lockedGatewayIds={fixture.lockedGatewayIds}
+          onChangeSpy={(ids) => emissions.push(ids)}
+        />,
+      );
+
+      let verified = 0;
+      const verifyNewEmissions = () => {
+        for (; verified < emissions.length; verified += 1) {
+          const emitted = emissions[verified];
+          const coveredEnvIds = new Set<string>();
+          emitted.forEach((uuid) => {
+            (fixture.envIdsByUuid[uuid] ?? []).forEach((envId) => {
+              if (coveredEnvIds.has(envId)) {
+                throw new Error(
+                  `seed ${seed}, emission ${verified}: env ${envId} covered ` +
+                    `twice in [${emitted.join(", ")}]`,
+                );
+              }
+              coveredEnvIds.add(envId);
+            });
+          });
+        }
+      };
+
+      for (let step = 0; step < 25; step += 1) {
+        performRandomAction(rand);
+        verifyNewEmissions();
+      }
+      expect(emissions.length).toBeGreaterThan(0);
+    },
+  );
+});

--- a/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.tsx
@@ -1,0 +1,421 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Checkbox,
+  Chip,
+  FormControl,
+  MenuItem,
+  Select,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@wso2/oxygen-ui";
+import type {
+  Environment,
+  GatewayResponse,
+} from "@agent-management-platform/types";
+import {
+  useListEnvironments,
+  useListGateways,
+} from "@agent-management-platform/api-client";
+
+export interface EnvironmentGatewaySelectorProps {
+  orgId: string;
+  /** Gateway UUIDs currently selected (controlled). */
+  value: string[];
+  onChange: (gatewayIds: string[]) => void;
+  /** Gateway UUIDs already deployed — rendered locked. Omit in create form. */
+  lockedGatewayIds?: string[];
+  /** false while any checked 2+-candidate environment lacks a resolved gateway. */
+  onValidityChange?: (isValid: boolean) => void;
+  disabled?: boolean;
+}
+
+export interface EnvironmentGatewaySelectorViewProps
+  extends Omit<EnvironmentGatewaySelectorProps, "orgId"> {
+  environments: Environment[];
+  gateways: GatewayResponse[];
+  isLoading?: boolean;
+}
+
+const environmentIdsOf = (gateway: GatewayResponse): string[] =>
+  (gateway.environments ?? []).flatMap((env) => (env.id ? [env.id] : []));
+
+const gatewayLabel = (gateway: GatewayResponse): string =>
+  gateway.displayName || gateway.name;
+
+const AMBIGUOUS_CAPTION = "Select an egress gateway for this environment.";
+const UNAVAILABLE_CAPTION =
+  "No egress-capable gateway is attached to this environment.";
+const DEPLOYED_CAPTION =
+  "Placement is fixed once deployed. To use a different gateway, uncheck " +
+  "this environment and save to undeploy, then select the new gateway and " +
+  "save again.";
+
+interface EnvironmentRow {
+  envId: string;
+  label: string;
+  candidates: GatewayResponse[];
+  lockedGateway?: GatewayResponse;
+  resolvedGateway?: GatewayResponse;
+  checked: boolean;
+}
+
+export const EnvironmentGatewaySelectorView: React.FC<
+  EnvironmentGatewaySelectorViewProps
+> = ({
+  environments,
+  gateways,
+  isLoading,
+  value,
+  onChange,
+  lockedGatewayIds = [],
+  onValidityChange,
+  disabled,
+}) => {
+  const [pendingEnvIds, setPendingEnvIds] = useState<Set<string>>(new Set());
+
+  const valueSet = useMemo(() => new Set(value), [value]);
+  const lockedSet = useMemo(() => new Set(lockedGatewayIds), [lockedGatewayIds]);
+  const gatewayByUuid = useMemo(
+    () => new Map(gateways.map((gateway) => [gateway.uuid, gateway])),
+    [gateways],
+  );
+
+  // Egress-capable only: ingress gateways are not legal LLM placement targets
+  // and the server rejects them. No status filter — the server's candidate set
+  // is not liveness-filtered either, so filtering here would offer a narrower
+  // set than the server accepts and hide a valid choice whenever a gateway is
+  // briefly disconnected.
+  const gatewaysByEnv = useMemo(() => {
+    const map: Record<string, GatewayResponse[]> = {};
+    gateways.forEach((gateway) => {
+      if (gateway.gatewayType !== "EGRESS" && gateway.gatewayType !== "BOTH") {
+        return;
+      }
+      (gateway.environments ?? []).forEach((env) => {
+        if (!env.id) return;
+        (map[env.id] ??= []).push(gateway);
+      });
+    });
+    return map;
+  }, [gateways]);
+
+  const lockedCoveredEnvIds = useMemo(() => {
+    const covered = new Set<string>();
+    value.forEach((uuid) => {
+      if (!lockedSet.has(uuid)) return;
+      const gateway = gatewayByUuid.get(uuid);
+      if (!gateway) return;
+      environmentIdsOf(gateway).forEach((envId) => covered.add(envId));
+    });
+    return covered;
+  }, [value, lockedSet, gatewayByUuid]);
+
+  const isBlockedByLocked = (gateway: GatewayResponse): boolean =>
+    !lockedSet.has(gateway.uuid) &&
+    environmentIdsOf(gateway).some((envId) => lockedCoveredEnvIds.has(envId));
+
+  const rows = useMemo<EnvironmentRow[]>(
+    () =>
+      environments.flatMap((env) => {
+        if (!env.id) return [];
+        const candidates = gatewaysByEnv[env.id] ?? [];
+        const lockedGateway = candidates.find((candidate) =>
+          lockedSet.has(candidate.uuid),
+        );
+        const resolvedGateway = candidates.find((candidate) =>
+          valueSet.has(candidate.uuid),
+        );
+        const checked = lockedGateway
+          ? valueSet.has(lockedGateway.uuid)
+          : resolvedGateway != null || pendingEnvIds.has(env.id);
+        return [
+          {
+            envId: env.id,
+            label: env.displayName || env.name,
+            candidates,
+            lockedGateway,
+            resolvedGateway,
+            checked,
+          },
+        ];
+      }),
+    [environments, gatewaysByEnv, lockedSet, valueSet, pendingEnvIds],
+  );
+
+  const unmappedSelectedUuids = useMemo(() => {
+    const candidateUuids = new Set(
+      rows.flatMap((row) => row.candidates.map((candidate) => candidate.uuid)),
+    );
+    return value.filter((uuid) => !candidateUuids.has(uuid));
+  }, [rows, value]);
+
+  const isValid = rows.every(
+    (row) => !(row.checked && !row.lockedGateway && !row.resolvedGateway),
+  );
+
+  useEffect(() => {
+    onValidityChange?.(isValid);
+  }, [isValid, onValidityChange]);
+
+  const setPending = (envId: string, pending: boolean) => {
+    setPendingEnvIds((prev) => {
+      const next = new Set(prev);
+      if (pending) next.add(envId);
+      else next.delete(envId);
+      return next;
+    });
+  };
+
+  const emitRemove = (uuid: string) => {
+    onChange(value.filter((selected) => selected !== uuid));
+  };
+
+  const emitAdd = (gateway: GatewayResponse) => {
+    if (isBlockedByLocked(gateway)) return;
+    const addedEnvIds = new Set(environmentIdsOf(gateway));
+    const next = value.filter((uuid) => {
+      if (uuid === gateway.uuid) return false;
+      if (lockedSet.has(uuid)) return true;
+      const other = gatewayByUuid.get(uuid);
+      if (!other) return true;
+      return !environmentIdsOf(other).some((envId) => addedEnvIds.has(envId));
+    });
+    onChange([...next, gateway.uuid]);
+  };
+
+  const handleToggle = (row: EnvironmentRow) => {
+    if (row.lockedGateway) {
+      if (row.checked) emitRemove(row.lockedGateway.uuid);
+      else emitAdd(row.lockedGateway);
+      return;
+    }
+    if (row.checked) {
+      setPending(row.envId, false);
+      if (row.resolvedGateway) emitRemove(row.resolvedGateway.uuid);
+      return;
+    }
+    if (row.candidates.length === 1) emitAdd(row.candidates[0]);
+    else setPending(row.envId, true);
+  };
+
+  const handleSelect = (row: EnvironmentRow, uuid: string) => {
+    const gateway = gatewayByUuid.get(uuid);
+    if (!gateway) return;
+    setPending(row.envId, false);
+    emitAdd(gateway);
+  };
+
+  if (isLoading) {
+    return (
+      <Stack spacing={1}>
+        {[0, 1, 2].map((index) => (
+          <Skeleton key={index} variant="rounded" height={40} />
+        ))}
+      </Stack>
+    );
+  }
+
+  const deployedCount = rows.filter((row) =>
+    row.candidates.some((candidate) => valueSet.has(candidate.uuid)),
+  ).length;
+
+  const renderRowContent = (row: EnvironmentRow) => {
+    if (row.candidates.length === 0) {
+      return (
+        <Typography variant="caption" color="text.secondary">
+          {UNAVAILABLE_CAPTION}
+        </Typography>
+      );
+    }
+    if (row.lockedGateway) {
+      return (
+        <>
+          <FormControl fullWidth>
+            <Select
+              size="small"
+              value={row.lockedGateway.uuid}
+              disabled
+              SelectDisplayProps={{
+                "aria-label": `Egress gateway for ${row.label}`,
+              }}
+            >
+              {row.candidates.map((candidate) => (
+                <MenuItem key={candidate.uuid} value={candidate.uuid}>
+                  {gatewayLabel(candidate)}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+            {DEPLOYED_CAPTION}
+          </Typography>
+        </>
+      );
+    }
+    if (row.candidates.length === 1) {
+      return (
+        <Typography variant="body2" color="text.secondary">
+          {gatewayLabel(row.candidates[0])}
+        </Typography>
+      );
+    }
+    return (
+      <>
+        <FormControl fullWidth>
+          <Select
+            size="small"
+            value={row.resolvedGateway?.uuid ?? ""}
+            disabled={disabled}
+            onChange={(event) => handleSelect(row, event.target.value)}
+            SelectDisplayProps={{
+              "aria-label": `Egress gateway for ${row.label}`,
+            }}
+          >
+            {row.candidates.map((candidate) => (
+              <MenuItem
+                key={candidate.uuid}
+                value={candidate.uuid}
+                disabled={isBlockedByLocked(candidate)}
+              >
+                {gatewayLabel(candidate)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {row.checked && !row.resolvedGateway && (
+          <Typography variant="caption" color="error" sx={{ mt: 0.5 }}>
+            {AMBIGUOUS_CAPTION}
+          </Typography>
+        )}
+      </>
+    );
+  };
+
+  const isRowCheckboxDisabled = (row: EnvironmentRow): boolean => {
+    if (disabled) return true;
+    if (row.candidates.length === 0) return true;
+    if (
+      row.candidates.length === 1 &&
+      !row.checked &&
+      isBlockedByLocked(row.candidates[0])
+    ) {
+      return true;
+    }
+    return false;
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      {rows.map((row) => (
+        <Stack
+          key={row.envId}
+          direction="row"
+          spacing={1}
+          alignItems="flex-start"
+          sx={row.candidates.length === 0 ? { opacity: 0.5 } : undefined}
+        >
+          <Checkbox
+            size="small"
+            checked={row.checked}
+            disabled={isRowCheckboxDisabled(row)}
+            onChange={() => handleToggle(row)}
+            inputProps={{ "aria-label": row.label }}
+            sx={{ p: 0.5 }}
+          />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              sx={{ mb: 0.5 }}
+            >
+              <Typography variant="body2">{row.label}</Typography>
+              {row.lockedGateway && (
+                <Chip
+                  label="Deployed"
+                  size="small"
+                  variant="outlined"
+                  color="success"
+                />
+              )}
+            </Stack>
+            {renderRowContent(row)}
+          </Box>
+        </Stack>
+      ))}
+      {unmappedSelectedUuids.map((uuid) => {
+        const gateway = gatewayByUuid.get(uuid);
+        const label = gateway ? gatewayLabel(gateway) : uuid;
+        return (
+          <Stack
+            key={uuid}
+            direction="row"
+            spacing={1}
+            alignItems="flex-start"
+          >
+            <Checkbox
+              size="small"
+              checked
+              disabled={disabled}
+              onChange={() => emitRemove(uuid)}
+              inputProps={{ "aria-label": label }}
+              sx={{ p: 0.5 }}
+            />
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Typography variant="body2">{label}</Typography>
+                <Chip label="Unmapped" size="small" variant="outlined" />
+              </Stack>
+            </Box>
+          </Stack>
+        );
+      })}
+      {rows.length > 1 && (
+        <Typography variant="caption" color="text.secondary">
+          {deployedCount} of {rows.length} environments deployed.
+        </Typography>
+      )}
+    </Stack>
+  );
+};
+
+export const EnvironmentGatewaySelector: React.FC<
+  EnvironmentGatewaySelectorProps
+> = ({ orgId, ...viewProps }) => {
+  const { data: environments, isLoading: isLoadingEnvironments } =
+    useListEnvironments({ orgName: orgId });
+  // limit: 500 — without it the server's default page size silently truncates
+  // the gateway list and environments would wrongly render as unavailable.
+  const { data: gatewaysData, isLoading: isLoadingGateways } = useListGateways(
+    { orgName: orgId },
+    { limit: 500 },
+  );
+  return (
+    <EnvironmentGatewaySelectorView
+      environments={environments ?? []}
+      gateways={gatewaysData?.gateways ?? []}
+      isLoading={isLoadingEnvironments || isLoadingGateways}
+      {...viewProps}
+    />
+  );
+};

--- a/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.tsx
@@ -221,7 +221,7 @@ export const EnvironmentGatewaySelectorView: React.FC<
     );
   }
 
-  const deployedCount = rows.filter((row) =>
+  const selectedCount = rows.filter((row) =>
     row.candidates.some((candidate) => valueSet.has(candidate.uuid)),
   ).length;
 
@@ -361,7 +361,7 @@ export const EnvironmentGatewaySelectorView: React.FC<
       })}
       {rows.length > 1 && (
         <Typography variant="caption" color="text.secondary">
-          {deployedCount} of {rows.length} environments deployed.
+          {selectedCount} of {rows.length} environments selected.
         </Typography>
       )}
     </Stack>

--- a/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/EnvironmentGatewaySelector.tsx
@@ -56,8 +56,10 @@ export interface EnvironmentGatewaySelectorViewProps
   isLoading?: boolean;
 }
 
-const environmentIdsOf = (gateway: GatewayResponse): string[] =>
-  (gateway.environments ?? []).flatMap((env) => (env.id ? [env.id] : []));
+// A gateway belongs to exactly one environment (business rule; the wire shape
+// is an array). A gateway with no mapping surfaces via the "Unmapped" row.
+const environmentIdOf = (gateway: GatewayResponse): string | undefined =>
+  gateway.environments?.[0]?.id;
 
 const gatewayLabel = (gateway: GatewayResponse): string =>
   gateway.displayName || gateway.name;
@@ -111,28 +113,12 @@ export const EnvironmentGatewaySelectorView: React.FC<
       if (gateway.gatewayType !== "EGRESS" && gateway.gatewayType !== "BOTH") {
         return;
       }
-      (gateway.environments ?? []).forEach((env) => {
-        if (!env.id) return;
-        (map[env.id] ??= []).push(gateway);
-      });
+      const envId = environmentIdOf(gateway);
+      if (!envId) return;
+      (map[envId] ??= []).push(gateway);
     });
     return map;
   }, [gateways]);
-
-  const lockedCoveredEnvIds = useMemo(() => {
-    const covered = new Set<string>();
-    value.forEach((uuid) => {
-      if (!lockedSet.has(uuid)) return;
-      const gateway = gatewayByUuid.get(uuid);
-      if (!gateway) return;
-      environmentIdsOf(gateway).forEach((envId) => covered.add(envId));
-    });
-    return covered;
-  }, [value, lockedSet, gatewayByUuid]);
-
-  const isBlockedByLocked = (gateway: GatewayResponse): boolean =>
-    !lockedSet.has(gateway.uuid) &&
-    environmentIdsOf(gateway).some((envId) => lockedCoveredEnvIds.has(envId));
 
   const rows = useMemo<EnvironmentRow[]>(
     () =>
@@ -190,15 +176,15 @@ export const EnvironmentGatewaySelectorView: React.FC<
     onChange(value.filter((selected) => selected !== uuid));
   };
 
+  // Evicting any same-environment gateway before adding keeps the emitted
+  // array inside the server's one-gateway-per-environment placement rule.
   const emitAdd = (gateway: GatewayResponse) => {
-    if (isBlockedByLocked(gateway)) return;
-    const addedEnvIds = new Set(environmentIdsOf(gateway));
+    const envId = environmentIdOf(gateway);
     const next = value.filter((uuid) => {
       if (uuid === gateway.uuid) return false;
-      if (lockedSet.has(uuid)) return true;
       const other = gatewayByUuid.get(uuid);
-      if (!other) return true;
-      return !environmentIdsOf(other).some((envId) => addedEnvIds.has(envId));
+      if (!other || envId === undefined) return true;
+      return environmentIdOf(other) !== envId;
     });
     onChange([...next, gateway.uuid]);
   };
@@ -292,11 +278,7 @@ export const EnvironmentGatewaySelectorView: React.FC<
             }}
           >
             {row.candidates.map((candidate) => (
-              <MenuItem
-                key={candidate.uuid}
-                value={candidate.uuid}
-                disabled={isBlockedByLocked(candidate)}
-              >
+              <MenuItem key={candidate.uuid} value={candidate.uuid}>
                 {gatewayLabel(candidate)}
               </MenuItem>
             ))}
@@ -309,19 +291,6 @@ export const EnvironmentGatewaySelectorView: React.FC<
         )}
       </>
     );
-  };
-
-  const isRowCheckboxDisabled = (row: EnvironmentRow): boolean => {
-    if (disabled) return true;
-    if (row.candidates.length === 0) return true;
-    if (
-      row.candidates.length === 1 &&
-      !row.checked &&
-      isBlockedByLocked(row.candidates[0])
-    ) {
-      return true;
-    }
-    return false;
   };
 
   return (
@@ -337,7 +306,7 @@ export const EnvironmentGatewaySelectorView: React.FC<
           <Checkbox
             size="small"
             checked={row.checked}
-            disabled={isRowCheckboxDisabled(row)}
+            disabled={disabled || row.candidates.length === 0}
             onChange={() => handleToggle(row)}
             inputProps={{ "aria-label": row.label }}
             sx={{ p: 0.5 }}

--- a/console/workspaces/libs/shared-component/src/components/index.ts
+++ b/console/workspaces/libs/shared-component/src/components/index.ts
@@ -91,3 +91,9 @@ export {
   type PermissionTreeItem,
   type PermissionTreeProps,
 } from "./PermissionTree/PermissionTree";
+export {
+  EnvironmentGatewaySelector,
+  EnvironmentGatewaySelectorView,
+  type EnvironmentGatewaySelectorProps,
+  type EnvironmentGatewaySelectorViewProps,
+} from "./EnvironmentGatewaySelector/EnvironmentGatewaySelector";

--- a/console/workspaces/libs/shared-component/vitest.config.ts
+++ b/console/workspaces/libs/shared-component/vitest.config.ts
@@ -26,5 +26,13 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './setupTests.tsx',
+    server: {
+      deps: {
+        // oxygen-ui's dist imports prismjs subpaths without file extensions
+        // and @mui/x-data-grid imports raw .css, neither of which Node's
+        // native ESM loader accepts; route them through Vite's resolver.
+        inline: ['@wso2/oxygen-ui', '@mui/x-data-grid'],
+      },
+    },
   },
 });

--- a/console/workspaces/pages/eval/src/subComponents/MonitorLLMProviderDrawer.tsx
+++ b/console/workspaces/pages/eval/src/subComponents/MonitorLLMProviderDrawer.tsx
@@ -527,7 +527,6 @@ export function MonitorLLMProviderDrawer({
               submitLabel="Create & use provider"
               showAdvancedBasicDetails={false}
               showGuardrails={false}
-              showGatewaySelector={false}
               onCancel={() => setMode("list")}
               onSubmit={handleCreateProvider}
             />

--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -19,7 +19,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
-  Autocomplete,
   Box,
   Button,
   CardContent,
@@ -39,6 +38,7 @@ import {
 } from "../form/schema";
 import { useValidatedForm } from "../hooks/useValidatedForm";
 import {
+  EnvironmentGatewaySelector,
   PolicyListSection,
   type PolicySelection as GuardrailSelection,
 } from "@agent-management-platform/shared-component";
@@ -97,12 +97,6 @@ interface AddLLMProviderFormProps {
    * connection config).
    */
   showGuardrails?: boolean;
-  /**
-   * Set to false to hide the multi-gateway Deployment Configuration section.
-   * A gateway is still required and auto-selected under the hood; only the
-   * UI is simplified based on how many active gateways the org has.
-   */
-  showGatewaySelector?: boolean;
   onCancel: () => void;
   onSubmit: (
     values: AddLLMProviderFormValues,
@@ -144,7 +138,6 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
   submitLabel = "Add provider",
   showAdvancedBasicDetails = true,
   showGuardrails = true,
-  showGatewaySelector = true,
   onCancel,
   onSubmit,
 }) => {
@@ -169,9 +162,12 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
     [formData.templateId, templates],
   );
 
-  const { data: gatewaysData, isLoading: isLoadingGateways } = useListGateways({
-    orgName: orgId,
-  });
+  // limit: 500 — without it the server's default page size silently truncates
+  // the list and the zero-egress warning could fire against a partial view.
+  const { data: gatewaysData, isLoading: isLoadingGateways } = useListGateways(
+    { orgName: orgId },
+    { limit: 500 },
+  );
 
   // Egress-capable only: ingress gateways are not legal LLM placement targets and the
   // server rejects them. No status filter — the server's candidate set is not
@@ -185,19 +181,12 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
     [gatewaysData?.gateways],
   );
 
-  // Auto-select only when the choice is unambiguous. With two egress gateways the user
-  // must pick, because the server 400s on an unnamed gateway in that case.
-  useEffect(() => {
-    if (gateways.length === 1 && formData.gatewayIds?.length === 0) {
-      setFormData({ ...formData, gatewayIds: [gateways[0].uuid] });
-    }
-  }, [gateways]);
-
   const hasTemplateUrl = Boolean(selectedTemplate?.hasTemplateUrl);
   const requiresUpstream = !hasTemplateUrl;
   const requiresApiKey = !!selectedTemplate?.hasTemplateAuthHeader;
 
   const [guardrails, setGuardrails] = useState<GuardrailSelection[]>([]);
+  const [isGatewaySelectionValid, setIsGatewaySelectionValid] = useState(true);
   const [endpointEditable, setEndpointEditable] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
 
@@ -631,83 +620,25 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
           />
         </Collapse>
       )}
-      {showGatewaySelector ? (
-        <Collapse in={!!formData.templateId}>
-          <Form.Section>
-            <Form.Subheader>Deployment Configuration</Form.Subheader>
-            <Form.ElementWrapper label="Gateway" name="gatewayIds">
-              {isLoadingGateways ? (
-                <Skeleton variant="rounded" height={40} />
-              ) : (
-                <Autocomplete
-                  multiple
-                  options={gateways}
-                  size="small"
-                  value={gateways.filter((g) =>
-                    (formData.gatewayIds ?? []).includes(g.uuid),
-                  )}
-                  onChange={(_, newValue) => {
-                    handleFieldChange(
-                      "gatewayIds",
-                      newValue.map((g) => g.uuid),
-                    );
-                  }}
-                  getOptionLabel={(option) =>
-                    option.displayName || option.name || option.uuid
-                  }
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      placeholder="Select gateway(s)"
-                      error={Boolean(errors.gatewayIds)}
-                      helperText={errors.gatewayIds}
-                    />
-                  )}
-                />
-              )}
-            </Form.ElementWrapper>
-          </Form.Section>
-        </Collapse>
-      ) : (
-        <Collapse in={!!formData.templateId}>
-          {!isLoadingGateways && gateways.length === 0 && (
-            <Alert severity="warning">
-              No egress-capable gateway is configured for this organization.
-              Ask an admin to configure one before creating an LLM provider.
-            </Alert>
-          )}
-          {!isLoadingGateways && gateways.length > 1 && (
-            <Form.ElementWrapper label="Gateway" name="gatewayIds">
-              <Autocomplete
-                options={gateways}
-                size="small"
-                value={
-                  gateways.find((g) =>
-                    (formData.gatewayIds ?? []).includes(g.uuid),
-                  ) ?? null
-                }
-                onChange={(_, newValue) => {
-                  handleFieldChange(
-                    "gatewayIds",
-                    newValue ? [newValue.uuid] : [],
-                  );
-                }}
-                getOptionLabel={(option) =>
-                  option.displayName || option.name || option.uuid
-                }
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    placeholder="Select gateway"
-                    error={Boolean(errors.gatewayIds)}
-                    helperText={errors.gatewayIds}
-                  />
-                )}
-              />
-            </Form.ElementWrapper>
-          )}
-        </Collapse>
-      )}
+      <Collapse in={!!formData.templateId}>
+        <Form.Section>
+          <Form.Subheader>Deployment Configuration</Form.Subheader>
+          <Form.Stack spacing={2}>
+            {!isLoadingGateways && gateways.length === 0 && (
+              <Alert severity="warning">
+                No egress-capable gateway is configured for this organization.
+                Ask an admin to configure one before creating an LLM provider.
+              </Alert>
+            )}
+            <EnvironmentGatewaySelector
+              orgId={orgId}
+              value={formData.gatewayIds ?? []}
+              onChange={(ids) => handleFieldChange("gatewayIds", ids)}
+              onValidityChange={setIsGatewaySelectionValid}
+            />
+          </Form.Stack>
+        </Form.Section>
+      </Collapse>
       {errorMessage && (
         <Alert severity="error">
           <Typography variant="body2">{errorMessage}</Typography>
@@ -740,7 +671,8 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
           disabled={
             isSubmitting ||
             !formData.gatewayIds ||
-            formData.gatewayIds?.length === 0
+            formData.gatewayIds?.length === 0 ||
+            !isGatewaySelectionValid
           }
         >
           {isSubmitting ? "Creating..." : submitLabel}

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.test.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ThemeProvider, createTheme } from "@wso2/oxygen-ui";
+import type {
+  Environment,
+  GatewayResponse,
+  LLMProviderResponse,
+} from "@agent-management-platform/types";
+
+// The tab renders the connected EnvironmentGatewaySelector, whose api-client
+// import crashes at import time outside a configured app shell. Stub the
+// module boundary and feed data through the two hooks the selector calls.
+vi.mock("@agent-management-platform/api-client", () => ({
+  useListEnvironments: vi.fn(),
+  useListGateways: vi.fn(),
+}));
+
+import {
+  useListEnvironments,
+  useListGateways,
+} from "@agent-management-platform/api-client";
+import { ConfirmationDialogProvider } from "@agent-management-platform/shared-component";
+import {
+  LLMProviderDeploymentTab,
+  type LLMProviderDeploymentTabProps,
+} from "./LLMProviderDeploymentTab";
+
+const mockUseListEnvironments = vi.mocked(useListEnvironments);
+const mockUseListGateways = vi.mocked(useListGateways);
+
+const makeEnvironment = (id: string, name: string): Environment => ({
+  id,
+  name,
+  displayName: name,
+  dataplaneRef: "dp-1",
+  isProduction: false,
+  createdAt: "2026-01-01T00:00:00Z",
+});
+
+const makeGateway = (uuid: string, envIds: string[]): GatewayResponse => ({
+  uuid,
+  organizationName: "org",
+  name: uuid,
+  displayName: `Gateway ${uuid}`,
+  gatewayType: "EGRESS",
+  vhost: "example.com",
+  isCritical: false,
+  status: "ACTIVE",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+  environments: envIds.map((envId) => ({
+    id: envId,
+    organizationName: "org",
+    name: envId,
+    displayName: envId,
+    dataplaneRef: "dp-1",
+    dnsPrefix: envId,
+    isProduction: false,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  })),
+});
+
+const makeProvider = (gateways: string[]): LLMProviderResponse => ({
+  uuid: "provider-1",
+  id: "provider-1",
+  name: "provider-1",
+  version: "v1",
+  context: "/llm/provider-1",
+  template: "openai",
+  upstream: { main: { url: "https://api.example.com" } },
+  status: "deployed",
+  gateways,
+});
+
+const seedSelectorData = () => {
+  mockUseListEnvironments.mockReturnValue({
+    data: [makeEnvironment("env-a", "Alpha"), makeEnvironment("env-b", "Beta")],
+    isLoading: false,
+  } as ReturnType<typeof useListEnvironments>);
+  mockUseListGateways.mockReturnValue({
+    data: {
+      gateways: [makeGateway("gw-a", ["env-a"]), makeGateway("gw-b", ["env-b"])],
+    },
+    isLoading: false,
+  } as ReturnType<typeof useListGateways>);
+};
+
+const renderTab = (props: Partial<LLMProviderDeploymentTabProps> = {}) => {
+  const defaultProps: LLMProviderDeploymentTabProps = {
+    providerData: makeProvider([]),
+    orgName: "org",
+    onUpdate: vi.fn().mockResolvedValue(makeProvider([])),
+    isUpdating: false,
+  };
+  const merged = { ...defaultProps, ...props };
+  const wrap = (p: LLMProviderDeploymentTabProps) => (
+    <ThemeProvider theme={createTheme()}>
+      <ConfirmationDialogProvider>
+        <LLMProviderDeploymentTab {...p} />
+      </ConfirmationDialogProvider>
+    </ThemeProvider>
+  );
+  const view = render(wrap(merged));
+  return {
+    ...view,
+    rerenderTab: (next: Partial<LLMProviderDeploymentTabProps>) =>
+      view.rerender(wrap({ ...merged, ...next })),
+  };
+};
+
+const getCheckbox = (name: string) =>
+  screen.getByRole("checkbox", { name }) as HTMLInputElement;
+const getSaveButton = () => screen.getByRole("button", { name: /save/i });
+
+describe("LLMProviderDeploymentTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seedSelectorData();
+  });
+
+  it("seeds from providerData.gateways and keeps Save disabled while clean", () => {
+    renderTab({ providerData: makeProvider(["gw-a"]) });
+    expect(getCheckbox("Alpha")).toBeChecked();
+    expect(getCheckbox("Beta")).not.toBeChecked();
+    expect(getSaveButton()).toBeDisabled();
+  });
+
+  it("saves the toggled selection as exactly { gateways: [...] }", async () => {
+    const onUpdate = vi
+      .fn()
+      .mockResolvedValue(makeProvider(["gw-a", "gw-b"]));
+    renderTab({ providerData: makeProvider(["gw-a"]), onUpdate });
+
+    fireEvent.click(getCheckbox("Beta"));
+    expect(getSaveButton()).toBeEnabled();
+    fireEvent.click(getSaveButton());
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate.mock.calls[0][0]).toEqual({ gateways: ["gw-a", "gw-b"] });
+  });
+
+  it("renders every row undeployed for a gateway-less provider and enables Save once a choice is made", () => {
+    renderTab({ providerData: makeProvider([]) });
+    expect(getCheckbox("Alpha")).not.toBeChecked();
+    expect(getCheckbox("Beta")).not.toBeChecked();
+    expect(getSaveButton()).toBeDisabled();
+
+    fireEvent.click(getCheckbox("Alpha"));
+    expect(getSaveButton()).toBeEnabled();
+  });
+
+  it("reconciles the selection down to the post-save refetch when a deploy fails", async () => {
+    const onUpdate = vi
+      .fn()
+      .mockResolvedValue(makeProvider(["gw-a", "gw-b"]));
+    const { rerenderTab } = renderTab({
+      providerData: makeProvider(["gw-a"]),
+      onUpdate,
+    });
+
+    fireEvent.click(getCheckbox("Beta"));
+    fireEvent.click(getSaveButton());
+    await screen.findByText("Deployment updated successfully.");
+    expect(onUpdate.mock.calls[0][0]).toEqual({ gateways: ["gw-a", "gw-b"] });
+
+    // The refetched GET only returns gw-a: the gw-b deploy failed server-side.
+    rerenderTab({ providerData: makeProvider(["gw-a"]) });
+
+    expect(getCheckbox("Alpha")).toBeChecked();
+    expect(getCheckbox("Beta")).not.toBeChecked();
+    expect(getSaveButton()).toBeDisabled();
+  });
+});

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.test.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.test.tsx
@@ -168,6 +168,19 @@ describe("LLMProviderDeploymentTab", () => {
     expect(getSaveButton()).toBeEnabled();
   });
 
+  it("keeps an unsaved selection across a background refetch that leaves the gateway set unchanged", () => {
+    const { rerenderTab } = renderTab({ providerData: makeProvider(["gw-a"]) });
+    fireEvent.click(getCheckbox("Beta"));
+    expect(getSaveButton()).toBeEnabled();
+
+    // New object identity, same gateway set — e.g. a window-focus refetch
+    // that changed an unrelated provider field.
+    rerenderTab({ providerData: makeProvider(["gw-a"]) });
+
+    expect(getCheckbox("Beta")).toBeChecked();
+    expect(getSaveButton()).toBeEnabled();
+  });
+
   it("reconciles the selection down to the post-save refetch when a deploy fails", async () => {
     const onUpdate = vi
       .fn()

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.tsx
@@ -48,7 +48,7 @@ export function LLMProviderDeploymentTab({
   onUpdate,
   isUpdating,
 }: LLMProviderDeploymentTabProps) {
-  const initializedProviderIdRef = useRef<string | null>(null);
+  const seededRef = useRef<{ uuid: string; gateways: string[] } | null>(null);
   const [selectedGatewayIds, setSelectedGatewayIds] = useState<string[]>([]);
   const [isSelectionValid, setIsSelectionValid] = useState(true);
   const [status, setStatus] = useState<{
@@ -57,11 +57,22 @@ export function LLMProviderDeploymentTab({
   } | null>(null);
   const { addConfirmation } = useConfirmationDialog();
 
+  // Re-seed only when the server's gateway set disagrees with the last seed:
+  // a background refetch that changes unrelated provider fields must not
+  // discard an unsaved selection.
   useEffect(() => {
     if (!providerData) return;
-    if (initializedProviderIdRef.current === providerData.uuid) return;
-    initializedProviderIdRef.current = providerData.uuid;
-    setSelectedGatewayIds(providerData.gateways ?? []);
+    const gateways = providerData.gateways ?? [];
+    const seeded = seededRef.current;
+    if (
+      seeded &&
+      seeded.uuid === providerData.uuid &&
+      sameGatewaySet(seeded.gateways, gateways)
+    ) {
+      return;
+    }
+    seededRef.current = { uuid: providerData.uuid, gateways };
+    setSelectedGatewayIds(gateways);
   }, [providerData]);
 
   const deployedGatewayIds = useMemo(
@@ -85,9 +96,15 @@ export function LLMProviderDeploymentTab({
       await onUpdate({ gateways: selectedGatewayIds });
       // The PUT response drops per-gateway deploy outcomes; only the refetched
       // GET (the mutation invalidates ["llm-provider"]) reports what actually
-      // deployed. Clearing the seed guard lets that refetch re-seed the
-      // selection, so a gateway whose deploy failed reverts to undeployed.
-      initializedProviderIdRef.current = null;
+      // deployed. Recording the requested set as the seed makes the effect
+      // re-seed from any refetch that disagrees with it, so a gateway whose
+      // deploy failed reverts to undeployed.
+      if (seededRef.current) {
+        seededRef.current = {
+          ...seededRef.current,
+          gateways: selectedGatewayIds,
+        };
+      }
       setStatus({
         message: "Deployment updated successfully.",
         severity: "success",

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.tsx
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  LLMProviderResponse,
+  UpdateLLMProviderRequest,
+} from "@agent-management-platform/types";
+import {
+  EnvironmentGatewaySelector,
+  useConfirmationDialog,
+} from "@agent-management-platform/shared-component";
+import { Alert, Button, Collapse, Skeleton, Stack } from "@wso2/oxygen-ui";
+
+export type LLMProviderDeploymentTabProps = {
+  providerData: LLMProviderResponse | null | undefined;
+  orgName: string | undefined;
+  isLoading?: boolean;
+  onUpdate: (fields: UpdateLLMProviderRequest) => Promise<LLMProviderResponse>;
+  isUpdating: boolean;
+};
+
+const sameGatewaySet = (a: string[], b: string[]): boolean => {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  return setA.size === setB.size && [...setA].every((uuid) => setB.has(uuid));
+};
+
+export function LLMProviderDeploymentTab({
+  providerData,
+  orgName,
+  isLoading = false,
+  onUpdate,
+  isUpdating,
+}: LLMProviderDeploymentTabProps) {
+  const initializedProviderIdRef = useRef<string | null>(null);
+  const [selectedGatewayIds, setSelectedGatewayIds] = useState<string[]>([]);
+  const [isSelectionValid, setIsSelectionValid] = useState(true);
+  const [status, setStatus] = useState<{
+    message: string;
+    severity: "success" | "error";
+  } | null>(null);
+  const { addConfirmation } = useConfirmationDialog();
+
+  useEffect(() => {
+    if (!providerData) return;
+    if (initializedProviderIdRef.current === providerData.uuid) return;
+    initializedProviderIdRef.current = providerData.uuid;
+    setSelectedGatewayIds(providerData.gateways ?? []);
+  }, [providerData]);
+
+  const deployedGatewayIds = useMemo(
+    () => providerData?.gateways ?? [],
+    [providerData],
+  );
+
+  const isDirty = useMemo(
+    () => !sameGatewaySet(selectedGatewayIds, deployedGatewayIds),
+    [selectedGatewayIds, deployedGatewayIds],
+  );
+
+  const handleDiscard = useCallback(() => {
+    if (!providerData) return;
+    setSelectedGatewayIds(providerData.gateways ?? []);
+    setStatus(null);
+  }, [providerData]);
+
+  const runUpdate = useCallback(async () => {
+    try {
+      await onUpdate({ gateways: selectedGatewayIds });
+      // The PUT response drops per-gateway deploy outcomes; only the refetched
+      // GET (the mutation invalidates ["llm-provider"]) reports what actually
+      // deployed. Clearing the seed guard lets that refetch re-seed the
+      // selection, so a gateway whose deploy failed reverts to undeployed.
+      initializedProviderIdRef.current = null;
+      setStatus({
+        message: "Deployment updated successfully.",
+        severity: "success",
+      });
+    } catch {
+      setStatus({ message: "Failed to update deployment.", severity: "error" });
+    }
+  }, [onUpdate, selectedGatewayIds]);
+
+  const handleSave = useCallback(() => {
+    if (!providerData) return;
+    const undeploysEverything =
+      selectedGatewayIds.length === 0 &&
+      (providerData.gateways ?? []).length > 0;
+    if (undeploysEverything) {
+      addConfirmation({
+        title: "Undeploy from all gateways?",
+        description:
+          "This will undeploy the provider from all gateways. Invoke URLs " +
+          "will stop working.",
+        confirmButtonColor: "error",
+        confirmButtonText: "Undeploy",
+        onConfirm: () => void runUpdate(),
+      });
+      return;
+    }
+    void runUpdate();
+  }, [providerData, selectedGatewayIds, addConfirmation, runUpdate]);
+
+  if (isLoading) {
+    return (
+      <Stack spacing={1}>
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} variant="rounded" height={40} />
+        ))}
+      </Stack>
+    );
+  }
+
+  if (!providerData) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={2}>
+      <EnvironmentGatewaySelector
+        orgId={orgName ?? ""}
+        value={selectedGatewayIds}
+        onChange={setSelectedGatewayIds}
+        lockedGatewayIds={providerData.gateways ?? []}
+        onValidityChange={setIsSelectionValid}
+        disabled={isUpdating}
+      />
+      <Stack spacing={1.5} width="100%">
+        <Collapse in={!!status} timeout={300}>
+          {status && (
+            <Alert
+              severity={status.severity}
+              onClose={() => setStatus(null)}
+              sx={{ width: "100%" }}
+            >
+              {status.message}
+            </Alert>
+          )}
+        </Collapse>
+        <Stack direction="row" spacing={1.5} justifyContent="flex-end">
+          <Button
+            variant="outlined"
+            onClick={handleDiscard}
+            disabled={!isDirty || isUpdating}
+          >
+            Discard
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            disabled={!isDirty || isUpdating || !isSelectionValid}
+          >
+            {isUpdating ? "Saving..." : "Save"}
+          </Button>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+}

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderOverviewTab.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderOverviewTab.tsx
@@ -45,6 +45,7 @@ import {
   Chip,
   Divider,
   Grid,
+  Link,
   useTheme,
   Skeleton,
   Stack,
@@ -71,6 +72,7 @@ export type LLMProviderOverviewTabProps = {
   error?: Error | null;
   onUpdate: (fields: UpdateLLMProviderRequest) => Promise<LLMProviderResponse>;
   isUpdating: boolean;
+  onGoToDeploymentTab?: () => void;
 };
 
 function buildInvokeUrl(vhost: string, context: string): string {
@@ -88,6 +90,7 @@ export function LLMProviderOverviewTab({
   error: providerError = null,
   onUpdate,
   isUpdating,
+  onGoToDeploymentTab,
 }: LLMProviderOverviewTabProps) {
   const theme = useTheme();
   const [isDownloading, setIsDownloading] = useState(false);
@@ -172,6 +175,29 @@ export function LLMProviderOverviewTab({
     orgName,
     providerId,
   ]);
+
+  const deployedPlacement = useMemo(() => {
+    const deployedIds = new Set(providerData?.gateways ?? []);
+    const deployedGateways = (gatewaysData?.gateways ?? []).filter((g) =>
+      deployedIds.has(g.uuid),
+    );
+    const environmentNames = new Set<string>();
+    const unmappedGatewayUuids: string[] = [];
+    deployedGateways.forEach((g) => {
+      const environments = g.environments ?? [];
+      if (environments.length === 0) {
+        unmappedGatewayUuids.push(g.uuid);
+        return;
+      }
+      environments.forEach((env) =>
+        environmentNames.add(env.displayName ?? env.name),
+      );
+    });
+    return {
+      environmentNames: [...environmentNames],
+      unmappedGatewayUuids,
+    };
+  }, [providerData?.gateways, gatewaysData]);
 
   const [generatedApiKey, setGeneratedApiKey] = useState<string | null>(null);
   const [apiKeyError, setApiKeyError] = useState<string | null>(null);
@@ -441,6 +467,56 @@ export function LLMProviderOverviewTab({
                 variant="outlined"
                 sx={{ width: "fit-content" }}
               />
+            </Stack>
+          </Card>
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+          <Card variant="outlined" sx={{ p: 2, height: "100%" }}>
+            <Stack spacing={0.5}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ fontWeight: 500 }}
+              >
+                Deployment
+              </Typography>
+              {(providerData.gateways ?? []).length > 0 ? (
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                  {deployedPlacement.environmentNames.map((name) => (
+                    <Chip
+                      key={name}
+                      label={name}
+                      size="small"
+                      variant="outlined"
+                      color="success"
+                    />
+                  ))}
+                  {deployedPlacement.unmappedGatewayUuids.map((uuid) => (
+                    <Chip
+                      key={uuid}
+                      label="Unmapped"
+                      size="small"
+                      variant="outlined"
+                    />
+                  ))}
+                </Stack>
+              ) : (
+                <>
+                  <Typography variant="body2" color="text.secondary">
+                    Not deployed
+                  </Typography>
+                  {onGoToDeploymentTab && (
+                    <Link
+                      component="button"
+                      variant="body2"
+                      onClick={onGoToDeploymentTab}
+                      sx={{ width: "fit-content" }}
+                    >
+                      Deploy to a gateway
+                    </Link>
+                  )}
+                </>
+              )}
             </Stack>
           </Card>
         </Grid>

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderOverviewTab.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderOverviewTab.tsx
@@ -147,7 +147,7 @@ export function LLMProviderOverviewTab({
     { orgName: orgName ?? "", providerId: providerId ?? "" },
     { status: "DEPLOYED" },
   );
-  const { data: gatewaysData } = useListGateways(
+  const { data: gatewaysData, isLoading: isLoadingGateways } = useListGateways(
     { orgName: orgName ?? "" },
     { limit: 500 },
   );
@@ -178,19 +178,23 @@ export function LLMProviderOverviewTab({
 
   const deployedPlacement = useMemo(() => {
     const deployedIds = new Set(providerData?.gateways ?? []);
-    const deployedGateways = (gatewaysData?.gateways ?? []).filter((g) =>
-      deployedIds.has(g.uuid),
-    );
+    const allGateways = gatewaysData?.gateways ?? [];
+    const knownIds = new Set(allGateways.map((g) => g.uuid));
     const environmentNames = new Set<string>();
-    const unmappedGatewayUuids: string[] = [];
-    deployedGateways.forEach((g) => {
+    // A deployed UUID absent from the fetched gateway list (deleted gateway,
+    // truncated page) still gets a chip rather than vanishing from the card.
+    const unmappedGatewayUuids = [...deployedIds].filter(
+      (uuid) => !knownIds.has(uuid),
+    );
+    allGateways.forEach((g) => {
+      if (!deployedIds.has(g.uuid)) return;
       const environments = g.environments ?? [];
       if (environments.length === 0) {
         unmappedGatewayUuids.push(g.uuid);
         return;
       }
       environments.forEach((env) =>
-        environmentNames.add(env.displayName ?? env.name),
+        environmentNames.add(env.displayName || env.name),
       );
     });
     return {
@@ -480,7 +484,12 @@ export function LLMProviderOverviewTab({
               >
                 Deployment
               </Typography>
-              {(providerData.gateways ?? []).length > 0 ? (
+              {/* Until the gateway list arrives, every deployed UUID would
+                  wrongly render as "Unmapped". */}
+              {(providerData.gateways ?? []).length > 0 && isLoadingGateways && (
+                <Skeleton variant="rounded" width={120} height={24} />
+              )}
+              {(providerData.gateways ?? []).length > 0 && !isLoadingGateways && (
                 <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
                   {deployedPlacement.environmentNames.map((name) => (
                     <Chip
@@ -500,7 +509,8 @@ export function LLMProviderOverviewTab({
                     />
                   ))}
                 </Stack>
-              ) : (
+              )}
+              {(providerData.gateways ?? []).length === 0 && (
                 <>
                   <Typography variant="body2" color="text.secondary">
                     Not deployed

--- a/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
@@ -42,6 +42,7 @@ import { LLMProviderAccessControlTab } from "./LLMProviderAccessControlTab";
 import { LLMProviderAPIKeysTab } from "./LLMProviderAPIKeysTab";
 import { LLMProviderConnectionTab } from "./LLMProviderConnectionTab";
 import { LLMProviderConsumersTab } from "./LLMProviderConsumersTab";
+import { LLMProviderDeploymentTab } from "./LLMProviderDeploymentTab";
 import { LLMProviderGuardrailsTab } from "./LLMProviderGuardrailsTab";
 // import { LLMProviderModelsTab } from "./LLMProviderModelsTab";
 import { LLMProviderOverviewTab } from "./LLMProviderOverviewTab";
@@ -54,6 +55,7 @@ import { LLMProviderSecurityTab } from "./LLMProviderSecurityTab";
 const TABS = [
   "Overview",
   "Connection",
+  "Deployment",
   "Access Control",
   "Security",
   "API Keys",
@@ -204,6 +206,9 @@ export const ViewLLMProvider: React.FC = () => {
                   : providerError ? new Error(getErrorMessage(providerError)) : null}
                 onUpdate={updateProvider}
                 isUpdating={isUpdating}
+                onGoToDeploymentTab={() =>
+                  setTabIndex(TABS.indexOf("Deployment"))
+                }
               />
             </TabPanel>
 
@@ -218,8 +223,19 @@ export const ViewLLMProvider: React.FC = () => {
               />
             </TabPanel>
 
-            {/* Access Control tab */}
+            {/* Deployment tab */}
             <TabPanel value={tabIndex} index={2}>
+              <LLMProviderDeploymentTab
+                providerData={providerData}
+                orgName={orgId}
+                isLoading={isLoading}
+                onUpdate={updateProvider}
+                isUpdating={isUpdating}
+              />
+            </TabPanel>
+
+            {/* Access Control tab */}
+            <TabPanel value={tabIndex} index={3}>
               <LLMProviderAccessControlTab
                 providerData={providerData}
                 openapiSpecUrl={openapiSpecUrl}
@@ -230,7 +246,7 @@ export const ViewLLMProvider: React.FC = () => {
             </TabPanel>
 
             {/* Security tab */}
-            <TabPanel value={tabIndex} index={3}>
+            <TabPanel value={tabIndex} index={4}>
               <LLMProviderSecurityTab
                 providerData={providerData}
                 isLoading={isLoading}
@@ -240,7 +256,7 @@ export const ViewLLMProvider: React.FC = () => {
             </TabPanel>
 
             {/* API Keys tab */}
-            <TabPanel value={tabIndex} index={4}>
+            <TabPanel value={tabIndex} index={5}>
               <LLMProviderAPIKeysTab
                 providerData={providerData}
                 orgName={orgId}
@@ -253,7 +269,7 @@ export const ViewLLMProvider: React.FC = () => {
             </TabPanel>
 
             {/* Rate Limiting tab */}
-            <TabPanel value={tabIndex} index={5}>
+            <TabPanel value={tabIndex} index={6}>
               <LLMProviderRateLimitingTab
                 providerData={providerData}
                 openapiSpecUrl={openapiSpecUrl}
@@ -264,7 +280,7 @@ export const ViewLLMProvider: React.FC = () => {
             </TabPanel>
 
             {/* Guardrails tab */}
-            <TabPanel value={tabIndex} index={6}>
+            <TabPanel value={tabIndex} index={7}>
               <LLMProviderGuardrailsTab
                 providerData={providerData}
                 openapiSpecUrl={openapiSpecUrl}
@@ -277,7 +293,7 @@ export const ViewLLMProvider: React.FC = () => {
             </TabPanel>
 
             {/* Consumers tab */}
-            <TabPanel value={tabIndex} index={7}>
+            <TabPanel value={tabIndex} index={8}>
               <LLMProviderConsumersTab
                 orgName={orgId}
                 providerId={providerId}
@@ -285,7 +301,7 @@ export const ViewLLMProvider: React.FC = () => {
             </TabPanel>
 
             {/* Models tab */}
-            {/* <TabPanel value={tabIndex} index={6}>
+            {/* <TabPanel value={tabIndex} index={9}>
               <LLMProviderModelsTab
                 providerData={providerData}
                 isLoading={isLoading}

--- a/console/workspaces/pages/llm-providers/vitest.config.ts
+++ b/console/workspaces/pages/llm-providers/vitest.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './setupTests.tsx',
+    server: {
+      deps: {
+        // oxygen-ui's dist imports prismjs subpaths without file extensions
+        // and @mui/x-data-grid imports raw .css, neither of which Node's
+        // native ESM loader accepts; route them through Vite's resolver.
+        inline: ['@wso2/oxygen-ui', '@mui/x-data-grid'],
+      },
+    },
   },
 });
 

--- a/docs/llm-provider-deployment-spec.md
+++ b/docs/llm-provider-deployment-spec.md
@@ -143,7 +143,8 @@ The checkbox is the single inclusion control in all four states, so the emitted 
 always "the resolved gateway of every checked row". Unchecking a **Deployed** row is how an
 undeploy is expressed — which is also the first half of the two-step gateway swap (§6).
 
-Footer: **"N of M environments deployed."** — only when `M > 1`, matching
+Footer: **"N of M environments selected."** — "selected", not "deployed": N counts
+unsaved staging too, and in the create form nothing is deployed yet. Only when `M > 1`, matching
 `EndpointsEditorSection.tsx:235-240`.
 
 `onChange` emits the flat union of resolved gateway UUIDs across all included

--- a/docs/llm-provider-deployment-spec.md
+++ b/docs/llm-provider-deployment-spec.md
@@ -1,0 +1,362 @@
+# LLM Provider — Deployment Tab & Environment-Aware Gateway Selection
+
+**Status:** Draft for review
+**Area:** `console` (agent-manager console). One optional backend follow-up, called out separately.
+**Related art:** [Mockup](https://claude.ai/code/artifact/831e749e-294d-406c-9d57-d340e2a01760)
+
+---
+
+## 1. Problem
+
+An LLM provider's gateway placement can only be chosen once, at creation, through a flat
+multi-select of every egress-capable gateway in the org. After that, the console offers no
+way to see where the provider is deployed, deploy it somewhere new, or move it. Three
+concrete failures follow:
+
+1. **No post-create management.** `ViewLLMProvider.tsx:54` defines 8 tabs — Overview,
+   Connection, Access Control, Security, API Keys, Rate Limiting, Guardrails, Consumers.
+   None of them read or write `gateways`. The Overview tab renders
+   `"No invoke URLs available. Deploy this provider to an AI gateway…"`
+   (`LLMProviderOverviewTab.tsx:457`) with no affordance to do so.
+
+2. **Silent create-time deploy failure strands providers with zero gateways.**
+   `CreateLLMProvider` (`controllers/llm_controller.go:352-370`) collects
+   `resp.Deployments []DeploymentResult` and **only logs** the failures — the HTTP response
+   is a plain 200 with the provider body. A provider whose every deploy failed looks
+   identical to one that succeeded. Since `GET` derives `gateways` from
+   `deployment_status.status = DEPLOYED` only (`repositories/deployment_repository.go:400`),
+   such a provider reports `gateways: []` forever, with no retry path in the UI. This is
+   the "it's not been deployed to any" case.
+
+3. **The flat picker can express an invalid selection.** The server enforces one gateway
+   per `(provider, environment)` via `validateEgressPlacement`
+   (`services/gateway_roles.go:169`), resolving each gateway's environments through
+   `gateway_environment_mappings`. The console does not model environments at all, so two
+   gateways sharing one environment are both selectable and the save 400s.
+
+The backend already supports everything needed to fix (1) and (3): `PUT` with a non-nil
+`gateways` array routes to `LLMProviderService.UpdateAndSync`
+(`controllers/llm_controller.go:601`), which diffs against currently-deployed gateways and
+deploys / updates / undeploys, validating placement up front and hard-failing *before*
+touching existing deployments (`services/llm_provider_service.go:656-681`).
+
+## 2. Prior art — how MCP proxies solve this
+
+MCP proxies are environment-first. A binding is
+`{environmentUuid, gatewayId?, deploymentStatus}` (`types/src/api/mcp-proxies.ts:74`); the
+user picks *environments*, and `gatewayId` is requested only when it is genuinely ambiguous:
+
+| Egress candidates in env | MCP behaviour |
+|---|---|
+| 0 | Environment is not offered |
+| 1 | Auto-assigned; `gatewayId` omitted and inferred server-side |
+| 2+ | `Select` rendered (`EndpointFormFields.tsx:521-567`); save blocked until chosen (`hasGatewaySelection`, `:218`) |
+| already deployed | `Select` disabled, caption *"Placement is fixed once deployed. Delete and recreate the binding to change it."* |
+
+Deployment state is visible as per-environment chips
+(`MCPProxyOverviewTab.tsx:173-195`) and editable post-create via `EditMCPProxyDrawer` →
+`EndpointsEditorSection`, which also renders the *"N of M environments have an endpoint"*
+footer (`EndpointsEditorSection.tsx:235-240`).
+
+**This spec adopts MCP's interaction model while keeping the LLM provider's flat
+`gateways: string[]` wire format.** No API shape change is required.
+
+## 3. Scope
+
+**In scope**
+
+- A new **Deployment** tab on the LLM provider detail page.
+- Replacing the create form's flat gateway picker with the same environment-grouped control.
+- A deployment summary card on the Overview tab.
+
+**Out of scope**
+
+- Adding an `environments` concept to the LLM provider API. Environments stay a client-side
+  projection derived from `gateway.environments`.
+- Per-environment `deploymentStatus` on the LLM provider response (see §10).
+- Surfacing per-gateway deploy failures — deferred and scoped in §9.
+- Any change to `llm_proxy` (the per-project proxy), the eval Monitor drawer flow, or
+  MCP proxies.
+
+## 4. Target design
+
+### 4.1 New shared component: `EnvironmentGatewaySelector`
+
+One component drives both the create form and the Deployment tab.
+
+**Location:** `console/workspaces/libs/shared-component/src/components/EnvironmentGatewaySelector/`
+
+Modeled on `EndpointFormFields.tsx:159-191` + `:521-567`, but reduced: no endpoint
+name/URL/auth/capability concerns, and its value is a flat gateway-UUID list rather than a
+per-environment binding array.
+
+```ts
+export interface EnvironmentGatewaySelectorProps {
+  orgId: string;
+  /** Gateway UUIDs currently selected. In the Deployment tab this is seeded from
+   *  `providerData.gateways` (deployed-only, see §5). */
+  value: string[];
+  onChange: (gatewayIds: string[]) => void;
+  /** Gateway UUIDs already deployed — rendered locked. Omit in the create form. */
+  lockedGatewayIds?: string[];
+  /** Blocks the caller's save action while any 2+-candidate environment is
+   *  selected without a resolved gateway. */
+  onValidityChange?: (isValid: boolean) => void;
+  disabled?: boolean;
+}
+```
+
+**Data sources**
+
+| Data | Hook | Notes |
+|---|---|---|
+| Environments | `useListEnvironments({ orgName })` → `Environment[]` | `id`, `name`, `displayName` (`types/src/api/deployments.ts:151`) |
+| Gateways | `useListGateways({ orgName }, { limit: 500 })` | Filter `gatewayType === "EGRESS" \|\| "BOTH"` |
+
+Group gateways by `gateway.environments[].id` into
+`Record<string, GatewayResponse[]>` — identical to `egressGatewaysByEnv`
+(`EndpointFormFields.tsx:159-171`).
+
+> **Pass `{ limit: 500 }`.** `useListGateways` takes an optional query and
+> `LLMProviderOverviewTab.tsx:147-150` already passes it; `EndpointFormFields.tsx:154`
+> does not, and silently truncates at the server default. Do not repeat that.
+
+**Do not filter on `gateway.status`.** The server's candidate set is not liveness-filtered,
+so filtering here would hide a valid choice whenever a gateway is briefly disconnected —
+the same reasoning already recorded at `AddLLMProviderForm.tsx:177-179`.
+
+### 4.2 Per-environment row states
+
+One row per environment in the org. **Every row leads with a checkbox** that includes or
+excludes that environment; what follows the checkbox is keyed on `candidates.length`:
+
+| State | Condition | Render |
+|---|---|---|
+| **Auto-assigned** | 1 candidate, not deployed | Checkbox + gateway name as static resolved text. No picker. |
+| **Ambiguous** | 2+ candidates, not deployed | Checkbox + `Select` of candidates. While checked and unresolved: error caption *"Select an egress gateway for this environment."* and `onValidityChange(false)`. |
+| **Deployed** | Any candidate is in `lockedGatewayIds` | Checkbox (checked; unchecking stages an undeploy) + `Select` `disabled` at the deployed gateway + green `Deployed` chip. Caption: *"Placement is fixed once deployed. To use a different gateway, uncheck this environment and save to undeploy, then select the new gateway and save again."* |
+| **Unavailable** | 0 candidates | Checkbox disabled, row dimmed, caption *"No egress-capable gateway is attached to this environment."* |
+
+The checkbox is the single inclusion control in all four states, so the emitted array is
+always "the resolved gateway of every checked row". Unchecking a **Deployed** row is how an
+undeploy is expressed — which is also the first half of the two-step gateway swap (§6).
+
+Footer: **"N of M environments deployed."** — only when `M > 1`, matching
+`EndpointsEditorSection.tsx:235-240`.
+
+`onChange` emits the flat union of resolved gateway UUIDs across all included
+environments. Because at most one gateway per environment can be selected, the emitted
+array can never violate the server's placement rule — which is the point.
+
+### 4.3 Deployment tab
+
+Insert into `TABS` in `ViewLLMProvider.tsx:54` at **index 2, after `"Connection"`**
+(decided; deployment is a primary concern, not a trailing one).
+
+> `LLMProviderAPIKeysTab` receives `onGoToSecurityTab={() => setTabIndex(TABS.indexOf("Security"))}`
+> (`ViewLLMProvider.tsx:251`), which is index-derived and stays correct. Every other
+> `TabPanel index={n}` is a literal and **must be renumbered** — this is the one mechanical
+> trap in the change.
+
+New file: `console/workspaces/pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.tsx`
+
+```ts
+export type LLMProviderDeploymentTabProps = {
+  providerData: LLMProviderResponse | null | undefined;
+  orgName: string | undefined;
+  isLoading?: boolean;
+  onUpdate: (fields: UpdateLLMProviderRequest) => Promise<LLMProviderResponse>;
+  isUpdating: boolean;
+};
+```
+
+Follows the established tab contract exactly — compare `LLMProviderConnectionTab.tsx`:
+seed local state from `providerData` once per provider UUID via an
+`initializedProviderIdRef` guard (`:74`, `:90-103`), derive `isDirty`, and render
+Discard / Save with `disabled={!isDirty || isUpdating}`.
+
+**Save:** `onUpdate({ gateways: nextGatewayIds })`.
+
+`updateProvider` in `ViewLLMProvider.tsx:99-110` spreads `...providerData` into the body,
+so `gateways` is *already* round-tripped on every existing tab save (harmless — it
+reconciles to itself). This tab simply varies the field.
+
+### 4.4 Overview tab summary card
+
+Add a `Deployment` card to the existing grid in `LLMProviderOverviewTab.tsx:333-447`,
+alongside Context / Upstream URL / Auth Type / Access Control / In Catalog. One chip per
+environment the provider is deployed to, `color="success"`, mirroring
+`MCPProxyOverviewTab.tsx:180-195`. Empty state: *"Not deployed"* with a link that switches
+to the Deployment tab.
+
+### 4.5 Create form
+
+In `AddLLMProviderForm.tsx`, replace **both** gateway-picker branches — the
+`showGatewaySelector` multi-select (`:642-666`) and the single-select fallback
+(`:681-707`) — with `EnvironmentGatewaySelector`, keeping the existing
+zero-egress-gateway warning `Alert` (`:673-678`).
+
+The auto-select effect at `:190-194` becomes redundant (the selector auto-assigns
+single-candidate environments itself) and should be deleted. Retain the submit guard at
+`:740-744` that blocks an empty `gatewayIds`, and additionally gate on the selector's
+`onValidityChange`.
+
+`showGatewaySelector` currently only toggles between two equally environment-blind
+controls. **Remove the prop entirely** and update its one consumer
+(`MonitorLLMProviderDrawer.tsx:530`) — the eval drawer gets the same full selector as the
+main create form. No `compact` variant; a second control is what created this divergence in
+the first place.
+
+## 5. Save semantics
+
+```
+PUT /organizations/{org}/llm-providers/{providerId}
+{ ...providerData, "gateways": ["<uuid>", "<uuid>"] }
+```
+
+`UpdateAndSync` reconciles: deploy to added, update in place for retained, undeploy from
+removed. Placement is validated for the whole requested set *before* any deploy or
+undeploy runs, and a violation returns `400` with existing deployments untouched
+(`services/llm_provider_service.go:648-681`).
+
+**The response body does not confirm the outcome.** Two facts, both verified:
+
+- `UpdateLLMProvider` discards `resp.Deployments` / `resp.Undeployments` — they are logged
+  and dropped (`controllers/llm_controller.go:625-651`).
+- The `PUT` response never calls `SetGateways`; only `GET` does
+  (`controllers/llm_controller.go:487`).
+
+So the tab **must not** trust the mutation result. `useUpdateLLMProvider` invalidates
+`["llm-provider"]` (`hooks/llm-providers.ts:241-243`), so the refetched `GET` is the source
+of truth for what actually deployed. The tab reconciles its local selection against that
+refetch; a gateway that fails to deploy simply does not come back in `gateways`, and the
+row reverts to undeployed.
+
+> **Bug to fix in the same change:** `useUpdateLLMProvider` does **not** invalidate
+> `["llm-deployments"]`, which `LLMProviderOverviewTab.tsx:143` uses to build invoke URLs.
+> Deploying via the new tab therefore leaves the Overview tab's invoke URLs stale until
+> remount. Add that invalidation to the hook's `onSuccess`.
+
+## 6. Recoverability analysis
+
+The goal of this change is that **no state reachable through the UI is a dead end**. Each
+candidate dead end below was traced through the service and repository layers; all are
+escapable console-side, so **no backend change is required to ship this tab**.
+
+| Candidate dead end | Verdict | Evidence |
+|---|---|---|
+| Provider created with all deploys failed → `gateways: []` | **Recoverable.** A genuine deploy error (bad gateway UUID, org mismatch, placement violation, YAML gen failure) returns before any row is written, so nothing stale blocks a retry. The tab shows "Not deployed"; selecting an environment and saving re-enters the deploy branch of `UpdateAndSync`. | `llm_deployment_service.go:116-215`; `llm_provider_service.go:698-701` |
+| Stale `deployment_status` row blocks re-deploy | **Cannot occur.** `deployment_status` is UPSERTed on `(artifact_uuid, ou_id, gateway_uuid)`, so a retry overwrites rather than conflicts. | `deployment_repository.go:131-144` |
+| Undeploy leaves the environment permanently occupied | **Cannot occur.** Undeploy flips the status row to `UNDEPLOYED` via `SetCurrent`; `GetDeployedGatewaysByProvider` filters on `DEPLOYED`, so the environment frees immediately and a different gateway can be deployed there. | `llm_deployment_service.go:305-310`; `deployment_repository.go:400-411` |
+| Repeated deploy/undeploy cycling exhausts the 25-row limit | **Cannot occur.** `ARCHIVED` is *derived* — a `deployments` row with no matching `deployment_status` row. Since only one status row exists per `(artifact, gateway)`, every prior deployment is archived by construction, so pruning always finds candidates. | `models/deployment.go:58`; `deployment_repository.go:100-124` |
+
+**One design constraint falls out of this.** Swapping the gateway within an
+already-deployed environment **cannot be done in a single save**: the placement accumulator
+seeds from `currentGateways`, so a body containing both the outgoing and incoming gateway
+fails validation and 400s before anything is touched
+(`llm_provider_service.go:648-681`). The user must undeploy, save, then redeploy.
+
+The locked-row design in §4.2 already enforces exactly this — a deployed row's `Select` is
+disabled, so the only way to change it is to deselect the environment (save → undeploy)
+and then reselect with a different gateway (save → deploy). The two mechanisms agree; the
+locked-row caption should make the two-step explicit rather than leaving the user to
+discover it via a 400.
+
+## 7. Edge cases
+
+| Case | Behaviour |
+|---|---|
+| Org has zero egress-capable gateways | Every row `Unavailable`; keep the existing warning Alert; Save disabled |
+| Environment has zero egress gateways | Row disabled with explanatory caption (do not hide it — hiding makes the org look misconfigured in a way the user can't see) |
+| Deployed gateway later deleted | It drops out of `gateways` on the next `GET`; the row reverts to undeployed. Acceptable |
+| Gateway attached to 2+ environments | Appears as a candidate in each. Selecting it in one environment must **disable it in the others**, or the emitted array would deploy it twice and trip `validateEgressPlacement`. Enforce client-side. |
+| Provider deployed to a gateway with no environment mapping | Cannot be attributed to a row. Render as an extra "Unmapped" locked row so it is visible and not silently dropped from the emitted array on save |
+| Deselecting the last environment | Emits `[]` → `UpdateAndSync` undeploys everything. Confirm via dialog; copy: *"This will undeploy the provider from all gateways. Invoke URLs will stop working."* |
+| User wants a different gateway in a deployed environment | Not doable in one save (see §6). Locked row forces deselect → save → reselect → save. Caption must say so |
+
+## 8. Files touched
+
+| File | Change |
+|---|---|
+| `libs/shared-component/src/components/EnvironmentGatewaySelector/*` | **New.** Selector + index export |
+| `pages/llm-providers/src/subComponents/LLMProviderDeploymentTab.tsx` | **New.** Tab wrapper |
+| `pages/llm-providers/src/subComponents/ViewLLMProvider.tsx` | Add tab to `TABS`; add `TabPanel`; **renumber literal indices** |
+| `pages/llm-providers/src/subComponents/LLMProviderOverviewTab.tsx` | Add Deployment summary card |
+| `pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx` | Replace both picker branches; drop `showGatewaySelector` and the `:190-194` auto-select effect |
+| `pages/eval/src/subComponents/MonitorLLMProviderDrawer.tsx` | Drop the `showGatewaySelector={false}` prop |
+| `libs/api-client/src/hooks/llm-providers.ts` | Invalidate `["llm-deployments"]` in `useUpdateLLMProvider` |
+
+## 9. Deferred: silent per-gateway deploy failure
+
+**Not in this change.** Scoped here so it can be picked up as separate work.
+
+A create or update whose per-gateway deploys fail returns `200` with a normal provider
+body. `CreateLLMProvider` and `UpdateLLMProvider` both collect
+`[]DeploymentResult{GatewayID, Success, Error}` and only write them to the log
+(`controllers/llm_controller.go:360-370`, `:625-651`). The client cannot tell a fully
+successful deploy from a fully failed one except by refetching `GET` and noticing
+`gateways` is shorter than requested — and even then it gets no reason.
+
+Per §6 this is a **diagnosability** gap, not an unrecoverable one: the tab surfaces
+"Not deployed" and the user can retry. That is why it is deferred.
+
+Scope when picked up:
+- Add `deployments` / `undeployments` (`[{gatewayId, success, error?}]`) to the `POST` and
+  `PUT` LLM provider response schemas in the OpenAPI spec. Additive and backward-compatible.
+- Have both controllers pass `resp.Deployments` / `resp.Undeployments` through instead of
+  dropping them; call `SetGateways` on the `PUT` response so it matches `GET`.
+- Console: render partial failure after save — "Deployed to 1 of 2 gateways" with the
+  per-gateway reason — instead of relying on the refetch diff.
+- Follow the `add-api-resource` skill for the spec-first + codegen workflow.
+
+Note that a *broadcast* failure is deliberately swallowed and still records `DEPLOYED`
+(`llm_deployment_service.go:249-257`, `:325-333`). So even after this work, `gateways`
+means "the control plane believes it is deployed", not "the gateway acknowledged it".
+Reporting true gateway-side health is a larger piece of work and is not implied here.
+
+## 10. Decisions
+
+All blocking questions are resolved; the spec is implementable as written.
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Tab placement | **Index 2**, after Connection. Renumber the literal `TabPanel index={n}` props (§4.3) |
+| 2 | Environment inclusion control | **Per-row checkbox** in all four states (§4.2) |
+| 3 | Locked-row copy | Drafted in §4.2 — states the two-step in terms of check/save rather than MCP's "binding" noun. Copy review welcome; not blocking |
+| 4 | One Save or two | **Single Save**, one `PUT` reconciled in one pass. Confirmation still required when the diff removes the last environment (§7) |
+| 5 | `MonitorLLMProviderDrawer` | **Full selector**, same component as the create form. `showGatewaySelector` removed, no compact variant (§4.5) |
+| 6 | Backend work needed for recoverability? | **No** — every candidate dead end is escapable console-side (§6) |
+| 7 | Per-environment `deploymentStatus` like MCP? | **Not now.** Inference from `gateways` is adequate; revisit only if `Failed` must be distinguished from `Undeployed` |
+| 8 | Surface per-gateway deploy failures? | **Yes, separately** — deferred and scoped in §9 |
+
+**Assumption worth checking during review:** decision 4 keeps the confirm dialog only for
+the remove-last-environment case (§7). If reviewers want a confirm on *any* undeploy — e.g.
+the first half of a gateway swap — that is a one-line change to the same guard.
+
+## 11. Test plan
+
+**Unit — `EnvironmentGatewaySelector`**
+- 1 candidate, checked → no `Select`; gateway present in `onChange`
+- 1 candidate, unchecked → contributes nothing to `onChange`
+- 2 candidates, checked → `Select` rendered; `onValidityChange(false)` until chosen
+- 2 candidates, unchecked and unresolved → does **not** block validity
+- 0 candidates → checkbox disabled, contributes nothing to `onChange`
+- `lockedGatewayIds` → checkbox checked, `Select` disabled, `Deployed` chip present
+- Unchecking a locked row → its gateway drops out of `onChange` (stages the undeploy)
+- Gateway spanning 2 environments → selecting it in one disables it in the other
+- `onChange` never emits 2 gateways sharing an environment (property test over generated fixtures)
+
+**Unit — `LLMProviderDeploymentTab`**
+- Seeds from `providerData.gateways`; `isDirty` false on mount
+- Save calls `onUpdate` with exactly `{ gateways: [...] }`
+- Provider with `gateways: []` renders all rows undeployed and Save enabled once a choice is made
+- Post-save refetch returning fewer gateways than requested reconciles down (deploy-failure path)
+
+**Integration**
+- Create → deploy to env A → verify invoke URL appears on Overview without remount (guards the `["llm-deployments"]` invalidation fix)
+- Add env B, save, verify both deployed
+- Remove env A, save, verify undeployed and its invoke URL disappears
+- Attempt a second gateway in an already-deployed environment → not offered by the UI
+
+Follow `add-service-unit-test` conventions for any Go-side test; console tests follow the
+existing pattern in `pages/add-new-agent/src/utils/buildAgentPayload.test.ts`.

--- a/docs/llm-provider-deployment-spec.md
+++ b/docs/llm-provider-deployment-spec.md
@@ -113,9 +113,11 @@ export interface EnvironmentGatewaySelectorProps {
 | Environments | `useListEnvironments({ orgName })` → `Environment[]` | `id`, `name`, `displayName` (`types/src/api/deployments.ts:151`) |
 | Gateways | `useListGateways({ orgName }, { limit: 500 })` | Filter `gatewayType === "EGRESS" \|\| "BOTH"` |
 
-Group gateways by `gateway.environments[].id` into
-`Record<string, GatewayResponse[]>` — identical to `egressGatewaysByEnv`
-(`EndpointFormFields.tsx:159-171`).
+Group gateways by `gateway.environments[0].id` into
+`Record<string, GatewayResponse[]>` — same shape as `egressGatewaysByEnv`
+(`EndpointFormFields.tsx:159-171`). A gateway belongs to exactly one
+environment (business rule; the wire field is an array). A gateway with no
+mapping is handled by the "Unmapped" row (§7).
 
 > **Pass `{ limit: 500 }`.** `useListGateways` takes an optional query and
 > `LLMProviderOverviewTab.tsx:147-150` already passes it; `EndpointFormFields.tsx:154`
@@ -269,7 +271,7 @@ discover it via a 400.
 | Org has zero egress-capable gateways | Every row `Unavailable`; keep the existing warning Alert; Save disabled |
 | Environment has zero egress gateways | Row disabled with explanatory caption (do not hide it — hiding makes the org look misconfigured in a way the user can't see) |
 | Deployed gateway later deleted | It drops out of `gateways` on the next `GET`; the row reverts to undeployed. Acceptable |
-| Gateway attached to 2+ environments | Appears as a candidate in each. Selecting it in one environment must **disable it in the others**, or the emitted array would deploy it twice and trip `validateEgressPlacement`. Enforce client-side. |
+| Gateway attached to 2+ environments | **Cannot happen** — a gateway belongs to exactly one environment (business rule; the wire field is an array only in shape). No cross-row conflict exists; the placement invariant reduces to replacing the previous same-environment selection when a row's candidate changes. |
 | Provider deployed to a gateway with no environment mapping | Cannot be attributed to a row. Render as an extra "Unmapped" locked row so it is visible and not silently dropped from the emitted array on save |
 | Deselecting the last environment | Emits `[]` → `UpdateAndSync` undeploys everything. Confirm via dialog; copy: *"This will undeploy the provider from all gateways. Invoke URLs will stop working."* |
 | User wants a different gateway in a deployed environment | Not doable in one save (see §6). Locked row forces deselect → save → reselect → save. Caption must say so |
@@ -343,7 +345,7 @@ the first half of a gateway swap — that is a one-line change to the same guard
 - 0 candidates → checkbox disabled, contributes nothing to `onChange`
 - `lockedGatewayIds` → checkbox checked, `Select` disabled, `Deployed` chip present
 - Unchecking a locked row → its gateway drops out of `onChange` (stages the undeploy)
-- Gateway spanning 2 environments → selecting it in one disables it in the other
+- Choosing a different candidate in an environment → previous selection evicted from `onChange`, never joined
 - `onChange` never emits 2 gateways sharing an environment (property test over generated fixtures)
 
 **Unit — `LLMProviderDeploymentTab`**


### PR DESCRIPTION
## Purpose
An LLM provider's gateway placement can only be chosen once, at creation, through a flat multi-select of every egress-capable gateway in the org. After creation the console offers no way to see where the provider is deployed, deploy it somewhere new, or move it. The flat picker can also express selections the server rejects: the backend enforces one gateway per (provider, environment), but the console does not model environments, so two gateways sharing an environment are both selectable and the save 400s. A provider whose create-time deploys all failed reports `gateways: []` forever with no retry path in the UI.

For:
- https://github.com/wso2/agent-manager/issues/1489

## Goals
- Make gateway placement visible and editable after creation.
- Make it impossible for the UI to express a placement the server will reject.
- Ensure no deployment state reachable through the UI is a dead end (a provider with zero gateways can always be re-deployed).

## Approach
Console-only change; no API shape change (the flat `gateways: string[]` wire format is kept). Full design doc: `docs/llm-provider-deployment-spec.md` (committed in this PR).

- New shared component `EnvironmentGatewaySelector` (`libs/shared-component`), adopting the MCP-proxy environment-first interaction model: one checkbox-led row per environment; single-candidate environments auto-assign; multi-candidate environments get a `Select`; already-deployed environments render locked with a `Deployed` chip and an explicit two-step caption for gateway swaps (undeploy + save, then redeploy); environments with no egress gateway render disabled rather than hidden. The component enforces by construction that its emitted selection never contains two gateways sharing an environment — the server's placement rule.
- New **Deployment** tab on the LLM provider detail page (inserted at index 2; all trailing literal `TabPanel` indices renumbered). Saves via the existing `PUT` (`UpdateAndSync` reconciles deploy/update/undeploy). Since the `PUT` response does not report per-gateway outcomes, the tab re-seeds its selection from the invalidation-triggered `GET` refetch, so a failed deploy visibly reverts. Removing the last environment asks for confirmation before undeploying everything.
- Overview tab gains a **Deployment** summary card (one success chip per deployed environment; "Not deployed" empty state with a link to the new tab).
- The create form's two gateway-picker branches are replaced with the same selector; the `showGatewaySelector` prop is removed and its one consumer (eval's `MonitorLLMProviderDrawer`) now gets the full selector.
- Bug fix: `useUpdateLLMProvider` now also invalidates `["llm-deployments"]`, so Overview invoke URLs refresh after a deployment change without a remount.
- Bug fix applied consistently: `useListGateways` calls now pass `{ limit: 500 }` so large orgs don't get a silently truncated gateway list.

Deliberately deferred (scoped in the design doc §9): surfacing per-gateway deploy failures from the `POST`/`PUT` responses — a backend change; the refetch-reconcile behavior above keeps every failure state recoverable in the meantime.

UI mock-up used during design review: https://claude.ai/code/artifact/831e749e-294d-406c-9d57-d340e2a01760

## User stories
- As a platform operator, I can see which environments an LLM provider is deployed to and deploy or undeploy it per environment after creation.
- As a platform operator, I cannot select a gateway combination the server would reject.
- As a platform operator, when a provider ends up with zero gateways (e.g. create-time deploy failure), I can re-deploy it from the console.

## Release note
LLM providers now have a Deployment tab for viewing and changing per-environment gateway placement after creation; the create form groups gateway selection by environment and prevents invalid placements.

## Documentation
N/A — console UI change; no product documentation currently covers LLM provider gateway placement. Can be added when the docs section for LLM providers is written.

## Training
N/A — no training-content impact for a console UI enhancement.

## Certification
N/A — console UI change with no new concepts beyond existing gateway/environment semantics.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `EnvironmentGatewaySelector` (shared-component): 14 vitest cases covering all four row states, locked-row undeploy staging, same-environment candidate switching (previous selection evicted, never joined), unmapped deployed gateways, validity reporting, and a seeded property test asserting `onChange` never emits two gateways sharing an environment. `LLMProviderDeploymentTab` (llm-providers): 4 cases — seeding/dirty tracking, exact `{ gateways }` save payload, zero-gateway recoverability, and post-save refetch reconciling a failed deploy. Both suites pass with `rushx test`. Note: both packages needed a `vitest` `server.deps.inline` config addition for oxygen-ui's ESM dist; two pre-existing shared-component suites (`CodeBlock`, `PermissionTree`) have failures unrelated to this change (they previously could not load at all under the old config and are untouched here).
 - Integration tests
   > None exist for the console (no e2e runner in the repo). Manual QA checklist: (1) create → deploy to env A → invoke URL appears on Overview without remount (guards the `["llm-deployments"]` invalidation fix); (2) add env B, save, both deployed; (3) remove env A, save, its invoke URL disappears; (4) a second gateway in an already-deployed environment is not offered by the UI.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no (Java-only tooling; this PR is TypeScript/React console code — `rush lint` passes)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or API change.

## Test environment
Linux (CachyOS), Node.js 20.20.2 (rush-supported range), pnpm 9.12.3 via Rush 5.157.0, vitest 3.1.3/jsdom. `rush build` (all console packages) and per-package `rushx lint`/`rushx test` pass.

## Learning
Design followed the existing MCP-proxy environment-first placement UX (`EndpointFormFields`/`EndpointsEditorSection`) and the repo's TanStack Query invalidation conventions; the design doc in `docs/llm-provider-deployment-spec.md` records the placement-validation analysis and the recoverability trace through the deployment service that justified deferring backend changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added environment-aware gateway selection for creating and managing LLM provider deployments.
  - Added a Deployment tab with gateway assignment, validation, save, discard, and undeployment workflows.
  - Added deployment summaries to provider overviews, including environment and unmapped gateway status.
  - Added warnings and submission safeguards for unavailable or conflicting gateway selections.

- **Bug Fixes**
  - Deployment data now refreshes after successful provider updates.

- **Documentation**
  - Added deployment management specifications and usage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->