### PR TITLE
Pin console doc links to the release's docs version

### DIFF
--- a/.github/scripts/update-helm-charts.sh
+++ b/.github/scripts/update-helm-charts.sh
@@ -29,9 +29,16 @@ else
 fi
 
 # A release must not ship a console pinned to documentation that was never
-# published, so fail early rather than emitting links that 404.
+# published, so fail early rather than emitting links that 404. The manifest is
+# tracked and this script runs from the repository root, so its absence means
+# something is wrong with the checkout and must not silently skip the check.
+# Candidates and nightlies never reach here, since DOCS_VERSION is empty.
 VERSIONS_FILE="./documentation/versions.json"
-if [ -n "$DOCS_VERSION" ] && [ -f "$VERSIONS_FILE" ]; then
+if [ -n "$DOCS_VERSION" ]; then
+  if [ ! -f "$VERSIONS_FILE" ]; then
+    echo "Error: documentation manifest $VERSIONS_FILE is missing, so $DOCS_VERSION cannot be verified."
+    exit 1
+  fi
   if ! grep -q "\"$DOCS_VERSION\"" "$VERSIONS_FILE"; then
     echo "Error: documentation version $DOCS_VERSION is not present in $VERSIONS_FILE."
     echo "Run the Documentation Release workflow for $DOCS_VERSION before releasing $TARGET_VERSION."

--- a/.github/scripts/update-helm-charts.sh
+++ b/.github/scripts/update-helm-charts.sh
@@ -12,6 +12,39 @@ if [ -z "$TARGET_VERSION" ]; then
   exit 1
 fi
 
