### PR TITLE
docs: fix stale Gin reference for agent-manager-service in root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This repo is a **multi-aspect monorepo**. Each aspect has its own `AGENTS.md` wi
 
 | Aspect | Dir | Stack | Guide |
 |---|---|---|---|
-| **Control-plane API** | `agent-manager-service/` | Go 1.25, Gin, GORM/pgx, gRPC, wire, sqlc, oapi-codegen | [`agent-manager-service/AGENTS.md`](agent-manager-service/AGENTS.md) |
+| **Control-plane API** | `agent-manager-service/` | Go 1.25, net/http (stdlib), GORM/pgx, gRPC, wire, sqlc, oapi-codegen | [`agent-manager-service/AGENTS.md`](agent-manager-service/AGENTS.md) |
 | **Web console** | `console/` | React 19, TS, Vite, Rush/pnpm, Oxygen UI (MUI 7), TanStack Query | [`console/AGENTS.md`](console/AGENTS.md) |
 | **Oxygen UI library** | `console/.ai/oxygen-ui/` | WSO2 React component lib | [`console/.ai/oxygen-ui/AGENTS.md`](console/.ai/oxygen-ui/AGENTS.md) |
 | **CLI (`amctl`)** | `cli/` | Go, cobra-style, factory-injected deps | [`cli/AGENTS.md`](cli/AGENTS.md) |


### PR DESCRIPTION
## Purpose
Fixes stale documentation. The root `AGENTS.md` component table lists `agent-manager-service`'s stack as using Gin, but the service actually uses stdlib `net/http`.

resolved #1534 

## Goals
Root `AGENTS.md` accurately reflects `agent-manager-service`'s actual HTTP stack.

## Approach
Updated the stack description in root `AGENTS.md`'s component table from "Gin" to "net/http (stdlib)", matching what `agent-manager-service/go.mod` and `agent-manager-service/api/app.go` actually show. No code changes.

## User stories
N/A — internal documentation accuracy fix.

## Release note
Fixed stale documentation referencing Gin for agent-manager-service; it uses stdlib net/http.

## Documentation
> N/A — this PR is itself the documentation fix (root AGENTS.md).

## Training
> N/A — no impact on training content.

## Certification
> N/A — no impact on certification exams.

## Marketing
> N/A — internal documentation fix, not user-facing.

## Automation tests
 - Unit tests
   > N/A — documentation-only change, no code affected.
 - Integration tests
   > N/A — documentation-only change, no code affected.

## Security checks
 - Followed secure coding standards? N/A — documentation-only change
 - Ran FindSecurityBugs plugin and verified report? N/A — documentation-only change
 - Confirmed no secrets committed? Yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A — documentation-only change

## Learning
Verified by checking `agent-manager-service/go.mod` (no gin-gonic dependency) and `agent-manager-service/api/app.go` (uses `http.NewServeMux()` and stdlib `net/http` throughout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Control-plane API stack to use Go’s standard HTTP library instead of Gin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->