### PR TITLE
Record both agent listener ports for added environments

### DIFF
--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -42,6 +42,10 @@ data:
   THUNDER_HOST_BASE_DOMAIN: {{ .Values.agentManagerService.config.thunderHostBaseDomain | default "amp.localhost" | quote }}
   # Read back by add-environment.sh so added environments inherit these domains.
   AGENTS_BASE_DOMAIN: {{ .Values.agentManagerService.config.agentsBaseDomain | default "am-gateway.localhost" | quote }}
+  # One port per listener variant: they coincide behind a single TLS front door but
+  # not on a plane gateway serving http on 80 and https on 443, so neither is inferred.
+  AGENTS_HTTP_PORT: {{ .Values.agentManagerService.config.agentsHttpPort | default "19080" | quote }}
+  AGENTS_HTTPS_PORT: {{ .Values.agentManagerService.config.agentsHttpsPort | default "443" | quote }}
   GATEWAY_BASE_DOMAIN: {{ .Values.agentManagerService.config.gatewayBaseDomain | default "gateway.localhost" | quote }}
   # ...and the scheme/port that domain is actually served on, so the vhost an added
   # environment publishes is callable and not just correctly named.

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -243,6 +243,13 @@ agentManagerService:
     agentsBaseDomain: "am-gateway.localhost"
     gatewayBaseDomain: "gateway.localhost"
 
+    # Port each agent-facing listener variant serves. Behind a single TLS front door
+    # both are 443; on a plane gateway they are typically 80 and 443. Set them to what
+    # the environment.gateway.http/https.port overrides on the platform-resources chart
+    # say, so an added environment advertises the same pair as the default one.
+    agentsHttpPort: "19080"
+    agentsHttpsPort: "443"
+
     # Scheme and port the gateway vhost above is published on. The defaults describe a
     # local k3d install (plain http on the node port). Set these to https/443 wherever a
     # front proxy terminates TLS, or added environments publish a reachable hostname on

--- a/deployments/scripts/add-environment.sh
+++ b/deployments/scripts/add-environment.sh
@@ -41,7 +41,10 @@ set -euo pipefail
 #   - ENV_INGRESS_HTTPS_HOST (default: unset): on TLS deployments, advertises an
 #     https listener variant. Set ENV_INGRESS_HTTPS_HOST=$ENV_INGRESS_HOST for
 #     the TLS toggle alone; without it the deployed-agent invoke URL is empty.
-#   - ENV_INGRESS_HTTPS_PORT (default: 443): port for the https listener variant.
+#   - ENV_INGRESS_PORT (default: the install's AGENTS_HTTP_PORT, else 19080) and
+#     ENV_INGRESS_HTTPS_PORT (default: the install's AGENTS_HTTPS_PORT, else 443):
+#     the port each listener variant serves. They differ on a plane gateway that
+#     serves http on 80 and https on 443; neither is inferred from the other.
 #   - GATEWAY_BASE_DOMAIN (default: the install's GATEWAY_BASE_DOMAIN, else
 #     gateway.localhost): base domain for this environment's api-platform gateway.
 #   - GATEWAY_VHOST_SCHEME (default: the install's GATEWAY_VHOST_SCHEME, else http)
@@ -279,6 +282,20 @@ if [ -z "${ENV_INGRESS_HOST:-}" ]; then
 fi
 ENV_INGRESS_HOST="${ENV_INGRESS_HOST:-am-gateway.localhost}"
 ENV_INGRESS_HTTPS_HOST="${ENV_INGRESS_HTTPS_HOST:-}"
