### PR TITLE
Canonicalize MCP resource server identifiers as absolute URIs

### DIFF
--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
@@ -95,10 +97,11 @@ type IdentityClient interface {
 	// Permissions catalog
 	ListAMPPermissions(ctx context.Context) ([]ThunderPermission, string, error)
 	// EnsureProxyResourceServer makes sure the proxy's resource server exists
-	// (handle = proxyHandle, identifier = the proxy's protocol-stripped public
-	// invocation URI in this environment, delimiter ":", type MCP) with every
-	// given action registered at the RS root, and returns the RS ID. A drifted
-	// identifier is updated in place; the handle never changes.
+	// (handle = proxyHandle, identifier = the proxy's absolute public invocation
+	// URI in this environment, delimiter ":", type MCP) with every given action
+	// registered at the RS root, and returns the RS ID. The identifier must be an
+	// RFC 8707 absolute URI; it is canonicalized and non-canonical input is
+	// rejected. A drifted identifier is updated in place; the handle never changes.
 	EnsureProxyResourceServer(ctx context.Context, proxyHandle, displayName, identifier string, actions []string) (string, error)
 	// DeleteProxyResourceServerAction best-effort deletes one root action.
 	// Missing RS or action is not an error. Returns the RS ID ("" if RS absent).
@@ -1082,7 +1085,46 @@ const (
 	// handles). Over-long inputs are rejected with a clear error instead of letting
 	// Thunder reject the handle with an opaque 400.
 	thunderHandleMaxLen = 100
+	// thunderIdentifierMaxLen is Thunder's cap on the RS identifier column, which
+	// holds a URI and is far wider than a handle.
+	thunderIdentifierMaxLen = 2048
 )
+
+// canonicalMCPResourceIdentifier returns raw in RFC 8707 canonical form, or an error if it cannot be one.
+func canonicalMCPResourceIdentifier(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("resource identifier %q is not a valid URI: %w", raw, err)
+	}
+	switch {
+	case u.Scheme == "":
+		return "", fmt.Errorf("resource identifier %q has no scheme; RFC 8707 requires an absolute URI", raw)
+	case u.Scheme != "http" && u.Scheme != "https":
+		return "", fmt.Errorf("resource identifier %q must use scheme http or https, got %q", raw, u.Scheme)
+	case u.Host == "":
+		return "", fmt.Errorf("resource identifier %q has no host", raw)
+	case u.User != nil:
+		return "", fmt.Errorf("resource identifier %q must not carry userinfo", raw)
+	case u.RawQuery != "" || u.ForceQuery:
+		return "", fmt.Errorf("resource identifier %q must not carry a query", raw)
+	case u.Fragment != "":
+		return "", fmt.Errorf("resource identifier %q must not carry a fragment", raw)
+	}
+	// url.Parse lowercases the scheme but not the host; the path stays as-is, being case-sensitive.
+	host := strings.ToLower(u.Host)
+	if port := u.Port(); port == defaultPortForScheme(u.Scheme) {
+		host = strings.TrimSuffix(host, ":"+port)
+	}
+	return u.Scheme + "://" + host + strings.TrimRight(u.EscapedPath(), "/"), nil
+}
+
+// defaultPortForScheme is the port an http(s) URI omits in canonical form.
+func defaultPortForScheme(scheme string) string {
+	if scheme == "https" {
+		return "443"
+	}
+	return "80"
+}
 
 // ensureProxyResourceServerMu returns the mutex serializing check-then-create
 // calls for one proxy handle. Entries are never removed; the map only grows by
@@ -1093,16 +1135,21 @@ func (c *thunderClient) ensureProxyResourceServerMu(proxyHandle string) *sync.Mu
 }
 
 // EnsureProxyResourceServer makes sure the resource server for a proxy exists
