### PR TITLE
Resolve the Try page auth mode per environment

### DIFF
--- a/console/workspaces/pages/agent-security/src/Security.Component.tsx
+++ b/console/workspaces/pages/agent-security/src/Security.Component.tsx
@@ -22,7 +22,7 @@ import { Alert, Button, ListingTable, Skeleton } from "@wso2/oxygen-ui";
 import { KeyRound, Rocket, ShieldOff } from "@wso2/oxygen-ui-icons-react";
 import {
   useCreateAgentAPIKey,
-  useGetAgent,
+  useGetAgentConfigurations,
   useListAgentDeployments,
   useListAgentAPIKeys,
   useRevokeAgentAPIKey,
@@ -38,11 +38,18 @@ import { absoluteRouteMap } from "@agent-management-platform/types";
 export const SecurityComponent: React.FC = () => {
   const { orgId, projectId, agentId, envId } = useParams();
 
-  const { data: agent, isLoading: isLoadingAgent } = useGetAgent({
-    orgName: orgId,
-    projName: projectId,
-    agentName: agentId,
-  });
+  // GetAgent returns only the lowest environment's config, so read per-env here.
+  const { data: envConfig, isLoading: isLoadingConfig } =
+    useGetAgentConfigurations(
+      {
+        orgName: orgId,
+        projName: projectId,
+        agentName: agentId,
+      },
+      {
+        environment: envId ?? "",
+      },
+    );
   const { data: deployments, isLoading: isLoadingDeployments } =
     useListAgentDeployments({
       orgName: orgId,
@@ -50,12 +57,12 @@ export const SecurityComponent: React.FC = () => {
       agentName: agentId,
     });
 
-  const securityEnabled = agent?.configurations?.enableApiKeySecurity ?? true;
-  const oauthEnabled = agent?.configurations?.enableOAuthSecurity ?? false;
+  const securityEnabled = envConfig?.enableApiKeySecurity ?? true;
+  const oauthEnabled = envConfig?.enableOAuthSecurity ?? false;
   const currentDeployment = envId ? deployments?.[envId] : undefined;
   const hasActiveDeployment = currentDeployment?.status === "active";
   const shouldLoadKeys =
-    !isLoadingAgent &&
+    !isLoadingConfig &&
     !isLoadingDeployments &&
     hasActiveDeployment &&
     securityEnabled &&
@@ -71,7 +78,7 @@ export const SecurityComponent: React.FC = () => {
     envId: shouldLoadKeys ? envId : undefined,
   });
   const isLoading =
-    isLoadingAgent || isLoadingDeployments || (shouldLoadKeys && isLoadingKeys);
+    isLoadingConfig || isLoadingDeployments || (shouldLoadKeys && isLoadingKeys);
 
   const { mutateAsync: createKey, isPending: isCreating } =
     useCreateAgentAPIKey();

--- a/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/AgentChat.tsx
@@ -27,7 +27,7 @@ import {
 } from "@wso2/oxygen-ui";
 import { MessageCircle, Send } from "@wso2/oxygen-ui-icons-react";
 import {
-  useGetAgent,
+  useGetAgentConfigurations,
   useGetAgentEndpoints,
   useTestAgentAPIKey,
 } from "@agent-management-platform/api-client";
@@ -78,15 +78,20 @@ export function AgentChat() {
         environment: envId ?? "",
       },
     );
-  const { data: agent } = useGetAgent({
-    orgName: orgId,
-    projName: projectId,
-    agentName: agentId,
-  });
-  const securityEnabled = agent?.configurations?.enableApiKeySecurity ?? true;
+  // GetAgent returns only the lowest environment's config, so read per-env here.
+  const { data: envConfig } = useGetAgentConfigurations(
+    {
+      orgName: orgId,
+      projName: projectId,
+      agentName: agentId,
+    },
+    {
+      environment: envId ?? "",
+    },
+  );
+  const securityEnabled = envConfig?.enableApiKeySecurity ?? true;
   const oauthOnly = !!(
-    agent?.configurations?.enableOAuthSecurity &&
-    !agent?.configurations?.enableApiKeySecurity
+    envConfig?.enableOAuthSecurity && !envConfig?.enableApiKeySecurity
   );
   const {
     data: testKey,

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -17,7 +17,7 @@
  */
 
 import {
-  useGetAgent,
+  useGetAgentConfigurations,
   useGetAgentEndpoints,
   useTestAgentAPIKey,
 } from "@agent-management-platform/api-client";
@@ -59,15 +59,21 @@ export function Swagger() {
     }
   );
 
-  const { data: agent } = useGetAgent({
-    orgName: orgId,
-    projName: projectId,
-    agentName: agentId,
-  });
-  const securityEnabled = !!agent?.configurations?.enableApiKeySecurity;
+  // GetAgent returns only the lowest environment's config, so read per-env here.
+  const { data: envConfig } = useGetAgentConfigurations(
+    {
+      orgName: orgId,
+      projName: projectId,
+      agentName: agentId,
+    },
+    {
+      environment: envId ?? "",
+    }
+  );
+  // Absent means no per-env config row yet, so assume a key is required.
+  const securityEnabled = envConfig?.enableApiKeySecurity ?? true;
   const oauthOnly = !!(
-    agent?.configurations?.enableOAuthSecurity &&
-    !agent?.configurations?.enableApiKeySecurity
+    envConfig?.enableOAuthSecurity && !envConfig?.enableApiKeySecurity
   );
   const {
     data: testKey,

--- a/console/workspaces/pages/test/src/Test.Component.tsx
+++ b/console/workspaces/pages/test/src/Test.Component.tsx
@@ -23,12 +23,13 @@ import {
   NoDataFound,
   PageLayout,
 } from "@agent-management-platform/views";
-import { Box, Skeleton } from "@wso2/oxygen-ui";
+import { Alert, Box, Skeleton } from "@wso2/oxygen-ui";
 import { Rocket } from "@wso2/oxygen-ui-icons-react";
 import { useParams } from "react-router-dom";
 import { Swagger } from "./AgentTest/Swagger";
 import {
   useGetAgent,
+  useGetAgentConfigurations,
   useListAgentDeployments,
 } from "@agent-management-platform/api-client";
 
@@ -74,9 +75,23 @@ export const TestComponent: React.FC = () => {
     });
   const currentDeployment = deployments?.[envId ?? ""];
 
-  const isLoading = isDeploymentsLoading || isAgentLoading;
+  // Children must not render as testable before this environment's auth mode is known.
+  const { isLoading: isEnvConfigLoading, isError: isEnvConfigError } =
+    useGetAgentConfigurations(
+      {
+        orgName: orgId,
+        projName: projectId,
+        agentName: agentId,
+      },
+      {
+        environment: envId ?? "",
+      },
+    );
 
-  if (!isLoading && currentDeployment?.status !== "active") {
+  const isDeploymentLoading = isDeploymentsLoading || isAgentLoading;
+  const isLoading = isDeploymentLoading || isEnvConfigLoading;
+
+  if (!isDeploymentLoading && currentDeployment?.status !== "active") {
     return (
       <PageLayout title="Try your agent" disableIcon actions={<EnvironmentSelector />}>
         <Box
@@ -100,8 +115,19 @@ export const TestComponent: React.FC = () => {
     <PageLayout title={"Try your agent"} disableIcon isLoading={isLoading} actions={<EnvironmentSelector />}>
       {isLoading ? (
         <SkeletonTestPageLayout />
+      ) : isEnvConfigError ? (
+        <Alert severity="error">
+          Could not load this environment&apos;s security settings, so testing is
+          unavailable. Retry in a moment or reload the page.
+        </Alert>
       ) : (
-        <>{isChatAgent ? <AgentChat key={agentId} /> : <Swagger key={agentId} />}</>
+        <>
+          {isChatAgent ? (
+            <AgentChat key={`${agentId}-${envId}`} />
+          ) : (
+            <Swagger key={`${agentId}-${envId}`} />
+          )}
+        </>
       )}
     </PageLayout>
   );


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

When an agent is configured to use OAuth in one environment and API keys in another, the **Try your agent** page showed the same authentication state in every environment. Picking a different environment from the selector had no effect, so an environment secured with API keys could still display "Testing is unavailable while OAuth is enabled" and refuse to let you test it.

The page derived its authentication mode from `GetAgent`, which deliberately populates `configurations` from only the lowest environment in the promotion chain. That endpoint takes no environment parameter, so the value cannot vary per environment and nothing refetches when the selector changes.

Both pages now read the authentication mode from the existing per-environment configurations endpoint, whose query key includes the environment — the same approach the Deploy page already uses for its overview chips. The **API Keys** page had the identical problem and is fixed alongside it. No backend change was needed.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security settings, API-key handling, and OAuth detection to use the selected environment’s configuration.
  * Added clear error handling when environment security configuration cannot be loaded.
  * Improved loading behavior so test tools wait for the relevant environment configuration.
  * Ensured chat and Swagger views refresh when switching agents or environments.
  * API-key security is enabled by default when no environment configuration is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->