### PR TITLE
Create project release bindings for environments

### DIFF
--- a/agent-manager-service/Makefile
+++ b/agent-manager-service/Makefile
@@ -77,7 +77,7 @@ OAPI_CODEGEN := go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@
 .PHONY: gen-oc-client
 gen-oc-client: ## Generate OpenChoreo API client from upstream OpenAPI spec.
 	@echo "Generating OpenChoreo client from upstream spec"
-	@curl -sL "https://raw.githubusercontent.com/openchoreo/openchoreo/v1.1.1/openapi/openchoreo-api.yaml" -o /tmp/openchoreo-api.yaml
+	@curl -sL "https://raw.githubusercontent.com/openchoreo/openchoreo/v1.2.0/openapi/openchoreo-api.yaml" -o /tmp/openchoreo-api.yaml
 	@$(OAPI_CODEGEN) -config clients/openchoreosvc/gen/oapi-codegen.yaml /tmp/openchoreo-api.yaml
 	@$(OAPI_CODEGEN) -config clients/openchoreosvc/gen/oapi-codegen-client.yaml /tmp/openchoreo-api.yaml
 	@rm /tmp/openchoreo-api.yaml

--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -81,6 +81,9 @@ import (
 //			EnsureClusterRoleBindingFunc: func(ctx context.Context, clientID string, roleName string) error {
 //				panic("mock out the EnsureClusterRoleBinding method")
 //			},
+//			EnsureProjectReleaseBindingFunc: func(ctx context.Context, ouID string, projectName string, environmentName string) error {
+//				panic("mock out the EnsureProjectReleaseBinding method")
+//			},
 //			EnsureReleaseBindingRuntimeClassFunc: func(ctx context.Context, ouID string, componentName string, environment string, desiredRuntimeClass string) error {
 //				panic("mock out the EnsureReleaseBindingRuntimeClass method")
 //			},
@@ -309,6 +312,9 @@ type OpenChoreoClientMock struct {
 
 	// EnsureClusterRoleBindingFunc mocks the EnsureClusterRoleBinding method.
 	EnsureClusterRoleBindingFunc func(ctx context.Context, clientID string, roleName string) error
+
+	// EnsureProjectReleaseBindingFunc mocks the EnsureProjectReleaseBinding method.
+	EnsureProjectReleaseBindingFunc func(ctx context.Context, ouID string, projectName string, environmentName string) error
 
 	// EnsureReleaseBindingRuntimeClassFunc mocks the EnsureReleaseBindingRuntimeClass method.
 	EnsureReleaseBindingRuntimeClassFunc func(ctx context.Context, ouID string, componentName string, environment string, desiredRuntimeClass string) error
@@ -687,6 +693,17 @@ type OpenChoreoClientMock struct {
 			ClientID string
 			// RoleName is the roleName argument value.
 			RoleName string
+		}
+		// EnsureProjectReleaseBinding holds details about calls to the EnsureProjectReleaseBinding method.
+		EnsureProjectReleaseBinding []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OuID is the ouID argument value.
+			OuID string
+			// ProjectName is the projectName argument value.
+			ProjectName string
+			// EnvironmentName is the environmentName argument value.
+			EnvironmentName string
 		}
 		// EnsureReleaseBindingRuntimeClass holds details about calls to the EnsureReleaseBindingRuntimeClass method.
 		EnsureReleaseBindingRuntimeClass []struct {
@@ -1315,6 +1332,7 @@ type OpenChoreoClientMock struct {
 	lockDeploy                                 sync.RWMutex
 	lockDetachTrait                            sync.RWMutex
 	lockEnsureClusterRoleBinding               sync.RWMutex
+	lockEnsureProjectReleaseBinding            sync.RWMutex
 	lockEnsureReleaseBindingRuntimeClass       sync.RWMutex
 	lockExpireWorkflowRun                      sync.RWMutex
 	lockGetBuild                               sync.RWMutex
@@ -2263,6 +2281,50 @@ func (mock *OpenChoreoClientMock) EnsureClusterRoleBindingCalls() []struct {
 	mock.lockEnsureClusterRoleBinding.RLock()
 	calls = mock.calls.EnsureClusterRoleBinding
 	mock.lockEnsureClusterRoleBinding.RUnlock()
+	return calls
+}
+
+// EnsureProjectReleaseBinding calls EnsureProjectReleaseBindingFunc.
+func (mock *OpenChoreoClientMock) EnsureProjectReleaseBinding(ctx context.Context, ouID string, projectName string, environmentName string) error {
+	if mock.EnsureProjectReleaseBindingFunc == nil {
+		panic("OpenChoreoClientMock.EnsureProjectReleaseBindingFunc: method is nil but OpenChoreoClient.EnsureProjectReleaseBinding was just called")
+	}
+	callInfo := struct {
+		Ctx             context.Context
+		OuID            string
+		ProjectName     string
+		EnvironmentName string
+	}{
+		Ctx:             ctx,
+		OuID:            ouID,
+		ProjectName:     projectName,
+		EnvironmentName: environmentName,
+	}
+	mock.lockEnsureProjectReleaseBinding.Lock()
+	mock.calls.EnsureProjectReleaseBinding = append(mock.calls.EnsureProjectReleaseBinding, callInfo)
+	mock.lockEnsureProjectReleaseBinding.Unlock()
+	return mock.EnsureProjectReleaseBindingFunc(ctx, ouID, projectName, environmentName)
+}
+
+// EnsureProjectReleaseBindingCalls gets all the calls that were made to EnsureProjectReleaseBinding.
+// Check the length with:
+//
+//	len(mockedOpenChoreoClient.EnsureProjectReleaseBindingCalls())
+func (mock *OpenChoreoClientMock) EnsureProjectReleaseBindingCalls() []struct {
+	Ctx             context.Context
+	OuID            string
+	ProjectName     string
+	EnvironmentName string
+} {
+	var calls []struct {
+		Ctx             context.Context
+		OuID            string
+		ProjectName     string
+		EnvironmentName string
+	}
+	mock.lockEnsureProjectReleaseBinding.RLock()
+	calls = mock.calls.EnsureProjectReleaseBinding
+	mock.lockEnsureProjectReleaseBinding.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/clients/openchoreosvc/client/client.go
+++ b/agent-manager-service/clients/openchoreosvc/client/client.go
@@ -64,6 +64,7 @@ type OpenChoreoClient interface {
 	PatchProject(ctx context.Context, ouID, projectName string, req PatchProjectRequest) error
 	DeleteProject(ctx context.Context, ouID, projectName string) error
 	ListProjects(ctx context.Context, ouID string) ([]*models.ProjectResponse, error)
+	EnsureProjectReleaseBinding(ctx context.Context, ouID, projectName, environmentName string) error
 
 	// Component Operations
 	CreateComponent(ctx context.Context, ouID, projectName string, req CreateComponentRequest) error

--- a/agent-manager-service/clients/openchoreosvc/client/project_release_bindings.go
+++ b/agent-manager-service/clients/openchoreosvc/client/project_release_bindings.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+)
+
+// -----------------------------------------------------------------------------
+// Project Release Binding Operations
+// -----------------------------------------------------------------------------
+
+// projectReleaseBindingName is the (project, environment) binding name convention.
+// It matches the one baked into the platform-resources Helm chart
+// (templates/project-release-binding.yaml) so the chart-managed binding for the
+// default project is recognised here instead of being duplicated.
+func projectReleaseBindingName(projectName, environmentName string) string {
+	return fmt.Sprintf("%s-%s", projectName, environmentName)
+}
+
+// EnsureProjectReleaseBinding creates the ProjectReleaseBinding for
+// (project, environment) if it does not already exist.
+//
+// From OpenChoreo 1.2.0 the cell namespace is no longer implicit: it is a
+// resource of the project's (Cluster)ProjectType, and a ProjectReleaseBinding is
+// what applies that type to an environment. Without a binding the namespace is
+// never created and every component ReleaseBinding in that environment fails
+// with `namespaces "dp-..." not found`.
+//
+// spec.projectRelease is deliberately left unset — the Project controller seeds
+// it once with the project's latest ProjectRelease.
+//
+// The call is idempotent: an existing binding for the same (project,
+// environment) is success. A name collision with a binding that belongs to a
+// different project or environment is an error rather than a silent no-op.
+func (c *openChoreoClient) EnsureProjectReleaseBinding(ctx context.Context, ouID, projectName, environmentName string) error {
+	namespaceName := c.NamespaceFor(ouID)
+	bindingName := projectReleaseBindingName(projectName, environmentName)
+
+	labels := map[string]string{
+		string(LabelKeyProjectName):     projectName,
+		string(LabelKeyEnvironmentName): environmentName,
+	}
+	body := gen.CreateProjectReleaseBindingJSONRequestBody{
+		Metadata: gen.ObjectMeta{
+			Name:      bindingName,
+			Namespace: &namespaceName,
+			Labels:    &labels,
+		},
+		Spec: &gen.ProjectReleaseBindingSpec{
+			Owner: struct {
+				ProjectName string `json:"projectName"`
+			}{ProjectName: projectName},
+			Environment: environmentName,
+		},
+	}
+
+	resp, err := c.ocClient.CreateProjectReleaseBindingWithResponse(ctx, namespaceName, body)
+	if err != nil {
+		return fmt.Errorf("failed to create project release binding %q: %w", bindingName, err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusCreated, http.StatusOK:
+		return nil
+	case http.StatusConflict:
+		// Already exists — confirm it is ours before treating it as success.
+		return c.verifyProjectReleaseBindingOwner(ctx, namespaceName, bindingName, projectName, environmentName)
+	default:
+		return handleErrorResponse(resp.StatusCode(), ErrorResponses{
+			JSON400: resp.JSON400,
+			JSON401: resp.JSON401,
+			JSON403: resp.JSON403,
+			JSON409: resp.JSON409,
+			JSON500: resp.JSON500,
+		})
+	}
+}
+
+// verifyProjectReleaseBindingOwner checks that an existing binding really is the
+// one for (project, environment). Binding names are derived from both, so a
+// mismatch means two different tuples collapsed onto the same name (e.g. project
+// "a-b" + env "c" vs project "a" + env "b-c"); silently accepting that would
+// point the project at another project's namespace.
+func (c *openChoreoClient) verifyProjectReleaseBindingOwner(ctx context.Context, namespaceName, bindingName, projectName, environmentName string) error {
+	resp, err := c.ocClient.GetProjectReleaseBindingWithResponse(ctx, namespaceName, bindingName)
+	if err != nil {
+		return fmt.Errorf("failed to get existing project release binding %q: %w", bindingName, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return handleErrorResponse(resp.StatusCode(), ErrorResponses{
+			JSON401: resp.JSON401,
+			JSON403: resp.JSON403,
+			JSON404: resp.JSON404,
+			JSON500: resp.JSON500,
+		})
+	}
+	if resp.JSON200 == nil || resp.JSON200.Spec == nil {
+		return fmt.Errorf("empty response from get project release binding %q", bindingName)
+	}
+
+	spec := resp.JSON200.Spec
+	if spec.Owner.ProjectName != projectName || spec.Environment != environmentName {
+		return fmt.Errorf(
+			"project release binding %q already exists for project %q environment %q, not project %q environment %q",
+			bindingName, spec.Owner.ProjectName, spec.Environment, projectName, environmentName,
+		)
+	}
+	return nil
+}

--- a/agent-manager-service/clients/openchoreosvc/client/project_release_bindings.go
+++ b/agent-manager-service/clients/openchoreosvc/client/project_release_bindings.go
@@ -85,13 +85,15 @@ func (c *openChoreoClient) EnsureProjectReleaseBinding(ctx context.Context, ouID
 		// Already exists — confirm it is ours before treating it as success.
 		return c.verifyProjectReleaseBindingOwner(ctx, namespaceName, bindingName, projectName, environmentName)
 	default:
-		return handleErrorResponse(resp.StatusCode(), ErrorResponses{
+		// Named so a caller can tell this apart from the lookup below, which
+		// maps the same set of statuses.
+		return fmt.Errorf("failed to create project release binding %q: %w", bindingName, handleErrorResponse(resp.StatusCode(), ErrorResponses{
 			JSON400: resp.JSON400,
 			JSON401: resp.JSON401,
 			JSON403: resp.JSON403,
 			JSON409: resp.JSON409,
 			JSON500: resp.JSON500,
-		})
+		}))
 	}
 }
 
@@ -106,12 +108,12 @@ func (c *openChoreoClient) verifyProjectReleaseBindingOwner(ctx context.Context,
 		return fmt.Errorf("failed to get existing project release binding %q: %w", bindingName, err)
 	}
 	if resp.StatusCode() != http.StatusOK {
-		return handleErrorResponse(resp.StatusCode(), ErrorResponses{
+		return fmt.Errorf("failed to get existing project release binding %q: %w", bindingName, handleErrorResponse(resp.StatusCode(), ErrorResponses{
 			JSON401: resp.JSON401,
 			JSON403: resp.JSON403,
 			JSON404: resp.JSON404,
 			JSON500: resp.JSON500,
-		})
+		}))
 	}
 	if resp.JSON200 == nil || resp.JSON200.Spec == nil {
 		return fmt.Errorf("empty response from get project release binding %q", bindingName)

--- a/agent-manager-service/clients/openchoreosvc/client/project_release_bindings_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/project_release_bindings_test.go
@@ -1,0 +1,147 @@
+//
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// newTestClient wires an openChoreoClient against a stub OpenChoreo API.
+func newTestClient(t *testing.T, handler http.Handler) *openChoreoClient {
+	t.Helper()
+	srv := httptest.NewServer(jsonContentType(handler))
+	t.Cleanup(srv.Close)
+
+	gc, err := gen.NewClientWithResponses(srv.URL)
+	require.NoError(t, err)
+	return &openChoreoClient{ocClient: gc, defaultNamespace: "default"}
+}
+
+// jsonContentType stamps the header the generated response parsers key on to
+// decide whether a body is decodable — without it every stub reply parses as an
+// empty struct.
+func jsonContentType(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func TestProjectReleaseBindingName(t *testing.T) {
+	// Must stay in step with the Helm chart's
+	// templates/project-release-binding.yaml, or the chart-managed binding for
+	// the default project would be duplicated under a second name.
+	assert.Equal(t, "my-project-dev", projectReleaseBindingName("my-project", "dev"))
+}
+
+func TestEnsureProjectReleaseBinding_CreatesBinding(t *testing.T) {
+	var gotBody gen.ProjectReleaseBinding
+	var gotPath string
+	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(gotBody))
+	}))
+
+	err := srv.EnsureProjectReleaseBinding(context.Background(), "acme", "my-project", "dev")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v1/namespaces/default/projectreleasebindings", gotPath)
+	assert.Equal(t, "my-project-dev", gotBody.Metadata.Name)
+	require.NotNil(t, gotBody.Spec)
+	assert.Equal(t, "my-project", gotBody.Spec.Owner.ProjectName)
+	assert.Equal(t, "dev", gotBody.Spec.Environment)
+	// The Project controller seeds the pin with the latest ProjectRelease;
+	// sending one here would freeze the project at whatever release existed now.
+	assert.Nil(t, gotBody.Spec.ProjectRelease)
+}
+
+func TestEnsureProjectReleaseBinding_ExistingBindingIsSuccess(t *testing.T) {
+	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusConflict)
+			require.NoError(t, json.NewEncoder(w).Encode(gen.Conflict{Error: "already exists"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(gen.ProjectReleaseBinding{
+			Metadata: gen.ObjectMeta{Name: "my-project-dev"},
+			Spec: &gen.ProjectReleaseBindingSpec{
+				Owner: struct {
+					ProjectName string `json:"projectName"`
+				}{ProjectName: "my-project"},
+				Environment: "dev",
+			},
+		}))
+	}))
+
+	err := srv.EnsureProjectReleaseBinding(context.Background(), "acme", "my-project", "dev")
+
+	require.NoError(t, err, "an existing binding for the same project and environment is what we wanted")
+}
+
+func TestEnsureProjectReleaseBinding_NameCollisionWithAnotherProjectIsAnError(t *testing.T) {
+	// Binding names are "<project>-<environment>", so project "my" + env
+	// "project-dev" collides with project "my-project" + env "dev". Treating
+	// that as success would silently point one project at another's namespace.
+	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusConflict)
+			require.NoError(t, json.NewEncoder(w).Encode(gen.Conflict{Error: "already exists"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(gen.ProjectReleaseBinding{
+			Metadata: gen.ObjectMeta{Name: "my-project-dev"},
+			Spec: &gen.ProjectReleaseBindingSpec{
+				Owner: struct {
+					ProjectName string `json:"projectName"`
+				}{ProjectName: "my"},
+				Environment: "project-dev",
+			},
+		}))
+	}))
+
+	err := srv.EnsureProjectReleaseBinding(context.Background(), "acme", "my-project", "dev")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `already exists for project "my" environment "project-dev"`)
+}
+
+func TestEnsureProjectReleaseBinding_PropagatesAPIErrors(t *testing.T) {
+	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		require.NoError(t, json.NewEncoder(w).Encode(gen.Forbidden{Error: "no permission"}))
+	}))
+
+	err := srv.EnsureProjectReleaseBinding(context.Background(), "acme", "my-project", "dev")
+
+	assert.ErrorIs(t, err, utils.ErrForbidden)
+}