-// (handle = proxyHandle, identifier = the proxy's protocol-stripped public
-// invocation URI, delimiter ":", type MCP) and that every given action is
-// registered as a root action, then returns the resource server ID. A drifted
+// (handle = proxyHandle, identifier = the proxy's public invocation URI,
+// delimiter ":", type MCP) and that every given action is registered as a root
+// action, then returns the resource server ID. The identifier is canonicalized
+// here, so both create and drift-update write an RFC 8707 absolute URI. A drifted
 // identifier is rewritten in place. Idempotent; called lazily before role writes.
 func (c *thunderClient) EnsureProxyResourceServer(ctx context.Context, proxyHandle, displayName, identifier string, actions []string) (string, error) {
+	identifier, err := canonicalMCPResourceIdentifier(identifier)
+	if err != nil {
+		return "", err
+	}
 	if len(proxyHandle) > thunderHandleMaxLen {
 		return "", fmt.Errorf("proxy handle %q exceeds the Thunder handle limit of %d characters", proxyHandle, thunderHandleMaxLen)
 	}
-	if len(identifier) > thunderHandleMaxLen {
-		return "", fmt.Errorf("resource identifier %q exceeds the Thunder limit of %d characters", identifier, thunderHandleMaxLen)
+	if len(identifier) > thunderIdentifierMaxLen {
+		return "", fmt.Errorf("resource identifier %q exceeds the Thunder limit of %d characters", identifier, thunderIdentifierMaxLen)
 	}
 	for _, action := range actions {
 		if len(action) > thunderHandleMaxLen {

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -1101,7 +1101,7 @@ func canonicalMCPResourceIdentifier(raw string) (string, error) {
 		return "", fmt.Errorf("resource identifier %q has no scheme; RFC 8707 requires an absolute URI", raw)
 	case u.Scheme != "http" && u.Scheme != "https":
 		return "", fmt.Errorf("resource identifier %q must use scheme http or https, got %q", raw, u.Scheme)
-	case u.Host == "":
+	case u.Host == "" || u.Hostname() == "":
 		return "", fmt.Errorf("resource identifier %q has no host", raw)
 	case u.User != nil:
 		return "", fmt.Errorf("resource identifier %q must not carry userinfo", raw)

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -122,6 +122,8 @@ func TestCanonicalMCPResourceIdentifier(t *testing.T) {
 		{name: "trailing slash dropped", raw: "https://gw.example.com/x/mcp/", want: "https://gw.example.com/x/mcp"},
 		{name: "scheme-less rejected", raw: "gw.example.com/x/mcp", wantErr: "scheme"},
 		{name: "non-http scheme rejected", raw: "ftp://gw.example.com/x/mcp", wantErr: "http"},
+		{name: "port-only authority rejected", raw: "https://:443/mcp", wantErr: "host"},
+		{name: "port-only authority with non-default port rejected", raw: "https://:8443/mcp", wantErr: "host"},
 		{name: "userinfo rejected", raw: "https://u:p@gw.example.com/x/mcp", wantErr: "userinfo"},
 		{name: "query rejected", raw: "https://gw.example.com/x/mcp?a=1", wantErr: "query"},
 		{name: "fragment rejected", raw: "https://gw.example.com/x/mcp#f", wantErr: "fragment"},

--- a/agent-manager-service/clients/thundersvc/identity_client_test.go
+++ b/agent-manager-service/clients/thundersvc/identity_client_test.go
@@ -106,6 +106,41 @@ func TestListGroupMemberEntries_ReturnsTypedEntries(t *testing.T) {
 	assert.Equal(t, GroupMember{ID: "u1", Type: "user"}, members[1])
 }
 
+func TestCanonicalMCPResourceIdentifier(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr string
+	}{
+		{name: "already canonical", raw: "https://gw.example.com/github/mcp", want: "https://gw.example.com/github/mcp"},
+		{name: "scheme and host lowercased", raw: "HTTPS://GW.Example.com/x/mcp", want: "https://gw.example.com/x/mcp"},
+		{name: "path case preserved", raw: "https://gw.example.com/GitHub/mcp", want: "https://gw.example.com/GitHub/mcp"},
+		{name: "default https port dropped", raw: "https://gw.example.com:443/x/mcp", want: "https://gw.example.com/x/mcp"},
+		{name: "default http port dropped", raw: "http://gw.example.com:80/x/mcp", want: "http://gw.example.com/x/mcp"},
+		{name: "non-default port kept", raw: "https://gw.example.com:8443/x/mcp", want: "https://gw.example.com:8443/x/mcp"},
+		{name: "trailing slash dropped", raw: "https://gw.example.com/x/mcp/", want: "https://gw.example.com/x/mcp"},
+		{name: "scheme-less rejected", raw: "gw.example.com/x/mcp", wantErr: "scheme"},
+		{name: "non-http scheme rejected", raw: "ftp://gw.example.com/x/mcp", wantErr: "http"},
+		{name: "userinfo rejected", raw: "https://u:p@gw.example.com/x/mcp", wantErr: "userinfo"},
+		{name: "query rejected", raw: "https://gw.example.com/x/mcp?a=1", wantErr: "query"},
+		{name: "fragment rejected", raw: "https://gw.example.com/x/mcp#f", wantErr: "fragment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := canonicalMCPResourceIdentifier(tc.raw)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestEnsureProxyResourceServer_CreatesRSWithHandleAndRootActions(t *testing.T) {
 	rsCreated, actCreated := 0, 0
 	var createRSBody map[string]string
@@ -119,7 +154,7 @@ func TestEnsureProxyResourceServer_CreatesRSWithHandleAndRootActions(t *testing.
 		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
 			rsCreated++
 			_ = json.NewDecoder(r.Body).Decode(&createRSBody)
-			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "gw.example.com/github/mcp"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "https://gw.example.com/github/mcp"})
 		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
 			_ = json.NewEncoder(w).Encode(map[string]any{"actions": []any{}, "totalResults": 0})
 		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers/rs-1/actions":
@@ -134,13 +169,13 @@ func TestEnsureProxyResourceServer_CreatesRSWithHandleAndRootActions(t *testing.
 	})
 	defer srv.Close()
 	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
-	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read", "write"})
+	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "https://gw.example.com/github/mcp", []string{"read", "write"})
 	assert.NoError(t, err)
 	assert.Equal(t, "rs-1", rsID)
 	assert.Equal(t, 1, rsCreated)
 	assert.Equal(t, 2, actCreated)
 	assert.Equal(t, "gh-proxy", createRSBody["handle"], "RS handle must be the proxy handle — it prefixes derived permissions")
-	assert.Equal(t, "gw.example.com/github/mcp", createRSBody["identifier"], "identifier must be the env invocation URI, not the handle")
+	assert.Equal(t, "https://gw.example.com/github/mcp", createRSBody["identifier"], "identifier must be the env invocation URI, not the handle")
 	assert.Equal(t, ":", createRSBody["delimiter"])
 	assert.Equal(t, "MCP", createRSBody["type"])
 	assert.Equal(t, "ou-1", createRSBody["ouId"])
@@ -154,7 +189,7 @@ func TestEnsureProxyResourceServer_IdempotentSkipsExistingActions(t *testing.T) 
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers":
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"resourceServers": []any{map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "gw.example.com/github/mcp"}},
+				"resourceServers": []any{map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "https://gw.example.com/github/mcp"}},
 				"total":           1,
 			})
 		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
@@ -178,7 +213,7 @@ func TestEnsureProxyResourceServer_IdempotentSkipsExistingActions(t *testing.T) 
 	})
 	defer srv.Close()
 	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