+# Work out which versioned documentation this release should point at.
+#
+# Docs versions are cut per minor line (vX.Y.x) for final releases, and pinned
+# exactly for pre-releases such as v1.0.0-alpha1. No docs version is cut for a
+# release candidate (X.Y.Z-rcN or X.Y.Z-<pre>.rcN) or for a nightly, so those
+# keep whatever the chart defaults to and follow /docs/latest instead.
+if [[ "$TARGET_VERSION" =~ (-|\.)rc[0-9]+$ ]]; then
+  DOCS_VERSION=""
+elif [[ "$TARGET_VERSION" == *-dev* ]]; then
+  DOCS_VERSION=""
+elif [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  DOCS_VERSION="v${TARGET_VERSION%.*}.x"
+else
+  DOCS_VERSION="v$TARGET_VERSION"
+fi
+
+# A release must not ship a console pinned to documentation that was never
+# published, so fail early rather than emitting links that 404.
+VERSIONS_FILE="./documentation/versions.json"
+if [ -n "$DOCS_VERSION" ] && [ -f "$VERSIONS_FILE" ]; then
+  if ! grep -q "\"$DOCS_VERSION\"" "$VERSIONS_FILE"; then
+    echo "Error: documentation version $DOCS_VERSION is not present in $VERSIONS_FILE."
+    echo "Run the Documentation Release workflow for $DOCS_VERSION before releasing $TARGET_VERSION."
+    exit 1
+  fi
+fi
+
+if [ -n "$DOCS_VERSION" ]; then
+  echo "Documentation version for this release: $DOCS_VERSION"
+else
+  echo "No documentation version for $TARGET_VERSION; the console will follow /docs/latest"
+fi
+
 # Find all Chart.yaml files and replace 0.0.0-dev
 find ./deployments/helm-charts -name "Chart.yaml" -type f | while read -r chart_file; do
   # Replace version: 0.0.0-dev with vTARGET_VERSION (using | as delimiter to avoid conflicts with / in version)
@@ -29,6 +62,11 @@ find ./deployments/helm-charts -name "values.yaml" -type f | while read -r value
   # Replace ampVersion: "0.0.0-dev" with vTARGET_VERSION — pins the console's
   # deployment-script git ref (amp/vX.Y.Z) to this release
   sed -i.bak "s|ampVersion: \"0\.0\.0-dev\"|ampVersion: \"v$TARGET_VERSION\"|g" "$values_file"
+  # Pin the console's in-product doc links to this release's documentation.
+  # Left untouched when there is no docs version, so the chart keeps "latest".
+  if [ -n "$DOCS_VERSION" ]; then
+    sed -i.bak "s|docsVersion: \"latest\"|docsVersion: \"$DOCS_VERSION\"|g" "$values_file"
+  fi
   # Remove backup files
   rm -f "${values_file}.bak"
 done

--- a/console/apps/web-ui/public/config.template.js
+++ b/console/apps/web-ui/public/config.template.js
@@ -59,7 +59,7 @@ window.__RUNTIME_CONFIG__ = {
     enableProfileManagement: '$FEATURE_FLAG_ENABLE_PROFILE_MANAGEMENT' === 'true',
     enableUserManagement: '$FEATURE_FLAG_ENABLE_USER_MANAGEMENT' === 'true',
   },
-  docsUrl: 'https://wso2.github.io/agent-manager/docs/latest',
+  docsUrl: '$DOCS_URL',
   footerLinks: {
     privacyPolicyUrl: 'https://wso2.com/agent-platform/agent-manager/',
     termsOfUseUrl: 'https://wso2.com/agent-platform/agent-manager/',

--- a/console/env.example
+++ b/console/env.example
@@ -19,6 +19,10 @@ GATEWAY_VERSION=v0.11.0
 # Observability / Instrumentation
 INSTRUMENTATION_URL=http://default-default.gateway.localhost:19080/otel
 
+# Documentation base URL for in-product doc links. "latest" tracks the newest
+# released docs; released charts pin this to their own documentation version.
+DOCS_URL=https://wso2.github.io/agent-manager/docs/latest
+
 # Guardrails Configuration
 GUARDRAILS_CATALOG_URL=https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=Guardrails,AI&limit=100
 GUARDRAILS_DEFINITION_BASE_URL=https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies

--- a/deployments/helm-charts/wso2-agent-manager/templates/console/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/console/configmap.yaml
@@ -26,6 +26,9 @@ data:
   GATEWAY_VERSION: {{ .Values.console.config.gatewayVersion | default "v1.0.0" | quote }}
   # Agent Manager release version — pins the deployment-script git tag (amp/vX.Y.Z)
   AMP_VERSION: {{ .Values.console.config.ampVersion | default "v1.0.0" | quote }}
+  # Documentation base URL for the console's in-product doc links. Built from
+  # the docs version so only the version segment varies per release.
+  DOCS_URL: {{ printf "https://wso2.github.io/agent-manager/docs/%s" (.Values.console.config.docsVersion | default "latest") | quote }}
   # Agent Instrumentation URL
   INSTRUMENTATION_URL: {{ .Values.console.config.instrumentationUrl | quote }}
   # Cluster-internal URLs the gateway uses to reach Agent Manager — surfaced to

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -450,6 +450,13 @@ console:
     # Placeholder is substituted with the real release version by the release
     # pipeline (.github/scripts/update-helm-charts.sh); dev builds fall back to main.
     ampVersion: "0.0.0-dev"
+    # Documentation version the console's in-product doc links point at, used as
+    # the path segment after /docs/. "latest" tracks the newest released docs.
+    # The release pipeline (.github/scripts/update-helm-charts.sh) pins this to
+    # the matching versioned docs (vX.Y.x, or the exact version for a
+    # pre-release) for final and pre-release builds. Release candidates and
+    # nightlies keep "latest", because no docs version is cut for them.
+    docsVersion: "latest"
     # Trace-export URL shown to external agent developers. kgateway-routed
     # vhost — independent of the gateway runtime's namespace; no port-forward.
     instrumentationUrl: "http://default-default.gateway.localhost:19080/otel"


### PR DESCRIPTION
## Purpose

The console's in-product documentation links are hardcoded to `/docs/latest`, so a console from any release always points at the newest published documentation. Someone running an older release is shown instructions for a version they are not on, and the base URL has to be kept in sync by hand inside `config.template.js`.

The same file already carries a stale hand-maintained version string (`ampVersion: "v0.17.0"` in the checked-in `config.js`), which is the same class of drift.

## Goals

Make the documentation base URL configurable rather than hardcoded, and have the release pipeline pin it to the documentation version that matches the release being cut — while leaving release candidates and nightlies alone, since no documentation version is created for those.

## Approach

Nothing new is invented here; the change wires up mechanisms the repository already has.

`config.template.js` is processed with `envsubst` at container start by `console/scripts/40-config-setup.sh`, which `console/Dockerfile` installs as `/docker-entrypoint.d/40-config-setup.sh`. Twenty-nine values already flow through that step, including `ampVersion: '$AMP_VERSION'`. `docsUrl` was the exception, so it becomes `'$DOCS_URL'`.

The chart gains a `console.config.docsVersion` value and the console ConfigMap composes the full URL from it, so the base URL is written once in the template and only the version segment varies per release. `deployments/docker-compose.yml` already sets `DOCS_URL` — that variable has been dead because the template ignored it, and this change activates it with no edit needed there.

`.github/scripts/update-helm-charts.sh` already rewrites `0.0.0-dev` placeholders for chart versions, image tags and `ampVersion`, and `release.yml` commits the result. Documentation pinning joins that same step.

### Which documentation version a release maps to

The rule follows the convention already visible in `documentation/versions.json`:

| Release version | Documentation version | Reason |
|---|---|---|
| `0.18.0` | `v0.18.x` | final releases map to their minor line |
| `0.13.1` | `v0.13.x` | patches reuse the minor line |
| `1.0.0-alpha1` | `v1.0.0-alpha1` | other pre-releases are pinned exactly |
| `0.18.0-rc1` | *none* | no documentation version is cut for a candidate |
| `1.0.0-alpha1.rc1` | *none* | same, for a candidate of a pre-release |
| `0.0.0-dev-20260809` | *none* | nightly |

Both release-candidate spellings are recognised. Candidates of a final release use `X.Y.Z-rcN`, while candidates of a pre-release use `X.Y.Z-<pre>.rcN` with a dot, because `release.yml`'s own version regex does not permit a second hyphen.

Builds with no documentation version keep `latest`. That is deliberate and is safe in both orderings: if the target version's documentation has not been cut, `latest` resolves to the most recent published documentation, which is the closest correct thing for a candidate; and if documentation is cut part-way through a candidate cycle, `make version` moves `latestVersion`, `/docs/latest` follows it, and the candidate's console starts showing the new documentation with no re-release. A candidate therefore never points at a version that does not exist.

### Guard for final releases

Documentation for a minor line is cut once, at its first release. If a final release runs before that has happened, pinning would produce links that 404. The script now checks the derived version against `documentation/versions.json` and fails with a pointer to the Documentation Release workflow instead. Candidates are never pinned, so the guard does not apply to them.

## User stories

N/A — no product behaviour or user-facing feature changes. The effect is that documentation links in a released console resolve to that release's documentation.

## Release note

The console's in-product documentation links now point at the documentation version matching the release, instead of always tracking the newest published documentation. The documentation base URL is configurable through `console.config.docsVersion`.

## Documentation

N/A for content changes — no documentation pages are modified. The behaviour is documented inline: `console.config.docsVersion` carries a comment in `values.yaml` explaining the pinning rule, the derivation block in `update-helm-charts.sh` explains why candidates and nightlies are excluded, and `console/env.example` now lists `DOCS_URL` for local runs.

## Training

N/A — no training content covers console configuration values.

## Certification

N/A — an internal configuration and release-pipeline change with no product concept for certification questions to assess.

## Marketing

N/A — internal correctness improvement with no new capability to promote.

## Automation tests

 - Unit tests
   > N/A — the change is one template value, two chart entries, and a derivation block in a release shell script. There is no unit-test harness for the release scripts or the chart.
 - Integration tests
   > N/A — no integration surface is touched. The derivation and the rendered output were verified directly, as below.

The derivation was exercised by running the real `update-helm-charts.sh` against a throwaway chart for each release shape, and checked against every historical `amp/v*` tag in the repository (about 130 of them). It reproduces all nine versioned documentation entries in `versions.json` and invents none:

| Input | `docsVersion` written | Expected |
|---|---|---|
| `1.0.0-alpha1.rc1` / `.rc2` | `latest` | not pinned |
| `1.0.0-alpha1` | `v1.0.0-alpha1` | matches `versions.json` |
| `0.18.0-rc1` | `latest` | not pinned |
| `0.18.0` | `v0.18.x` | matches `versions.json` |
| `0.17.0` | `v0.17.x` | matches `versions.json` |
| `0.13.1` | `v0.13.x` | patch reuses the minor line |
| `0.0.0-dev-20260809` | `latest` | not pinned |
| `1.1.0` | *release fails* | guard fires: `v1.1.x` is not published |

Rendered output and runtime behaviour:

| Check | Result |
|---|---|
| `helm lint` on `wso2-agent-manager` | 1 chart linted, 0 failed |
| ConfigMap with chart defaults | `DOCS_URL: "…/docs/latest"` |
| ConfigMap with `docsVersion=v0.18.x` | `DOCS_URL: "…/docs/v0.18.x"` |
| ConfigMap with `docsVersion=v1.0.0-alpha1` | `DOCS_URL: "…/docs/v1.0.0-alpha1"` |
| ConfigMap with `docsVersion` set empty | falls back to `…/docs/latest` |
| `DOCS_URL` reaches the console container | yes, via the existing `envFrom: configMapRef: amp-console` |
| `envsubst` with `DOCS_URL` set | `docsUrl: '…/docs/v0.18.x'`, passes `node --check` |
| `envsubst` with `DOCS_URL` unset | `docsUrl: ''`, passes `node --check`; consumers already treat an absent value as "no link" |

End-to-end, a `v1.0.0-alpha1` release produces `…/docs/v1.0.0-alpha1/get-started/what-is-amp/`, `…/guides/isolation-tiers/gvisor/`, `…/guides/isolation-tiers/kata/` and `…/guides/amp-instrumentation/#manual-instrumentation`. All four resolve, because the corresponding pages in that snapshot carry matching `slug` overrides.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java or application code is changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no sample code or sample configuration changes.

## Migrations (if applicable)

No migration. Existing installs are unaffected: the chart default is `latest`, which is the behaviour the console has today, so an upgrade that does not set `docsVersion` keeps the current links. Operators who want a specific version can set `--set console.config.docsVersion=vX.Y.x`.

## Test environment

macOS 15 (Darwin 25.5.0), Helm v4.0.5, Node.js 20, GNU `envsubst` from gettext. Chart rendering via `helm template` and `helm lint`; the release script exercised with bash against throwaway chart fixtures. No JDK, database or browser matrix applies.

## Related PRs

Builds on #1544, which reorganised the documentation and made the console read `globalConfig.docsUrl` consistently. That PR moved the paths; this one makes the version segment follow the release. The two compose: with `docsVersion` pinned, the isolation-tier and instrumentation links resolve inside the pinned snapshot because #1544 added the matching `slug` overrides there.

## Learning

The non-obvious part was that release candidates and pre-releases are different things here. `v1.0.0-alpha1` is a pre-release that legitimately has its own documentation version, so a naive "final releases only" rule would have skipped it, while a naive "strip the pre-release suffix" rule would have pinned candidates to documentation that does not exist. Reading the actual tag history settled it: candidates are identifiable by an `rc` segment, they use a dot rather than a hyphen when they are candidates of a pre-release, and validating the rule against all ~130 historical tags confirmed it reproduces exactly the set of documentation versions that were created by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable in-product documentation links for console deployments.
  * Helm deployments can select a specific documentation version or use the latest documentation by default.
  * Release packaging now selects and validates the appropriate documentation version for stable and pre-release builds.

* **Bug Fixes**
  * Improved documentation URL configuration consistency across deployed console environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->