+# Each listener variant carries the port ITS listener serves, and the two are not
+# always the same: a Caddy-fronted VM terminates both on 443, while a plane gateway
+# commonly serves http on 80 and https on 443. Guessing one from the other publishes
+# "http://<host>:443" — an http scheme on the TLS port, which a browser blocks as
+# mixed content from the https console. So take both from the install.
+if [ -z "${ENV_INGRESS_PORT:-}" ]; then
+    ams_config_value AGENTS_HTTP_PORT
+    ENV_INGRESS_PORT="${AMS_CONFIG_VALUE}"
+fi
+ENV_INGRESS_PORT="${ENV_INGRESS_PORT:-19080}"
+if [ -z "${ENV_INGRESS_HTTPS_PORT:-}" ]; then
+    ams_config_value AGENTS_HTTPS_PORT
+    ENV_INGRESS_HTTPS_PORT="${AMS_CONFIG_VALUE}"
+fi
 ENV_INGRESS_HTTPS_PORT="${ENV_INGRESS_HTTPS_PORT:-443}"
 
 # --- Published gateway vhost (scheme + host + port) ---
@@ -315,15 +332,11 @@ gateway_vhost_url() {   # <scheme> <host> <port>
 }
 
 # Without an https variant the console reports an empty invoke URL on TLS deployments.
-# A recorded (non-localhost) agents base means the install fronts agents with TLS on
-# ENV_INGRESS_HTTPS_PORT, so pin the http variant to the same port rather than leaving
-# it on the gateway runtime's node port — the two variants describe one listener, and
-# the default environment seeded by the chart advertises both on 443.
+# A recorded (non-localhost) agents base means the install fronts agents publicly, so
+# advertise the TLS variant alongside the plain one.
 if [ -z "${ENV_INGRESS_HTTPS_HOST}" ] && [ "${ENV_INGRESS_HOST}" != "am-gateway.localhost" ]; then
     ENV_INGRESS_HTTPS_HOST="${ENV_INGRESS_HOST}"
-    ENV_INGRESS_PORT="${ENV_INGRESS_PORT:-${ENV_INGRESS_HTTPS_PORT}}"
 fi