-	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read", "write"})
+	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "https://gw.example.com/github/mcp", []string{"read", "write"})
 	assert.NoError(t, err)
 	assert.Equal(t, "rs-1", rsID)
 	require.Len(t, createActionBodies, 1, "only the missing action must be created")
@@ -216,11 +251,11 @@ func TestEnsureProxyResourceServer_ReconcilesDriftedIdentifier(t *testing.T) {
 	})
 	defer srv.Close()
 	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
-	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read"})
+	rsID, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "https://gw.example.com/github/mcp", []string{"read"})
 	assert.NoError(t, err)
 	assert.Equal(t, "rs-1", rsID)
 	assert.Equal(t, 1, rsUpdated)
-	assert.Equal(t, "gw.example.com/github/mcp", updateBody["identifier"])
+	assert.Equal(t, "https://gw.example.com/github/mcp", updateBody["identifier"])
 	assert.Equal(t, "gh-proxy", updateBody["handle"], "handle must never change — permissions derive from it")
 	assert.Equal(t, ":", updateBody["delimiter"])
 	assert.Equal(t, "MCP", updateBody["type"])
@@ -262,14 +297,14 @@ func TestEnsureProxyResourceServer_DistinctProxiesDoNotSerialize(t *testing.T) {
 
 	firstErr := make(chan error, 1)
 	go func() {
-		_, err := client.EnsureProxyResourceServer(context.Background(), "proxy-a", "Proxy A", "gw.example.com/a/mcp", []string{"read"})
+		_, err := client.EnsureProxyResourceServer(context.Background(), "proxy-a", "Proxy A", "https://gw.example.com/a/mcp", []string{"read"})
 		firstErr <- err
 	}()
 	<-firstListArrived
 
 	secondErr := make(chan error, 1)
 	go func() {
-		_, err := client.EnsureProxyResourceServer(context.Background(), "proxy-b", "Proxy B", "gw.example.com/b/mcp", []string{"read"})
+		_, err := client.EnsureProxyResourceServer(context.Background(), "proxy-b", "Proxy B", "https://gw.example.com/b/mcp", []string{"read"})
 		secondErr <- err
 	}()
 	select {
@@ -295,7 +330,7 @@ func TestEnsureProxyResourceServer_ConcurrentSameHandleCreatesOnce(t *testing.T)
 			mu.Lock()
 			servers := []any{}
 			if exists {
-				servers = append(servers, map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "gw.example.com/github/mcp"})
+				servers = append(servers, map[string]string{"id": "rs-1", "handle": "gh-proxy", "identifier": "https://gw.example.com/github/mcp"})
 			}
 			mu.Unlock()
 			_ = json.NewEncoder(w).Encode(map[string]any{"resourceServers": servers, "total": len(servers)})
@@ -326,7 +361,7 @@ func TestEnsureProxyResourceServer_ConcurrentSameHandleCreatesOnce(t *testing.T)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			rsIDs[i], errs[i] = client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read"})
+			rsIDs[i], errs[i] = client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "https://gw.example.com/github/mcp", []string{"read"})
 		}()
 	}
 	wg.Wait()
