### PR TITLE
Improve state management and performance in trace view

### DIFF
--- a/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
+++ b/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
@@ -28,7 +28,7 @@ import {
   Typography,
   Alert,
 } from '@wso2/oxygen-ui';
-import { useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import {
   Clock,
   Brain,
@@ -55,7 +55,6 @@ interface TraceExplorerProps {
 
 interface RenderSpan {
   span: Span;
-  children: RenderSpan[];
   key: string;
   parentKey: string | null;
   childrenKeys: string[] | null;
@@ -179,7 +178,6 @@ const populateRenderSpans = (
     const childrenKeys = childrenMap.get(span.spanId) || null;
     spanMap.set(span.spanId, {
       span,
-      children: [],
       key: span.spanId,
       parentKey: span.parentSpanId || null,
       childrenKeys: childrenKeys,
@@ -189,254 +187,231 @@ const populateRenderSpans = (
   return { spanMap, rootSpans };
 };
 
-export function TraceExplorer(props: TraceExplorerProps) {
-  const { spans, onOpenAttributesClick, selectedSpan } = props;
-  const renderSpan = useCallback(
-    (
-      key: string,
-      spanMap: Map<string, RenderSpan>,
-      expandedSpans: Record<string, boolean>,
-      toggleExpanded: (key: string) => void,
-      isLastChild?: boolean,
-      isRoot?: boolean
-    ) => {
-      const span = spanMap.get(key);
-      if (!span) {
-        return null;
-      }
-      const expanded = expandedSpans[key];
-      const hasChildren = span.childrenKeys && span.childrenKeys.length > 0;
-      return (
-        <Stack key={key} spacing={1} width="100%">
-          {/* Connecting lines - only show for non-root nodes */}
-          {!isRoot && (
-            <>
-              {/* Horizontal line */}
-              <Box
-                position="absolute"
-                sx={{
-                  width: 32,
-                  height: 40,
-                  borderLeft: isLastChild ? `2px solid` : 'none',
-                  borderBottom: `2px solid`,
-                  borderColor: 'divider',
-                  left: -32,
-                  top: -14,
-                  borderBottomLeftRadius: isLastChild ? 8 : 0,
-                }}
-              />
-              {/* Vertical line continuing down (only if not last child) */}
-              {!isLastChild && (
-                <Box
-                  position="absolute"
-                  sx={{
-                    width: 1,
-                    height: '100%',
-                    borderLeft: `2px solid`,
-                    borderColor: 'divider',
-                    left: -32,
-                    top: -20,
-                  }}
-                />
-              )}
-            </>
-          )}
-          <ButtonBase
-            onClick={() => onOpenAttributesClick(span.span)}
+// Below this span count, every row starts expanded (matches the pre-existing
+// UX for the common case). Above it, only root spans start expanded so a
+// large trace doesn't mount hundreds of rows at once.
+const EXPAND_ALL_THRESHOLD = 50;
+
+interface SpanRowProps {
+  node: RenderSpan;
+  spanMap: Map<string, RenderSpan>;
+  onOpenAttributesClick: (span: Span) => void;
+  selectedSpanId: string | null;
+  expandAllByDefault: boolean;
+  isLastChild?: boolean;
+  isRoot?: boolean;
+}
+
+// Each row owns its own expand/collapse state so toggling one span only
+// re-renders that span's subtree, not the whole tree.
+const SpanRow = memo(function SpanRow({
+  node,
+  spanMap,
+  onOpenAttributesClick,
+  selectedSpanId,
+  expandAllByDefault,
+  isLastChild,
+  isRoot,
+}: SpanRowProps) {
+  const [expanded, setExpanded] = useState(!!isRoot || expandAllByDefault);
+  const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
+  const isSelected = selectedSpanId === node.key;
+  const childCount = node.childrenKeys?.length ?? 0;
+  const hasChildren = childCount > 0;
+
+  return (
+    <Stack spacing={1} width="100%">
+      {/* Connecting lines - only show for non-root nodes */}
+      {!isRoot && (
+        <>
+          {/* Horizontal line */}
+          <Box
+            position="absolute"
             sx={{
-              width: '100%',
+              width: 32,
+              height: 40,
+              borderLeft: isLastChild ? `2px solid` : 'none',
+              borderBottom: `2px solid`,
+              borderColor: 'divider',
+              left: -32,
+              top: -14,
+              borderBottomLeftRadius: isLastChild ? 8 : 0,
             }}
-          >
-            <Stack
-              direction="row"
-              width="100%"
-              justifyContent="space-between"
+          />
+          {/* Vertical line continuing down (only if not last child) */}
+          {!isLastChild && (
+            <Box
+              position="absolute"
               sx={{
-                border: `1px solid`,
-                borderColor:
-                  selectedSpan?.spanId === span.span.spanId
-                    ? 'primary.main'
-                    : 'divider',
-                borderRadius: 0.5,
-                backgroundColor: 'background.paper',
-                px: 1,
-                transition: 'all 0.2s ease-in-out',
-                '&:hover': {
-                  backgroundColor: 'background.default',
-                },
+                width: 1,
+                height: '100%',
+                borderLeft: `2px solid`,
+                borderColor: 'divider',
+                left: -32,
+                top: -20,
               }}
+            />
+          )}
+        </>
+      )}
+      <ButtonBase
+        onClick={() => onOpenAttributesClick(node.span)}
+        sx={{
+          width: '100%',
+        }}
+      >
+        <Stack
+          direction="row"
+          width="100%"
+          justifyContent="space-between"
+          sx={{
+            border: `1px solid`,
+            borderColor: isSelected ? 'primary.main' : 'divider',
+            borderRadius: 0.5,
+            backgroundColor: 'background.paper',
+            px: 1,
+            transition: 'all 0.2s ease-in-out',
+            '&:hover': {
+              backgroundColor: 'background.default',
+            },
+          }}
+        >
+          <Stack
+            direction="row"
+            spacing={1}
+            flexGrow={1}
+            alignItems="center"
+            maxWidth="100%"
+          >
+            <IconButton
+              disabled={!hasChildren}
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                toggleExpanded();
+              }}
+              size="small"
+              color="primary"
+            >
+              {hasChildren ? (
+                <>
+                  <Box
+                    component="span"
+                    sx={{
+                      transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                      display: 'inline-flex',
+                      transition: 'transform 0.2s ease-in-out',
+                    }}
+                  >
+                    <ChevronDown size={16} />
+                  </Box>
+                </>
+              ) : (
+                <Minus size={16} />
+              )}
+            </IconButton>
+            <SpanIcon span={node.span} />
+            <Stack
+              direction="column"
+              p={0.5}
+              alignItems="start"
+              overflow="hidden"
             >
               <Stack
                 direction="row"
                 spacing={1}
-                flexGrow={1}
                 alignItems="center"
                 maxWidth="100%"
               >
-                <IconButton
-                  disabled={!hasChildren}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    toggleExpanded(key);
-                  }}
-                  size="small"
-                  color="primary"
+                <Tooltip
+                  title={node.span.name}
+                  disableHoverListener={node.span.name.length < 30}
                 >
-                  {hasChildren ? (
-                    <>
-                      <Box
-                        component="span"
-                        sx={{
-                          transform: expanded
-                            ? 'rotate(180deg)'
-                            : 'rotate(0deg)',
-                          display: 'inline-flex',
-                          transition: 'transform 0.2s ease-in-out',
-                        }}
-                      >
-                        <ChevronDown size={16} />
-                      </Box>
-                    </>
-                  ) : (
-                    <Minus size={16} />
-                  )}
-                </IconButton>
-                <SpanIcon span={span.span} />
-                <Stack
-                  direction="column"
-                  p={0.5}
-                  alignItems="start"
-                  overflow="hidden"
-                >
-                  <Stack
-                    direction="row"
-                    spacing={1}
-                    alignItems="center"
-                    maxWidth="100%"
+                  <Typography
+                    variant="body2"
+                    noWrap
+                    textOverflow="ellipsis"
+                    maxWidth="70%"
+                    overflow="hidden"
                   >
-                    <Tooltip
-                      title={span.span.name}
-                      disableHoverListener={span.span.name.length < 30}
-                    >
-                      <Typography
-                        variant="body2"
-                        noWrap
-                        textOverflow="ellipsis"
-                        maxWidth="70%"
-                        overflow="hidden"
-                      >
-                        {span.span.name}
-                      </Typography>
-                    </Tooltip>
-                    {span.span.ampAttributes?.status?.error && (
-                      <Stack
-                        justifyContent="center"
-                        sx={{ color: 'error.main' }}
-                      >
-                        <XCircle size={16} />
-                      </Stack>
-                    )}
-                    {(() => {
-                      const tokenUsage = getTokenUsage(span.span);
-                      return (
-                        tokenUsage && (
-                          <Tooltip
-                            title={`${tokenUsage.inputTokens} input tokens, ${tokenUsage.outputTokens} output tokens`}
-                          >
-                            <Chip
-                              icon={<Coins size={16} />}
-                              label={tokenUsage.totalTokens}
-                              size="small"
-                              variant="outlined"
-                            />
-                          </Tooltip>
-                        )
-                      );
-                    })()}
-                    <Chip
-                      icon={<Clock size={16} />}
-                      label={formatDuration(span.span.durationInNanos)}
-                      size="small"
-                      variant="outlined"
-                    />
+                    {node.span.name}
+                  </Typography>
+                </Tooltip>
+                {node.span.ampAttributes?.status?.error && (
+                  <Stack justifyContent="center" sx={{ color: 'error.main' }}>
+                    <XCircle size={16} />
                   </Stack>
-                </Stack>
-              </Stack>
-              <Stack direction="row" spacing={1} alignItems="center">
-                {isRoot && span.parentKey && (
-                  <Tooltip title="Unable to determine the parent span">
-                    <Box color="warning.main">
-                      <Info size={16} />
-                    </Box>
-                  </Tooltip>
                 )}
+                {(() => {
+                  const tokenUsage = getTokenUsage(node.span);
+                  return (
+                    tokenUsage && (
+                      <Tooltip
+                        title={`${tokenUsage.inputTokens} input tokens, ${tokenUsage.outputTokens} output tokens`}
+                      >
+                        <Chip
+                          icon={<Coins size={16} />}
+                          label={tokenUsage.totalTokens}
+                          size="small"
+                          variant="outlined"
+                        />
+                      </Tooltip>
+                    )
+                  );
+                })()}
+                <Chip
+                  icon={<Clock size={16} />}
+                  label={formatDuration(node.span.durationInNanos)}
+                  size="small"
+                  variant="outlined"
+                />
               </Stack>
             </Stack>
-          </ButtonBase>
-          {hasChildren && (
-            <Collapse in={expanded} unmountOnExit>
-              <Box
-                display="flex"
-                flexDirection="column"
-                pl={4}
-                position="relative"
-              >
-                {span.childrenKeys?.map((childKey, index) => (
-                  <Box key={childKey} display="flex" position="relative">
-                    {renderSpan(
-                      childKey,
-                      spanMap,
-                      expandedSpans,
-                      toggleExpanded,
-                      index === (span.childrenKeys?.length || 0) - 1,
-                      false
-                    )}
-                  </Box>
-                ))}
-              </Box>
-            </Collapse>
-          )}
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center">
+            {isRoot && node.parentKey && (
+              <Tooltip title="Unable to determine the parent span">
+                <Box color="warning.main">
+                  <Info size={16} />
+                </Box>
+              </Tooltip>
+            )}
+          </Stack>
         </Stack>
-      );
-    },
-    [onOpenAttributesClick, selectedSpan]
+      </ButtonBase>
+      {hasChildren && (
+        <Collapse in={expanded} unmountOnExit>
+          <Box display="flex" flexDirection="column" pl={4} position="relative">
+            {node.childrenKeys?.map((childKey, index) => {
+              const childNode = spanMap.get(childKey);
+              if (!childNode) return null;
+              return (
+                <Box key={childKey} display="flex" position="relative">
+                  <SpanRow
+                    node={childNode}
+                    spanMap={spanMap}
+                    onOpenAttributesClick={onOpenAttributesClick}
+                    selectedSpanId={selectedSpanId}
+                    expandAllByDefault={expandAllByDefault}
+                    isLastChild={index === childCount - 1}
+                    isRoot={false}
+                  />
+                </Box>
+              );
+            })}
+          </Box>
+        </Collapse>
+      )}
+    </Stack>
   );
+});
 
-  const [expandedSpans, setExpandedSpans] = useState<Record<string, boolean>>(
-    () => {
-      return spans.reduce(
-        (acc, span) => {
-          acc[span.spanId] = true;
-          return acc;
-        },
-        {} as Record<string, boolean>
-      );
-    }
-  );
+export function TraceExplorer(props: TraceExplorerProps) {
+  const { spans, onOpenAttributesClick, selectedSpan } = props;
+  const selectedSpanId = selectedSpan?.spanId ?? null;
+  const expandAllByDefault = spans.length <= EXPAND_ALL_THRESHOLD;
 
   const renderingSpans = useMemo(() => populateRenderSpans(spans), [spans]);
-
-  const renderedSpans = useMemo(() => {
-    const toggleExpanded = (key: string) => {
-      setExpandedSpans((prev) => ({
-        ...prev,
-        [key]: !prev[key],
-      }));
-    };
-    return renderingSpans.rootSpans.map((rootSpan, index) => (
-      <Stack key={rootSpan}>
-        {renderSpan(
-          rootSpan,
-          renderingSpans.spanMap,
-          expandedSpans,
-          toggleExpanded,
-          index === renderingSpans.rootSpans.length - 1,
-          true // isRoot,
-        )}
-      </Stack>
-    ));
-  }, [renderingSpans, expandedSpans, renderSpan]);
 
   return (
     <Stack direction="column" spacing={2}>
@@ -445,7 +420,23 @@ export function TraceExplorer(props: TraceExplorerProps) {
           Some trace details are missing or incomplete.
         </Alert>
       )}
-      {renderedSpans}
+      {renderingSpans.rootSpans.map((rootKey, index) => {
+        const rootNode = renderingSpans.spanMap.get(rootKey);
+        if (!rootNode) return null;
+        return (
+          <Stack key={rootKey}>
+            <SpanRow
+              node={rootNode}
+              spanMap={renderingSpans.spanMap}
+              onOpenAttributesClick={onOpenAttributesClick}
+              selectedSpanId={selectedSpanId}
+              expandAllByDefault={expandAllByDefault}
+              isLastChild={index === renderingSpans.rootSpans.length - 1}
+              isRoot
+            />
+          </Stack>
+        );
+      })}
     </Stack>
   );
 }

--- a/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
+++ b/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
@@ -197,24 +197,26 @@ interface SpanRowProps {
   spanMap: Map<string, RenderSpan>;
   onOpenAttributesClick: (span: Span) => void;
   selectedSpanId: string | null;
-  expandAllByDefault: boolean;
+  expandedKeys: Set<string>;
+  onToggleExpanded: (key: string) => void;
   isLastChild?: boolean;
   isRoot?: boolean;
 }
 
-// Each row owns its own expand/collapse state so toggling one span only
-// re-renders that span's subtree, not the whole tree.
+// Expand/collapse state is lifted to TraceExplorer (rather than kept as local
+// state here) so it survives a Collapse's unmountOnExit remounting this row
+// when an ancestor is collapsed and re-expanded.
 const SpanRow = memo(function SpanRow({
   node,
   spanMap,
   onOpenAttributesClick,
   selectedSpanId,
-  expandAllByDefault,
+  expandedKeys,
+  onToggleExpanded,
   isLastChild,
   isRoot,
 }: SpanRowProps) {
-  const [expanded, setExpanded] = useState(!!isRoot || expandAllByDefault);
-  const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
+  const expanded = expandedKeys.has(node.key);
   const isSelected = selectedSpanId === node.key;
   const childCount = node.childrenKeys?.length ?? 0;
   const hasChildren = childCount > 0;
@@ -288,7 +290,7 @@ const SpanRow = memo(function SpanRow({
               onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();
-                toggleExpanded();
+                onToggleExpanded(node.key);
               }}
               size="small"
               color="primary"
@@ -392,7 +394,8 @@ const SpanRow = memo(function SpanRow({
                     spanMap={spanMap}
                     onOpenAttributesClick={onOpenAttributesClick}
                     selectedSpanId={selectedSpanId}
-                    expandAllByDefault={expandAllByDefault}
+                    expandedKeys={expandedKeys}
+                    onToggleExpanded={onToggleExpanded}
                     isLastChild={index === childCount - 1}
                     isRoot={false}
                   />
@@ -409,9 +412,29 @@ const SpanRow = memo(function SpanRow({
 export function TraceExplorer(props: TraceExplorerProps) {
   const { spans, onOpenAttributesClick, selectedSpan } = props;
   const selectedSpanId = selectedSpan?.spanId ?? null;
-  const expandAllByDefault = spans.length <= EXPAND_ALL_THRESHOLD;
 
   const renderingSpans = useMemo(() => populateRenderSpans(spans), [spans]);
+
+  // Expanded keys live for the lifetime of this TraceExplorer instance (reset
+  // only when it's given a different trace's spans, i.e. remounted), so
+  // collapsing/re-expanding an ancestor doesn't discard descendants' choices.
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(() =>
+    spans.length <= EXPAND_ALL_THRESHOLD
+      ? new Set(spans.map((span) => span.spanId))
+      : new Set(renderingSpans.rootSpans)
+  );
+
+  const toggleExpanded = useCallback((key: string) => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
 
   return (
     <Stack direction="column" spacing={2}>
@@ -430,7 +453,8 @@ export function TraceExplorer(props: TraceExplorerProps) {
               spanMap={renderingSpans.spanMap}
               onOpenAttributesClick={onOpenAttributesClick}
               selectedSpanId={selectedSpanId}
-              expandAllByDefault={expandAllByDefault}
+              expandedKeys={expandedKeys}
+              onToggleExpanded={toggleExpanded}
               isLastChild={index === renderingSpans.rootSpans.length - 1}
               isRoot
             />

--- a/console/workspaces/pages/traces/src/subComponents/TraceDetails.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/TraceDetails.tsx
@@ -34,7 +34,7 @@ import {
   TraceSpanSummary,
 } from "@agent-management-platform/types";
 import { Workflow } from "@wso2/oxygen-ui-icons-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { SpanDetailsPanel } from "./SpanDetailsPanel";
 import { SpanDetailsPanelSkeleton } from "./spanDetails/SpanDetailsPanelSkeleton";
 
@@ -104,6 +104,11 @@ export function TraceDetails({
   );
 
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
+
+  const handleOpenAttributesClick = useCallback(
+    (span: Span) => setSelectedSpanId(span.spanId),
+    [],
+  );
 
   const spanKey = useMemo(
     () => traceDetails?.spans?.map((s) => s.spanId).join(',') ?? '',
@@ -221,7 +226,7 @@ export function TraceDetails({
         <Box sx={{ width: "45%" }} pr={1} overflow="auto">
           {traceId && (
             <TraceExplorer
-              onOpenAttributesClick={(span) => setSelectedSpanId(span.spanId)}
+              onOpenAttributesClick={handleOpenAttributesClick}
               selectedSpan={displaySelectedSpan}
               spans={spansForExplorer}
             />

--- a/console/workspaces/pages/traces/src/subComponents/spanDetails/AttributesSection.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/spanDetails/AttributesSection.tsx
@@ -30,7 +30,7 @@ import {
   ChevronDown,
   Search,
 } from "@wso2/oxygen-ui-icons-react";
-import { useState, useRef } from "react";
+import { useState, useRef, useMemo, useEffect } from "react";
 
 interface AttributesSectionProps {
   attributes?: Record<string, unknown>;
@@ -153,6 +153,11 @@ export function AttributesSection({ attributes }: AttributesSectionProps) {
   const editorRef = useRef<EditorInstance | null>(null);
   const matchesRef = useRef<Array<{ range: MatchRange }>>([]);
 
+  const attributesText = useMemo(
+    () => (attributes ? safeStringifyAttributes(attributes) : ""),
+    [attributes],
+  );
+
   const handleEditorWillMount = (monaco: Monaco) => {
     defineCustomThemes(monaco);
   };
@@ -160,6 +165,16 @@ export function AttributesSection({ attributes }: AttributesSectionProps) {
   const handleEditorMount = (editor: EditorInstance) => {
     editorRef.current = editor;
   };
+
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    };
+  }, []);
 
   const navigateToMatch = (index: number) => {
     if (!editorRef.current || matchesRef.current.length === 0) return;
@@ -220,7 +235,10 @@ export function AttributesSection({ attributes }: AttributesSectionProps) {
 
   const handleSearchChange = (value: string) => {
     setSearchText(value);
-    performSearch(value);
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+    }
+    searchDebounceRef.current = setTimeout(() => performSearch(value), 200);
   };
 
   const handleNext = () => {
@@ -312,7 +330,7 @@ export function AttributesSection({ attributes }: AttributesSectionProps) {
         theme={
           colorSchemeMode === "dark" ? CUSTOM_DARK_THEME : CUSTOM_LIGHT_THEME
         }
-        value={safeStringifyAttributes(attributes)}
+        value={attributesText}
         language="json"
         beforeMount={handleEditorWillMount}
         onMount={handleEditorMount}

--- a/console/workspaces/pages/traces/src/subComponents/spanDetails/AttributesSection.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/spanDetails/AttributesSection.tsx
@@ -168,13 +168,21 @@ export function AttributesSection({ attributes }: AttributesSectionProps) {
 
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Reset search state whenever the viewed span's attributes change so a
+  // query (or its stale matches/pending debounce) from the previous span
+  // doesn't carry over.
   useEffect(() => {
+    setSearchText("");
+    matchesRef.current = [];
+    setTotalMatches(0);
+    setCurrentMatchIndex(0);
     return () => {
       if (searchDebounceRef.current) {
         clearTimeout(searchDebounceRef.current);
+        searchDebounceRef.current = null;
       }
     };
-  }, []);
+  }, [attributes]);
 
   const navigateToMatch = (index: number) => {
     if (!editorRef.current || matchesRef.current.length === 0) return;
@@ -241,13 +249,25 @@ export function AttributesSection({ attributes }: AttributesSectionProps) {
     searchDebounceRef.current = setTimeout(() => performSearch(value), 200);
   };
 
+  // If a search is still debounced, run it now instead of navigating against
+  // stale (or empty) matches from before the latest keystroke.
+  const flushPendingSearch = () => {
+    if (!searchDebounceRef.current) return false;
+    clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = null;
+    performSearch(searchText);
+    return true;
+  };
+
   const handleNext = () => {
+    if (flushPendingSearch()) return;
     if (matchesRef.current.length === 0) return;
     const nextIndex = currentMatchIndex % matchesRef.current.length;
     navigateToMatch(nextIndex);
   };
 
   const handlePrevious = () => {
+    if (flushPendingSearch()) return;
     if (matchesRef.current.length === 0) return;
     const prevIndex =
       currentMatchIndex <= 1


### PR DESCRIPTION
## Purpose
This pull request refactors and optimizes the `TraceExplorer` component and related span details components to improve rendering performance, state management, and user experience in the trace explorer UI. The changes introduce per-row memoization for span rows, localize expand/collapse state, improve handling of large traces, and add debouncing to attribute search. These updates make the UI more efficient, especially for traces with many spans, and enhance code maintainability.

### TraceExplorer refactor and performance improvements

* Refactored `TraceExplorer.tsx` to move expand/collapse state into each individual row (`SpanRow`), using `memo` and `useState` for local state, so toggling a span only re-renders the relevant subtree instead of the entire tree. [[1]](diffhunk://#diff-c2e84fd5214161ea85a012d92ba76a8327e4045938d92dd249a1b63d4ec4151dL31-R31) [[2]](diffhunk://#diff-c2e84fd5214161ea85a012d92ba76a8327e4045938d92dd249a1b63d4ec4151dL192-R230)
* Introduced an `EXPAND_ALL_THRESHOLD` constant to only auto-expand all spans for traces with 50 or fewer spans; for larger traces, only root spans are expanded by default.
* Simplified the rendering logic by replacing the previous recursive function with a `SpanRow` component, improving code clarity and maintainability. [[1]](diffhunk://#diff-c2e84fd5214161ea85a012d92ba76a8327e4045938d92dd249a1b63d4ec4151dL192-R230) [[2]](diffhunk://#diff-c2e84fd5214161ea85a012d92ba76a8327e4045938d92dd249a1b63d4ec4151dL379-R448)

### UI and selection handling improvements

* Updated how selected spans are highlighted and how selection is handled, passing selection state and handlers through props for better encapsulation and easier integration with parent components. [[1]](diffhunk://#diff-c2e84fd5214161ea85a012d92ba76a8327e4045938d92dd249a1b63d4ec4151dL256-R276) [[2]](diffhunk://#diff-442057c17dc84dccf7140e9ed28b301632878cbefdac2ba7e91ce70e36a70785R108-R112) [[3]](diffhunk://#diff-442057c17dc84dccf7140e9ed28b301632878cbefdac2ba7e91ce70e36a70785L224-R229)
* Refactored the span details panel to use `useCallback` for selection, improving performance and preventing unnecessary re-renders. [[1]](diffhunk://#diff-442057c17dc84dccf7140e9ed28b301632878cbefdac2ba7e91ce70e36a70785L37-R37) [[2]](diffhunk://#diff-442057c17dc84dccf7140e9ed28b301632878cbefdac2ba7e91ce70e36a70785R108-R112)

### Attribute section usability

* Added debouncing to the attribute search in `AttributesSection.tsx` to avoid excessive search operations while typing, and ensured cleanup of timers on unmount. [[1]](diffhunk://#diff-93f0e34affddae789f42c02a687672629cadfc3846a2db379379ece10dbc1806L33-R33) [[2]](diffhunk://#diff-93f0e34affddae789f42c02a687672629cadfc3846a2db379379ece10dbc1806R155-R168) [[3]](diffhunk://#diff-93f0e34affddae789f42c02a687672629cadfc3846a2db379379ece10dbc1806L223-R240)
* Optimized attribute rendering by memoizing the stringified attributes, so the editor value only updates when attributes actually change.

These changes collectively enhance the responsiveness and scalability of the trace explorer UI, especially for traces with a large number of spans.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved trace exploration responsiveness by rendering span rows independently and memoizing them.
  - Optimized expansion behavior for small and large traces.

- **Bug Fixes**
  - Improved span selection when opening attributes.
  - Enhanced attribute search with delayed execution and cleanup to prevent stale results.
  - Reduced unnecessary attribute serialization and editor updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->