### PR TITLE
Set MCP rs ID based on deployed url 

### DIFF
--- a/agent-manager-service/audit/actions_domain_test.go
+++ b/agent-manager-service/audit/actions_domain_test.go
@@ -145,7 +145,8 @@ func TestPrivilegeChangeRecordsWhatChanged(t *testing.T) {
 	ctx := WithRecorder(context.Background(), rec)
 
 	granted := []string{"amp:agent:deploy-production", "amp:audit-event:read"}
-	Record(ctx, ActionRoleGrantPermission,
+	Record(
+		ctx, ActionRoleGrantPermission,
 		ResourceNamed(ResourceRole, "role-77", "SRE"),
 		Detail("roleName", "SRE"),
 		Detail("permissions", granted),
@@ -183,7 +184,8 @@ func TestUserCreateRecordsAttributeKeysNotValues(t *testing.T) {
 	keys, count, sensitive := AttributeKeySummary(map[string]string{
 		"username": "carol", "password": "hunter2", "apiToken": "sk-live-xyz",
 	})
-	Record(ctx, ActionUserCreate,
+	Record(
+		ctx, ActionUserCreate,
 		ResourceNamed(ResourceUser, "carol", "carol"),
 		Detail("username", "carol"),
 		Detail("attributeKeys", keys),
@@ -221,7 +223,8 @@ func TestDeployRecordsTargetEnvironment(t *testing.T) {
 	rec := NewRecorder(sink, quietLogger(), Config{BatchSize: 1})
 	ctx := WithRecorder(context.Background(), rec)
 
-	Record(ctx, ActionAgentDeploy,
+	Record(
+		ctx, ActionAgentDeploy,
 		ResourceNamed(ResourceAgent, "agent-1", "checkout-agent"),
 		Environment("production"),
 		Detail("agentName", "checkout-agent"),

--- a/agent-manager-service/clients/clientmocks/env_identity_client_mock.go
+++ b/agent-manager-service/clients/clientmocks/env_identity_client_mock.go
@@ -52,7 +52,7 @@ import (
 //			DeleteUserFunc: func(ctx context.Context, userID string) error {
 //				panic("mock out the DeleteUser method")
 //			},
-//			EnsureProxyResourceServerFunc: func(ctx context.Context, proxyHandle string, displayName string, actions []string) (string, error) {
+//			EnsureProxyResourceServerFunc: func(ctx context.Context, proxyHandle string, displayName string, identifier string, actions []string) (string, error) {
 //				panic("mock out the EnsureProxyResourceServer method")
 //			},
 //			GetAgentGroupsFunc: func(ctx context.Context, ouID string, agentID string) ([]thundersvc.ThunderGroup, error) {
@@ -186,7 +186,7 @@ type EnvIdentityClientMock struct {
 	DeleteUserFunc func(ctx context.Context, userID string) error
 
 	// EnsureProxyResourceServerFunc mocks the EnsureProxyResourceServer method.
-	EnsureProxyResourceServerFunc func(ctx context.Context, proxyHandle string, displayName string, actions []string) (string, error)
+	EnsureProxyResourceServerFunc func(ctx context.Context, proxyHandle string, displayName string, identifier string, actions []string) (string, error)
 
 	// GetAgentGroupsFunc mocks the GetAgentGroups method.
 	GetAgentGroupsFunc func(ctx context.Context, ouID string, agentID string) ([]thundersvc.ThunderGroup, error)
@@ -379,6 +379,8 @@ type EnvIdentityClientMock struct {
 			ProxyHandle string
 			// DisplayName is the displayName argument value.
 			DisplayName string
+			// Identifier is the identifier argument value.
+			Identifier string
 			// Actions is the actions argument value.
 			Actions []string
 		}
@@ -1127,7 +1129,7 @@ func (mock *EnvIdentityClientMock) DeleteUserCalls() []struct {
 }
 
 // EnsureProxyResourceServer calls EnsureProxyResourceServerFunc.
-func (mock *EnvIdentityClientMock) EnsureProxyResourceServer(ctx context.Context, proxyHandle string, displayName string, actions []string) (string, error) {
+func (mock *EnvIdentityClientMock) EnsureProxyResourceServer(ctx context.Context, proxyHandle string, displayName string, identifier string, actions []string) (string, error) {
 	if mock.EnsureProxyResourceServerFunc == nil {
 		panic("EnvIdentityClientMock.EnsureProxyResourceServerFunc: method is nil but EnvIdentityClient.EnsureProxyResourceServer was just called")
 	}
@@ -1135,17 +1137,19 @@ func (mock *EnvIdentityClientMock) EnsureProxyResourceServer(ctx context.Context
 		Ctx         context.Context
 		ProxyHandle string
 		DisplayName string
+		Identifier  string
 		Actions     []string
 	}{
 		Ctx:         ctx,
 		ProxyHandle: proxyHandle,
 		DisplayName: displayName,
+		Identifier:  identifier,
 		Actions:     actions,
 	}
 	mock.lockEnsureProxyResourceServer.Lock()
 	mock.calls.EnsureProxyResourceServer = append(mock.calls.EnsureProxyResourceServer, callInfo)
 	mock.lockEnsureProxyResourceServer.Unlock()
-	return mock.EnsureProxyResourceServerFunc(ctx, proxyHandle, displayName, actions)
+	return mock.EnsureProxyResourceServerFunc(ctx, proxyHandle, displayName, identifier, actions)
 }
 
 // EnsureProxyResourceServerCalls gets all the calls that were made to EnsureProxyResourceServer.
@@ -1156,12 +1160,14 @@ func (mock *EnvIdentityClientMock) EnsureProxyResourceServerCalls() []struct {
 	Ctx         context.Context
 	ProxyHandle string
 	DisplayName string
+	Identifier  string
 	Actions     []string
 } {
 	var calls []struct {
 		Ctx         context.Context
 		ProxyHandle string
 		DisplayName string
+		Identifier  string
 		Actions     []string
 	}
 	mock.lockEnsureProxyResourceServer.RLock()

--- a/agent-manager-service/clients/clientmocks/identity_client_mock.go
+++ b/agent-manager-service/clients/clientmocks/identity_client_mock.go
@@ -52,7 +52,7 @@ import (
 //			DeleteUserFunc: func(ctx context.Context, userID string) error {
 //				panic("mock out the DeleteUser method")
 //			},
-//			EnsureProxyResourceServerFunc: func(ctx context.Context, proxyHandle string, displayName string, actions []string) (string, error) {
+//			EnsureProxyResourceServerFunc: func(ctx context.Context, proxyHandle string, displayName string, identifier string, actions []string) (string, error) {
 //				panic("mock out the EnsureProxyResourceServer method")
 //			},
 //			GetAgentGroupsFunc: func(ctx context.Context, ouID string, agentID string) ([]thundersvc.ThunderGroup, error) {
@@ -183,7 +183,7 @@ type IdentityClientMock struct {
 	DeleteUserFunc func(ctx context.Context, userID string) error
 
 	// EnsureProxyResourceServerFunc mocks the EnsureProxyResourceServer method.
-	EnsureProxyResourceServerFunc func(ctx context.Context, proxyHandle string, displayName string, actions []string) (string, error)
+	EnsureProxyResourceServerFunc func(ctx context.Context, proxyHandle string, displayName string, identifier string, actions []string) (string, error)
 
 	// GetAgentGroupsFunc mocks the GetAgentGroups method.
 	GetAgentGroupsFunc func(ctx context.Context, ouID string, agentID string) ([]thundersvc.ThunderGroup, error)
@@ -373,6 +373,8 @@ type IdentityClientMock struct {
 			ProxyHandle string
 			// DisplayName is the displayName argument value.
 			DisplayName string
+			// Identifier is the identifier argument value.
+			Identifier string
 			// Actions is the actions argument value.
 			Actions []string
 		}
@@ -1115,7 +1117,7 @@ func (mock *IdentityClientMock) DeleteUserCalls() []struct {
 }
 
 // EnsureProxyResourceServer calls EnsureProxyResourceServerFunc.
-func (mock *IdentityClientMock) EnsureProxyResourceServer(ctx context.Context, proxyHandle string, displayName string, actions []string) (string, error) {
+func (mock *IdentityClientMock) EnsureProxyResourceServer(ctx context.Context, proxyHandle string, displayName string, identifier string, actions []string) (string, error) {
 	if mock.EnsureProxyResourceServerFunc == nil {
 		panic("IdentityClientMock.EnsureProxyResourceServerFunc: method is nil but IdentityClient.EnsureProxyResourceServer was just called")
 	}
@@ -1123,17 +1125,19 @@ func (mock *IdentityClientMock) EnsureProxyResourceServer(ctx context.Context, p
 		Ctx         context.Context
 		ProxyHandle string
 		DisplayName string
+		Identifier  string
 		Actions     []string
 	}{
 		Ctx:         ctx,
 		ProxyHandle: proxyHandle,
 		DisplayName: displayName,
+		Identifier:  identifier,
 		Actions:     actions,
 	}
 	mock.lockEnsureProxyResourceServer.Lock()
 	mock.calls.EnsureProxyResourceServer = append(mock.calls.EnsureProxyResourceServer, callInfo)
 	mock.lockEnsureProxyResourceServer.Unlock()
-	return mock.EnsureProxyResourceServerFunc(ctx, proxyHandle, displayName, actions)
+	return mock.EnsureProxyResourceServerFunc(ctx, proxyHandle, displayName, identifier, actions)
 }
 
 // EnsureProxyResourceServerCalls gets all the calls that were made to EnsureProxyResourceServer.
@@ -1144,12 +1148,14 @@ func (mock *IdentityClientMock) EnsureProxyResourceServerCalls() []struct {
 	Ctx         context.Context
 	ProxyHandle string
 	DisplayName string
+	Identifier  string
 	Actions     []string
 } {
 	var calls []struct {
 		Ctx         context.Context
 		ProxyHandle string
 		DisplayName string
+		Identifier  string
 		Actions     []string
 	}
 	mock.lockEnsureProxyResourceServer.RLock()

--- a/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
@@ -245,7 +245,8 @@ func TestNotReadyResourceIsReportedAsFailed(t *testing.T) {
 		}
 
 		state := runtimeReplicaStateFromTree(
-			treeWith(map[string]interface{}{"replicas": float64(1)}, accepted, blocked))
+			treeWith(map[string]interface{}{"replicas": float64(1)}, accepted, blocked),
+		)
 
 		assert.Contains(t, state.notReadyResource, "SomeFutureKind")
 		assert.NotContains(t, state.notReadyResource, "Backend", "a non-Ready condition type is ignored")

--- a/agent-manager-service/clients/thundersvc/client.go
+++ b/agent-manager-service/clients/thundersvc/client.go
@@ -95,7 +95,7 @@ type thunderClient struct {
 	tokenExpiry time.Time
 	tokenSfg    singleflight.Group // deduplicates concurrent token fetches
 
-	ensureResourceServerMu sync.Mutex // serializes resource-server check-then-create paths (scope + proxy)
+	ensureResourceServerMus sync.Map // proxyHandle -> *sync.Mutex; serializes each proxy's resource-server check-then-create
 }
 
 const httpClientTimeout = 30 * time.Second

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
 	"github.com/wso2/agent-manager/agent-manager-service/rbac"
@@ -1083,6 +1084,14 @@ const (
 	thunderHandleMaxLen = 100
 )
 
+// ensureProxyResourceServerMu returns the mutex serializing check-then-create
+// calls for one proxy handle. Entries are never removed; the map only grows by
+// the small set of proxy handles a client touches.
+func (c *thunderClient) ensureProxyResourceServerMu(proxyHandle string) *sync.Mutex {
+	mu, _ := c.ensureResourceServerMus.LoadOrStore(proxyHandle, &sync.Mutex{})
+	return mu.(*sync.Mutex)
+}
+
 // EnsureProxyResourceServer makes sure the resource server for a proxy exists
 // (handle = proxyHandle, identifier = the proxy's protocol-stripped public
 // invocation URI, delimiter ":", type MCP) and that every given action is
@@ -1107,10 +1116,11 @@ func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHand
 	}
 
 	// Avoids a TOCTOU race where concurrent callers both create a duplicate
-	// resource server or action; safe to scope per-client since clients are
-	// cached per org/env.
-	c.ensureResourceServerMu.Lock()
-	defer c.ensureResourceServerMu.Unlock()
+	// resource server or action; keyed per handle so unrelated proxies don't
+	// serialize behind each other's Thunder round-trips.
+	mu := c.ensureProxyResourceServerMu(proxyHandle)
+	mu.Lock()
+	defer mu.Unlock()
 
 	rs, err := c.findProxyResourceServer(ctx, token, proxyHandle)
 	if err != nil {

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -1126,29 +1126,14 @@ func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHand
 	if err != nil {
 		return "", err
 	}
-	rsID := ""
-	if rs != nil {
-		rsID = rs.ID
-		if rs.Identifier != identifier {
-			if err := c.updateProxyResourceServerIdentifier(ctx, token, rs, proxyHandle, identifier); err != nil {
-				return "", err
-			}
-		}
-	}
-	if rsID == "" {
+	var rsID string
+	if rs == nil {
 		ouID, err := c.getDefaultOUID(ctx, token)
 		if err != nil {
 			return "", fmt.Errorf("thunder ensure proxy resource server (default ou): %w", err)
 		}
 		body, err := c.doRequest(ctx, http.MethodPost, c.baseURL+"/resource-servers", token,
-			map[string]string{
-				"name":       displayName,
-				"identifier": identifier,
-				"handle":     proxyHandle,
-				"ouId":       ouID,
-				"delimiter":  proxyResourceServerDelimiter,
-				"type":       proxyResourceServerType,
-			})
+			proxyResourceServerBody(displayName, identifier, proxyHandle, ouID))
 		if err != nil {
 			return "", fmt.Errorf("thunder create proxy resource server: %w", err)
 		}
@@ -1157,6 +1142,13 @@ func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHand
 			return "", fmt.Errorf("thunder create proxy resource server decode: %w", err)
 		}
 		rsID = created.ID
+	} else {
+		rsID = rs.ID
+		if rs.Identifier != identifier {
+			if err := c.updateProxyResourceServerIdentifier(ctx, token, rs, proxyHandle, identifier); err != nil {
+				return "", err
+			}
+		}
 	}
 
 	existing, err := c.listProxyRootActions(ctx, token, rsID)
@@ -1178,8 +1170,21 @@ func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHand
 	return rsID, nil
 }
 
+// proxyResourceServerBody is the request payload shared by the proxy RS create
+// (POST) and identifier-update (PUT) calls.
+func proxyResourceServerBody(name, identifier, proxyHandle, ouID string) map[string]string {
+	return map[string]string{
+		"name":       name,
+		"identifier": identifier,
+		"handle":     proxyHandle,
+		"ouId":       ouID,
+		"delimiter":  proxyResourceServerDelimiter,
+		"type":       proxyResourceServerType,
+	}
+}
+
 // updateProxyResourceServerIdentifier rewrites a drifted identifier in place via
-// PUT /resource-servers/{id}; the body mirrors the create payload.
+// PUT /resource-servers/{id}.
 func (c *thunderClient) updateProxyResourceServerIdentifier(ctx context.Context, token string, rs *ThunderResourceServer, proxyHandle, identifier string) error {
 	ouID, err := c.getDefaultOUID(ctx, token)
 	if err != nil {
@@ -1190,14 +1195,7 @@ func (c *thunderClient) updateProxyResourceServerIdentifier(ctx context.Context,
 		name = proxyHandle
 	}
 	_, err = c.doRequest(ctx, http.MethodPut, c.baseURL+"/resource-servers/"+rs.ID, token,
-		map[string]string{
-			"name":       name,
-			"identifier": identifier,
-			"handle":     proxyHandle,
-			"ouId":       ouID,
-			"delimiter":  proxyResourceServerDelimiter,
-			"type":       proxyResourceServerType,
-		})
+		proxyResourceServerBody(name, identifier, proxyHandle, ouID))
 	if err != nil {
 		return fmt.Errorf("thunder update proxy resource server identifier: %w", err)
 	}

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -94,9 +94,11 @@ type IdentityClient interface {
 	// Permissions catalog
 	ListAMPPermissions(ctx context.Context) ([]ThunderPermission, string, error)
 	// EnsureProxyResourceServer makes sure the proxy's resource server exists
-	// (handle = identifier = proxyHandle, delimiter ":", type MCP) with every
-	// given action registered at the RS root, and returns the RS ID.
-	EnsureProxyResourceServer(ctx context.Context, proxyHandle, displayName string, actions []string) (string, error)
+	// (handle = proxyHandle, identifier = the proxy's protocol-stripped public
+	// invocation URI in this environment, delimiter ":", type MCP) with every
+	// given action registered at the RS root, and returns the RS ID. A drifted
+	// identifier is updated in place; the handle never changes.
+	EnsureProxyResourceServer(ctx context.Context, proxyHandle, displayName, identifier string, actions []string) (string, error)
 	// DeleteProxyResourceServerAction best-effort deletes one root action.
 	// Missing RS or action is not an error. Returns the RS ID ("" if RS absent).
 	DeleteProxyResourceServerAction(ctx context.Context, proxyHandle, action string) (string, error)
@@ -1018,31 +1020,49 @@ func (c *thunderClient) ListAMPPermissions(ctx context.Context) ([]ThunderPermis
 	return perms, ampRSID, nil
 }
 
-// findResourceServerID paginates through resource servers and returns the ID of
-// the one whose identifier matches, or "" if none match.
-func (c *thunderClient) findResourceServerID(ctx context.Context, token, identifier string) (string, error) {
+// findResourceServer paginates through resource servers and returns the first one
+// match accepts, or nil if none match.
+func (c *thunderClient) findResourceServer(ctx context.Context, token string, match func(*ThunderResourceServer) bool) (*ThunderResourceServer, error) {
 	const rsPageSize = 20
 	rsOffset := 0
 	for {
 		rsURL := fmt.Sprintf("%s/resource-servers?offset=%d&limit=%d", c.baseURL, rsOffset, rsPageSize)
 		rsBody, err := c.doRequest(ctx, http.MethodGet, rsURL, token, nil)
 		if err != nil {
-			return "", fmt.Errorf("thunder list resource servers: %w", err)
+			return nil, fmt.Errorf("thunder list resource servers: %w", err)
 		}
 		var page thunderResourceServerList
 		if err := json.Unmarshal(rsBody, &page); err != nil {
-			return "", fmt.Errorf("thunder list resource servers decode: %w", err)
+			return nil, fmt.Errorf("thunder list resource servers decode: %w", err)
 		}
-		for _, rs := range page.ResourceServers {
-			if rs.Identifier == identifier {
-				return rs.ID, nil
+		for i := range page.ResourceServers {
+			if match(&page.ResourceServers[i]) {
+				return &page.ResourceServers[i], nil
 			}
 		}
 		rsOffset += len(page.ResourceServers)
 		if rsOffset >= page.Total || len(page.ResourceServers) == 0 {
-			return "", nil
+			return nil, nil //nolint:nilnil // absent resource server is not an error
 		}
 	}
+}
+
+// findResourceServerID returns the ID of the RS whose identifier matches, or "".
+// Still used for the platform AMP resource server lookup (rbac.ResourceServer).
+func (c *thunderClient) findResourceServerID(ctx context.Context, token, identifier string) (string, error) {
+	rs, err := c.findResourceServer(ctx, token, func(rs *ThunderResourceServer) bool { return rs.Identifier == identifier })
+	if err != nil || rs == nil {
+		return "", err
+	}
+	return rs.ID, nil
+}
+
+// findProxyResourceServer locates a proxy's RS by its stable handle. Falls back
+// to identifier match for rows created before identifiers became URIs.
+func (c *thunderClient) findProxyResourceServer(ctx context.Context, token, proxyHandle string) (*ThunderResourceServer, error) {
+	return c.findResourceServer(ctx, token, func(rs *ThunderResourceServer) bool {
+		return rs.Handle == proxyHandle || rs.Identifier == proxyHandle
+	})
 }
 
 // --- Per-proxy resource servers ---
@@ -1063,12 +1083,16 @@ const (
 )
 
 // EnsureProxyResourceServer makes sure the resource server for a proxy exists
-// (identifier = handle = proxyHandle, delimiter ":", type MCP) and that every
-// given action is registered as a root action, then returns the resource server
-// ID. Idempotent; called lazily before role writes.
-func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHandle, displayName string, actions []string) (string, error) {
+// (handle = proxyHandle, identifier = the proxy's protocol-stripped public
+// invocation URI, delimiter ":", type MCP) and that every given action is
+// registered as a root action, then returns the resource server ID. A drifted
+// identifier is rewritten in place. Idempotent; called lazily before role writes.
+func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHandle, displayName, identifier string, actions []string) (string, error) {
 	if len(proxyHandle) > thunderHandleMaxLen {
 		return "", fmt.Errorf("proxy handle %q exceeds the Thunder handle limit of %d characters", proxyHandle, thunderHandleMaxLen)
+	}
+	if len(identifier) > thunderHandleMaxLen {
+		return "", fmt.Errorf("resource identifier %q exceeds the Thunder limit of %d characters", identifier, thunderHandleMaxLen)
 	}
 	for _, action := range actions {
 		if len(action) > thunderHandleMaxLen {
@@ -1087,9 +1111,18 @@ func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHand
 	c.ensureResourceServerMu.Lock()
 	defer c.ensureResourceServerMu.Unlock()
 
-	rsID, err := c.findResourceServerID(ctx, token, proxyHandle)
+	rs, err := c.findProxyResourceServer(ctx, token, proxyHandle)
 	if err != nil {
 		return "", err
+	}
+	rsID := ""
+	if rs != nil {
+		rsID = rs.ID
+		if rs.Identifier != identifier {
+			if err := c.updateProxyResourceServerIdentifier(ctx, token, rs, proxyHandle, identifier); err != nil {
+				return "", err
+			}
+		}
 	}
 	if rsID == "" {
 		ouID, err := c.getDefaultOUID(ctx, token)
@@ -1099,7 +1132,7 @@ func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHand
 		body, err := c.doRequest(ctx, http.MethodPost, c.baseURL+"/resource-servers", token,
 			map[string]string{
 				"name":       displayName,
-				"identifier": proxyHandle,
+				"identifier": identifier,
 				"handle":     proxyHandle,
 				"ouId":       ouID,
 				"delimiter":  proxyResourceServerDelimiter,
@@ -1134,6 +1167,32 @@ func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHand
 	return rsID, nil
 }
 
+// updateProxyResourceServerIdentifier rewrites a drifted identifier in place via
+// PUT /resource-servers/{id}; the body mirrors the create payload.
+func (c *thunderClient) updateProxyResourceServerIdentifier(ctx context.Context, token string, rs *ThunderResourceServer, proxyHandle, identifier string) error {
+	ouID, err := c.getDefaultOUID(ctx, token)
+	if err != nil {
+		return fmt.Errorf("thunder update proxy resource server (default ou): %w", err)
+	}
+	name := rs.Name
+	if name == "" {
+		name = proxyHandle
+	}
+	_, err = c.doRequest(ctx, http.MethodPut, c.baseURL+"/resource-servers/"+rs.ID, token,
+		map[string]string{
+			"name":       name,
+			"identifier": identifier,
+			"handle":     proxyHandle,
+			"ouId":       ouID,
+			"delimiter":  proxyResourceServerDelimiter,
+			"type":       proxyResourceServerType,
+		})
+	if err != nil {
+		return fmt.Errorf("thunder update proxy resource server identifier: %w", err)
+	}
+	return nil
+}
+
 // DeleteProxyResourceServerAction best-effort deletes a single root action from
 // the proxy's resource server. A missing resource server or missing action is
 // not an error. Returns the resource server ID ("" if the RS is absent).
@@ -1142,13 +1201,14 @@ func (c *thunderClient) DeleteProxyResourceServerAction(ctx context.Context, pro
 	if err != nil {
 		return "", err
 	}
-	rsID, err := c.findResourceServerID(ctx, token, proxyHandle)
+	rs, err := c.findProxyResourceServer(ctx, token, proxyHandle)
 	if err != nil {
 		return "", err
 	}
-	if rsID == "" {
+	if rs == nil {
 		return "", nil
 	}
+	rsID := rs.ID
 	actions, err := c.listProxyRootActions(ctx, token, rsID)
 	if err != nil {
 		return rsID, err
@@ -1172,13 +1232,14 @@ func (c *thunderClient) DeleteProxyResourceServer(ctx context.Context, proxyHand
 	if err != nil {
 		return err
 	}
-	rsID, err := c.findResourceServerID(ctx, token, proxyHandle)
+	rs, err := c.findProxyResourceServer(ctx, token, proxyHandle)
 	if err != nil {
 		return err
 	}
-	if rsID == "" {
+	if rs == nil {
 		return nil
 	}
+	rsID := rs.ID
 	actions, err := c.listProxyRootActions(ctx, token, rsID)
 	if err != nil {
 		return err

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -1058,10 +1058,11 @@ func (c *thunderClient) findResourceServerID(ctx context.Context, token, identif
 }
 
 // findProxyResourceServer locates a proxy's RS by its stable handle. Falls back
-// to identifier match for rows created before identifiers became URIs.
+// to identifier match only for handle-less legacy rows, so a foreign RS whose
+// identifier happens to equal the proxy handle is never picked up.
 func (c *thunderClient) findProxyResourceServer(ctx context.Context, token, proxyHandle string) (*ThunderResourceServer, error) {
 	return c.findResourceServer(ctx, token, func(rs *ThunderResourceServer) bool {
-		return rs.Handle == proxyHandle || rs.Identifier == proxyHandle
+		return rs.Handle == proxyHandle || (rs.Handle == "" && rs.Identifier == proxyHandle)
 	})
 }
 

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -148,7 +148,7 @@ func TestEnsureProxyResourceServer_CreatesRSWithHandleAndRootActions(t *testing.
 }
 
 func TestEnsureProxyResourceServer_IdempotentSkipsExistingActions(t *testing.T) {
-	rsCreated, rsUpdated, actCreated := 0, 0, 0
+	actCreated := 0
 	var createActionBodies []map[string]string
 	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -158,10 +158,8 @@ func TestEnsureProxyResourceServer_IdempotentSkipsExistingActions(t *testing.T) 
 				"total":           1,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
-			rsCreated++
 			t.Fatalf("no RS create expected when the resource server already exists")
 		case r.Method == http.MethodPut && r.URL.Path == "/resource-servers/rs-1":
-			rsUpdated++
 			t.Fatalf("no RS update expected when the identifier already matches")
 		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -183,8 +181,6 @@ func TestEnsureProxyResourceServer_IdempotentSkipsExistingActions(t *testing.T) 
 	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read", "write"})
 	assert.NoError(t, err)
 	assert.Equal(t, "rs-1", rsID)
-	assert.Equal(t, 0, rsCreated)
-	assert.Equal(t, 0, rsUpdated)
 	require.Len(t, createActionBodies, 1, "only the missing action must be created")
 	assert.Equal(t, "write", createActionBodies[0]["handle"])
 }

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -24,7 +24,10 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,6 +228,118 @@ func TestEnsureProxyResourceServer_ReconcilesDriftedIdentifier(t *testing.T) {
 	assert.Equal(t, "gh-proxy", updateBody["handle"], "handle must never change — permissions derive from it")
 	assert.Equal(t, ":", updateBody["delimiter"])
 	assert.Equal(t, "MCP", updateBody["type"])
+}
+
+func TestEnsureProxyResourceServer_DistinctProxiesDoNotSerialize(t *testing.T) {
+	// proxy-a's ensure is held mid-flight at the list call; proxy-b's ensure must
+	// still complete — only same-handle ensures may serialize.
+	firstListArrived := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFirst) }) }
+	var listCalls atomic.Int32
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers":
+			if listCalls.Add(1) == 1 {
+				close(firstListArrived)
+				<-releaseFirst
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceServers": []any{}, "total": 0})
+		case r.Method == http.MethodGet && r.URL.Path == "/organization-units/tree/default":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "ou-1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-" + body["handle"]})
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/actions"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"actions": []any{}, "totalResults": 0})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/actions"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "act-1"})
+		default:
+			t.Errorf("unexpected call %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	defer release()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+
+	firstErr := make(chan error, 1)
+	go func() {
+		_, err := client.EnsureProxyResourceServer(context.Background(), "proxy-a", "Proxy A", "gw.example.com/a/mcp", []string{"read"})
+		firstErr <- err
+	}()
+	<-firstListArrived
+
+	secondErr := make(chan error, 1)
+	go func() {
+		_, err := client.EnsureProxyResourceServer(context.Background(), "proxy-b", "Proxy B", "gw.example.com/b/mcp", []string{"read"})
+		secondErr <- err
+	}()
+	select {
+	case err := <-secondErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ensure for proxy-b blocked behind proxy-a's in-flight ensure")
+	}
+
+	release()
+	require.NoError(t, <-firstErr)
+}
+
+func TestEnsureProxyResourceServer_ConcurrentSameHandleCreatesOnce(t *testing.T) {
+	// The per-handle TOCTOU guard: concurrent ensures for one proxy must yield a
+	// single RS create; late callers find the row the first caller created.
+	var mu sync.Mutex
+	created := 0
+	exists := false
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers":
+			mu.Lock()
+			servers := []any{}
+			if exists {
+				servers = append(servers, map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "gw.example.com/github/mcp"})
+			}
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceServers": servers, "total": len(servers)})
+		case r.Method == http.MethodGet && r.URL.Path == "/organization-units/tree/default":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "ou-1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
+			mu.Lock()
+			created++
+			exists = true
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1"})
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"actions":      []any{map[string]string{"id": "act-1", "handle": "read"}},
+				"totalResults": 1,
+			})
+		default:
+			t.Errorf("unexpected call %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	rsIDs := make([]string, 4)
+	for i := range errs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rsIDs[i], errs[i] = client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read"})
+		}()
+	}
+	wg.Wait()
+
+	for i := range errs {
+		require.NoError(t, errs[i])
+		assert.Equal(t, "rs-1", rsIDs[i])
+	}
+	assert.Equal(t, 1, created, "concurrent same-handle ensures must create exactly one resource server")
 }
 
 func TestFindProxyResourceServer_IdentifierFallbackOnlyMatchesHandleLessRows(t *testing.T) {

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -116,7 +116,7 @@ func TestEnsureProxyResourceServer_CreatesRSWithHandleAndRootActions(t *testing.
 		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
 			rsCreated++
 			_ = json.NewDecoder(r.Body).Decode(&createRSBody)
-			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1", "identifier": "gh-proxy"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "gw.example.com/github/mcp"})
 		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
 			_ = json.NewEncoder(w).Encode(map[string]any{"actions": []any{}, "totalResults": 0})
 		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers/rs-1/actions":
@@ -131,13 +131,13 @@ func TestEnsureProxyResourceServer_CreatesRSWithHandleAndRootActions(t *testing.
 	})
 	defer srv.Close()
 	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
-	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", []string{"read", "write"})
+	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read", "write"})
 	assert.NoError(t, err)
 	assert.Equal(t, "rs-1", rsID)
 	assert.Equal(t, 1, rsCreated)
 	assert.Equal(t, 2, actCreated)
 	assert.Equal(t, "gh-proxy", createRSBody["handle"], "RS handle must be the proxy handle — it prefixes derived permissions")
-	assert.Equal(t, "gh-proxy", createRSBody["identifier"])
+	assert.Equal(t, "gw.example.com/github/mcp", createRSBody["identifier"], "identifier must be the env invocation URI, not the handle")
 	assert.Equal(t, ":", createRSBody["delimiter"])
 	assert.Equal(t, "MCP", createRSBody["type"])
 	assert.Equal(t, "ou-1", createRSBody["ouId"])
@@ -145,18 +145,21 @@ func TestEnsureProxyResourceServer_CreatesRSWithHandleAndRootActions(t *testing.
 }
 
 func TestEnsureProxyResourceServer_IdempotentSkipsExistingActions(t *testing.T) {
-	rsCreated, actCreated := 0, 0
+	rsCreated, rsUpdated, actCreated := 0, 0, 0
 	var createActionBodies []map[string]string
 	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"resourceServers": []any{map[string]string{"id": "rs-1", "identifier": "gh-proxy"}},
+				"resourceServers": []any{map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "gw.example.com/github/mcp"}},
 				"total":           1,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
 			rsCreated++
 			t.Fatalf("no RS create expected when the resource server already exists")
+		case r.Method == http.MethodPut && r.URL.Path == "/resource-servers/rs-1":
+			rsUpdated++
+			t.Fatalf("no RS update expected when the identifier already matches")
 		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"actions":      []any{map[string]string{"id": "act-1", "handle": "read"}},
@@ -174,12 +177,54 @@ func TestEnsureProxyResourceServer_IdempotentSkipsExistingActions(t *testing.T) 
 	})
 	defer srv.Close()
 	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
-	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", []string{"read", "write"})
+	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read", "write"})
 	assert.NoError(t, err)
 	assert.Equal(t, "rs-1", rsID)
 	assert.Equal(t, 0, rsCreated)
+	assert.Equal(t, 0, rsUpdated)
 	require.Len(t, createActionBodies, 1, "only the missing action must be created")
 	assert.Equal(t, "write", createActionBodies[0]["handle"])
+}
+
+func TestEnsureProxyResourceServer_ReconcilesDriftedIdentifier(t *testing.T) {
+	// Legacy RS row: identifier still equals the handle. Must be found (by handle
+	// or by legacy identifier) and PUT with the URI identifier, not recreated.
+	rsUpdated := 0
+	var updateBody map[string]string
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resourceServers": []any{map[string]string{"id": "rs-1", "name": "GitHub Proxy", "handle": "gh-proxy", "identifier": "gh-proxy"}},
+				"total":           1,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/organization-units/tree/default":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "ou-1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
+			t.Fatalf("drifted identifier must be updated in place, not recreated")
+		case r.Method == http.MethodPut && r.URL.Path == "/resource-servers/rs-1":
+			rsUpdated++
+			_ = json.NewDecoder(r.Body).Decode(&updateBody)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1"})
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"actions":      []any{map[string]string{"id": "act-1", "handle": "read"}},
+				"totalResults": 1,
+			})
+		default:
+			t.Fatalf("unexpected call %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read"})
+	assert.NoError(t, err)
+	assert.Equal(t, "rs-1", rsID)
+	assert.Equal(t, 1, rsUpdated)
+	assert.Equal(t, "gw.example.com/github/mcp", updateBody["identifier"])
+	assert.Equal(t, "gh-proxy", updateBody["handle"], "handle must never change — permissions derive from it")
+	assert.Equal(t, ":", updateBody["delimiter"])
+	assert.Equal(t, "MCP", updateBody["type"])
 }
 
 func TestEnsureProxyResourceServer_RejectsOverlongInputs(t *testing.T) {
@@ -189,15 +234,17 @@ func TestEnsureProxyResourceServer_RejectsOverlongInputs(t *testing.T) {
 	defer srv.Close()
 	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
 
-	_, err := client.EnsureProxyResourceServer(context.Background(), strings.Repeat("h", 101), "Too Long", []string{"read"})
+	_, err := client.EnsureProxyResourceServer(context.Background(), strings.Repeat("h", 101), "Too Long", "gw.example.com/x/mcp", []string{"read"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "100", "over-long handle error should state the 100-character Thunder limit")
 
-	_, err = client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", []string{strings.Repeat("a", 101)})
+	_, err = client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/x/mcp", []string{strings.Repeat("a", 101)})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "100", "over-long action error should state the 100-character Thunder limit")
 }
 
+// The list fixture carries only a legacy identifier match (no handle key) to lock
+// the fallback that finds resource servers created before identifiers were URIs.
 func TestDeleteProxyResourceServer_DeletesActionsThenRS(t *testing.T) {
 	var calls []string
 	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -227,6 +227,31 @@ func TestEnsureProxyResourceServer_ReconcilesDriftedIdentifier(t *testing.T) {
 	assert.Equal(t, "MCP", updateBody["type"])
 }
 
+func TestFindProxyResourceServer_IdentifierFallbackOnlyMatchesHandleLessRows(t *testing.T) {
+	// A foreign RS whose identifier happens to equal the proxy handle must not be
+	// matched (ensure would rewrite it, delete would remove it); only a legacy
+	// handle-less row may match by identifier.
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/resource-servers", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resourceServers": []any{
+				map[string]string{"id": "rs-foreign", "handle": "billing-api", "identifier": "gh-proxy"},
+				map[string]string{"id": "rs-legacy", "identifier": "gh-proxy"},
+			},
+			"total": 2,
+		})
+	})
+	defer srv.Close()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret").(*thunderClient)
+
+	rs, err := client.findProxyResourceServer(context.Background(), "test-system-token", "gh-proxy")
+
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	assert.Equal(t, "rs-legacy", rs.ID, "identifier fallback must skip rows that carry a different handle")
+}
+
 func TestEnsureProxyResourceServer_RejectsOverlongInputs(t *testing.T) {
 	srv := newTestThunderServer(t, func(_ http.ResponseWriter, r *http.Request) {
 		t.Fatalf("no Thunder calls expected for over-long input, got %s %s", r.Method, r.URL.Path)

--- a/agent-manager-service/clients/thundersvc/identity_types.go
+++ b/agent-manager-service/clients/thundersvc/identity_types.go
@@ -197,6 +197,7 @@ type RoleAssignmentsRequest struct {
 type ThunderResourceServer struct {
 	ID         string            `json:"id"`
 	Name       string            `json:"name"`
+	Handle     string            `json:"handle"`
 	Identifier string            `json:"identifier"`
 	Resources  []ThunderResource `json:"resources,omitempty"`
 }

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -489,7 +489,8 @@ func validateAuditConfig(cfg AuditConfig) []error {
 	if cfg.BatchSize > 0 && cfg.BufferSize > 0 && cfg.BatchSize > cfg.BufferSize {
 		errs = append(errs, fmt.Errorf(
 			"AUDIT_BATCH_SIZE (%d) must not exceed AUDIT_BUFFER_SIZE (%d)",
-			cfg.BatchSize, cfg.BufferSize))
+			cfg.BatchSize, cfg.BufferSize,
+		))
 	}
 	return errs
 }

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -646,7 +646,8 @@ func (c *agentController) RegenerateTracingToken(w http.ResponseWriter, r *http.
 
 	// Rotating the tracing token invalidates the one the deployed agent is
 	// using, so it is credential material and is refused when unrecordable.
-	attempt, ok := beginAuditOrFail(w, r, "RegenerateTracingToken", "Failed to regenerate tracing token", audit.ActionAgentTokenRegenerateTracing,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RegenerateTracingToken", "Failed to regenerate tracing token", audit.ActionAgentTokenRegenerateTracing,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgent, agentName, agentName),
 		audit.Project(projName),
@@ -840,7 +841,8 @@ func (c *agentController) UpdateDeploymentState(w http.ResponseWriter, r *http.R
 
 	// The gating permission is agent:suspend, but this route also resumes and
 	// undeploys, so the record names the state actually requested.
-	stateAttempt, ok := beginAuditOrFail(w, r, "UpdateDeploymentState", "Failed to update deployment state", audit.ActionAgentChangeDeploymentState,
+	stateAttempt, ok := beginAuditOrFail(
+		w, r, "UpdateDeploymentState", "Failed to update deployment state", audit.ActionAgentChangeDeploymentState,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgent, agentName, agentName),
 		audit.Project(projName),
@@ -1100,7 +1102,8 @@ func (c *agentController) RegenerateAgentIdentitySecret(w http.ResponseWriter, r
 
 	log.Info("RegenerateAgentIdentitySecret: starting", "orgName", orgName, "agentName", agentName, "envID", envID)
 
-	attempt, ok := beginAuditOrFail(w, r, "RegenerateAgentIdentitySecret", "Failed to regenerate agent identity secret", audit.ActionAgentIdentityRegenerateSecret,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RegenerateAgentIdentitySecret", "Failed to regenerate agent identity secret", audit.ActionAgentIdentityRegenerateSecret,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgentIdentity, agentName, agentName),
 		audit.Project(projName),
@@ -1151,7 +1154,8 @@ func (c *agentController) RevokeAgentIdentitySecret(w http.ResponseWriter, r *ht
 
 	log.Info("RevokeAgentIdentitySecret: starting", "orgName", orgName, "agentName", agentName, "envID", envID)
 
-	attempt, ok := beginAuditOrFail(w, r, "RevokeAgentIdentitySecret", "Failed to revoke agent identity secret", audit.ActionAgentIdentityRevokeSecret,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RevokeAgentIdentitySecret", "Failed to revoke agent identity secret", audit.ActionAgentIdentityRevokeSecret,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgentIdentity, agentName, agentName),
 		audit.Project(projName),
@@ -1206,7 +1210,8 @@ func (c *agentController) ProvisionAgentIdentity(w http.ResponseWriter, r *http.
 
 	log.Info("ProvisionAgentIdentity: starting", "orgName", orgName, "agentName", agentName, "envID", envID)
 
-	attempt, ok := beginAuditOrFail(w, r, "ProvisionAgentIdentity", "Failed to provision agent identity", audit.ActionAgentIdentityProvision,
+	attempt, ok := beginAuditOrFail(
+		w, r, "ProvisionAgentIdentity", "Failed to provision agent identity", audit.ActionAgentIdentityProvision,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgentIdentity, agentName, agentName),
 		audit.Project(projName),

--- a/agent-manager-service/controllers/agent_identity_controller.go
+++ b/agent-manager-service/controllers/agent_identity_controller.go
@@ -67,11 +67,18 @@ type AgentIdentityController interface {
 	ListAgents(w http.ResponseWriter, r *http.Request)
 }
 
+// MCPResourceServerIdentifierResolver derives the protocol-stripped public URI an
+// MCP proxy is invoked at in one environment — the env-Thunder RS identifier.
+type MCPResourceServerIdentifierResolver interface {
+	MCPResourceServerIdentifier(ctx context.Context, ouID, envName string, proxy *models.MCPProxy) (string, error)
+}
+
 type agentIdentityController struct {
-	resolver    thundersvc.EnvThunderResolver
-	bindingRepo repositories.AgentThunderClientRepository
-	proxyRepo   repositories.MCPProxyRepository
-	scopeRepo   repositories.MCPProxyScopeRepository
+	resolver      thundersvc.EnvThunderResolver
+	bindingRepo   repositories.AgentThunderClientRepository
+	proxyRepo     repositories.MCPProxyRepository
+	scopeRepo     repositories.MCPProxyScopeRepository
+	rsIdentifiers MCPResourceServerIdentifierResolver
 }
 
 // NewAgentIdentityController creates a new agent-identity passthrough controller.
@@ -80,8 +87,41 @@ func NewAgentIdentityController(
 	bindingRepo repositories.AgentThunderClientRepository,
 	proxyRepo repositories.MCPProxyRepository,
 	scopeRepo repositories.MCPProxyScopeRepository,
+	rsIdentifiers MCPResourceServerIdentifierResolver,
 ) AgentIdentityController {
-	return &agentIdentityController{resolver: resolver, bindingRepo: bindingRepo, proxyRepo: proxyRepo, scopeRepo: scopeRepo}
+	return &agentIdentityController{
+		resolver:      resolver,
+		bindingRepo:   bindingRepo,
+		proxyRepo:     proxyRepo,
+		scopeRepo:     scopeRepo,
+		rsIdentifiers: rsIdentifiers,
+	}
+}
+
+// ensureGroupResourceServer derives the group's per-environment identifier and
+// ensures its resource server, writing the HTTP error itself when ok=false.
+func (c *agentIdentityController) ensureGroupResourceServer(w http.ResponseWriter, r *http.Request, client thundersvc.EnvIdentityClient, g *proxyScopeGroup) (string, bool) {
+	ctx := r.Context()
+	ouID := middleware.OUIDFromRequest(r)
+	envName := r.PathValue("envName")
+	identifier, err := c.rsIdentifiers.MCPResourceServerIdentifier(ctx, ouID, envName, g.proxy)
+	if err != nil {
+		if errors.Is(err, services.ErrMCPProxyNotDeployedToEnvironment) {
+			utils.WriteErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("MCP proxy %q is not deployed to environment %q; deploy it there before granting its scopes", g.handle, envName))
+			return "", false
+		}
+		logger.GetLogger(ctx).Error("agent-identity: derive RS identifier failed", "proxy", g.handle, "env", envName, "error", err)
+		utils.WriteErrorResponse(w, http.StatusBadGateway, "Failed to resolve the MCP proxy's gateway address")
+		return "", false
+	}
+	rsID, err := client.EnsureProxyResourceServer(ctx, g.handle, displayName(g), identifier, g.actions)
+	if err != nil {
+		logger.GetLogger(ctx).Error("agent-identity: ensure proxy resource server failed", "proxy", g.handle, "error", err)
+		utils.WriteErrorResponse(w, http.StatusBadGateway, "Failed to register scopes with the environment identity provider")
+		return "", false
+	}
+	return rsID, true
 }
 
 // envClient resolves the env-Thunder identity client for the request's org+env,
@@ -460,10 +500,8 @@ func (c *agentIdentityController) CreateRole(w http.ResponseWriter, r *http.Requ
 	rsIDByHandle := make(map[string]string, len(groups))
 	for _, handle := range sortedKeys(groups) {
 		g := groups[handle]
-		rsID, err := client.EnsureProxyResourceServer(ctx, g.handle, displayName(g), g.actions)
-		if err != nil {
-			log.Error("agent-identity CreateRole: ensure proxy resource server failed", "proxy", g.handle, "error", err)
-			utils.WriteErrorResponse(w, http.StatusBadGateway, "Failed to register scopes with the environment identity provider")
+		rsID, ok := c.ensureGroupResourceServer(w, r, client, g)
+		if !ok {
 			return
 		}
 		rsIDByHandle[handle] = rsID
@@ -610,10 +648,8 @@ func (c *agentIdentityController) UpdateRole(w http.ResponseWriter, r *http.Requ
 	desired := make(map[string][]string, len(groups))
 	for _, handle := range sortedKeys(groups) {
 		g := groups[handle]
-		rsID, err := client.EnsureProxyResourceServer(ctx, g.handle, displayName(g), g.actions)
-		if err != nil {
-			log.Error("agent-identity UpdateRole: ensure proxy resource server failed", "roleID", roleID, "proxy", g.handle, "error", err)
-			utils.WriteErrorResponse(w, http.StatusBadGateway, "Failed to register scopes with the environment identity provider")
+		rsID, ok := c.ensureGroupResourceServer(w, r, client, g)
+		if !ok {
 			return
 		}
 		desired[rsID] = g.scopes

--- a/agent-manager-service/controllers/agent_identity_controller.go
+++ b/agent-manager-service/controllers/agent_identity_controller.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
@@ -69,8 +70,11 @@ type AgentIdentityController interface {
 
 // MCPResourceServerIdentifierResolver derives the protocol-stripped public URI an
 // MCP proxy is invoked at in one environment — the env-Thunder RS identifier.
+// The environment is resolved once per request and its UUID passed to each
+// per-proxy identifier derivation.
 type MCPResourceServerIdentifierResolver interface {
-	MCPResourceServerIdentifier(ctx context.Context, ouID, envName string, proxy *models.MCPProxy) (string, error)
+	EnvironmentUUIDByName(ctx context.Context, ouID, envName string) (uuid.UUID, error)
+	MCPResourceServerIdentifier(ctx context.Context, ouID string, envID uuid.UUID, proxy *models.MCPProxy) (string, error)
 }
 
 type agentIdentityController struct {
@@ -98,13 +102,28 @@ func NewAgentIdentityController(
 	}
 }
 
-// ensureGroupResourceServer derives the group's per-environment identifier and
-// ensures its resource server, writing the HTTP error itself when ok=false.
-func (c *agentIdentityController) ensureGroupResourceServer(w http.ResponseWriter, r *http.Request, client thundersvc.EnvIdentityClient, g *proxyScopeGroup) (string, bool) {
+// resolveScopeEnvironment resolves the request's environment UUID once for the
+// resource-server ensure loop, writing the HTTP error itself when ok=false.
+func (c *agentIdentityController) resolveScopeEnvironment(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
 	ctx := r.Context()
 	ouID := middleware.OUIDFromRequest(r)
 	envName := r.PathValue("envName")
-	identifier, err := c.rsIdentifiers.MCPResourceServerIdentifier(ctx, ouID, envName, g.proxy)
+	envID, err := c.rsIdentifiers.EnvironmentUUIDByName(ctx, ouID, envName)
+	if err != nil {
+		logger.GetLogger(ctx).Error("agent-identity: resolve environment failed", "env", envName, "error", err)
+		utils.WriteErrorResponse(w, http.StatusBadGateway, "Failed to resolve the MCP proxy's gateway address")
+		return uuid.Nil, false
+	}
+	return envID, true
+}
+
+// ensureGroupResourceServer derives the group's per-environment identifier and
+// ensures its resource server, writing the HTTP error itself when ok=false.
+func (c *agentIdentityController) ensureGroupResourceServer(w http.ResponseWriter, r *http.Request, client thundersvc.EnvIdentityClient, envID uuid.UUID, g *proxyScopeGroup) (string, bool) {
+	ctx := r.Context()
+	ouID := middleware.OUIDFromRequest(r)
+	envName := r.PathValue("envName")
+	identifier, err := c.rsIdentifiers.MCPResourceServerIdentifier(ctx, ouID, envID, g.proxy)
 	if err != nil {
 		if errors.Is(err, services.ErrMCPProxyNotDeployedToEnvironment) {
 			utils.WriteErrorResponse(w, http.StatusBadRequest,
@@ -498,13 +517,19 @@ func (c *agentIdentityController) CreateRole(w http.ResponseWriter, r *http.Requ
 	// before the role write, so no permission add below references an unknown
 	// resource server. rsIDByHandle keeps the ensured RS ID per proxy handle.
 	rsIDByHandle := make(map[string]string, len(groups))
-	for _, handle := range sortedKeys(groups) {
-		g := groups[handle]
-		rsID, ok := c.ensureGroupResourceServer(w, r, client, g)
+	if len(groups) > 0 {
+		envID, ok := c.resolveScopeEnvironment(w, r)
 		if !ok {
 			return
 		}
-		rsIDByHandle[handle] = rsID
+		for _, handle := range sortedKeys(groups) {
+			g := groups[handle]
+			rsID, ok := c.ensureGroupResourceServer(w, r, client, envID, g)
+			if !ok {
+				return
+			}
+			rsIDByHandle[handle] = rsID
+		}
 	}
 
 	role, err := client.CreateRole(ctx, thundersvc.CreateRoleRequest{
@@ -646,13 +671,19 @@ func (c *agentIdentityController) UpdateRole(w http.ResponseWriter, r *http.Requ
 	// desired[rsID] is the requested scope set for that proxy's resource server,
 	// ensured to exist before any reconcile write.
 	desired := make(map[string][]string, len(groups))
-	for _, handle := range sortedKeys(groups) {
-		g := groups[handle]
-		rsID, ok := c.ensureGroupResourceServer(w, r, client, g)
+	if len(groups) > 0 {
+		envID, ok := c.resolveScopeEnvironment(w, r)
 		if !ok {
 			return
 		}
-		desired[rsID] = g.scopes
+		for _, handle := range sortedKeys(groups) {
+			g := groups[handle]
+			rsID, ok := c.ensureGroupResourceServer(w, r, client, envID, g)
+			if !ok {
+				return
+			}
+			desired[rsID] = g.scopes
+		}
 	}
 
 	// currentByRS is the role's existing permission set per resource server.

--- a/agent-manager-service/controllers/agent_identity_controller_unit_test.go
+++ b/agent-manager-service/controllers/agent_identity_controller_unit_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
@@ -34,7 +35,19 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/middleware"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
 )
+
+// stubRSIdentifierResolver returns "<handle>.uri" so tests can assert the derived
+// identifier reaches the RS ensure call.
+type stubRSIdentifierResolver struct{ err error }
+
+func (s stubRSIdentifierResolver) MCPResourceServerIdentifier(_ context.Context, _, _ string, proxy *models.MCPProxy) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	return proxy.Handle + ".uri", nil
+}
 
 // TestAgentIdentityCreateRole_EnsuresPerProxyRSBeforePermissionWrite proves each
 // proxy's resource server is ensured before any role permission is written, so a
@@ -45,8 +58,9 @@ func TestAgentIdentityCreateRole_EnsuresPerProxyRSBeforePermissionWrite(t *testi
 	addByRS := map[string][]string{}
 	envClient := &clientmocks.EnvIdentityClientMock{
 		GetDefaultOUIDFunc: func(_ context.Context) (string, error) { return "ou-env", nil },
-		EnsureProxyResourceServerFunc: func(_ context.Context, handle, _ string, _ []string) (string, error) {
+		EnsureProxyResourceServerFunc: func(_ context.Context, handle, _, identifier string, _ []string) (string, error) {
 			calls = append(calls, "ensure:"+handle)
+			assert.Equal(t, handle+".uri", identifier, "the resolver-derived identifier must reach the RS ensure")
 			return "rs-" + handle, nil
 		},
 		CreateRoleFunc: func(_ context.Context, req thundersvc.CreateRoleRequest) (*thundersvc.ThunderRole, error) {
@@ -77,9 +91,9 @@ func TestAgentIdentityCreateRole_EnsuresPerProxyRSBeforePermissionWrite(t *testi
 		GetByHandleFunc: func(_ context.Context, handle, _ string) (*models.MCPProxy, error) {
 			switch handle {
 			case "gh-proxy":
-				return &models.MCPProxy{UUID: ghUUID}, nil
+				return &models.MCPProxy{UUID: ghUUID, Handle: handle}, nil
 			case "jira-proxy":
-				return &models.MCPProxy{UUID: jiraUUID}, nil
+				return &models.MCPProxy{UUID: jiraUUID, Handle: handle}, nil
 			}
 			return nil, gorm.ErrRecordNotFound
 		},
@@ -89,7 +103,7 @@ func TestAgentIdentityCreateRole_EnsuresPerProxyRSBeforePermissionWrite(t *testi
 			return &models.MCPProxyScope{MCPProxyUUID: proxyUUID, Action: action}, nil
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo)
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo, stubRSIdentifierResolver{})
 
 	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles",
 		strings.NewReader(`{"name":"readers","scopes":["gh-proxy:read","jira-proxy:write"]}`))
@@ -111,6 +125,45 @@ func TestAgentIdentityCreateRole_EnsuresPerProxyRSBeforePermissionWrite(t *testi
 	assert.Contains(t, w.Body.String(), "jira-proxy:write")
 }
 
+func TestAgentIdentityCreateRole_ProxyNotDeployedToEnvRejected(t *testing.T) {
+	proxyUUID := uuid.New()
+	envClient := &clientmocks.EnvIdentityClientMock{
+		GetDefaultOUIDFunc: func(_ context.Context) (string, error) { return "ou-env", nil },
+		EnsureProxyResourceServerFunc: func(_ context.Context, _, _, _ string, _ []string) (string, error) {
+			t.Fatal("RS ensure must not run when the identifier cannot be derived")
+			return "", nil
+		},
+	}
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveIdentityFunc: func(_ context.Context, _, _, _ string) (thundersvc.EnvIdentityClient, error) {
+			return envClient, nil
+		},
+	}
+	proxyRepo := &repomocks.MCPProxyRepositoryMock{
+		GetByHandleFunc: func(_ context.Context, handle, _ string) (*models.MCPProxy, error) {
+			return &models.MCPProxy{UUID: proxyUUID, Handle: handle}, nil
+		},
+	}
+	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
+		GetFunc: func(_ context.Context, _ uuid.UUID, action string) (*models.MCPProxyScope, error) {
+			return &models.MCPProxyScope{MCPProxyUUID: proxyUUID, Action: action}, nil
+		},
+	}
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo,
+		stubRSIdentifierResolver{err: fmt.Errorf("%w: proxy \"gh-proxy\", environment \"dev\"", services.ErrMCPProxyNotDeployedToEnvironment)})
+
+	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles",
+		strings.NewReader(`{"name":"readers","scopes":["gh-proxy:read"]}`))
+	req.SetPathValue("orgName", "o1")
+	req.SetPathValue("envName", "dev")
+	req = req.WithContext(middleware.WithResolvedOrg(req.Context(), middleware.ResolvedOrg{OUID: "ou-org"}))
+	rec := httptest.NewRecorder()
+	ctrl.CreateRole(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "not deployed")
+}
+
 // TestAgentIdentityCreateRole_UnknownProxyHandleRejected proves a scope naming a
 // proxy that does not exist is rejected with 400 before the environment's Thunder
 // is contacted (the resolver's ResolveIdentityFunc is left nil, so any call panics).
@@ -122,7 +175,7 @@ func TestAgentIdentityCreateRole_UnknownProxyHandleRejected(t *testing.T) {
 		},
 	}
 	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{} // GetFunc nil: must not be reached
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo)
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles",
 		strings.NewReader(`{"name":"readers","scopes":["ghost:read"]}`))
@@ -151,7 +204,7 @@ func TestAgentIdentityCreateRole_UnknownActionRejected(t *testing.T) {
 			return nil, gorm.ErrRecordNotFound
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo)
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles",
 		strings.NewReader(`{"name":"readers","scopes":["gh-proxy:read"]}`))
@@ -173,7 +226,7 @@ func TestAgentIdentityCreateRole_MalformedScopeRejected(t *testing.T) {
 	resolver := &clientmocks.EnvThunderResolverMock{}
 	proxyRepo := &repomocks.MCPProxyRepositoryMock{}      // GetByHandleFunc nil: must not be called
 	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{} // GetFunc nil: must not be called
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo)
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/orgs/o1/environments/dev/agent-identities/roles",
 		strings.NewReader(`{"name":"readers","scopes":["no-colon"]}`))
@@ -207,7 +260,8 @@ func TestAgentIdentityUpdateRole_ReconcilesAcrossResourceServers(t *testing.T) {
 		UpdateRoleFunc: func(_ context.Context, roleID string, req thundersvc.UpdateRoleRequest) (*thundersvc.ThunderRole, error) {
 			return &thundersvc.ThunderRole{ID: roleID, Name: req.Name}, nil
 		},
-		EnsureProxyResourceServerFunc: func(_ context.Context, handle, _ string, _ []string) (string, error) {
+		EnsureProxyResourceServerFunc: func(_ context.Context, handle, _, identifier string, _ []string) (string, error) {
+			assert.Equal(t, handle+".uri", identifier, "the resolver-derived identifier must reach the RS ensure")
 			switch handle {
 			case "gh-proxy":
 				return "rs-gh", nil
@@ -234,9 +288,9 @@ func TestAgentIdentityUpdateRole_ReconcilesAcrossResourceServers(t *testing.T) {
 		GetByHandleFunc: func(_ context.Context, handle, _ string) (*models.MCPProxy, error) {
 			switch handle {
 			case "gh-proxy":
-				return &models.MCPProxy{UUID: ghUUID}, nil
+				return &models.MCPProxy{UUID: ghUUID, Handle: handle}, nil
 			case "jira-proxy":
-				return &models.MCPProxy{UUID: jiraUUID}, nil
+				return &models.MCPProxy{UUID: jiraUUID, Handle: handle}, nil
 			}
 			return nil, gorm.ErrRecordNotFound
 		},
@@ -246,7 +300,7 @@ func TestAgentIdentityUpdateRole_ReconcilesAcrossResourceServers(t *testing.T) {
 			return &models.MCPProxyScope{MCPProxyUUID: proxyUUID, Action: action}, nil
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo)
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, proxyRepo, scopeRepo, stubRSIdentifierResolver{})
 
 	req := httptest.NewRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/role-1",
 		strings.NewReader(`{"name":"readers","scopes":["gh-proxy:read","jira-proxy:track"]}`))
@@ -285,7 +339,7 @@ func TestAgentIdentityUpdateRole_PreservesNameWhenOmitted(t *testing.T) {
 			return envClient, nil
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 
 	req := httptest.NewRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/role-1",
 		strings.NewReader(`{"description":"metadata only"}`))
@@ -331,7 +385,7 @@ func TestAgentIdentityUpdateRole_OmittedScopesPreservesPermissions(t *testing.T)
 			return envClient, nil
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 
 	req := httptest.NewRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/role-1",
 		strings.NewReader(`{"description":"metadata only"}`))
@@ -374,7 +428,7 @@ func TestAgentIdentityUpdateRole_ExplicitEmptyScopesClearsPermissions(t *testing
 			return envClient, nil
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 
 	req := httptest.NewRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/roles/role-1",
 		strings.NewReader(`{"scopes":[]}`))
@@ -412,7 +466,7 @@ func TestAgentIdentityUpdateGroup_PreservesNameWhenOmitted(t *testing.T) {
 			return envClient, nil
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 
 	req := httptest.NewRequest(http.MethodPut, "/orgs/o1/environments/dev/agent-identities/groups/grp-1",
 		strings.NewReader(`{"description":"x"}`))
@@ -438,7 +492,7 @@ func TestAgentIdentityRoutes_EnvThunderUnavailable(t *testing.T) {
 			return nil, thundersvc.ErrThunderNotProvisioned
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/orgs/o1/environments/dev/agent-identities/groups", nil)
 	req.SetPathValue("orgName", "o1")
@@ -471,7 +525,7 @@ func TestAgentIdentityListAgents_ReturnsBindings(t *testing.T) {
 		},
 	}
 	resolver := &clientmocks.EnvThunderResolverMock{} // must not be called
-	ctrl := NewAgentIdentityController(resolver, bindingRepo, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	ctrl := NewAgentIdentityController(resolver, bindingRepo, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/orgs/o1/environments/dev/agent-identities/agents", nil)
 	req.SetPathValue("orgName", "o1")
@@ -518,7 +572,7 @@ func TestAgentIdentityGetRoleAssignments_UsesAgentSemantics(t *testing.T) {
 			return envClient, nil
 		},
 	}
-	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	ctrl := NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/orgs/o1/environments/dev/agent-identities/roles/r1/assignments", nil)
 	req.SetPathValue("orgName", "o1")
@@ -564,7 +618,7 @@ func adminRoleController(envClient *clientmocks.EnvIdentityClientMock) AgentIden
 			return envClient, nil
 		},
 	}
-	return NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{})
+	return NewAgentIdentityController(resolver, &repomocks.AgentThunderClientRepositoryMock{}, &repomocks.MCPProxyRepositoryMock{}, &repomocks.MCPProxyScopeRepositoryMock{}, nil)
 }
 
 // adminRoleRequest builds a request with the org/env/role path values shared by

--- a/agent-manager-service/controllers/agent_identity_controller_unit_test.go
+++ b/agent-manager-service/controllers/agent_identity_controller_unit_test.go
@@ -42,7 +42,11 @@ import (
 // identifier reaches the RS ensure call.
 type stubRSIdentifierResolver struct{ err error }
 
-func (s stubRSIdentifierResolver) MCPResourceServerIdentifier(_ context.Context, _, _ string, proxy *models.MCPProxy) (string, error) {
+func (s stubRSIdentifierResolver) EnvironmentUUIDByName(_ context.Context, _, _ string) (uuid.UUID, error) {
+	return uuid.MustParse("11111111-1111-1111-1111-111111111111"), nil
+}
+
+func (s stubRSIdentifierResolver) MCPResourceServerIdentifier(_ context.Context, _ string, _ uuid.UUID, proxy *models.MCPProxy) (string, error) {
 	if s.err != nil {
 		return "", s.err
 	}

--- a/agent-manager-service/controllers/audit_helpers.go
+++ b/agent-manager-service/controllers/audit_helpers.go
@@ -66,7 +66,8 @@ func beginConfigAPIKeyAudit(
 	action audit.Action,
 	ownerType, ouID, projName, agentName, envName, configID, keyName string,
 ) (*audit.Attempt, bool) {
-	return beginAuditOrFail(w, r, operation, failureMessage, action,
+	return beginAuditOrFail(
+		w, r, operation, failureMessage, action,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAPIKey, configID, keyName),
 		audit.Project(projName),

--- a/agent-manager-service/controllers/environment_controller.go
+++ b/agent-manager-service/controllers/environment_controller.go
@@ -418,7 +418,8 @@ func (c *environmentController) SetThunderSystemClient(w http.ResponseWriter, r 
 	// The clientId identifies the credential; clientSecret is never passed to
 	// the recorder. Refused when unrecordable — this credential is what AMS uses
 	// to reach the environment's identity provider.
-	attempt, ok := beginAuditOrFail(w, r, "SetThunderSystemClient", "Failed to store system-client credential", audit.ActionServiceAccountConfigure,
+	attempt, ok := beginAuditOrFail(
+		w, r, "SetThunderSystemClient", "Failed to store system-client credential", audit.ActionServiceAccountConfigure,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceServiceAccount, envName, envName),
 		audit.Environment(envName),
@@ -453,7 +454,8 @@ func (c *environmentController) DeleteThunderSystemClient(w http.ResponseWriter,
 	ouID := middleware.OUIDFromRequest(r)
 	envName := r.PathValue("envID")
 
-	attempt, ok := beginAuditOrFail(w, r, "DeleteThunderSystemClient", "Failed to delete system-client credential", audit.ActionServiceAccountRemove,
+	attempt, ok := beginAuditOrFail(
+		w, r, "DeleteThunderSystemClient", "Failed to delete system-client credential", audit.ActionServiceAccountRemove,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceServiceAccount, envName, envName),
 		audit.Environment(envName),

--- a/agent-manager-service/controllers/gateway_controller.go
+++ b/agent-manager-service/controllers/gateway_controller.go
@@ -206,7 +206,8 @@ func (c *gatewayController) RegisterGateway(w http.ResponseWriter, r *http.Reque
 		properties,
 		req.EnvironmentIds,
 	)
-	audit.Record(ctx, audit.ActionGatewayCreate,
+	audit.Record(
+		ctx, audit.ActionGatewayCreate,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceGateway, gatewayResponseID(gateway), req.Name),
 		audit.Detail("gatewayName", req.Name),
@@ -353,7 +354,8 @@ func (c *gatewayController) UpdateGateway(w http.ResponseWriter, r *http.Request
 	var properties *map[string]interface{}
 	var description *string // Description not in spec
 	gateway, err := c.gatewayService.UpdateGateway(gatewayID, ouID, description, req.DisplayName, req.IsCritical, properties, req.RuntimeUrl)
-	audit.Record(ctx, audit.ActionGatewayUpdate,
+	audit.Record(
+		ctx, audit.ActionGatewayUpdate,
 		audit.Org(ouID),
 		audit.Resource(audit.ResourceGateway, gatewayID),
 		audit.Result(err),
@@ -377,7 +379,8 @@ func (c *gatewayController) DeleteGateway(w http.ResponseWriter, r *http.Request
 	ouID := middleware.OUIDFromRequest(r)
 	gatewayID := strings.TrimSpace(r.PathValue("gatewayID"))
 
-	attempt, ok := beginAuditOrFail(w, r, "DeleteGateway", "Failed to delete gateway", audit.ActionGatewayDelete,
+	attempt, ok := beginAuditOrFail(
+		w, r, "DeleteGateway", "Failed to delete gateway", audit.ActionGatewayDelete,
 		audit.Org(ouID),
 		audit.Resource(audit.ResourceGateway, gatewayID),
 	)
@@ -419,7 +422,8 @@ func (c *gatewayController) AssignGatewayToEnvironment(w http.ResponseWriter, r 
 
 	// Assign via service
 	assignErr := c.gatewayService.AssignGatewayToEnvironment(gatewayID, resolvedEnvID)
-	audit.Record(ctx, audit.ActionGatewayAssignEnvironment,
+	audit.Record(
+		ctx, audit.ActionGatewayAssignEnvironment,
 		audit.Org(ouID),
 		audit.Resource(audit.ResourceGateway, gatewayID),
 		audit.Environment(resolvedEnvID),
@@ -458,7 +462,8 @@ func (c *gatewayController) RemoveGatewayFromEnvironment(w http.ResponseWriter, 
 
 	// Remove via service
 	removeErr := c.gatewayService.RemoveGatewayFromEnvironment(gatewayID, resolvedEnvID)
-	audit.Record(ctx, audit.ActionGatewayUnassignEnvironment,
+	audit.Record(
+		ctx, audit.ActionGatewayUnassignEnvironment,
 		audit.Org(ouID),
 		audit.Resource(audit.ResourceGateway, gatewayID),
 		audit.Environment(resolvedEnvID),
@@ -589,7 +594,8 @@ func (c *gatewayController) RotateGatewayToken(w http.ResponseWriter, r *http.Re
 	// context; the audit trail needs the caller identity that only the request
 	// context carries. A rotated gateway token is live credential material, so
 	// the operation is refused when it cannot be recorded.
-	attempt, ok := beginAuditOrFail(w, r, "RotateGatewayToken", "Failed to rotate gateway token", audit.ActionGatewayTokenRotate,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RotateGatewayToken", "Failed to rotate gateway token", audit.ActionGatewayTokenRotate,
 		audit.Org(ouID),
 		audit.Resource(audit.ResourceGateway, gatewayID),
 	)
@@ -628,7 +634,8 @@ func (c *gatewayController) RevokeGatewayToken(w http.ResponseWriter, r *http.Re
 
 	log.Info("RevokeGatewayToken: starting", "ouID", ouID, "gatewayID", gatewayID, "tokenID", tokenID)
 
-	attempt, ok := beginAuditOrFail(w, r, "RevokeGatewayToken", "Failed to revoke token", audit.ActionGatewayTokenRevoke,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RevokeGatewayToken", "Failed to revoke token", audit.ActionGatewayTokenRevoke,
 		audit.Org(ouID),
 		audit.Resource(audit.ResourceGateway, gatewayID),
 		audit.Detail("tokenId", tokenID),

--- a/agent-manager-service/controllers/gateway_identity_provider_controller.go
+++ b/agent-manager-service/controllers/gateway_identity_provider_controller.go
@@ -154,7 +154,8 @@ func (c *gatewayController) UpsertGatewayIdentityProvider(w http.ResponseWriter,
 	// fetch validates TLS — an issuer on its own does not say who can actually
 	// mint an accepted token.
 	ctx := r.Context()
-	attempt, ok := beginAuditOrFail(w, r, "UpsertGatewayIdentityProvider", "Failed to upsert identity provider", audit.ActionGatewaySetIdentityProvider,
+	attempt, ok := beginAuditOrFail(
+		w, r, "UpsertGatewayIdentityProvider", "Failed to upsert identity provider", audit.ActionGatewaySetIdentityProvider,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceGateway, gatewayID, gatewayID),
 		audit.Detail("identityProviderName", name),
@@ -192,7 +193,8 @@ func (c *gatewayController) DeleteGatewayIdentityProvider(w http.ResponseWriter,
 	name := strings.TrimSpace(r.PathValue("name"))
 
 	ctx := r.Context()
-	attempt, ok := beginAuditOrFail(w, r, "DeleteGatewayIdentityProvider", "Failed to delete identity provider", audit.ActionGatewayRemoveIdentityProvider,
+	attempt, ok := beginAuditOrFail(
+		w, r, "DeleteGatewayIdentityProvider", "Failed to delete identity provider", audit.ActionGatewayRemoveIdentityProvider,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceGateway, gatewayID, gatewayID),
 		audit.Detail("identityProviderName", name),

--- a/agent-manager-service/controllers/gateway_internal_audit.go
+++ b/agent-manager-service/controllers/gateway_internal_audit.go
@@ -42,7 +42,8 @@ func recordGatewayAuthFailure(r *http.Request, reason, gatewayID string) {
 		return
 	}
 
-	audit.RecordAncillary(r.Context(), audit.ActionAuthnFailure,
+	audit.RecordAncillary(
+		r.Context(), audit.ActionAuthnFailure,
 		audit.SurfaceOpt(audit.SurfaceInternal),
 		audit.Actor(audit.ActorGateway, gatewayID, ""),
 		audit.AuthMethod("api-key"),

--- a/agent-manager-service/controllers/gateway_internal_controller.go
+++ b/agent-manager-service/controllers/gateway_internal_controller.go
@@ -452,7 +452,8 @@ func (c *gatewayInternalController) PushGatewayManifest(w http.ResponseWriter, r
 	// gateway is a machine client that retries, so refusing the push when the
 	// trail is unavailable would leave the mirror stale for no gain.
 	err := c.gatewayService.SaveGatewayPolicyManifest(gatewayID, manifest)
-	audit.Record(r.Context(), audit.ActionGatewayPushManifest,
+	audit.Record(
+		r.Context(), audit.ActionGatewayPushManifest,
 		audit.Org(identity.OUID),
 		audit.Resource(audit.ResourceGateway, gatewayID),
 		audit.SurfaceOpt(audit.SurfaceInternal),

--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -198,7 +198,8 @@ func (c *identityController) CreateUser(w http.ResponseWriter, r *http.Request) 
 	// its key names and shape are recorded — never a value. See
 	// audit.AttributeKeySummary.
 	attrKeys, attrCount, hasSensitive := audit.AttributeKeySummary(body.Attributes)
-	attempt, ok := beginAuditOrFail(w, r, "CreateUser", "Failed to create user", audit.ActionUserCreate,
+	attempt, ok := beginAuditOrFail(
+		w, r, "CreateUser", "Failed to create user", audit.ActionUserCreate,
 		audit.Org(ouID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceUser, body.Attributes["username"], body.Attributes["username"]),
 		audit.Detail("username", body.Attributes["username"]),
@@ -301,7 +302,8 @@ func (c *identityController) DeleteUser(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	attempt, ok := beginAuditOrFail(w, r, "DeleteUser", "Failed to delete user", audit.ActionUserDelete,
+	attempt, ok := beginAuditOrFail(
+		w, r, "DeleteUser", "Failed to delete user", audit.ActionUserDelete,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceUser, userID, userIdentifier(user)),
 		audit.Detail("username", userIdentifier(user)),
@@ -428,7 +430,8 @@ func (c *identityController) InviteUser(w http.ResponseWriter, r *http.Request) 
 	// The invite link grants org access to whoever holds it, so an invite is a
 	// membership change and is refused when it cannot be recorded. The link
 	// itself is never recorded.
-	attempt, ok := beginAuditOrFail(w, r, "InviteUser", "Failed to invite user", audit.ActionUserInvite,
+	attempt, ok := beginAuditOrFail(
+		w, r, "InviteUser", "Failed to invite user", audit.ActionUserInvite,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceUser, body.Email, body.Email),
 		audit.Detail("email", body.Email),
@@ -710,7 +713,8 @@ func (c *identityController) AddGroupMembers(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	attempt, ok := beginAuditOrFail(w, r, "AddGroupMembers", "Failed to add group members", audit.ActionGroupAddMember,
+	attempt, ok := beginAuditOrFail(
+		w, r, "AddGroupMembers", "Failed to add group members", audit.ActionGroupAddMember,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceGroup, groupID, group.Name),
 		audit.Detail("groupName", group.Name),
@@ -773,7 +777,8 @@ func (c *identityController) RemoveGroupMembers(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	attempt, ok := beginAuditOrFail(w, r, "RemoveGroupMembers", "Failed to remove group members", audit.ActionGroupRemoveMember,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RemoveGroupMembers", "Failed to remove group members", audit.ActionGroupRemoveMember,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceGroup, groupID, group.Name),
 		audit.Detail("groupName", group.Name),
@@ -1166,7 +1171,8 @@ func (c *identityController) AddRolePermissions(w http.ResponseWriter, r *http.R
 	// The granted scopes are recorded in full. This is the privilege-escalation
 	// path, and a record naming only the role cannot answer "who granted what
 	// to whom" — which is the question this event exists for.
-	attempt, ok := beginAuditOrFail(w, r, "AddRolePermissions", "Failed to add role permissions", audit.ActionRoleGrantPermission,
+	attempt, ok := beginAuditOrFail(
+		w, r, "AddRolePermissions", "Failed to add role permissions", audit.ActionRoleGrantPermission,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceRole, roleID, role.Name),
 		audit.Detail("roleName", role.Name),
@@ -1220,7 +1226,8 @@ func (c *identityController) RemoveRolePermissions(w http.ResponseWriter, r *htt
 		return
 	}
 
-	attempt, ok := beginAuditOrFail(w, r, "RemoveRolePermissions", "Failed to remove role permissions", audit.ActionRoleRevokePermission,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RemoveRolePermissions", "Failed to remove role permissions", audit.ActionRoleRevokePermission,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceRole, roleID, role.Name),
 		audit.Detail("roleName", role.Name),
@@ -1275,7 +1282,8 @@ func (c *identityController) AddRoleAssignees(w http.ResponseWriter, r *http.Req
 	}
 
 	assigneeIDs, assigneeTypes := assignmentSummary(req.Assignments)
-	attempt, ok := beginAuditOrFail(w, r, "AddRoleAssignees", "Failed to add role assignees", audit.ActionRoleAssign,
+	attempt, ok := beginAuditOrFail(
+		w, r, "AddRoleAssignees", "Failed to add role assignees", audit.ActionRoleAssign,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceRole, roleID, role.Name),
 		audit.Detail("roleName", role.Name),
@@ -1330,7 +1338,8 @@ func (c *identityController) RemoveRoleAssignees(w http.ResponseWriter, r *http.
 	}
 
 	assigneeIDs, assigneeTypes := assignmentSummary(req.Assignments)
-	attempt, ok := beginAuditOrFail(w, r, "RemoveRoleAssignees", "Failed to remove role assignees", audit.ActionRoleUnassign,
+	attempt, ok := beginAuditOrFail(
+		w, r, "RemoveRoleAssignees", "Failed to remove role assignees", audit.ActionRoleUnassign,
 		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceRole, roleID, role.Name),
 		audit.Detail("roleName", role.Name),

--- a/agent-manager-service/controllers/monitor_scores_publisher_controller.go
+++ b/agent-manager-service/controllers/monitor_scores_publisher_controller.go
@@ -89,7 +89,8 @@ func (c *monitorScoresPublisherController) PublishScores(w http.ResponseWriter, 
 	// for a run. The actor is the machine client from the token audience, not a
 	// user.
 	publishErr := c.scoresService.PublishScores(monitorID, runID, &req)
-	audit.Record(r.Context(), audit.ActionMonitorScorePublish,
+	audit.Record(
+		r.Context(), audit.ActionMonitorScorePublish,
 		audit.ResourceNamed("monitor-run", runID.String(), runID.String()),
 		audit.SurfaceOpt(audit.SurfacePublisher),
 		audit.Actor(audit.ActorService, publisherAudience(r.Context()), ""),

--- a/agent-manager-service/mcp/tools/authz.go
+++ b/agent-manager-service/mcp/tools/authz.go
@@ -178,7 +178,8 @@ func sessionOrgMatchesRequest(ctx context.Context, info *auth.TokenInfo) bool {
 // the request path so that MCP denials and REST denials answer the same query.
 func recordToolDeny(ctx context.Context, toolName, reason string, opts ...audit.Option) {
 	all := make([]audit.Option, 0, len(opts)+4)
-	all = append(all,
+	all = append(
+		all,
 		audit.SurfaceOpt(audit.SurfaceMCP),
 		audit.OutcomeOpt(audit.OutcomeDeny),
 		audit.Detail("reason", reason),

--- a/agent-manager-service/mcp/tools/helpers.go
+++ b/agent-manager-service/mcp/tools/helpers.go
@@ -192,7 +192,8 @@ func withToolAudit[T any](
 		if audited {
 			// A handler that already emitted its own semantic record marks the
 			// request scope, so this does not double-record; see audit.Record.
-			audit.Record(ctx, action,
+			audit.Record(
+				ctx, action,
 				audit.SurfaceOpt(audit.SurfaceMCP),
 				audit.Detail("tool", toolName),
 				audit.Result(err),

--- a/agent-manager-service/services/agent_apikey_service.go
+++ b/agent-manager-service/services/agent_apikey_service.go
@@ -362,7 +362,8 @@ func (s *AgentAPIKeyService) IssueTestAPIKey(
 	// Recorded after the fact rather than fail-closed: a console test key is
 	// short-lived and scoped to the requesting user, so refusing the Try-It
 	// flow when the trail is unavailable would cost more than it protects.
-	audit.Record(ctx, audit.ActionAPIKeyIssueTest,
+	audit.Record(
+		ctx, audit.ActionAPIKeyIssueTest,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAPIKey, artifactUUID, keyName),
 		audit.Project(projectName),

--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -17,108 +17,51 @@
 package services
 
 import (
-	"bytes"
-	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
-func TestBuildProxyURLUsesStoredRuntimeURLForInternal(t *testing.T) {
-	contextPath := "/llm/proxy"
+func TestBuildProxyURLUsesVhost(t *testing.T) {
+	// RuntimeURL present but must be ignored: every agent gets the public URL.
 	gateway := &models.Gateway{
-		Name:       "api-platform-acme-dev",
 		Vhost:      "https://dev-acme.gateway.example.com",
 		RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
 	}
-
-	require.Equal(
-		t,
-		"http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy",
-		buildProxyURL(gateway, &contextPath, true),
-	)
-	require.Equal(
-		t,
-		"https://dev-acme.gateway.example.com/llm/proxy",
-		buildProxyURL(gateway, &contextPath, false),
-	)
-}
-
-// An empty runtime URL is the designed path for external agents and a diagnosable
-// failure for internal ones — the ERROR log is what makes deleting the derivation
-// survivable, so exercise both branches rather than only the happy one.
-func TestBuildProxyURLFallsBackToVhostWhenRuntimeURLEmpty(t *testing.T) {
 	contextPath := "/llm/proxy"
-	gateway := &models.Gateway{
-		UUID:  uuid.New(),
-		Name:  "default",
-		Vhost: "https://dev-acme.gateway.example.com",
-	}
-
-	logs := captureDefaultLogger(t)
-
-	require.Equal(t, "https://dev-acme.gateway.example.com/llm/proxy", buildProxyURL(gateway, &contextPath, true))
-
-	// Pin the level and the identifying attributes, not the prose: a downgrade to WARN or a
-	// dropped gateway identifier would silently remove the only signal of a misconfigured gateway.
-	require.Contains(t, logs.String(), "level=ERROR")
-	require.Contains(t, logs.String(), "gatewayName=default")
-	require.Contains(t, logs.String(), "gatewayID="+gateway.UUID.String())
-
-	// The external branch is not a misconfiguration, so it must stay silent.
-	logs.Reset()
-	require.Equal(t, "https://dev-acme.gateway.example.com/llm/proxy", buildProxyURL(gateway, &contextPath, false))
-	require.Empty(t, logs.String())
+	require.Equal(t, "https://dev-acme.gateway.example.com/llm/proxy", buildProxyURL(gateway, &contextPath))
+	require.Equal(t, "https://dev-acme.gateway.example.com", buildProxyURL(gateway, nil))
 }
 
-// captureDefaultLogger redirects slog's default logger into a buffer for the duration of the
-// test, restoring the previous default unconditionally so no capture leaks into sibling tests.
-func captureDefaultLogger(t *testing.T) *bytes.Buffer {
-	t.Helper()
-	buf := &bytes.Buffer{}
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
-	return buf
-}
-
-func TestBuildProxyURLWithoutContextPath(t *testing.T) {
+func TestBuildMCPProxyURLUsesGatewayVhost(t *testing.T) {
 	gateway := &models.Gateway{
-		Vhost:      "https://dev-acme.gateway.example.com",
+		Vhost:      "https://gateway.example.com",
 		RuntimeURL: "http://runtime.acme-dev:22893",
 	}
-
-	require.Equal(t, "http://runtime.acme-dev:22893", buildProxyURL(gateway, nil, true))
+	ctxPath := "/github"
+	require.Equal(t, "https://gateway.example.com/github/mcp", buildMCPProxyURL(gateway, models.MCPProxyConfig{Context: &ctxPath}))
+	require.Equal(t, "https://gateway.example.com/mcp", buildMCPProxyURL(gateway, models.MCPProxyConfig{}))
 }
 
-func TestBuildMCPProxyURLUsesStoredRuntimeURLForInternal(t *testing.T) {
-	contextPath := "  /tools/  "
-	gateway := &models.Gateway{
-		Name:       "api-platform-acme-dev",
-		Vhost:      "https://dev-acme.gateway.example.com/",
-		RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
-	}
-
-	require.Equal(
-		t,
-		"http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/tools/mcp",
-		buildMCPProxyURL(gateway, &contextPath, true),
-	)
-	require.Equal(
-		t,
-		"https://dev-acme.gateway.example.com/tools/mcp",
-		buildMCPProxyURL(gateway, &contextPath, false),
-	)
+func TestBuildMCPProxyURLPrefersProxyVhostOverride(t *testing.T) {
+	// The deployment spec forwards the proxy's own vhost to the gateway, so the
+	// override — not the gateway default — is where the proxy is actually served.
+	gateway := &models.Gateway{Vhost: "https://gateway.example.com"}
+	vhost := "mcp.example.com"
+	ctxPath := "/github"
+	require.Equal(t, "https://mcp.example.com/github/mcp",
+		buildMCPProxyURL(gateway, models.MCPProxyConfig{Vhost: &vhost, Context: &ctxPath}))
+	full := "http://mcp.example.com"
+	require.Equal(t, "http://mcp.example.com/mcp",
+		buildMCPProxyURL(gateway, models.MCPProxyConfig{Vhost: &full}))
+	empty := "  "
+	require.Equal(t, "https://gateway.example.com/mcp",
+		buildMCPProxyURL(gateway, models.MCPProxyConfig{Vhost: &empty}))
 }
 
-func TestBuildMCPProxyURLFallsBackToVhostWhenRuntimeURLEmpty(t *testing.T) {
-	gateway := &models.Gateway{
-		Name:  "custom-gateway",
-		Vhost: "https://gateway.example.com/",
-	}
-
-	require.Equal(t, "https://gateway.example.com/mcp", buildMCPProxyURL(gateway, nil, true))
+func TestStripURLScheme(t *testing.T) {
+	require.Equal(t, "gw.example.com/github/mcp", stripURLScheme("https://gw.example.com/github/mcp"))
+	require.Equal(t, "gw.example.com/mcp", stripURLScheme("gw.example.com/mcp"))
 }

--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -61,6 +61,32 @@ func TestBuildMCPProxyURLPrefersProxyVhostOverride(t *testing.T) {
 		buildMCPProxyURL(gateway, models.MCPProxyConfig{Vhost: &empty}))
 }
 
+func TestBuildProxyURLDefaultsBareVhostToHTTPS(t *testing.T) {
+	// Gateways registered with a scheme-less vhost must still yield absolute URLs.
+	gateway := &models.Gateway{Vhost: "gw.example.com"}
+	contextPath := "/llm/proxy"
+	require.Equal(t, "https://gw.example.com/llm/proxy", buildProxyURL(gateway, &contextPath))
+	require.Equal(t, "https://gw.example.com", buildProxyURL(gateway, nil))
+}
+
+func TestBuildMCPProxyURLDefaultsBareGatewayVhostToHTTPS(t *testing.T) {
+	gateway := &models.Gateway{Vhost: "gw.example.com"}
+	ctxPath := "/github"
+	require.Equal(t, "https://gw.example.com/github/mcp", buildMCPProxyURL(gateway, models.MCPProxyConfig{Context: &ctxPath}))
+	require.Equal(t, "https://gw.example.com/mcp", buildMCPProxyURL(gateway, models.MCPProxyConfig{}))
+}
+
+func TestResourceIdentifierUnchangedByVhostScheme(t *testing.T) {
+	// The RS identifier (scheme-stripped proxy URL) must be identical whether the
+	// gateway registered a bare or an https:// vhost.
+	bare := &models.Gateway{Vhost: "gw.example.com"}
+	prefixed := &models.Gateway{Vhost: "https://gw.example.com"}
+	ctxPath := "/github"
+	cfg := models.MCPProxyConfig{Context: &ctxPath}
+	require.Equal(t, "gw.example.com/github/mcp", stripURLScheme(buildMCPProxyURL(bare, cfg)))
+	require.Equal(t, stripURLScheme(buildMCPProxyURL(prefixed, cfg)), stripURLScheme(buildMCPProxyURL(bare, cfg)))
+}
+
 func TestStripURLScheme(t *testing.T) {
 	require.Equal(t, "gw.example.com/github/mcp", stripURLScheme("https://gw.example.com/github/mcp"))
 	require.Equal(t, "gw.example.com/mcp", stripURLScheme("gw.example.com/mcp"))

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -325,29 +325,30 @@ func buildEmptyMCPEnvVars(templates []EnvConfigTemplate) []client.EnvVar {
 	return envVars
 }
 
-// mcpProxyServingBase is the public base the gateway actually serves the proxy
-// on: the proxy's own vhost override when set (the deployment spec forwards it),
-// else the gateway's vhost. Bare hosts default to https.
+// mcpProxyServingBase is the fully normalized public base the gateway actually
+// serves the proxy on: the proxy's own vhost override when set (the deployment
+// spec forwards it), else the gateway's vhost. Bare hosts default to https and
+// any trailing slash is dropped.
 func mcpProxyServingBase(gateway *models.Gateway, override *string) string {
+	base := gateway.Vhost
 	if override != nil {
 		if host := strings.TrimSpace(*override); host != "" {
-			return ensureURLScheme(host)
+			base = host
 		}
 	}
-	return ensureURLScheme(gateway.Vhost)
+	return strings.TrimRight(ensureURLScheme(strings.TrimSpace(base)), "/")
 }
 
 // buildMCPProxyURL constructs the MCP proxy URL from the serving base and the
 // proxy's optional context path, appending the "/mcp" route.
 func buildMCPProxyURL(gateway *models.Gateway, cfg models.MCPProxyConfig) string {
-	base := strings.TrimRight(strings.TrimSpace(mcpProxyServingBase(gateway, cfg.Vhost)), "/")
 	path := "/mcp"
 	if cfg.Context != nil {
 		if trimmed := strings.TrimSpace(*cfg.Context); trimmed != "" {
 			path = strings.TrimRight(trimmed, "/") + "/mcp"
 		}
 	}
-	return base + path
+	return mcpProxyServingBase(gateway, cfg.Vhost) + path
 }
 
 // stripURLScheme drops the leading scheme, yielding the resource-identifier form.

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -245,14 +245,24 @@ func (s *agentConfigurationService) ensureExternalAgentForAPIKey(ctx context.Con
 	return nil
 }
 
+// ensureURLScheme returns the host as an absolute URL, defaulting scheme-less
+// hosts to https. Gateways may be registered with bare vhosts.
+func ensureURLScheme(host string) string {
+	if strings.Contains(host, "://") {
+		return host
+	}
+	return "https://" + host
+}
+
 // buildProxyURL constructs the proxy base URL from the gateway's public vhost and
 // an optional context path. Every agent — sandboxed included — gets the public
 // URL so the address always matches the identity resource identifier.
 func buildProxyURL(gateway *models.Gateway, contextPath *string) string {
+	base := ensureURLScheme(gateway.Vhost)
 	if contextPath != nil {
-		return fmt.Sprintf("%s%s", gateway.Vhost, *contextPath)
+		return fmt.Sprintf("%s%s", base, *contextPath)
 	}
-	return gateway.Vhost
+	return base
 }
 
 // buildLLMEnvVars constructs the two env vars (URL and API key) from the env config templates.
@@ -317,17 +327,14 @@ func buildEmptyMCPEnvVars(templates []EnvConfigTemplate) []client.EnvVar {
 
 // mcpProxyServingBase is the public base the gateway actually serves the proxy
 // on: the proxy's own vhost override when set (the deployment spec forwards it),
-// else the gateway's vhost. A bare-host override defaults to https.
+// else the gateway's vhost. Bare hosts default to https.
 func mcpProxyServingBase(gateway *models.Gateway, override *string) string {
 	if override != nil {
 		if host := strings.TrimSpace(*override); host != "" {
-			if strings.Contains(host, "://") {
-				return host
-			}
-			return "https://" + host
+			return ensureURLScheme(host)
 		}
 	}
-	return gateway.Vhost
+	return ensureURLScheme(gateway.Vhost)
 }
 
 // buildMCPProxyURL constructs the MCP proxy URL from the serving base and the

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -3417,7 +3417,8 @@ func (s *agentConfigurationService) recordConfigUpdate(ctx context.Context, conf
 	// A real audit record. This previously wrote only an slog line labelled as
 	// an audit log: it carried no actor, no outcome and no durability, so it
 	// could not answer who changed the configuration.
-	audit.Record(ctx, audit.ActionAgentConfigUpdate,
+	audit.Record(
+		ctx, audit.ActionAgentConfigUpdate,
 		audit.Org(ouID),
 		audit.ResourceNamed("agent-config", configUUID.String(), configName),
 		audit.Project(projectName),
@@ -3702,7 +3703,8 @@ func (s *agentConfigurationService) deleteLLMConfig(ctx context.Context, existin
 		return err
 	}
 
-	audit.Record(ctx, audit.ActionAgentConfigDelete,
+	audit.Record(
+		ctx, audit.ActionAgentConfigDelete,
 		audit.Org(ouID),
 		audit.ResourceNamed("agent-config", configUUID.String(), existingConfig.Name),
 		audit.Project(projectName),

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -245,33 +245,13 @@ func (s *agentConfigurationService) ensureExternalAgentForAPIKey(ctx context.Con
 	return nil
 }
 
-// buildProxyURL constructs the proxy base URL from a gateway and an optional context path.
-// Internal (platform-hosted, sandboxed) agents get the gateway's stored in-cluster runtime
-// address, which cluster DNS resolves and the sandbox NetworkPolicy egress allows; external
-// agents get the vhost, which a sandboxed pod cannot route to.
-func buildProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool) string {
-	base := internalBaseOrVhost(gateway, isInternal)
+// buildProxyURL constructs the proxy base URL from the gateway's public vhost and
+// an optional context path. Every agent — sandboxed included — gets the public
+// URL so the address always matches the identity resource identifier.
+func buildProxyURL(gateway *models.Gateway, contextPath *string) string {
 	if contextPath != nil {
-		return fmt.Sprintf("%s%s", base, *contextPath)
+		return fmt.Sprintf("%s%s", gateway.Vhost, *contextPath)
 	}
-	return base
-}
-
-// internalBaseOrVhost picks the stored runtime address for internal consumers and the vhost
-// otherwise. An internal consumer with no stored address logs at ERROR: falling back to the
-// vhost is correct for external agents but an unreachable address for a sandboxed pod, and
-// naming that condition is what replaces the deleted name-based derivation as a diagnostic.
-func internalBaseOrVhost(gateway *models.Gateway, isInternal bool) string {
-	if !isInternal {
-		return gateway.Vhost
-	}
-	if runtimeURL := strings.TrimSpace(gateway.RuntimeURL); runtimeURL != "" {
-		return runtimeURL
-	}
-	slog.Error("gateway has no registered runtimeUrl; falling back to the externally-reachable "+
-		"vhost, which sandboxed agents cannot route to. Upgrade the gateway extension chart so "+
-		"registration supplies runtimeUrl",
-		"gatewayName", gateway.Name, "gatewayID", gateway.UUID, "vhost", gateway.Vhost)
 	return gateway.Vhost
 }
 
@@ -335,17 +315,40 @@ func buildEmptyMCPEnvVars(templates []EnvConfigTemplate) []client.EnvVar {
 	return envVars
 }
 
-// buildMCPProxyURL constructs the MCP proxy URL from a gateway and the proxy's optional
-// context path, appending the "/mcp" route. Same internal/external split as buildProxyURL.
-func buildMCPProxyURL(gateway *models.Gateway, contextPath *string, isInternal bool) string {
-	base := strings.TrimRight(strings.TrimSpace(internalBaseOrVhost(gateway, isInternal)), "/")
+// mcpProxyServingBase is the public base the gateway actually serves the proxy
+// on: the proxy's own vhost override when set (the deployment spec forwards it),
+// else the gateway's vhost. A bare-host override defaults to https.
+func mcpProxyServingBase(gateway *models.Gateway, override *string) string {
+	if override != nil {
+		if host := strings.TrimSpace(*override); host != "" {
+			if strings.Contains(host, "://") {
+				return host
+			}
+			return "https://" + host
+		}
+	}
+	return gateway.Vhost
+}
+
+// buildMCPProxyURL constructs the MCP proxy URL from the serving base and the
+// proxy's optional context path, appending the "/mcp" route.
+func buildMCPProxyURL(gateway *models.Gateway, cfg models.MCPProxyConfig) string {
+	base := strings.TrimRight(strings.TrimSpace(mcpProxyServingBase(gateway, cfg.Vhost)), "/")
 	path := "/mcp"
-	if contextPath != nil {
-		if trimmedContextPath := strings.TrimSpace(*contextPath); trimmedContextPath != "" {
-			path = strings.TrimRight(trimmedContextPath, "/") + "/mcp"
+	if cfg.Context != nil {
+		if trimmed := strings.TrimSpace(*cfg.Context); trimmed != "" {
+			path = strings.TrimRight(trimmed, "/") + "/mcp"
 		}
 	}
 	return base + path
+}
+
+// stripURLScheme drops the leading scheme, yielding the resource-identifier form.
+func stripURLScheme(u string) string {
+	if i := strings.Index(u, "://"); i >= 0 {
+		return u[i+3:]
+	}
+	return u
 }
 
 // mcpProxyAPIKeySecurityEnabled reports whether the source MCP proxy requires API
@@ -1122,7 +1125,7 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		if proxy != nil {
 			proxyContext = proxy.Configuration.Context
 		}
-		proxyURL := buildProxyURL(gateway, proxyContext, !isExternalAgent)
+		proxyURL := buildProxyURL(gateway, proxyContext)
 
 		// Capture credentials for external agents.
 		if isExternalAgent {
@@ -1451,7 +1454,7 @@ func (s *agentConfigurationService) createMCPConfig(ctx context.Context, ouID, p
 			return nil, fmt.Errorf("failed to create MCP environment variables for %s: %w", envName, err)
 		}
 
-		proxyURL := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, !isExternalAgent)
+		proxyURL := buildMCPProxyURL(gateway, deployedProxy.Configuration)
 		if isExternalAgent {
 			apiKey := ""
 			if proxyAPIKey != nil {
@@ -1796,7 +1799,7 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	// Internal-agent only: inject env vars into Component/ReleaseBinding.
 	// SecretReference is already created/updated by secretClient.CreateSecret above.
 	if !isExternalAgent {
-		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context, true)
+		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context)
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		if uvErr := s.ocClient.UpdateComponentEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envVarsToInject); uvErr != nil {
 			s.logger.Error("failed to update Component CR env vars in Scenario A — Component CR in inconsistent state", "env", envName, "err", uvErr)
@@ -2052,7 +2055,7 @@ func (s *agentConfigurationService) processNewEnv(
 	// last-write-wins clobbering across multiple environments (HIGH-3).
 	if !isExternalAgent {
 		// Reuse the gateway already resolved for deployment (resolveGatewayForProvider)
-		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context, true)
+		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context)
 
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		// Inject per-env URL into the ReleaseBinding for this specific environment.
@@ -2606,7 +2609,7 @@ func (s *agentConfigurationService) updateMCPConfigEnvironmentVariableNames(
 			s.logger.Warn("failed to load MCP SecretReference for env var rename", "environment", envName, "err", refErr)
 			continue
 		}
-		envVarsToInject := buildMCPEnvVars(newTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
+		envVarsToInject := buildMCPEnvVars(newTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration), secretRefName)
 		if err := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); err != nil {
 			s.logger.Warn("failed to replace MCP env vars in ReleaseBinding", "environment", envName, "err", err)
 		}
@@ -2716,7 +2719,7 @@ func (s *agentConfigurationService) injectMCPMappingEnvVars(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	envVarsToInject := buildMCPEnvVars(envTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
+	envVarsToInject := buildMCPEnvVars(envTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration), secretRefName)
 	if err := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); err != nil {
 		return err
 	}
@@ -3132,7 +3135,7 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to load MCP SecretReference for re-injection", "environment", envName, "err", refErr)
 								continue
 							}
-							envVarsToInject := buildMCPEnvVars(newEnvConfigTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), secretRefName)
+							envVarsToInject := buildMCPEnvVars(newEnvConfigTemplates, buildMCPProxyURL(gateway, deployedProxy.Configuration), secretRefName)
 							s.logger.Info("Phase 1b: atomically replacing MCP env vars in ReleaseBinding",
 								"environment", envName, "keysToRemove", changedOldKeys, "envVarsToAdd", len(envVarsToInject))
 							if rbErr := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); rbErr != nil {
@@ -3161,7 +3164,7 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to resolve gateway for re-injection", "environment", envName, "err", gwErr)
 								continue
 							}
-							proxyURL := buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context, true)
+							proxyURL := buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
 							// Use persisted SecretReference from DB rather than deriving from mutable config name.
 							envVars1b, varErr1b := s.envVariableRepo.ListByConfigAndEnv(ctx, existingConfig.UUID, mapping.EnvironmentUUID)
 							secretRefName := ""
@@ -5044,7 +5047,7 @@ func (s *agentConfigurationService) buildConfigResponse(ctx context.Context, con
 				deployedProxy := buildAgentMCPConfigProxy(config, &mapping, mapping.MCPProxy, envName, config.OUID,
 					mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, envName))
 				// User-facing invoke URL in the config response: externally-reachable vhost.
-				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false)
+				url := buildMCPProxyURL(gateway, deployedProxy.Configuration)
 				proxyInfo.URL = &url
 			}
 		}
@@ -5199,7 +5202,7 @@ func (s *agentConfigurationService) buildExternalAgentConfigResponse(
 				deployedProxy := buildAgentMCPConfigProxy(reloadedConfig, &mapping, mapping.MCPProxy, envName, config.OUID,
 					mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, envName))
 				// External agent's invoke URL: externally-reachable vhost.
-				url := buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, false)
+				url := buildMCPProxyURL(gateway, deployedProxy.Configuration)
 				proxyInfo.URL = &url
 			} else {
 				s.logger.Warn(
@@ -5418,7 +5421,7 @@ func (s *agentConfigurationService) systemManagedLLMURL(
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for LLM proxy in %s: %w", environmentName, err)
 	}
-	return buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context, true), nil
+	return buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context), nil
 }
 
 func (s *agentConfigurationService) systemManagedMCPURL(
@@ -5446,7 +5449,7 @@ func (s *agentConfigurationService) systemManagedMCPURL(
 		}
 		handle := mcpMappingProxyName(config.ProjectName, config.AgentID, config.Name, environmentName)
 		deployedProxy := buildAgentMCPConfigProxy(config, mapping, mapping.MCPProxy, environmentName, ouID, handle)
-		return buildMCPProxyURL(gateway, deployedProxy.Configuration.Context, true), nil
+		return buildMCPProxyURL(gateway, deployedProxy.Configuration), nil
 	}
 	return "", nil
 }

--- a/agent-manager-service/services/agent_identity_injection_service.go
+++ b/agent-manager-service/services/agent_identity_injection_service.go
@@ -454,9 +454,8 @@ func (s *agentIdentityInjectionService) deleteSecretReference(ctx context.Contex
 }
 
 // buildEnvVars assembles the four identity env vars for one binding. The
-// token endpoint uses the cluster-internal env-Thunder URL — pods run inside
-// the cluster, matching the convention that internal agents reach platform
-// services via in-cluster addresses (see buildProxyURL).
+// token endpoint uses the cluster-internal env-Thunder URL: env-Thunder is not
+// published on the gateway vhost, so pods reach it by in-cluster address.
 //
 // The URL is built from ThunderOrgNamespace(), NOT binding.OUID: env-Thunder
 // is addressed by the org's namespace/handle (e.g. "default"), and binding.OUID

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -2403,7 +2403,8 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 
 	// Deletion is irreversible and cascades into configs, identities and
 	// monitors, so it is refused when it cannot be recorded.
-	deleteAttempt, auditErr := audit.Begin(ctx, audit.ActionAgentDelete,
+	deleteAttempt, auditErr := audit.Begin(
+		ctx, audit.ActionAgentDelete,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgent, agentName, agentName),
 		audit.Project(projectName),
@@ -2581,7 +2582,8 @@ func (s *agentManagerService) BuildAgent(ctx context.Context, ouID string, proje
 	// Builds are frequent and produce no credential, so this is recorded after
 	// the fact rather than refusing the build when the trail is unavailable.
 	build, err := s.ocClient.TriggerBuild(ctx, ouID, projectName, agentName, commitId)
-	audit.Record(ctx, audit.ActionAgentBuild,
+	audit.Record(
+		ctx, audit.ActionAgentBuild,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgent, agent.UUID, agentName),
 		audit.Project(projectName),
@@ -2913,7 +2915,8 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	// the pipeline's lowest environment actually is, so the record has to carry
 	// the real target and whether it is production. Without that the trail
 	// cannot distinguish a sandbox push from a production one.
-	deployAttempt, auditErr := audit.Begin(ctx, audit.ActionAgentDeploy,
+	deployAttempt, auditErr := audit.Begin(
+		ctx, audit.ActionAgentDeploy,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgent, agent.UUID, agentName),
 		audit.Project(projectName),
@@ -3919,7 +3922,8 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 	// to OpenChoreo just to enrich a record would put a network call on the
 	// promotion path. The environment name identifies the target, and the org's
 	// environment list resolves whether it is production.
-	promoteAttempt, auditErr := audit.Begin(ctx, audit.ActionAgentPromote,
+	promoteAttempt, auditErr := audit.Begin(
+		ctx, audit.ActionAgentPromote,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceAgent, agent.UUID, agentName),
 		audit.Project(projectName),

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -755,7 +755,8 @@ func (s *agentThunderProvisioningService) AttemptProvision(ctx context.Context, 
 	// A credential issued with no request behind it: the actor is this service,
 	// and the user who originally asked for the agent is carried as OnBehalfOf.
 	// That attribution is exactly what requested_by was captured for.
-	audit.Record(ctx, audit.ActionSystemAgentIdentityProvisioned,
+	audit.Record(
+		ctx, audit.ActionSystemAgentIdentityProvisioned,
 		audit.Org(binding.OUID),
 		audit.ResourceNamed(audit.ResourceAgentIdentity, binding.AgentName, binding.AgentName),
 		audit.Project(binding.ProjectName),
@@ -806,7 +807,8 @@ func (s *agentThunderProvisioningService) recordFailure(ctx context.Context, bin
 		update.Status = models.AgentThunderStatusFailed
 		// The agent will not get an identity without operator action, so this
 		// is recorded rather than left as one more retry log line.
-		audit.Record(ctx, audit.ActionSystemAgentIdentityExhausted,
+		audit.Record(
+			ctx, audit.ActionSystemAgentIdentityExhausted,
 			audit.Org(binding.OUID),
 			audit.ResourceNamed(audit.ResourceAgentIdentity, binding.AgentName, binding.AgentName),
 			audit.Project(binding.ProjectName),

--- a/agent-manager-service/services/agent_token_manager.go
+++ b/agent-manager-service/services/agent_token_manager.go
@@ -361,7 +361,8 @@ func (s *agentTokenManagerService) GenerateToken(ctx context.Context, req Genera
 	// no credential in circulation, which makes this genuinely fail-closed
 	// rather than merely best-effort. The signed token is never passed to the
 	// recorder; the jti identifies it.
-	if err := audit.RecordSync(ctx, audit.ActionAgentTokenMint,
+	if err := audit.RecordSync(
+		ctx, audit.ActionAgentTokenMint,
 		audit.Org(req.OrgId),
 		audit.ResourceNamed(audit.ResourceAgent, component.UUID, req.AgentName),
 		audit.Project(req.ProjectName),

--- a/agent-manager-service/services/gateway_anchoring_unit_test.go
+++ b/agent-manager-service/services/gateway_anchoring_unit_test.go
@@ -186,9 +186,9 @@ func TestAnchoring_MonitorRunAgainstDeployedProxy(t *testing.T) {
 		}
 		url, err := exec.resolveProxyURL(context.Background(), "org", env.String(), proxy)
 		require.NoError(t, err)
-		// The monitor runs in-cluster, so the stored internal address is the correct base —
-		// asserting it rules out the vhost fallback as well as the wrong gateway.
-		require.Equal(t, both.RuntimeURL, url)
+		// Vhosts are per-gateway in the fixture, so asserting this one rules out the
+		// other gateway; every proxy URL is the public address now.
+		require.Equal(t, both.Vhost, url)
 	})
 
 	t.Run("ambiguity fires only with no deployment", func(t *testing.T) {

--- a/agent-manager-service/services/gateway_anchoring_unit_test.go
+++ b/agent-manager-service/services/gateway_anchoring_unit_test.go
@@ -187,8 +187,9 @@ func TestAnchoring_MonitorRunAgainstDeployedProxy(t *testing.T) {
 		url, err := exec.resolveProxyURL(context.Background(), "org", env.String(), proxy)
 		require.NoError(t, err)
 		// Vhosts are per-gateway in the fixture, so asserting this one rules out the
-		// other gateway; every proxy URL is the public address now.
-		require.Equal(t, both.Vhost, url)
+		// other gateway; every proxy URL is the public address now, and the bare
+		// fixture vhost gets the default https scheme.
+		require.Equal(t, "https://"+both.Vhost, url)
 	})
 
 	t.Run("ambiguity fires only with no deployment", func(t *testing.T) {

--- a/agent-manager-service/services/git_secret_service.go
+++ b/agent-manager-service/services/git_secret_service.go
@@ -76,7 +76,8 @@ func (s *GitSecretService) Create(ctx context.Context, ouID string, req *spec.Cr
 	// the operation if that fails: a credential written with no trace of who
 	// wrote it is worse than a failed request. Only the name, type and username
 	// are recorded — the password never leaves this function.
-	attempt, err := audit.Begin(ctx, audit.ActionGitSecretCreate,
+	attempt, err := audit.Begin(
+		ctx, audit.ActionGitSecretCreate,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceGitSecret, req.Name, req.Name),
 		audit.Detail("secretType", string(secretType)),
@@ -150,7 +151,8 @@ func (s *GitSecretService) Delete(ctx context.Context, ouID, secretName string) 
 		return utils.ErrInvalidInput
 	}
 
-	attempt, err := audit.Begin(ctx, audit.ActionGitSecretDelete,
+	attempt, err := audit.Begin(
+		ctx, audit.ActionGitSecretDelete,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceGitSecret, secretName, secretName),
 	)

--- a/agent-manager-service/services/infra_resource_manager.go
+++ b/agent-manager-service/services/infra_resource_manager.go
@@ -235,7 +235,8 @@ func (s *infraResourceManager) DeleteProject(ctx context.Context, ouID string, p
 	s.logger.Debug("No associated agents found, proceeding with deletion", "projectName", projectName)
 
 	// Delete project from OpenChoreo
-	deleteAttempt, auditErr := audit.Begin(ctx, audit.ActionProjectDelete,
+	deleteAttempt, auditErr := audit.Begin(
+		ctx, audit.ActionProjectDelete,
 		audit.Org(ouID),
 		audit.ResourceNamed("project", projectName, projectName),
 		audit.Project(projectName),

--- a/agent-manager-service/services/llm_proxy_provisioner.go
+++ b/agent-manager-service/services/llm_proxy_provisioner.go
@@ -286,7 +286,7 @@ func (p *LLMProxyProvisioner) ProvisionProxy(ctx context.Context, params Provisi
 		rb.ProxySecretLoc = &proxySecretLoc
 	}
 
-	proxyURL := buildProxyURL(params.Gateway, proxy.Configuration.Context, true)
+	proxyURL := buildProxyURL(params.Gateway, proxy.Configuration.Context)
 
 	p.logger.Info(
 		"Provisioned LLM proxy",

--- a/agent-manager-service/services/mcp_proxy_scope_service.go
+++ b/agent-manager-service/services/mcp_proxy_scope_service.go
@@ -370,26 +370,9 @@ func (s *mcpProxyScopeService) List(ctx context.Context, ouID, proxyHandle strin
 }
 
 func (s *mcpProxyScopeService) ListEnvironmentScopes(ctx context.Context, ouID, envName string) ([]models.EnvironmentScopeEntry, error) {
-	envs, err := s.infraManager.ListOrgEnvironments(ctx, ouID)
+	envUUID, err := environmentUUIDByName(ctx, s.infraManager, ouID, envName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list org environments: %w", err)
-	}
-
-	var envUUID uuid.UUID
-	found := false
-	for _, env := range envs {
-		if env.Name == envName {
-			parsed, err := uuid.Parse(env.UUID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse environment UUID %q: %w", env.UUID, err)
-			}
-			envUUID = parsed
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("%w: %s", utils.ErrEnvironmentNotFound, envName)
+		return nil, err
 	}
 
 	const pageSize = 100

--- a/agent-manager-service/services/mcp_rs_identifier.go
+++ b/agent-manager-service/services/mcp_rs_identifier.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+)
+
+// ErrMCPProxyNotDeployedToEnvironment means the proxy has no deployed
+// (endpoint, environment) binding to anchor a resource identifier on.
+var ErrMCPProxyNotDeployedToEnvironment = errors.New("MCP proxy is not deployed to this environment")
+
+// MCPResourceServerIdentifier derives the protocol-stripped public URI the proxy
+// is invoked at in the named environment — the value the env-Thunder resource
+// server's identifier must carry.
+func (s *MCPProxyService) MCPResourceServerIdentifier(ctx context.Context, ouID, envName string, proxy *models.MCPProxy) (string, error) {
+	envs, err := s.infraManager.ListOrgEnvironments(ctx, ouID)
+	if err != nil {
+		return "", fmt.Errorf("failed to list environments: %w", err)
+	}
+	envID := ""
+	for _, env := range envs {
+		if env.Name == envName {
+			envID = env.UUID
+			break
+		}
+	}
+	if envID == "" {
+		return "", fmt.Errorf("environment %q not found", envName)
+	}
+
+	_, ee := resolveMCPEndpointForEnv(proxy, envID)
+	if ee == nil || ee.ArtifactUUID == uuid.Nil {
+		return "", fmt.Errorf("%w: proxy %q, environment %q", ErrMCPProxyNotDeployedToEnvironment, proxyHandleOf(proxy), envName)
+	}
+
+	deployed, err := s.deploymentRepo.GetDeployedGatewaysByProvider(ee.ArtifactUUID, ouID)
+	if err != nil {
+		return "", fmt.Errorf("failed to list deployed gateways for MCP artifact %s: %w", ee.ArtifactUUID, err)
+	}
+	envUUID, err := uuid.Parse(envID)
+	if err != nil {
+		return "", fmt.Errorf("invalid environment UUID %q: %w", envID, err)
+	}
+	gateway, err := resolveEgressGatewayForArtifact(s.gatewayRepo, ouID, envUUID, deployed, nil)
+	if err != nil {
+		if errors.Is(err, errNoGatewayForEnvironment) || errors.Is(err, errNoEgressGatewayForEnvironment) {
+			return "", fmt.Errorf("%w: proxy %q, environment %q", ErrMCPProxyNotDeployedToEnvironment, proxyHandleOf(proxy), envName)
+		}
+		return "", err
+	}
+
+	return stripURLScheme(buildMCPProxyURL(gateway, proxy.Configuration)), nil
+}

--- a/agent-manager-service/services/mcp_rs_identifier.go
+++ b/agent-manager-service/services/mcp_rs_identifier.go
@@ -24,48 +24,58 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // ErrMCPProxyNotDeployedToEnvironment means the proxy has no deployed
 // (endpoint, environment) binding to anchor a resource identifier on.
 var ErrMCPProxyNotDeployedToEnvironment = errors.New("MCP proxy is not deployed to this environment")
 
-// MCPResourceServerIdentifier derives the protocol-stripped public URI the proxy
-// is invoked at in the named environment — the value the env-Thunder resource
-// server's identifier must carry.
-func (s *MCPProxyService) MCPResourceServerIdentifier(ctx context.Context, ouID, envName string, proxy *models.MCPProxy) (string, error) {
-	envs, err := s.infraManager.ListOrgEnvironments(ctx, ouID)
+// environmentUUIDByName resolves an environment's UUID from its name, wrapping
+// a missing environment in utils.ErrEnvironmentNotFound.
+func environmentUUIDByName(ctx context.Context, infra InfraResourceManager, ouID, envName string) (uuid.UUID, error) {
+	envs, err := infra.ListOrgEnvironments(ctx, ouID)
 	if err != nil {
-		return "", fmt.Errorf("failed to list environments: %w", err)
+		return uuid.Nil, fmt.Errorf("failed to list org environments: %w", err)
 	}
-	envID := ""
 	for _, env := range envs {
-		if env.Name == envName {
-			envID = env.UUID
-			break
+		if env.Name != envName {
+			continue
 		}
+		envUUID, err := uuid.Parse(env.UUID)
+		if err != nil {
+			return uuid.Nil, fmt.Errorf("failed to parse environment UUID %q: %w", env.UUID, err)
+		}
+		return envUUID, nil
 	}
-	if envID == "" {
-		return "", fmt.Errorf("environment %q not found", envName)
-	}
+	return uuid.Nil, fmt.Errorf("%w: %s", utils.ErrEnvironmentNotFound, envName)
+}
 
-	_, ee := resolveMCPEndpointForEnv(proxy, envID)
+// EnvironmentUUIDByName resolves the named environment's UUID for the org.
+// Callers deriving identifiers for several proxies in one environment resolve
+// once and pass the UUID to each MCPResourceServerIdentifier call.
+func (s *MCPProxyService) EnvironmentUUIDByName(ctx context.Context, ouID, envName string) (uuid.UUID, error) {
+	return environmentUUIDByName(ctx, s.infraManager, ouID, envName)
+}
+
+// MCPResourceServerIdentifier derives the protocol-stripped public URI the proxy
+// is invoked at in the given environment — the value the env-Thunder resource
+// server's identifier must carry.
+func (s *MCPProxyService) MCPResourceServerIdentifier(ctx context.Context, ouID string, envID uuid.UUID, proxy *models.MCPProxy) (string, error) {
+	_ = ctx
+	_, ee := resolveMCPEndpointForEnv(proxy, envID.String())
 	if ee == nil || ee.ArtifactUUID == uuid.Nil {
-		return "", fmt.Errorf("%w: proxy %q, environment %q", ErrMCPProxyNotDeployedToEnvironment, proxyHandleOf(proxy), envName)
+		return "", fmt.Errorf("%w: proxy %q, environment %s", ErrMCPProxyNotDeployedToEnvironment, proxyHandleOf(proxy), envID)
 	}
 
 	deployed, err := s.deploymentRepo.GetDeployedGatewaysByProvider(ee.ArtifactUUID, ouID)
 	if err != nil {
 		return "", fmt.Errorf("failed to list deployed gateways for MCP artifact %s: %w", ee.ArtifactUUID, err)
 	}
-	envUUID, err := uuid.Parse(envID)
-	if err != nil {
-		return "", fmt.Errorf("invalid environment UUID %q: %w", envID, err)
-	}
-	gateway, err := resolveEgressGatewayForArtifact(s.gatewayRepo, ouID, envUUID, deployed, nil)
+	gateway, err := resolveEgressGatewayForArtifact(s.gatewayRepo, ouID, envID, deployed, nil)
 	if err != nil {
 		if errors.Is(err, errNoGatewayForEnvironment) || errors.Is(err, errNoEgressGatewayForEnvironment) {
-			return "", fmt.Errorf("%w: proxy %q, environment %q", ErrMCPProxyNotDeployedToEnvironment, proxyHandleOf(proxy), envName)
+			return "", fmt.Errorf("%w: proxy %q, environment %s", ErrMCPProxyNotDeployedToEnvironment, proxyHandleOf(proxy), envID)
 		}
 		return "", err
 	}

--- a/agent-manager-service/services/mcp_rs_identifier_unit_test.go
+++ b/agent-manager-service/services/mcp_rs_identifier_unit_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 func TestMCPResourceServerIdentifier_DerivesPublicURI(t *testing.T) {
@@ -64,7 +65,11 @@ func TestMCPResourceServerIdentifier_DerivesPublicURI(t *testing.T) {
 		logger: discardLogger(),
 	}
 
-	id, err := svc.MCPResourceServerIdentifier(context.Background(), "ou-1", "dev", proxy)
+	envID, err := svc.EnvironmentUUIDByName(context.Background(), "ou-1", "dev")
+	require.NoError(t, err)
+	require.Equal(t, envUUID, envID)
+
+	id, err := svc.MCPResourceServerIdentifier(context.Background(), "ou-1", envID, proxy)
 
 	require.NoError(t, err)
 	require.Equal(t, "gw.example.com/github/mcp", id)
@@ -72,6 +77,14 @@ func TestMCPResourceServerIdentifier_DerivesPublicURI(t *testing.T) {
 
 func TestMCPResourceServerIdentifier_NotDeployedToEnvironment(t *testing.T) {
 	proxy := &models.MCPProxy{UUID: uuid.New(), Handle: "gh-proxy"}
+	svc := &MCPProxyService{logger: discardLogger()}
+
+	_, err := svc.MCPResourceServerIdentifier(context.Background(), "ou-1", uuid.New(), proxy)
+
+	require.ErrorIs(t, err, ErrMCPProxyNotDeployedToEnvironment)
+}
+
+func TestEnvironmentUUIDByName_NotFound(t *testing.T) {
 	svc := &MCPProxyService{
 		infraManager: stubInfraManager{listOrgEnvs: func(_ context.Context, _ string) ([]*models.EnvironmentResponse, error) {
 			return []*models.EnvironmentResponse{{Name: "dev", UUID: uuid.NewString()}}, nil
@@ -79,7 +92,7 @@ func TestMCPResourceServerIdentifier_NotDeployedToEnvironment(t *testing.T) {
 		logger: discardLogger(),
 	}
 
-	_, err := svc.MCPResourceServerIdentifier(context.Background(), "ou-1", "dev", proxy)
+	_, err := svc.EnvironmentUUIDByName(context.Background(), "ou-1", "prod")
 
-	require.ErrorIs(t, err, ErrMCPProxyNotDeployedToEnvironment)
+	require.ErrorIs(t, err, utils.ErrEnvironmentNotFound)
 }

--- a/agent-manager-service/services/mcp_rs_identifier_unit_test.go
+++ b/agent-manager-service/services/mcp_rs_identifier_unit_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+)
+
+func TestMCPResourceServerIdentifier_DerivesPublicURI(t *testing.T) {
+	envUUID := uuid.New()
+	gwUUID := uuid.New()
+	artifactUUID := uuid.New()
+	ctxPath := "/github"
+	proxy := &models.MCPProxy{
+		UUID:          uuid.New(),
+		Handle:        "gh-proxy",
+		Configuration: models.MCPProxyConfig{Context: &ctxPath},
+		Endpoints: []models.MCPProxyEndpoint{{
+			Environments: []models.MCPProxyEndpointEnvironment{{
+				EnvironmentUUID: envUUID,
+				ArtifactUUID:    artifactUUID,
+			}},
+		}},
+	}
+	svc := &MCPProxyService{
+		infraManager: stubInfraManager{listOrgEnvs: func(_ context.Context, _ string) ([]*models.EnvironmentResponse, error) {
+			return []*models.EnvironmentResponse{{Name: "dev", UUID: envUUID.String()}}, nil
+		}},
+		deploymentRepo: &repomocks.DeploymentRepositoryMock{
+			GetDeployedGatewaysByProviderFunc: func(providerUUID uuid.UUID, _ string) ([]string, error) {
+				require.Equal(t, artifactUUID, providerUUID)
+				return []string{gwUUID.String()}, nil
+			},
+		},
+		gatewayRepo: &repomocks.GatewayRepositoryMock{
+			EnvironmentMappingExistsFunc: func(gatewayID, environmentID string) (bool, error) {
+				return gatewayID == gwUUID.String() && environmentID == envUUID.String(), nil
+			},
+			GetByUUIDFunc: func(_ string) (*models.Gateway, error) {
+				return &models.Gateway{UUID: gwUUID, Vhost: "https://gw.example.com"}, nil
+			},
+		},
+		logger: discardLogger(),
+	}
+
+	id, err := svc.MCPResourceServerIdentifier(context.Background(), "ou-1", "dev", proxy)
+
+	require.NoError(t, err)
+	require.Equal(t, "gw.example.com/github/mcp", id)
+}
+
+func TestMCPResourceServerIdentifier_NotDeployedToEnvironment(t *testing.T) {
+	proxy := &models.MCPProxy{UUID: uuid.New(), Handle: "gh-proxy"}
+	svc := &MCPProxyService{
+		infraManager: stubInfraManager{listOrgEnvs: func(_ context.Context, _ string) ([]*models.EnvironmentResponse, error) {
+			return []*models.EnvironmentResponse{{Name: "dev", UUID: uuid.NewString()}}, nil
+		}},
+		logger: discardLogger(),
+	}
+
+	_, err := svc.MCPResourceServerIdentifier(context.Background(), "ou-1", "dev", proxy)
+
+	require.ErrorIs(t, err, ErrMCPProxyNotDeployedToEnvironment)
+}

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -268,7 +268,7 @@ func (e *monitorExecutor) resolveProxyURL(ctx context.Context, ouID, environment
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for environment %s: %w", environmentID, err)
 	}
-	return buildProxyURL(gateway, proxy.Configuration.Context, true), nil
+	return buildProxyURL(gateway, proxy.Configuration.Context), nil
 }
 
 // buildWorkflowRunRequest constructs the workflow run request for a monitor.

--- a/agent-manager-service/services/monitor_manager.go
+++ b/agent-manager-service/services/monitor_manager.go
@@ -338,7 +338,8 @@ func (s *monitorManagerService) CreateMonitor(ctx context.Context, ouID string, 
 		}
 	}
 
-	audit.Record(ctx, audit.ActionMonitorCreate,
+	audit.Record(
+		ctx, audit.ActionMonitorCreate,
 		audit.Org(ouID),
 		audit.ResourceNamed("monitor", monitor.ID.String(), req.Name),
 		audit.Project(req.ProjectName),
@@ -711,7 +712,8 @@ func (s *monitorManagerService) UpdateMonitor(ctx context.Context, ouID, project
 
 	s.logger.Info("Monitor updated successfully", "name", monitorName)
 
-	audit.Record(ctx, audit.ActionMonitorUpdate,
+	audit.Record(
+		ctx, audit.ActionMonitorUpdate,
 		audit.Org(ouID),
 		audit.ResourceNamed("monitor", monitor.ID.String(), monitorName),
 		audit.Project(projectName),
@@ -787,7 +789,8 @@ func (s *monitorManagerService) DeleteMonitor(ctx context.Context, ouID, project
 		}
 	}
 
-	audit.Record(ctx, audit.ActionMonitorDelete,
+	audit.Record(
+		ctx, audit.ActionMonitorDelete,
 		audit.Org(ouID),
 		audit.ResourceNamed("monitor", monitor.ID.String(), monitorName),
 		audit.Project(projectName),
@@ -861,7 +864,8 @@ func (s *monitorManagerService) StopMonitor(ctx context.Context, ouID, projectNa
 	latestRun := s.getLatestRun(monitor.ID)
 	status := s.getMonitorStatus(monitor.ID, monitor.Type, monitor.NextRunTime)
 
-	audit.Record(ctx, audit.ActionMonitorStop,
+	audit.Record(
+		ctx, audit.ActionMonitorStop,
 		audit.Org(ouID),
 		audit.ResourceNamed("monitor", monitor.ID.String(), monitorName),
 		audit.Project(projectName),
@@ -916,7 +920,8 @@ func (s *monitorManagerService) StartMonitor(ctx context.Context, ouID, projectN
 	latestRun := s.getLatestRun(monitor.ID)
 	status := s.getMonitorStatus(monitor.ID, monitor.Type, monitor.NextRunTime)
 
-	audit.Record(ctx, audit.ActionMonitorStart,
+	audit.Record(
+		ctx, audit.ActionMonitorStart,
 		audit.Org(ouID),
 		audit.ResourceNamed("monitor", monitor.ID.String(), monitorName),
 		audit.Project(projectName),
@@ -1048,7 +1053,8 @@ func (s *monitorManagerService) RerunMonitor(ctx context.Context, ouID, projectN
 		return nil, err
 	}
 
-	audit.Record(ctx, audit.ActionMonitorRerun,
+	audit.Record(
+		ctx, audit.ActionMonitorRerun,
 		audit.Org(ouID),
 		audit.ResourceNamed("monitor", monitor.ID.String(), monitorName),
 		audit.Project(projectName),

--- a/agent-manager-service/services/monitor_scheduler.go
+++ b/agent-manager-service/services/monitor_scheduler.go
@@ -198,7 +198,8 @@ func (s *monitorSchedulerService) triggerMonitor(ctx context.Context, monitor *m
 		// A scheduled run that never started. Recorded with a system actor
 		// because no user asked for this one — successful runs are not
 		// recorded, since their scores are the record.
-		audit.Record(ctx, audit.ActionMonitorRunFail,
+		audit.Record(
+			ctx, audit.ActionMonitorRunFail,
 			audit.Org(monitor.OUID),
 			audit.ResourceNamed("monitor", monitor.ID.String(), monitor.Name),
 			audit.Actor(audit.ActorSystem, systemActorMonitorScheduler, ""),

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -96,6 +96,8 @@ var serviceProviderSet = wire.NewSet(
 	// MCPProxyScopeService only needs the narrow redeploy surface; bind it to
 	// the concrete service so scope mutations can re-emit gateway policies.
 	wire.Bind(new(services.MCPProxyRedeployer), new(*services.MCPProxyService)),
+	// The agent-identity controller needs only the identifier-derivation surface.
+	wire.Bind(new(controllers.MCPResourceServerIdentifierResolver), new(*services.MCPProxyService)),
 	services.NewGatewayInternalAPIService,
 	services.NewMonitorScoresService,
 	services.NewCatalogService,

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -168,7 +168,7 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	identityController := controllers.NewIdentityController(identityClient)
 	mcpProxyScopeService := services.NewMCPProxyScopeService(mcpProxyScopeRepository, mcpProxyRepository, infraResourceManager, envThunderResolver, mcpProxyService, logger)
 	mcpProxyScopeController := controllers.NewMCPProxyScopeController(mcpProxyScopeService)
-	agentIdentityController := controllers.NewAgentIdentityController(envThunderResolver, agentThunderClientRepository, mcpProxyRepository, mcpProxyScopeRepository)
+	agentIdentityController := controllers.NewAgentIdentityController(envThunderResolver, agentThunderClientRepository, mcpProxyRepository, mcpProxyScopeRepository, mcpProxyService)
 	monitorSchedulerService := services.NewMonitorSchedulerService(openChoreoClient, publisherCredentialProvisioner, logger, monitorExecutor, monitorRepository)
 	agentThunderReconcilerService := services.NewAgentThunderReconcilerService(agentThunderProvisioning, agentIdentityInjectionService, agentThunderClientRepository, logger)
 	appParams := &AppParams{
@@ -346,7 +346,7 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	identityController := controllers.NewIdentityController(identityClient)
 	mcpProxyScopeService := services.NewMCPProxyScopeService(mcpProxyScopeRepository, mcpProxyRepository, infraResourceManager, envThunderResolver, mcpProxyService, logger)
 	mcpProxyScopeController := controllers.NewMCPProxyScopeController(mcpProxyScopeService)
-	agentIdentityController := controllers.NewAgentIdentityController(envThunderResolver, agentThunderClientRepository, mcpProxyRepository, mcpProxyScopeRepository)
+	agentIdentityController := controllers.NewAgentIdentityController(envThunderResolver, agentThunderClientRepository, mcpProxyRepository, mcpProxyScopeRepository, mcpProxyService)
 	monitorSchedulerService := services.NewMonitorSchedulerService(openChoreoClient, publisherCredentialProvisioner, logger, monitorExecutor, monitorRepository)
 	agentThunderReconcilerService := services.NewAgentThunderReconcilerService(agentThunderProvisioningService, agentIdentityInjectionService, agentThunderClientRepository, logger)
 	appParams := &AppParams{
@@ -416,7 +416,7 @@ var clientProviderSet = wire.NewSet(
 	ProvideEnvThunderResolver,
 )
 
-var serviceProviderSet = wire.NewSet(services.NewAgentManagerService, services.NewAgentKindService, services.NewInfraResourceManager, services.NewAgentTokenManagerService, ProvideGitCredentialsService, services.NewRepositoryService, services.NewMonitorExecutor, services.NewMonitorManagerService, ProvideThunderConfig, services.NewMonitorSchedulerService, ProvideAgentIdentityInjectionService, services.NewAgentThunderReconcilerService, services.NewEvaluatorManagerService, services.NewEnvironmentService, services.NewPlatformGatewayService, services.NewLLMProviderTemplateService, services.NewLLMProviderService, services.NewLLMProxyService, services.NewLLMProviderDeploymentService, services.NewLLMProviderAPIKeyService, services.NewLLMProxyAPIKeyService, services.NewAgentAPIKeyService, services.NewLLMProxyDeploymentService, services.NewMCPProxyService, services.NewMCPProxyScopeService, wire.Bind(new(services.MCPProxyRedeployer), new(*services.MCPProxyService)), services.NewGatewayInternalAPIService, services.NewMonitorScoresService, services.NewCatalogService, services.NewLLMProxyProvisioner, services.NewAgentConfigurationService, services.NewLLMTemplateStore, services.NewGitSecretService, services.NewAIApplicationService)
+var serviceProviderSet = wire.NewSet(services.NewAgentManagerService, services.NewAgentKindService, services.NewInfraResourceManager, services.NewAgentTokenManagerService, ProvideGitCredentialsService, services.NewRepositoryService, services.NewMonitorExecutor, services.NewMonitorManagerService, ProvideThunderConfig, services.NewMonitorSchedulerService, ProvideAgentIdentityInjectionService, services.NewAgentThunderReconcilerService, services.NewEvaluatorManagerService, services.NewEnvironmentService, services.NewPlatformGatewayService, services.NewLLMProviderTemplateService, services.NewLLMProviderService, services.NewLLMProxyService, services.NewLLMProviderDeploymentService, services.NewLLMProviderAPIKeyService, services.NewLLMProxyAPIKeyService, services.NewAgentAPIKeyService, services.NewLLMProxyDeploymentService, services.NewMCPProxyService, services.NewMCPProxyScopeService, wire.Bind(new(services.MCPProxyRedeployer), new(*services.MCPProxyService)), wire.Bind(new(controllers.MCPResourceServerIdentifierResolver), new(*services.MCPProxyService)), services.NewGatewayInternalAPIService, services.NewMonitorScoresService, services.NewCatalogService, services.NewLLMProxyProvisioner, services.NewAgentConfigurationService, services.NewLLMTemplateStore, services.NewGitSecretService, services.NewAIApplicationService)
 
 var instrumentationProviderSet = wire.NewSet(
 	ProvideInstrumentationCatalog,

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/_helpers.tpl
@@ -74,6 +74,23 @@ Defaults to "<environment>-<orgName>.gateway.localhost" when not explicitly set.
 {{- end }}
 
 {{/*
+Bare hostname MCP proxies are publicly served on — the mcp-auth policy's
+gatewayhost system parameter (the policy adds scheme and request port itself).
+Derived from gateway.vhost so OAuth challenge URLs agree with the Thunder
+resource-server identifiers AMS registers from the same vhost; falls back to
+the routed kgateway hostname.
+*/}}
+{{- define "wso2-amp-gateway-extension.mcpGatewayHost" -}}
+{{- $vhost := .Values.gateway.vhost | default "" | trim -}}
+{{- if $vhost -}}
+{{- if not (contains "://" $vhost) -}}{{- $vhost = printf "https://%s" $vhost -}}{{- end -}}
+{{- regexReplaceAll ":[0-9]+$" (urlParse $vhost).host "" -}}
+{{- else -}}
+{{- include "wso2-amp-gateway-extension.gatewayHostname" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Label value used to bind a RestApi to its APIGateway via the
 `gateway.api-platform.wso2.com/restapi-target` label/selector. The APIGateway
 name is already unique per environment (see apiGatewayName), so we reuse it

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-config.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-config.yaml
@@ -78,10 +78,14 @@ data:
           logging:
             level: info
             format: json
-        {{- if .Values.apiGateway.config.policyConfigurations }}
-        policy_configurations:
-          {{- .Values.apiGateway.config.policyConfigurations | toYaml | nindent 10 }}
+        {{- $policyConfigs := deepCopy (.Values.apiGateway.config.policyConfigurations | default dict) }}
+        {{- $mcpauth := $policyConfigs.mcpauth_v1 | default dict }}
+        {{- if not $mcpauth.gatewayhost }}
+        {{- $_ := set $mcpauth "gatewayhost" (include "wso2-amp-gateway-extension.mcpGatewayHost" .) }}
         {{- end }}
+        {{- $_ := set $policyConfigs "mcpauth_v1" $mcpauth }}
+        policy_configurations:
+          {{- $policyConfigs | toYaml | nindent 10 }}
 
       controller:
         controlPlane:

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
@@ -172,6 +172,9 @@ apiGateway:
         validateissuer: true
 
       # --- MCP Authentication (additional to jwtauth_v1) ---
+      # gatewayhost defaults to the bare hostname of gateway.vhost (else the
+      # routed kgateway hostname), so mcp-auth OAuth challenges advertise the
+      # public serving host. Set it here only to override that derivation.
       # mcpauth_v1:
       #   gatewayhost: "localhost"
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

For:
- https://github.com/wso2/agent-manager/issues/1546

- Sets the mcp resource servers resource ID based on its normalized deployed URL. 
- It also updates the mcp_auth policies gatewayHost so PRM <resource> parameter matches the resource ID.
- Also formats code

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP resource servers now use environment-specific public gateway identifiers.
  - Added support for reconciling existing resource servers and preserving compatibility with legacy identifiers.
  - MCP proxy URLs now honor gateway virtual hosts, proxy overrides, context paths, and normalized schemes.
  - Helm deployments now automatically configure the MCP gateway host, with override support.

- **Bug Fixes**
  - Improved handling of undeployed MCP proxies and missing gateway bindings.
  - Corrected proxy URL generation to consistently use public gateway addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->