### PR TITLE
Add BYOC TLS mode to the advanced VM install

### DIFF
--- a/deployments/scripts/add-environment-thunder.sh
+++ b/deployments/scripts/add-environment-thunder.sh
@@ -176,6 +176,16 @@ platform_thunder_ca_cert() {
   operator_ca="$(kubectl get configmap amp-platform-ca -n openchoreo-control-plane \
     -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)"
   if [ -n "$operator_ca" ]; then
+    # Any non-empty value would otherwise be accepted and folded into the trust bundle,
+    # so a truncated or non-PEM ConfigMap would reproduce the exact silent failure this
+    # lookup exists to prevent. The Mozilla bundle download applies the same check.
+    if ! printf '%s' "$operator_ca" | grep -q "BEGIN CERTIFICATE"; then
+      echo "❌ ConfigMap amp-platform-ca exists but ca.crt is not a PEM certificate." >&2
+      echo "   Replace it with the CA that signed platform Thunder's certificate:" >&2
+      echo "     kubectl create configmap amp-platform-ca -n openchoreo-control-plane \\" >&2
+      echo "       --from-file=ca.crt=<ca.pem> --dry-run=client -o yaml | kubectl apply -f -" >&2
+      return 1
+    fi
     echo "🔐 Using the operator-supplied platform CA (ConfigMap amp-platform-ca)" >&2
     printf '%s' "$operator_ca"
     return 0

--- a/deployments/scripts/add-environment-thunder.sh
+++ b/deployments/scripts/add-environment-thunder.sh
@@ -148,12 +148,36 @@ platform_thunder_jwks_url() {
   printf 'https://thunder.amp.localhost:8443/oauth2/jwks'
 }
 
-# platform_thunder_ca_cert -> prints the PEM CA cert that signed the
-# thunder.amp.localhost TLS certificate, or returns 1 if not yet provisioned.
-# Set PLATFORM_THUNDER_CA_PEM to inject a cert directly (useful in tests/CI).
+# platform_thunder_ca_cert -> prints the PEM CA cert that signed the certificate
+# platform Thunder's issuer is served with, or returns 1 if not yet provisioned.
+# Sources, in order:
+#   1. PLATFORM_THUNDER_CA_PEM  — explicit injection (tests/CI, and the installer's
+#      own in-process call).
+#   2. ConfigMap amp-platform-ca — the operator-supplied CA persisted at install time
+#      by a TLS_MODE=byoc advanced VM install (see deployments/vm/install-advanced.sh).
+#   3. amp-local-root-ca-secret — the cert-manager self-signed root used by local/k3d
+#      and any install where platform Thunder is served with the in-cluster CA.
+#
+# Source 2 exists because environments are created LONG AFTER the install exits. On a
+# byoc install the public listener is served with the operator's certificate, so the
+# self-signed root in (3) is the wrong CA: env-Thunder would mount a bundle that cannot
+# validate the JWKS URL, and this script would still exit 0 — a silent failure that only
+# surfaces later as a broken login into that environment. Persisting the CA in-cluster
+# makes the trust decision durable instead of living in the installer's process env.
 platform_thunder_ca_cert() {
   if [ -n "${PLATFORM_THUNDER_CA_PEM:-}" ]; then
     printf '%s' "$PLATFORM_THUNDER_CA_PEM"
+    return 0
+  fi
+
+  # Operator-supplied CA persisted by a byoc install. Absent on every other install
+  # path, so this lookup is a no-op there and the behaviour below is unchanged.
+  local operator_ca
+  operator_ca="$(kubectl get configmap amp-platform-ca -n openchoreo-control-plane \
+    -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)"
+  if [ -n "$operator_ca" ]; then
+    echo "🔐 Using the operator-supplied platform CA (ConfigMap amp-platform-ca)" >&2
+    printf '%s' "$operator_ca"
     return 0
   fi
 

--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # install-advanced.sh — config-driven Agent Manager install on a VM with Docker.
-# Run ON the target VM with sudo. Custom domain + publicly-trusted TLS via cert-manager's
-# ACME DNS-01 challenge (kgateway terminates TLS on :443 — no Caddy, no lego). Works on a
-# public OR private VM: issuance is egress-only (the ACME CA reads a DNS TXT record).
+# Run ON the target VM with sudo. Custom domain, with kgateway terminating TLS on :443
+# (no Caddy, no lego). Two TLS modes, both ending at the same Secret:
+#   TLS_MODE=dns01 (default) — cert-manager issues and auto-renews a publicly-trusted
+#     wildcard cert via the ACME DNS-01 challenge. Works on a public OR private VM:
+#     issuance is egress-only (the ACME CA reads a DNS TXT record, never calls the VM).
+#   TLS_MODE=byoc — you supply the certificate and key. No ACME, no DNS-provider
+#     credential, no egress to a CA — so this also covers air-gapped VMs — but nothing
+#     auto-renews, and the cert must carry every SAN this install serves.
 # See --init for the annotated config template.
 #
 # Usage:
@@ -32,21 +37,26 @@ print_template() {
 # amp-config.env — Agent Manager advanced VM install configuration.
 # Sourced by install-advanced.sh. Lines are shell assignments.
 #
-# TLS is always publicly-trusted certificates issued in-cluster by cert-manager
-# using the ACME DNS-01 challenge (kgateway terminates TLS on :443 — there is no
-# Caddy). The ACME CA validates by reading a DNS TXT record, so the VM needs NO
-# inbound access for issuance (egress only) and this works on a private VM too.
+# kgateway terminates TLS on :443 (there is no Caddy). Pick how the certificate
+# it serves is obtained with TLS_MODE — everything downstream is identical.
 
 # --- Required ---
 AMP_VERSION=0.15.0                 # amp/v* release tag (see github.com/wso2/agent-manager/releases)
 DOMAIN_BASE=amp.mycompany.com      # service hosts derived as <svc>.<DOMAIN_BASE>
-ACME_EMAIL=ops@mycompany.com       # ACME account contact (required)
 
-# --- DNS-01 provider (you must control the DNS zone for DOMAIN_BASE) ---
+# --- TLS mode: dns01 (default) or byoc ---
+TLS_MODE=dns01
+
+# === TLS_MODE=dns01 — cert-manager issues + auto-renews a publicly-trusted cert ===
+# The ACME CA validates by reading a DNS TXT record, so the VM needs NO inbound
+# access for issuance (egress only) and this works on a private VM too. You must
+# control the DNS zone for DOMAIN_BASE.
+#
 # cert-manager writes a TXT record to prove control of the zone, then issues a
-# wildcard certificate covering every service host, the deployed-agent wildcard, and
-# the env-Thunder wildcard. Set DNS_PROVIDER and that provider's credentials below;
-# the installer turns them into the Kubernetes Secret the ClusterIssuer references.
+# wildcard certificate covering every service host and the three dynamic-tier
+# wildcards. Set DNS_PROVIDER and that provider's credentials below; the installer
+# turns them into the Kubernetes Secret the ClusterIssuer references.
+ACME_EMAIL=ops@mycompany.com       # ACME account contact (required for dns01)
 DNS_PROVIDER=cloudflare            # cloudflare | route53 | clouddns | azuredns
 #   Cloudflare:        CLOUDFLARE_API_TOKEN=...            (scoped Zone.DNS:Edit token)
 #   AWS Route53:       AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_REGION=us-east-1
@@ -54,6 +64,18 @@ DNS_PROVIDER=cloudflare            # cloudflare | route53 | clouddns | azuredns
 #   Azure DNS:         AZURE_TENANT_ID=... AZURE_CLIENT_ID=... AZURE_CLIENT_SECRET=... \
 #                      AZURE_SUBSCRIPTION_ID=... AZURE_RESOURCE_GROUP=...
 # ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory  # optional: LE staging for testing
+
+# === TLS_MODE=byoc — you supply the certificate ===
+# No ACME and no DNS-provider credential, so this works even with no route to a
+# public CA. Nothing auto-renews: you must replace the cert before it expires.
+# The certificate must carry ALL of these SANs (--dry-run prints the exact list):
+#   console/api/thunder/observer/gateway[/cp].<DOMAIN_BASE>
+#   *.agents.<DOMAIN_BASE>    *.thunder.<DOMAIN_BASE>    *.gateway.<DOMAIN_BASE>
+# A *.<DOMAIN_BASE> wildcard does NOT cover those three — they sit one label deeper.
+# TLS_CERT_FILE=/opt/amp/certs/fullchain.pem   # cert + intermediates, PEM
+# TLS_KEY_FILE=/opt/amp/certs/privkey.pem      # matching private key, PEM
+# TLS_CA_FILE=/opt/amp/certs/ca.pem            # only if the cert chains to a private CA:
+#                                              # makes in-cluster components trust it
 
 # --- Optional ---
 EXTERNAL_GATEWAYS=true             # expose the cp endpoint for external data-plane gateways
@@ -93,6 +115,20 @@ AMP_HOST_CONSOLE="" AMP_HOST_API="" AMP_HOST_THUNDER="" AMP_HOST_OBSERVER=""
 AMP_HOST_GATEWAY="" AMP_HOST_CP="" AMP_AGENTS_BASE=""
 derive_hosts
 
+TLS_MODE_RESOLVED="$(tls_mode)"
+
+# In byoc mode, check the supplied certificate now — validate_cert needs the derived
+# hostnames, so it cannot run inside validate_config. This must still happen before
+# phase 1, which opens the firewall and creates the cluster: a cert whose SANs miss a
+# tier would otherwise only surface as a browser error at the end of a 20-minute install.
+if [[ "$TLS_MODE_RESOLVED" == "byoc" ]]; then
+  if ! validate_cert "$TLS_CERT_FILE" "$TLS_KEY_FILE"; then
+    printf '%s\n' "${CERT_ERRORS[@]}" >&2
+    die "certificate validation failed (${#CERT_ERRORS[@]} error(s)) — reissue the cert with the required SANs and re-run"
+  fi
+  log "Certificate check passed: cert/key match, not expired, SANs cover every service host and dynamic tier"
+fi
+
 # Names of the cert-manager + gateway resources the installer creates post-install.
 DNS01_SECRET="amp-dns01-credentials"
 ACME_ISSUER="amp-acme-dns01"
@@ -125,27 +161,59 @@ preflight_dns() {
   fi
 }
 
-# apply_advanced_tls — after the base install, create the cert-manager DNS-01 resources
-# (provider Secret + ACME ClusterIssuer + wildcard Certificate), the single :443 HTTPS
-# Gateway that terminates TLS with the issued cert, and the front-proxy routes that
-# forward by host to each plane's own gateway. This replaces the old lego + Caddy path
-# entirely; cert-manager auto-renews the cert in-cluster.
+# apply_advanced_tls — after the base install, create the TLS Secret, the single :443
+# HTTPS Gateway that terminates TLS with it, and the front-proxy routes that forward by
+# host to each plane's own gateway. This replaces the old lego + Caddy path entirely.
+#
+# The two modes differ only in how the Secret comes to exist: dns01 creates the
+# cert-manager objects (provider Secret + ACME ClusterIssuer + Certificate) and waits
+# for issuance; byoc writes the operator's cert/key straight into the Secret. The
+# Gateway and the routes are byte-identical either way.
 apply_advanced_tls() {
-  log "Applying cert-manager DNS-01 resources (provider=${DNS_PROVIDER}) + consolidated :443 gateway + front-proxy routes"
-  { render_dns01_credentials_secret "$DNS01_SECRET"
-    echo "---"
-    render_acme_clusterissuer "$ACME_ISSUER" "$DNS01_SECRET"
-    echo "---"
-    render_wildcard_certificate "$WILDCARD_CERT" "$WILDCARD_SECRET" "$ACME_ISSUER"
-    echo "---"
-    render_consolidated_gateway "$CONSOLIDATED_GATEWAY" "$WILDCARD_SECRET" 443
-    echo "---"
-    render_frontproxy_resources
-  } | kubectl apply -f - || die "failed to apply cert-manager/gateway resources"
+  if [[ "$TLS_MODE_RESOLVED" == "byoc" ]]; then
+    log "Applying supplied TLS certificate + consolidated :443 gateway + front-proxy routes"
+    { render_byoc_tls_secret "$WILDCARD_SECRET" "$TLS_CERT_FILE" "$TLS_KEY_FILE"
+      echo "---"
+      # Persist the operator CA so environments created after this install can trust the
+      # listener too. Phase 2's default env-Thunder gets it via PLATFORM_THUNDER_CA_PEM,
+      # but the cluster does not exist before Phase 2, so this is the earliest it can be
+      # written — and every LATER environment reads it from here.
+      if [[ -n "${TLS_CA_FILE:-}" ]]; then
+        render_platform_ca_configmap "$TLS_CA_FILE"
+        echo "---"
+      fi
+      render_consolidated_gateway "$CONSOLIDATED_GATEWAY" "$WILDCARD_SECRET" 443
+      echo "---"
+      render_frontproxy_resources
+    } | kubectl apply -f - || die "failed to apply TLS/gateway resources"
+  else
+    log "Applying cert-manager DNS-01 resources (provider=${DNS_PROVIDER}) + consolidated :443 gateway + front-proxy routes"
+    { render_dns01_credentials_secret "$DNS01_SECRET"
+      echo "---"
+      render_acme_clusterissuer "$ACME_ISSUER" "$DNS01_SECRET"
+      echo "---"
+      render_wildcard_certificate "$WILDCARD_CERT" "$WILDCARD_SECRET" "$ACME_ISSUER"
+      echo "---"
+      render_consolidated_gateway "$CONSOLIDATED_GATEWAY" "$WILDCARD_SECRET" 443
+      echo "---"
+      render_frontproxy_resources
+    } | kubectl apply -f - || die "failed to apply cert-manager/gateway resources"
 
-  log "Waiting for cert-manager to issue the wildcard cert via DNS-01 (can take a few minutes)…"
-  kubectl wait --for=condition=Ready "certificate/${WILDCARD_CERT}" -n "$GATEWAY_NS" --timeout=600s \
-    || die "cert-manager did not issue the cert — inspect: kubectl describe certificate ${WILDCARD_CERT} -n ${GATEWAY_NS}; kubectl get challenge -A"
+    log "Waiting for cert-manager to issue the wildcard cert via DNS-01 (can take a few minutes)…"
+    kubectl wait --for=condition=Ready "certificate/${WILDCARD_CERT}" -n "$GATEWAY_NS" --timeout=600s \
+      || die "cert-manager did not issue the cert — inspect: kubectl describe certificate ${WILDCARD_CERT} -n ${GATEWAY_NS}; kubectl get challenge -A"
+  fi
+
+  # The Secret exists either way by now; the remaining question is whether kgateway has
+  # accepted the listener and programmed the dataplane. This matters most in byoc mode,
+  # which has no certificate wait above and would otherwise print its access URLs before
+  # :443 could answer. Advisory, not fatal: the platform is fully installed by this point,
+  # so aborting would gain nothing, and a slow VM taking longer than the timeout is not a
+  # failure. Same rationale as preflight_dns.
+  log "Waiting for the consolidated :443 gateway to be programmed…"
+  if ! kubectl wait --for=condition=Programmed "gateway/${CONSOLIDATED_GATEWAY}" -n "$GATEWAY_NS" --timeout=300s; then
+    log "NOTE: the consolidated gateway is not Programmed yet. It may still settle; if :443 stays unreachable, inspect: kubectl describe gateway ${CONSOLIDATED_GATEWAY} -n ${GATEWAY_NS}"
+  fi
 }
 
 # render_frontproxy_resources — emit the host-based routes (and the cross-namespace
@@ -184,11 +252,11 @@ run_advanced_install() {
   log "Phase 1/3: preflight (verify tools + firewall)"
   verify_prerequisites
   ensure_inotify_limits
-  ensure_firewall 443     # inbound :443 for client traffic; DNS-01 issuance itself needs no inbound
+  ensure_firewall 443     # inbound :443 for client traffic; certificate issuance needs no inbound
   ensure_disk
   preflight_dns
 
-  log "Phase 2/3: install Agent Manager (cert-manager DNS-01, no Caddy) — 8-15 min"
+  log "Phase 2/3: install Agent Manager (TLS_MODE=${TLS_MODE_RESOLVED}, no Caddy) — 8-15 min"
   # Hostname-driven helm overrides (identical cores to the simple path). Every plane keeps
   # its own native gateway-default routes — the consolidated :443 gateway forwards to them
   # by host (see render_frontproxy_resources), so no ocIngress/external-gateway repointing
@@ -210,13 +278,26 @@ run_advanced_install() {
   export VERSION="$AMP_VERSION"
   export SHOW_LOCALHOST_URLS=false
 
-  # Env-Thunder deployment-wide config (inherited by install_default_env_thunder). The
-  # wildcard cert is publicly trusted, so env-Thunder trusts platform Thunder's HTTPS via
-  # the container's default trust store — no custom CA bundle needed. AMP_HOST_THUNDER is
-  # "thunder.<DOMAIN_BASE>"; stripping "thunder." gives env-Thunder's base domain.
+  # Env-Thunder deployment-wide config (inherited by install_default_env_thunder).
+  # AMP_HOST_THUNDER is "thunder.<DOMAIN_BASE>"; stripping "thunder." gives env-Thunder's
+  # base domain.
   export THUNDER_HOST_BASE_DOMAIN="${AMP_HOST_THUNDER#thunder.}"
   export TLS_ENABLED=true
-  export SKIP_CA_BUNDLE_TRUST=true
+  # CA trust for env-Thunder. PLATFORM_THUNDER_JWKS_URL below is an HTTPS URL that
+  # egresses back through the consolidated :443 gateway, so env-Thunder's Go TLS stack
+  # has to trust whatever certificate that gateway serves. A dns01 cert is publicly
+  # trusted, so the container's default trust store suffices and the custom-CA-bundle
+  # machinery can be skipped. A byoc cert from a private CA is NOT trusted by default:
+  # without the bundle, JWKS fetches fail and agent-environment login breaks while every
+  # other host looks perfectly healthy. TLS_CA_FILE feeds add-environment-thunder.sh's
+  # PLATFORM_THUNDER_CA_PEM seam, which mounts the CA into the env-Thunder Deployment.
+  if [[ "$TLS_MODE_RESOLVED" == "byoc" && -n "${TLS_CA_FILE:-}" ]]; then
+    export SKIP_CA_BUNDLE_TRUST=false
+    PLATFORM_THUNDER_CA_PEM="$(cat "$TLS_CA_FILE")"; export PLATFORM_THUNDER_CA_PEM
+    log "TLS_CA_FILE set — env-Thunder will trust platform Thunder via the supplied CA"
+  else
+    export SKIP_CA_BUNDLE_TRUST=true
+  fi
   export PLATFORM_THUNDER_ISSUER="https://${AMP_HOST_THUNDER}"
   export PLATFORM_THUNDER_JWKS_URL="https://${AMP_HOST_THUNDER}/oauth2/jwks"
   # install_default_env_thunder() runs off-cluster and calls both the AMP API and
@@ -238,12 +319,16 @@ run_advanced_install() {
   COREDNS_FILE="$(mktemp)"; export COREDNS_FILE
   render_coredns_vm_config "k3d-amp-local-server-0" >"$COREDNS_FILE"
 
-  log "Running base installer with custom-domain overrides (DNS-01)"
+  log "Running base installer with custom-domain overrides (TLS_MODE=${TLS_MODE_RESOLVED})"
   local rc=0
   ( set +e; source "${QS_DIR}/install.sh" ) || rc=$?
   [[ "$rc" -eq 0 ]] || die "Base installer exited $rc"
 
-  log "Phase 3/3: issue TLS certificate (cert-manager DNS-01) + expose :443"
+  if [[ "$TLS_MODE_RESOLVED" == "byoc" ]]; then
+    log "Phase 3/3: install the supplied TLS certificate + expose :443"
+  else
+    log "Phase 3/3: issue TLS certificate (cert-manager DNS-01) + expose :443"
+  fi
   apply_advanced_tls
 
   log "Done. Access URLs:"
@@ -264,16 +349,34 @@ if [[ "$DRY_RUN" == "true" ]]; then
   printf '  console=%s api=%s thunder=%s observer=%s gateway=%s cp=%s agents=%s\n' \
     "$AMP_HOST_CONSOLE" "$AMP_HOST_API" "$AMP_HOST_THUNDER" "$AMP_HOST_OBSERVER" \
     "$AMP_HOST_GATEWAY" "${AMP_HOST_CP:-<none>}" "$AMP_AGENTS_BASE"
+  log "DRY RUN — TLS mode: ${TLS_MODE_RESOLVED}"
   log "DRY RUN — amp helm args:"; amp_helm_args
-  log "DRY RUN — wildcard cert SANs:"; cert_dns_names
-  log "DRY RUN — cert-manager + gateway + front-proxy resources:"
-  # Do NOT render the provider-credential Secret here: it holds the live token/key
-  # (Cloudflare token, AWS secret, GCP SA JSON, Azure secret) and dry-run goes to stdout
-  # (terminal scrollback, CI logs). Show a redacted placeholder instead.
-  printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\ntype: Opaque\nstringData:\n  <%s credentials omitted in dry-run>\n---\n' \
-    "$DNS01_SECRET" "$CERT_MANAGER_NS" "$DNS_PROVIDER"
-  render_acme_clusterissuer "$ACME_ISSUER" "$DNS01_SECRET"; echo "---"
-  render_wildcard_certificate "$WILDCARD_CERT" "$WILDCARD_SECRET" "$ACME_ISSUER"; echo "---"
+  log "DRY RUN — required cert SANs:"; cert_dns_names
+  if [[ "$TLS_MODE_RESOLVED" == "byoc" ]]; then
+    # Show what the supplied cert actually carries next to the required list above, so a
+    # missing SAN is obvious here rather than after a 20-minute install.
+    log "DRY RUN — SANs in ${TLS_CERT_FILE}:"
+    cert_sans "$TLS_CERT_FILE"
+    log "DRY RUN — TLS + gateway + front-proxy resources:"
+    # Do NOT render the real Secret: it embeds the private key, and dry-run goes to
+    # stdout (terminal scrollback, CI logs). Same reasoning as the DNS-01 branch below.
+    printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\ntype: kubernetes.io/tls\ndata:\n  <tls.crt and tls.key omitted in dry-run>\n---\n' \
+      "$WILDCARD_SECRET" "$GATEWAY_NS"
+    # The CA is public (it travels in the TLS handshake), so unlike the key it is safe
+    # to render in full here.
+    if [[ -n "${TLS_CA_FILE:-}" ]]; then
+      render_platform_ca_configmap "$TLS_CA_FILE"; echo "---"
+    fi
+  else
+    log "DRY RUN — cert-manager + gateway + front-proxy resources:"
+    # Do NOT render the provider-credential Secret here: it holds the live token/key
+    # (Cloudflare token, AWS secret, GCP SA JSON, Azure secret) and dry-run goes to stdout
+    # (terminal scrollback, CI logs). Show a redacted placeholder instead.
+    printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n  namespace: %s\ntype: Opaque\nstringData:\n  <%s credentials omitted in dry-run>\n---\n' \
+      "$DNS01_SECRET" "$CERT_MANAGER_NS" "$DNS_PROVIDER"
+    render_acme_clusterissuer "$ACME_ISSUER" "$DNS01_SECRET"; echo "---"
+    render_wildcard_certificate "$WILDCARD_CERT" "$WILDCARD_SECRET" "$ACME_ISSUER"; echo "---"
+  fi
   render_consolidated_gateway "$CONSOLIDATED_GATEWAY" "$WILDCARD_SECRET" 443; echo "---"
   render_frontproxy_resources
   log "DRY RUN — DNS pre-flight (advisory):"; preflight_dns

--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -21,29 +21,145 @@ derive_hosts() {
   fi
 }
 
+# The TLS modes the advanced installer supports. Both end at the same seam — a
+# kubernetes.io/tls Secret in the gateway's namespace that the consolidated :443
+# Gateway references by name — they only differ in who produces it:
+#   dns01 — cert-manager issues (and auto-renews) it via the ACME DNS-01 challenge.
+#   byoc  — the operator supplies the cert/key; the installer creates the Secret
+#           verbatim. No ACME, no DNS-provider credential, no auto-renewal.
+SUPPORTED_TLS_MODES="dns01 byoc"
+
+# tls_mode — print the configured mode, defaulting to dns01. Every existing config
+# file predates TLS_MODE, so an unset value must keep the DNS-01 behaviour.
+tls_mode() { printf '%s' "${TLS_MODE:-dns01}"; }
+
 # load_config <file> — source an env-style config file in the caller's scope.
 load_config() {
   local file="${1:?load_config requires a config file path}"
   [[ -f "$file" ]] || { printf 'config file not found: %s\n' "$file" >&2; return 1; }
-  # Export every assignment so DNS-provider credentials (CF_*, AWS_*, GCE_*, ...) reach
-  # the dockerized lego: _lego_cred_env_args lists them via `compgen -e` (exported only)
-  # and forwards them with `docker run -e`. A plain `source` leaves them unexported, so
-  # token-based providers (Cloudflare/route53/azuredns) would silently get no credentials.
+  # Export every assignment so config values survive into the base installer, which
+  # runs in a subshell (`source install.sh`), and into the helper scripts it invokes.
+  # A plain `source` leaves them unexported and they would silently not propagate.
   # shellcheck disable=SC1090
   set -a; source "$file"; set +a
 }
 
-# validate_config — check required keys and the DNS-01 provider/credentials. Populates
-# the CONFIG_ERRORS array (reset on each call) and returns 1 if any error was recorded.
-# TLS is always cert-manager DNS-01 (there is a single mode), so this validates the
-# common keys plus the provider block (validate_dns01_config, from lib-certmanager.sh).
+# validate_config — check the required keys for the configured TLS mode. Populates the
+# CONFIG_ERRORS array (reset on each call) and returns 1 if any error was recorded.
+# Note this validates config *keys* only. The BYOC certificate itself is checked by
+# validate_cert, which needs the derived hostnames and so runs after derive_hosts.
 validate_config() {
   CONFIG_ERRORS=()
   [[ -n "${AMP_VERSION:-}" ]] || CONFIG_ERRORS+=("AMP_VERSION is required (an amp/v* release tag, e.g. 0.15.0)")
   [[ -n "${DOMAIN_BASE:-}" ]] || CONFIG_ERRORS+=("DOMAIN_BASE is required (e.g. amp.mycompany.com)")
-  [[ -n "${ACME_EMAIL:-}" ]]  || CONFIG_ERRORS+=("ACME_EMAIL is required (cert-manager registers an ACME account with it)")
-  validate_dns01_config   # DNS_PROVIDER + provider-specific credentials (lib-certmanager.sh)
+  local mode; mode="$(tls_mode)"
+  case " ${SUPPORTED_TLS_MODES} " in
+    *" ${mode} "*) ;;
+    *) CONFIG_ERRORS+=("TLS_MODE must be one of: ${SUPPORTED_TLS_MODES} (got '${TLS_MODE:-<unset>}')")
+       return 1 ;;
+  esac
+  case "$mode" in
+    dns01)
+      [[ -n "${ACME_EMAIL:-}" ]] || CONFIG_ERRORS+=("ACME_EMAIL is required for TLS_MODE=dns01 (cert-manager registers an ACME account with it)")
+      validate_dns01_config   # DNS_PROVIDER + provider-specific credentials (lib-certmanager.sh)
+      ;;
+    byoc)
+      validate_byoc_config
+      ;;
+  esac
   (( ${#CONFIG_ERRORS[@]} == 0 ))
+}
+
+# validate_byoc_config — confirm the operator-supplied cert/key (and the optional CA
+# bundle) are configured and readable. Appends to CONFIG_ERRORS (does not reset it —
+# the caller owns that array). ACME_EMAIL/DNS_PROVIDER are deliberately NOT required:
+# byoc never contacts an ACME CA or a DNS provider.
+validate_byoc_config() {
+  local v
+  for v in TLS_CERT_FILE TLS_KEY_FILE; do
+    if [[ -z "${!v:-}" ]]; then
+      CONFIG_ERRORS+=("${v} is required for TLS_MODE=byoc")
+    elif [[ ! -r "${!v}" ]]; then
+      CONFIG_ERRORS+=("${v} not readable: ${!v}")
+    fi
+  done
+  # TLS_CA_FILE is optional (only needed when the cert chains to a private CA), but if
+  # given it must be usable — a typo'd path would otherwise silently skip CA trust.
+  if [[ -n "${TLS_CA_FILE:-}" && ! -r "${TLS_CA_FILE}" ]]; then
+    CONFIG_ERRORS+=("TLS_CA_FILE not readable: ${TLS_CA_FILE}")
+  fi
+}
+
+# cert_sans <cert_file> — print the DNS SANs in a certificate, one per line. Parses only
+# the `DNS:` entries, so the "X509v3 Subject Alternative Name:" header line and any
+# non-DNS SAN types (IP:, email:) are dropped rather than treated as hostnames.
+cert_sans() {
+  openssl x509 -noout -ext subjectAltName -in "$1" 2>/dev/null \
+    | tr ',' '\n' | sed -n 's/^[[:space:]]*DNS:[[:space:]]*//p' | sed 's/[[:space:]]//g'
+}
+
+# validate_cert <cert_file> <key_file> — verify a BYOC cert is usable and covers every
+# hostname this install serves. Populates CERT_ERRORS; returns 1 on any error. Prints a
+# soft note (does not fail) when expiry is under 30 days.
+#
+# The required SAN list comes from cert_dns_names() (lib-certmanager.sh) — the same
+# function that builds the DNS-01 Certificate's dnsNames — so the two can never drift.
+# That matters: the per-environment API Platform Gateway tier (*.<gateway host>) was
+# added after the original BYOC implementation, and a hardcoded list silently misses it.
+validate_cert() {
+  local cert="$1" key="$2"
+  CERT_ERRORS=()
+  [[ -r "$cert" ]] || CERT_ERRORS+=("cert file not readable: $cert")
+  [[ -r "$key" ]]  || CERT_ERRORS+=("key file not readable: $key")
+  if (( ${#CERT_ERRORS[@]} )); then return 1; fi
+
+  # 1. Cert and key are a pair — compare public keys. Works for RSA and EC keys
+  #    (the older `openssl rsa -modulus` only handles RSA and errors on EC).
+  local cpub kpub
+  cpub="$(openssl x509 -noout -pubkey -in "$cert" 2>/dev/null | openssl md5)"
+  kpub="$(openssl pkey -pubout -in "$key" 2>/dev/null | openssl md5)"
+  [[ -n "$cpub" && "$cpub" == "$kpub" ]] || CERT_ERRORS+=("cert and key do not match (public key mismatch)")
+
+  # 2. Expiry: hard-fail if already expired; soft-note if < 30 days remain. There is no
+  #    auto-renewal in byoc mode, so a short-dated cert is worth flagging up front.
+  if ! openssl x509 -checkend 0 -noout -in "$cert" >/dev/null 2>&1; then
+    CERT_ERRORS+=("cert is expired")
+  elif ! openssl x509 -checkend $((30*24*3600)) -noout -in "$cert" >/dev/null 2>&1; then
+    printf '[preflight] NOTE: cert expires in under 30 days, and byoc certs are NOT auto-renewed\n' >&2
+  fi
+
+  # 3. SAN coverage for every name in cert_dns_names().
+  local sans want
+  sans="$(cert_sans "$cert")"
+  _san_covers() {  # _san_covers <hostname>
+    local host="$1" s
+    while IFS= read -r s; do
+      [[ -z "$s" ]] && continue
+      [[ "$s" == "$host" ]] && return 0
+      # wildcard match: *.foo.com covers bar.foo.com (exactly one extra label)
+      if [[ "$s" == \*.* ]]; then
+        local base="${s#\*.}"
+        [[ "$host" == *."$base" && "${host%."$base"}" != *.* ]] && return 0
+      fi
+    done <<<"$sans"
+    return 1
+  }
+  while IFS= read -r want; do
+    [[ -z "$want" ]] && continue
+    if [[ "$want" == \*.* ]]; then
+      # A wildcard requirement needs a literal wildcard SAN. A broader wildcard one
+      # level up does NOT satisfy it: *.<base> matches only a single extra label, so
+      # it never covers <org>-<project>.agents.<base>. This is the certificate-side
+      # analogue of the RFC 4592 trap the DNS records section documents.
+      grep -qxF "$want" <<<"$sans" \
+        || CERT_ERRORS+=("cert is missing the wildcard SAN: ${want}")
+    else
+      _san_covers "$want" || CERT_ERRORS+=("cert SANs do not cover ${want}")
+    fi
+  done < <(cert_dns_names)
+  unset -f _san_covers
+
+  (( ${#CERT_ERRORS[@]} == 0 ))
 }
 
 # _resolve_host <hostname> — print ALL A records (one per line). Overridable in tests.

--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -90,12 +90,20 @@ validate_byoc_config() {
   fi
 }
 
-# cert_sans <cert_file> — print the DNS SANs in a certificate, one per line. Parses only
-# the `DNS:` entries, so the "X509v3 Subject Alternative Name:" header line and any
-# non-DNS SAN types (IP:, email:) are dropped rather than treated as hostnames.
+# cert_sans <cert_file> — print the DNS SANs in a certificate, one per line, lowercased.
+# Parses only the `DNS:` entries, so the "X509v3 Subject Alternative Name:" header line
+# and any non-DNS SAN types (IP:, email:) are dropped rather than treated as hostnames.
+#
+# DNS names are case-insensitive (RFC 4343), and both this list and the required names it
+# is matched against are compared literally, so both sides are lowercased: a cert carrying
+# "DNS:Console.example.com", or a config written as DOMAIN_BASE=Example.com, would
+# otherwise be reported as a missing SAN. (The `DNS:` prefix itself is openssl's own
+# output, not user data, so matching it literally is safe — and keeps this portable to
+# BSD sed, which has no case-insensitive substitution flag.)
 cert_sans() {
   openssl x509 -noout -ext subjectAltName -in "$1" 2>/dev/null \
-    | tr ',' '\n' | sed -n 's/^[[:space:]]*DNS:[[:space:]]*//p' | sed 's/[[:space:]]//g'
+    | tr ',' '\n' | sed -n 's/^[[:space:]]*DNS:[[:space:]]*//p' | sed 's/[[:space:]]//g' \
+    | tr '[:upper:]' '[:lower:]'
 }
 
 # validate_cert <cert_file> <key_file> — verify a BYOC cert is usable and covers every
@@ -113,12 +121,26 @@ validate_cert() {
   [[ -r "$key" ]]  || CERT_ERRORS+=("key file not readable: $key")
   if (( ${#CERT_ERRORS[@]} )); then return 1; fi
 
-  # 1. Cert and key are a pair — compare public keys. Works for RSA and EC keys
-  #    (the older `openssl rsa -modulus` only handles RSA and errors on EC).
+  # 1. Both files actually parse, THEN that they are a pair. Compare the public keys
+  #    themselves rather than digests of them: piping a failed openssl into `openssl md5`
+  #    yields the digest of empty input, which is non-empty and identical on both sides —
+  #    so an unparseable cert AND key would silently "match". Comparing public keys (not
+  #    moduli) also keeps this working for EC keys, which `openssl rsa -modulus` rejects.
   local cpub kpub
-  cpub="$(openssl x509 -noout -pubkey -in "$cert" 2>/dev/null | openssl md5)"
-  kpub="$(openssl pkey -pubout -in "$key" 2>/dev/null | openssl md5)"
-  [[ -n "$cpub" && "$cpub" == "$kpub" ]] || CERT_ERRORS+=("cert and key do not match (public key mismatch)")
+  cpub="$(openssl x509 -noout -pubkey -in "$cert" 2>/dev/null)"
+  kpub="$(openssl pkey -pubout -in "$key" 2>/dev/null)"
+  [[ -n "$cpub" ]] || CERT_ERRORS+=("cert is not a readable X.509 certificate: $cert")
+  # An encrypted private key lands here too: openssl cannot read it unattended, which is
+  # worth naming, because "cert and key do not match" would send the operator hunting for
+  # the wrong problem entirely.
+  [[ -n "$kpub" ]] || CERT_ERRORS+=("key is not a readable unencrypted private key (decrypt it first): $key")
+  if [[ -n "$cpub" && -n "$kpub" && "$cpub" != "$kpub" ]]; then
+    CERT_ERRORS+=("cert and key do not match (public key mismatch)")
+  fi
+
+  # Everything below reads the certificate, so it can only mislead if the cert did not
+  # parse — "cert is expired" for a file that is not a certificate, say.
+  if [[ -z "$cpub" ]]; then return 1; fi
 
   # 2. Expiry: hard-fail if already expired; soft-note if < 30 days remain. There is no
   #    auto-renewal in byoc mode, so a short-dated cert is worth flagging up front.
@@ -128,7 +150,8 @@ validate_cert() {
     printf '[preflight] NOTE: cert expires in under 30 days, and byoc certs are NOT auto-renewed\n' >&2
   fi
 
-  # 3. SAN coverage for every name in cert_dns_names().
+  # 3. SAN coverage for every name in cert_dns_names(). Both sides are lowercased, since
+  #    DNS names are case-insensitive but these comparisons are literal.
   local sans want
   sans="$(cert_sans "$cert")"
   _san_covers() {  # _san_covers <hostname>
@@ -146,6 +169,7 @@ validate_cert() {
   }
   while IFS= read -r want; do
     [[ -z "$want" ]] && continue
+    want="$(printf '%s' "$want" | tr '[:upper:]' '[:lower:]')"
     if [[ "$want" == \*.* ]]; then
       # A wildcard requirement needs a literal wildcard SAN. A broader wildcard one
       # level up does NOT satisfy it: *.<base> matches only a single extra label, so

--- a/deployments/vm/lib-certmanager.sh
+++ b/deployments/vm/lib-certmanager.sh
@@ -220,7 +220,15 @@ EOF
 # multi-line and any indentation slip silently corrupts the key. `openssl base64 -A`
 # (not `base64 -w0`, which is GNU-only) keeps this portable across macOS and Linux.
 render_byoc_tls_secret() {
-  local name="$1" cert="$2" key="$3"
+  local name="$1" cert="$2" key="$3" crt_b64 key_b64
+  # Encode before the heredoc, not inside it. Command substitution in a heredoc swallows
+  # the exit status, so a file that moved or lost its permissions after the pre-flight
+  # would expand to an empty value here and still return 0 — the caller would then see
+  # only kubectl's decoding complaint, which never names the file at fault.
+  crt_b64="$(openssl base64 -A -in "$cert")" && [[ -n "$crt_b64" ]] \
+    || die "render_byoc_tls_secret: could not read/encode the certificate: ${cert}"
+  key_b64="$(openssl base64 -A -in "$key")" && [[ -n "$key_b64" ]] \
+    || die "render_byoc_tls_secret: could not read/encode the private key: ${key}"
   cat <<EOF
 apiVersion: v1
 kind: Secret
@@ -229,8 +237,8 @@ metadata:
   namespace: ${GATEWAY_NS}
 type: kubernetes.io/tls
 data:
-  tls.crt: $(openssl base64 -A -in "$cert")
-  tls.key: $(openssl base64 -A -in "$key")
+  tls.crt: ${crt_b64}
+  tls.key: ${key_b64}
 EOF
 }
 
@@ -247,8 +255,20 @@ EOF
 #
 # A CA certificate is public by definition (it is sent in the TLS handshake), so a
 # ConfigMap is the right kind — no Secret needed.
+#
+# YAML infers a block scalar's indentation from its first non-empty line, so the sed
+# below strips any leading whitespace before applying exactly four spaces. Otherwise a CA
+# file opening with an indented line — the human-readable preamble `openssl x509 -text`
+# emits, for instance — would set a deeper inferred indent, and every subsequent line
+# would either gain leading spaces inside the value or end the block early. The ConfigMap
+# still applies either way; the damage only appears later as a trust failure.
+#
+# An explicit indentation indicator (`|4`) looks like the tidier fix but is not: the
+# indicator counts from the parent node's indentation, not from column zero, so here it
+# would demand six spaces and fail to parse at all.
 render_platform_ca_configmap() {
   local ca="$1"
+  [[ -s "$ca" ]] || die "render_platform_ca_configmap: CA file is missing or empty: ${ca}"
   cat <<EOF
 apiVersion: v1
 kind: ConfigMap
@@ -257,7 +277,7 @@ metadata:
   namespace: ${GATEWAY_NS}
 data:
   ca.crt: |
-$(sed 's/^/    /' "$ca")
+$(sed -e 's/[[:space:]]*$//' -e 's/^[[:space:]]*//' -e 's/^/    /' "$ca")
 EOF
 }
 

--- a/deployments/vm/lib-certmanager.sh
+++ b/deployments/vm/lib-certmanager.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-# lib-certmanager.sh — render the cert-manager resources that replace the old lego +
-# Caddy TLS path for the advanced (DNS-01) VM install. Sourcing only defines functions
-# (no side effects); the render_* functions write YAML to stdout, so the caller pipes
-# them to `kubectl apply`. cert-manager (installed as a cluster prerequisite) then does
-# the ACME DNS-01 challenge, issues a wildcard cert into a Secret, and auto-renews it —
-# kgateway terminates TLS on :443 with that Secret. No lego container, no systemd timer.
+# lib-certmanager.sh — render the TLS + gateway resources for the advanced VM install,
+# which replaced the old lego + Caddy path. Sourcing only defines functions (no side
+# effects); the render_* functions write YAML to stdout, so the caller pipes them to
+# `kubectl apply`. No lego container, no systemd timer.
+#
+# Both TLS modes converge on one seam: a kubernetes.io/tls Secret in GATEWAY_NS that
+# the consolidated :443 Gateway references by name, with kgateway terminating TLS.
+#   dns01 — cert-manager (a cluster prerequisite) does the ACME DNS-01 challenge,
+#           issues a wildcard cert into that Secret, and auto-renews it.
+#   byoc  — render_byoc_tls_secret writes the operator's cert/key into that Secret
+#           directly; no cert-manager objects are created and nothing auto-renews.
+# Everything downstream of the Secret (Gateway, front-proxy routes, ReferenceGrants) is
+# identical in both modes.
 #
 # The caller defines log()/die(); fallbacks are provided so this file is usable standalone.
 command -v log >/dev/null 2>&1 || log() { printf '\033[0;34m[certmgr]\033[0m %s\n' "$*"; }
@@ -199,6 +206,58 @@ EOF
     name: ${issuer}
     kind: ClusterIssuer
     group: cert-manager.io
+EOF
+}
+
+# render_byoc_tls_secret <secret_name> <cert_file> <key_file> — print the
+# kubernetes.io/tls Secret holding an operator-supplied certificate chain and private
+# key, in GATEWAY_NS so the consolidated :443 Gateway's certificateRefs resolves
+# same-namespace. This is the byoc counterpart to render_wildcard_certificate: it
+# produces the very same Secret the DNS-01 path has cert-manager issue, so nothing
+# downstream (Gateway, routes, grants) can tell the two modes apart.
+#
+# Uses `data:` with base64 rather than `stringData:` with a block scalar: PEM is
+# multi-line and any indentation slip silently corrupts the key. `openssl base64 -A`
+# (not `base64 -w0`, which is GNU-only) keeps this portable across macOS and Linux.
+render_byoc_tls_secret() {
+  local name="$1" cert="$2" key="$3"
+  cat <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${name}
+  namespace: ${GATEWAY_NS}
+type: kubernetes.io/tls
+data:
+  tls.crt: $(openssl base64 -A -in "$cert")
+  tls.key: $(openssl base64 -A -in "$key")
+EOF
+}
+
+# render_platform_ca_configmap <ca_file> — print the ConfigMap holding the operator's
+# CA certificate, so components created AFTER the install can find it.
+#
+# Environments are added long after install-advanced.sh exits, and each one provisions
+# its own env-Thunder that must validate platform Thunder's HTTPS JWKS URL. On a byoc
+# install that URL is served with the operator's certificate, so the in-cluster
+# self-signed root add-environment-thunder.sh otherwise falls back to is the wrong CA —
+# it mounts a bundle that cannot verify the chain, exits 0, and the failure only shows
+# up later as a broken login into that environment. Persisting the CA here is what makes
+# `TLS_CA_FILE` apply to every future environment rather than only the default one.
+#
+# A CA certificate is public by definition (it is sent in the TLS handshake), so a
+# ConfigMap is the right kind — no Secret needed.
+render_platform_ca_configmap() {
+  local ca="$1"
+  cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: amp-platform-ca
+  namespace: ${GATEWAY_NS}
+data:
+  ca.crt: |
+$(sed 's/^/    /' "$ca")
 EOF
 }
 

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -99,6 +99,13 @@ openssl req -x509 -newkey rsa:2048 -nodes -days 90 -keyout "$tmp_key" -out "$tmp
   -subj "/CN=amp.mycompany.com" \
   -addext "subjectAltName=DNS:console.amp.mycompany.com,DNS:api.amp.mycompany.com,DNS:thunder.amp.mycompany.com,DNS:observer.amp.mycompany.com,DNS:gateway.amp.mycompany.com,DNS:cp.amp.mycompany.com,DNS:*.agents.amp.mycompany.com,DNS:*.thunder.amp.mycompany.com,DNS:*.gateway.amp.mycompany.com" \
   >/dev/null 2>&1
+# Fail with the real cause if generation did not work (an openssl without -addext, say).
+# Every assertion below reads these files, so without this they all fail at once with
+# messages that say nothing about why.
+[[ -s "$tmp_cert" && -s "$tmp_key" ]] || {
+  printf 'FAIL - could not generate the BYOC test certificate (openssl lacking -addext?)\n'
+  echo 1 >>"$FAILLOG"; exit 1
+}
 
 n="$(TLS_MODE=byoc AMP_VERSION=1 DOMAIN_BASE=d TLS_CERT_FILE="$tmp_cert" TLS_KEY_FILE="$tmp_key" run_vc)"
 assert_eq "byoc without ACME_EMAIL/DNS_PROVIDER: 0 errors" "0" "$n"
@@ -132,6 +139,38 @@ assert_eq "missing *.gateway is named" "yes" \
 validate_cert "$tmp_cert" "$tmp_k2" 2>/dev/null
 assert_eq "mismatched key is rejected" "yes" \
   "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'cert and key do not match' && echo yes || echo no)"
+
+# Unparseable inputs must be named as such. Digesting openssl's (empty) output on failure
+# would make two unreadable files compare equal, so a garbage cert+key pair would pass the
+# pairing check and then be reported as an expired certificate.
+tmp_junk="$(mktemp)"; printf 'not a certificate\n' > "$tmp_junk"
+validate_cert "$tmp_junk" "$tmp_junk" 2>/dev/null
+assert_eq "garbage cert+key is not reported as matching" "no" \
+  "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'cert and key do not match' && echo yes || echo no)"
+assert_eq "garbage cert is named unreadable" "yes" \
+  "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'not a readable X.509 certificate' && echo yes || echo no)"
+assert_eq "garbage cert is not called expired" "no" \
+  "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'cert is expired' && echo yes || echo no)"
+# An encrypted key is the realistic case: it must not surface as a pairing mismatch.
+tmp_enc="$(mktemp)"
+openssl genrsa -aes256 -passout pass:secret 2048 > "$tmp_enc" 2>/dev/null
+if [[ -s "$tmp_enc" ]] && grep -q "ENCRYPTED" "$tmp_enc"; then
+  validate_cert "$tmp_cert" "$tmp_enc" 2>/dev/null
+  assert_eq "encrypted key is named, not a mismatch" "yes" \
+    "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'not a readable unencrypted private key' && echo yes || echo no)"
+else
+  printf 'ok   - encrypted key is named, not a mismatch (skipped: could not build one)\n'
+fi
+
+# SAN matching is case-insensitive (RFC 4343): DNS names differing only in case must match.
+tmp_c4="$(mktemp)"; tmp_k4="$(mktemp)"
+openssl req -x509 -newkey rsa:2048 -nodes -days 90 -keyout "$tmp_k4" -out "$tmp_c4" \
+  -subj "/CN=amp.mycompany.com" \
+  -addext "subjectAltName=DNS:CONSOLE.amp.mycompany.com,DNS:API.amp.mycompany.com,DNS:Thunder.amp.mycompany.com,DNS:observer.amp.mycompany.com,DNS:gateway.amp.mycompany.com,DNS:cp.amp.mycompany.com,DNS:*.Agents.amp.mycompany.com,DNS:*.thunder.amp.mycompany.com,DNS:*.gateway.amp.mycompany.com" \
+  >/dev/null 2>&1
+validate_cert "$tmp_c4" "$tmp_k4" 2>/dev/null
+assert_eq "mixed-case SANs are accepted" "0" "${#CERT_ERRORS[@]}"
+rm -f "$tmp_junk" "$tmp_enc" "$tmp_c4" "$tmp_k4"
 
 # Expired cert. -days 1 with a backdated start puts notAfter in the past.
 tmp_c3="$(mktemp)"; tmp_k3="$(mktemp)"
@@ -173,6 +212,30 @@ assert_eq "platform CA cm has ca.crt key"  "yes" "$(grep -q 'ca.crt: |' <<<"$ca_
 ca_body="$(sed -n '/ca.crt: |/,$p' <<<"$ca_cm" | tail -n +2 | sed 's/^    //')"
 assert_eq "platform CA cm PEM round-trips" "yes" \
   "$(printf '%s\n' "$ca_body" | openssl x509 -noout -subject >/dev/null 2>&1 && echo yes || echo no)"
+
+# Parse the rendered YAML for real when kubectl is available. The manual de-indent above
+# cannot tell a valid block scalar from an invalid header (an explicit indentation
+# indicator, say), so on its own it would pass on YAML that no parser accepts.
+if command -v kubectl >/dev/null 2>&1; then
+  ca_parsed="$(printf '%s\n' "$ca_cm" | kubectl create --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
+  assert_eq "platform CA cm is valid YAML" "yes" \
+    "$(printf '%s' "$ca_parsed" | grep -q 'BEGIN CERTIFICATE' && echo yes || echo no)"
+  assert_eq "platform CA cm PEM is not indented" "no" \
+    "$(printf '%s' "$ca_parsed" | grep -qE '^[[:space:]]+-----BEGIN' && echo yes || echo no)"
+  # A CA file whose first line is indented (openssl x509 -text preamble) must not shift
+  # the inferred block indentation.
+  tmp_messy="$(mktemp)"
+  { printf '\n  Certificate:\n    Data:\n'; cat "$tmp_cert"; } > "$tmp_messy"
+  messy_parsed="$(render_platform_ca_configmap "$tmp_messy" | kubectl create --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
+  assert_eq "indented-preamble CA still renders valid YAML" "yes" \
+    "$(printf '%s' "$messy_parsed" | openssl x509 -noout -subject >/dev/null 2>&1 && echo yes || echo no)"
+  rm -f "$tmp_messy"
+  # The byoc Secret must parse too.
+  sec_type="$(render_byoc_tls_secret amp-wildcard-tls "$tmp_cert" "$tmp_key" | kubectl create --dry-run=client -o jsonpath='{.type}' -f - 2>/dev/null || true)"
+  assert_eq "byoc secret is valid YAML" "kubernetes.io/tls" "$sec_type"
+else
+  printf 'ok   - rendered YAML parses (skipped: kubectl not installed)\n'
+fi
 
 rm -f "$tmp_cert" "$tmp_key" "$tmp_c2" "$tmp_k2" "$tmp_c3" "$tmp_k3"
 

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -80,6 +80,102 @@ k3d_out="$(printf 'ports:\n  - port: 8080:8080\n    nodeFilters:\n      - loadba
 assert_eq "k3d advanced publishes 443"        "yes" "$(grep -q -- '- port: 443:443' <<<"$k3d_out" && echo yes || echo no)"
 assert_eq "k3d advanced loopback-binds 8080"  "yes" "$(grep -q -- '- port: 127.0.0.1:8080:8080' <<<"$k3d_out" && echo yes || echo no)"
 
+# --- validate_config: TLS_MODE branching ---
+# An absent TLS_MODE must keep the DNS-01 behaviour — every config file written before
+# byoc existed omits the key entirely.
+run_vc() { CONFIG_ERRORS=(); validate_config >/dev/null; echo "${#CONFIG_ERRORS[@]}"; }
+
+n="$(AMP_VERSION=1 DOMAIN_BASE=d ACME_EMAIL=o@x.com DNS_PROVIDER=cloudflare CLOUDFLARE_API_TOKEN=tok run_vc)"
+assert_eq "no TLS_MODE defaults to dns01: 0 errors" "0" "$n"
+n="$(AMP_VERSION=1 DOMAIN_BASE=d run_vc)"   # dns01 default still demands the ACME keys
+assert_eq "no TLS_MODE still requires ACME keys" "2" "$n"
+n="$(TLS_MODE=bogus AMP_VERSION=1 DOMAIN_BASE=d run_vc)"
+assert_eq "unknown TLS_MODE: 1 error" "1" "$n"
+
+# byoc must NOT require ACME_EMAIL or DNS_PROVIDER — needing an ACME contact for a
+# certificate you already hold is exactly the coupling this mode removes.
+tmp_cert="$(mktemp)"; tmp_key="$(mktemp)"
+openssl req -x509 -newkey rsa:2048 -nodes -days 90 -keyout "$tmp_key" -out "$tmp_cert" \
+  -subj "/CN=amp.mycompany.com" \
+  -addext "subjectAltName=DNS:console.amp.mycompany.com,DNS:api.amp.mycompany.com,DNS:thunder.amp.mycompany.com,DNS:observer.amp.mycompany.com,DNS:gateway.amp.mycompany.com,DNS:cp.amp.mycompany.com,DNS:*.agents.amp.mycompany.com,DNS:*.thunder.amp.mycompany.com,DNS:*.gateway.amp.mycompany.com" \
+  >/dev/null 2>&1
+
+n="$(TLS_MODE=byoc AMP_VERSION=1 DOMAIN_BASE=d TLS_CERT_FILE="$tmp_cert" TLS_KEY_FILE="$tmp_key" run_vc)"
+assert_eq "byoc without ACME_EMAIL/DNS_PROVIDER: 0 errors" "0" "$n"
+n="$(TLS_MODE=byoc AMP_VERSION=1 DOMAIN_BASE=d run_vc)"
+assert_eq "byoc without cert/key: 2 errors" "2" "$n"
+n="$(TLS_MODE=byoc AMP_VERSION=1 DOMAIN_BASE=d TLS_CERT_FILE=/nope/c.pem TLS_KEY_FILE="$tmp_key" run_vc)"
+assert_eq "byoc unreadable cert: 1 error" "1" "$n"
+n="$(TLS_MODE=byoc AMP_VERSION=1 DOMAIN_BASE=d TLS_CERT_FILE="$tmp_cert" TLS_KEY_FILE="$tmp_key" TLS_CA_FILE=/nope/ca.pem run_vc)"
+assert_eq "byoc unreadable TLS_CA_FILE: 1 error" "1" "$n"
+
+# --- cert_sans: DNS entries only (no header line, no non-DNS SAN types) ---
+assert_eq "cert_sans drops the header line" "no" \
+  "$(cert_sans "$tmp_cert" | grep -q 'Alternative' && echo yes || echo no)"
+assert_eq "cert_sans count matches" "9" "$(cert_sans "$tmp_cert" | grep -c .)"
+
+# --- validate_cert: pairing, expiry, and SAN coverage driven by cert_dns_names ---
+validate_cert "$tmp_cert" "$tmp_key" 2>/dev/null
+assert_eq "full-SAN cert passes" "0" "${#CERT_ERRORS[@]}"
+
+# A *.<DOMAIN_BASE> wildcard covers the service hosts but NOT the three dynamic tiers,
+# which sit one label deeper — the single most common BYOC mistake.
+tmp_c2="$(mktemp)"; tmp_k2="$(mktemp)"
+openssl req -x509 -newkey rsa:2048 -nodes -days 90 -keyout "$tmp_k2" -out "$tmp_c2" \
+  -subj "/CN=amp.mycompany.com" -addext "subjectAltName=DNS:*.amp.mycompany.com" >/dev/null 2>&1
+validate_cert "$tmp_c2" "$tmp_k2" 2>/dev/null
+assert_eq "*.<base> alone misses 3 wildcards" "3" "${#CERT_ERRORS[@]}"
+assert_eq "missing *.gateway is named" "yes" \
+  "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'missing the wildcard SAN: *.gateway.amp.mycompany.com' && echo yes || echo no)"
+
+# Mismatched key: cert from one pair, key from the other.
+validate_cert "$tmp_cert" "$tmp_k2" 2>/dev/null
+assert_eq "mismatched key is rejected" "yes" \
+  "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'cert and key do not match' && echo yes || echo no)"
+
+# Expired cert. -days 1 with a backdated start puts notAfter in the past.
+tmp_c3="$(mktemp)"; tmp_k3="$(mktemp)"
+openssl req -x509 -newkey rsa:2048 -nodes -not_before 20200101000000Z -not_after 20200102000000Z \
+  -keyout "$tmp_k3" -out "$tmp_c3" -subj "/CN=amp.mycompany.com" \
+  -addext "subjectAltName=DNS:*.amp.mycompany.com" >/dev/null 2>&1
+if [[ -s "$tmp_c3" ]]; then
+  validate_cert "$tmp_c3" "$tmp_k3" 2>/dev/null
+  assert_eq "expired cert is rejected" "yes" \
+    "$(printf '%s\n' "${CERT_ERRORS[@]}" | grep -qF 'cert is expired' && echo yes || echo no)"
+else
+  # -not_before/-not_after need OpenSSL 3.2+; skip rather than fail on older toolchains.
+  printf 'ok   - expired cert is rejected (skipped: openssl lacks -not_after)\n'
+fi
+
+# --- render_byoc_tls_secret: kubernetes.io/tls in the gateway namespace ---
+byoc_secret="$(render_byoc_tls_secret amp-wildcard-tls "$tmp_cert" "$tmp_key")"
+assert_eq "byoc secret type"      "yes" "$(grep -q 'type: kubernetes.io/tls' <<<"$byoc_secret" && echo yes || echo no)"
+assert_eq "byoc secret namespace" "yes" "$(grep -q 'namespace: openchoreo-control-plane' <<<"$byoc_secret" && echo yes || echo no)"
+assert_eq "byoc secret has tls.crt" "yes" "$(grep -q 'tls.crt:' <<<"$byoc_secret" && echo yes || echo no)"
+assert_eq "byoc secret has tls.key" "yes" "$(grep -q 'tls.key:' <<<"$byoc_secret" && echo yes || echo no)"
+# The base64 must round-trip: a truncated or line-wrapped encoding yields a Secret that
+# applies cleanly but serves a corrupt key, which only shows up as a TLS handshake error.
+decoded="$(grep 'tls.crt:' <<<"$byoc_secret" | awk '{print $2}' | openssl base64 -d -A)"
+assert_eq "byoc secret tls.crt round-trips" "yes" \
+  "$(grep -q 'BEGIN CERTIFICATE' <<<"$decoded" && echo yes || echo no)"
+
+# --- render_platform_ca_configmap: persists the operator CA for LATER environments ---
+# Without this, an environment created after install falls back to the in-cluster
+# self-signed root — the wrong CA on a byoc install — and fails to validate the JWKS
+# URL while still reporting success.
+ca_cm="$(render_platform_ca_configmap "$tmp_cert")"
+assert_eq "platform CA cm is a ConfigMap"  "yes" "$(grep -q '^kind: ConfigMap' <<<"$ca_cm" && echo yes || echo no)"
+assert_eq "platform CA cm name"            "yes" "$(grep -q 'name: amp-platform-ca' <<<"$ca_cm" && echo yes || echo no)"
+assert_eq "platform CA cm namespace"       "yes" "$(grep -q 'namespace: openchoreo-control-plane' <<<"$ca_cm" && echo yes || echo no)"
+assert_eq "platform CA cm has ca.crt key"  "yes" "$(grep -q 'ca.crt: |' <<<"$ca_cm" && echo yes || echo no)"
+# The PEM must survive the block-scalar indent: a mis-indented body yields a ConfigMap
+# that applies cleanly but hands env-Thunder an unparseable trust bundle.
+ca_body="$(sed -n '/ca.crt: |/,$p' <<<"$ca_cm" | tail -n +2 | sed 's/^    //')"
+assert_eq "platform CA cm PEM round-trips" "yes" \
+  "$(printf '%s\n' "$ca_body" | openssl x509 -noout -subject >/dev/null 2>&1 && echo yes || echo no)"
+
+rm -f "$tmp_cert" "$tmp_key" "$tmp_c2" "$tmp_k2" "$tmp_c3" "$tmp_k3"
+
 # --- validate_dns is advisory: records errors but never fails (no more hard-fail mode) ---
 _resolve_host() { echo "198.51.100.5"; }        # resolves to a non-candidate IP
 validate_dns 203.0.113.10; rc=$?

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -643,7 +643,10 @@ assert_eq "init has DOMAIN_BASE"   "yes" "$(has "$init_out" 'DOMAIN_BASE=')"
 assert_eq "init has ACME_EMAIL"    "yes" "$(has "$init_out" 'ACME_EMAIL=')"
 assert_eq "init has DNS_PROVIDER"  "yes" "$(has "$init_out" 'DNS_PROVIDER=')"
 assert_eq "init mentions ACME_SERVER" "yes" "$(has "$init_out" 'ACME_SERVER=')"
-assert_eq "init has no TLS_MODE (single DNS-01 path)" "no" "$(has "$init_out" 'TLS_MODE=')"
+assert_eq "init has TLS_MODE"      "yes" "$(has "$init_out" 'TLS_MODE=dns01')"
+assert_eq "init mentions TLS_CERT_FILE" "yes" "$(has "$init_out" 'TLS_CERT_FILE=')"
+assert_eq "init mentions TLS_KEY_FILE"  "yes" "$(has "$init_out" 'TLS_KEY_FILE=')"
+assert_eq "init mentions TLS_CA_FILE"   "yes" "$(has "$init_out" 'TLS_CA_FILE=')"
 # The emitted template must be valid shell (sourceable without error).
 tmp_init="$(mktemp)"; printf '%s\n' "$init_out" > "$tmp_init"
 if bash -n "$tmp_init"; then assert_eq "init template is valid shell" "0" "0"; else assert_eq "init template is valid shell" "0" "1"; fi
@@ -665,6 +668,56 @@ assert_eq "dry-run renders consolidated gateway" "yes" "$(has "$dry_out" 'kind: 
 assert_eq "dry-run renders amp helm arg" "yes" "$(has "$dry_out" 'serverPublicURL=https://api.amp.mycompany.com')"
 assert_eq "dry-run does NOT start install" "no" "$(has "$dry_out" 'Running base installer')"
 rm -f "$tmp_cfg"
+
+# --- --dry-run in byoc mode: TLS Secret instead of the cert-manager objects ---
+# A config with no ACME_EMAIL and no DNS_PROVIDER must be accepted, and the private key
+# must never reach stdout (dry-run output lands in terminal scrollback and CI logs).
+byoc_dir="$(mktemp -d)"
+byoc_d=amp.mycompany.com
+openssl req -x509 -newkey rsa:2048 -nodes -days 90 \
+  -keyout "${byoc_dir}/key.pem" -out "${byoc_dir}/cert.pem" -subj "/CN=${byoc_d}" \
+  -addext "subjectAltName=DNS:console.${byoc_d},DNS:api.${byoc_d},DNS:thunder.${byoc_d},DNS:observer.${byoc_d},DNS:gateway.${byoc_d},DNS:cp.${byoc_d},DNS:*.agents.${byoc_d},DNS:*.thunder.${byoc_d},DNS:*.gateway.${byoc_d}" \
+  >/dev/null 2>&1
+cat > "${byoc_dir}/config.env" <<CFG
+AMP_VERSION=0.15.0
+DOMAIN_BASE=${byoc_d}
+TLS_MODE=byoc
+TLS_CERT_FILE=${byoc_dir}/cert.pem
+TLS_KEY_FILE=${byoc_dir}/key.pem
+CFG
+byoc_out="$(bash "$ADV" --config "${byoc_dir}/config.env" --dry-run 2>&1)"
+assert_eq "byoc dry-run renders a TLS Secret"      "yes" "$(has "$byoc_out" 'type: kubernetes.io/tls')"
+assert_eq "byoc dry-run renders the gateway"       "yes" "$(has "$byoc_out" 'kind: Gateway')"
+assert_eq "byoc dry-run renders frontproxy routes" "yes" "$(has "$byoc_out" 'amp-frontproxy-dataplane')"
+assert_eq "byoc dry-run has no ClusterIssuer"      "no"  "$(has "$byoc_out" 'kind: ClusterIssuer')"
+assert_eq "byoc dry-run has no Certificate"        "no"  "$(has "$byoc_out" 'kind: Certificate')"
+assert_eq "byoc dry-run never prints the key"      "no"  "$(has "$byoc_out" 'PRIVATE KEY')"
+assert_eq "byoc dry-run never prints the cert"     "no"  "$(has "$byoc_out" 'BEGIN CERTIFICATE')"
+# No TLS_CA_FILE in this config, so no CA ConfigMap should be rendered.
+assert_eq "byoc without TLS_CA_FILE: no CA cm"     "no"  "$(has "$byoc_out" 'name: amp-platform-ca')"
+
+# With TLS_CA_FILE the installer must persist the CA, so environments created later
+# can trust the listener instead of falling back to the wrong in-cluster root.
+cp "${byoc_dir}/cert.pem" "${byoc_dir}/ca.pem"
+printf 'TLS_CA_FILE=%s/ca.pem\n' "$byoc_dir" >> "${byoc_dir}/config.env"
+ca_out="$(bash "$ADV" --config "${byoc_dir}/config.env" --dry-run 2>&1)"
+assert_eq "byoc with TLS_CA_FILE renders CA cm"    "yes" "$(has "$ca_out" 'name: amp-platform-ca')"
+assert_eq "CA cm lands in the gateway namespace"   "yes" "$(has "$ca_out" 'namespace: openchoreo-control-plane')"
+assert_eq "byoc with TLS_CA_FILE still hides key"  "no"  "$(has "$ca_out" 'PRIVATE KEY')"
+
+# A cert missing one dynamic-tier wildcard must be rejected before any cluster work,
+# naming the SAN. *.<DOMAIN_BASE> covers the service hosts but NOT the deeper tiers.
+openssl req -x509 -newkey rsa:2048 -nodes -days 90 \
+  -keyout "${byoc_dir}/bad-key.pem" -out "${byoc_dir}/bad-cert.pem" -subj "/CN=${byoc_d}" \
+  -addext "subjectAltName=DNS:*.${byoc_d},DNS:*.agents.${byoc_d},DNS:*.thunder.${byoc_d}" \
+  >/dev/null 2>&1
+sed -e "s#${byoc_dir}/cert.pem#${byoc_dir}/bad-cert.pem#" -e "s#${byoc_dir}/key.pem#${byoc_dir}/bad-key.pem#" \
+  "${byoc_dir}/config.env" > "${byoc_dir}/bad.env"
+bad_out="$(bash "$ADV" --config "${byoc_dir}/bad.env" --dry-run 2>&1)"; bad_rc=$?
+assert_eq "byoc bad-SAN cert exits non-zero"  "1"   "$bad_rc"
+assert_eq "byoc bad-SAN names the missing SAN" "yes" "$(has "$bad_out" "missing the wildcard SAN: *.gateway.${byoc_d}")"
+assert_eq "byoc bad-SAN stops before install" "no"  "$(has "$bad_out" 'DRY RUN — derived hosts')"
+rm -rf "$byoc_dir"
 
 # --- inotify_bump_target: bump to floor only when below it (or unreadable) ---
 assert_eq "inotify below floor bumps"         "512"    "$(inotify_bump_target 128 512)"

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -702,7 +702,11 @@ cp "${byoc_dir}/cert.pem" "${byoc_dir}/ca.pem"
 printf 'TLS_CA_FILE=%s/ca.pem\n' "$byoc_dir" >> "${byoc_dir}/config.env"
 ca_out="$(bash "$ADV" --config "${byoc_dir}/config.env" --dry-run 2>&1)"
 assert_eq "byoc with TLS_CA_FILE renders CA cm"    "yes" "$(has "$ca_out" 'name: amp-platform-ca')"
-assert_eq "CA cm lands in the gateway namespace"   "yes" "$(has "$ca_out" 'namespace: openchoreo-control-plane')"
+# Scope the namespace check to the ConfigMap: the Gateway and the front-proxy routes in
+# the same dry-run output also sit in openchoreo-control-plane, so an unscoped grep would
+# pass even if the CA landed somewhere else entirely.
+assert_eq "CA cm lands in the gateway namespace"   "yes" \
+  "$(grep -A1 'name: amp-platform-ca' <<<"$ca_out" | grep -q 'namespace: openchoreo-control-plane' && echo yes || echo no)"
 assert_eq "byoc with TLS_CA_FILE still hides key"  "no"  "$(has "$ca_out" 'PRIVATE KEY')"
 
 # A cert missing one dynamic-tier wildcard must be rejected before any cluster work,

--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -349,7 +349,8 @@ If you installed with a private-CA certificate but no `TLS_CA_FILE`, environment
 
 ```bash
 kubectl create configmap amp-platform-ca -n openchoreo-control-plane \
-  --from-file=ca.crt=/opt/amp/certs/ca.pem
+  --from-file=ca.crt=/opt/amp/certs/ca.pem \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 :::
 
@@ -563,7 +564,7 @@ Then point every service hostname at the tunnel in your workstation's `/etc/host
 If agent invocation fails with a DNS error while the console works, this is almost always why. A local DNS resolver that supports wildcards (dnsmasq, or a private DNS zone) avoids the per-agent edits.
 :::
 
-TLS still validates normally through the tunnel: the certificate is publicly trusted and the `Host` header is preserved, so the browser sees the real hostname and the gateway routes on it.
+TLS still validates normally through the tunnel, because the `Host` header and SNI are preserved: the browser sees the real hostname and the gateway routes on it, regardless of which address the tunnel connected to. With `dns01` the certificate is publicly trusted, so nothing else is needed. With `byoc` the browser trusts it only if it already trusts the issuing CA — for an internal PKI that means importing your CA (see [Certificates from a private CA](#adv-byoc)).
 
 </TabItem>
 </Tabs>
@@ -639,10 +640,15 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 - **Certificate rejected before install (`byoc`).** The pre-flight found that the certificate and key don't match, the certificate has expired, or its SANs don't cover a required name. The message names the specific problem. The most common one is a missing `*.agents`, `*.thunder`, or `*.gateway` wildcard: a `*.<DOMAIN_BASE>` wildcard does not reach those tiers (see [Bring your own certificate](#adv-byoc)). Reissue with the full SAN list.
 - **Certificate never becomes Ready (`dns01`).** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
 - **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
-- **Login to an agent environment fails while the console works (`byoc` with a private CA).** Per-environment Thunder cannot validate the chain when it fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`. Set `TLS_CA_FILE` (see [Certificates from a private CA](#adv-byoc)). Environments created before the CA was configured need to be recreated.
+- **Login to an agent environment fails while the console works (`byoc` with a private CA).** That environment's Thunder cannot validate the chain when it fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`. Environment creation reports success regardless, so this only ever surfaces at login. Check whether the CA is published in the cluster:
+
+  ```bash
+  kubectl get configmap amp-platform-ca -n openchoreo-control-plane
+  ```
+
+  If it is **missing**, the install ran without `TLS_CA_FILE`. Create it from your CA using the command under [Certificates from a private CA](#adv-byoc), then re-add the affected environments. If it is **present**, only environments created before it existed are affected; re-add those. Setting `TLS_CA_FILE` at install time covers both cases from the start.
 - **Everything stops working at once (`byoc`).** Check whether the certificate expired — `byoc` certificates are never auto-renewed. `echo | openssl s_client -connect console.<DOMAIN_BASE>:443 -servername console.<DOMAIN_BASE> 2>/dev/null | openssl x509 -noout -dates`, then rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
 - **Cert issued but a host is unreachable.** Confirm the service host's A record points at the VM (public or private IP) and that clients can reach `:443` on it. Issuance does not need this, but client access does.
-- **Login to a newly created environment fails (`byoc` with a private CA).** That environment's Thunder could not validate platform Thunder's JWKS URL. Confirm the CA is published in-cluster with `kubectl get configmap amp-platform-ca -n openchoreo-control-plane`; if it is missing, create it and re-add the environment (see [Certificates from a private CA](#adv-byoc)). Environment creation reports success either way, so this only surfaces at login.
 - **Login fails but every other host works.** `thunder.<DOMAIN_BASE>` is probably not resolving because the deeper `*.thunder` wildcard shadows it. Check with `dig +short thunder.<DOMAIN_BASE> A` and add the explicit A record (see **DNS records** under [How clients reach the VM](#adv-reachability)).
 - **A host returns a connection failure rather than an HTTP status.** The front-proxy route for that plane is not bound. List them with `kubectl get httproute -n openchoreo-control-plane` and check that each `amp-frontproxy-*` route reports `Accepted=True` and `ResolvedRefs=True`; a failed `ResolvedRefs` on the observability or data-plane route usually means its ReferenceGrant is missing. Note that a gateway-level `404` is a *healthy* response from an unrouted path: it proves TLS terminated and the request reached the gateway.
 - **Deployed agent unreachable while the console works.** On a public VM, confirm the `*.agents.<DOMAIN_BASE>` A record exists; on a private VM, add the agent's exact hostname to `/etc/hosts` (see the **Private network** tab under [How clients reach the VM](#adv-reachability)), since `/etc/hosts` cannot match wildcards.

--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -22,7 +22,7 @@ Agents run sandboxed under the standard **runc** runtime by default. Agent Manag
 Install Agent Manager on a Linux VM where Docker is the only host dependency. Pick the path that fits you:
 
 - **Simple**: give the installer the VM's public IP and it does everything else: hostnames are derived from the IP via [sslip.io](https://sslip.io) and TLS certificates are issued automatically by Let's Encrypt. No domain, no DNS setup, no certificate handling. Best for demos and quick evaluations.
-- **Advanced**: a config-file-driven installer for a **custom domain**, on a VM that is either publicly reachable or **private-network-only**. TLS is always a publicly-trusted wildcard certificate issued in-cluster by cert-manager through the ACME **DNS-01** challenge (Let's Encrypt by default, any ACME CA via `ACME_SERVER`), so issuance needs outbound access only and works on a private VM. Requires a DNS zone you control on a supported provider (Cloudflare, Route 53, Cloud DNS, or Azure DNS). Validates your config before installing and reports whether your DNS points at the VM.
+- **Advanced**: a config-file-driven installer for a **custom domain**, on a VM that is either publicly reachable or **private-network-only**. TLS is a single wildcard certificate, obtained either way you prefer: cert-manager issues and auto-renews a publicly-trusted one through the ACME **DNS-01** challenge (Let's Encrypt by default, any ACME CA via `ACME_SERVER`), which needs outbound access only and so works on a private VM but requires a DNS zone you control on a supported provider (Cloudflare, Route 53, Cloud DNS, or Azure DNS); or you supply your own certificate, which needs no DNS credential and no reachable CA. Validates your config and certificate before installing, and reports whether your DNS points at the VM.
 
 <Tabs groupId="vm-installer">
 <TabItem value="simple" label="Simple (IP + automatic TLS)" default>
@@ -205,7 +205,12 @@ Agent Manager can drive external WSO2 AI gateways. The control-plane endpoint `h
 </TabItem>
 <TabItem value="advanced" label="Advanced">
 
-The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you have your own domain. It issues **publicly-trusted certificates** via cert-manager's ACME **DNS-01** challenge and terminates TLS on `:443` at a single in-cluster gateway. Because DNS-01 validates by writing a DNS TXT record rather than by connecting to the VM, the same flow works whether the VM is **public** or reachable only from a **private network**. Issuance needs outbound access only.
+The advanced installer (`install-advanced.sh`) is config-file driven and runs **on the VM** with `sudo`. Use it when you have your own domain. It terminates TLS on `:443` at a single in-cluster gateway, and gives you two ways to obtain the certificate that gateway serves:
+
+- **`TLS_MODE=dns01`** (the default) — cert-manager issues a **publicly-trusted** certificate via the ACME **DNS-01** challenge and auto-renews it. You supply a DNS-provider API credential; the VM needs outbound access to the ACME and provider APIs.
+- **`TLS_MODE=byoc`** — you supply the certificate and key ([Bring your own certificate](#adv-byoc)). No ACME, no DNS-provider credential, and no outbound access to a CA, so this also covers air-gapped VMs and certificates from a corporate PKI. Nothing auto-renews, so you rotate it yourself.
+
+Everything downstream of the certificate is identical in both modes. Neither mode needs inbound access for issuance, so both work whether the VM is **public** or reachable only from a **private network**.
 
 Setup is the same for both up to and including the install; only how clients reach the VM differs. Work through [Prerequisites](#adv-prerequisites), [Configure](#adv-configure), and [Install](#adv-install), then switch the **Public network / Private network** selector below to the one matching your VM. Everything after that selector applies to both again.
 
@@ -214,9 +219,8 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 ## Prerequisites {#adv-prerequisites}
 
 - **Docker, k3d, kubectl, Helm, curl, and `lsof`** must already be installed on the VM. The installer **verifies** they are present and exits with install hints if any are missing. It does **not** install them for you.
-- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access (to pull images/charts and reach the ACME + DNS-provider APIs). Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works.
-- **A domain you control**, hosted on one of the supported DNS providers: **Cloudflare**, **AWS Route 53**, **Google Cloud DNS**, or **Azure DNS**.
-- **A DNS-provider API credential** scoped to edit that zone's records. cert-manager uses it to write the `_acme-challenge` TXT record; you do **not** create TXT records by hand.
+- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works.
+- **A domain you control.** With `TLS_MODE=dns01` it must additionally be hosted on one of the supported DNS providers — **Cloudflare**, **AWS Route 53**, **Google Cloud DNS**, or **Azure DNS** — and you need **a DNS-provider API credential** scoped to edit that zone's records, which cert-manager uses to write the `_acme-challenge` TXT record. You do **not** create TXT records by hand. With `TLS_MODE=byoc` neither the provider nor the credential matters; you need only [a certificate covering the right names](#adv-byoc).
 
 ## Configure {#adv-configure}
 
@@ -226,16 +230,21 @@ The config file is plain shell, one `KEY=value` assignment per line. Generate an
 |---|---|---|
 | `AMP_VERSION` | yes | Agent Manager release to install (an `amp/v*` [release](https://github.com/wso2/agent-manager/releases)) |
 | `DOMAIN_BASE` | yes | Base domain; service hosts are derived as `<svc>.<DOMAIN_BASE>` |
-| `ACME_EMAIL` | yes | ACME account contact; cert-manager registers the account with it |
-| `DNS_PROVIDER` | yes | `cloudflare`, `route53`, `clouddns`, or `azuredns`; supply that provider's credentials below |
+| `TLS_MODE` | no | `dns01` (default) or `byoc`. Omitting it keeps the cert-manager DNS-01 behaviour |
+| `ACME_EMAIL` | dns01 | ACME account contact; cert-manager registers the account with it |
+| `DNS_PROVIDER` | dns01 | `cloudflare`, `route53`, `clouddns`, or `azuredns`; supply that provider's credentials below |
 | `ACME_SERVER` | no | Override the ACME directory (e.g. Let's Encrypt **staging**) while testing, to avoid rate limits |
+| `TLS_CERT_FILE` / `TLS_KEY_FILE` | byoc | Paths on the VM to your certificate chain and its private key, both PEM |
+| `TLS_CA_FILE` | no | Only for `byoc` with a **private** CA: the CA certificate, so in-cluster components trust it |
 | `EXTERNAL_GATEWAYS` | no | `true` (default) exposes the `cp` endpoint for external data-plane gateways |
 | `HOST_CONSOLE`, `HOST_API`, `HOST_THUNDER`, `HOST_OBSERVER`, `HOST_GATEWAY`, `HOST_CP` | no | Override an individual service hostname (default `<svc>.<DOMAIN_BASE>`) |
 | `AGENTS_BASE` | no | Base for deployed-agent hostnames (default `agents.<DOMAIN_BASE>`) |
 
-With `DOMAIN_BASE=amp.mycompany.com`, the derived hosts are `console.amp.mycompany.com`, `api.amp.mycompany.com`, `thunder.amp.mycompany.com`, `observer.amp.mycompany.com`, `gateway.amp.mycompany.com`, and `cp.amp.mycompany.com`, plus three dynamic tiers: deployed agents at `<org>-<project>.agents.amp.mycompany.com`, per-environment Thunder at `<org>-<env>.thunder.amp.mycompany.com`, and per-environment API Platform Gateways at `<env>-<org>.gateway.amp.mycompany.com`. cert-manager issues one **wildcard** certificate covering all of them, so there are no per-host certificate steps.
+With `DOMAIN_BASE=amp.mycompany.com`, the derived hosts are `console.amp.mycompany.com`, `api.amp.mycompany.com`, `thunder.amp.mycompany.com`, `observer.amp.mycompany.com`, `gateway.amp.mycompany.com`, and `cp.amp.mycompany.com`, plus three dynamic tiers: deployed agents at `<org>-<project>.agents.amp.mycompany.com`, per-environment Thunder at `<org>-<env>.thunder.amp.mycompany.com`, and per-environment API Platform Gateways at `<env>-<org>.gateway.amp.mycompany.com`. A single **wildcard** certificate covers all of them, so there are no per-host certificate steps.
 
-### DNS provider credentials {#adv-dns-provider}
+Fill in the section below that matches your `TLS_MODE`.
+
+### DNS provider credentials (`dns01`) {#adv-dns-provider}
 
 Add the block for your provider to `amp-config.env`. Only the credential is secret; keep the file `chmod 600`.
 
@@ -274,9 +283,83 @@ AZURE_SUBSCRIPTION_ID=<subscription-id>
 AZURE_RESOURCE_GROUP=<zone-resource-group>
 ```
 
+### Bring your own certificate (`byoc`) {#adv-byoc}
+
+Use this when you already hold a certificate — purchased, issued by your corporate PKI, or obtained by an ACME client you run elsewhere — or when the VM cannot reach a public CA or your DNS provider's API at all. The installer loads your certificate and key into the same Kubernetes Secret the DNS-01 path would have cert-manager issue, so the gateway, routes, and everything downstream behave identically.
+
+The certificate must carry **every** name this install serves as a SAN:
+
+| SAN | Covers |
+|---|---|
+| `console.<DOMAIN_BASE>` | Console |
+| `api.<DOMAIN_BASE>` | Agent Manager API |
+| `thunder.<DOMAIN_BASE>` | Platform Thunder (OAuth) |
+| `observer.<DOMAIN_BASE>` | Observer |
+| `gateway.<DOMAIN_BASE>` | AI Gateway (LLM proxy, OTel ingest) |
+| `cp.<DOMAIN_BASE>` | Gateway control plane (omit if `EXTERNAL_GATEWAYS=false`) |
+| `*.agents.<DOMAIN_BASE>` | Deployed agents |
+| `*.thunder.<DOMAIN_BASE>` | Per-environment Thunder |
+| `*.gateway.<DOMAIN_BASE>` | Per-environment API Platform Gateways |
+
+:::warning A `*.<DOMAIN_BASE>` wildcard does **not** cover the three dynamic tiers
+A wildcard matches exactly one label. `*.amp.mycompany.com` therefore covers `console.amp.mycompany.com` but **not** `myorg-myproject.agents.amp.mycompany.com`, which sits one level deeper. The three `*.agents`, `*.thunder`, and `*.gateway` entries must appear in the certificate literally, and unlike the `dns01` path there is no ACME to issue per-host certificates on demand.
+
+This is the certificate-side counterpart of the DNS wildcard trap described under [How clients reach the VM](#adv-reachability) — the same one-label rule, biting in a different layer.
+:::
+
+The installer checks all of this **before** it touches the cluster, and fails naming the specific problem: a missing SAN, a key that doesn't match the certificate, or an expired certificate. Run `--dry-run` to print the required SANs next to the ones your certificate actually carries.
+
+A self-signed certificate covering every tier, if you are testing or running an internal-only deployment:
+
+```bash
+D=amp.mycompany.com
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -keyout privkey.pem -out fullchain.pem -subj "/CN=$D" \
+  -addext "subjectAltName=DNS:console.$D,DNS:api.$D,DNS:thunder.$D,DNS:observer.$D,DNS:gateway.$D,DNS:cp.$D,DNS:*.agents.$D,DNS:*.thunder.$D,DNS:*.gateway.$D"
+```
+
+Then point the installer at the certificate and key:
+
+```sh
+AMP_VERSION=<AMP_VERSION>
+DOMAIN_BASE=amp.mycompany.com
+TLS_MODE=byoc
+TLS_CERT_FILE=/opt/amp/certs/fullchain.pem
+TLS_KEY_FILE=/opt/amp/certs/privkey.pem
+```
+
+`TLS_CERT_FILE` should be the **full chain** (leaf plus any intermediates). A leaf-only file makes clients that don't already hold the intermediate fail to validate, which typically shows up as some clients working and others not.
+
+#### Certificates from a private CA
+
+If your certificate chains to a corporate CA rather than a public one, also set `TLS_CA_FILE` to that CA certificate:
+
+```sh
+TLS_CA_FILE=/opt/amp/certs/corporate-ca.pem
+```
+
+This matters more than it looks. Per-environment Thunder fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`, which goes back through the same `:443` gateway. Without the CA, that fetch fails on an untrusted chain and **logging in to an agent environment breaks**, even though the console and every other host look completely healthy.
+
+The installer stores the CA in the cluster as the ConfigMap `amp-platform-ca` (namespace `openchoreo-control-plane`). That is what makes the setting durable: environments are created long after the install finishes, and each one provisions its own Thunder that has to validate the same HTTPS endpoint. Every later environment reads the CA from there automatically, so there is nothing extra to pass when you add one.
+
+Browsers and API clients are a separate matter: they still need the CA in their own trust stores, which is a distribution problem the installer cannot solve for you.
+
+:::note Adding environments to an install that did not set `TLS_CA_FILE`
+If you installed with a private-CA certificate but no `TLS_CA_FILE`, environments created afterwards fall back to the cluster's own self-signed root — the wrong CA — and their Thunder cannot validate the JWKS URL. The environment is still reported as created successfully; only the login fails. Create the ConfigMap and re-add the environment:
+
+```bash
+kubectl create configmap amp-platform-ca -n openchoreo-control-plane \
+  --from-file=ca.crt=/opt/amp/certs/ca.pem
+```
+:::
+
+:::warning `byoc` certificates are never renewed automatically
+cert-manager renews the `dns01` certificate in-cluster with no involvement from you. Nothing does that for `byoc`. When the certificate expires, **every** host stops working at once — console, API, login, and deployed agents. Track the expiry date yourself and see [Persistence and teardown](#adv-persistence) for the rotation command, which does not require a reinstall.
+:::
+
 ## How TLS and routing work {#adv-tls}
 
-cert-manager (installed in the cluster) runs the ACME DNS-01 challenge, issues one **wildcard certificate** into a Kubernetes Secret, and auto-renews it.
+With `TLS_MODE=dns01`, cert-manager (installed in the cluster) runs the ACME DNS-01 challenge, issues one **wildcard certificate** into a Kubernetes Secret, and auto-renews it. With `TLS_MODE=byoc` the installer writes your certificate and key into that same Secret and creates no cert-manager objects at all — in the diagram below, the gateway and everything under it are unchanged and only the three numbered ACME steps disappear.
 
 Routing uses a **front-proxy** model. A single consolidated Gateway (`amp-consolidated-gateway`) is the only thing listening on `:443`; it terminates TLS with the wildcard certificate and then forwards **by `Host` header** to each plane's own `gateway-default` gateway, which keeps its native routes. Three HTTPRoutes do the forwarding, and because two of the planes live in other namespaces, each cross-namespace hop is authorised by a ReferenceGrant.
 
@@ -345,17 +428,17 @@ Edit `amp-config.env` with the keys from [Configure](#adv-configure), then valid
 sudo deployments/vm/install-advanced.sh --config amp-config.env --dry-run
 ```
 
-The dry run loads the config, runs the advisory DNS check, and prints the derived hosts, the wildcard certificate's SAN list, the helm overrides, and every cert-manager and gateway resource it would apply. It never contacts the cluster and it redacts the DNS-provider credential. When it looks right, run the real install:
+The dry run loads the config, runs the advisory DNS check, and prints the derived hosts, the required certificate SAN list, the helm overrides, and every TLS and gateway resource it would apply. It never contacts the cluster, and it redacts secrets — the DNS-provider credential in `dns01`, the certificate and key in `byoc`. In `byoc` mode it also validates your certificate and prints the SANs it actually carries beside the required list, so a mismatch surfaces here rather than after a 20-minute install. When it looks right, run the real install:
 
 ```bash
 sudo deployments/vm/install-advanced.sh --config amp-config.env
 ```
 
-The installer runs in three phases: preflight (verify tools + firewall), platform install, and TLS (cert-manager issues the wildcard certificate via DNS-01, then the consolidated gateway serves `:443`). Allow 15-20 minutes plus a few minutes for issuance. It needs `sudo` because it opens the firewall and creates the cluster. On completion it prints the access URLs.
+The installer runs in three phases: preflight (verify tools + firewall, and in `byoc` mode validate the certificate), platform install, and TLS (obtain or install the certificate, then the consolidated gateway serves `:443`). Allow 15-20 minutes, plus a few minutes for issuance in `dns01` mode. It needs `sudo` because it opens the firewall and creates the cluster. On completion it prints the access URLs.
 
 There are **no per-setting command-line flags** on the advanced path; everything comes from the config file.
 
-:::tip Use Let's Encrypt staging first
+:::tip Use Let's Encrypt staging first (`dns01` only)
 Set `ACME_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory` for your first run. Staging exercises the entire DNS-01 flow but has far looser rate limits than production, which enforces a weekly cap per registered domain that is easy to burn through while iterating. The staging certificate is **not** publicly trusted, so browsers and `curl` will warn, which is expected. Once a staging run succeeds end to end, remove `ACME_SERVER` (or point it at production), delete the cluster, and reinstall for a trusted certificate.
 
 If you opened the console in a browser while the staging certificate was being served and clicked through the warning, clear that decision after switching to production. Browsers remember the approval for the rest of the session and keep reporting the page as insecure even once the trusted certificate is in place. Chrome shows "active content with certificate errors" while simultaneously reporting the certificate itself as valid and trusted. Quit **every** window of that browser profile (for an incognito window, closing one tab is not enough, because the session survives until all incognito windows are closed) and reopen it.
@@ -383,7 +466,7 @@ Open inbound **`443/tcp` only** in your cloud security group or firewall. Nothin
 
 ### DNS records {#adv-dns-records}
 
-Certificate issuance itself needs **no A records**, because cert-manager proves control of the zone by writing the `_acme-challenge` TXT record through your provider credential. A records exist only so clients can **reach** the services. Point them at the VM's public IP:
+Certificate issuance itself needs **no A records** — in `dns01` mode cert-manager proves control of the zone by writing the `_acme-challenge` TXT record through your provider credential, and `byoc` proves nothing at all. A records exist only so clients can **reach** the services. Point them at the VM's public IP:
 
 ```
 *.amp.mycompany.com          A  <VM_PUBLIC_IP>   # console/api/thunder/observer/gateway/cp
@@ -413,9 +496,11 @@ done
 </TabItem>
 <TabItem value="private" label="Private network">
 
-Use this when the VM has **no public IP** and is reachable only from inside your network. The advanced installer supports this unchanged, because DNS-01 validation never requires an inbound connection: the ACME CA reads a TXT record from your DNS provider instead of calling the VM. The result is a **publicly-trusted certificate on a private host**, with no private CA to distribute.
+Use this when the VM has **no public IP** and is reachable only from inside your network. The advanced installer supports this unchanged in both TLS modes, because neither ever requires an inbound connection. With `dns01` the ACME CA reads a TXT record from your DNS provider instead of calling the VM, giving you a **publicly-trusted certificate on a private host** with no private CA to distribute.
 
-The VM still needs **outbound** internet access to pull images and charts and to reach the ACME and DNS-provider APIs. On Google Cloud, for example, that means a **Cloud NAT** gateway attached to the VM's subnet; AWS and Azure have equivalent NAT gateways.
+The VM still needs **outbound** internet access to pull images and charts, and in `dns01` mode to reach the ACME and DNS-provider APIs. On Google Cloud, for example, that means a **Cloud NAT** gateway attached to the VM's subnet; AWS and Azure have equivalent NAT gateways.
+
+If the VM has no route to a public CA or to your DNS provider's API — a genuinely isolated network, or a policy that forbids handing the VM a zone-editing credential — use [`TLS_MODE=byoc`](#adv-byoc) instead and supply a certificate from your internal PKI.
 
 ### Reaching the console
 
@@ -485,7 +570,7 @@ TLS still validates normally through the tunnel: the certificate is publicly tru
 
 ## Persistence and teardown {#adv-persistence}
 
-Application data (PostgreSQL), the issued certificate (a Kubernetes Secret, auto-renewed by cert-manager), and the k3d cluster persist across restarts. To tear down completely, delete the cluster. Everything the installer created lives inside it, including the certificate and the gateway resources:
+Application data (PostgreSQL), the certificate (a Kubernetes Secret), and the k3d cluster persist across restarts. To tear down completely, delete the cluster. Everything the installer created lives inside it, including the certificate and the gateway resources:
 
 ```bash
 sudo k3d cluster delete amp-local     # delete the cluster (workloads, app data, cert, gateways)
@@ -497,15 +582,50 @@ To remove only the TLS and routing layer while keeping the platform running (for
 kubectl delete httproute amp-frontproxy-controlplane amp-frontproxy-observability \
   amp-frontproxy-dataplane -n openchoreo-control-plane
 kubectl delete gateway amp-consolidated-gateway -n openchoreo-control-plane
-kubectl delete certificate amp-wildcard-tls -n openchoreo-control-plane
 kubectl delete secret amp-wildcard-tls -n openchoreo-control-plane
 kubectl delete referencegrant amp-frontproxy-to-services -n openchoreo-observability-plane
 kubectl delete referencegrant amp-frontproxy-to-services -n openchoreo-data-plane
+
+# byoc with TLS_CA_FILE only
+kubectl delete configmap amp-platform-ca -n openchoreo-control-plane
+
+# dns01 only — byoc creates none of these
+kubectl delete certificate amp-wildcard-tls -n openchoreo-control-plane
 kubectl delete clusterissuer amp-acme-dns01
 kubectl delete secret amp-dns01-credentials amp-acme-dns01-account-key -n cert-manager
 ```
 
-Delete the `amp-wildcard-tls` Secret as well as the Certificate. cert-manager will not re-issue into a Secret that already holds a valid certificate, so leaving it behind silently keeps the old (for example, staging) certificate in place. The ACME account key Secret only needs deleting if you are also changing `ACME_EMAIL` or the ACME server.
+In `dns01` mode, delete the `amp-wildcard-tls` Secret as well as the Certificate. cert-manager will not re-issue into a Secret that already holds a valid certificate, so leaving it behind silently keeps the old (for example, staging) certificate in place. The ACME account key Secret only needs deleting if you are also changing `ACME_EMAIL` or the ACME server.
+
+### Rotating a `byoc` certificate {#adv-byoc-rotate}
+
+Nothing renews a `byoc` certificate for you, so replace it before it expires. This is a Secret update, not a reinstall — the Gateway references the Secret by name, so the routes, the cluster, and your data are untouched:
+
+```bash
+kubectl create secret tls amp-wildcard-tls -n openchoreo-control-plane \
+  --cert=/opt/amp/certs/fullchain.pem --key=/opt/amp/certs/privkey.pem \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+The replacement must carry the same SAN list as the original (see [Bring your own certificate](#adv-byoc)) — the checks the installer runs do not apply here, so verify it first:
+
+```bash
+openssl x509 -noout -ext subjectAltName -in /opt/amp/certs/fullchain.pem
+```
+
+Confirm the new certificate is being served, from a machine that can reach the VM:
+
+```bash
+echo | openssl s_client -connect console.amp.mycompany.com:443 \
+  -servername console.amp.mycompany.com 2>/dev/null | openssl x509 -noout -dates
+```
+
+If the old certificate is still being served, restart the gateway deployment to force a reload:
+
+```bash
+kubectl rollout restart deployment -n openchoreo-control-plane \
+  -l gateway.networking.k8s.io/gateway-name=amp-consolidated-gateway
+```
 
 **Changing the domain or hostnames after install requires a full teardown first.** The platform install is idempotent in the "create if missing" sense, so editing `DOMAIN_BASE` (or the `HOST_*` overrides) and re-running does **not** reconfigure already-installed services. To move an existing install to a different domain, delete the cluster and install again with the new config.
 
@@ -515,9 +635,14 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 
 ## Troubleshooting {#adv-troubleshooting}
 
-- **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER`, or a missing provider credential). Fix `amp-config.env` and re-run.
-- **Certificate never becomes Ready.** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
+- **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER` or `TLS_MODE`, a missing provider credential, or `byoc` without `TLS_CERT_FILE`). Fix `amp-config.env` and re-run.
+- **Certificate rejected before install (`byoc`).** The pre-flight found that the certificate and key don't match, the certificate has expired, or its SANs don't cover a required name. The message names the specific problem. The most common one is a missing `*.agents`, `*.thunder`, or `*.gateway` wildcard: a `*.<DOMAIN_BASE>` wildcard does not reach those tiers (see [Bring your own certificate](#adv-byoc)). Reissue with the full SAN list.
+- **Certificate never becomes Ready (`dns01`).** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
+- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
+- **Login to an agent environment fails while the console works (`byoc` with a private CA).** Per-environment Thunder cannot validate the chain when it fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`. Set `TLS_CA_FILE` (see [Certificates from a private CA](#adv-byoc)). Environments created before the CA was configured need to be recreated.
+- **Everything stops working at once (`byoc`).** Check whether the certificate expired — `byoc` certificates are never auto-renewed. `echo | openssl s_client -connect console.<DOMAIN_BASE>:443 -servername console.<DOMAIN_BASE> 2>/dev/null | openssl x509 -noout -dates`, then rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
 - **Cert issued but a host is unreachable.** Confirm the service host's A record points at the VM (public or private IP) and that clients can reach `:443` on it. Issuance does not need this, but client access does.
+- **Login to a newly created environment fails (`byoc` with a private CA).** That environment's Thunder could not validate platform Thunder's JWKS URL. Confirm the CA is published in-cluster with `kubectl get configmap amp-platform-ca -n openchoreo-control-plane`; if it is missing, create it and re-add the environment (see [Certificates from a private CA](#adv-byoc)). Environment creation reports success either way, so this only surfaces at login.
 - **Login fails but every other host works.** `thunder.<DOMAIN_BASE>` is probably not resolving because the deeper `*.thunder` wildcard shadows it. Check with `dig +short thunder.<DOMAIN_BASE> A` and add the explicit A record (see **DNS records** under [How clients reach the VM](#adv-reachability)).
 - **A host returns a connection failure rather than an HTTP status.** The front-proxy route for that plane is not bound. List them with `kubectl get httproute -n openchoreo-control-plane` and check that each `amp-frontproxy-*` route reports `Accepted=True` and `ResolvedRefs=True`; a failed `ResolvedRefs` on the observability or data-plane route usually means its ReferenceGrant is missing. Note that a gateway-level `404` is a *healthy* response from an unrouted path: it proves TLS terminated and the request reached the gateway.
 - **Deployed agent unreachable while the console works.** On a public VM, confirm the `*.agents.<DOMAIN_BASE>` A record exists; on a private VM, add the agent's exact hostname to `/etc/hosts` (see the **Private network** tab under [How clients reach the VM](#adv-reachability)), since `/etc/hosts` cannot match wildcards.


### PR DESCRIPTION
## Purpose
The advanced VM installer has required cert-manager's ACME **DNS-01** challenge ever since it moved off Caddy and lego, which means every operator must hand the VM a zone-editing DNS credential. That leaves several groups with no supported path:

- operators who **already hold a certificate** (purchased, corporate PKI, or issued by an ACME client they run elsewhere)
- operators whose DNS lives on a provider we ship no solver for (only `cloudflare`, `route53`, `clouddns`, `azuredns` are wired up)
- operators whose policy forbids giving a VM a zone-editing credential
- **air-gapped VMs** — DNS-01 still needs egress to the ACME CA *and* the provider API, so "private network" works today but "no internet at all" does not

Earlier releases offered a `byoc` mode for exactly this; it was dropped when the advanced path was rewritten onto cert-manager.

## Goals
Restore bring-your-own-certificate as a first-class option on the advanced path, without disturbing the existing DNS-01 flow or any config file already in use.

## Approach
The rewrite left the TLS layer with a single seam: a `kubernetes.io/tls` Secret named `amp-wildcard-tls` in `openchoreo-control-plane`, referenced **by name** by the consolidated `:443` Gateway. cert-manager is only one way to fill it, so `byoc` reuses everything downstream unchanged — the Gateway, the three front-proxy `HTTPRoute`s and their `ReferenceGrant`s are untouched.

```
TLS_MODE=dns01 (default)        TLS_MODE=byoc
  DNS-01 credentials Secret       (none)
  ACME ClusterIssuer              (none)
  Certificate ──issues──┐         TLS_CERT_FILE + TLS_KEY_FILE ──┐
                        ▼                                        ▼
          Secret amp-wildcard-tls (kubernetes.io/tls, openchoreo-control-plane)
                        │
                        ▼
          amp-consolidated-gateway :443 ──▶ front-proxy routes   (UNCHANGED)
```

Notable details:

- **`TLS_MODE` defaults to `dns01`**, so config files written before this change keep working with no edit.
- **The certificate is validated before any cluster work** — cert/key pairing (public-key comparison, so EC keys work), expiry, and SAN coverage. It runs after host derivation but before the phase that opens the firewall and creates the cluster.
- **The required SAN list comes from `cert_dns_names()`**, the same function that builds the DNS-01 `Certificate`'s `dnsNames`, so the two cannot drift. A hardcoded list would already be wrong: the per-environment API Platform Gateway tier postdates the original `byoc` implementation, whose SAN check would silently not require `*.<gateway host>`.
- **The Secret uses `data:` with `openssl base64 -A`**, not a `stringData:` block scalar (PEM indentation is a silent-corruption hazard) and not GNU-only `base64 -w0`.
- **`TLS_CA_FILE` handles private CAs.** Per-environment Thunder validates platform Thunder's JWKS over this same `:443` listener, so an untrusted chain breaks environment login while every other host looks healthy. The CA feeds the existing `PLATFORM_THUNDER_CA_PEM` seam for the default environment, and is **persisted as the ConfigMap `amp-platform-ca`** so environments created long after the install resolve the same CA. Without persistence they fall back to the cluster's own self-signed root, mount a bundle that cannot verify the chain, and `add-environment-thunder.sh` still exits 0 — a silent failure surfacing later as a broken login. The new lookup in `platform_thunder_ca_cert()` sits between the existing env-var check and that fallback, and only fires when the ConfigMap exists, so every other install path is unaffected.
- Dry-run renders the `byoc` variant and prints the certificate's actual SANs beside the required list, with the key redacted (the CA is rendered in full — it is public by definition).

## User stories
- As an operator with a certificate from my corporate PKI, I can install Agent Manager on a VM without giving it DNS credentials.
- As an operator on an air-gapped VM with no route to a public CA, I can still get a working TLS install.
- As an operator whose DNS provider has no cert-manager solver, I am no longer blocked.
- As an existing operator, my `amp-config.env` continues to work untouched.

## Release note
The advanced VM installer now supports `TLS_MODE=byoc`, letting operators supply their own TLS certificate and key instead of having cert-manager issue one via ACME DNS-01. `TLS_CA_FILE` additionally makes in-cluster components trust a certificate issued by a private CA. `TLS_MODE` defaults to `dns01`, so existing configurations are unaffected.

## Documentation
Updated in this PR: `documentation/docs/guides/on-a-vm.mdx` — a new **Bring your own certificate** section (required SANs, the one-label wildcard trap, an `openssl` example, private-CA guidance, rotation), plus updates to the intro, prerequisites, config table, "How TLS and routing work", teardown, and troubleshooting.

## Training
N/A — no training content covers VM installation TLS configuration.

## Certification
N/A — VM installer TLS modes are not covered by certification exams.

## Marketing
N/A — this removes an adoption blocker for existing deployment scenarios rather than introducing a promotable feature.

## Automation tests
- Unit tests

  `deployments/vm/tests/preflight.sh` and `deployments/vm/tests/run.sh` (both pass). New coverage: `TLS_MODE` branching in `validate_config` (including that an **absent** `TLS_MODE` still validates as `dns01`, and that `byoc` does not require `ACME_EMAIL`/`DNS_PROVIDER`); `validate_cert` against generated certificates for the good case, a missing `*.agents` wildcard, **a missing `*.gateway` wildcard** (the case the earlier implementation would have let through), a mismatched key, and an expired certificate; `cert_sans` parsing; `render_byoc_tls_secret` type/namespace/base64 round-trip; `render_platform_ca_configmap` shape and PEM round-trip; and `--init`/`--dry-run` assertions including that the private key never reaches stdout.

- Integration tests

  No automated integration coverage exists for the VM installers; validated manually on GCP VMs instead (see **Test environment**).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — shell and documentation only, no Java.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — the diff was scanned; the only credential-shaped string is an existing-style dummy (`CLOUDFLARE_API_TOKEN=tok`) in a unit test. Handling of real material was reviewed explicitly: the private key is written only into the Secret and is redacted in dry-run output, and `amp-config.env` is documented as `chmod 600`.

## Samples
N/A — installer configuration, no samples. The guide includes a copy-pasteable `openssl` invocation covering every required SAN.

## Related PRs
None.

## Migrations (if applicable)
None required. `TLS_MODE` defaults to `dns01`, so existing installs and existing `amp-config.env` files are unaffected. Switching an existing install to `byoc` means replacing the `amp-wildcard-tls` Secret; changing hostnames still requires a teardown, as before.

## Test environment
Validated end to end on GCP VMs (Ubuntu 24.04, e2-standard-4, k3d), installing `amp/v0.0.0-dev-20260811` — the same commit as this branch's base:

| scenario | result |
|---|---|
| **`byoc`, private CA** (real root-CA → leaf chain) | kgateway serves the supplied Secret on `:443`; served leaf fingerprint identical to the supplied `fullchain.pem` and the full chain preserved; no `ClusterIssuer`/`Certificate` created; all service hosts and all three wildcard tiers verify 0 |
| **`byoc` CA trust** | inside the env-Thunder pod, the JWKS fetch returns `200` with `ssl_verify_result=0` using the mounted bundle, and fails with curl exit 60 (peer verification) without it |
| **`byoc` later environments** | reproduced the pre-fix defect (new environment lacked the CA, curl exit 60, script still exited 0), then confirmed the `amp-platform-ca` fix resolves it (CA present, `200`/verify 0) |
| **`dns01` regression, config with no `TLS_MODE`** | resolved to `dns01` and installed clean on a real delegated domain with `DNS_PROVIDER=clouddns`; publicly-trusted Let's Encrypt certificate, `verify=0` from a browser with no custom CA, all 9 SANs, all wildcard tiers verify 0 |
| **mode isolation** | `dns01` creates the `ClusterIssuer`, `Certificate` and DNS-01 credential Secret and mounts no custom CA bundle; `byoc` creates none of those and does create `amp-platform-ca` — each mode produces exactly what it should and nothing the other needs |

Also run locally: both unit suites, `shellcheck` (output unchanged from base), and the Docusaurus build.

The **simple** installer (`install-vm.sh`) was also verified, since this PR touches the shared `add-environment-thunder.sh`:

| scenario | result |
|---|---|
| **simple install** | completes clean with the modified script present; Caddy fronts `:443`, publicly-trusted Let's Encrypt certificate, `verify=0`. `SKIP_CA_BUNDLE_TRUST=true` short-circuits the modified function, so it is not called during install |
| **simple, post-install environment** | this is where the modified `platform_thunder_ca_cert()` *is* called. With no `amp-platform-ca` ConfigMap present it falls through to the pre-existing `amp-local-root-ca-secret` behaviour, and the new environment's Thunder validates the JWKS URL (`200`/verify 0) — unchanged from before this PR |
| **no cross-mode leakage** | the simple install has no `amp-platform-ca` ConfigMap and no `amp-consolidated-gateway`; the advanced install has no Caddy container |

## Learning
The key realisation was that the move away from Caddy and lego made this *cheaper* rather than harder: with TLS funnelled through a single named Secret, `byoc` needed no changes at all to the Gateway or routing layer. The subtler lesson was that an env-var-based trust decision does not survive the process that set it — persisting the CA in-cluster is what makes `TLS_CA_FILE` apply to environments created after the install, and the original approach failed silently rather than loudly. Background reading: [RFC 4592](https://datatracker.ietf.org/doc/html/rfc4592#section-2.2.1) on wildcard matching, which explains both the DNS empty-non-terminal trap the guide documents and its certificate-side analogue (a `*.<base>` wildcard cannot cover the one-level-deeper dynamic tiers).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DNS-01 and bring-your-own-certificate (BYOC) TLS modes in the Advanced VM installer.
  * Added validation for certificate files, private keys, expiry, matching, and required wildcard SANs.
  * Added support for private certificate authorities and air-gapped deployments.
  * Added secure dry-run output that redacts certificate and private-key contents.

* **Bug Fixes**
  * Improved platform CA certificate discovery using operator-provided configuration.

* **Documentation**
  * Updated VM installation, configuration, renewal, rotation, teardown, and troubleshooting guidance for both TLS modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->