### PR TITLE
Unblock docs audit and bump vulnerable deps

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Security Audit
         working-directory: ./documentation
-        run: npm audit --audit-level=high --omit=dev
+        run: npm run audit
         
       - name: Build documentation
         working-directory: ./documentation

--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Security Audit
         working-directory: ./documentation
-        run: npm audit --audit-level=high --omit=dev
+        run: npm run audit
 
   build:
     name: Build Documentation Site

--- a/.github/workflows/docs-pr-checks.yml
+++ b/.github/workflows/docs-pr-checks.yml
@@ -8,6 +8,10 @@ on:
       - 'documentation/**'
       - '.github/workflows/docs-pr-checks.yml'
 
+# Both jobs only check out the repository and run npm; nothing needs write access.
+permissions:
+  contents: read
+
 jobs:
   audit:
     name: Security Audit

--- a/documentation/.audit-ci.jsonc
+++ b/documentation/.audit-ci.jsonc
@@ -1,0 +1,17 @@
+{
+  // Fail the build on high (and critical) severity advisories in production
+  // dependencies, matching the previous `npm audit --audit-level=high --omit=dev`.
+  "high": true,
+  "skip-dev": true,
+  "allowlist": [
+    // image-size: ICNS / JXL / HEIF parsers allow denial of service through
+    // infinite loops. Every published version (<= 2.0.2) is affected and there
+    // is no patched release, so this cannot be resolved by upgrading or by an
+    // override. It reaches us only through @docusaurus/mdx-loader, which uses
+    // it at build time to measure images committed to this repository, so the
+    // malformed-input path is not reachable from user input.
+    // Remove these entries once image-size ships a fix.
+    "GHSA-w3rx-r6r6-pgpr",
+    "GHSA-5p2g-fcmc-qvqq"
+  ]
+}

--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -26,6 +26,7 @@
         "@docusaurus/module-type-aliases": "3.10.2",
         "@docusaurus/tsconfig": "3.10.2",
         "@docusaurus/types": "3.10.2",
+        "audit-ci": "^7.1.0",
         "typescript": "~5.6.2"
       },
       "engines": {
@@ -6529,6 +6530,30 @@
         "astring": "bin/astring"
       }
     },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/autocomplete.js": {
       "version": "0.37.1",
       "resolved": "https://registry.npmjs.org/autocomplete.js/-/autocomplete.js-0.37.1.tgz",
@@ -7283,6 +7308,61 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone-deep": {
@@ -9383,9 +9463,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -9857,6 +9937,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -10314,6 +10410,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "11.4.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
@@ -10399,6 +10502,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -12072,6 +12185,13 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/joi": {
       "version": "17.13.4",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