@@ -370,13 +405,99 @@ func TestEnsureProxyResourceServer_RejectsOverlongInputs(t *testing.T) {
 	defer srv.Close()
 	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
 
-	_, err := client.EnsureProxyResourceServer(context.Background(), strings.Repeat("h", 101), "Too Long", "gw.example.com/x/mcp", []string{"read"})
+	_, err := client.EnsureProxyResourceServer(context.Background(), strings.Repeat("h", 101), "Too Long", "https://gw.example.com/x/mcp", []string{"read"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "100", "over-long handle error should state the 100-character Thunder limit")
 
-	_, err = client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/x/mcp", []string{strings.Repeat("a", 101)})
+	_, err = client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "https://gw.example.com/x/mcp", []string{strings.Repeat("a", 101)})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "100", "over-long action error should state the 100-character Thunder limit")
+}
+
+func TestEnsureProxyResourceServer_RejectsNonCanonicalIdentifierBeforeAnyCall(t *testing.T) {
+	srv := newTestThunderServer(t, func(_ http.ResponseWriter, r *http.Request) {
+		t.Fatalf("no Thunder calls expected for a non-canonical identifier, got %s %s", r.Method, r.URL.Path)
+	})
+	defer srv.Close()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+
+	_, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "gw.example.com/github/mcp", []string{"read"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scheme", "a scheme-less identifier must be rejected as non-absolute")
+}
+
+func TestEnsureProxyResourceServer_CanonicalizesIdentifierOnCreate(t *testing.T) {
+	// The uppercase host and default port are normalized at the Thunder boundary,
+	// so the identifier Thunder mints aud claims from is RFC 8707 canonical.
+	var createRSBody map[string]string
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers":
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceServers": []any{}, "total": 0})
+		case r.Method == http.MethodGet && r.URL.Path == "/organization-units/tree/default":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "ou-1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
+			_ = json.NewDecoder(r.Body).Decode(&createRSBody)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1"})
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
+			_ = json.NewEncoder(w).Encode(map[string]any{"actions": []any{}, "totalResults": 0})
+		default:
+			t.Fatalf("unexpected call %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+
+	_, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", "HTTPS://GW.Example.com:443/github/mcp/", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://gw.example.com/github/mcp", createRSBody["identifier"])
+}
+
+func TestEnsureProxyResourceServer_IdentifierLimitIsTheIdentifierColumn(t *testing.T) {
+	// The identifier column is VARCHAR(2048); it was previously capped at the
+	// 100-character handle limit, rejecting legitimate long URIs.
+	longIdentifier := "https://gw.example.com/" + strings.Repeat("a", 123) + "/mcp"
+	require.Len(t, longIdentifier, 150)
+
+	var createRSBody map[string]string
+	srv := newTestThunderServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers":
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceServers": []any{}, "total": 0})
+		case r.Method == http.MethodGet && r.URL.Path == "/organization-units/tree/default":
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "ou-1"})
+		case r.Method == http.MethodPost && r.URL.Path == "/resource-servers":
+			_ = json.NewDecoder(r.Body).Decode(&createRSBody)
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "rs-1"})
+		case r.Method == http.MethodGet && r.URL.Path == "/resource-servers/rs-1/actions":
+			_ = json.NewEncoder(w).Encode(map[string]any{"actions": []any{}, "totalResults": 0})
+		default:
+			t.Fatalf("unexpected call %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+
+	_, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", longIdentifier, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, longIdentifier, createRSBody["identifier"])
+}
+
+func TestEnsureProxyResourceServer_RejectsIdentifierOverColumnLimit(t *testing.T) {
+	srv := newTestThunderServer(t, func(_ http.ResponseWriter, r *http.Request) {
+		t.Fatalf("no Thunder calls expected for an over-long identifier, got %s %s", r.Method, r.URL.Path)
+	})
+	defer srv.Close()
+	client := NewIdentityClient(srv.URL, "sys-client", "sys-secret")
+	overLimit := "https://gw.example.com/" + strings.Repeat("a", 2048)
+
+	_, err := client.EnsureProxyResourceServer(context.Background(), "gh-proxy", "GitHub Proxy", overLimit, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "2048", "over-long identifier error should state the 2048-character limit")
 }
 
 // The list fixture carries only a legacy identifier match (no handle key) to lock

