### PR TITLE
Correct advanced VM install TLS description

### DIFF
--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -22,7 +22,7 @@ Agents run sandboxed under the standard **runc** runtime by default. Agent Manag
 Install Agent Manager on a Linux VM where Docker is the only host dependency. Pick the path that fits you:
 
 - **Simple**: give the installer the VM's public IP and it does everything else: hostnames are derived from the IP via [sslip.io](https://sslip.io) and TLS certificates are issued automatically by Let's Encrypt. No domain, no DNS setup, no certificate handling. Best for demos and quick evaluations.
-- **Advanced**: a config-file-driven installer for a **custom domain**, on a VM that is either publicly reachable or **private-network-only**. Choose how TLS is handled: automatic Let's Encrypt, the DNS-01 challenge for a private VM, your own certificate, a generated local CA, or a load balancer in front. Adds pre-flight validation of your config, certificates, and DNS.
+- **Advanced**: a config-file-driven installer for a **custom domain**, on a VM that is either publicly reachable or **private-network-only**. TLS is always a publicly-trusted wildcard certificate issued in-cluster by cert-manager through the ACME **DNS-01** challenge (Let's Encrypt by default, any ACME CA via `ACME_SERVER`), so issuance needs outbound access only and works on a private VM. Requires a DNS zone you control on a supported provider (Cloudflare, Route 53, Cloud DNS, or Azure DNS). Validates your config before installing and reports whether your DNS points at the VM.
 
 <Tabs groupId="vm-installer">
 <TabItem value="simple" label="Simple (IP + automatic TLS)" default>

--- a/documentation/versioned_docs/version-v1.0.0-alpha1/getting-started/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-alpha1/getting-started/on-a-vm.mdx
@@ -22,7 +22,7 @@ Agents run sandboxed under the standard **runc** runtime by default. Agent Manag
 Install Agent Manager on a Linux VM where Docker is the only host dependency. Pick the path that fits you:
 
 - **Simple**: give the installer the VM's public IP and it does everything else: hostnames are derived from the IP via [sslip.io](https://sslip.io) and TLS certificates are issued automatically by Let's Encrypt. No domain, no DNS setup, no certificate handling. Best for demos and quick evaluations.
-- **Advanced**: a config-file-driven installer for a **custom domain**, on a VM that is either publicly reachable or **private-network-only**. Choose how TLS is handled: automatic Let's Encrypt, the DNS-01 challenge for a private VM, your own certificate, a generated local CA, or a load balancer in front. Adds pre-flight validation of your config, certificates, and DNS.
+- **Advanced**: a config-file-driven installer for a **custom domain**, on a VM that is either publicly reachable or **private-network-only**. TLS is always a publicly-trusted wildcard certificate issued in-cluster by cert-manager through the ACME **DNS-01** challenge (Let's Encrypt by default, any ACME CA via `ACME_SERVER`), so issuance needs outbound access only and works on a private VM. Requires a DNS zone you control on a supported provider (Cloudflare, Route 53, Cloud DNS, or Azure DNS). Validates your config before installing and reports whether your DNS points at the VM.
 
 <Tabs groupId="vm-installer">
 <TabItem value="simple" label="Simple (IP + automatic TLS)" default>


### PR DESCRIPTION
## Purpose
The "Run Agent Manager on a VM with Docker" guide introduces the advanced installer with a TLS description left over from the Caddy-era design: *"Choose how TLS is handled: automatic Let's Encrypt, the DNS-01 challenge for a private VM, your own certificate, a generated local CA, or a load balancer in front. Adds pre-flight validation of your config, certificates, and DNS."*

None of that choice exists any more. `install-advanced.sh` was rewritten to a single cert-manager DNS-01 path: `--init` emits no `TLS_MODE` key (asserted by `deployments/vm/tests/run.sh`), `validate_config` only checks `AMP_VERSION`, `DOMAIN_BASE`, `ACME_EMAIL` and the DNS-01 provider block, and the `byoc` / `selfsigned` / `upstream` modes were removed along with Caddy and lego. Two smaller claims in the same sentence are wrong as well: there is no certificate pre-flight left (nothing to validate without BYOC cert files), and the DNS check is advisory — `preflight_dns()` never aborts the install.

Readers evaluating the advanced path can currently pick a TLS approach the installer will reject.

## Goals
Make the introduction match the installer, so the DNS-zone requirement (a prerequisite, not an option) is visible before someone starts.

## Approach
Rewrote the bullet to state the single supported path: a publicly-trusted wildcard certificate issued in-cluster by cert-manager over the ACME DNS-01 challenge, Let's Encrypt by default and any ACME CA via `ACME_SERVER`, requiring a DNS zone on one of the four supported providers (Cloudflare, Route 53, Cloud DNS, Azure DNS). Pre-flight is described as config validation plus an advisory DNS report.

The same stale bullet was in the `v1.0.0-alpha1` versioned copy while the body of that page already documented the DNS-01-only design, so it is corrected too. Older versioned docs (`v0.18.x` and earlier) are untouched — the modes they list were real in those releases. The Simple tab's Caddy / TLS-ALPN-01 text is untouched and still matches `install-vm.sh`.

## User stories
N/A — documentation correction, no user-facing feature.

## Release note
Corrected the TLS description for the advanced VM installer: it supports the ACME DNS-01 challenge only, not the removed bring-your-own-certificate, self-signed CA, or upstream load balancer modes.

## Documentation
This PR is the documentation change: `documentation/docs/guides/on-a-vm.mdx` and `documentation/versioned_docs/version-v1.0.0-alpha1/getting-started/on-a-vm.mdx`.

## Training
N/A — no training content covers the VM installer's TLS options.

## Certification
N/A — no certification exam covers the VM installer's TLS options.

## Marketing
N/A — a correction to existing docs, nothing to promote.

## Automation tests
 - Unit tests
   > N/A — prose change, no code. The behaviour asserted here is already covered by `deployments/vm/tests/run.sh` ("init has no TLS_MODE (single DNS-01 path)").
 - Integration tests
   > N/A — no code paths changed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java/code changes.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples relate to this change.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no migration; the installer behaviour is unchanged, only its description.

## Test environment
N/A — no runtime change. Verified against the sources on `main`: `deployments/vm/install-advanced.sh`, `lib-advanced.sh`, `lib-certmanager.sh`, and `tests/run.sh`.

## Learning
Traced the discrepancy back through the installer rewrite to cert-manager DNS-01, which dropped Caddy, lego, and the `TLS_MODE` switch. `install-advanced.sh` still carries the marker in a comment — "validate_dns hard-fails only in the (removed) letsencrypt mode" — which confirms the modes were deliberately removed rather than refactored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that Advanced VM installations use cert-manager with the ACME DNS-01 challenge for publicly trusted wildcard TLS certificates.
  - Documented support for Let’s Encrypt or another ACME provider through `ACME_SERVER`.
  - Added requirements for a supported DNS provider and outbound access, including for private-network VMs.
  - Removed documentation for unsupported custom certificate, local CA, and external load balancer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->