--- a/agent-manager-service/clients/openchoreosvc/gen/client.gen.go
+++ b/agent-manager-service/clients/openchoreosvc/gen/client.gen.go
@@ -204,6 +204,28 @@ type ClientInterface interface {
 
 	UpdateClusterObservabilityPlane(ctx context.Context, clusterObservabilityPlaneName ClusterObservabilityPlaneNameParam, body UpdateClusterObservabilityPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListClusterProjectTypes request
+	ListClusterProjectTypes(ctx context.Context, params *ListClusterProjectTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateClusterProjectTypeWithBody request with any body
+	CreateClusterProjectTypeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateClusterProjectType(ctx context.Context, body CreateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteClusterProjectType request
+	DeleteClusterProjectType(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetClusterProjectType request
+	GetClusterProjectType(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateClusterProjectTypeWithBody request with any body
+	UpdateClusterProjectTypeWithBody(ctx context.Context, cptName ClusterProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateClusterProjectType(ctx context.Context, cptName ClusterProjectTypeNameParam, body UpdateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetClusterProjectTypeSchema request
+	GetClusterProjectTypeSchema(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListClusterResourceTypes request
 	ListClusterResourceTypes(ctx context.Context, params *ListClusterResourceTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -504,6 +526,39 @@ type ClientInterface interface {
 
 	UpdateObservabilityPlane(ctx context.Context, namespaceName NamespaceNameParam, observabilityPlaneName ObservabilityPlaneNameParam, body UpdateObservabilityPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListProjectReleaseBindings request
+	ListProjectReleaseBindings(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleaseBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateProjectReleaseBindingWithBody request with any body
+	CreateProjectReleaseBindingWithBody(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectReleaseBinding request
+	DeleteProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectReleaseBinding request
+	GetProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProjectReleaseBindingWithBody request with any body
+	UpdateProjectReleaseBindingWithBody(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, body UpdateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProjectReleases request
+	ListProjectReleases(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleasesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateProjectReleaseWithBody request with any body
+	CreateProjectReleaseWithBody(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateProjectRelease(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectRelease request
+	DeleteProjectRelease(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectRelease request
+	GetProjectRelease(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListProjects request
 	ListProjects(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -522,6 +577,28 @@ type ClientInterface interface {
 	UpdateProjectWithBody(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateProject(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListProjectTypes request
+	ListProjectTypes(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateProjectTypeWithBody request with any body
+	CreateProjectTypeWithBody(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateProjectType(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteProjectType request
+	DeleteProjectType(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectType request
+	GetProjectType(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateProjectTypeWithBody request with any body
+	UpdateProjectTypeWithBody(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateProjectType(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, body UpdateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetProjectTypeSchema request
+	GetProjectTypeSchema(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListReleaseBindings request
 	ListReleaseBindings(ctx context.Context, namespaceName NamespaceNameParam, params *ListReleaseBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -769,6 +846,9 @@ type ClientInterface interface {
 
 	// DeleteGitSecret request
 	DeleteGitSecret(ctx context.Context, namespaceName NamespaceNameParam, gitSecretName GitSecretNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// TriggerReleaseBindingCronJob request
+	TriggerReleaseBindingCronJob(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListSecrets request
 	ListSecrets(ctx context.Context, namespaceName NamespaceNameParam, params *ListSecretsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1296,6 +1376,102 @@ func (c *Client) UpdateClusterObservabilityPlaneWithBody(ctx context.Context, cl
 
 func (c *Client) UpdateClusterObservabilityPlane(ctx context.Context, clusterObservabilityPlaneName ClusterObservabilityPlaneNameParam, body UpdateClusterObservabilityPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateClusterObservabilityPlaneRequest(c.Server, clusterObservabilityPlaneName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListClusterProjectTypes(ctx context.Context, params *ListClusterProjectTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListClusterProjectTypesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateClusterProjectTypeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateClusterProjectTypeRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateClusterProjectType(ctx context.Context, body CreateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateClusterProjectTypeRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteClusterProjectType(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteClusterProjectTypeRequest(c.Server, cptName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetClusterProjectType(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetClusterProjectTypeRequest(c.Server, cptName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateClusterProjectTypeWithBody(ctx context.Context, cptName ClusterProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateClusterProjectTypeRequestWithBody(c.Server, cptName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateClusterProjectType(ctx context.Context, cptName ClusterProjectTypeNameParam, body UpdateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateClusterProjectTypeRequest(c.Server, cptName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetClusterProjectTypeSchema(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetClusterProjectTypeSchemaRequest(c.Server, cptName)
 	if err != nil {
 		return nil, err
 	}
@@ -2626,6 +2802,150 @@ func (c *Client) UpdateObservabilityPlane(ctx context.Context, namespaceName Nam
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListProjectReleaseBindings(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleaseBindingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProjectReleaseBindingsRequest(c.Server, namespaceName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectReleaseBindingWithBody(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectReleaseBindingRequestWithBody(c.Server, namespaceName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectReleaseBindingRequest(c.Server, namespaceName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectReleaseBindingRequest(c.Server, namespaceName, projectReleaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectReleaseBindingRequest(c.Server, namespaceName, projectReleaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectReleaseBindingWithBody(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectReleaseBindingRequestWithBody(c.Server, namespaceName, projectReleaseBindingName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectReleaseBinding(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, body UpdateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectReleaseBindingRequest(c.Server, namespaceName, projectReleaseBindingName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProjectReleases(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleasesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProjectReleasesRequest(c.Server, namespaceName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectReleaseWithBody(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectReleaseRequestWithBody(c.Server, namespaceName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectRelease(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectReleaseRequest(c.Server, namespaceName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectRelease(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectReleaseRequest(c.Server, namespaceName, projectReleaseName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectRelease(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectReleaseRequest(c.Server, namespaceName, projectReleaseName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListProjects(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListProjectsRequest(c.Server, namespaceName, params)
 	if err != nil {
@@ -2700,6 +3020,102 @@ func (c *Client) UpdateProjectWithBody(ctx context.Context, namespaceName Namesp
 
 func (c *Client) UpdateProject(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateProjectRequest(c.Server, namespaceName, projectName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListProjectTypes(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectTypesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListProjectTypesRequest(c.Server, namespaceName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectTypeWithBody(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectTypeRequestWithBody(c.Server, namespaceName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateProjectType(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateProjectTypeRequest(c.Server, namespaceName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteProjectType(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteProjectTypeRequest(c.Server, namespaceName, ptName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectType(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectTypeRequest(c.Server, namespaceName, ptName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectTypeWithBody(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectTypeRequestWithBody(c.Server, namespaceName, ptName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateProjectType(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, body UpdateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateProjectTypeRequest(c.Server, namespaceName, ptName, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetProjectTypeSchema(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetProjectTypeSchemaRequest(c.Server, namespaceName, ptName)
 	if err != nil {
 		return nil, err
 	}
@@ -3780,6 +4196,18 @@ func (c *Client) CreateGitSecret(ctx context.Context, namespaceName NamespaceNam
 
 func (c *Client) DeleteGitSecret(ctx context.Context, namespaceName NamespaceNameParam, gitSecretName GitSecretNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteGitSecretRequest(c.Server, namespaceName, gitSecretName)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) TriggerReleaseBindingCronJob(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewTriggerReleaseBindingCronJobRequest(c.Server, namespaceName, releaseBindingName)
 	if err != nil {
 		return nil, err
 	}
@@ -5350,6 +5778,276 @@ func NewUpdateClusterObservabilityPlaneRequestWithBody(server string, clusterObs
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListClusterProjectTypesRequest generates requests for ListClusterProjectTypes
+func NewListClusterProjectTypesRequest(server string, params *ListClusterProjectTypesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clusterprojecttypes")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.LabelSelector != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "labelSelector", runtime.ParamLocationQuery, *params.LabelSelector); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateClusterProjectTypeRequest calls the generic CreateClusterProjectType builder with application/json body
+func NewCreateClusterProjectTypeRequest(server string, body CreateClusterProjectTypeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateClusterProjectTypeRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateClusterProjectTypeRequestWithBody generates requests for CreateClusterProjectType with any type of body
+func NewCreateClusterProjectTypeRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clusterprojecttypes")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteClusterProjectTypeRequest generates requests for DeleteClusterProjectType
+func NewDeleteClusterProjectTypeRequest(server string, cptName ClusterProjectTypeNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "cptName", runtime.ParamLocationPath, cptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clusterprojecttypes/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetClusterProjectTypeRequest generates requests for GetClusterProjectType
+func NewGetClusterProjectTypeRequest(server string, cptName ClusterProjectTypeNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "cptName", runtime.ParamLocationPath, cptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clusterprojecttypes/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateClusterProjectTypeRequest calls the generic UpdateClusterProjectType builder with application/json body
+func NewUpdateClusterProjectTypeRequest(server string, cptName ClusterProjectTypeNameParam, body UpdateClusterProjectTypeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateClusterProjectTypeRequestWithBody(server, cptName, "application/json", bodyReader)
+}
+
+// NewUpdateClusterProjectTypeRequestWithBody generates requests for UpdateClusterProjectType with any type of body
+func NewUpdateClusterProjectTypeRequestWithBody(server string, cptName ClusterProjectTypeNameParam, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "cptName", runtime.ParamLocationPath, cptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clusterprojecttypes/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetClusterProjectTypeSchemaRequest generates requests for GetClusterProjectTypeSchema
+func NewGetClusterProjectTypeSchemaRequest(server string, cptName ClusterProjectTypeNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "cptName", runtime.ParamLocationPath, cptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/clusterprojecttypes/%s/schema", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -9460,6 +10158,526 @@ func NewUpdateObservabilityPlaneRequestWithBody(server string, namespaceName Nam
 	return req, nil
 }
 
+// NewListProjectReleaseBindingsRequest generates requests for ListProjectReleaseBindings
+func NewListProjectReleaseBindingsRequest(server string, namespaceName NamespaceNameParam, params *ListProjectReleaseBindingsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleasebindings", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Project != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "project", runtime.ParamLocationQuery, *params.Project); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.LabelSelector != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "labelSelector", runtime.ParamLocationQuery, *params.LabelSelector); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateProjectReleaseBindingRequest calls the generic CreateProjectReleaseBinding builder with application/json body
+func NewCreateProjectReleaseBindingRequest(server string, namespaceName NamespaceNameParam, body CreateProjectReleaseBindingJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateProjectReleaseBindingRequestWithBody(server, namespaceName, "application/json", bodyReader)
+}
+
+// NewCreateProjectReleaseBindingRequestWithBody generates requests for CreateProjectReleaseBinding with any type of body
+func NewCreateProjectReleaseBindingRequestWithBody(server string, namespaceName NamespaceNameParam, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleasebindings", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectReleaseBindingRequest generates requests for DeleteProjectReleaseBinding
+func NewDeleteProjectReleaseBindingRequest(server string, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "projectReleaseBindingName", runtime.ParamLocationPath, projectReleaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleasebindings/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectReleaseBindingRequest generates requests for GetProjectReleaseBinding
+func NewGetProjectReleaseBindingRequest(server string, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "projectReleaseBindingName", runtime.ParamLocationPath, projectReleaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleasebindings/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProjectReleaseBindingRequest calls the generic UpdateProjectReleaseBinding builder with application/json body
+func NewUpdateProjectReleaseBindingRequest(server string, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, body UpdateProjectReleaseBindingJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProjectReleaseBindingRequestWithBody(server, namespaceName, projectReleaseBindingName, "application/json", bodyReader)
+}
+
+// NewUpdateProjectReleaseBindingRequestWithBody generates requests for UpdateProjectReleaseBinding with any type of body
+func NewUpdateProjectReleaseBindingRequestWithBody(server string, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "projectReleaseBindingName", runtime.ParamLocationPath, projectReleaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleasebindings/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListProjectReleasesRequest generates requests for ListProjectReleases
+func NewListProjectReleasesRequest(server string, namespaceName NamespaceNameParam, params *ListProjectReleasesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleases", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Project != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "project", runtime.ParamLocationQuery, *params.Project); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.LabelSelector != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "labelSelector", runtime.ParamLocationQuery, *params.LabelSelector); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateProjectReleaseRequest calls the generic CreateProjectRelease builder with application/json body
+func NewCreateProjectReleaseRequest(server string, namespaceName NamespaceNameParam, body CreateProjectReleaseJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateProjectReleaseRequestWithBody(server, namespaceName, "application/json", bodyReader)
+}
+
+// NewCreateProjectReleaseRequestWithBody generates requests for CreateProjectRelease with any type of body
+func NewCreateProjectReleaseRequestWithBody(server string, namespaceName NamespaceNameParam, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleases", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectReleaseRequest generates requests for DeleteProjectRelease
+func NewDeleteProjectReleaseRequest(server string, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "projectReleaseName", runtime.ParamLocationPath, projectReleaseName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleases/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectReleaseRequest generates requests for GetProjectRelease
+func NewGetProjectReleaseRequest(server string, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "projectReleaseName", runtime.ParamLocationPath, projectReleaseName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projectreleases/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListProjectsRequest generates requests for ListProjects
 func NewListProjectsRequest(server string, namespaceName NamespaceNameParam, params *ListProjectsParams) (*http.Request, error) {
 	var err error
@@ -9727,6 +10945,318 @@ func NewUpdateProjectRequestWithBody(server string, namespaceName NamespaceNameP
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewListProjectTypesRequest generates requests for ListProjectTypes
+func NewListProjectTypesRequest(server string, namespaceName NamespaceNameParam, params *ListProjectTypesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projecttypes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.LabelSelector != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "labelSelector", runtime.ParamLocationQuery, *params.LabelSelector); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateProjectTypeRequest calls the generic CreateProjectType builder with application/json body
+func NewCreateProjectTypeRequest(server string, namespaceName NamespaceNameParam, body CreateProjectTypeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateProjectTypeRequestWithBody(server, namespaceName, "application/json", bodyReader)
+}
+
+// NewCreateProjectTypeRequestWithBody generates requests for CreateProjectType with any type of body
+func NewCreateProjectTypeRequestWithBody(server string, namespaceName NamespaceNameParam, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projecttypes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteProjectTypeRequest generates requests for DeleteProjectType
+func NewDeleteProjectTypeRequest(server string, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "ptName", runtime.ParamLocationPath, ptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projecttypes/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetProjectTypeRequest generates requests for GetProjectType
+func NewGetProjectTypeRequest(server string, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "ptName", runtime.ParamLocationPath, ptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projecttypes/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateProjectTypeRequest calls the generic UpdateProjectType builder with application/json body
+func NewUpdateProjectTypeRequest(server string, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, body UpdateProjectTypeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateProjectTypeRequestWithBody(server, namespaceName, ptName, "application/json", bodyReader)
+}
+
+// NewUpdateProjectTypeRequestWithBody generates requests for UpdateProjectType with any type of body
+func NewUpdateProjectTypeRequestWithBody(server string, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "ptName", runtime.ParamLocationPath, ptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projecttypes/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetProjectTypeSchemaRequest generates requests for GetProjectTypeSchema
+func NewGetProjectTypeSchemaRequest(server string, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "ptName", runtime.ParamLocationPath, ptName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/projecttypes/%s/schema", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -10163,6 +11693,22 @@ func NewGetReleaseBindingK8sResourceLogsRequest(server string, namespaceName Nam
 					queryValues.Add(k, v2)
 				}
 			}
+		}
+
+		if params.Container != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "container", runtime.ParamLocationQuery, *params.Container); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
 		}
 
 		if params.SinceSeconds != nil {
@@ -13347,6 +14893,17 @@ func NewHandleAutoBuildRequestWithBody(server string, params *HandleAutoBuildPar
 			req.Header.Set("X-Event-Key", headerParam2)
 		}
 
+		if params.XHubSignature != nil {
+			var headerParam3 string
+
+			headerParam3, err = runtime.StyleParamWithLocation("simple", false, "X-Hub-Signature", runtime.ParamLocationHeader, *params.XHubSignature)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Hub-Signature", headerParam3)
+		}
+
 	}
 
 	return req, nil
@@ -13467,6 +15024,47 @@ func NewDeleteGitSecretRequest(server string, namespaceName NamespaceNameParam, 
 	}
 
 	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewTriggerReleaseBindingCronJobRequest generates requests for TriggerReleaseBindingCronJob
+func NewTriggerReleaseBindingCronJobRequest(server string, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "releaseBindingName", runtime.ParamLocationPath, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1alpha1/namespaces/%s/releasebindings/%s/trigger", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -13995,6 +15593,28 @@ type ClientWithResponsesInterface interface {
 
 	UpdateClusterObservabilityPlaneWithResponse(ctx context.Context, clusterObservabilityPlaneName ClusterObservabilityPlaneNameParam, body UpdateClusterObservabilityPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateClusterObservabilityPlaneResp, error)
 
+	// ListClusterProjectTypesWithResponse request
+	ListClusterProjectTypesWithResponse(ctx context.Context, params *ListClusterProjectTypesParams, reqEditors ...RequestEditorFn) (*ListClusterProjectTypesResp, error)
+
+	// CreateClusterProjectTypeWithBodyWithResponse request with any body
+	CreateClusterProjectTypeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateClusterProjectTypeResp, error)
+
+	CreateClusterProjectTypeWithResponse(ctx context.Context, body CreateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateClusterProjectTypeResp, error)
+
+	// DeleteClusterProjectTypeWithResponse request
+	DeleteClusterProjectTypeWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*DeleteClusterProjectTypeResp, error)
+
+	// GetClusterProjectTypeWithResponse request
+	GetClusterProjectTypeWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetClusterProjectTypeResp, error)
+
+	// UpdateClusterProjectTypeWithBodyWithResponse request with any body
+	UpdateClusterProjectTypeWithBodyWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateClusterProjectTypeResp, error)
+
+	UpdateClusterProjectTypeWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, body UpdateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateClusterProjectTypeResp, error)
+
+	// GetClusterProjectTypeSchemaWithResponse request
+	GetClusterProjectTypeSchemaWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetClusterProjectTypeSchemaResp, error)
+
 	// ListClusterResourceTypesWithResponse request
 	ListClusterResourceTypesWithResponse(ctx context.Context, params *ListClusterResourceTypesParams, reqEditors ...RequestEditorFn) (*ListClusterResourceTypesResp, error)
 
@@ -14295,6 +15915,39 @@ type ClientWithResponsesInterface interface {
 
 	UpdateObservabilityPlaneWithResponse(ctx context.Context, namespaceName NamespaceNameParam, observabilityPlaneName ObservabilityPlaneNameParam, body UpdateObservabilityPlaneJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateObservabilityPlaneResp, error)
 
+	// ListProjectReleaseBindingsWithResponse request
+	ListProjectReleaseBindingsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleaseBindingsParams, reqEditors ...RequestEditorFn) (*ListProjectReleaseBindingsResp, error)
+
+	// CreateProjectReleaseBindingWithBodyWithResponse request with any body
+	CreateProjectReleaseBindingWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectReleaseBindingResp, error)
+
+	CreateProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectReleaseBindingResp, error)
+
+	// DeleteProjectReleaseBindingWithResponse request
+	DeleteProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*DeleteProjectReleaseBindingResp, error)
+
+	// GetProjectReleaseBindingWithResponse request
+	GetProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*GetProjectReleaseBindingResp, error)
+
+	// UpdateProjectReleaseBindingWithBodyWithResponse request with any body
+	UpdateProjectReleaseBindingWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectReleaseBindingResp, error)
+
+	UpdateProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, body UpdateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectReleaseBindingResp, error)
+
+	// ListProjectReleasesWithResponse request
+	ListProjectReleasesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleasesParams, reqEditors ...RequestEditorFn) (*ListProjectReleasesResp, error)
+
+	// CreateProjectReleaseWithBodyWithResponse request with any body
+	CreateProjectReleaseWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectReleaseResp, error)
+
+	CreateProjectReleaseWithResponse(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectReleaseResp, error)
+
+	// DeleteProjectReleaseWithResponse request
+	DeleteProjectReleaseWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*DeleteProjectReleaseResp, error)
+
+	// GetProjectReleaseWithResponse request
+	GetProjectReleaseWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*GetProjectReleaseResp, error)
+
 	// ListProjectsWithResponse request
 	ListProjectsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectsParams, reqEditors ...RequestEditorFn) (*ListProjectsResp, error)
 
@@ -14313,6 +15966,28 @@ type ClientWithResponsesInterface interface {
 	UpdateProjectWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectResp, error)
 
 	UpdateProjectWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectName ProjectNameParam, body UpdateProjectJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectResp, error)
+
+	// ListProjectTypesWithResponse request
+	ListProjectTypesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectTypesParams, reqEditors ...RequestEditorFn) (*ListProjectTypesResp, error)
+
+	// CreateProjectTypeWithBodyWithResponse request with any body
+	CreateProjectTypeWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectTypeResp, error)
+
+	CreateProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectTypeResp, error)
+
+	// DeleteProjectTypeWithResponse request
+	DeleteProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*DeleteProjectTypeResp, error)
+
+	// GetProjectTypeWithResponse request
+	GetProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetProjectTypeResp, error)
+
+	// UpdateProjectTypeWithBodyWithResponse request with any body
+	UpdateProjectTypeWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectTypeResp, error)
+
+	UpdateProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, body UpdateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectTypeResp, error)
+
+	// GetProjectTypeSchemaWithResponse request
+	GetProjectTypeSchemaWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetProjectTypeSchemaResp, error)
 
 	// ListReleaseBindingsWithResponse request
 	ListReleaseBindingsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListReleaseBindingsParams, reqEditors ...RequestEditorFn) (*ListReleaseBindingsResp, error)
@@ -14560,6 +16235,9 @@ type ClientWithResponsesInterface interface {
 
 	// DeleteGitSecretWithResponse request
 	DeleteGitSecretWithResponse(ctx context.Context, namespaceName NamespaceNameParam, gitSecretName GitSecretNameParam, reqEditors ...RequestEditorFn) (*DeleteGitSecretResp, error)
+
+	// TriggerReleaseBindingCronJobWithResponse request
+	TriggerReleaseBindingCronJobWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*TriggerReleaseBindingCronJobResp, error)
 
 	// ListSecretsWithResponse request
 	ListSecretsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListSecretsParams, reqEditors ...RequestEditorFn) (*ListSecretsResp, error)
@@ -15406,6 +17084,164 @@ func (r UpdateClusterObservabilityPlaneResp) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateClusterObservabilityPlaneResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListClusterProjectTypesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ClusterProjectTypeList
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListClusterProjectTypesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListClusterProjectTypesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateClusterProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ClusterProjectType
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON409      *Conflict
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateClusterProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateClusterProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteClusterProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteClusterProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteClusterProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetClusterProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ClusterProjectType
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetClusterProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetClusterProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateClusterProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ClusterProjectType
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateClusterProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateClusterProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetClusterProjectTypeSchemaResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SchemaResponse
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetClusterProjectTypeSchemaResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetClusterProjectTypeSchemaResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -17552,6 +19388,241 @@ func (r UpdateObservabilityPlaneResp) StatusCode() int {
 	return 0
 }
 
+type ListProjectReleaseBindingsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectReleaseBindingList
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProjectReleaseBindingsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProjectReleaseBindingsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateProjectReleaseBindingResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ProjectReleaseBinding
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON409      *Conflict
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateProjectReleaseBindingResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateProjectReleaseBindingResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectReleaseBindingResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectReleaseBindingResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectReleaseBindingResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectReleaseBindingResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectReleaseBinding
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectReleaseBindingResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectReleaseBindingResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateProjectReleaseBindingResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectReleaseBinding
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProjectReleaseBindingResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProjectReleaseBindingResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListProjectReleasesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectReleaseList
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProjectReleasesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProjectReleasesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateProjectReleaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ProjectRelease
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON409      *Conflict
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateProjectReleaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateProjectReleaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectReleaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectReleaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectReleaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectReleaseResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectRelease
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectReleaseResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectReleaseResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListProjectsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17681,6 +19752,164 @@ func (r UpdateProjectResp) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateProjectResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListProjectTypesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectTypeList
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListProjectTypesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListProjectTypesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ProjectType
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON409      *Conflict
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectType
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateProjectTypeResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProjectType
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON409      *Conflict
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateProjectTypeResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateProjectTypeResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetProjectTypeSchemaResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SchemaResponse
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetProjectTypeSchemaResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetProjectTypeSchemaResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -19462,6 +21691,33 @@ func (r DeleteGitSecretResp) StatusCode() int {
 	return 0
 }
 
+type TriggerReleaseBindingCronJobResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *CronJobTriggerResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r TriggerReleaseBindingCronJobResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r TriggerReleaseBindingCronJobResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListSecretsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -20053,6 +22309,76 @@ func (c *ClientWithResponses) UpdateClusterObservabilityPlaneWithResponse(ctx co
 		return nil, err
 	}
 	return ParseUpdateClusterObservabilityPlaneResp(rsp)
+}
+
+// ListClusterProjectTypesWithResponse request returning *ListClusterProjectTypesResp
+func (c *ClientWithResponses) ListClusterProjectTypesWithResponse(ctx context.Context, params *ListClusterProjectTypesParams, reqEditors ...RequestEditorFn) (*ListClusterProjectTypesResp, error) {
+	rsp, err := c.ListClusterProjectTypes(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListClusterProjectTypesResp(rsp)
+}
+
+// CreateClusterProjectTypeWithBodyWithResponse request with arbitrary body returning *CreateClusterProjectTypeResp
+func (c *ClientWithResponses) CreateClusterProjectTypeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateClusterProjectTypeResp, error) {
+	rsp, err := c.CreateClusterProjectTypeWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateClusterProjectTypeResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateClusterProjectTypeWithResponse(ctx context.Context, body CreateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateClusterProjectTypeResp, error) {
+	rsp, err := c.CreateClusterProjectType(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateClusterProjectTypeResp(rsp)
+}
+
+// DeleteClusterProjectTypeWithResponse request returning *DeleteClusterProjectTypeResp
+func (c *ClientWithResponses) DeleteClusterProjectTypeWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*DeleteClusterProjectTypeResp, error) {
+	rsp, err := c.DeleteClusterProjectType(ctx, cptName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteClusterProjectTypeResp(rsp)
+}
+
+// GetClusterProjectTypeWithResponse request returning *GetClusterProjectTypeResp
+func (c *ClientWithResponses) GetClusterProjectTypeWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetClusterProjectTypeResp, error) {
+	rsp, err := c.GetClusterProjectType(ctx, cptName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetClusterProjectTypeResp(rsp)
+}
+
+// UpdateClusterProjectTypeWithBodyWithResponse request with arbitrary body returning *UpdateClusterProjectTypeResp
+func (c *ClientWithResponses) UpdateClusterProjectTypeWithBodyWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateClusterProjectTypeResp, error) {
+	rsp, err := c.UpdateClusterProjectTypeWithBody(ctx, cptName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateClusterProjectTypeResp(rsp)
+}
+
+func (c *ClientWithResponses) UpdateClusterProjectTypeWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, body UpdateClusterProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateClusterProjectTypeResp, error) {
+	rsp, err := c.UpdateClusterProjectType(ctx, cptName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateClusterProjectTypeResp(rsp)
+}
+
+// GetClusterProjectTypeSchemaWithResponse request returning *GetClusterProjectTypeSchemaResp
+func (c *ClientWithResponses) GetClusterProjectTypeSchemaWithResponse(ctx context.Context, cptName ClusterProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetClusterProjectTypeSchemaResp, error) {
+	rsp, err := c.GetClusterProjectTypeSchema(ctx, cptName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetClusterProjectTypeSchemaResp(rsp)
 }
 
 // ListClusterResourceTypesWithResponse request returning *ListClusterResourceTypesResp
@@ -21015,6 +23341,111 @@ func (c *ClientWithResponses) UpdateObservabilityPlaneWithResponse(ctx context.C
 	return ParseUpdateObservabilityPlaneResp(rsp)
 }
 
+// ListProjectReleaseBindingsWithResponse request returning *ListProjectReleaseBindingsResp
+func (c *ClientWithResponses) ListProjectReleaseBindingsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleaseBindingsParams, reqEditors ...RequestEditorFn) (*ListProjectReleaseBindingsResp, error) {
+	rsp, err := c.ListProjectReleaseBindings(ctx, namespaceName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProjectReleaseBindingsResp(rsp)
+}
+
+// CreateProjectReleaseBindingWithBodyWithResponse request with arbitrary body returning *CreateProjectReleaseBindingResp
+func (c *ClientWithResponses) CreateProjectReleaseBindingWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectReleaseBindingResp, error) {
+	rsp, err := c.CreateProjectReleaseBindingWithBody(ctx, namespaceName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectReleaseBindingResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectReleaseBindingResp, error) {
+	rsp, err := c.CreateProjectReleaseBinding(ctx, namespaceName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectReleaseBindingResp(rsp)
+}
+
+// DeleteProjectReleaseBindingWithResponse request returning *DeleteProjectReleaseBindingResp
+func (c *ClientWithResponses) DeleteProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*DeleteProjectReleaseBindingResp, error) {
+	rsp, err := c.DeleteProjectReleaseBinding(ctx, namespaceName, projectReleaseBindingName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectReleaseBindingResp(rsp)
+}
+
+// GetProjectReleaseBindingWithResponse request returning *GetProjectReleaseBindingResp
+func (c *ClientWithResponses) GetProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*GetProjectReleaseBindingResp, error) {
+	rsp, err := c.GetProjectReleaseBinding(ctx, namespaceName, projectReleaseBindingName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectReleaseBindingResp(rsp)
+}
+
+// UpdateProjectReleaseBindingWithBodyWithResponse request with arbitrary body returning *UpdateProjectReleaseBindingResp
+func (c *ClientWithResponses) UpdateProjectReleaseBindingWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectReleaseBindingResp, error) {
+	rsp, err := c.UpdateProjectReleaseBindingWithBody(ctx, namespaceName, projectReleaseBindingName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectReleaseBindingResp(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProjectReleaseBindingWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseBindingName ProjectReleaseBindingNameParam, body UpdateProjectReleaseBindingJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectReleaseBindingResp, error) {
+	rsp, err := c.UpdateProjectReleaseBinding(ctx, namespaceName, projectReleaseBindingName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectReleaseBindingResp(rsp)
+}
+
+// ListProjectReleasesWithResponse request returning *ListProjectReleasesResp
+func (c *ClientWithResponses) ListProjectReleasesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectReleasesParams, reqEditors ...RequestEditorFn) (*ListProjectReleasesResp, error) {
+	rsp, err := c.ListProjectReleases(ctx, namespaceName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProjectReleasesResp(rsp)
+}
+
+// CreateProjectReleaseWithBodyWithResponse request with arbitrary body returning *CreateProjectReleaseResp
+func (c *ClientWithResponses) CreateProjectReleaseWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectReleaseResp, error) {
+	rsp, err := c.CreateProjectReleaseWithBody(ctx, namespaceName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectReleaseResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateProjectReleaseWithResponse(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectReleaseJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectReleaseResp, error) {
+	rsp, err := c.CreateProjectRelease(ctx, namespaceName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectReleaseResp(rsp)
+}
+
+// DeleteProjectReleaseWithResponse request returning *DeleteProjectReleaseResp
+func (c *ClientWithResponses) DeleteProjectReleaseWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*DeleteProjectReleaseResp, error) {
+	rsp, err := c.DeleteProjectRelease(ctx, namespaceName, projectReleaseName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectReleaseResp(rsp)
+}
+
+// GetProjectReleaseWithResponse request returning *GetProjectReleaseResp
+func (c *ClientWithResponses) GetProjectReleaseWithResponse(ctx context.Context, namespaceName NamespaceNameParam, projectReleaseName ProjectReleaseNameParam, reqEditors ...RequestEditorFn) (*GetProjectReleaseResp, error) {
+	rsp, err := c.GetProjectRelease(ctx, namespaceName, projectReleaseName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectReleaseResp(rsp)
+}
+
 // ListProjectsWithResponse request returning *ListProjectsResp
 func (c *ClientWithResponses) ListProjectsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectsParams, reqEditors ...RequestEditorFn) (*ListProjectsResp, error) {
 	rsp, err := c.ListProjects(ctx, namespaceName, params, reqEditors...)
@@ -21074,6 +23505,76 @@ func (c *ClientWithResponses) UpdateProjectWithResponse(ctx context.Context, nam
 		return nil, err
 	}
 	return ParseUpdateProjectResp(rsp)
+}
+
+// ListProjectTypesWithResponse request returning *ListProjectTypesResp
+func (c *ClientWithResponses) ListProjectTypesWithResponse(ctx context.Context, namespaceName NamespaceNameParam, params *ListProjectTypesParams, reqEditors ...RequestEditorFn) (*ListProjectTypesResp, error) {
+	rsp, err := c.ListProjectTypes(ctx, namespaceName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListProjectTypesResp(rsp)
+}
+
+// CreateProjectTypeWithBodyWithResponse request with arbitrary body returning *CreateProjectTypeResp
+func (c *ClientWithResponses) CreateProjectTypeWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateProjectTypeResp, error) {
+	rsp, err := c.CreateProjectTypeWithBody(ctx, namespaceName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectTypeResp(rsp)
+}
+
+func (c *ClientWithResponses) CreateProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, body CreateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateProjectTypeResp, error) {
+	rsp, err := c.CreateProjectType(ctx, namespaceName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateProjectTypeResp(rsp)
+}
+
+// DeleteProjectTypeWithResponse request returning *DeleteProjectTypeResp
+func (c *ClientWithResponses) DeleteProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*DeleteProjectTypeResp, error) {
+	rsp, err := c.DeleteProjectType(ctx, namespaceName, ptName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteProjectTypeResp(rsp)
+}
+
+// GetProjectTypeWithResponse request returning *GetProjectTypeResp
+func (c *ClientWithResponses) GetProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetProjectTypeResp, error) {
+	rsp, err := c.GetProjectType(ctx, namespaceName, ptName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectTypeResp(rsp)
+}
+
+// UpdateProjectTypeWithBodyWithResponse request with arbitrary body returning *UpdateProjectTypeResp
+func (c *ClientWithResponses) UpdateProjectTypeWithBodyWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateProjectTypeResp, error) {
+	rsp, err := c.UpdateProjectTypeWithBody(ctx, namespaceName, ptName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectTypeResp(rsp)
+}
+
+func (c *ClientWithResponses) UpdateProjectTypeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, body UpdateProjectTypeJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateProjectTypeResp, error) {
+	rsp, err := c.UpdateProjectType(ctx, namespaceName, ptName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateProjectTypeResp(rsp)
+}
+
+// GetProjectTypeSchemaWithResponse request returning *GetProjectTypeSchemaResp
+func (c *ClientWithResponses) GetProjectTypeSchemaWithResponse(ctx context.Context, namespaceName NamespaceNameParam, ptName ProjectTypeNameParam, reqEditors ...RequestEditorFn) (*GetProjectTypeSchemaResp, error) {
+	rsp, err := c.GetProjectTypeSchema(ctx, namespaceName, ptName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetProjectTypeSchemaResp(rsp)
 }
 
 // ListReleaseBindingsWithResponse request returning *ListReleaseBindingsResp
@@ -21861,6 +24362,15 @@ func (c *ClientWithResponses) DeleteGitSecretWithResponse(ctx context.Context, n
 		return nil, err
 	}
 	return ParseDeleteGitSecretResp(rsp)
+}
+
+// TriggerReleaseBindingCronJobWithResponse request returning *TriggerReleaseBindingCronJobResp
+func (c *ClientWithResponses) TriggerReleaseBindingCronJobWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*TriggerReleaseBindingCronJobResp, error) {
+	rsp, err := c.TriggerReleaseBindingCronJob(ctx, namespaceName, releaseBindingName, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseTriggerReleaseBindingCronJobResp(rsp)
 }
 
 // ListSecretsWithResponse request returning *ListSecretsResp
@@ -23712,6 +26222,344 @@ func ParseUpdateClusterObservabilityPlaneResp(rsp *http.Response) (*UpdateCluste
 			return nil, err
 		}
 		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListClusterProjectTypesResp parses an HTTP response from a ListClusterProjectTypesWithResponse call
+func ParseListClusterProjectTypesResp(rsp *http.Response) (*ListClusterProjectTypesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListClusterProjectTypesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ClusterProjectTypeList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateClusterProjectTypeResp parses an HTTP response from a CreateClusterProjectTypeWithResponse call
+func ParseCreateClusterProjectTypeResp(rsp *http.Response) (*CreateClusterProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateClusterProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ClusterProjectType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteClusterProjectTypeResp parses an HTTP response from a DeleteClusterProjectTypeWithResponse call
+func ParseDeleteClusterProjectTypeResp(rsp *http.Response) (*DeleteClusterProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteClusterProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetClusterProjectTypeResp parses an HTTP response from a GetClusterProjectTypeWithResponse call
+func ParseGetClusterProjectTypeResp(rsp *http.Response) (*GetClusterProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetClusterProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ClusterProjectType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateClusterProjectTypeResp parses an HTTP response from a UpdateClusterProjectTypeWithResponse call
+func ParseUpdateClusterProjectTypeResp(rsp *http.Response) (*UpdateClusterProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateClusterProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ClusterProjectType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetClusterProjectTypeSchemaResp parses an HTTP response from a GetClusterProjectTypeSchemaWithResponse call
+func ParseGetClusterProjectTypeSchemaResp(rsp *http.Response) (*GetClusterProjectTypeSchemaResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetClusterProjectTypeSchemaResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchemaResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -28465,6 +31313,499 @@ func ParseUpdateObservabilityPlaneResp(rsp *http.Response) (*UpdateObservability
 	return response, nil
 }
 
+// ParseListProjectReleaseBindingsResp parses an HTTP response from a ListProjectReleaseBindingsWithResponse call
+func ParseListProjectReleaseBindingsResp(rsp *http.Response) (*ListProjectReleaseBindingsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProjectReleaseBindingsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectReleaseBindingList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateProjectReleaseBindingResp parses an HTTP response from a CreateProjectReleaseBindingWithResponse call
+func ParseCreateProjectReleaseBindingResp(rsp *http.Response) (*CreateProjectReleaseBindingResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateProjectReleaseBindingResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ProjectReleaseBinding
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectReleaseBindingResp parses an HTTP response from a DeleteProjectReleaseBindingWithResponse call
+func ParseDeleteProjectReleaseBindingResp(rsp *http.Response) (*DeleteProjectReleaseBindingResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectReleaseBindingResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectReleaseBindingResp parses an HTTP response from a GetProjectReleaseBindingWithResponse call
+func ParseGetProjectReleaseBindingResp(rsp *http.Response) (*GetProjectReleaseBindingResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectReleaseBindingResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectReleaseBinding
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProjectReleaseBindingResp parses an HTTP response from a UpdateProjectReleaseBindingWithResponse call
+func ParseUpdateProjectReleaseBindingResp(rsp *http.Response) (*UpdateProjectReleaseBindingResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProjectReleaseBindingResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectReleaseBinding
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProjectReleasesResp parses an HTTP response from a ListProjectReleasesWithResponse call
+func ParseListProjectReleasesResp(rsp *http.Response) (*ListProjectReleasesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProjectReleasesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectReleaseList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateProjectReleaseResp parses an HTTP response from a CreateProjectReleaseWithResponse call
+func ParseCreateProjectReleaseResp(rsp *http.Response) (*CreateProjectReleaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateProjectReleaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ProjectRelease
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectReleaseResp parses an HTTP response from a DeleteProjectReleaseWithResponse call
+func ParseDeleteProjectReleaseResp(rsp *http.Response) (*DeleteProjectReleaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectReleaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectReleaseResp parses an HTTP response from a GetProjectReleaseWithResponse call
+func ParseGetProjectReleaseResp(rsp *http.Response) (*GetProjectReleaseResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectReleaseResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectRelease
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListProjectsResp parses an HTTP response from a ListProjectsWithResponse call
 func ParseListProjectsResp(rsp *http.Response) (*ListProjectsResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -28757,6 +32098,344 @@ func ParseUpdateProjectResp(rsp *http.Response) (*UpdateProjectResp, error) {
 			return nil, err
 		}
 		response.JSON422 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListProjectTypesResp parses an HTTP response from a ListProjectTypesWithResponse call
+func ParseListProjectTypesResp(rsp *http.Response) (*ListProjectTypesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListProjectTypesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectTypeList
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateProjectTypeResp parses an HTTP response from a CreateProjectTypeWithResponse call
+func ParseCreateProjectTypeResp(rsp *http.Response) (*CreateProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ProjectType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteProjectTypeResp parses an HTTP response from a DeleteProjectTypeWithResponse call
+func ParseDeleteProjectTypeResp(rsp *http.Response) (*DeleteProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectTypeResp parses an HTTP response from a GetProjectTypeWithResponse call
+func ParseGetProjectTypeResp(rsp *http.Response) (*GetProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateProjectTypeResp parses an HTTP response from a UpdateProjectTypeWithResponse call
+func ParseUpdateProjectTypeResp(rsp *http.Response) (*UpdateProjectTypeResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateProjectTypeResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProjectType
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetProjectTypeSchemaResp parses an HTTP response from a GetProjectTypeSchemaWithResponse call
+func ParseGetProjectTypeSchemaResp(rsp *http.Response) (*GetProjectTypeSchemaResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetProjectTypeSchemaResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SchemaResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalError
@@ -32586,6 +36265,67 @@ func ParseDeleteGitSecretResp(rsp *http.Response) (*DeleteGitSecretResp, error) 
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseTriggerReleaseBindingCronJobResp parses an HTTP response from a TriggerReleaseBindingCronJobWithResponse call
+func ParseTriggerReleaseBindingCronJobResp(rsp *http.Response) (*TriggerReleaseBindingCronJobResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &TriggerReleaseBindingCronJobResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest CronJobTriggerResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest Unauthorized
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/agent-manager-service/clients/openchoreosvc/gen/types.gen.go
+++ b/agent-manager-service/clients/openchoreosvc/gen/types.gen.go
@@ -228,9 +228,33 @@ const (
 	ObservabilityPlaneRefKindObservabilityPlane        ObservabilityPlaneRefKind = "ObservabilityPlane"
 )
 
+// Defines values for PostRenderValidationTargetPlane.
+const (
+	PostRenderValidationTargetPlaneDataplane          PostRenderValidationTargetPlane = "dataplane"
+	PostRenderValidationTargetPlaneObservabilityplane PostRenderValidationTargetPlane = "observabilityplane"
+)
+
+// Defines values for ProjectReleaseSpecProjectTypeKind.
+const (
+	ProjectReleaseSpecProjectTypeKindClusterProjectType ProjectReleaseSpecProjectTypeKind = "ClusterProjectType"
+	ProjectReleaseSpecProjectTypeKindProjectType        ProjectReleaseSpecProjectTypeKind = "ProjectType"
+)
+
 // Defines values for ProjectSpecDeploymentPipelineRefKind.
 const (
 	ProjectSpecDeploymentPipelineRefKindDeploymentPipeline ProjectSpecDeploymentPipelineRefKind = "DeploymentPipeline"
+)
+
+// Defines values for ProjectTypeRefKind.
+const (
+	ProjectTypeRefKindClusterProjectType ProjectTypeRefKind = "ClusterProjectType"
+	ProjectTypeRefKindProjectType        ProjectTypeRefKind = "ProjectType"
+)
+
+// Defines values for ProjectTypeSpecResourcesTargetPlane.
+const (
+	ProjectTypeSpecResourcesTargetPlaneDataplane          ProjectTypeSpecResourcesTargetPlane = "dataplane"
+	ProjectTypeSpecResourcesTargetPlaneObservabilityplane ProjectTypeSpecResourcesTargetPlane = "observabilityplane"
 )
 
 // Defines values for PromotionPathSourceEnvironmentRefKind.
@@ -336,6 +360,12 @@ const (
 	TargetPlaneRefKindWorkflowPlane        TargetPlaneRefKind = "WorkflowPlane"
 )
 
+// Defines values for TraitRemoveTargetPlane.
+const (
+	TraitRemoveTargetPlaneDataplane          TraitRemoveTargetPlane = "dataplane"
+	TraitRemoveTargetPlaneObservabilityplane TraitRemoveTargetPlane = "observabilityplane"
+)
+
 // Defines values for TraitSpecCreatesTargetPlane.
 const (
 	TraitSpecCreatesTargetPlaneDataplane          TraitSpecCreatesTargetPlane = "dataplane"
@@ -351,8 +381,8 @@ const (
 
 // Defines values for TraitSpecPatchesTargetPlane.
 const (
-	TraitSpecPatchesTargetPlaneDataplane          TraitSpecPatchesTargetPlane = "dataplane"
-	TraitSpecPatchesTargetPlaneObservabilityplane TraitSpecPatchesTargetPlane = "observabilityplane"
+	Dataplane          TraitSpecPatchesTargetPlane = "dataplane"
+	Observabilityplane TraitSpecPatchesTargetPlane = "observabilityplane"
 )
 
 // Defines values for WorkflowPlaneRefKind.
@@ -489,8 +519,17 @@ type AuthzCondition struct {
 type AuthzContext struct {
 	// Resource Resource-level attributes for condition evaluation
 	Resource *struct {
-		// Environment Target deployment environment (e.g. "dev", "staging", "prod")
+		// ComponentType ComponentType referenced by the Component as an authz identifier. Namespace-scoped ComponentTypes are namespace-prefixed (e.g. "acme/web-app"); cluster-scoped ClusterComponentTypes are unprefixed (e.g. "web-app").
+		ComponentType *string `json:"componentType,omitempty"`
+
+		// Environment Namespace-prefixed target deployment Environment name (e.g. "acme/dev").
 		Environment *string `json:"environment,omitempty"`
+
+		// ResourceType ResourceType referenced by the Resource as an authz identifier. Namespace-scoped ResourceTypes are namespace-prefixed (e.g. "acme/postgres"); cluster-scoped ClusterResourceTypes are unprefixed (e.g. "postgres").
+		ResourceType *string `json:"resourceType,omitempty"`
+
+		// Workflow Workflow referenced by the WorkflowRun as an authz identifier. Namespace-scoped Workflows are namespace-prefixed (e.g. "acme/build-go"); cluster-scoped ClusterWorkflows are unprefixed (e.g. "build-go").
+		Workflow *string `json:"workflow,omitempty"`
 	} `json:"resource,omitempty"`
 }
 
@@ -780,6 +819,12 @@ type ClusterComponentTypeSpec struct {
 	// Parameters Schema section using openAPIV3Schema format
 	Parameters *SchemaSection `json:"parameters,omitempty"`
 
+	// PostRenderValidations CEL-based validation rules evaluated after all traits are applied, against the final rendered Kubernetes resources
+	PostRenderValidations *[]PostRenderValidation `json:"postRenderValidations,omitempty"`
+
+	// PreRenderValidations CEL-based validation rules evaluated before rendering; replaces the deprecated validations field
+	PreRenderValidations *[]ValidationRule `json:"preRenderValidations,omitempty"`
+
 	// Resources Templates that generate Kubernetes resources dynamically
 	Resources []struct {
 		// ForEach CEL expression for generating multiple resources from a list
@@ -819,7 +864,7 @@ type ClusterComponentTypeSpec struct {
 		Parameters *map[string]interface{} `json:"parameters,omitempty"`
 	} `json:"traits,omitempty"`
 
-	// Validations CEL-based validation rules evaluated during rendering
+	// Validations CEL-based validation rules evaluated before rendering. Deprecated: use preRenderValidations (mutually exclusive).
 	Validations *[]ValidationRule `json:"validations,omitempty"`
 
 	// WorkloadType Primary workload resource type for this component type
@@ -972,6 +1017,35 @@ type ClusterObservabilityPlaneStatus struct {
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
 
+// ClusterProjectType ClusterProjectType resource.
+// Cluster-scoped sibling of ProjectType. Projects in any namespace can reference it.
+type ClusterProjectType struct {
+	// ApiVersion API version of the resource
+	ApiVersion *string `json:"apiVersion,omitempty"`
+
+	// Kind Kind of the resource
+	Kind *string `json:"kind,omitempty"`
+
+	// Metadata Standard Kubernetes object metadata (without kind/apiVersion).
+	// Matches the structure of metav1.ObjectMeta for the fields exposed via the API.
+	Metadata ObjectMeta `json:"metadata"`
+
+	// Spec Desired state of a (Cluster)ProjectType.
+	Spec *ProjectTypeSpec `json:"spec,omitempty"`
+
+	// Status ClusterProjectType status (currently empty)
+	Status *map[string]interface{} `json:"status,omitempty"`
+}
+
+// ClusterProjectTypeList Paginated list of cluster project types
+type ClusterProjectTypeList struct {
+	Items []ClusterProjectType `json:"items"`
+
+	// Pagination Cursor-based pagination metadata. Uses Kubernetes-native continuation tokens
+	// for efficient pagination through large result sets.
+	Pagination Pagination `json:"pagination"`
+}
+
 // ClusterResourceType ClusterResourceType resource.
 // Cluster-scoped sibling of ResourceType. Resources in any namespace can reference it.
 type ClusterResourceType struct {
@@ -1093,7 +1167,16 @@ type ClusterTraitSpec struct {
 		Var *string `json:"var,omitempty"`
 	} `json:"patches,omitempty"`
 
-	// Validations CEL-based validation rules evaluated during rendering
+	// PostRenderValidations CEL-based validation rules evaluated after all traits are applied, against the final rendered Kubernetes resources
+	PostRenderValidations *[]PostRenderValidation `json:"postRenderValidations,omitempty"`
+
+	// PreRenderValidations CEL-based validation rules evaluated before rendering; replaces the deprecated validations field
+	PreRenderValidations *[]ValidationRule `json:"preRenderValidations,omitempty"`
+
+	// Removes Whole resources to delete that were previously produced by the ComponentType or earlier traits. Workload resource kinds (e.g. Deployment, StatefulSet, CronJob) cannot be removed.
+	Removes *[]TraitRemove `json:"removes,omitempty"`
+
+	// Validations CEL-based validation rules evaluated before rendering. Deprecated: use preRenderValidations (mutually exclusive).
 	Validations *[]ValidationRule `json:"validations,omitempty"`
 }
 
@@ -1441,6 +1524,12 @@ type ComponentTypeSpec struct {
 	// Parameters Schema section using openAPIV3Schema format
 	Parameters *SchemaSection `json:"parameters,omitempty"`
 
+	// PostRenderValidations CEL-based validation rules evaluated after all traits are applied, against the final rendered Kubernetes resources
+	PostRenderValidations *[]PostRenderValidation `json:"postRenderValidations,omitempty"`
+
+	// PreRenderValidations CEL-based validation rules evaluated before rendering; replaces the deprecated validations field
+	PreRenderValidations *[]ValidationRule `json:"preRenderValidations,omitempty"`
+
 	// Resources Templates that generate Kubernetes resources dynamically
 	Resources []struct {
 		// ForEach CEL expression for generating multiple resources from a list
@@ -1480,7 +1569,7 @@ type ComponentTypeSpec struct {
 		Parameters *map[string]interface{} `json:"parameters,omitempty"`
 	} `json:"traits,omitempty"`
 
-	// Validations CEL-based validation rules evaluated during rendering
+	// Validations CEL-based validation rules evaluated before rendering. Deprecated: use preRenderValidations (mutually exclusive).
 	Validations *[]ValidationRule `json:"validations,omitempty"`
 
 	// WorkloadType Primary workload resource type for this component type
@@ -1627,6 +1716,18 @@ type CreateSecretRequest struct {
 
 	// TargetPlane Reference to the plane that hosts the secret data.
 	TargetPlane TargetPlaneRef `json:"targetPlane"`
+}
+
+// CronJobTriggerResponse Response describing the Job created from a manual cronjob trigger
+type CronJobTriggerResponse struct {
+	// CronJobName Name of the CronJob the Job was created from
+	CronJobName string `json:"cronJobName"`
+
+	// JobName Name of the Job that was created from the CronJob's jobTemplate
+	JobName string `json:"jobName"`
+
+	// Namespace Data plane namespace where the Job was created
+	Namespace string `json:"namespace"`
 }
 
 // DataPlane DataPlane resource.
@@ -1913,8 +2014,8 @@ type EvaluateRequest struct {
 	// Resource Resource for authorization evaluation
 	Resource Resource `json:"resource"`
 
-	// SubjectContext Authenticated subject context
-	SubjectContext SubjectContext `json:"subject_context"`
+	// SubjectContext Subject to evaluate. Optional; defaults to the authenticated caller when omitted.
+	SubjectContext *SubjectContext `json:"subject_context,omitempty"`
 }
 
 // ExternalRef Reference to an external CR whose spec is resolved and injected into the CEL context under the given id.
@@ -2412,12 +2513,57 @@ type PendingConnection struct {
 
 // PodLogEntry A single log entry from a pod
 type PodLogEntry struct {
+	// Container Name of the container that produced this log entry
+	Container string `json:"container"`
+
 	// Log Log message content
 	Log string `json:"log"`
 
 	// Timestamp Timestamp of the log entry in RFC3339 format
 	Timestamp time.Time `json:"timestamp"`
 }
+
+// PostRenderValidation CEL-based validation rule evaluated after all traits are applied, against the final rendered Kubernetes resources
+type PostRenderValidation struct {
+	// ForEach Optional CEL expression yielding a list; the validation is repeated per item with the loop variable bound. Requires var.
+	ForEach *string `json:"forEach,omitempty"`
+
+	// Message Error message shown when the rule evaluates to false
+	Message string `json:"message"`
+
+	// Rule CEL expression wrapped in ${...}, evaluated with resource bound to each match; must evaluate to true
+	Rule string `json:"rule"`
+
+	// Target Rendered resources this validation applies to
+	Target struct {
+		// Group API group of the resource
+		Group string `json:"group"`
+
+		// Kind Resource type to select
+		Kind string `json:"kind"`
+
+		// MustMatch Require at least one rendered resource to match this target; when true and none match, the validation fails
+		MustMatch *bool `json:"mustMatch,omitempty"`
+
+		// Version API version of the resource
+		Version string `json:"version"`
+
+		// Where CEL expression to filter which resources to select
+		Where *string `json:"where,omitempty"`
+	} `json:"target"`
+
+	// TargetPlane Plane to scope selection to; without it a rule matches resources of the same GVK across every plane
+	TargetPlane *PostRenderValidationTargetPlane `json:"targetPlane,omitempty"`
+
+	// Var Loop variable name for forEach iterations; available in target.where and rule. Required when forEach is set.
+	Var *string `json:"var,omitempty"`
+
+	// When Optional CEL guard evaluated against the source's context; if it evaluates to false the validation is skipped
+	When *string `json:"when,omitempty"`
+}
+
+// PostRenderValidationTargetPlane Plane to scope selection to; without it a rule matches resources of the same GVK across every plane
+type PostRenderValidationTargetPlane string
 
 // Project Project resource.
 // Projects group components within a namespace and reference a deployment pipeline.
@@ -2446,6 +2592,131 @@ type ProjectList struct {
 	Pagination Pagination `json:"pagination"`
 }
 
+// ProjectRelease ProjectRelease resource.
+// Immutable snapshot of Project.spec and the referenced (Cluster)ProjectType.spec
+// at the time it was cut. Normally cut by the Project controller; the create
+// endpoint is exposed only for offline-emit parity. Spec is immutable.
+type ProjectRelease struct {
+	// ApiVersion API version of the resource
+	ApiVersion *string `json:"apiVersion,omitempty"`
+
+	// Kind Kind of the resource
+	Kind *string `json:"kind,omitempty"`
+
+	// Metadata Standard Kubernetes object metadata (without kind/apiVersion).
+	// Matches the structure of metav1.ObjectMeta for the fields exposed via the API.
+	Metadata ObjectMeta `json:"metadata"`
+
+	// Spec Desired state of a ProjectRelease. Immutable after creation.
+	Spec *ProjectReleaseSpec `json:"spec,omitempty"`
+
+	// Status ProjectRelease status (currently empty, immutable after creation)
+	Status *map[string]interface{} `json:"status,omitempty"`
+}
+
+// ProjectReleaseBinding ProjectReleaseBinding resource.
+// Pins a ProjectRelease to an Environment, owns the namespace for the
+// (Project, Environment) tuple, and applies the inlined
+// (Cluster)ProjectType resources to that namespace. Authored externally.
+type ProjectReleaseBinding struct {
+	// ApiVersion API version of the resource
+	ApiVersion *string `json:"apiVersion,omitempty"`
+
+	// Kind Kind of the resource
+	Kind *string `json:"kind,omitempty"`
+
+	// Metadata Standard Kubernetes object metadata (without kind/apiVersion).
+	// Matches the structure of metav1.ObjectMeta for the fields exposed via the API.
+	Metadata ObjectMeta `json:"metadata"`
+
+	// Spec Desired state of a ProjectReleaseBinding. spec.owner and spec.environment
+	// are immutable after creation. spec.projectRelease is the promote pin:
+	// left unset, the Project controller seeds it once with the project's
+	// latest release; advancing it afterwards is manual (API update, GitOps,
+	// kubectl edit).
+	Spec   *ProjectReleaseBindingSpec   `json:"spec,omitempty"`
+	Status *ProjectReleaseBindingStatus `json:"status,omitempty"`
+}
+
+// ProjectReleaseBindingList Paginated list of project release bindings
+type ProjectReleaseBindingList struct {
+	Items []ProjectReleaseBinding `json:"items"`
+
+	// Pagination Cursor-based pagination metadata. Uses Kubernetes-native continuation tokens
+	// for efficient pagination through large result sets.
+	Pagination Pagination `json:"pagination"`
+}
+
+// ProjectReleaseBindingSpec Desired state of a ProjectReleaseBinding. spec.owner and spec.environment
+// are immutable after creation. spec.projectRelease is the promote pin:
+// left unset, the Project controller seeds it once with the project's
+// latest release; advancing it afterwards is manual (API update, GitOps,
+// kubectl edit).
+type ProjectReleaseBindingSpec struct {
+	// Environment Target environment name. Immutable after creation.
+	Environment string `json:"environment"`
+
+	// EnvironmentConfigs Per-environment values for the inlined (Cluster)ProjectType.spec.environmentConfigs.
+	EnvironmentConfigs *map[string]interface{} `json:"environmentConfigs,omitempty"`
+
+	// Owner Identifies the project this binding belongs to.
+	Owner struct {
+		// ProjectName Parent project name
+		ProjectName string `json:"projectName"`
+	} `json:"owner"`
+
+	// ProjectRelease Pinned ProjectRelease name. Left unset, it is seeded once by the Project controller with the latest release; advanced manually afterwards (e.g. via `occ project promote`).
+	ProjectRelease *string `json:"projectRelease,omitempty"`
+}
+
+// ProjectReleaseBindingStatus Observed state of a ProjectReleaseBinding.
+type ProjectReleaseBindingStatus struct {
+	// Conditions Latest available observations of the binding's state. Includes Synced, NamespaceReady, ResourcesReady, and Ready (aggregate).
+	Conditions *[]Condition `json:"conditions,omitempty"`
+
+	// Namespace The data-plane namespace owned by this binding.
+	Namespace *string `json:"namespace,omitempty"`
+
+	// ObservedGeneration Most recent generation observed by the controller.
+	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
+}
+
+// ProjectReleaseList Paginated list of project releases
+type ProjectReleaseList struct {
+	Items []ProjectRelease `json:"items"`
+
+	// Pagination Cursor-based pagination metadata. Uses Kubernetes-native continuation tokens
+	// for efficient pagination through large result sets.
+	Pagination Pagination `json:"pagination"`
+}
+
+// ProjectReleaseSpec Desired state of a ProjectRelease. Immutable after creation.
+type ProjectReleaseSpec struct {
+	// Owner Identifies the project this ProjectRelease belongs to.
+	Owner struct {
+		// ProjectName Parent project name
+		ProjectName string `json:"projectName"`
+	} `json:"owner"`
+
+	// Parameters Snapshot of parameter values from Project.spec at release time.
+	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+
+	// ProjectType Frozen snapshot of the referenced (Cluster)ProjectType.
+	ProjectType struct {
+		// Kind Source kind (ProjectType or ClusterProjectType)
+		Kind ProjectReleaseSpecProjectTypeKind `json:"kind"`
+
+		// Name Source project type name
+		Name string `json:"name"`
+
+		// Spec Desired state of a (Cluster)ProjectType.
+		Spec ProjectTypeSpec `json:"spec"`
+	} `json:"projectType"`
+}
+
+// ProjectReleaseSpecProjectTypeKind Source kind (ProjectType or ClusterProjectType)
+type ProjectReleaseSpecProjectTypeKind string
+
 // ProjectSpec Desired state of a Project
 type ProjectSpec struct {
 	// DeploymentPipelineRef Reference to the DeploymentPipeline that defines the environments
@@ -2457,6 +2728,16 @@ type ProjectSpec struct {
 		// Name Name of the deployment pipeline resource
 		Name string `json:"name"`
 	} `json:"deploymentPipelineRef,omitempty"`
+
+	// Parameters Values for the parameter schema declared on the referenced
+	// (Cluster)ProjectType. Validated by the controller and inlined into
+	// each ProjectRelease snapshot.
+	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+
+	// Type Reference to a ProjectType or ClusterProjectType template. Immutable
+	// after the Project is created. When omitted on create, the API defaults
+	// to the cluster-scoped `default` ClusterProjectType.
+	Type *ProjectTypeRef `json:"type,omitempty"`
 }
 
 // ProjectSpecDeploymentPipelineRefKind Kind of deployment pipeline resource
@@ -2467,9 +2748,97 @@ type ProjectStatus struct {
 	// Conditions Current state conditions of the Project
 	Conditions *[]Condition `json:"conditions,omitempty"`
 
+	// LatestRelease Most recent ProjectRelease cut for this Project. ProjectReleaseBindings pin spec.projectRelease to a value here (or an older release for rollback).
+	LatestRelease *struct {
+		// Hash Content hash of Project.spec + (Cluster)ProjectType.spec captured at release time
+		Hash string `json:"hash"`
+
+		// Name Name of the ProjectRelease resource
+		Name string `json:"name"`
+	} `json:"latestRelease,omitempty"`
+
 	// ObservedGeneration Generation of the most recently observed Project
 	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
 }
+
+// ProjectType ProjectType resource.
+// PE-published template scoped to a namespace. Developers reference it from Project.spec.type.
+type ProjectType struct {
+	// ApiVersion API version of the resource
+	ApiVersion *string `json:"apiVersion,omitempty"`
+
+	// Kind Kind of the resource
+	Kind *string `json:"kind,omitempty"`
+
+	// Metadata Standard Kubernetes object metadata (without kind/apiVersion).
+	// Matches the structure of metav1.ObjectMeta for the fields exposed via the API.
+	Metadata ObjectMeta `json:"metadata"`
+
+	// Spec Desired state of a (Cluster)ProjectType.
+	Spec *ProjectTypeSpec `json:"spec,omitempty"`
+
+	// Status ProjectType status (currently empty)
+	Status *map[string]interface{} `json:"status,omitempty"`
+}
+
+// ProjectTypeList Paginated list of project types
+type ProjectTypeList struct {
+	Items []ProjectType `json:"items"`
+
+	// Pagination Cursor-based pagination metadata. Uses Kubernetes-native continuation tokens
+	// for efficient pagination through large result sets.
+	Pagination Pagination `json:"pagination"`
+}
+
+// ProjectTypeRef Reference to a ProjectType or ClusterProjectType template. Immutable
+// after the Project is created. When omitted on create, the API defaults
+// to the cluster-scoped `default` ClusterProjectType.
+type ProjectTypeRef struct {
+	// Kind Project type kind. Defaults to ProjectType (namespaced).
+	Kind *ProjectTypeRefKind `json:"kind,omitempty"`
+
+	// Name Template name.
+	Name string `json:"name"`
+}
+
+// ProjectTypeRefKind Project type kind. Defaults to ProjectType (namespaced).
+type ProjectTypeRefKind string
+
+// ProjectTypeSpec Desired state of a (Cluster)ProjectType.
+type ProjectTypeSpec struct {
+	// EnvironmentConfigs Schema section using openAPIV3Schema format
+	EnvironmentConfigs *SchemaSection `json:"environmentConfigs,omitempty"`
+
+	// Parameters Schema section using openAPIV3Schema format
+	Parameters *SchemaSection `json:"parameters,omitempty"`
+
+	// Resources Templates that generate namespace-scoped Kubernetes manifests applied to the namespace owned by every ProjectReleaseBinding of this type.
+	Resources []struct {
+		// ForEach CEL expression for generating multiple resources from a list.
+		ForEach *string `json:"forEach,omitempty"`
+
+		// Id Unique identifier for this resource within the project type.
+		Id string `json:"id"`
+
+		// IncludeWhen CEL expression determining if this resource should be created.
+		IncludeWhen *string `json:"includeWhen,omitempty"`
+
+		// TargetPlane Target plane for deployment.
+		TargetPlane *ProjectTypeSpecResourcesTargetPlane `json:"targetPlane,omitempty"`
+
+		// Template Kubernetes resource template with CEL expressions.
+		Template map[string]interface{} `json:"template"`
+
+		// Var Loop variable name when using forEach.
+		Var *string `json:"var,omitempty"`
+	} `json:"resources"`
+
+	// Validations CEL-based validation rules evaluated during rendering.
+	Validations *[]ValidationRule `json:"validations,omitempty"`
+}
+
+// ProjectTypeSpecResourcesTargetPlane Target plane for deployment.
+type ProjectTypeSpecResourcesTargetPlane string
 
 // PromotionPath Promotion path between environments
 type PromotionPath struct {
@@ -3407,6 +3776,36 @@ type TraitList struct {
 	Pagination Pagination `json:"pagination"`
 }
 
+// TraitRemove Whole resource to delete that was previously produced by the ComponentType or earlier traits. Shared by TraitSpec and ClusterTraitSpec.
+type TraitRemove struct {
+	// ForEach CEL expression for repeating this remove
+	ForEach *string `json:"forEach,omitempty"`
+
+	// Target Target resource to remove; matching resources are deleted entirely
+	Target struct {
+		// Group API group of the resource
+		Group string `json:"group"`
+
+		// Kind Resource type to remove
+		Kind string `json:"kind"`
+
+		// Version API version of the resource
+		Version string `json:"version"`
+
+		// Where CEL expression to filter which resources to remove
+		Where *string `json:"where,omitempty"`
+	} `json:"target"`
+
+	// TargetPlane Target plane for this remove
+	TargetPlane *TraitRemoveTargetPlane `json:"targetPlane,omitempty"`
+
+	// Var Loop variable name when using forEach
+	Var *string `json:"var,omitempty"`
+}
+
+// TraitRemoveTargetPlane Target plane for this remove
+type TraitRemoveTargetPlane string
+
 // TraitSpec Desired state of a Trait
 type TraitSpec struct {
 	// Creates New Kubernetes resources to create when this trait is applied
@@ -3472,7 +3871,16 @@ type TraitSpec struct {
 		Var *string `json:"var,omitempty"`
 	} `json:"patches,omitempty"`
 
-	// Validations CEL-based validation rules evaluated during rendering
+	// PostRenderValidations CEL-based validation rules evaluated after all traits are applied, against the final rendered Kubernetes resources
+	PostRenderValidations *[]PostRenderValidation `json:"postRenderValidations,omitempty"`
+
+	// PreRenderValidations CEL-based validation rules evaluated before rendering; replaces the deprecated validations field
+	PreRenderValidations *[]ValidationRule `json:"preRenderValidations,omitempty"`
+
+	// Removes Whole resources to delete that were previously produced by the ComponentType or earlier traits. Workload resource kinds (e.g. Deployment, StatefulSet, CronJob) cannot be removed.
+	Removes *[]TraitRemove `json:"removes,omitempty"`
+
+	// Validations CEL-based validation rules evaluated before rendering. Deprecated: use preRenderValidations (mutually exclusive).
 	Validations *[]ValidationRule `json:"validations,omitempty"`
 }
 
@@ -3998,6 +4406,9 @@ type ClusterDataPlaneNameParam = string
 // ClusterObservabilityPlaneNameParam defines model for ClusterObservabilityPlaneNameParam.
 type ClusterObservabilityPlaneNameParam = string
 
+// ClusterProjectTypeNameParam defines model for ClusterProjectTypeNameParam.
+type ClusterProjectTypeNameParam = string
+
 // ClusterResourceTypeNameParam defines model for ClusterResourceTypeNameParam.
 type ClusterResourceTypeNameParam = string
 
@@ -4054,6 +4465,15 @@ type ProjectNameParam = string
 
 // ProjectQueryParam defines model for ProjectQueryParam.
 type ProjectQueryParam = string
+
+// ProjectReleaseBindingNameParam defines model for ProjectReleaseBindingNameParam.
+type ProjectReleaseBindingNameParam = string
+
+// ProjectReleaseNameParam defines model for ProjectReleaseNameParam.
+type ProjectReleaseNameParam = string
+
+// ProjectTypeNameParam defines model for ProjectTypeNameParam.
+type ProjectTypeNameParam = string
 
 // ReleaseBindingNameParam defines model for ReleaseBindingNameParam.
 type ReleaseBindingNameParam = string
@@ -4209,6 +4629,23 @@ type ListClusterDataPlanesParams struct {
 
 // ListClusterObservabilityPlanesParams defines parameters for ListClusterObservabilityPlanes.
 type ListClusterObservabilityPlanesParams struct {
+	// LabelSelector A label selector to filter resources using Kubernetes label selector syntax.
+	// Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+	// Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+	// Supports existence checks: "key" (label exists), "!key" (label does not exist).
+	// Multiple requirements are comma-separated and ANDed together.
+	LabelSelector *LabelSelectorParam `form:"labelSelector,omitempty" json:"labelSelector,omitempty"`
+
+	// Limit Maximum number of items to return per page
+	Limit *LimitParam `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Opaque pagination cursor from a previous response.
+	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
+	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// ListClusterProjectTypesParams defines parameters for ListClusterProjectTypes.
+type ListClusterProjectTypesParams struct {
 	// LabelSelector A label selector to filter resources using Kubernetes label selector syntax.
 	// Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
 	// Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
@@ -4485,8 +4922,65 @@ type ListObservabilityPlanesParams struct {
 	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
 }
 
+// ListProjectReleaseBindingsParams defines parameters for ListProjectReleaseBindings.
+type ListProjectReleaseBindingsParams struct {
+	// Project Filter resources by project name
+	Project *ProjectQueryParam `form:"project,omitempty" json:"project,omitempty"`
+
+	// LabelSelector A label selector to filter resources using Kubernetes label selector syntax.
+	// Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+	// Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+	// Supports existence checks: "key" (label exists), "!key" (label does not exist).
+	// Multiple requirements are comma-separated and ANDed together.
+	LabelSelector *LabelSelectorParam `form:"labelSelector,omitempty" json:"labelSelector,omitempty"`
+
+	// Limit Maximum number of items to return per page
+	Limit *LimitParam `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Opaque pagination cursor from a previous response.
+	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
+	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// ListProjectReleasesParams defines parameters for ListProjectReleases.
+type ListProjectReleasesParams struct {
+	// Project Filter resources by project name
+	Project *ProjectQueryParam `form:"project,omitempty" json:"project,omitempty"`
+
+	// LabelSelector A label selector to filter resources using Kubernetes label selector syntax.
+	// Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+	// Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+	// Supports existence checks: "key" (label exists), "!key" (label does not exist).
+	// Multiple requirements are comma-separated and ANDed together.
+	LabelSelector *LabelSelectorParam `form:"labelSelector,omitempty" json:"labelSelector,omitempty"`
+
+	// Limit Maximum number of items to return per page
+	Limit *LimitParam `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Opaque pagination cursor from a previous response.
+	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
+	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
 // ListProjectsParams defines parameters for ListProjects.
 type ListProjectsParams struct {
+	// LabelSelector A label selector to filter resources using Kubernetes label selector syntax.
+	// Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
+	// Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
+	// Supports existence checks: "key" (label exists), "!key" (label does not exist).
+	// Multiple requirements are comma-separated and ANDed together.
+	LabelSelector *LabelSelectorParam `form:"labelSelector,omitempty" json:"labelSelector,omitempty"`
+
+	// Limit Maximum number of items to return per page
+	Limit *LimitParam `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Cursor Opaque pagination cursor from a previous response.
+	// Pass the `nextCursor` value from pagination metadata to fetch the next page.
+	Cursor *CursorParam `form:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+// ListProjectTypesParams defines parameters for ListProjectTypes.
+type ListProjectTypesParams struct {
 	// LabelSelector A label selector to filter resources using Kubernetes label selector syntax.
 	// Supports equality-based requirements: "key=value" (equality), "key!=value" (inequality).
 	// Supports set-based requirements: "key in (val1,val2)" (value in set), "key notin (val1,val2)" (value not in set).
@@ -4541,6 +5035,9 @@ type GetReleaseBindingK8sResourceEventsParams struct {
 type GetReleaseBindingK8sResourceLogsParams struct {
 	// PodName Name of the pod
 	PodName string `form:"podName" json:"podName"`
+
+	// Container Name of the container to fetch logs from. If omitted, logs from all containers in the pod are returned, with each entry tagged by container.
+	Container *string `form:"container,omitempty" json:"container,omitempty"`
 
 	// SinceSeconds Number of seconds since which to show logs
 	SinceSeconds *int64 `form:"sinceSeconds,omitempty" json:"sinceSeconds,omitempty"`
@@ -4759,6 +5256,9 @@ type HandleAutoBuildParams struct {
 
 	// XEventKey Bitbucket webhook event-key header used to detect Bitbucket events.
 	XEventKey *string `json:"X-Event-Key,omitempty"`
+
+	// XHubSignature Bitbucket webhook HMAC-SHA256 signature (`sha256=<hex>`) used to validate Bitbucket events.
+	XHubSignature *string `json:"X-Hub-Signature,omitempty"`
 }
 
 // ListSecretsParams defines parameters for ListSecrets.
@@ -4803,6 +5303,12 @@ type CreateClusterObservabilityPlaneJSONRequestBody = ClusterObservabilityPlane
 
 // UpdateClusterObservabilityPlaneJSONRequestBody defines body for UpdateClusterObservabilityPlane for application/json ContentType.
 type UpdateClusterObservabilityPlaneJSONRequestBody = ClusterObservabilityPlane
+
+// CreateClusterProjectTypeJSONRequestBody defines body for CreateClusterProjectType for application/json ContentType.
+type CreateClusterProjectTypeJSONRequestBody = ClusterProjectType
+
+// UpdateClusterProjectTypeJSONRequestBody defines body for UpdateClusterProjectType for application/json ContentType.
+type UpdateClusterProjectTypeJSONRequestBody = ClusterProjectType
 
 // CreateClusterResourceTypeJSONRequestBody defines body for CreateClusterResourceType for application/json ContentType.
 type CreateClusterResourceTypeJSONRequestBody = ClusterResourceType
@@ -4894,11 +5400,26 @@ type CreateObservabilityPlaneJSONRequestBody = ObservabilityPlane
 // UpdateObservabilityPlaneJSONRequestBody defines body for UpdateObservabilityPlane for application/json ContentType.
 type UpdateObservabilityPlaneJSONRequestBody = ObservabilityPlane
 
+// CreateProjectReleaseBindingJSONRequestBody defines body for CreateProjectReleaseBinding for application/json ContentType.
+type CreateProjectReleaseBindingJSONRequestBody = ProjectReleaseBinding
+
+// UpdateProjectReleaseBindingJSONRequestBody defines body for UpdateProjectReleaseBinding for application/json ContentType.
+type UpdateProjectReleaseBindingJSONRequestBody = ProjectReleaseBinding
+
+// CreateProjectReleaseJSONRequestBody defines body for CreateProjectRelease for application/json ContentType.
+type CreateProjectReleaseJSONRequestBody = ProjectRelease
+
 // CreateProjectJSONRequestBody defines body for CreateProject for application/json ContentType.
 type CreateProjectJSONRequestBody = Project
 
 // UpdateProjectJSONRequestBody defines body for UpdateProject for application/json ContentType.
 type UpdateProjectJSONRequestBody = Project
+
+// CreateProjectTypeJSONRequestBody defines body for CreateProjectType for application/json ContentType.
+type CreateProjectTypeJSONRequestBody = ProjectType
+
+// UpdateProjectTypeJSONRequestBody defines body for UpdateProjectType for application/json ContentType.
+type UpdateProjectTypeJSONRequestBody = ProjectType
 
 // CreateReleaseBindingJSONRequestBody defines body for CreateReleaseBinding for application/json ContentType.
 type CreateReleaseBindingJSONRequestBody = ReleaseBinding

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -2628,6 +2628,17 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 		return "", fmt.Errorf("no environment found in deployment pipeline")
 	}
 
+	// The cell namespace for (project, environment) is owned by a
+	// ProjectReleaseBinding. Without one the release binding this deploy creates
+	// fails to apply with `namespaces "dp-..." not found`. Ensure it here rather
+	// than only at project creation, so projects created before this existed and
+	// environments added after the project was created are both covered.
+	if err := s.ocClient.EnsureProjectReleaseBinding(ctx, ouID, projectName, lowestEnv); err != nil {
+		s.logger.Error("Failed to ensure project release binding before deploy",
+			"ouID", ouID, "projectName", projectName, "environment", lowestEnv, "error", err)
+		return "", fmt.Errorf("failed to prepare environment %q for deployment: %w", lowestEnv, err)
+	}
+
 	// Convert to deploy request with user-provided env vars
 	deployReq := client.DeployRequest{
 		ImageID:     req.ImageId,
@@ -3908,6 +3919,17 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			s.logger.Error("Failed to persist agent config for target environment", "agentName", agentName, "environment", req.TargetEnvironment, "error", upsertErr)
 			return fmt.Errorf("failed to persist agent config for target environment %q: %w", req.TargetEnvironment, upsertErr)
 		}
+	}
+
+	// The target environment's cell namespace is owned by a ProjectReleaseBinding.
+	// A project promoted into an environment for the first time — or into one
+	// added after the project was created — has no binding there yet, and the
+	// promoted release binding would fail to apply with `namespaces "dp-..." not
+	// found`.
+	if err := s.ocClient.EnsureProjectReleaseBinding(ctx, ouID, projectName, req.TargetEnvironment); err != nil {
+		s.logger.Error("Failed to ensure project release binding before promote",
+			"ouID", ouID, "projectName", projectName, "environment", req.TargetEnvironment, "error", err)
+		return fmt.Errorf("failed to prepare environment %q for promotion: %w", req.TargetEnvironment, err)
 	}
 
 	// Promote via OC client. The target environment's AgentID is already

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -3629,6 +3629,23 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 		return fmt.Errorf("%w for agent %s in environment %s", utils.ErrDeploymentInProgress, agentName, req.TargetEnvironment)
 	}
 
+	// The target environment's cell namespace is owned by a ProjectReleaseBinding.
+	// A project promoted into an environment for the first time — or into one
+	// added after the project was created — has no binding there yet, and the
+	// promoted release binding would fail to apply with `namespaces "dp-..." not
+	// found`.
+	//
+	// This runs before the first write to the target environment (AgentID
+	// provisioning, the API key, the persisted agent config), so a promotion
+	// that cannot get a namespace leaves no half-provisioned target behind. It
+	// runs after the read-only guards above so a promotion they already reject
+	// does not create a binding for an environment nothing was promoted into.
+	if err := s.ocClient.EnsureProjectReleaseBinding(ctx, ouID, projectName, req.TargetEnvironment); err != nil {
+		s.logger.Error("Failed to ensure project release binding before promote",
+			"ouID", ouID, "projectName", projectName, "environment", req.TargetEnvironment, "error", err)
+		return fmt.Errorf("failed to prepare environment %q for promotion: %w", req.TargetEnvironment, err)
+	}
+
 	// System-managed env vars (LLM provider URL/key, MCP, etc.) live per-environment in
 	// agent_env_config_variables_mapping. Promotion must enforce this invariant: if the
 	// SOURCE environment has any system-managed vars, the TARGET environment must also
@@ -3919,17 +3936,6 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			s.logger.Error("Failed to persist agent config for target environment", "agentName", agentName, "environment", req.TargetEnvironment, "error", upsertErr)
 			return fmt.Errorf("failed to persist agent config for target environment %q: %w", req.TargetEnvironment, upsertErr)
 		}
-	}
-
-	// The target environment's cell namespace is owned by a ProjectReleaseBinding.
-	// A project promoted into an environment for the first time — or into one
-	// added after the project was created — has no binding there yet, and the
-	// promoted release binding would fail to apply with `namespaces "dp-..." not
-	// found`.
-	if err := s.ocClient.EnsureProjectReleaseBinding(ctx, ouID, projectName, req.TargetEnvironment); err != nil {
-		s.logger.Error("Failed to ensure project release binding before promote",
-			"ouID", ouID, "projectName", projectName, "environment", req.TargetEnvironment, "error", err)
-		return fmt.Errorf("failed to prepare environment %q for promotion: %w", req.TargetEnvironment, err)
 	}
 
 	// Promote via OC client. The target environment's AgentID is already

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -518,6 +518,7 @@ func TestDeployAgent_IdentityInjectionError_AbortsDeploy(t *testing.T) {
 		GetComponentConfigurationsFunc: func(context.Context, string, string, string, string) ([]models.EnvVars, error) {
 			return nil, nil
 		},
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, _ string) error { return nil },
 		DeployFunc: func(context.Context, string, string, string, client.DeployRequest) error {
 			deployCalled = true
 			return nil
@@ -631,7 +632,8 @@ func promoteAgentTestFixture(t *testing.T, tgtIdentityEnvVars []client.EnvVar, t
 				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}}},
 			}}, nil
 		},
-		IsDeploymentInProgressFunc: func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		IsDeploymentInProgressFunc:      func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, _ string) error { return nil },
 		PromoteComponentFunc: func(_ context.Context, _, _, _, _, _ string, _ []client.EnvVar, _ []client.FileVar, _, _ map[string]interface{}) error {
 			promoteCalled = true
 			return nil
@@ -788,7 +790,8 @@ func TestPromoteAgent_KickOffThenRetry_SucceedsOnceTargetIdentityCompletes(t *te
 				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}}},
 			}}, nil
 		},
-		IsDeploymentInProgressFunc: func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		IsDeploymentInProgressFunc:      func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, _ string) error { return nil },
 		PromoteComponentFunc: func(_ context.Context, _, _, _, _, _ string, envOverrides []client.EnvVar, _ []client.FileVar, _, _ map[string]interface{}) error {
 			promoteCalled = true
 			capturedOverrides = envOverrides
@@ -886,7 +889,8 @@ func TestPromoteAgent_PollSucceedsWithinBudget_PromotesOnFirstCall(t *testing.T)
 				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}}},
 			}}, nil
 		},
-		IsDeploymentInProgressFunc: func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		IsDeploymentInProgressFunc:      func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, _ string) error { return nil },
 		PromoteComponentFunc: func(_ context.Context, _, _, _, _, _ string, _ []client.EnvVar, _ []client.FileVar, _, _ map[string]interface{}) error {
 			promoteCalled = true
 			return nil
@@ -1010,7 +1014,8 @@ func TestPromoteAgent_ProvisioningDisabled_SkipsIdentityCheckAndPromotes(t *test
 				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}}},
 			}}, nil
 		},
-		IsDeploymentInProgressFunc: func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		IsDeploymentInProgressFunc:      func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, _ string) error { return nil },
 		PromoteComponentFunc: func(_ context.Context, _, _, _, _, _ string, _ []client.EnvVar, _ []client.FileVar, _, _ map[string]interface{}) error {
 			promoteCalled = true
 			return nil
@@ -1073,7 +1078,8 @@ func TestPromoteAgent_ProvisioningDisabledButLowestEnvHasRealCredential_StillBlo
 				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}}},
 			}}, nil
 		},
-		IsDeploymentInProgressFunc: func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		IsDeploymentInProgressFunc:      func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, _ string) error { return nil },
 		PromoteComponentFunc: func(_ context.Context, _, _, _, _, _ string, _ []client.EnvVar, _ []client.FileVar, _, _ map[string]interface{}) error {
 			promoteCalled = true
 			return nil
@@ -1433,6 +1439,7 @@ func deployAPIAgentMocks(existingConfig *models.AgentConfig) (*agentManagerServi
 			capturedDeployConfig = req
 			return nil
 		},
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, _ string) error { return nil },
 		DeployFunc: func(context.Context, string, string, string, client.DeployRequest) error {
 			return nil
 		},

--- a/agent-manager-service/services/infra_resource_manager.go
+++ b/agent-manager-service/services/infra_resource_manager.go
@@ -124,6 +124,12 @@ func (s *infraResourceManager) CreateProject(ctx context.Context, ouID string, p
 	}
 	s.logger.Info("Project created successfully", "ouID", ouID, "projectName", payload.Name)
 
+	// Provision the cell namespace for every environment the project can reach.
+	// Best effort: the project itself exists and is usable, and the deploy and
+	// promote paths ensure the binding for the environment they target, so a
+	// failure here is recoverable rather than a reason to fail the request.
+	s.ensureProjectReleaseBindings(ctx, ouID, payload.Name)
+
 	return &models.ProjectResponse{
 		Name:               payload.Name,
 		OrgName:            ouID,
@@ -132,6 +138,58 @@ func (s *infraResourceManager) CreateProject(ctx context.Context, ouID string, p
 		CreatedAt:          time.Now(),
 		DeploymentPipeline: payload.DeploymentPipeline,
 	}, nil
+}
+
+// ensureProjectReleaseBindings creates a ProjectReleaseBinding for the project in
+// every environment of its deployment pipeline, so the cell namespace exists
+// before anything is deployed there. Failures are logged, not returned — see the
+// call site for why.
+func (s *infraResourceManager) ensureProjectReleaseBindings(ctx context.Context, ouID, projectName string) {
+	pipeline, err := s.ocClient.GetProjectDeploymentPipeline(ctx, ouID, projectName)
+	if err != nil {
+		s.logger.Error("Failed to resolve deployment pipeline for project release bindings",
+			"ouID", ouID, "projectName", projectName, "error", err)
+		return
+	}
+
+	for _, envName := range pipelineEnvironments(pipeline) {
+		if err := s.ocClient.EnsureProjectReleaseBinding(ctx, ouID, projectName, envName); err != nil {
+			s.logger.Error("Failed to ensure project release binding",
+				"ouID", ouID, "projectName", projectName, "environment", envName, "error", err)
+			continue
+		}
+		s.logger.Debug("Ensured project release binding",
+			"ouID", ouID, "projectName", projectName, "environment", envName)
+	}
+}
+
+// pipelineEnvironments returns every environment named by a pipeline's promotion
+// paths — sources and targets alike — in a stable order and without duplicates.
+func pipelineEnvironments(pipeline *models.DeploymentPipelineResponse) []string {
+	if pipeline == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	envNames := make([]string, 0, len(pipeline.PromotionPaths))
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		envNames = append(envNames, name)
+	}
+
+	for _, path := range pipeline.PromotionPaths {
+		add(path.SourceEnvironmentRef)
+		for _, target := range path.TargetEnvironmentRefs {
+			add(target.Name)
+		}
+	}
+	return envNames
 }
 
 func (s *infraResourceManager) UpdateProject(ctx context.Context, ouID string, projectName string, payload spec.UpdateProjectRequest) (*models.ProjectResponse, error) {

--- a/agent-manager-service/services/infra_resource_manager_unit_test.go
+++ b/agent-manager-service/services/infra_resource_manager_unit_test.go
@@ -161,6 +161,16 @@ func TestInfraResourceManager_CreateProject(t *testing.T) {
 				captured = req
 				return nil
 			},
+			// Reached only on the success path, where the created project's cell
+			// namespaces are provisioned per environment.
+			GetProjectDeploymentPipelineFunc: func(context.Context, string, string) (*models.DeploymentPipelineResponse, error) {
+				return &models.DeploymentPipelineResponse{PromotionPaths: []models.PromotionPath{
+					{SourceEnvironmentRef: "default"},
+				}}, nil
+			},
+			EnsureProjectReleaseBindingFunc: func(context.Context, string, string, string) error {
+				return nil
+			},
 		}
 		got, err := newInfraManager(oc).CreateProject(context.Background(), org, payload)
 

--- a/agent-manager-service/services/project_release_binding_unit_test.go
+++ b/agent-manager-service/services/project_release_binding_unit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -181,6 +182,82 @@ func TestPipelineEnvironments(t *testing.T) {
 			assert.Equal(t, tc.want, pipelineEnvironments(tc.pipeline))
 		})
 	}
+}
+
+// recordingProvisioningStub records whether the promote path reached the first
+// write to the target environment.
+type recordingProvisioningStub struct {
+	*stubAgentThunderProvisioning
+	provisionCalled *bool
+}
+
+func (s *recordingProvisioningStub) ProvisionForEnvironmentIfMissing(_ context.Context, _, _, _, _ string, _ models.AgentProvisioningType, _ string) (bool, error) {
+	*s.provisionCalled = true
+	return false, nil
+}
+
+func TestPromoteAgent_BindingFailureAbortsBeforeAnyTargetWrite(t *testing.T) {
+	boom := errors.New("openchoreo unavailable")
+	promoteCalled := false
+	provisionCalled := false
+	configUpserted := false
+
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+			return &models.OrganizationResponse{Name: name}, nil
+		},
+		GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+			return &models.AgentResponse{
+				Provisioning: models.Provisioning{Type: string(utils.InternalAgent)},
+				Type:         models.AgentType{Type: "agent-chat"},
+			}, nil
+		},
+		GetProjectDeploymentPipelineFunc: func(context.Context, string, string) (*models.DeploymentPipelineResponse, error) {
+			return &models.DeploymentPipelineResponse{PromotionPaths: []models.PromotionPath{
+				{SourceEnvironmentRef: "dev", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}}},
+			}}, nil
+		},
+		IsDeploymentInProgressFunc: func(_ context.Context, _, _, _ string) (bool, error) { return false, nil },
+		EnsureProjectReleaseBindingFunc: func(context.Context, string, string, string) error {
+			return boom
+		},
+		PromoteComponentFunc: func(_ context.Context, _, _, _, _, _ string, _ []client.EnvVar, _ []client.FileVar, _, _ map[string]interface{}) error {
+			promoteCalled = true
+			return nil
+		},
+	}
+	// Nil funcs on purpose: reaching the source/target system-managed key reads
+	// would mean the binding check ran too late to be a real guard.
+	agentConfigSvc := &stubAgentConfigurationServiceForPromote{}
+	provisioning := &recordingProvisioningStub{
+		stubAgentThunderProvisioning: &stubAgentThunderProvisioning{},
+		provisionCalled:              &provisionCalled,
+	}
+	agentConfigRepo := &repomocks.AgentConfigRepositoryMock{
+		UpsertFunc: func(context.Context, *models.AgentConfig) error {
+			configUpserted = true
+			return nil
+		},
+	}
+	s := &agentManagerService{
+		ocClient:                  ocClient,
+		agentConfigurationService: agentConfigSvc,
+		agentThunderProvisioning:  provisioning,
+		agentConfigRepo:           agentConfigRepo,
+		logger:                    discardLogger(),
+	}
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	require.ErrorIs(t, err, boom)
+	assert.False(t, promoteCalled, "the promote must not run without a namespace to release into")
+	assert.False(t, provisionCalled,
+		"a promotion that cannot get a namespace must not leave an AgentID binding behind in the target environment")
+	assert.False(t, configUpserted,
+		"a promotion that cannot get a namespace must not persist agent config for the target environment")
 }
 
 func TestDeployAgent_BindingFailureAbortsDeploy(t *testing.T) {

--- a/agent-manager-service/services/project_release_binding_unit_test.go
+++ b/agent-manager-service/services/project_release_binding_unit_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// From OpenChoreo 1.2.0 the cell namespace for (project, environment) is owned
+// by a ProjectReleaseBinding. A project with no binding gets no namespace, and
+// every deployment into that environment fails to apply with
+// `namespaces "dp-..." not found`. These tests pin the three places that have
+// to create one: project creation, deploy, and promote.
+
+func threeEnvPipeline() *models.DeploymentPipelineResponse {
+	return &models.DeploymentPipelineResponse{
+		Name: "default",
+		PromotionPaths: []models.PromotionPath{
+			{
+				SourceEnvironmentRef:  "dev",
+				TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "staging"}},
+			},
+			{
+				SourceEnvironmentRef:  "staging",
+				TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: "prod"}},
+			},
+		},
+	}
+}
+
+func TestCreateProject_EnsuresBindingForEveryPipelineEnvironment(t *testing.T) {
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+			return &models.OrganizationResponse{Name: name}, nil
+		},
+		CreateProjectFunc: func(context.Context, string, client.CreateProjectRequest) error {
+			return nil
+		},
+		GetProjectDeploymentPipelineFunc: func(context.Context, string, string) (*models.DeploymentPipelineResponse, error) {
+			return threeEnvPipeline(), nil
+		},
+		EnsureProjectReleaseBindingFunc: func(context.Context, string, string, string) error {
+			return nil
+		},
+	}
+	mgr := NewInfraResourceManager(ocClient, discardLogger())
+
+	project, err := mgr.CreateProject(context.Background(), "acme", spec.CreateProjectRequest{
+		Name:               "my-project",
+		DisplayName:        "My Project",
+		DeploymentPipeline: "default",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, project)
+
+	calls := ocClient.EnsureProjectReleaseBindingCalls()
+	require.Len(t, calls, 3, "one binding per environment reachable through the pipeline")
+	envs := make([]string, 0, len(calls))
+	for _, call := range calls {
+		assert.Equal(t, "acme", call.OuID)
+		assert.Equal(t, "my-project", call.ProjectName)
+		envs = append(envs, call.EnvironmentName)
+	}
+	// dev and staging each appear once even though staging is both a target of
+	// the first path and the source of the second.
+	assert.Equal(t, []string{"dev", "staging", "prod"}, envs)
+}
+
+func TestCreateProject_BindingFailureDoesNotFailProjectCreation(t *testing.T) {
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+			return &models.OrganizationResponse{Name: name}, nil
+		},
+		CreateProjectFunc: func(context.Context, string, client.CreateProjectRequest) error {
+			return nil
+		},
+		GetProjectDeploymentPipelineFunc: func(context.Context, string, string) (*models.DeploymentPipelineResponse, error) {
+			return threeEnvPipeline(), nil
+		},
+		EnsureProjectReleaseBindingFunc: func(_ context.Context, _, _, envName string) error {
+			if envName == "staging" {
+				return errors.New("openchoreo unavailable")
+			}
+			return nil
+		},
+	}
+	mgr := NewInfraResourceManager(ocClient, discardLogger())
+
+	project, err := mgr.CreateProject(context.Background(), "acme", spec.CreateProjectRequest{
+		Name:               "my-project",
+		DeploymentPipeline: "default",
+	})
+
+	// The project exists in OpenChoreo by this point, and deploy/promote ensure
+	// the binding for the environment they target, so a binding failure must not
+	// turn a created project into a failed request.
+	require.NoError(t, err)
+	require.NotNil(t, project)
+	assert.Len(t, ocClient.EnsureProjectReleaseBindingCalls(), 3,
+		"a failure for one environment must not stop the remaining environments")
+}
+
+func TestCreateProject_PipelineLookupFailureSkipsBindings(t *testing.T) {
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+			return &models.OrganizationResponse{Name: name}, nil
+		},
+		CreateProjectFunc: func(context.Context, string, client.CreateProjectRequest) error {
+			return nil
+		},
+		GetProjectDeploymentPipelineFunc: func(context.Context, string, string) (*models.DeploymentPipelineResponse, error) {
+			return nil, errors.New("pipeline lookup failed")
+		},
+		// Deliberately nil: a pipeline we could not read must not produce
+		// binding calls with a guessed environment name.
+	}
+	mgr := NewInfraResourceManager(ocClient, discardLogger())
+
+	project, err := mgr.CreateProject(context.Background(), "acme", spec.CreateProjectRequest{
+		Name:               "my-project",
+		DeploymentPipeline: "default",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, project)
+	assert.Empty(t, ocClient.EnsureProjectReleaseBindingCalls())
+}
+
+func TestPipelineEnvironments(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline *models.DeploymentPipelineResponse
+		want     []string
+	}{
+		{"nil pipeline", nil, nil},
+		{"no promotion paths", &models.DeploymentPipelineResponse{}, []string{}},
+		{"dedupes and preserves order", threeEnvPipeline(), []string{"dev", "staging", "prod"}},
+		{
+			"single environment with no targets",
+			&models.DeploymentPipelineResponse{PromotionPaths: []models.PromotionPath{
+				{SourceEnvironmentRef: "default"},
+			}},
+			[]string{"default"},
+		},
+		{
+			"skips empty names",
+			&models.DeploymentPipelineResponse{PromotionPaths: []models.PromotionPath{
+				{SourceEnvironmentRef: "", TargetEnvironmentRefs: []models.TargetEnvironmentRef{{Name: ""}, {Name: "dev"}}},
+			}},
+			[]string{"dev"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pipelineEnvironments(tc.pipeline))
+		})
+	}
+}
+
+func TestDeployAgent_BindingFailureAbortsDeploy(t *testing.T) {
+	boom := errors.New("openchoreo unavailable")
+	deployCalled := false
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
+			return &models.OrganizationResponse{Name: name}, nil
+		},
+		GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+			return &models.AgentResponse{Provisioning: models.Provisioning{Type: string(utils.InternalAgent)}}, nil
+		},
+		GetProjectDeploymentPipelineFunc: func(context.Context, string, string) (*models.DeploymentPipelineResponse, error) {
+			return threeEnvPipeline(), nil
+		},
+		EnsureProjectReleaseBindingFunc: func(context.Context, string, string, string) error {
+			return boom
+		},
+		DeployFunc: func(context.Context, string, string, string, client.DeployRequest) error {
+			deployCalled = true
+			return nil
+		},
+	}
+	s := &agentManagerService{ocClient: ocClient, logger: discardLogger()}
+
+	_, err := s.DeployAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.DeployAgentRequest{
+		ImageId: "registry.example.com/my-agent:v1",
+	})
+
+	require.ErrorIs(t, err, boom)
+	assert.False(t, deployCalled,
+		"without a cell namespace the release binding cannot apply — deploying anyway only fails later and less legibly")
+
+	calls := ocClient.EnsureProjectReleaseBindingCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "dev", calls[0].EnvironmentName, "the deploy target is the pipeline's lowest environment")
+}

--- a/agent-manager-service/tests/apitestutils/mock_clients.go
+++ b/agent-manager-service/tests/apitestutils/mock_clients.go
@@ -108,6 +108,11 @@ func CreateMockOpenChoreoClient() *clientmocks.OpenChoreoClientMock {
 				},
 			}, nil
 		},
+		// Project creation, deploy and promote all provision the cell namespace
+		// for the environment they touch before anything is released into it.
+		EnsureProjectReleaseBindingFunc: func(ctx context.Context, namespaceName, projectName, environmentName string) error {
+			return nil
+		},
 		GetComponentFunc: func(ctx context.Context, namespaceName, projectName, componentName string) (*models.AgentResponse, error) {
 			if strings.Contains(componentName, "nonexistent-agent") {
 				return nil, utils.ErrAgentNotFound


### PR DESCRIPTION
## Purpose
From OpenChoreo 1.2.0 the cell namespace for a `(project, environment)` pair is no longer implicit. It is a resource of the project's `(Cluster)ProjectType`, and what applies that type to an environment is a `ProjectReleaseBinding`. The only thing that created one was the platform-resources Helm chart, and only for the bootstrap project (`.Values.project.name` × `.Values.environment.name`).

Every project created through the API therefore had a `Project` and a `ProjectRelease` — both reconciling green — but no binding, so no namespace was ever provisioned. Each component `ReleaseBinding` in that environment then failed to apply:

```
Failed to apply resources to target plane: failed to apply resource
backend-<component>-api-gw-backend: namespaces
"dp-default-<project>-<env>-<hash>" not found
```

This surfaced as 16/16 heavy-tier instrumentation-matrix cells failing at deploy (builds all succeeded; no agent pod was ever scheduled, and no `dp-*` namespace existed in the cluster). It is not test-only: any project created from the API or the console hits it.

## Goals
Make the service create the `ProjectReleaseBinding` that owns the cell namespace, so projects created outside the Helm chart get a namespace to deploy into.

## Approach
A new `EnsureProjectReleaseBinding(ctx, ouID, projectName, environmentName)` on the OpenChoreo client, called from three places:

| Call site | Scope | On failure |
| --- | --- | --- |
| `CreateProject` | every environment the project's deployment pipeline can reach | logged, non-fatal |
| `DeployAgent` | the pipeline's lowest environment | hard error |
| `PromoteAgent` | the target environment | hard error |

Ensuring at deploy and promote — not only at project creation — is deliberate: it also covers projects created before this change and environments added to a pipeline after a project was created (`add-environment.sh` does not create bindings for existing projects either).

Project creation treats a binding failure as non-fatal because the project genuinely exists at that point and the deploy/promote paths recreate what is missing; turning a created project into a failed request would be worse. Deploy and promote fail hard, because without the namespace the release binding cannot apply, and deploying anyway just fails later and less legibly.

The call is idempotent — an existing binding for the same project and environment is success. Binding names follow the chart's `<project>-<environment>` convention so the chart-managed binding for the default project is recognised rather than duplicated; because that name is derived from both parts, a 409 is verified against the existing binding's `spec.owner.projectName` / `spec.environment` and a genuine collision (project `my` + env `project-dev` vs project `my-project` + env `dev`) is an error rather than a silent no-op. `spec.projectRelease` is left unset so the Project controller seeds it with the project's latest release.

The generated OpenChoreo client is regenerated from the **v1.2.0** spec (was pinned at v1.1.1) — that is what makes the `ProjectReleaseBinding` operations available, and the pin was already stale against the 1.2.0 control plane `deployments/setup/env.sh` installs. That accounts for the bulk of the diff; the only hand-written client change is the new file plus one interface line.

No change is needed for `Project.spec.type`: the v1.2.0 API defaults an omitted type to the cluster-scoped `default` ClusterProjectType, which is the one the chart creates with the `cell-namespace` resource.

## User stories
As a platform user, when I create a project and deploy an agent into it, the agent actually runs — instead of the deployment failing with a missing-namespace error that names an internal namespace I cannot see or create.

## Release note
Fixed agent deployments failing with `namespaces "dp-..." not found` for projects created through the API. The platform now provisions each project's cell namespace per environment.

## Documentation
N/A — no user-facing behaviour or configuration changes; this restores deployment behaviour that existed before the OpenChoreo 1.2.0 project-release model.

## Training
N/A

## Certification
N/A — no user-facing feature or configuration surface is added, so there is nothing new to examine on.

## Marketing
N/A

## Automation tests
- Unit tests

  New `clients/openchoreosvc/client/project_release_bindings_test.go` (binding name convention; create; existing binding treated as success; name collision with another project rejected; API errors propagated) and `services/project_release_binding_unit_test.go` (a binding per pipeline environment with de-duplication and order; a binding failure does not fail project creation and does not stop the remaining environments; an unreadable pipeline creates no bindings with a guessed environment; deploy aborts before calling Deploy when the binding cannot be ensured). Existing deploy/promote fixtures updated for the new client method. `make test-unit` passes; `make codegenfmt-check` is clean.

- Integration tests

  N/A — the effect is on the live OpenChoreo control plane. The end-to-end signal is the heavy tier of the instrumentation matrix, which currently fails 16/16 at deploy on this exact cause; it should be re-run once this merges.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — Go codebase, not applicable; `go vet` is clean
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None.

## Migrations (if applicable)
None required. Existing projects are healed in place: the first deploy or promote into an environment ensures the binding for it.

## Test environment
Go 1.26.3, macOS (darwin/arm64). Root cause was diagnosed from a k3d/OpenChoreo 1.2.0 cluster on `ubuntu-latest` — 16 release bindings failing with the missing-namespace error, no `dp-*` namespace present, and no `ProjectReleaseBinding` objects for any of the 16 API-created projects.

## Learning
The diagnosis came from reading `ReleaseBinding` status conditions rather than pod state: the builds and the `Project`/`ProjectRelease` CRs all reported healthy, and the only signal was `ResourceApplyFailed` on the binding naming a namespace that nothing had created. Comparing that against the v1.2.0 OpenAPI spec and the chart's own `project-release-binding.yaml` — which documents this exact failure mode in a comment — identified the missing owner of the namespace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic project release-binding setup across deployment pipeline environments.
  * Deployments and promotions now verify the required environment binding before proceeding.
  * Existing valid bindings are reused safely, while conflicting bindings are rejected.
  * Project creation continues even if individual binding setup steps fail.

* **Bug Fixes**
  * Improved handling and reporting of binding and API errors during deployment workflows.

* **Tests**
  * Added coverage for binding creation, reuse, conflicts, failures, and environment deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->