### PR TITLE
Take the OU for identity creates from the token, not the request body

### DIFF
--- a/agent-manager-service/controllers/identity_controller.go
+++ b/agent-manager-service/controllers/identity_controller.go
@@ -181,14 +181,11 @@ func (c *identityController) CreateUser(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	ouID := resolvedOrg.OUID
-	if body.OuId != nil && *body.OuId != "" {
-		ouID = *body.OuId
-	}
-
-	// Convert spec.CreateUserRequest to thundersvc.CreateUserRequest
+	// Convert spec.CreateUserRequest to thundersvc.CreateUserRequest. The OU comes
+	// from the token-resolved org only; a body-supplied one would let a caller
+	// create users in another tenant's OU.
 	req := thundersvc.CreateUserRequest{
-		OuID:       ouID,
+		OuID:       resolvedOrg.OUID,
 		Type:       body.Type,
 		Attributes: body.Attributes,
 		Password:   password,
@@ -200,7 +197,7 @@ func (c *identityController) CreateUser(w http.ResponseWriter, r *http.Request) 
 	attrKeys, attrCount, hasSensitive := audit.AttributeKeySummary(body.Attributes)
 	attempt, ok := beginAuditOrFail(
 		w, r, "CreateUser", "Failed to create user", audit.ActionUserCreate,
-		audit.Org(ouID), audit.OrgHandle(resolvedOrg.OuHandle),
+		audit.Org(resolvedOrg.OUID), audit.OrgHandle(resolvedOrg.OuHandle),
 		audit.ResourceNamed(audit.ResourceUser, body.Attributes["username"], body.Attributes["username"]),
 		audit.Detail("username", body.Attributes["username"]),
 		audit.Detail("userType", body.Type),
@@ -548,19 +545,16 @@ func (c *identityController) CreateGroup(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	ouID := resolvedOrg.OUID
-	if body.OuId != nil && *body.OuId != "" {
-		ouID = *body.OuId
-	}
-
 	description := ""
 	if body.Description != nil {
 		description = *body.Description
 	}
 
+	// The OU comes from the token-resolved org only; a body-supplied one would let
+	// a caller create groups in another tenant's OU.
 	req := thundersvc.CreateGroupRequest{
 		Name:        body.Name,
-		OuID:        ouID,
+		OuID:        resolvedOrg.OUID,
 		Description: description,
 	}
 
@@ -975,19 +969,16 @@ func (c *identityController) CreateRole(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	ouID := resolvedOrg.OUID
-	if body.OuId != nil && *body.OuId != "" {
-		ouID = *body.OuId
-	}
-
 	description := ""
 	if body.Description != nil {
 		description = *body.Description
 	}
 
+	// The OU comes from the token-resolved org only; a body-supplied one would let
+	// a caller create roles in another tenant's OU.
 	req := thundersvc.CreateRoleRequest{
 		Name:        body.Name,
-		OuID:        ouID,
+		OuID:        resolvedOrg.OUID,
 		Description: description,
 	}
 

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -17659,10 +17659,6 @@ components:
         - attributes
         - type
       properties:
-        ouId:
-          type: string
-          description: Organization unit ID (optional; resolved from org context when omitted)
-          example: "ou-456"
         type:
           type: string
           description: User type
@@ -17744,10 +17740,6 @@ components:
           description: Group name
           minLength: 1
           example: "developers"
-        ouId:
-          type: string
-          description: Organization unit ID
-          example: "ou-456"
         description:
           type: string
           description: Group description
@@ -17838,10 +17830,6 @@ components:
           description: Role name
           minLength: 1
           example: "developer"
-        ouId:
-          type: string
-          description: Organization unit ID
-          example: "ou-456"
         description:
           type: string
           description: Role description

--- a/agent-manager-service/spec/model_create_group_request.go
+++ b/agent-manager-service/spec/model_create_group_request.go
@@ -21,8 +21,6 @@ var _ MappedNullable = &CreateGroupRequest{}
 type CreateGroupRequest struct {
 	// Group name
 	Name string `json:"name"`
-	// Organization unit ID
-	OuId *string `json:"ouId,omitempty"`
 	// Group description
 	Description *string `json:"description,omitempty"`
 }
@@ -69,38 +67,6 @@ func (o *CreateGroupRequest) SetName(v string) {
 	o.Name = v
 }
 
-// GetOuId returns the OuId field value if set, zero value otherwise.
-func (o *CreateGroupRequest) GetOuId() string {
-	if o == nil || IsNil(o.OuId) {
-		var ret string
-		return ret
-	}
-	return *o.OuId
-}
-
-// GetOuIdOk returns a tuple with the OuId field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *CreateGroupRequest) GetOuIdOk() (*string, bool) {
-	if o == nil || IsNil(o.OuId) {
-		return nil, false
-	}
-	return o.OuId, true
-}
-
-// HasOuId returns a boolean if a field has been set.
-func (o *CreateGroupRequest) HasOuId() bool {
-	if o != nil && !IsNil(o.OuId) {
-		return true
-	}
-
-	return false
-}
-
-// SetOuId gets a reference to the given string and assigns it to the OuId field.
-func (o *CreateGroupRequest) SetOuId(v string) {
-	o.OuId = &v
-}
-
 // GetDescription returns the Description field value if set, zero value otherwise.
 func (o *CreateGroupRequest) GetDescription() string {
 	if o == nil || IsNil(o.Description) {
@@ -144,9 +110,6 @@ func (o CreateGroupRequest) MarshalJSON() ([]byte, error) {
 func (o CreateGroupRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
-	if !IsNil(o.OuId) {
-		toSerialize["ouId"] = o.OuId
-	}
 	if !IsNil(o.Description) {
 		toSerialize["description"] = o.Description
 	}

--- a/agent-manager-service/spec/model_create_role_request.go
+++ b/agent-manager-service/spec/model_create_role_request.go
@@ -21,8 +21,6 @@ var _ MappedNullable = &CreateRoleRequest{}
 type CreateRoleRequest struct {
 	// Role name
 	Name string `json:"name"`
-	// Organization unit ID
-	OuId *string `json:"ouId,omitempty"`
 	// Role description
 	Description *string `json:"description,omitempty"`
 }
@@ -69,38 +67,6 @@ func (o *CreateRoleRequest) SetName(v string) {
 	o.Name = v
 }
 
-// GetOuId returns the OuId field value if set, zero value otherwise.
-func (o *CreateRoleRequest) GetOuId() string {
-	if o == nil || IsNil(o.OuId) {
-		var ret string
-		return ret
-	}
-	return *o.OuId
-}
-
-// GetOuIdOk returns a tuple with the OuId field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *CreateRoleRequest) GetOuIdOk() (*string, bool) {
-	if o == nil || IsNil(o.OuId) {
-		return nil, false
-	}
-	return o.OuId, true
-}
-
-// HasOuId returns a boolean if a field has been set.
-func (o *CreateRoleRequest) HasOuId() bool {
-	if o != nil && !IsNil(o.OuId) {
-		return true
-	}
-
-	return false
-}
-
-// SetOuId gets a reference to the given string and assigns it to the OuId field.
-func (o *CreateRoleRequest) SetOuId(v string) {
-	o.OuId = &v
-}
-
 // GetDescription returns the Description field value if set, zero value otherwise.
 func (o *CreateRoleRequest) GetDescription() string {
 	if o == nil || IsNil(o.Description) {
@@ -144,9 +110,6 @@ func (o CreateRoleRequest) MarshalJSON() ([]byte, error) {
 func (o CreateRoleRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["name"] = o.Name
-	if !IsNil(o.OuId) {
-		toSerialize["ouId"] = o.OuId
-	}
 	if !IsNil(o.Description) {
 		toSerialize["description"] = o.Description
 	}

--- a/agent-manager-service/spec/model_create_user_request.go
+++ b/agent-manager-service/spec/model_create_user_request.go
@@ -19,8 +19,6 @@ var _ MappedNullable = &CreateUserRequest{}
 
 // CreateUserRequest struct for CreateUserRequest
 type CreateUserRequest struct {
-	// Organization unit ID (optional; resolved from org context when omitted)
-	OuId *string `json:"ouId,omitempty"`
 	// User type
 	Type string `json:"type"`
 	// User attributes map (include password when creating credentials)
@@ -44,38 +42,6 @@ func NewCreateUserRequest(type_ string, attributes map[string]string) *CreateUse
 func NewCreateUserRequestWithDefaults() *CreateUserRequest {
 	this := CreateUserRequest{}
 	return &this
-}
-
-// GetOuId returns the OuId field value if set, zero value otherwise.
-func (o *CreateUserRequest) GetOuId() string {
-	if o == nil || IsNil(o.OuId) {
-		var ret string
-		return ret
-	}
-	return *o.OuId
-}
-
-// GetOuIdOk returns a tuple with the OuId field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *CreateUserRequest) GetOuIdOk() (*string, bool) {
-	if o == nil || IsNil(o.OuId) {
-		return nil, false
-	}
-	return o.OuId, true
-}
-
-// HasOuId returns a boolean if a field has been set.
-func (o *CreateUserRequest) HasOuId() bool {
-	if o != nil && !IsNil(o.OuId) {
-		return true
-	}
-
-	return false
-}
-
-// SetOuId gets a reference to the given string and assigns it to the OuId field.
-func (o *CreateUserRequest) SetOuId(v string) {
-	o.OuId = &v
 }
 
 // GetType returns the Type field value
@@ -136,9 +102,6 @@ func (o CreateUserRequest) MarshalJSON() ([]byte, error) {
 
 func (o CreateUserRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.OuId) {
-		toSerialize["ouId"] = o.OuId
-	}
 	toSerialize["type"] = o.Type
 	toSerialize["attributes"] = o.Attributes
 	return toSerialize, nil

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -2300,9 +2300,6 @@ type CreateGroupRequest struct {
 
 	// Name Group name
 	Name string `json:"name"`
-
-	// OuId Organization unit ID
-	OuId *string `json:"ouId,omitempty"`
 }
 
 // CreateLLMAPIKeyRequest defines model for CreateLLMAPIKeyRequest.
@@ -2477,18 +2474,12 @@ type CreateRoleRequest struct {
 
 	// Name Role name
 	Name string `json:"name"`
-
-	// OuId Organization unit ID
-	OuId *string `json:"ouId,omitempty"`
 }
 
 // CreateUserRequest defines model for CreateUserRequest.
 type CreateUserRequest struct {
 	// Attributes User attributes map (include password when creating credentials)
 	Attributes map[string]string `json:"attributes"`
-
-	// OuId Organization unit ID (optional; resolved from org context when omitted)
-	OuId *string `json:"ouId,omitempty"`
 
 	// Type User type
 	Type string `json:"type"`

--- a/console/workspaces/libs/types/src/api/identities.ts
+++ b/console/workspaces/libs/types/src/api/identities.ts
@@ -42,7 +42,6 @@ export interface ThunderUserListResponse extends PaginationMeta {
 export interface CreateUserRequest {
   type: string;
   attributes: Record<string, string>;
-  ouId?: string;
 }
 
 export interface UpdateUserRequest {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The three identity create endpoints (`POST /orgs/{orgName}/identities/users`, `.../groups`, `.../roles`) resolved the caller's organization unit from the validated token and then let an `ouId` field in the request body replace it, without checking that the supplied OU belonged to the caller. A user holding `org:invite-member`, `group:create` or `role:create` in their own org could therefore create users, groups and roles inside another org's OU in Thunder, and a created user comes with a password chosen by the caller.

The OU now always comes from the token-resolved org, which is how the read, update and delete paths in the same controller already behave (they validate the fetched object's OU against the caller's). The `ouId` field is removed from the three create request schemas since nothing reads it any more; the `ouId` in the user, group and role *response* schemas stays, as Thunder returns it. `spec/` and the amctl client are regenerated from the spec, and the console's `CreateUserRequest` type drops the field it never set.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