--- a/agent-manager-service/controllers/agent_identity_controller.go
+++ b/agent-manager-service/controllers/agent_identity_controller.go
@@ -68,8 +68,8 @@ type AgentIdentityController interface {
 	ListAgents(w http.ResponseWriter, r *http.Request)
 }
 
-// MCPResourceServerIdentifierResolver derives the protocol-stripped public URI an
-// MCP proxy is invoked at in one environment — the env-Thunder RS identifier.
+// MCPResourceServerIdentifierResolver derives the absolute public URI an MCP
+// proxy is invoked at in one environment — the env-Thunder RS identifier.
 // The environment is resolved once per request and its UUID passed to each
 // per-proxy identifier derivation.
 type MCPResourceServerIdentifierResolver interface {

--- a/agent-manager-service/controllers/agent_identity_controller_unit_test.go
+++ b/agent-manager-service/controllers/agent_identity_controller_unit_test.go
@@ -38,8 +38,8 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/services"
 )
 
-// stubRSIdentifierResolver returns "<handle>.uri" so tests can assert the derived
-// identifier reaches the RS ensure call.
+// stubRSIdentifierResolver returns the absolute per-proxy invocation URI so tests
+// can assert the derived identifier reaches the RS ensure call.
 type stubRSIdentifierResolver struct{ err error }
 
 func (s stubRSIdentifierResolver) EnvironmentUUIDByName(_ context.Context, _, _ string) (uuid.UUID, error) {
@@ -50,7 +50,7 @@ func (s stubRSIdentifierResolver) MCPResourceServerIdentifier(_ context.Context,
 	if s.err != nil {
 		return "", s.err
 	}
-	return proxy.Handle + ".uri", nil
+	return "https://gw.example.com/" + proxy.Handle + "/mcp", nil
 }
 
 // TestAgentIdentityCreateRole_EnsuresPerProxyRSBeforePermissionWrite proves each
@@ -64,7 +64,7 @@ func TestAgentIdentityCreateRole_EnsuresPerProxyRSBeforePermissionWrite(t *testi
 		GetDefaultOUIDFunc: func(_ context.Context) (string, error) { return "ou-env", nil },
 		EnsureProxyResourceServerFunc: func(_ context.Context, handle, _, identifier string, _ []string) (string, error) {
 			calls = append(calls, "ensure:"+handle)
-			assert.Equal(t, handle+".uri", identifier, "the resolver-derived identifier must reach the RS ensure")
+			assert.Equal(t, "https://gw.example.com/"+handle+"/mcp", identifier, "the resolver-derived identifier must reach the RS ensure")
 			return "rs-" + handle, nil
 		},
 		CreateRoleFunc: func(_ context.Context, req thundersvc.CreateRoleRequest) (*thundersvc.ThunderRole, error) {
@@ -265,7 +265,7 @@ func TestAgentIdentityUpdateRole_ReconcilesAcrossResourceServers(t *testing.T) {
 			return &thundersvc.ThunderRole{ID: roleID, Name: req.Name}, nil
 		},
 		EnsureProxyResourceServerFunc: func(_ context.Context, handle, _, identifier string, _ []string) (string, error) {
-			assert.Equal(t, handle+".uri", identifier, "the resolver-derived identifier must reach the RS ensure")
+			assert.Equal(t, "https://gw.example.com/"+handle+"/mcp", identifier, "the resolver-derived identifier must reach the RS ensure")
 			switch handle {
 			case "gh-proxy":
 				return "rs-gh", nil

--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -77,17 +77,12 @@ func TestBuildMCPProxyURLDefaultsBareGatewayVhostToHTTPS(t *testing.T) {
 }
 
 func TestResourceIdentifierUnchangedByVhostScheme(t *testing.T) {
-	// The RS identifier (scheme-stripped proxy URL) must be identical whether the
+	// The RS identifier is the absolute proxy URL and must be identical whether the
 	// gateway registered a bare or an https:// vhost.
 	bare := &models.Gateway{Vhost: "gw.example.com"}
 	prefixed := &models.Gateway{Vhost: "https://gw.example.com"}
 	ctxPath := "/github"
 	cfg := models.MCPProxyConfig{Context: &ctxPath}
-	require.Equal(t, "gw.example.com/github/mcp", stripURLScheme(buildMCPProxyURL(bare, cfg)))
-	require.Equal(t, stripURLScheme(buildMCPProxyURL(prefixed, cfg)), stripURLScheme(buildMCPProxyURL(bare, cfg)))
-}
-
-func TestStripURLScheme(t *testing.T) {
-	require.Equal(t, "gw.example.com/github/mcp", stripURLScheme("https://gw.example.com/github/mcp"))
-	require.Equal(t, "gw.example.com/mcp", stripURLScheme("gw.example.com/mcp"))
+	require.Equal(t, "https://gw.example.com/github/mcp", buildMCPProxyURL(bare, cfg))
+	require.Equal(t, buildMCPProxyURL(prefixed, cfg), buildMCPProxyURL(bare, cfg))
 }

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -351,14 +351,6 @@ func buildMCPProxyURL(gateway *models.Gateway, cfg models.MCPProxyConfig) string
 	return mcpProxyServingBase(gateway, cfg.Vhost) + path
 }
 
-// stripURLScheme drops the leading scheme, yielding the resource-identifier form.
-func stripURLScheme(u string) string {
-	if i := strings.Index(u, "://"); i >= 0 {
-		return u[i+3:]
-	}
-	return u
-}
-
 // mcpProxyAPIKeySecurityEnabled reports whether the source MCP proxy requires API
 // key security for the given environment. When it returns false, agent mappings
 // derived from the proxy are deployed without minting a gateway key, binding an app

--- a/agent-manager-service/services/mcp_rs_identifier.go
+++ b/agent-manager-service/services/mcp_rs_identifier.go
@@ -58,8 +58,8 @@ func (s *MCPProxyService) EnvironmentUUIDByName(ctx context.Context, ouID, envNa
 	return environmentUUIDByName(ctx, s.infraManager, ouID, envName)
 }
 
-// MCPResourceServerIdentifier derives the protocol-stripped public URI the proxy
-// is invoked at in the given environment — the value the env-Thunder resource
+// MCPResourceServerIdentifier derives the absolute public URI the proxy is
+// invoked at in the given environment — the value the env-Thunder resource
 // server's identifier must carry.
 func (s *MCPProxyService) MCPResourceServerIdentifier(ctx context.Context, ouID string, envID uuid.UUID, proxy *models.MCPProxy) (string, error) {
 	_ = ctx
@@ -80,5 +80,5 @@ func (s *MCPProxyService) MCPResourceServerIdentifier(ctx context.Context, ouID 
 		return "", err
 	}
 
-	return stripURLScheme(buildMCPProxyURL(gateway, proxy.Configuration)), nil
+	return buildMCPProxyURL(gateway, proxy.Configuration), nil
 }

--- a/agent-manager-service/services/mcp_rs_identifier_unit_test.go
+++ b/agent-manager-service/services/mcp_rs_identifier_unit_test.go
@@ -72,7 +72,7 @@ func TestMCPResourceServerIdentifier_DerivesPublicURI(t *testing.T) {
 	id, err := svc.MCPResourceServerIdentifier(context.Background(), "ou-1", envID, proxy)
 
 	require.NoError(t, err)
-	require.Equal(t, "gw.example.com/github/mcp", id)
+	require.Equal(t, "https://gw.example.com/github/mcp", id)
 }
 
 func TestMCPResourceServerIdentifier_NotDeployedToEnvironment(t *testing.T) {


### PR DESCRIPTION
## Purpose
When an MCP proxy is deployed to an environment, AMS registers a resource server in that environment's Thunder under an identifier derived from the proxy's public invocation URL — but with the scheme stripped (`gw.example.com/github/mcp`).

RFC 8707 §2 requires the `resource` value be an **absolute URI** (RFC 3986 §4.3), so the scheme is mandatory. Consequences of the stripped form:

- every MCP resource server AMP creates carries a non-compliant identifier;
- the `aud` claim Thunder mints for tokens scoped to that resource server is non-compliant with it;
- a client following RFC 8707 and passing `resource=https://gw.example.com/github/mcp` cannot match the registered identifier.

`buildMCPProxyURL` already produced the correct absolute URL; a single `stripURLScheme` call discarded it.

## Goals
- MCP resource server identifiers are RFC 8707 absolute URIs, on both the create and the drift-update path.
- The invariant is guaranteed structurally, not by convention: non-canonical input cannot reach Thunder.
- Fix the latent length bug where the identifier was validated against the 100-character *handle* cap.

## Approach
**Canonicalize at the Thunder boundary.** New unexported `canonicalMCPResourceIdentifier` in `clients/thundersvc/identity_client.go`, called at the top of `EnsureProxyResourceServer` before the length guards — so create, drift-update, and any future caller all go through it. The identifier reaches Thunder through exactly one function, which is where the invariant is cheapest to guarantee.

It normalizes what RFC 3986 declares case- or default-insensitive and rejects what cannot be fixed without guessing intent:

| input | result |
|---|---|
| `https://gw.example.com/github/mcp` | unchanged |
| `HTTPS://GW.Example.com/x/mcp` | `https://gw.example.com/x/mcp` |
| `https://gw.example.com:443/x/mcp` | `https://gw.example.com/x/mcp` |
| `http://gw.example.com:80/x/mcp` | `http://gw.example.com/x/mcp` |
| `https://gw.example.com/x/mcp/` | `https://gw.example.com/x/mcp` |
| `gw.example.com/x/mcp` | error — no scheme |
| `ftp://gw.example.com/x/mcp` | error — scheme not http(s) |
| `https://u:p@gw/x/mcp` | error — userinfo |
| `https://gw/x/mcp?a=1` | error — query |
| `https://gw/x/mcp#f` | error — fragment |

Path case is preserved (paths are case-sensitive) and non-default ports are kept.

**The deriver stops stripping.** `services/mcp_rs_identifier.go` returns `buildMCPProxyURL(...)` directly; `stripURLScheme` had no other production caller and is deleted. This is the same change as the boundary edit — the boundary now rejects a scheme-less identifier, so the two cannot ship independently.

**Identifier length cap corrected** to `thunderIdentifierMaxLen = 2048`, matching the `VARCHAR(2048)` identifier column. The handle and action checks keep the 100-character handle cap.

**No migration and no new error path**, both by explicit design decision:
- Thunder resource servers are looked up by handle, not identifier, and a drifted identifier is already rewritten in place via `PUT` — existing development-environment rows self-heal on the next role write.
- A canonicalization failure means a malformed gateway vhost: platform misconfiguration, not request input. The error propagates to `ensureGroupResourceServer`, which already logs the wrapped error with proxy and environment and returns 502 with a generic message — consistent with every other branch in that controller.

Also corrected four comments that described the identifier as "protocol-stripped".

## User stories
As an MCP client author, I can request a token for an AMP-hosted MCP proxy using the RFC 8707 `resource` parameter with the proxy's actual URL, and have it match the registered resource server.

## Release note
MCP resource servers are now registered in Thunder under an RFC 8707-compliant absolute URI (e.g. `https://gw.example.com/github/mcp`) instead of a scheme-less form, and long identifiers are no longer rejected at 100 characters.

## Documentation
N/A — no operator-facing behaviour or configuration changes; the identifier is derived internally from the gateway vhost and the proxy context path.

## Training
N/A — no training content covers MCP resource server identifier derivation.

## Certification
N/A — internal identifier format with no impact on certification exam content.

## Marketing
N/A — spec-compliance fix, not a promotable feature.

## Automation tests
 - Unit tests
   > Test-driven, unit tier (no build tag). New 12-case table test for `canonicalMCPResourceIdentifier` covering every normalize and reject rule. In `identity_client_test.go`: every identifier fixture updated to an absolute URI; new tests asserting the create `POST` body carries the canonical identifier, that a non-canonical identifier is rejected **before any HTTP call is made**, that a 150-character identifier now succeeds (it previously failed against the 100-character handle cap), and that an identifier over 2048 characters is rejected citing that limit. The drift-update `PUT` body assertion now expects the absolute URI. `services/mcp_rs_identifier_unit_test.go` and `controllers/agent_identity_controller_unit_test.go` fixtures updated so no test models an invalid identifier. `make test-unit` passes; `clients/thundersvc` package coverage 48.3%.
 - Integration tests
   > No new integration tests: the change is in the Thunder HTTP client boundary and the identifier deriver, both fully covered in the unit tier with an `httptest` Thunder. `go build -tags=integration ./...` verified to compile.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Java-only plugin; this is a Go change. `golangci-lint` with the CI config (`.github/linters/.golangci.yaml`, includes `gosec`) reports 0 issues on the touched packages.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes; identifiers are derived internally.

## Related PRs
- wso2/agent-manager#1552 — the preceding change that moved MCP resource server identifiers onto the public proxy URL. This PR completes it by keeping the scheme.

## Migrations (if applicable)
None. Resource servers are looked up by handle, so changing the identifier cannot orphan or duplicate a row, and the existing drift-detect `PUT` in `EnsureProxyResourceServer` rewrites any pre-existing scheme-less identifier on the next role write. Fresh installs need nothing.

## Test environment
Go 1.25 (Homebrew, `GOTOOLCHAIN=local`), macOS 15 (darwin/arm64). Unit tier requires no database.

## Learning
RFC 8707 §2 (Resource Indicators for OAuth 2.0) and RFC 3986 §3.1/§3.2.2/§4.3 for which URI components are case- and default-insensitive. Measured Go's `net/url` behaviour rather than assuming it: `url.Parse` lowercases the scheme but not the host, preserves path case, and parses a scheme-less input to an empty `Scheme`/`Host` with everything in `Path` — which makes the non-absolute case cleanly detectable. Mirrored the existing `validateGatewayRuntimeURL` house pattern rather than inventing a new one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resource-server identifiers now use absolute HTTPS URIs.
  - Identifiers are normalized consistently, including host casing, default ports, and trailing slashes.
  - Longer identifiers are supported, up to 2,048 characters.

- **Bug Fixes**
  - Invalid identifiers containing unsupported components are rejected before processing.
  - Resource-server creation and updates now consistently reconcile equivalent identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->