### PR TITLE
Take the org for repository routes from the token, not the request body

### DIFF
--- a/agent-manager-service/api/repository_routes.go
+++ b/agent-manager-service/api/repository_routes.go
@@ -23,6 +23,6 @@ import (
 )
 
 func registerRepositoryRoutes(rr *middleware.RouteRegistrar, ctrl controllers.RepositoryController) {
-	rr.HandleFuncWithValidationAndAuthz("POST /repositories/branches", rbac.RepositoryRead, ctrl.ListBranches)
-	rr.HandleFuncWithValidationAndAuthz("POST /repositories/commits", rbac.RepositoryRead, ctrl.ListCommits)
+	rr.HandleFuncWithValidationAndAuthz("POST /orgs/{orgName}/repositories/branches", rbac.RepositoryRead, ctrl.ListBranches)
+	rr.HandleFuncWithValidationAndAuthz("POST /orgs/{orgName}/repositories/commits", rbac.RepositoryRead, ctrl.ListCommits)
 }

--- a/agent-manager-service/audit/policy.go
+++ b/agent-manager-service/audit/policy.go
@@ -308,8 +308,8 @@ var actionOverrides = map[string]Action{
 	// only by an audience check — so there is nothing to derive from.
 	"POST /publisher/monitors/{monitorId}/runs/{runId}/scores": "monitor-score:publish",
 
-	"POST /repositories/branches":                        "repository:list-branches",
-	"POST /repositories/commits":                         "repository:list-commits",
+	"POST /orgs/{orgName}/repositories/branches":         "repository:list-branches",
+	"POST /orgs/{orgName}/repositories/commits":          "repository:list-commits",
 	"POST /orgs/{orgName}/mcp-proxies/fetch-server-info": "mcp-server:fetch-server-info",
 
 	// Sensitive reads.

--- a/agent-manager-service/controllers/repository_controller.go
+++ b/agent-manager-service/controllers/repository_controller.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/gitprovider"
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 	"github.com/wso2/agent-manager/agent-manager-service/services"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
@@ -81,8 +82,10 @@ func (c *repositoryController) ListBranches(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	ouID := middleware.OUIDFromRequest(r)
+
 	// Call service
-	response, err := c.repositoryService.ListBranches(ctx, reqBody, gitprovider.ProviderGitHub, limit, offset)
+	response, err := c.repositoryService.ListBranches(ctx, reqBody, ouID, gitprovider.ProviderGitHub, limit, offset)
 	if err != nil {
 		log.Error("ListBranches: failed to list branches", "owner", reqBody.Owner, "repository", reqBody.Repository, "error", err)
 		handleGitProviderError(w, err)
@@ -121,8 +124,10 @@ func (c *repositoryController) ListCommits(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	ouID := middleware.OUIDFromRequest(r)
+
 	// Call service
-	response, err := c.repositoryService.ListCommits(ctx, reqBody, gitprovider.ProviderGitHub, limit, offset)
+	response, err := c.repositoryService.ListCommits(ctx, reqBody, ouID, gitprovider.ProviderGitHub, limit, offset)
 	if err != nil {
 		log.Error("ListCommits: failed to list commits", "owner", reqBody.Owner, "repo", reqBody.Repo, "error", err)
 		handleGitProviderError(w, err)

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -4813,7 +4813,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /repositories/branches:
+  /orgs/{orgName}/repositories/branches:
+    parameters:
+      - name: orgName
+        in: path
+        required: true
+        description: Organization name/handle
+        schema:
+          type: string
+          pattern: "^[a-z0-9-]+$"
+          minLength: 1
+          maxLength: 64
+
     post:
       summary: List branches for a repository
       description: |
@@ -4876,7 +4887,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /repositories/commits:
+  /orgs/{orgName}/repositories/commits:
+    parameters:
+      - name: orgName
+        in: path
+        required: true
+        description: Organization name/handle
+        schema:
+          type: string
+          pattern: "^[a-z0-9-]+$"
+          minLength: 1
+          maxLength: 64
+
     post:
       summary: List commits for a repository
       description: |
@@ -13669,9 +13691,6 @@ components:
         secretRef:
           type: string
           description: Secret reference name for private repository Git credentials
-        orgName:
-          type: string
-          description: Organization name for resolving the secret reference
 
     ListBranchesResponse:
       type: object
@@ -13757,9 +13776,6 @@ components:
         secretRef:
           type: string
           description: Secret reference name for private repository Git credentials
-        orgName:
-          type: string
-          description: Organization name for resolving the secret reference
 
     ListCommitsResponse:
       type: object

--- a/agent-manager-service/services/repository_service.go
+++ b/agent-manager-service/services/repository_service.go
@@ -28,10 +28,12 @@ import (
 
 // RepositoryService defines the interface for repository operations
 type RepositoryService interface {
-	// ListBranches returns branches for a repository
-	ListBranches(ctx context.Context, req spec.ListBranchesRequest, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListBranchesResponse, error)
-	// ListCommits returns commits for a repository
-	ListCommits(ctx context.Context, req spec.ListCommitsRequest, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListCommitsResponse, error)
+	// ListBranches returns branches for a repository. ouID comes from the caller's
+	// token, never the request body — it scopes the secretRef lookup.
+	ListBranches(ctx context.Context, req spec.ListBranchesRequest, ouID string, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListBranchesResponse, error)
+	// ListCommits returns commits for a repository. ouID comes from the caller's
+	// token, never the request body — it scopes the secretRef lookup.
+	ListCommits(ctx context.Context, req spec.ListCommitsRequest, ouID string, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListCommitsResponse, error)
 	// GetLatestCommit returns the latest commit SHA for a given branch
 	GetLatestCommit(ctx context.Context, owner, repo, branch string) (string, error)
 }
@@ -73,15 +75,15 @@ func getGitProviderConfigWithCredentials(creds *GitCredentials) (gitprovider.Con
 }
 
 // ListBranches returns branches for a repository
-func (s *repositoryService) ListBranches(ctx context.Context, req spec.ListBranchesRequest, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListBranchesResponse, error) {
+func (s *repositoryService) ListBranches(ctx context.Context, req spec.ListBranchesRequest, ouID string, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListBranchesResponse, error) {
 	// Determine git provider configuration
 	providerConfig := getGitProviderConfig()
 
 	// If secretRef is provided, fetch git credentials from workflow plane OpenBao
-	if req.HasSecretRef() && req.HasOrgName() {
-		creds, err := s.gitCredentialsService.GetGitCredentials(ctx, req.GetOrgName(), req.GetSecretRef())
+	if req.HasSecretRef() && ouID != "" {
+		creds, err := s.gitCredentialsService.GetGitCredentials(ctx, ouID, req.GetSecretRef())
 		if err != nil {
-			s.logger.Error("failed to get git credentials", "error", err, "secretRef", req.GetSecretRef(), "ouID", req.GetOrgName())
+			s.logger.Error("failed to get git credentials", "error", err, "secretRef", req.GetSecretRef(), "ouID", ouID)
 			return nil, err
 		}
 		providerConfig, err = getGitProviderConfigWithCredentials(creds)
@@ -133,15 +135,15 @@ func (s *repositoryService) ListBranches(ctx context.Context, req spec.ListBranc
 }
 
 // ListCommits returns commits for a repository
-func (s *repositoryService) ListCommits(ctx context.Context, req spec.ListCommitsRequest, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListCommitsResponse, error) {
+func (s *repositoryService) ListCommits(ctx context.Context, req spec.ListCommitsRequest, ouID string, providerType gitprovider.ProviderType, limit, offset int) (*spec.ListCommitsResponse, error) {
 	// Determine git provider configuration
 	providerConfig := getGitProviderConfig()
 
 	// If secretRef is provided, fetch git credentials from workflow plane OpenBao
-	if req.HasSecretRef() && req.HasOrgName() {
-		creds, err := s.gitCredentialsService.GetGitCredentials(ctx, req.GetOrgName(), req.GetSecretRef())
+	if req.HasSecretRef() && ouID != "" {
+		creds, err := s.gitCredentialsService.GetGitCredentials(ctx, ouID, req.GetSecretRef())
 		if err != nil {
-			s.logger.Error("failed to get git credentials", "error", err, "secretRef", req.GetSecretRef(), "ouID", req.GetOrgName())
+			s.logger.Error("failed to get git credentials", "error", err, "secretRef", req.GetSecretRef(), "ouID", ouID)
 			return nil, err
 		}
 		providerConfig, err = getGitProviderConfigWithCredentials(creds)

--- a/agent-manager-service/services/repository_service.go
+++ b/agent-manager-service/services/repository_service.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/gitprovider"
@@ -79,8 +80,13 @@ func (s *repositoryService) ListBranches(ctx context.Context, req spec.ListBranc
 	// Determine git provider configuration
 	providerConfig := getGitProviderConfig()
 
-	// If secretRef is provided, fetch git credentials from workflow plane OpenBao
-	if req.HasSecretRef() && ouID != "" {
+	// If secretRef is provided, fetch git credentials from workflow plane OpenBao.
+	// A secretRef without an org is a missing-tenant-identity condition, not a
+	// reason to fall back to the platform's default (public-repo) credentials.
+	if req.HasSecretRef() {
+		if ouID == "" {
+			return nil, fmt.Errorf("organization identity is required to resolve secretRef %q", req.GetSecretRef())
+		}
 		creds, err := s.gitCredentialsService.GetGitCredentials(ctx, ouID, req.GetSecretRef())
 		if err != nil {
 			s.logger.Error("failed to get git credentials", "error", err, "secretRef", req.GetSecretRef(), "ouID", ouID)
@@ -139,8 +145,13 @@ func (s *repositoryService) ListCommits(ctx context.Context, req spec.ListCommit
 	// Determine git provider configuration
 	providerConfig := getGitProviderConfig()
 
-	// If secretRef is provided, fetch git credentials from workflow plane OpenBao
-	if req.HasSecretRef() && ouID != "" {
+	// If secretRef is provided, fetch git credentials from workflow plane OpenBao.
+	// A secretRef without an org is a missing-tenant-identity condition, not a
+	// reason to fall back to the platform's default (public-repo) credentials.
+	if req.HasSecretRef() {
+		if ouID == "" {
+			return nil, fmt.Errorf("organization identity is required to resolve secretRef %q", req.GetSecretRef())
+		}
 		creds, err := s.gitCredentialsService.GetGitCredentials(ctx, ouID, req.GetSecretRef())
 		if err != nil {
 			s.logger.Error("failed to get git credentials", "error", err, "secretRef", req.GetSecretRef(), "ouID", ouID)

--- a/agent-manager-service/services/repository_service_unit_test.go
+++ b/agent-manager-service/services/repository_service_unit_test.go
@@ -69,24 +69,23 @@ func newRepoService(creds GitCredentialsService) RepositoryService {
 	return NewRepositoryService(creds, discardLogger())
 }
 
-// branchReq builds a ListBranchesRequest carrying a secretRef + ouID, which is
-// what triggers the credential-resolution branch.
-func branchReq(secretRef, ouID string) spec.ListBranchesRequest {
+// branchReq builds a ListBranchesRequest carrying a secretRef, which together
+// with a non-empty org triggers the credential-resolution branch. The org now
+// comes from the caller's token, so it is passed to the service separately.
+func branchReq(secretRef string) spec.ListBranchesRequest {
 	return spec.ListBranchesRequest{
 		Owner:      "acme",
 		Repository: "widgets",
 		SecretRef:  strPtr(secretRef),
-		OrgName:    strPtr(ouID),
 	}
 }
 
 // commitReq mirrors branchReq for ListCommits.
-func commitReq(secretRef, ouID string) spec.ListCommitsRequest {
+func commitReq(secretRef string) spec.ListCommitsRequest {
 	return spec.ListCommitsRequest{
 		Owner:     "acme",
 		Repo:      "widgets",
 		SecretRef: strPtr(secretRef),
-		OrgName:   strPtr(ouID),
 	}
 }
 
@@ -134,7 +133,7 @@ func TestRepositoryService_ListBranches(t *testing.T) {
 		}
 		svc := newRepoService(creds)
 
-		_, err := svc.ListBranches(context.Background(), branchReq("git-secret", "acme"), gitprovider.ProviderGitHub, 10, 0)
+		_, err := svc.ListBranches(context.Background(), branchReq("git-secret"), "acme", gitprovider.ProviderGitHub, 10, 0)
 
 		require.Error(t, err)
 		assert.ErrorIs(t, err, boom)
@@ -151,7 +150,7 @@ func TestRepositoryService_ListBranches(t *testing.T) {
 		}
 		svc := newRepoService(creds)
 
-		_, err := svc.ListBranches(context.Background(), branchReq("git-secret", "acme"), gitprovider.ProviderGitHub, 10, 0)
+		_, err := svc.ListBranches(context.Background(), branchReq("git-secret"), "acme", gitprovider.ProviderGitHub, 10, 0)
 
 		assert.ErrorIs(t, err, utils.ErrGitSecretInvalidType)
 		assert.NotErrorIs(t, err, gitprovider.ErrNotFound)
@@ -164,7 +163,7 @@ func TestRepositoryService_ListBranches(t *testing.T) {
 		svc := newRepoService(&gitCredsStub{})
 
 		req := spec.ListBranchesRequest{Owner: "acme", Repository: "widgets"}
-		_, err := svc.ListBranches(context.Background(), req, gitprovider.ProviderType("bitbucket"), 10, 0)
+		_, err := svc.ListBranches(context.Background(), req, "acme", gitprovider.ProviderType("bitbucket"), 10, 0)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported git provider")
@@ -187,7 +186,7 @@ func TestRepositoryService_ListCommits(t *testing.T) {
 		}
 		svc := newRepoService(creds)
 
-		_, err := svc.ListCommits(context.Background(), commitReq("git-secret", "acme"), gitprovider.ProviderGitHub, 10, 0)
+		_, err := svc.ListCommits(context.Background(), commitReq("git-secret"), "acme", gitprovider.ProviderGitHub, 10, 0)
 
 		require.Error(t, err)
 		assert.ErrorIs(t, err, boom)
@@ -203,7 +202,7 @@ func TestRepositoryService_ListCommits(t *testing.T) {
 		}
 		svc := newRepoService(creds)
 
-		_, err := svc.ListCommits(context.Background(), commitReq("git-secret", "acme"), gitprovider.ProviderGitHub, 10, 0)
+		_, err := svc.ListCommits(context.Background(), commitReq("git-secret"), "acme", gitprovider.ProviderGitHub, 10, 0)
 
 		assert.ErrorIs(t, err, utils.ErrGitSecretInvalidType)
 		assert.NotErrorIs(t, err, gitprovider.ErrNotFound)
@@ -213,7 +212,7 @@ func TestRepositoryService_ListCommits(t *testing.T) {
 		svc := newRepoService(&gitCredsStub{})
 
 		req := spec.ListCommitsRequest{Owner: "acme", Repo: "widgets"}
-		_, err := svc.ListCommits(context.Background(), req, gitprovider.ProviderType("gitlab"), 10, 0)
+		_, err := svc.ListCommits(context.Background(), req, "acme", gitprovider.ProviderType("gitlab"), 10, 0)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported git provider")

--- a/agent-manager-service/services/repository_service_unit_test.go
+++ b/agent-manager-service/services/repository_service_unit_test.go
@@ -156,6 +156,17 @@ func TestRepositoryService_ListBranches(t *testing.T) {
 		assert.NotErrorIs(t, err, gitprovider.ErrNotFound)
 	})
 
+	t.Run("secretRef without an org identity is rejected, not silently downgraded", func(t *testing.T) {
+		// Stub func left nil: a missing org must fail before any credential fetch,
+		// rather than falling back to the platform's default (public-repo) config.
+		svc := newRepoService(&gitCredsStub{})
+
+		_, err := svc.ListBranches(context.Background(), branchReq("git-secret"), "", gitprovider.ProviderGitHub, 10, 0)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "organization identity is required")
+	})
+
 	t.Run("unsupported provider type fails locally without network", func(t *testing.T) {
 		// No secretRef/ouID => credential branch is skipped (stub func left nil
 		// to assert it is never called). NewProvider rejects the unknown type
@@ -206,6 +217,15 @@ func TestRepositoryService_ListCommits(t *testing.T) {
 
 		assert.ErrorIs(t, err, utils.ErrGitSecretInvalidType)
 		assert.NotErrorIs(t, err, gitprovider.ErrNotFound)
+	})
+
+	t.Run("secretRef without an org identity is rejected, not silently downgraded", func(t *testing.T) {
+		svc := newRepoService(&gitCredsStub{})
+
+		_, err := svc.ListCommits(context.Background(), commitReq("git-secret"), "", gitprovider.ProviderGitHub, 10, 0)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "organization identity is required")
 	})
 
 	t.Run("unsupported provider type fails locally without network", func(t *testing.T) {

--- a/agent-manager-service/spec/api_default.go
+++ b/agent-manager-service/spec/api_default.go
@@ -7145,6 +7145,7 @@ func (a *DefaultAPIService) ListProjectsExecute(r ApiListProjectsRequest) (*Proj
 type ApiListRepositoryBranchesRequest struct {
 	ctx                 context.Context
 	ApiService          *DefaultAPIService
+	orgName             string
 	listBranchesRequest *ListBranchesRequest
 	limit               *int32
 	offset              *int32
@@ -7178,12 +7179,14 @@ Returns a list of branches for the specified public repository.
 Currently supports GitHub repositories only.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param orgName Organization name/handle
 	@return ApiListRepositoryBranchesRequest
 */
-func (a *DefaultAPIService) ListRepositoryBranches(ctx context.Context) ApiListRepositoryBranchesRequest {
+func (a *DefaultAPIService) ListRepositoryBranches(ctx context.Context, orgName string) ApiListRepositoryBranchesRequest {
 	return ApiListRepositoryBranchesRequest{
 		ApiService: a,
 		ctx:        ctx,
+		orgName:    orgName,
 	}
 }
 
@@ -7203,11 +7206,18 @@ func (a *DefaultAPIService) ListRepositoryBranchesExecute(r ApiListRepositoryBra
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/repositories/branches"
+	localVarPath := localBasePath + "/orgs/{orgName}/repositories/branches"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+	if strlen(r.orgName) < 1 {
+		return localVarReturnValue, nil, reportError("orgName must have at least 1 elements")
+	}
+	if strlen(r.orgName) > 64 {
+		return localVarReturnValue, nil, reportError("orgName must have less than 64 elements")
+	}
 	if r.listBranchesRequest == nil {
 		return localVarReturnValue, nil, reportError("listBranchesRequest is required and must be specified")
 	}
@@ -7320,6 +7330,7 @@ func (a *DefaultAPIService) ListRepositoryBranchesExecute(r ApiListRepositoryBra
 type ApiListRepositoryCommitsRequest struct {
 	ctx                context.Context
 	ApiService         *DefaultAPIService
+	orgName            string
 	listCommitsRequest *ListCommitsRequest
 	limit              *int32
 	offset             *int32
@@ -7353,12 +7364,14 @@ Returns a list of commits for the specified public repository.
 Currently supports GitHub repositories only.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param orgName Organization name/handle
 	@return ApiListRepositoryCommitsRequest
 */
-func (a *DefaultAPIService) ListRepositoryCommits(ctx context.Context) ApiListRepositoryCommitsRequest {
+func (a *DefaultAPIService) ListRepositoryCommits(ctx context.Context, orgName string) ApiListRepositoryCommitsRequest {
 	return ApiListRepositoryCommitsRequest{
 		ApiService: a,
 		ctx:        ctx,
+		orgName:    orgName,
 	}
 }
 
@@ -7378,11 +7391,18 @@ func (a *DefaultAPIService) ListRepositoryCommitsExecute(r ApiListRepositoryComm
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/repositories/commits"
+	localVarPath := localBasePath + "/orgs/{orgName}/repositories/commits"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
+	if strlen(r.orgName) < 1 {
+		return localVarReturnValue, nil, reportError("orgName must have at least 1 elements")
+	}
+	if strlen(r.orgName) > 64 {
+		return localVarReturnValue, nil, reportError("orgName must have less than 64 elements")
+	}
 	if r.listCommitsRequest == nil {
 		return localVarReturnValue, nil, reportError("listCommitsRequest is required and must be specified")
 	}

--- a/agent-manager-service/spec/model_list_branches_request.go
+++ b/agent-manager-service/spec/model_list_branches_request.go
@@ -27,8 +27,6 @@ type ListBranchesRequest struct {
 	IncludeDefault *bool `json:"includeDefault,omitempty"`
 	// Secret reference name for private repository Git credentials
 	SecretRef *string `json:"secretRef,omitempty"`
-	// Organization name for resolving the secret reference
-	OrgName *string `json:"orgName,omitempty"`
 }
 
 // NewListBranchesRequest instantiates a new ListBranchesRequest object
@@ -166,38 +164,6 @@ func (o *ListBranchesRequest) SetSecretRef(v string) {
 	o.SecretRef = &v
 }
 
-// GetOrgName returns the OrgName field value if set, zero value otherwise.
-func (o *ListBranchesRequest) GetOrgName() string {
-	if o == nil || IsNil(o.OrgName) {
-		var ret string
-		return ret
-	}
-	return *o.OrgName
-}
-
-// GetOrgNameOk returns a tuple with the OrgName field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ListBranchesRequest) GetOrgNameOk() (*string, bool) {
-	if o == nil || IsNil(o.OrgName) {
-		return nil, false
-	}
-	return o.OrgName, true
-}
-
-// HasOrgName returns a boolean if a field has been set.
-func (o *ListBranchesRequest) HasOrgName() bool {
-	if o != nil && !IsNil(o.OrgName) {
-		return true
-	}
-
-	return false
-}
-
-// SetOrgName gets a reference to the given string and assigns it to the OrgName field.
-func (o *ListBranchesRequest) SetOrgName(v string) {
-	o.OrgName = &v
-}
-
 func (o ListBranchesRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -215,9 +181,6 @@ func (o ListBranchesRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.SecretRef) {
 		toSerialize["secretRef"] = o.SecretRef
-	}
-	if !IsNil(o.OrgName) {
-		toSerialize["orgName"] = o.OrgName
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/spec/model_list_commits_request.go
+++ b/agent-manager-service/spec/model_list_commits_request.go
@@ -36,8 +36,6 @@ type ListCommitsRequest struct {
 	Until *time.Time `json:"until,omitempty"`
 	// Secret reference name for private repository Git credentials
 	SecretRef *string `json:"secretRef,omitempty"`
-	// Organization name for resolving the secret reference
-	OrgName *string `json:"orgName,omitempty"`
 }
 
 // NewListCommitsRequest instantiates a new ListCommitsRequest object
@@ -299,38 +297,6 @@ func (o *ListCommitsRequest) SetSecretRef(v string) {
 	o.SecretRef = &v
 }
 
-// GetOrgName returns the OrgName field value if set, zero value otherwise.
-func (o *ListCommitsRequest) GetOrgName() string {
-	if o == nil || IsNil(o.OrgName) {
-		var ret string
-		return ret
-	}
-	return *o.OrgName
-}
-
-// GetOrgNameOk returns a tuple with the OrgName field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *ListCommitsRequest) GetOrgNameOk() (*string, bool) {
-	if o == nil || IsNil(o.OrgName) {
-		return nil, false
-	}
-	return o.OrgName, true
-}
-
-// HasOrgName returns a boolean if a field has been set.
-func (o *ListCommitsRequest) HasOrgName() bool {
-	if o != nil && !IsNil(o.OrgName) {
-		return true
-	}
-
-	return false
-}
-
-// SetOrgName gets a reference to the given string and assigns it to the OrgName field.
-func (o *ListCommitsRequest) SetOrgName(v string) {
-	o.OrgName = &v
-}
-
 func (o ListCommitsRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -360,9 +326,6 @@ func (o ListCommitsRequest) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.SecretRef) {
 		toSerialize["secretRef"] = o.SecretRef
-	}
-	if !IsNil(o.OrgName) {
-		toSerialize["orgName"] = o.OrgName
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/utils/utils.go
+++ b/agent-manager-service/utils/utils.go
@@ -1256,13 +1256,10 @@ func ValidateListBranchesRequest(payload *spec.ListBranchesRequest) error {
 		return fmt.Errorf("repository contains invalid characters or path traversal patterns")
 	}
 
-	// Validate that both secretRef and orgName are provided together
-	if payload.HasSecretRef() != payload.HasOrgName() {
-		return fmt.Errorf("both secretRef and orgName must be provided together")
-	}
-
-	if payload.HasSecretRef() && (payload.GetSecretRef() == "" || payload.GetOrgName() == "") {
-		return fmt.Errorf("secretRef and orgName cannot be empty")
+	// The org that scopes the secretRef comes from the caller's token, not the
+	// payload, so only the reference itself is validated here.
+	if payload.HasSecretRef() && payload.GetSecretRef() == "" {
+		return fmt.Errorf("secretRef cannot be empty")
 	}
 	return nil
 }
@@ -1347,13 +1344,10 @@ func ValidateListCommitsRequest(payload *spec.ListCommitsRequest) error {
 		return fmt.Errorf("until time cannot be in the future")
 	}
 
-	// Validate that both secretRef and orgName are provided together
-	if payload.HasSecretRef() != payload.HasOrgName() {
-		return fmt.Errorf("both secretRef and orgName must be provided")
-	}
-
-	if payload.HasSecretRef() && (payload.GetSecretRef() == "" || payload.GetOrgName() == "") {
-		return fmt.Errorf("secretRef and orgName cannot be empty")
+	// The org that scopes the secretRef comes from the caller's token, not the
+	// payload, so only the reference itself is validated here.
+	if payload.HasSecretRef() && payload.GetSecretRef() == "" {
+		return fmt.Errorf("secretRef cannot be empty")
 	}
 	return nil
 }

--- a/cli/pkg/clients/amsvc/gen/client.gen.go
+++ b/cli/pkg/clients/amsvc/gen/client.gen.go
@@ -862,20 +862,20 @@ type ClientInterface interface {
 
 	RotateLLMProxyAPIKey(ctx context.Context, orgName string, projName string, id string, keyName string, body RotateLLMProxyAPIKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListRepositoryBranchesWithBody request with any body
+	ListRepositoryBranchesWithBody(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ListRepositoryBranches(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListRepositoryCommitsWithBody request with any body
+	ListRepositoryCommitsWithBody(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ListRepositoryCommits(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetNameByDisplayNameWithBody request with any body
 	GetNameByDisplayNameWithBody(ctx context.Context, orgName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	GetNameByDisplayName(ctx context.Context, orgName string, body GetNameByDisplayNameJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// ListRepositoryBranchesWithBody request with any body
-	ListRepositoryBranchesWithBody(ctx context.Context, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	ListRepositoryBranches(ctx context.Context, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// ListRepositoryCommitsWithBody request with any body
-	ListRepositoryCommitsWithBody(ctx context.Context, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	ListRepositoryCommits(ctx context.Context, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) GetJWKS(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -4262,6 +4262,54 @@ func (c *Client) RotateLLMProxyAPIKey(ctx context.Context, orgName string, projN
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListRepositoryBranchesWithBody(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepositoryBranchesRequestWithBody(c.Server, orgName, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRepositoryBranches(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepositoryBranchesRequest(c.Server, orgName, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRepositoryCommitsWithBody(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepositoryCommitsRequestWithBody(c.Server, orgName, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRepositoryCommits(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepositoryCommitsRequest(c.Server, orgName, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetNameByDisplayNameWithBody(ctx context.Context, orgName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetNameByDisplayNameRequestWithBody(c.Server, orgName, contentType, body)
 	if err != nil {
@@ -4276,54 +4324,6 @@ func (c *Client) GetNameByDisplayNameWithBody(ctx context.Context, orgName strin
 
 func (c *Client) GetNameByDisplayName(ctx context.Context, orgName string, body GetNameByDisplayNameJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetNameByDisplayNameRequest(c.Server, orgName, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) ListRepositoryBranchesWithBody(ctx context.Context, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListRepositoryBranchesRequestWithBody(c.Server, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) ListRepositoryBranches(ctx context.Context, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListRepositoryBranchesRequest(c.Server, params, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) ListRepositoryCommitsWithBody(ctx context.Context, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListRepositoryCommitsRequestWithBody(c.Server, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) ListRepositoryCommits(ctx context.Context, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListRepositoryCommitsRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -16200,19 +16200,19 @@ func NewRotateLLMProxyAPIKeyRequestWithBody(server string, orgName string, projN
 	return req, nil
 }
 
-// NewGetNameByDisplayNameRequest calls the generic GetNameByDisplayName builder with application/json body
-func NewGetNameByDisplayNameRequest(server string, orgName string, body GetNameByDisplayNameJSONRequestBody) (*http.Request, error) {
+// NewListRepositoryBranchesRequest calls the generic ListRepositoryBranches builder with application/json body
+func NewListRepositoryBranchesRequest(server string, orgName string, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewGetNameByDisplayNameRequestWithBody(server, orgName, "application/json", bodyReader)
+	return NewListRepositoryBranchesRequestWithBody(server, orgName, params, "application/json", bodyReader)
 }
 
-// NewGetNameByDisplayNameRequestWithBody generates requests for GetNameByDisplayName with any type of body
-func NewGetNameByDisplayNameRequestWithBody(server string, orgName string, contentType string, body io.Reader) (*http.Request, error) {
+// NewListRepositoryBranchesRequestWithBody generates requests for ListRepositoryBranches with any type of body
+func NewListRepositoryBranchesRequestWithBody(server string, orgName string, params *ListRepositoryBranchesParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -16227,47 +16227,7 @@ func NewGetNameByDisplayNameRequestWithBody(server string, orgName string, conte
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/orgs/%s/utils/generate-name", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewListRepositoryBranchesRequest calls the generic ListRepositoryBranches builder with application/json body
-func NewListRepositoryBranchesRequest(server string, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewListRepositoryBranchesRequestWithBody(server, params, "application/json", bodyReader)
-}
-
-// NewListRepositoryBranchesRequestWithBody generates requests for ListRepositoryBranches with any type of body
-func NewListRepositoryBranchesRequestWithBody(server string, params *ListRepositoryBranchesParams, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/repositories/branches")
+	operationPath := fmt.Sprintf("/orgs/%s/repositories/branches", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -16326,26 +16286,33 @@ func NewListRepositoryBranchesRequestWithBody(server string, params *ListReposit
 }
 
 // NewListRepositoryCommitsRequest calls the generic ListRepositoryCommits builder with application/json body
-func NewListRepositoryCommitsRequest(server string, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody) (*http.Request, error) {
+func NewListRepositoryCommitsRequest(server string, orgName string, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewListRepositoryCommitsRequestWithBody(server, params, "application/json", bodyReader)
+	return NewListRepositoryCommitsRequestWithBody(server, orgName, params, "application/json", bodyReader)
 }
 
 // NewListRepositoryCommitsRequestWithBody generates requests for ListRepositoryCommits with any type of body
-func NewListRepositoryCommitsRequestWithBody(server string, params *ListRepositoryCommitsParams, contentType string, body io.Reader) (*http.Request, error) {
+func NewListRepositoryCommitsRequestWithBody(server string, orgName string, params *ListRepositoryCommitsParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/repositories/commits")
+	operationPath := fmt.Sprintf("/orgs/%s/repositories/commits", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -16391,6 +16358,53 @@ func NewListRepositoryCommitsRequestWithBody(server string, params *ListReposito
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetNameByDisplayNameRequest calls the generic GetNameByDisplayName builder with application/json body
+func NewGetNameByDisplayNameRequest(server string, orgName string, body GetNameByDisplayNameJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewGetNameByDisplayNameRequestWithBody(server, orgName, "application/json", bodyReader)
+}
+
+// NewGetNameByDisplayNameRequestWithBody generates requests for GetNameByDisplayName with any type of body
+func NewGetNameByDisplayNameRequestWithBody(server string, orgName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/orgs/%s/utils/generate-name", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest("POST", queryURL.String(), body)
@@ -17218,20 +17232,20 @@ type ClientWithResponsesInterface interface {
 
 	RotateLLMProxyAPIKeyWithResponse(ctx context.Context, orgName string, projName string, id string, keyName string, body RotateLLMProxyAPIKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*RotateLLMProxyAPIKeyResp, error)
 
+	// ListRepositoryBranchesWithBodyWithResponse request with any body
+	ListRepositoryBranchesWithBodyWithResponse(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error)
+
+	ListRepositoryBranchesWithResponse(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error)
+
+	// ListRepositoryCommitsWithBodyWithResponse request with any body
+	ListRepositoryCommitsWithBodyWithResponse(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error)
+
+	ListRepositoryCommitsWithResponse(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error)
+
 	// GetNameByDisplayNameWithBodyWithResponse request with any body
 	GetNameByDisplayNameWithBodyWithResponse(ctx context.Context, orgName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetNameByDisplayNameResp, error)
 
 	GetNameByDisplayNameWithResponse(ctx context.Context, orgName string, body GetNameByDisplayNameJSONRequestBody, reqEditors ...RequestEditorFn) (*GetNameByDisplayNameResp, error)
-
-	// ListRepositoryBranchesWithBodyWithResponse request with any body
-	ListRepositoryBranchesWithBodyWithResponse(ctx context.Context, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error)
-
-	ListRepositoryBranchesWithResponse(ctx context.Context, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error)
-
-	// ListRepositoryCommitsWithBodyWithResponse request with any body
-	ListRepositoryCommitsWithBodyWithResponse(ctx context.Context, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error)
-
-	ListRepositoryCommitsWithResponse(ctx context.Context, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error)
 }
 
 type GetJWKSResp struct {
@@ -22414,30 +22428,6 @@ func (r RotateLLMProxyAPIKeyResp) StatusCode() int {
 	return 0
 }
 
-type GetNameByDisplayNameResp struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *ResourceNameResponse
-	JSON404      *ErrorResponse
-	JSON500      *ErrorResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r GetNameByDisplayNameResp) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetNameByDisplayNameResp) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type ListRepositoryBranchesResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -22484,6 +22474,30 @@ func (r ListRepositoryCommitsResp) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListRepositoryCommitsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetNameByDisplayNameResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ResourceNameResponse
+	JSON404      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetNameByDisplayNameResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetNameByDisplayNameResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -24954,6 +24968,40 @@ func (c *ClientWithResponses) RotateLLMProxyAPIKeyWithResponse(ctx context.Conte
 	return ParseRotateLLMProxyAPIKeyResp(rsp)
 }
 
+// ListRepositoryBranchesWithBodyWithResponse request with arbitrary body returning *ListRepositoryBranchesResp
+func (c *ClientWithResponses) ListRepositoryBranchesWithBodyWithResponse(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error) {
+	rsp, err := c.ListRepositoryBranchesWithBody(ctx, orgName, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepositoryBranchesResp(rsp)
+}
+
+func (c *ClientWithResponses) ListRepositoryBranchesWithResponse(ctx context.Context, orgName string, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error) {
+	rsp, err := c.ListRepositoryBranches(ctx, orgName, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepositoryBranchesResp(rsp)
+}
+
+// ListRepositoryCommitsWithBodyWithResponse request with arbitrary body returning *ListRepositoryCommitsResp
+func (c *ClientWithResponses) ListRepositoryCommitsWithBodyWithResponse(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error) {
+	rsp, err := c.ListRepositoryCommitsWithBody(ctx, orgName, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepositoryCommitsResp(rsp)
+}
+
+func (c *ClientWithResponses) ListRepositoryCommitsWithResponse(ctx context.Context, orgName string, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error) {
+	rsp, err := c.ListRepositoryCommits(ctx, orgName, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepositoryCommitsResp(rsp)
+}
+
 // GetNameByDisplayNameWithBodyWithResponse request with arbitrary body returning *GetNameByDisplayNameResp
 func (c *ClientWithResponses) GetNameByDisplayNameWithBodyWithResponse(ctx context.Context, orgName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*GetNameByDisplayNameResp, error) {
 	rsp, err := c.GetNameByDisplayNameWithBody(ctx, orgName, contentType, body, reqEditors...)
@@ -24969,40 +25017,6 @@ func (c *ClientWithResponses) GetNameByDisplayNameWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseGetNameByDisplayNameResp(rsp)
-}
-
-// ListRepositoryBranchesWithBodyWithResponse request with arbitrary body returning *ListRepositoryBranchesResp
-func (c *ClientWithResponses) ListRepositoryBranchesWithBodyWithResponse(ctx context.Context, params *ListRepositoryBranchesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error) {
-	rsp, err := c.ListRepositoryBranchesWithBody(ctx, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListRepositoryBranchesResp(rsp)
-}
-
-func (c *ClientWithResponses) ListRepositoryBranchesWithResponse(ctx context.Context, params *ListRepositoryBranchesParams, body ListRepositoryBranchesJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryBranchesResp, error) {
-	rsp, err := c.ListRepositoryBranches(ctx, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListRepositoryBranchesResp(rsp)
-}
-
-// ListRepositoryCommitsWithBodyWithResponse request with arbitrary body returning *ListRepositoryCommitsResp
-func (c *ClientWithResponses) ListRepositoryCommitsWithBodyWithResponse(ctx context.Context, params *ListRepositoryCommitsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error) {
-	rsp, err := c.ListRepositoryCommitsWithBody(ctx, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListRepositoryCommitsResp(rsp)
-}
-
-func (c *ClientWithResponses) ListRepositoryCommitsWithResponse(ctx context.Context, params *ListRepositoryCommitsParams, body ListRepositoryCommitsJSONRequestBody, reqEditors ...RequestEditorFn) (*ListRepositoryCommitsResp, error) {
-	rsp, err := c.ListRepositoryCommits(ctx, params, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseListRepositoryCommitsResp(rsp)
 }
 
 // ParseGetJWKSResp parses an HTTP response from a GetJWKSWithResponse call
@@ -34602,46 +34616,6 @@ func ParseRotateLLMProxyAPIKeyResp(rsp *http.Response) (*RotateLLMProxyAPIKeyRes
 	return response, nil
 }
 
-// ParseGetNameByDisplayNameResp parses an HTTP response from a GetNameByDisplayNameWithResponse call
-func ParseGetNameByDisplayNameResp(rsp *http.Response) (*GetNameByDisplayNameResp, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetNameByDisplayNameResp{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ResourceNameResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseListRepositoryBranchesResp parses an HTTP response from a ListRepositoryBranchesWithResponse call
 func ParseListRepositoryBranchesResp(rsp *http.Response) (*ListRepositoryBranchesResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -34737,6 +34711,46 @@ func ParseListRepositoryCommitsResp(rsp *http.Response) (*ListRepositoryCommitsR
 			return nil, err
 		}
 		response.JSON429 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetNameByDisplayNameResp parses an HTTP response from a GetNameByDisplayNameWithResponse call
+func ParseGetNameByDisplayNameResp(rsp *http.Response) (*GetNameByDisplayNameResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetNameByDisplayNameResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ResourceNameResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ErrorResponse

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -3724,9 +3724,6 @@ type ListBranchesRequest struct {
 	// IncludeDefault Whether to include default branch information in the response
 	IncludeDefault *bool `json:"includeDefault,omitempty"`
 
-	// OrgName Organization name for resolving the secret reference
-	OrgName *string `json:"orgName,omitempty"`
-
 	// Owner Repository owner (organization or user)
 	Owner string `json:"owner"`
 
@@ -3759,9 +3756,6 @@ type ListCommitsRequest struct {
 
 	// Branch Branch name or SHA to list commits from (defaults to repository's default branch)
 	Branch *string `json:"branch,omitempty"`
-
-	// OrgName Organization name for resolving the secret reference
-	OrgName *string `json:"orgName,omitempty"`
 
 	// Owner Repository owner (organization or user)
 	Owner string `json:"owner"`
@@ -6061,14 +6055,14 @@ type CreateLLMProxyAPIKeyJSONRequestBody = CreateLLMAPIKeyRequest
 // RotateLLMProxyAPIKeyJSONRequestBody defines body for RotateLLMProxyAPIKey for application/json ContentType.
 type RotateLLMProxyAPIKeyJSONRequestBody = RotateLLMAPIKeyRequest
 
-// GetNameByDisplayNameJSONRequestBody defines body for GetNameByDisplayName for application/json ContentType.
-type GetNameByDisplayNameJSONRequestBody = ResourceNameRequest
-
 // ListRepositoryBranchesJSONRequestBody defines body for ListRepositoryBranches for application/json ContentType.
 type ListRepositoryBranchesJSONRequestBody = ListBranchesRequest
 
 // ListRepositoryCommitsJSONRequestBody defines body for ListRepositoryCommits for application/json ContentType.
 type ListRepositoryCommitsJSONRequestBody = ListCommitsRequest
+
+// GetNameByDisplayNameJSONRequestBody defines body for GetNameByDisplayName for application/json ContentType.
+type GetNameByDisplayNameJSONRequestBody = ResourceNameRequest
 
 // AsBuildpackBuild returns the union data inside the Build as a BuildpackBuild
 func (t Build) AsBuildpackBuild() (BuildpackBuild, error) {

--- a/console/workspaces/libs/api-client/src/apis/repositories.ts
+++ b/console/workspaces/libs/api-client/src/apis/repositories.ts
@@ -28,6 +28,7 @@ import  {
 } from "@agent-management-platform/types";
 
 export async function listBranches(
+  orgName: string,
   body: ListBranchesRequest,
   query?: ListBranchesQuery,
   getToken?: () => Promise<string>,
@@ -51,7 +52,7 @@ export async function listBranches(
   }
 
   const response = await fetch(
-    `${baseUrl}${SERVICE_BASE}/repositories/branches?${new URLSearchParams(search).toString()}`,
+    `${baseUrl}${SERVICE_BASE}/orgs/${orgName}/repositories/branches?${new URLSearchParams(search).toString()}`,
     {
       method: "POST",
       headers: requestHeaders,
@@ -72,6 +73,7 @@ export async function listBranches(
 }
 
 export async function listCommits(
+  orgName: string,
   body: ListCommitsRequest,
   query?: ListCommitsQuery,
   getToken?: () => Promise<string>,
@@ -95,7 +97,7 @@ export async function listCommits(
   }
 
   const response = await fetch(
-    `${baseUrl}${SERVICE_BASE}/repositories/commits?${new URLSearchParams(search).toString()}`,
+    `${baseUrl}${SERVICE_BASE}/orgs/${orgName}/repositories/commits?${new URLSearchParams(search).toString()}`,
     {
       method: "POST",
       headers: requestHeaders,

--- a/console/workspaces/libs/api-client/src/hooks/repositories.ts
+++ b/console/workspaces/libs/api-client/src/hooks/repositories.ts
@@ -36,7 +36,16 @@ export function useListBranches(
 ) {
   const { getToken } = useAuthHooks();
   return useApiQuery<ListBranchesResponse>({
-    queryKey: ["branches", orgName, body.owner, body.repository, body.secretRef, query],
+    queryKey: [
+      "branches",
+      {
+        orgName,
+        owner: body.owner,
+        repository: body.repository,
+        secretRef: body.secretRef,
+      },
+      query,
+    ],
     queryFn: () => listBranches(orgName, body, query, getToken),
     enabled: enabled && !!orgName && !!body.owner && !!body.repository,
   });
@@ -50,7 +59,17 @@ export function useListCommits(
 ) {
   const { getToken } = useAuthHooks();
   return useApiQuery<ListCommitsResponse>({
-    queryKey: ["commits", orgName, body.owner, body.repo, body.branch, body.secretRef, query],
+    queryKey: [
+      "commits",
+      {
+        orgName,
+        owner: body.owner,
+        repo: body.repo,
+        branch: body.branch,
+        secretRef: body.secretRef,
+      },
+      query,
+    ],
     queryFn: () => listCommits(orgName, body, query, getToken),
     enabled: enabled && !!orgName && !!body.owner && !!body.repo,
   });

--- a/console/workspaces/libs/api-client/src/hooks/repositories.ts
+++ b/console/workspaces/libs/api-client/src/hooks/repositories.ts
@@ -29,27 +29,29 @@ import { useAuthHooks } from "@agent-management-platform/auth";
 import { useApiQuery } from "./react-query-notifications";
 
 export function useListBranches(
+  orgName: string,
   body: ListBranchesRequest,
   query?: ListBranchesQuery,
   enabled: boolean = true,
 ) {
   const { getToken } = useAuthHooks();
   return useApiQuery<ListBranchesResponse>({
-    queryKey: ["branches", body.owner, body.repository, body.orgName, body.secretRef, query],
-    queryFn: () => listBranches(body, query, getToken),
-    enabled: enabled && !!body.owner && !!body.repository,
+    queryKey: ["branches", orgName, body.owner, body.repository, body.secretRef, query],
+    queryFn: () => listBranches(orgName, body, query, getToken),
+    enabled: enabled && !!orgName && !!body.owner && !!body.repository,
   });
 }
 
 export function useListCommits(
+  orgName: string,
   body: ListCommitsRequest,
   query?: ListCommitsQuery,
   enabled: boolean = true,
 ) {
   const { getToken } = useAuthHooks();
   return useApiQuery<ListCommitsResponse>({
-    queryKey: ["commits", body.owner, body.repo, body.branch, body.orgName, body.secretRef, query],
-    queryFn: () => listCommits(body, query, getToken),
-    enabled: enabled && !!body.owner && !!body.repo,
+    queryKey: ["commits", orgName, body.owner, body.repo, body.branch, body.secretRef, query],
+    queryFn: () => listCommits(orgName, body, query, getToken),
+    enabled: enabled && !!orgName && !!body.owner && !!body.repo,
   });
 }

--- a/console/workspaces/libs/shared-component/src/components/BuildPanel.tsx
+++ b/console/workspaces/libs/shared-component/src/components/BuildPanel.tsx
@@ -80,12 +80,14 @@ export function BuildPanel({
     isLoading: isLoadingCommits,
     isError: isCommitsError,
   } = useListCommits(
+    orgName,
     {
       owner: repoInfo?.owner || "",
       repo: repoInfo?.repo || "",
       branch: selectedBranch || undefined,
-      // Include orgName and secretRef for private repo support
-      ...(secretRef ? { orgName: orgName, secretRef: secretRef } : {}),
+      // Include secretRef for private repo support; the org that scopes it comes
+      // from the URL/token, not the body.
+      ...(secretRef ? { secretRef: secretRef } : {}),
     },
     { limit: 50 },
     !!repoInfo && !!selectedBranch,

--- a/console/workspaces/libs/types/src/api/repositories.ts
+++ b/console/workspaces/libs/types/src/api/repositories.ts
@@ -20,8 +20,6 @@
 export interface ListBranchesRequest {
   owner: string;
   repository: string;
-  // Organization name (required for private repositories)
-  orgName?: string;
   // Git secret reference name for private repository authentication
   secretRef?: string;
 }
@@ -34,8 +32,6 @@ export interface ListCommitsRequest {
   author?: string;
   since?: string;
   until?: string;
-  // Organization name (required for private repositories)
-  orgName?: string;
   // Git secret reference name for private repository authentication
   secretRef?: string;
 }


### PR DESCRIPTION
listRepositoryBranches and listRepositoryCommits read the org that scopes the secretRef lookup from an orgName field in the request body, so a caller could name any org while authenticated as another. The org identity already travels in the token, and every other org-scoped route resolves it from there.

The org matters only for private repositories: it scopes the secretRef lookup that resolves that org's stored Git credentials. Public repositories carry no secretRef, are listed with the platform's configured provider token, and are readable by any authenticated caller — that path is unchanged and needs no org at all.

Move both routes under /orgs/{orgName}/repositories/... and drop orgName from ListBranchesRequest and ListCommitsRequest. The path segment makes the route registrar apply RequireOrgMatch, so the controllers resolve the org with middleware.OUIDFromRequest like the rest of the API and pass it to the service explicitly. Using the OU ID rather than the handle keeps the value consistent with every other OpenChoreo client call and unaffected by an org rename.

Validation no longer requires secretRef and orgName to be supplied together, since only the reference itself now comes from the payload.


## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Repository branch and commit requests are now scoped to an organization in the URL.
  * Organization names must be 1–64 characters.
  * Organization information is no longer sent in request bodies.

* **Improvements**
  * Repository credentials are resolved using the authenticated organization context.
  * Client hooks and API methods now require an organization name and wait for a valid value before sending requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->