-ENV_INGRESS_PORT="${ENV_INGRESS_PORT:-${GATEWAY_VHOST_PORT}}"
 
 # Build the external listener set. Always advertise http; add an https variant when
 # ENV_INGRESS_HTTPS_HOST is set (TLS deployments). The console reads the https

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -49,6 +49,8 @@ amp_helm_args() {
       "--set" "${k}.config.tlsEnabled=true" \
       "--set" "${k}.config.thunderHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
       "--set" "${k}.config.agentsBaseDomain=${AMP_AGENTS_BASE}" \
+      "--set" "${k}.config.agentsHttpPort=443" \
+      "--set" "${k}.config.agentsHttpsPort=443" \
       "--set" "${k}.config.gatewayBaseDomain=${AMP_HOST_GATEWAY}" \
       "--set" "${k}.config.gatewayVhostScheme=https" \
       "--set" "${k}.config.gatewayVhostPort=443"

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -106,6 +106,15 @@ assert_eq "amp gateway-mgmt route hostname when cp on" \
 assert_eq "amp agentsBaseDomain (service key)" \
   "agentManagerService.config.agentsBaseDomain=agents.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.agentsBaseDomain' <<<"$amp")"
+# Both agent listener variants sit behind Caddy on :443 here — there is no :80 on a
+# VM at all — so an added environment must advertise the same pair the installer
+# writes for the default environment rather than inferring one port from the other.
+assert_eq "amp agentsHttpPort (service key)" \
+  "agentManagerService.config.agentsHttpPort=443" \
+  "$(grep -F 'agentManagerService.config.agentsHttpPort' <<<"$amp")"
+assert_eq "amp agentsHttpsPort (service key)" \
+  "agentManagerService.config.agentsHttpsPort=443" \
+  "$(grep -F 'agentManagerService.config.agentsHttpsPort' <<<"$amp")"
 assert_eq "amp gatewayBaseDomain (service key)" \
   "agentManagerService.config.gatewayBaseDomain=gateway.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.gatewayBaseDomain' <<<"$amp")"

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -1381,6 +1381,36 @@ The Environment's gateway binding **wholly replaces** the data plane's, so a par
 Putting `443` on the `http` variant is the trap: the console then publishes `http://<host>:443`, an HTTP scheme on the TLS port, and a browser refuses to call it from the HTTPS console as mixed content. Nothing in the platform reports an error, because the gateway and the agent are both fine.
 :::
 
+**Environments you add later** — the override above applies to the default Environment only. Environments created afterwards with [`add-environment.sh`](../administration/environment-management.mdx) read their hostnames from Agent Manager's own config, which still holds the chart's placeholder defaults. Record the same values there so an added environment resolves the way the default one does:
+
+```bash
+helm upgrade amp oci://${HELM_CHART_REGISTRY}/wso2-agent-manager \
+  --version ${VERSION} \
+  --namespace ${AMP_NS} \
+  --reuse-values \
+  --set agentManagerService.config.agentsBaseDomain="${AGENTS_DOMAIN}" \
+  --set agentManagerService.config.agentsHttpPort=80 \
+  --set agentManagerService.config.agentsHttpsPort=443
+```
+
+The two ports must match the `environment.gateway.http.port` and `https.port` you set above — the same one-port-per-listener rule, for the same reason.
+
+Skip this and added environments still install, but their agents are published on `am-gateway.localhost`: the console shows an empty invoke URL and try-out returns `405` against its own host. The symptom appears only when you create a second environment, long after this step.
+
+:::note Publishing added environments' gateways
+Each added environment also gets its own API Platform Gateway at `<env>-<org>.<gatewayBaseDomain>`, which carries that environment's OTel ingest and LLM-proxy endpoints. Those stay in-cluster unless you gave the gateway a public hostname (see [`INSTRUMENTATION_URL`](#1-hostnames)) — deployed agents reach the runtime in-cluster either way, so this only matters for callers outside the cluster.
+
+If you did, record it too, so added environments publish a reachable URL rather than a `localhost` one:
+
+```bash
+  --set agentManagerService.config.gatewayBaseDomain="otel.${BASE_DOMAIN}" \
+  --set agentManagerService.config.gatewayVhostScheme=https \
+  --set agentManagerService.config.gatewayVhostPort=443
+```
+
+That needs a `*.otel.${BASE_DOMAIN}` DNS record and gateway certificate coverage — and, per [RFC 4592](https://www.rfc-editor.org/rfc/rfc4592), adding that wildcard makes `otel.${BASE_DOMAIN}` an empty non-terminal that a broader `*.${BASE_DOMAIN}` stops covering, so keep an explicit record for it. This is the same trap the `*.thunder.${BASE_DOMAIN}` record carries.
+:::
+
 ### Provision Thunder Identity Provider for the Default Environment
 
 Every Environment needs its own dedicated Thunder ID instance. This is separate from the platform Thunder installed in Phase 1, which only handles console and API login. This instance is what issues each agent its own OAuth2 credential (AgentID) in that Environment. Run this once for the default Environment: agents can still be created without it, but they will never get an AgentID there, since there is no Thunder instance to provision one against, and Agent Manager will keep retrying and failing in the background. Run it after Agent Manager (`amp`) is installed and reachable at `API_PUBLIC_URL`, since this step registers the generated credential with the Agent Manager API.

--- a/documentation/docs/getting-started/on-your-environment.mdx
+++ b/documentation/docs/getting-started/on-your-environment.mdx
@@ -1400,9 +1400,16 @@ Skip this and added environments still install, but their agents are published o
 :::note Publishing added environments' gateways
 Each added environment also gets its own API Platform Gateway at `<env>-<org>.<gatewayBaseDomain>`, which carries that environment's OTel ingest and LLM-proxy endpoints. Those stay in-cluster unless you gave the gateway a public hostname (see [`INSTRUMENTATION_URL`](#1-hostnames)) — deployed agents reach the runtime in-cluster either way, so this only matters for callers outside the cluster.
 
-If you did, record it too, so added environments publish a reachable URL rather than a `localhost` one:
+If you did, record it too, so added environments publish a reachable URL rather than a `localhost` one. Run this instead of the command above — it carries the same three agent settings plus the gateway ones:
 
 ```bash
+helm upgrade amp oci://${HELM_CHART_REGISTRY}/wso2-agent-manager \
+  --version ${VERSION} \
+  --namespace ${AMP_NS} \
+  --reuse-values \
+  --set agentManagerService.config.agentsBaseDomain="${AGENTS_DOMAIN}" \
+  --set agentManagerService.config.agentsHttpPort=80 \
+  --set agentManagerService.config.agentsHttpsPort=443 \
   --set agentManagerService.config.gatewayBaseDomain="otel.${BASE_DOMAIN}" \
   --set agentManagerService.config.gatewayVhostScheme=https \
   --set agentManagerService.config.gatewayVhostPort=443


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Follow-up to #1522, which taught `add-environment.sh` to inherit the install's recorded base domains. Two gaps remain, both of which only bite on a non-VM install.

**An added environment still guesses its listener ports.** #1522 pinned the `http` variant's port to the `https` variant's whenever the recorded agents domain was not the localhost placeholder. That holds only where a single TLS front door terminates both, as on a VM install fronted by Caddy. A plane gateway commonly serves `http` on `80` and `https` on `443`, and there the guess publishes `http://<host>:443` — an http scheme on the TLS port, which a browser blocks as mixed content from the https console. Nothing reports an error, because the gateway and the agent are both healthy. `on-your-environment.mdx` already warns against exactly this when setting the default environment's override, so the script was reproducing a documented trap.

**The cluster guide never records the domains at all.** `on-your-environment.mdx` points the default Environment's gateway at the public agents domain via `environment.gateway.http/https.host`, but that override lives on the Environment CR and never reaches the config `add-environment.sh` reads. Following the guide end to end therefore leaves the *second* environment publishing agents on `am-gateway.localhost`: an empty invoke URL in the console and a `405` from try-out. The symptom appears long after the step that caused it. Before #1522 there was no mechanism to fix this; now there is one, and the guide does not mention it.

Related to #1520

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

An environment added after install should publish the same hostnames and ports as the default one, on every deployment flavour rather than only on a VM — and the cluster guide should say how, at the point where the operator is already setting the equivalent values for the default environment.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

**Record both ports rather than deriving one from the other.** Two new keys on the AMS ConfigMap alongside the base domains `#1522` added:

| Key | Chart value | Default |
|---|---|---|
| `AGENTS_HTTP_PORT` | `agentManagerService.config.agentsHttpPort` | `19080` |
| `AGENTS_HTTPS_PORT` | `agentManagerService.config.agentsHttpsPort` | `443` |

`add-environment.sh` reads each back independently into `ENV_INGRESS_PORT` and `ENV_INGRESS_HTTPS_PORT`, and the pin-http-to-https inference is removed. Explicit environment variables still take precedence, and the chart defaults reproduce today's local-install behaviour exactly.

The VM installer records `443` for both. That looks like the trap above but is not: a VM install has no `:80` listener at all, and `443/443` is already what the installer writes onto the default Environment CR, so an added environment now matches it. VM behaviour is unchanged.

**Document the recording step in the cluster guide.** A new *"Environments you add later"* block sits directly after the existing default-Environment override, carrying the three `--set` flags and stating that the two ports must match the `environment.gateway.*.port` values set immediately above — the same one-port-per-listener rule as the neighbouring warning. It also names the symptom of skipping it, because that only surfaces on the second environment.

The per-environment API Platform Gateway is handled as a separate note rather than the main path. The guide treats a public gateway hostname as opt-in, and deployed agents reach the runtime in-cluster either way, so it matters only for callers outside the cluster. The note carries the `*.otel.${BASE_DOMAIN}` DNS record it needs and the [RFC 4592](https://www.rfc-editor.org/rfc/rfc4592) empty-non-terminal trap that record brings, mirroring how the guide already handles `*.thunder.${BASE_DOMAIN}`.

## User stories
> Summary of user stories addressed by this change>

As an operator who installed Agent Manager on my own cluster following the production guide, I can add a second environment and have its agents published on my domain and its listener ports, rather than on a placeholder host that resolves nowhere.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Environments added after install now inherit the agent-facing listener ports recorded by the install, so an added environment publishes agents on the same host and ports as the default one on cluster deployments as well as on VMs.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

Included in this PR: `documentation/docs/getting-started/on-your-environment.mdx` gains the *"Environments you add later"* block and the per-environment gateway note described under Approach.

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

N/A — no training content covers post-install environment creation.

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

N/A — an internal deployment-configuration detail, not exam material.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

N/A — a bug fix with no promotable surface.

## Automation tests
 - Unit tests
   > Code coverage information

`deployments/vm/tests/run.sh` — 188 assertions pass, including two new ones covering the ports the VM installer records. No coverage tooling applies to these shell libraries; the suite asserts on rendered helm-arg and Caddyfile output.

 - Integration tests
   > Details about the test cases and coverage

None added. `add-environment.sh` is exercised end to end by `test/e2e/tests/environment`, which runs against a local k3d install where these values keep their chart defaults, so the existing cases cover the no-regression path but not the recorded-value path.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — shell and Helm templates only, no Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature

N/A — no sample applications are affected.

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

None required. The new keys default to the values the script previously used, so an existing install that has not been upgraded resolves exactly as before. As with #1522, the ConfigMap half only reaches a deployed install once a release carrying these chart values is published — the guide's `--set` flags depend on that release.

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested

Verified statically rather than on a live cluster:

- `bash deployments/vm/tests/run.sh` — 188/188 pass
- `helm template` on `wso2-agent-manager` with defaults and with overrides — renders the four keys correctly
- `shellcheck -S warning` on `add-environment.sh` — clean
- The script's resolution block driven against a stubbed `kubectl` across five ConfigMap states:

| Install | http listener | https listener | gateway vhost |
|---|---|---|---|
| VM | `agents.<ip>.sslip.io:443` | `:443` | `https://staging-default.gateway.amp.<ip>.sslip.io` |
| Cluster guide, full | `agents.mycompany.com:80` | `:443` | `https://staging-default.otel.mycompany.com` |
| Cluster guide, agents only | `:80` | `:443` | `http://staging-default.gateway.localhost:19080` |
| Local k3d | `am-gateway.localhost:19080` | not emitted | `http://staging-default.gateway.localhost:19080` |
| ConfigMap without the keys | `am-gateway.localhost:19080` | not emitted | `http://staging-default.gateway.localhost:19080` |

The last two rows are the no-regression check; the second row is the case this PR fixes.

Not yet done: an end-to-end run creating a real second environment on a cluster or VM install. Worth doing before this ships, since the failure it prevents is only visible at that point.

## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

The one-port-per-listener rule and the http-on-443 mixed-content failure were already documented in `on-your-environment.mdx`; the fix is mostly a matter of making the script obey guidance the guide had already written down. [RFC 4592 §2.2.1](https://datatracker.ietf.org/doc/html/rfc4592#section-2.2.1) covers the empty-non-terminal behaviour that makes a deeper wildcard shadow the bare name above it, which is why the gateway note insists on an explicit record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable HTTP and HTTPS listener ports for the Agent Manager, defaulting to `19080` and `443`.
  - Environment setup now resolves HTTP and HTTPS ingress ports independently.
  - VM deployments configure both listener ports consistently.

- **Documentation**
  - Added guidance for configuring public Agent Manager endpoints, gateway access, DNS, and certificates.

- **Tests**
  - Added validation for the configured Agent Manager HTTP and HTTPS ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->