@@ -12165,6 +12285,33 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/katex": {
@@ -12413,6 +12560,13 @@
       "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.20.0.tgz",
       "integrity": "sha512-3LVgE7ekWXt04NBci/hjm+NXJxXZeRXuyClL0kA0HONyBOjxhP3ZQkuWIM4Ok3pbeptUW/rj3XcJcJuJVPwPYA==",
       "license": "MPL-1.1"
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
@@ -15023,9 +15177,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -15658,6 +15812,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
       }
     },
     "node_modules/picocolors": {
@@ -17632,6 +17799,16 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -18105,6 +18282,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -18925,6 +19112,19 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/srcset": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
@@ -18951,6 +19151,17 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -19319,6 +19530,23 @@
       },
       "peerDependencies": {
         "tslib": "^2"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/thunky": {
@@ -20694,11 +20922,72 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -12,7 +12,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "audit": "audit-ci --config .audit-ci.jsonc"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.2",
@@ -33,6 +34,7 @@
     "@docusaurus/module-type-aliases": "3.10.2",
     "@docusaurus/tsconfig": "3.10.2",
     "@docusaurus/types": "3.10.2",
+    "audit-ci": "^7.1.0",
     "typescript": "~5.6.2"
   },
   "browserslist": {
@@ -60,6 +62,8 @@
     "fast-uri": "^3.1.5",
     "js-yaml": "^4.3.1",
     "mermaid": "^11.16.1",
+    "nanoid": "^3.3.17",
+    "dompurify": "^3.4.13",
     "shell-quote": "^1.10.0",
     "uuid": "^11.1.1",
     "svgo": "^3.3.4",


### PR DESCRIPTION
## Purpose

Newly published advisories have turned the documentation site's `Security Audit` job (`npm audit --audit-level=high --omit=dev`) red. The job now fails on every documentation pull request and will fail the next deploy from `main`. The failures are unrelated to the content of the PRs that hit them.

Three transitive packages account for all 22 findings:

| Package | Reached through | Severity | Patch available |
| --- | --- | --- | --- |
| `nanoid` 3.3.16 | `postcss` (`^3.3.16`) | high — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | yes, 3.3.17 |
| `dompurify` 3.4.12 | `mermaid` (`^3.3.3`) | moderate — [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7) | yes, 3.4.13 |
| `image-size` 2.0.2 | `@docusaurus/mdx-loader` (`^2.0.2`) | high ×2 — [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr), [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) | **no** |

The `image-size` advisories cover `<= 2.0.2`, and 2.0.2 is the latest published release. `@docusaurus/mdx-loader@3.10.2` (the newest Docusaurus, which we are already on) still requires `^2.0.2`, so no upgrade or `overrides` entry can resolve it. Those two advisories are responsible for 20 of the 22 rows, since every Docusaurus package that transitively depends on `mdx-loader` is reported as well.

## Goals

Get the audit gate green again without weakening it — high-severity findings in any other package must still fail the build.

## Approach

**Patchable advisories — dependency bumps.** `nanoid` and `dompurify` both have fixed releases that already fall inside the ranges their parents allow, so they are pinned through the `overrides` block that `documentation/package.json` already uses for this purpose. They resolve to `nanoid@3.3.18` and `dompurify@3.4.13`.

**Unpatchable advisories — explicit allowlist.** Dropping the workflow to `--audit-level=critical` would have been a one-line fix, but it would silently stop failing on every future high-severity finding. Instead the check now runs through [`audit-ci`](https://github.com/IBM/audit-ci), which enforces the same threshold but supports a per-advisory allowlist. `documentation/.audit-ci.jsonc` allowlists only the two `image-size` advisories and records why next to them; the entries should be removed once upstream ships a fix.

The risk being accepted is narrow: `image-size` runs at build time, where Docusaurus uses it to measure images committed to this repository. The malformed-input path the advisories describe is not reachable from user input.

Both workflows now call `npm run audit`, so the threshold and the allowlist live in one committed config instead of being duplicated in YAML.

## User stories

N/A — CI and dependency maintenance, with no user-facing behaviour change.

## Release note

N/A — build tooling only; no shipped artifact changes.

## Documentation

N/A — no documentation content is affected. The change is limited to the documentation site's build dependencies and CI configuration.

## Training

N/A — no training content impact.

## Certification

N/A — no impact on certification exams; this is a CI dependency change.

## Marketing

N/A — internal build tooling change.

## Automation tests

- Unit tests
  > N/A — no application code changed.
- Integration tests
  > Verified locally in a clean checkout of this branch:
  > - `npm ci` — succeeds
  > - `npm run audit` — exits 0, with the two allowlisted advisories reported as accepted
  > - `npm run build` — succeeds, 276 documents processed and static files generated
  >
  > Gate strength was checked by removing the two entries from the allowlist and re-running `npm run audit`, which exits 1 as expected. Reintroducing a vulnerable `nanoid` also fails the check, confirming the high-severity threshold still applies to everything outside the allowlist.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no samples relate to this change.

## Related PRs

N/A — no related PRs. Any open documentation PR failing the `Security Audit` job will go green once this merges and the branch picks up `main`.

## Migrations (if applicable)

N/A — no migration required.

## Test environment

Node.js 20.20.2 on macOS (Darwin 25.5.0). CI runs Node.js 20 on the CodeBuild-hosted runners already configured in both workflows.

## Learning

Reviewed the four GitHub advisories to separate the patchable findings from the unpatchable one, and confirmed against the npm registry that `image-size` has no fixed release and that the latest `@docusaurus/mdx-loader` still depends on it. Compared the available options for handling an unpatchable transitive advisory — lowering the audit level, dropping the gate, and allowlisting via `audit-ci` — and chose the allowlist because it is the only one that keeps failing on everything else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation build security checks by using the project’s standardized audit process.
  * Added stricter checks for high-severity production dependency vulnerabilities.
  * Documented and safely allowlisted two known unresolved advisories.
  * Added documentation type-checking support and dependency safeguards to improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->