### PR TITLE
Move the nightly build to a self-hosted runner

### DIFF
--- a/.github/actions/preflight-k3d/action.yml
+++ b/.github/actions/preflight-k3d/action.yml
@@ -1,0 +1,40 @@
+name: Preflight for k3d-based jobs
+description: >
+  Verifies a runner can actually host the k3d-based AMP stack before anything
+  expensive is attempted: the Docker daemon is reachable, container ports it
+  publishes land on *this* runner's loopback (the Docker-in-Docker trap from
+  PR #1233, where k3d creates the cluster and then every kubectl call hangs),
+  and the host ports the k3d config publishes are free. Also reports vCPU,
+  memory and disk, warning when the host is below what the full platform needs.
+
+inputs:
+  required-ports:
+    description: >
+      Space-separated host ports that must be unbound. Defaults to the set
+      deployments/quick-start/k3d-config.yaml publishes.
+    required: false
+    default: '6550 8080 8443 10082 11080 11082 11085 19080 19443'
+  min-cpus:
+    description: vCPU count below which the job warns (does not fail).
+    required: false
+    default: '4'
+  min-memory-gb:
+    description: Total RAM in GiB below which the job warns (does not fail).
+    required: false
+    default: '16'
+  min-disk-gb:
+    description: Free space on / in GiB below which the job warns (does not fail).
+    required: false
+    default: '60'
+
+runs:
+  using: composite
+  steps:
+    - name: Preflight checks
+      shell: bash
+      env:
+        REQUIRED_PORTS: ${{ inputs.required-ports }}
+        MIN_CPUS: ${{ inputs.min-cpus }}
+        MIN_MEM_GB: ${{ inputs.min-memory-gb }}
+        MIN_DISK_GB: ${{ inputs.min-disk-gb }}
+      run: bash "${GITHUB_ACTION_PATH}/preflight.sh"

--- a/.github/actions/preflight-k3d/preflight.sh
+++ b/.github/actions/preflight-k3d/preflight.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Fail-fast checks for a runner that is about to stand up the k3d-based AMP
+# stack.
+#
+# The expensive failure this exists to prevent is the one from #1233: on a
+# runner whose Docker daemon lives in a *different* network namespace
+# (Docker-in-Docker, a remote DOCKER_HOST, a rootful daemon reached from a
+# container), k3d reports "Cluster created successfully" and then every
+# kubectl call against the published API port hangs, because the port was
+# published onto the daemon's host rather than this one. quick-start's
+# installer only surfaces that as a generic readiness timeout, minutes later.
+# A three-second probe with a throwaway container settles it up front.
+#
+# The remaining checks catch the other two ways a long-lived VM differs from a
+# fresh GitHub-hosted image: host ports still held by a previous run, and a
+# machine too small for the full platform.
+
+set -uo pipefail
+
+PROBE_PORT="${PROBE_PORT:-6551}"
+PROBE_IMAGE="${PROBE_IMAGE:-busybox:1.37}"
+REQUIRED_PORTS="${REQUIRED_PORTS:-6550 8080 8443 10082 11080 11082 11085 19080 19443}"
+MIN_CPUS="${MIN_CPUS:-4}"
+MIN_MEM_GB="${MIN_MEM_GB:-16}"
+MIN_DISK_GB="${MIN_DISK_GB:-60}"
+
+log()  { echo "  $*"; }
+ok()   { echo "✅ $*"; }
+warn() { echo "::warning::$*"; }
+die()  { echo "::error::$*"; exit 1; }
+
+failed=0
+
+# ---------------------------------------------------------------------------
+# Host capacity
+#
+# Reported, and warned on, rather than enforced: the nightly e2e suite already
+# runs ginkgo with --procs=1 because a single-node k3d cluster cannot fit
+# several per-environment stacks at once, and an undersized host shows up as
+# pods stuck Pending on "Insufficient cpu" — worth naming in the log before the
+# run rather than diagnosing after it.
+# ---------------------------------------------------------------------------
+
+echo "::group::Host capacity"
+# Fall back to 0 on anything non-numeric so a missing/limited coreutils turns
+# into a warning rather than a "integer expression expected" error.
+numeric_or_zero() {
+  case "$1" in
+    ''|*[!0-9]*) echo 0 ;;
+    *) echo "$1" ;;
+  esac
+}
+cpus="$(numeric_or_zero "$(nproc 2>/dev/null)")"
+mem_gb="$(numeric_or_zero "$(awk '/MemTotal/ {printf "%d", $2/1024/1024}' /proc/meminfo 2>/dev/null)")"
+disk_gb="$(numeric_or_zero "$(df -BG --output=avail / 2>/dev/null | tail -1 | tr -dc '0-9')")"
+log "vCPUs: ${cpus} (want >= ${MIN_CPUS})"
+log "Memory: ${mem_gb} GiB (want >= ${MIN_MEM_GB})"
+log "Free disk on /: ${disk_gb} GiB (want >= ${MIN_DISK_GB})"
+[ "${cpus:-0}" -lt "${MIN_CPUS}" ] && warn "Runner has ${cpus} vCPUs; the full AMP stack needs about ${MIN_CPUS}. Expect pods Pending with 'Insufficient cpu'."
+[ "${mem_gb:-0}" -lt "${MIN_MEM_GB}" ] && warn "Runner has ${mem_gb} GiB RAM; the full AMP stack (OpenSearch, per-environment Thunder and gateway stacks) needs about ${MIN_MEM_GB}."
+[ "${disk_gb:-0}" -lt "${MIN_DISK_GB}" ] && warn "Only ${disk_gb} GiB free on /; image pulls plus k3d state need about ${MIN_DISK_GB}. k3s will start evicting pods once imagefs drops below 10%."
+echo "::endgroup::"
+
+# ---------------------------------------------------------------------------
+# Docker reachability
+# ---------------------------------------------------------------------------
+
+echo "::group::Docker daemon"
+if ! docker info >/dev/null 2>&1; then
+  die "Docker is not reachable from this runner. Check 'systemctl status docker' and that $(id -un) can use the socket."
+fi
+log "DOCKER_HOST=${DOCKER_HOST:-<unset>}"
+log "context: $(docker context show 2>/dev/null || echo '<none>')"
+log "daemon:  $(docker info --format '{{.Name}} / {{.ServerVersion}} / {{.OperatingSystem}}' 2>/dev/null)"
+echo "::endgroup::"
+
+# ---------------------------------------------------------------------------
+# Published-port reachability — the #1233 guard
+# ---------------------------------------------------------------------------
+
+echo "::group::Docker published-port reachability"
+docker rm -f amp-portprobe >/dev/null 2>&1 || true
+if ! docker run -d --rm --name amp-portprobe \
+      -p "127.0.0.1:${PROBE_PORT}:80" "${PROBE_IMAGE}" \
+      httpd -f -p 80 -h /etc >/dev/null 2>&1; then
+  docker rm -f amp-portprobe >/dev/null 2>&1 || true
+  die "Could not start the port probe container from ${PROBE_IMAGE}. Either the daemon cannot pull images, or host port ${PROBE_PORT} is already bound."
+fi
+
+reachable=0
+for _ in $(seq 1 15); do
+  if curl -fsS -m 2 "http://127.0.0.1:${PROBE_PORT}/hostname" >/dev/null 2>&1; then
+    reachable=1
+    break
+  fi
+  sleep 1
+done
+docker rm -f amp-portprobe >/dev/null 2>&1 || true
+
+if [ "${reachable}" -eq 1 ]; then
+  ok "Container ports published by this daemon are reachable on the runner's loopback"
+else
+  failed=1
+  echo "::error::A container port published to 127.0.0.1:${PROBE_PORT} is NOT reachable from this runner."
+  cat <<'EOF'
+  This is the failure mode from PR #1233. The Docker daemon publishes ports
+  into its own network namespace, not this runner's, so k3d will create the
+  cluster successfully and then every kubectl call against the published API
+  port (kubeAPI 6550) will hang until quick-start/install.sh times out.
+
+  It means the runner is not its own Docker host — typically Docker-in-Docker,
+  a containerised runner sharing the host daemon, or a remote DOCKER_HOST.
+
+  Fixes, in order of preference:
+    1. Run the runner agent directly on the VM (as a systemd service) against
+       a local Docker Engine, so published ports land on the runner itself.
+    2. If the runner must stay containerised, give it the daemon's network
+       namespace (--network host against a local daemon), so published ports
+       and the runner share one namespace.
+EOF
+fi
+echo "::endgroup::"
+
+# ---------------------------------------------------------------------------
+# Host ports the k3d config publishes
+#
+# On a discarded GitHub-hosted runner these are free by construction. On a VM
+# they are only free if the previous run's teardown actually ran, so check
+# explicitly and name the holder — quick-start/install.sh's own check reports
+# the port but not the process.
+# ---------------------------------------------------------------------------
+
+echo "::group::Required host ports"
+busy=""
+for p in ${REQUIRED_PORTS}; do
+  if holder="$(lsof -nP -iTCP:"${p}" -sTCP:LISTEN 2>/dev/null | tail -n +2)" && [ -n "${holder}" ]; then
+    busy="${busy} ${p}"
+    echo "  port ${p} IN USE:"
+    echo "${holder}" | sed 's/^/    /'
+  fi
+done
+if [ -n "${busy}" ]; then
+  failed=1
+  echo "::error::Host port(s)${busy} are already bound; the k3d cluster cannot publish them. A previous run's teardown did not complete — remove the leftovers (k3d cluster delete --all; docker ps -a) and re-run."
+else
+  ok "All k3d host ports are free: ${REQUIRED_PORTS}"
+fi
+echo "::endgroup::"
+
+[ "${failed}" -eq 0 ] || die "Preflight failed; not attempting the install."
+ok "Preflight passed"

--- a/.github/actions/preflight-k3d/preflight.sh
+++ b/.github/actions/preflight-k3d/preflight.sh
@@ -33,6 +33,29 @@ die()  { echo "::error::$*"; exit 1; }
 failed=0
 
 # ---------------------------------------------------------------------------
+# Tools this script needs
+#
+# Checked up front, because both checks below infer their verdict from an
+# absence — the probe from a failed curl, the port scan from empty output. A
+# missing tool would silently become "Docker-in-Docker detected" or "all ports
+# free", which is worse than no check at all: this script exists to stop the
+# job with an accurate diagnosis, and a confident wrong one sends whoever reads
+# it after the wrong problem.
+# ---------------------------------------------------------------------------
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+have curl || die "curl is missing, so the published-port probe below cannot run. Add curl to the runner (the setup-self-hosted-tools action installs it)."
+have docker || die "docker is missing; run the setup-self-hosted-tools action with tools: docker before this preflight."
+
+# Either tool can answer "is this port bound"; lsof additionally names the
+# process holding it, which is the useful half of the message.
+PORT_TOOL=""
+have ss && PORT_TOOL="ss"
+have lsof && PORT_TOOL="lsof"
+[ -n "${PORT_TOOL}" ] || die "Neither lsof nor ss is available, so the host-port check cannot distinguish 'free' from 'unknown'. Add lsof to the runner (the setup-self-hosted-tools action installs it)."
+
+# ---------------------------------------------------------------------------
 # Host capacity
 #
 # Reported, and warned on, rather than enforced: the nightly e2e suite already
@@ -132,13 +155,18 @@ echo "::endgroup::"
 # ---------------------------------------------------------------------------
 
 echo "::group::Required host ports"
+log "using ${PORT_TOOL} to inspect listening sockets"
 busy=""
 for p in ${REQUIRED_PORTS}; do
-  if holder="$(lsof -nP -iTCP:"${p}" -sTCP:LISTEN 2>/dev/null | tail -n +2)" && [ -n "${holder}" ]; then
-    busy="${busy} ${p}"
-    echo "  port ${p} IN USE:"
-    echo "${holder}" | sed 's/^/    /'
+  if [ "${PORT_TOOL}" = "lsof" ]; then
+    holder="$(lsof -nP -iTCP:"${p}" -sTCP:LISTEN 2>/dev/null | tail -n +2)"
+  else
+    holder="$(ss -H -ltnp "sport = :${p}" 2>/dev/null)"
   fi
+  [ -n "${holder}" ] || continue
+  busy="${busy} ${p}"
+  echo "  port ${p} IN USE:"
+  echo "${holder}" | sed 's/^/    /'
 done
 if [ -n "${busy}" ]; then
   failed=1

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -3,7 +3,89 @@ description: Sets up Go environment
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v6.1.0
+    - id: setup
+      uses: actions/setup-go@v6.1.0
       with:
         go-version-file: agent-manager-service/go.mod
         cache-dependency-path: agent-manager-service/go.sum
+
+    # actions/setup-go installs the right toolchain and adds it to PATH, but it
+    # cannot stop a runner from overriding that. The self-hosted VM ships its
+    # own Go at /build/software/go/go and exports GOROOT machine-wide, which
+    # wins: run 31668341652 logged "Successfully set up Go version 1.25.7" and
+    # then "go version go1.25.4" three lines later. Because setup-go also sets
+    # GOTOOLCHAIN=local to keep builds hermetic, the older Go could not fetch
+    # the version go.mod asks for either, and every Go step failed instantly
+    # with "go.mod requires go >= 1.25.7".
+    #
+    # That VM's globals should be removed, but a workflow should not depend on
+    # a runner being configured correctly. Pointing GOROOT and PATH at the
+    # toolchain we just installed makes the outcome the same everywhere.
+    #
+    # GOPATH moves too: the VM sets it equal to GOROOT, which Go itself warns
+    # about. Consequence worth knowing — it also moves GOMODCACHE, so
+    # setup-go's cache restore above lands somewhere Go no longer reads. That
+    # costs a cold module download, not correctness.
+    - name: Pin Go to the toolchain setup-go installed
+      shell: bash
+      env:
+        GO_VERSION: ${{ steps.setup.outputs.go-version }}
+      run: |
+        set -euo pipefail
+        root=""
+        for arch in x64 arm64; do
+          cand="${RUNNER_TOOL_CACHE}/go/${GO_VERSION}/${arch}"
+          if [ -x "${cand}/bin/go" ]; then
+            root="${cand}"
+            break
+          fi
+        done
+
+        if [ -z "${root}" ]; then
+          echo "::warning::Could not find the Go ${GO_VERSION} toolchain under ${RUNNER_TOOL_CACHE}; leaving GOROOT as the runner set it. If this is a self-hosted runner with its own Go, expect a 'go.mod requires go >= ${GO_VERSION}' failure."
+          exit 0
+        fi
+
+        {
+          echo "GOROOT=${root}"
+          echo "GOPATH=${HOME}/go"
+        } >> "${GITHUB_ENV}"
+        echo "${root}/bin" >> "${GITHUB_PATH}"
+
+        # Report the version from the pinned binary directly, not via PATH:
+        # $GITHUB_PATH does not affect the step that writes it, so `go version`
+        # here would still resolve to whatever the runner had.
+        echo "✅ Go pinned to ${root} ($("${root}/bin/go" version))"
+
+    # Cheap assertion that the pin above actually took, in the first step where
+    # $GITHUB_PATH and $GITHUB_ENV are in effect. Without it a shadowed Go is
+    # only discovered by whatever compiles next, often several steps later and
+    # with a message that points at the code rather than the runner.
+    #
+    # Six other workflows share this action, so the check is "not older than
+    # required" rather than an exact match: a runner carrying a *newer* Go
+    # still satisfies the go directive, and failing that would break builds
+    # that work today.
+    - name: Verify Go version
+      shell: bash
+      env:
+        GO_VERSION: ${{ steps.setup.outputs.go-version }}
+      run: |
+        set -euo pipefail
+        have="$(go env GOVERSION)"          # e.g. go1.25.7
+        echo "  go:      $(command -v go)"
+        echo "  GOROOT:  $(go env GOROOT)"
+        echo "  GOPATH:  $(go env GOPATH)"
+        echo "  version: ${have}"
+
+        oldest="$(printf '%s\n%s\n' "${GO_VERSION}" "${have#go}" | sort -V | head -1)"
+        if [ "${oldest}" != "${GO_VERSION}" ]; then
+          echo "::error::Go on PATH is ${have}, older than the go${GO_VERSION} this repo requires. A runner-level GOROOT or PATH entry is shadowing the toolchain setup-go installed — check for a machine-wide Go on this runner."
+          exit 1
+        fi
+
+        if [ "$(go env GOPATH)" = "$(go env GOROOT)" ]; then
+          echo "::error::GOPATH and GOROOT are both $(go env GOROOT). Go warns about this and module operations misbehave; the runner has a misconfigured Go installation."
+          exit 1
+        fi
+        echo "✅ Go ${have} satisfies go${GO_VERSION}"

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -26,23 +26,46 @@ runs:
     # about. Consequence worth knowing — it also moves GOMODCACHE, so
     # setup-go's cache restore above lands somewhere Go no longer reads. That
     # costs a cold module download, not correctness.
+    #
+    # The required version comes from go.mod, NOT from
+    # steps.setup.outputs.go-version. That output looks like the obvious
+    # source and is actively wrong here: setup-go derives it by running
+    # `go version` after installing, so on a runner with a shadowing Go it
+    # reports the shadow. Run 31670349845 logged "Successfully set up Go
+    # version 1.25.7" and still emitted 1.25.4 as its output — corrupted by
+    # the exact problem this step exists to correct. go.mod is the one input
+    # no runner can taint.
     - name: Pin Go to the toolchain setup-go installed
       shell: bash
-      env:
-        GO_VERSION: ${{ steps.setup.outputs.go-version }}
       run: |
         set -euo pipefail
+        required="$(awk '$1 == "go" { print $2; exit }' "${GITHUB_WORKSPACE}/agent-manager-service/go.mod")"
+        if [ -z "${required}" ]; then
+          echo "::warning::Could not read the go directive from agent-manager-service/go.mod; leaving GOROOT as the runner set it."
+          exit 0
+        fi
+        echo "AMP_GO_REQUIRED=${required}" >> "${GITHUB_ENV}"
+
+        # Exact match first; otherwise the newest installed toolchain that
+        # still satisfies the directive, since a `go 1.25` line would have
+        # resolved to some 1.25.x that is not named in the file.
         root=""
         for arch in x64 arm64; do
-          cand="${RUNNER_TOOL_CACHE}/go/${GO_VERSION}/${arch}"
-          if [ -x "${cand}/bin/go" ]; then
-            root="${cand}"
-            break
-          fi
+          cand="${RUNNER_TOOL_CACHE}/go/${required}/${arch}"
+          [ -x "${cand}/bin/go" ] && root="${cand}" && break
         done
+        if [ -z "${root}" ] && [ -d "${RUNNER_TOOL_CACHE}/go" ]; then
+          for v in $(ls -1 "${RUNNER_TOOL_CACHE}/go" 2>/dev/null | sort -Vr); do
+            [ "$(printf '%s\n%s\n' "${required}" "${v}" | sort -V | head -1)" = "${required}" ] || continue
+            for arch in x64 arm64; do
+              cand="${RUNNER_TOOL_CACHE}/go/${v}/${arch}"
+              [ -x "${cand}/bin/go" ] && root="${cand}" && break 2
+            done
+          done
+        fi
 
         if [ -z "${root}" ]; then
-          echo "::warning::Could not find the Go ${GO_VERSION} toolchain under ${RUNNER_TOOL_CACHE}; leaving GOROOT as the runner set it. If this is a self-hosted runner with its own Go, expect a 'go.mod requires go >= ${GO_VERSION}' failure."
+          echo "::warning::No Go toolchain satisfying go${required} found under ${RUNNER_TOOL_CACHE}; leaving GOROOT as the runner set it."
           exit 0
         fi
 
@@ -52,9 +75,9 @@ runs:
         } >> "${GITHUB_ENV}"
         echo "${root}/bin" >> "${GITHUB_PATH}"
 
-        # Report the version from the pinned binary directly, not via PATH:
-        # $GITHUB_PATH does not affect the step that writes it, so `go version`
-        # here would still resolve to whatever the runner had.
+        # Report from the pinned binary directly: $GITHUB_PATH does not affect
+        # the step that writes it, so `go version` here would still resolve to
+        # whatever the runner had.
         echo "✅ Go pinned to ${root} ($("${root}/bin/go" version))"
 
     # Cheap assertion that the pin above actually took, in the first step where
@@ -68,19 +91,23 @@ runs:
     # that work today.
     - name: Verify Go version
       shell: bash
-      env:
-        GO_VERSION: ${{ steps.setup.outputs.go-version }}
       run: |
         set -euo pipefail
+        required="${AMP_GO_REQUIRED:-}"
+        if [ -z "${required}" ]; then
+          echo "::warning::Go requirement unknown (the pin step could not read go.mod); skipping verification."
+          exit 0
+        fi
+
         have="$(go env GOVERSION)"          # e.g. go1.25.7
         echo "  go:      $(command -v go)"
         echo "  GOROOT:  $(go env GOROOT)"
         echo "  GOPATH:  $(go env GOPATH)"
         echo "  version: ${have}"
 
-        oldest="$(printf '%s\n%s\n' "${GO_VERSION}" "${have#go}" | sort -V | head -1)"
-        if [ "${oldest}" != "${GO_VERSION}" ]; then
-          echo "::error::Go on PATH is ${have}, older than the go${GO_VERSION} this repo requires. A runner-level GOROOT or PATH entry is shadowing the toolchain setup-go installed — check for a machine-wide Go on this runner."
+        oldest="$(printf '%s\n%s\n' "${required}" "${have#go}" | sort -V | head -1)"
+        if [ "${oldest}" != "${required}" ]; then
+          echo "::error::Go on PATH is ${have}, older than the go${required} this repo requires. A runner-level GOROOT or PATH entry is shadowing the toolchain setup-go installed — check for a machine-wide Go on this runner."
           exit 1
         fi
 
@@ -88,4 +115,4 @@ runs:
           echo "::error::GOPATH and GOROOT are both $(go env GOROOT). Go warns about this and module operations misbehave; the runner has a misconfigured Go installation."
           exit 1
         fi
-        echo "✅ Go ${have} satisfies go${GO_VERSION}"
+        echo "✅ Go ${have} satisfies go${required}"

--- a/.github/actions/setup-self-hosted-tools/README.md
+++ b/.github/actions/setup-self-hosted-tools/README.md
@@ -1,0 +1,39 @@
+# Self-hosted runner VM — provisioning notes
+
+`.github/workflows/nightly.yml` runs on a dedicated, long-lived VM instead of GitHub-hosted runners. The workflow provisions its own tooling (this action) and cleans up after itself (`../teardown-self-hosted`), so the VM needs very little set up by hand — but the few things it does need are not optional.
+
+## What the VM must provide
+
+| Requirement | Why |
+| --- | --- |
+| Ubuntu (or any `apt-get` distro), x86_64 | The pinned k3d/yq checksums cover `linux/amd64` only; the action fails fast on other architectures rather than skipping verification. |
+| Passwordless `sudo` for the runner user | Needed once, to install the Docker engine and OS packages and to raise the kernel limits below. Everything else installs into the runner user's home. |
+| The runner agent running **directly on the VM** (systemd service), not in a container | See "The #1233 trap" below. |
+| Exactly **one** runner registered on the VM | Teardown prunes the whole Docker state; a second concurrent job on the same daemon would have its images and containers removed mid-run. |
+| ≥ 4 vCPU, ≥ 16 GiB RAM, ≥ 60 GiB free on `/` | The e2e job stands up OpenChoreo's four planes plus a per-environment Thunder and gateway stack. Below this, pods sit `Pending` on "Insufficient cpu" and k3s starts evicting once imagefs passes 90%. The preflight reports the actual numbers and warns. |
+| Outbound HTTPS to ghcr.io, github.com, dl.k8s.io, get.helm.sh, docker.io, quay.io | Tool downloads plus every image the platform install pulls. |
+
+Nothing else: `docker`, `helm`, `kubectl`, `k3d`, `yq`, `gh`, `go`, `jq`, `curl`, `git`, `lsof` and `openssl` are all installed by the workflow on first run and reused thereafter.
+
+## What gets installed where
+
+- Pinned single binaries (k3d, yq, kubectl, helm, gh) → `~/.local/share/amp-ci/bin`, prepended to `PATH` via `$GITHUB_PATH`. Every download is checksum-verified: k3d and yq against digests pinned in `install-tools.sh` (matching `../amp-dev-stack`), kubectl, helm and gh against the digest each project publishes alongside the release.
+- Docker engine → system-wide, via the official `get.docker.com` script, only when `docker` is absent. The runner user is added to the `docker` group (durable) *and* granted socket access with `setfacl` (effective immediately, since a group change does not apply to the already-running runner process).
+- Go → `actions/setup-go`, into the runner tool cache, unchanged from before.
+- Kernel limits → `vm.max_map_count=262144` and raised `fs.inotify.*`, written to `/etc/sysctl.d/99-amp-ci.conf` so a reboot does not regress them. Without the first, the observability plane's OpenSearch fails its bootstrap check and CrashLoopBackOffs with no hint that a host sysctl is responsible.
+
+Bumping a pin in `install-tools.sh` is enough to replace an already-installed binary: each tool is reinstalled when its reported version does not contain the pin.
+
+## The #1233 trap
+
+[PR #1233](https://github.com/wso2/agent-manager/pull/1233) had to move the instrumentation matrix's heavy tier *back* to GitHub-hosted runners because k3d could not work on the CodeBuild self-hosted runners. Those runners reach a Docker-in-Docker daemon, so k3d publishes the API server's host port (`kubeAPI: 6550`) into the *daemon's* network namespace rather than the runner's. The cluster reports "created successfully" and then every `kubectl` call gets connection-refused until the readiness wait times out.
+
+The same failure will hit this VM if the runner is containerised against a shared daemon, or points at a remote `DOCKER_HOST`. `../preflight-k3d` checks for it explicitly before anything expensive runs: it publishes a throwaway container port on `127.0.0.1` and curls it. If that fails the job stops in seconds with an explanation, instead of timing out several minutes into the install.
+
+Run the runner agent directly on the VM against a local Docker Engine and the check passes. If it must stay containerised, give it the daemon's network namespace so published ports and the runner share one.
+
+## Falling back to GitHub-hosted
+
+The nightly's `workflow_dispatch` takes a `runner` input (default `self-hosted`). Dispatch it with `ubuntu-latest` to run everything on GitHub-hosted runners for one run — useful for isolating whether a failure is the VM or the code.
+
+Note that `self-hosted` matches *any* self-hosted runner registered for the repo or org. If more get registered later, give this VM a distinctive label and change the input's default to it.

--- a/.github/actions/setup-self-hosted-tools/action.yml
+++ b/.github/actions/setup-self-hosted-tools/action.yml
@@ -1,0 +1,37 @@
+name: Setup self-hosted runner tools
+description: >
+  Idempotently provisions the CLI tooling a job needs on the long-lived
+  self-hosted runner VM, which — unlike the GitHub-hosted images — starts with
+  none of it installed. Base packages (curl, jq, git, lsof, openssl, tar,
+  unzip, acl) are always ensured; everything else is opt-in via `tools`.
+
+  Safe and cheap to call from every job: each tool is skipped when it is
+  already present at the pinned version, so only the first run on a fresh VM
+  actually downloads anything.
+
+inputs:
+  tools:
+    description: >
+      Comma-separated list of extra components to ensure. Supported values:
+      docker (engine + buildx plugin + socket access), k3d, yq, kubectl, helm,
+      gh, sysctl (raise vm.max_map_count and fs.inotify.* for k3s/OpenSearch).
+      Leave empty for base packages only.
+    required: false
+    default: ''
+  bin-dir:
+    description: >
+      Directory the pinned single-file binaries are installed into and which is
+      prepended to PATH for later steps. Defaults to a per-user location so no
+      step needs root to run them.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install runner tooling
+      shell: bash
+      env:
+        TOOLS: ${{ inputs.tools }}
+        TOOL_BIN_DIR: ${{ inputs.bin-dir }}
+      run: bash "${GITHUB_ACTION_PATH}/install-tools.sh"

--- a/.github/actions/setup-self-hosted-tools/action.yml
+++ b/.github/actions/setup-self-hosted-tools/action.yml
@@ -25,6 +25,15 @@ inputs:
       step needs root to run them.
     required: false
     default: ''
+  allow-docker-socket-chmod:
+    description: >
+      Permit relaxing /var/run/docker.sock to 0666 as a last resort when the
+      runner user cannot otherwise reach the daemon. Off by default: the mode
+      persists until the daemon restarts and grants every local user
+      root-equivalent access through Docker. The supported fix is to restart
+      the runner service so it picks up its docker group membership.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -34,4 +43,5 @@ runs:
       env:
         TOOLS: ${{ inputs.tools }}
         TOOL_BIN_DIR: ${{ inputs.bin-dir }}
+        ALLOW_DOCKER_SOCKET_CHMOD: ${{ inputs.allow-docker-socket-chmod }}
       run: bash "${GITHUB_ACTION_PATH}/install-tools.sh"

--- a/.github/actions/setup-self-hosted-tools/install-tools.sh
+++ b/.github/actions/setup-self-hosted-tools/install-tools.sh
@@ -79,6 +79,27 @@ if [ -n "${GITHUB_PATH:-}" ]; then
   echo "${BIN_DIR}" >> "${GITHUB_PATH}"
 fi
 
+# Registry credentials get their own per-job store.
+#
+# By default docker and helm write to the runner user's home, which on this VM
+# is shared by every job of every run. That leaks credentials forward in a way
+# that breaks unrelated work: `helm registry login ghcr.io` in package-charts
+# left a token behind, and the e2e job's *anonymous* pull of a third-party
+# public chart then presented it and got 403 Forbidden from ghcr.io — an
+# install failure three jobs downstream of the job that caused it.
+#
+# RUNNER_TEMP is per-job and cleared by the runner, so pointing both tools
+# there makes the leak structurally impossible rather than something teardown
+# has to remember to undo.
+if [ -n "${RUNNER_TEMP:-}" ] && [ -n "${GITHUB_ENV:-}" ]; then
+  mkdir -p "${RUNNER_TEMP}/docker-config"
+  {
+    echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config"
+    echo "HELM_REGISTRY_CONFIG=${RUNNER_TEMP}/helm-registry-config.json"
+  } >> "${GITHUB_ENV}"
+  ok "Registry credentials isolated to this job (${RUNNER_TEMP})"
+fi
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "${TMP}"' EXIT
 

--- a/.github/actions/setup-self-hosted-tools/install-tools.sh
+++ b/.github/actions/setup-self-hosted-tools/install-tools.sh
@@ -111,8 +111,8 @@ install_base_packages() {
   log "Missing base packages: ${missing[*]}"
   have apt-get || die "Base packages ${missing[*]} are missing and this runner has no apt-get. Install them with the VM's package manager and re-run."
   need_root "${missing[*]}" "apt-get update && apt-get install -y ca-certificates ${missing[*]}"
-  ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get update -qq
-  ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates "${missing[@]}"
+  ${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  ${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates "${missing[@]}"
   ok "Installed base packages: ${missing[*]}"
 }
 
@@ -147,8 +147,15 @@ install_docker() {
     [ -n "${SUDO}" ] || die "Docker is installed but not reachable as $(id -un), and there is no passwordless sudo to fix it. Run once on the VM: usermod -aG docker $(id -un) && systemctl restart docker, then restart the runner service."
     ${SUDO} usermod -aG docker "$(id -un)" || true
     have setfacl && ${SUDO} setfacl -m "u:$(id -un):rw" /var/run/docker.sock 2>/dev/null || true
+    # World-writing the socket is a last resort and no longer automatic. The
+    # mode outlives the job — it persists until the daemon restarts — and it
+    # hands every local user root-equivalent access through Docker, which is
+    # too much to trade for one green run without someone deciding to. The
+    # usermod above is the durable fix; it just needs the runner service
+    # restarted to take effect.
     if ! docker info >/dev/null 2>&1; then
-      warn "Falling back to chmod 0666 on /var/run/docker.sock. Acceptable on a dedicated CI VM, but it grants every local user root-equivalent access through Docker."
+      [ "${ALLOW_DOCKER_SOCKET_CHMOD:-false}" = "true" ] || die "Docker is installed but not reachable as $(id -un). $(id -un) was added to the docker group, but a group change does not apply to the already-running runner process, and setfacl could not grant access either. Restart the runner service on the VM to pick up the group, or set allow-docker-socket-chmod: 'true' on this action to relax the socket mode instead."
+      warn "Relaxing /var/run/docker.sock to 0666 because allow-docker-socket-chmod is set. This grants every local user root-equivalent access through Docker until the daemon restarts."
       ${SUDO} chmod 0666 /var/run/docker.sock || true
     fi
   fi
@@ -162,7 +169,7 @@ install_docker() {
   if ! docker buildx version >/dev/null 2>&1; then
     log "docker buildx plugin missing — installing docker-buildx-plugin"
     if have apt-get && [ -n "${SUDO}" ]; then
-      ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-buildx-plugin || true
+      ${SUDO} env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-buildx-plugin || true
     fi
     docker buildx version >/dev/null 2>&1 || die "docker buildx is unavailable and could not be installed. Install the docker-buildx-plugin package on the runner VM."
   fi

--- a/.github/actions/setup-self-hosted-tools/install-tools.sh
+++ b/.github/actions/setup-self-hosted-tools/install-tools.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+#
+# Idempotent tool bootstrap for the long-lived self-hosted runner VM.
+#
+# GitHub-hosted images ship docker, helm, kubectl, jq and gh preinstalled; a
+# bare datacenter VM does not. This installs only what is missing (or pinned
+# to a different version), so the first nightly on a fresh VM provisions the
+# host and every later run is a near no-op — a handful of `command -v` calls.
+#
+# Binaries that don't need root land in a per-user bin dir appended to
+# $GITHUB_PATH, so the provisioning survives across runs without touching
+# /usr/local. Only the Docker engine, OS packages and sysctl tuning need root;
+# when sudo isn't available the script fails with the exact one-off command a
+# human has to run on the VM, instead of failing obscurely later.
+
+set -euo pipefail
+
+TOOLS="${TOOLS:-}"
+BIN_DIR="${TOOL_BIN_DIR:-${HOME}/.local/share/amp-ci/bin}"
+
+# Version pins. k3d and yq (and their sha256s) mirror
+# .github/actions/amp-dev-stack so the nightly and the instrumentation matrix
+# stand up byte-identical tooling. helm matches the version package-charts
+# previously pulled via azure/setup-helm; kubectl matches amp-dev-stack.
+K3D_VERSION="v5.8.3"
+K3D_SHA256="dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e"
+YQ_VERSION="v4.45.4"
+YQ_SHA256="b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69"
+HELM_VERSION="v3.14.0"
+KUBECTL_VERSION="v1.31.0"
+GH_VERSION="2.97.0"
+
+log()  { echo "  $*"; }
+ok()   { echo "✅ $*"; }
+warn() { echo "::warning::$*"; }
+die()  { echo "::error::$*"; exit 1; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+wants() {
+  case ",${TOOLS}," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True when the tool is installed AND its version output contains the pin, so
+# bumping a pin above actually replaces a binary this action installed on an
+# earlier run.
+version_matches() {
+  local want="$1"
+  shift
+  "$@" 2>/dev/null | grep -qF "${want}"
+}
+
+# ---------------------------------------------------------------------------
+# Environment probing
+# ---------------------------------------------------------------------------
+
+case "$(uname -m)" in
+  x86_64|amd64) ARCH="amd64" ;;
+  *) die "Unsupported runner architecture '$(uname -m)'. The pinned k3d/yq checksums in this action cover linux/amd64 only; add the matching arm64 digests before running the nightly on an arm64 VM." ;;
+esac
+
+SUDO=""
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO="env"
+elif sudo -n true 2>/dev/null; then
+  SUDO="sudo -n"
+fi
+
+need_root() {
+  [ -n "${SUDO}" ] || die "'$1' is missing and installing it needs root, but this runner has no passwordless sudo. Provision it once on the VM, then re-run: $2"
+}
+
+mkdir -p "${BIN_DIR}"
+export PATH="${BIN_DIR}:${PATH}"
+if [ -n "${GITHUB_PATH:-}" ]; then
+  echo "${BIN_DIR}" >> "${GITHUB_PATH}"
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+# ---------------------------------------------------------------------------
+# Base OS packages
+#
+# Every job needs some of these: the workflow shells out to curl, jq and git;
+# deployments/quick-start/install.sh hard-requires curl and lsof and aborts at
+# its prerequisite check without them; deployments/scripts/*.sh use openssl and
+# jq. Resolve by *command*, not package name, so a VM that already has them
+# from another source is left alone.
+# ---------------------------------------------------------------------------
+
+install_base_packages() {
+  declare -A pkg_for_cmd=(
+    [curl]=curl [jq]=jq [git]=git [lsof]=lsof [openssl]=openssl
+    [tar]=tar [unzip]=unzip [setfacl]=acl [envsubst]=gettext-base
+  )
+
+  local cmd missing=()
+  for cmd in "${!pkg_for_cmd[@]}"; do
+    have "${cmd}" || missing+=("${pkg_for_cmd[${cmd}]}")
+  done
+
+  if [ ${#missing[@]} -eq 0 ]; then
+    ok "Base packages already present"
+    return 0
+  fi
+
+  log "Missing base packages: ${missing[*]}"
+  have apt-get || die "Base packages ${missing[*]} are missing and this runner has no apt-get. Install them with the VM's package manager and re-run."
+  need_root "${missing[*]}" "apt-get update && apt-get install -y ca-certificates ${missing[*]}"
+  ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get update -qq
+  ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ca-certificates "${missing[@]}"
+  ok "Installed base packages: ${missing[*]}"
+}
+
+# ---------------------------------------------------------------------------
+# Docker engine + buildx
+# ---------------------------------------------------------------------------
+
+install_docker() {
+  if ! have docker; then
+    need_root docker "curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh"
+    log "Installing Docker Engine via the official get.docker.com script"
+    curl -fsSL https://get.docker.com -o "${TMP}/get-docker.sh"
+    ${SUDO} sh "${TMP}/get-docker.sh"
+    ok "Docker Engine installed"
+  fi
+
+  # `docker info` failing means either the daemon is down (fresh install, or a
+  # VM reboot with the unit not enabled) or the runner user cannot reach the
+  # socket. Starting the daemon is harmless in both cases, so try it first.
+  if ! docker info >/dev/null 2>&1 && [ -n "${SUDO}" ]; then
+    if have systemctl; then
+      ${SUDO} systemctl enable --now docker || true
+    else
+      ${SUDO} service docker start || true
+    fi
+  fi
+
+  # Socket access for the non-root runner user. usermod makes it durable across
+  # reboots, but a group change does NOT apply to the already-running runner
+  # process — setfacl grants access to *this* session immediately.
+  if ! docker info >/dev/null 2>&1; then
+    [ -n "${SUDO}" ] || die "Docker is installed but not reachable as $(id -un), and there is no passwordless sudo to fix it. Run once on the VM: usermod -aG docker $(id -un) && systemctl restart docker, then restart the runner service."
+    ${SUDO} usermod -aG docker "$(id -un)" || true
+    have setfacl && ${SUDO} setfacl -m "u:$(id -un):rw" /var/run/docker.sock 2>/dev/null || true
+    if ! docker info >/dev/null 2>&1; then
+      warn "Falling back to chmod 0666 on /var/run/docker.sock. Acceptable on a dedicated CI VM, but it grants every local user root-equivalent access through Docker."
+      ${SUDO} chmod 0666 /var/run/docker.sock || true
+    fi
+  fi
+
+  docker info >/dev/null 2>&1 || die "Docker is installed but 'docker info' still fails. Check 'systemctl status docker' on the runner VM."
+  ok "Docker $(docker version --format '{{.Server.Version}}' 2>/dev/null || echo '?') reachable as $(id -un)"
+
+  # build-images pushes a multi-arch manifest, which needs the buildx plugin.
+  # get.docker.com ships docker-buildx-plugin; a pre-existing distro Docker
+  # often does not.
+  if ! docker buildx version >/dev/null 2>&1; then
+    log "docker buildx plugin missing — installing docker-buildx-plugin"
+    if have apt-get && [ -n "${SUDO}" ]; then
+      ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-buildx-plugin || true
+    fi
+    docker buildx version >/dev/null 2>&1 || die "docker buildx is unavailable and could not be installed. Install the docker-buildx-plugin package on the runner VM."
+  fi
+  ok "$(docker buildx version)"
+}
+
+# ---------------------------------------------------------------------------
+# Pinned single-binary tools
+# ---------------------------------------------------------------------------
+
+install_k3d() {
+  if ! version_matches "${K3D_VERSION}" k3d version; then
+    curl -fsSL -o "${TMP}/k3d" "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-${ARCH}"
+    echo "${K3D_SHA256}  ${TMP}/k3d" | sha256sum -c -
+    install -m 0755 "${TMP}/k3d" "${BIN_DIR}/k3d"
+  fi
+  ok "$(k3d version | head -1)"
+}
+
+install_yq() {
+  if ! version_matches "${YQ_VERSION}" yq --version; then
+    curl -fsSL -o "${TMP}/yq" "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}"
+    echo "${YQ_SHA256}  ${TMP}/yq" | sha256sum -c -
+    install -m 0755 "${TMP}/yq" "${BIN_DIR}/yq"
+  fi
+  ok "$(yq --version)"
+}
+
+install_kubectl() {
+  if ! version_matches "${KUBECTL_VERSION}" kubectl version --client; then
+    # Verify against the officially published digest rather than a hardcoded
+    # one, so bumping KUBECTL_VERSION needs no hash update here.
+    curl -fsSL -o "${TMP}/kubectl" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+    curl -fsSL -o "${TMP}/kubectl.sha256" "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256"
+    echo "$(cat "${TMP}/kubectl.sha256")  ${TMP}/kubectl" | sha256sum -c -
+    install -m 0755 "${TMP}/kubectl" "${BIN_DIR}/kubectl"
+  fi
+  ok "kubectl $(kubectl version --client 2>/dev/null | head -1)"
+}
+
+install_helm() {
+  if ! version_matches "${HELM_VERSION}" helm version --short; then
+    local tarball="helm-${HELM_VERSION}-linux-${ARCH}.tar.gz"
+    curl -fsSL -o "${TMP}/${tarball}" "https://get.helm.sh/${tarball}"
+    curl -fsSL -o "${TMP}/${tarball}.sha256sum" "https://get.helm.sh/${tarball}.sha256sum"
+    (cd "${TMP}" && sha256sum -c "${tarball}.sha256sum")
+    tar -xzf "${TMP}/${tarball}" -C "${TMP}"
+    install -m 0755 "${TMP}/linux-${ARCH}/helm" "${BIN_DIR}/helm"
+  fi
+  ok "helm $(helm version --short)"
+}
+
+install_gh() {
+  if ! version_matches "${GH_VERSION}" gh --version; then
+    local tarball="gh_${GH_VERSION}_linux_${ARCH}.tar.gz"
+    curl -fsSL -o "${TMP}/${tarball}" "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${tarball}"
+    curl -fsSL -o "${TMP}/checksums.txt" "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt"
+    (cd "${TMP}" && grep " ${tarball}\$" checksums.txt | sha256sum -c -)
+    tar -xzf "${TMP}/${tarball}" -C "${TMP}"
+    install -m 0755 "${TMP}/gh_${GH_VERSION}_linux_${ARCH}/bin/gh" "${BIN_DIR}/gh"
+  fi
+  ok "$(gh --version | head -1)"
+}
+
+# ---------------------------------------------------------------------------
+# Kernel tuning for k3s + OpenSearch
+#
+# GitHub-hosted images ship generous defaults; a stock Ubuntu VM does not, and
+# the resulting failures are non-obvious:
+#   * vm.max_map_count — the observability plane runs OpenSearch, whose
+#     bootstrap check hard-fails below 262144 and the pod CrashLoopBackOffs
+#     with no hint that a host sysctl is responsible.
+#   * fs.inotify.* — k3s plus the controller set AMP installs blows past the
+#     128-instance default; the symptom is "too many open files" surfacing in
+#     an unrelated controller.
+# Best-effort: warn rather than fail, so a locked-down VM still gets as far as
+# it can and the log states exactly what to set.
+# ---------------------------------------------------------------------------
+
+tune_kernel() {
+  declare -A want=(
+    [vm.max_map_count]=262144
+    [fs.inotify.max_user_instances]=1024
+    [fs.inotify.max_user_watches]=1048576
+  )
+  local key current
+  for key in "${!want[@]}"; do
+    current="$(sysctl -n "${key}" 2>/dev/null || echo 0)"
+    case "${current}" in
+      ''|*[!0-9]*) current=0 ;;
+    esac
+    [ "${current}" -ge "${want[${key}]}" ] && continue
+
+    if [ -z "${SUDO}" ]; then
+      warn "${key} is ${current}, needs >= ${want[${key}]} for k3s/OpenSearch, and there is no sudo to raise it. Run on the VM: sysctl -w ${key}=${want[${key}]} and persist it in /etc/sysctl.d/99-amp-ci.conf."
+      continue
+    fi
+
+    if ${SUDO} sysctl -w "${key}=${want[${key}]}" >/dev/null 2>&1; then
+      log "sysctl ${key}: ${current} -> ${want[${key}]}"
+      # Persist so a VM reboot doesn't silently regress the next nightly.
+      echo "${key}=${want[${key}]}" | ${SUDO} tee -a /etc/sysctl.d/99-amp-ci.conf >/dev/null 2>&1 || true
+    else
+      warn "Could not raise ${key} (currently ${current}, want ${want[${key}]})."
+    fi
+  done
+  ok "Kernel parameters checked"
+}
+
+# ---------------------------------------------------------------------------
+
+echo "Requested tools: ${TOOLS:-<base only>}"
+install_base_packages
+wants docker  && install_docker
+wants k3d     && install_k3d
+wants yq      && install_yq
+wants kubectl && install_kubectl
+wants helm    && install_helm
+wants gh      && install_gh
+wants sysctl  && tune_kernel
+
+echo ""
+ok "Runner tooling ready (user bin: ${BIN_DIR})"

--- a/.github/actions/teardown-self-hosted/action.yml
+++ b/.github/actions/teardown-self-hosted/action.yml
@@ -32,6 +32,15 @@ inputs:
       runner itself is containerised) is always preserved.
     required: false
     default: ''
+  self-container-id:
+    description: >
+      Container ID or name of the runner itself, when it is containerised
+      against the same Docker daemon. Normally detected automatically by
+      resolving the candidate IDs in /proc/self/mountinfo and /proc/self/cgroup
+      against the daemon; set this to skip the detection when the runner's ID
+      is known up front.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -42,4 +51,5 @@ runs:
         PRUNE_IMAGES: ${{ inputs.prune-images }}
         REGISTRY: ${{ inputs.registry }}
         KEEP_CONTAINERS: ${{ inputs.keep-containers }}
+        SELF_CID: ${{ inputs.self-container-id }}
       run: bash "${GITHUB_ACTION_PATH}/teardown.sh"

--- a/.github/actions/teardown-self-hosted/action.yml
+++ b/.github/actions/teardown-self-hosted/action.yml
@@ -1,0 +1,45 @@
+name: Teardown self-hosted runner state
+description: >
+  Returns the long-lived self-hosted runner VM to a "tools installed, nothing
+  else" state: deletes every k3d cluster, removes leftover containers, volumes,
+  networks and buildx builders, prunes the image cache, and drops registry
+  credentials. Tool installations are deliberately left in place — only the
+  environment under test is torn down, so the next nightly installs from
+  scratch on a clean host.
+
+  Always invoke with `if: always()`. Every step is best-effort and the action
+  never fails the job.
+
+inputs:
+  prune-images:
+    description: >
+      Remove all unused images as well ("true"), not just stopped containers
+      and dangling layers. On by default: the nightly tags a fresh image set
+      every day, so without it the VM's disk grows without bound.
+    required: false
+    default: 'true'
+  registry:
+    description: >
+      Container/OCI registry to log out of, clearing the credentials
+      docker/login-action and `helm registry login` leave in the runner user's
+      home directory. Empty to skip.
+    required: false
+    default: ''
+  keep-containers:
+    description: >
+      Extended regex of container names to preserve during the sweep, for a VM
+      that also hosts unrelated containers. The job's own container (when the
+      runner itself is containerised) is always preserved.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Tear down runner state
+      shell: bash
+      env:
+        PRUNE_IMAGES: ${{ inputs.prune-images }}
+        REGISTRY: ${{ inputs.registry }}
+        KEEP_CONTAINERS: ${{ inputs.keep-containers }}
+      run: bash "${GITHUB_ACTION_PATH}/teardown.sh"

--- a/.github/actions/teardown-self-hosted/teardown.sh
+++ b/.github/actions/teardown-self-hosted/teardown.sh
@@ -69,21 +69,47 @@ echo "::group::Teardown — containers, volumes, networks"
 # --- containers ------------------------------------------------------------
 # Force-remove everything left over. The one container that must survive is
 # this job's own, in the case where the runner itself is containerised against
-# the same daemon — identify it from the 64-hex container id that appears in
-# our mountinfo (absent when the runner is an ordinary host process, in which
-# case nothing is excluded).
-self_cid="$(grep -o -m1 -E '[0-9a-f]{64}' /proc/self/mountinfo 2>/dev/null | head -1)"
-if [ -n "${self_cid}" ]; then
-  log "Runner appears containerised (${self_cid:0:12}); it is excluded from the sweep"
+# the same daemon: removing that one kills the job mid-teardown.
+#
+# Finding our own id is the delicate part. /proc/self/mountinfo does carry it,
+# in the bind mounts Docker sets up for /etc/hosts and friends — but it also
+# carries 64-hex *storage layer* ids from the overlay2 root mount, and which
+# kind appears first depends on the storage driver. Taking the first match
+# happens to be right on some hosts and silently wrong on others, and "silently
+# wrong" here means force-removing the runner.
+#
+# So collect every candidate and let the daemon adjudicate: a real container id
+# resolves through `docker inspect`, an overlay layer id does not. SELF_CID
+# short-circuits all of it when the caller already knows the answer.
+protected=""
+if [ -n "${SELF_CID:-}" ]; then
+  protected="$(docker inspect --type=container --format '{{.Id}}' "${SELF_CID}" 2>/dev/null)"
+  [ -n "${protected}" ] || warn "SELF_CID='${SELF_CID}' does not resolve to a container on this daemon; ignoring it."
+fi
+if [ -z "${protected}" ]; then
+  for candidate in $( { grep -oE '[0-9a-f]{64}' /proc/self/mountinfo; grep -oE '[0-9a-f]{64}' /proc/self/cgroup; } 2>/dev/null | sort -u); do
+    resolved="$(docker inspect --type=container --format '{{.Id}}' "${candidate}" 2>/dev/null)"
+    [ -n "${resolved}" ] && protected="${protected} ${resolved}"
+  done
+fi
+if [ -n "${protected}" ]; then
+  for p in ${protected}; do
+    log "Runner is containerised in ${p:0:12}; excluded from the sweep"
+  done
+else
+  log "Runner is not containerised against this daemon; sweeping every container"
 fi
 
 leftover="$(docker ps -aq --no-trunc 2>/dev/null)"
 if [ -n "${leftover}" ]; then
   for cid in ${leftover}; do
-    [ -n "${self_cid}" ] && [ "${cid}" = "${self_cid}" ] && continue
+    case " ${protected} " in
+      *" ${cid} "*) continue ;;
+    esac
     if [ -n "${KEEP_CONTAINERS}" ]; then
       name="$(docker inspect -f '{{.Name}}' "${cid}" 2>/dev/null | sed 's|^/||')"
-      if echo "${name}" | grep -qE "${KEEP_CONTAINERS}"; then
+      # -- so a keep pattern beginning with a hyphen is a pattern, not a flag.
+      if echo "${name}" | grep -qE -- "${KEEP_CONTAINERS}"; then
         log "Keeping container ${name} (matches keep-containers)"
         continue
       fi
@@ -131,6 +157,17 @@ echo "::group::Teardown — credentials and workspace"
 if [ -n "${REGISTRY}" ]; then
   docker logout "${REGISTRY}" >/dev/null 2>&1 && log "docker logout ${REGISTRY}" || true
   have helm && helm registry logout "${REGISTRY}" >/dev/null 2>&1 && log "helm registry logout ${REGISTRY}" || true
+fi
+
+# --- persisted git credential ----------------------------------------------
+# actions/checkout writes an authorization header into .git/config unless
+# persist-credentials is off. Its post-step removes it on a clean finish, but a
+# cancelled or timed-out job never reaches that — and on this VM the workspace
+# is still there tomorrow. The jobs that push tags need the credential during
+# the run, so scrub it here instead of disabling it for them.
+if [ -n "${GITHUB_WORKSPACE:-}" ] && [ -d "${GITHUB_WORKSPACE}/.git" ] && have git; then
+  git -C "${GITHUB_WORKSPACE}" config --unset-all 'http.https://github.com/.extraheader' 2>/dev/null \
+    && log "Cleared a persisted git credential from the workspace" || true
 fi
 
 # --- workspace leftovers ---------------------------------------------------

--- a/.github/actions/teardown-self-hosted/teardown.sh
+++ b/.github/actions/teardown-self-hosted/teardown.sh
@@ -23,7 +23,34 @@ log()  { echo "  $*"; }
 ok()   { echo "✅ $*"; }
 warn() { echo "::warning::$*"; }
 
-have() { command -v "$1" >/dev/null 2>&1; }
+# type -P searches PATH only. `command -v` would also match the docker and k3d
+# shell functions defined just below and report them as installed even on a
+# host that has neither binary.
+have() { type -P "$1" >/dev/null 2>&1; }
+
+# Every docker and k3d call here talks to a daemon that may be wedged — this
+# action runs after the job that broke things, so a hung daemon is a normal
+# input, not an edge case. An unbounded call would make the cleanup itself the
+# thing that needs cleaning up. Wrap them so each one gives up and lets the
+# rest of the teardown proceed.
+# Resolve the real binaries up front. `timeout` execs a program, so it cannot
+# be handed the `command` builtin — and the no-timeout fallback below would
+# recurse into these same wrappers if it re-ran the bare name. Absolute paths
+# avoid both traps.
+DOCKER_BIN="$(type -P docker || true)"
+K3D_BIN="$(type -P k3d || true)"
+
+run_bounded() {
+  local secs="$1"
+  shift
+  if have timeout; then
+    timeout --kill-after=10s "${secs}" "$@"
+  else
+    "$@"
+  fi
+}
+[ -n "${DOCKER_BIN}" ] && docker() { run_bounded 180 "${DOCKER_BIN}" "$@"; }
+[ -n "${K3D_BIN}" ]    && k3dcmd() { run_bounded 300 "${K3D_BIN}" "$@"; }
 
 echo "::group::Teardown — cluster and workloads"
 
@@ -32,10 +59,10 @@ echo "::group::Teardown — cluster and workloads"
 # 8443, 10082, 11080/11082/11085, 19080, 19443) the next run's port check
 # requires, and it drops the kubeconfig contexts along with the containers.
 if have k3d; then
-  clusters="$(k3d cluster list --no-headers 2>/dev/null | awk '{print $1}')"
+  clusters="$(k3dcmd cluster list --no-headers 2>/dev/null | awk '{print $1}')"
   if [ -n "${clusters}" ]; then
     log "Deleting k3d clusters: $(echo "${clusters}" | tr '\n' ' ')"
-    k3d cluster delete --all >/dev/null 2>&1 || warn "k3d cluster delete --all did not complete cleanly; the container sweep below should still remove the nodes."
+    k3dcmd cluster delete --all >/dev/null 2>&1 || warn "k3d cluster delete --all did not complete cleanly; the container sweep below should still remove the nodes."
   else
     log "No k3d clusters present"
   fi
@@ -143,7 +170,7 @@ if [ "${PRUNE_IMAGES}" = "true" ]; then
   # -a (not just dangling) is deliberate: the nightly's whole point is that the
   # next run installs from scratch, and the dated 0.0.0-dev-* tags would
   # otherwise accumulate a new full image set on disk every single night.
-  docker system prune -af --volumes >/dev/null 2>&1 || true
+  run_bounded 600 "${DOCKER_BIN}" system prune -af --volumes >/dev/null 2>&1 || true
   ok "Pruned all unused images, volumes and networks"
 else
   docker container prune -f >/dev/null 2>&1 || true

--- a/.github/actions/teardown-self-hosted/teardown.sh
+++ b/.github/actions/teardown-self-hosted/teardown.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Teardown for the long-lived self-hosted runner VM.
+#
+# A GitHub-hosted runner is discarded after every job, so the nightly could
+# assume a pristine host. A dedicated VM cannot: a k3d cluster, its containers,
+# volumes and published host ports all survive the job that created them, and
+# the *next* nightly would then either reuse a half-broken cluster
+# (quick-start/install.sh is idempotent and adopts an existing `amp-local`
+# instead of building it fresh) or fail its port-availability check outright.
+#
+# So this runs with `if: always()` and returns the VM to "tools installed,
+# nothing else" — every command is best-effort and the script always exits 0,
+# because a cleanup hiccup must never turn a green nightly red.
+
+set -uo pipefail
+
+PRUNE_IMAGES="${PRUNE_IMAGES:-true}"
+REGISTRY="${REGISTRY:-}"
+KEEP_CONTAINERS="${KEEP_CONTAINERS:-}"
+
+log()  { echo "  $*"; }
+ok()   { echo "✅ $*"; }
+warn() { echo "::warning::$*"; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+echo "::group::Teardown — cluster and workloads"
+
+# --- k3d ------------------------------------------------------------------
+# Deleting the cluster is what frees the published host ports (6550, 8080,
+# 8443, 10082, 11080/11082/11085, 19080, 19443) the next run's port check
+# requires, and it drops the kubeconfig contexts along with the containers.
+if have k3d; then
+  clusters="$(k3d cluster list --no-headers 2>/dev/null | awk '{print $1}')"
+  if [ -n "${clusters}" ]; then
+    log "Deleting k3d clusters: $(echo "${clusters}" | tr '\n' ' ')"
+    k3d cluster delete --all >/dev/null 2>&1 || warn "k3d cluster delete --all did not complete cleanly; the container sweep below should still remove the nodes."
+  else
+    log "No k3d clusters present"
+  fi
+else
+  log "k3d not installed — nothing to delete"
+fi
+
+# --- compose --------------------------------------------------------------
+# The nightly's e2e job installs via quick-start (no compose), but jobs that
+# reuse this action may have started the deployments/docker-compose.yml stack;
+# leaving its postgres volume behind would carry state into the next run.
+if have docker && [ -f deployments/docker-compose.yml ]; then
+  docker compose -f deployments/docker-compose.yml down -v --remove-orphans >/dev/null 2>&1 \
+    && log "Compose stack removed" || true
+fi
+
+# --- stray port-forwards ---------------------------------------------------
+# deployments/setup/port-forward.sh backgrounds kubectl processes that outlive
+# the job and would hold host ports (and log noise) into the next one.
+pkill -f 'kubectl.*port-forward' >/dev/null 2>&1 && log "Killed stray kubectl port-forwards" || true
+
+echo "::endgroup::"
+
+if ! have docker; then
+  ok "Teardown complete (no Docker on this runner)"
+  exit 0
+fi
+
+echo "::group::Teardown — containers, volumes, networks"
+
+# --- containers ------------------------------------------------------------
+# Force-remove everything left over. The one container that must survive is
+# this job's own, in the case where the runner itself is containerised against
+# the same daemon — identify it from the 64-hex container id that appears in
+# our mountinfo (absent when the runner is an ordinary host process, in which
+# case nothing is excluded).
+self_cid="$(grep -o -m1 -E '[0-9a-f]{64}' /proc/self/mountinfo 2>/dev/null | head -1)"
+if [ -n "${self_cid}" ]; then
+  log "Runner appears containerised (${self_cid:0:12}); it is excluded from the sweep"
+fi
+
+leftover="$(docker ps -aq --no-trunc 2>/dev/null)"
+if [ -n "${leftover}" ]; then
+  for cid in ${leftover}; do
+    [ -n "${self_cid}" ] && [ "${cid}" = "${self_cid}" ] && continue
+    if [ -n "${KEEP_CONTAINERS}" ]; then
+      name="$(docker inspect -f '{{.Name}}' "${cid}" 2>/dev/null | sed 's|^/||')"
+      if echo "${name}" | grep -qE "${KEEP_CONTAINERS}"; then
+        log "Keeping container ${name} (matches keep-containers)"
+        continue
+      fi
+    fi
+    docker rm -f "${cid}" >/dev/null 2>&1 || true
+  done
+  ok "Removed leftover containers"
+else
+  log "No containers to remove"
+fi
+
+# --- buildx ----------------------------------------------------------------
+# docker/setup-buildx-action creates a builder per job. Its own post-step
+# removes it on a clean finish, but a cancelled or killed job leaks both the
+# builder and its cache volume.
+if docker buildx version >/dev/null 2>&1; then
+  # Parse the plain table rather than --format, which older buildx lacks.
+  docker buildx ls 2>/dev/null | awk '{gsub(/\*$/, "", $1); print $1}' | grep -E '^builder-' | while read -r b; do
+    docker buildx rm -f "${b}" >/dev/null 2>&1 && log "Removed buildx builder ${b}" || true
+  done
+  docker buildx prune -af >/dev/null 2>&1 && log "Pruned buildx cache" || true
+fi
+
+# --- images, volumes, networks --------------------------------------------
+if [ "${PRUNE_IMAGES}" = "true" ]; then
+  # -a (not just dangling) is deliberate: the nightly's whole point is that the
+  # next run installs from scratch, and the dated 0.0.0-dev-* tags would
+  # otherwise accumulate a new full image set on disk every single night.
+  docker system prune -af --volumes >/dev/null 2>&1 || true
+  ok "Pruned all unused images, volumes and networks"
+else
+  docker container prune -f >/dev/null 2>&1 || true
+  docker volume prune -f >/dev/null 2>&1 || true
+  docker network prune -f >/dev/null 2>&1 || true
+  ok "Pruned stopped containers, unused volumes and networks (image cache kept)"
+fi
+
+echo "::endgroup::"
+
+echo "::group::Teardown — credentials and workspace"
+
+# --- registry credentials --------------------------------------------------
+# docker/login-action writes ~/.docker/config.json, which persists on a VM
+# runner; the same for `helm registry login` inside package-helm-chart.sh.
+if [ -n "${REGISTRY}" ]; then
+  docker logout "${REGISTRY}" >/dev/null 2>&1 && log "docker logout ${REGISTRY}" || true
+  have helm && helm registry logout "${REGISTRY}" >/dev/null 2>&1 && log "helm registry logout ${REGISTRY}" || true
+fi
+
+# --- workspace leftovers ---------------------------------------------------
+rm -rf /tmp/pod-logs >/dev/null 2>&1 || true
+rm -f "${HOME}/.kube/config.lock" >/dev/null 2>&1 || true
+
+echo "::endgroup::"
+
+echo "::group::Teardown — remaining host state"
+df -h / 2>/dev/null
+docker system df 2>/dev/null || true
+docker ps -a 2>/dev/null || true
+echo "::endgroup::"
+
+ok "Teardown complete"
+exit 0

--- a/.github/actions/teardown-self-hosted/teardown.sh
+++ b/.github/actions/teardown-self-hosted/teardown.sh
@@ -59,10 +59,15 @@ pkill -f 'kubectl.*port-forward' >/dev/null 2>&1 && log "Killed stray kubectl po
 
 echo "::endgroup::"
 
+# Skip only the Docker-specific sweeps when there is no daemon here — the
+# credential and workspace cleanup further down still has to run, since a job
+# can leave a registry token behind without ever touching Docker (helm does
+# exactly that).
 if ! have docker; then
-  ok "Teardown complete (no Docker on this runner)"
-  exit 0
+  log "No Docker on this runner; skipping the container, image and volume sweep"
 fi
+
+if have docker; then
 
 echo "::group::Teardown — containers, volumes, networks"
 
@@ -149,15 +154,34 @@ fi
 
 echo "::endgroup::"
 
+fi  # have docker
+
 echo "::group::Teardown — credentials and workspace"
 
 # --- registry credentials --------------------------------------------------
-# docker/login-action writes ~/.docker/config.json, which persists on a VM
-# runner; the same for `helm registry login` inside package-helm-chart.sh.
+# docker/login-action writes ~/.docker/config.json and `helm registry login`
+# inside package-helm-chart.sh writes helm's own store; both persist on a VM
+# runner.
 if [ -n "${REGISTRY}" ]; then
   docker logout "${REGISTRY}" >/dev/null 2>&1 && log "docker logout ${REGISTRY}" || true
   have helm && helm registry logout "${REGISTRY}" >/dev/null 2>&1 && log "helm registry logout ${REGISTRY}" || true
 fi
+
+# Then delete the stores outright, rather than trusting the logouts above.
+# `logout <host>` only removes an entry filed under exactly that key, and
+# package-helm-chart.sh logs in to "${HELM_REGISTRY#oci://}" — a host *and
+# path* — so a logout of the bare host can miss it and report failure, which
+# is what happened in run 31617009772: the surviving token made the e2e job's
+# anonymous chart pull 403. Removing the file needs no key to match.
+for cred in \
+  "${DOCKER_CONFIG:-${HOME}/.docker}/config.json" \
+  "${HOME}/.docker/config.json" \
+  "${HELM_REGISTRY_CONFIG:-${HOME}/.config/helm/registry/config.json}" \
+  "${HOME}/.config/helm/registry/config.json"
+do
+  [ -f "${cred}" ] || continue
+  rm -f "${cred}" && log "Removed credential store ${cred}" || true
+done
 
 # --- persisted git credential ----------------------------------------------
 # actions/checkout writes an authorization header into .git/config unless

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -511,9 +511,20 @@ jobs:
             --poll-progress-after=600s --keep-going --junit-report=report.xml \
             ./tests/... 2>&1 | tee e2e-output.log
 
+      # Bounded, twice. Every kubectl call below is unattended and there are
+      # well over a hundred of them, so a cluster whose API server has stopped
+      # answering — exactly the state worth diagnosing — makes each one block
+      # forever. In run 31620869475 this step hung for 19 minutes and ate the
+      # rest of the job's budget: the artifact uploads never ran, Teardown
+      # never ran, GitHub never finalized the log, and the diagnostics this
+      # step exists to collect were lost along with the reason for the
+      # failure. --request-timeout bounds each call, timeout-minutes bounds
+      # the step, and partial diagnostics still get uploaded either way.
       - name: Dump pod logs on failure
         if: failure()
+        timeout-minutes: 10
         run: |
+          kubectl() { command kubectl --request-timeout=15s "$@"; }
           mkdir -p /tmp/pod-logs
           kubectl logs deployment/amp-api -n wso2-amp --tail=500 --all-containers=true > /tmp/pod-logs/amp-api.txt 2>&1 || true
           kubectl logs deployment/openchoreo-api -n openchoreo-control-plane --tail=500 --all-containers=true > /tmp/pod-logs/openchoreo-api.txt 2>&1 || true
@@ -696,16 +707,30 @@ jobs:
       - notify-google-chat
     if: always()
     runs-on: ${{ inputs.runner || 'self-hosted' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
+      # This job is the safety net, so it has to reach its Teardown step even
+      # when the VM is in the state that made the net necessary. In run
+      # 31620869475 it did not: the e2e job was cancelled with the full AMP
+      # stack still running, and checking out on the thrashing box took over
+      # 20 minutes, hit the job timeout, and skipped Teardown entirely — the
+      # cluster was left running.
+      #
+      # So: fetch only .github (a fraction of the I/O), bound the step so a
+      # slow checkout fails instead of consuming the job, and run Teardown
+      # even if it does fail. A stale .github is still enough to clean up.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 10
+        continue-on-error: true
         with:
+          sparse-checkout: .github
           # Long-lived runner: the default true writes the token into
           # .git/config, which outlives the job if the post-step is
           # skipped (cancel, timeout). Nothing here pushes over git.
           persist-credentials: false
 
       - name: Teardown
+        if: always()
         uses: ./.github/actions/teardown-self-hosted
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,8 +68,8 @@ jobs:
         run: |
           command -v git >/dev/null && { git --version; exit 0; }
           sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
           echo "✅ Installed $(git --version)"
 
       - name: Compute dev version
@@ -107,6 +107,11 @@ jobs:
       # `gh` is preinstalled on GitHub-hosted images but not on the VM, and
       # the package probe below is pure `gh api`.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Long-lived runner: the default true writes the token into
+          # .git/config, which outlives the job if the post-step is
+          # skipped (cancel, timeout). Nothing here pushes over git.
+          persist-credentials: false
       - uses: ./.github/actions/setup-self-hosted-tools
         with:
           tools: gh
@@ -184,8 +189,8 @@ jobs:
         run: |
           command -v git >/dev/null && { git --version; exit 0; }
           sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -218,6 +223,11 @@ jobs:
       charts: ${{ steps.set-matrix.outputs.charts }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Long-lived runner: the default true writes the token into
+          # .git/config, which outlives the job if the post-step is
+          # skipped (cancel, timeout). Nothing here pushes over git.
+          persist-credentials: false
 
       # The matrix below is built entirely with jq.
       - uses: ./.github/actions/setup-self-hosted-tools
@@ -258,6 +268,11 @@ jobs:
         image: ${{ fromJson(needs.load-config.outputs.images) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Long-lived runner: the default true writes the token into
+          # .git/config, which outlives the job if the post-step is
+          # skipped (cancel, timeout). Nothing here pushes over git.
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-self-hosted-tools
         with:
@@ -317,6 +332,11 @@ jobs:
         chart: ${{ fromJson(needs.load-config.outputs.charts) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Long-lived runner: the default true writes the token into
+          # .git/config, which outlives the job if the post-step is
+          # skipped (cancel, timeout). Nothing here pushes over git.
+          persist-credentials: false
 
       # Replaces azure/setup-helm: the same 3.14.0 pin, but installed from the
       # single place the VM's helm version is now defined, so this job and the
@@ -381,8 +401,8 @@ jobs:
         run: |
           command -v git >/dev/null && { git --version; exit 0; }
           sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -432,10 +452,15 @@ jobs:
         run: |
           command -v git >/dev/null && { git --version; exit 0; }
           sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
-          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Long-lived runner: the default true writes the token into
+          # .git/config, which outlives the job if the post-step is
+          # skipped (cancel, timeout). Nothing here pushes over git.
+          persist-credentials: false
 
       # kubectl and helm were preinstalled on ubuntu-24.04 and only k3d and yq
       # had to be fetched; on the VM all four come from here, at the same pins.
@@ -622,6 +647,11 @@ jobs:
     steps:
       # The alert payload is assembled with jq and posted with curl.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Long-lived runner: the default true writes the token into
+          # .git/config, which outlives the job if the post-step is
+          # skipped (cancel, timeout). Nothing here pushes over git.
+          persist-credentials: false
       - uses: ./.github/actions/setup-self-hosted-tools
 
       - name: Post failure alert
@@ -669,6 +699,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Long-lived runner: the default true writes the token into
+          # .git/config, which outlives the job if the post-step is
+          # skipped (cancel, timeout). Nothing here pushes over git.
+          persist-credentials: false
 
       - name: Teardown
         uses: ./.github/actions/teardown-self-hosted

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,10 +2,35 @@ name: Nightly Dev Build
 
 run-name: Nightly Dev Build #${{ github.run_number }}
 
+# Runs on a dedicated, long-lived self-hosted VM in our datacenter rather than
+# GitHub-hosted runners. Two consequences shape every job below:
+#
+#   1. The VM starts with none of the tooling a GitHub-hosted image ships.
+#      Each job opens with ./.github/actions/setup-self-hosted-tools, which
+#      installs only what is missing at pinned versions — a no-op on every run
+#      after the first.
+#   2. Nothing is discarded when a job ends. Any job that touches Docker or
+#      Kubernetes therefore closes with ./.github/actions/teardown-self-hosted
+#      under `if: always()`, so the next nightly starts from a clean host.
+#      Tool installations survive; the environment under test does not.
+#
+# Register exactly ONE runner on this VM. The teardown prunes the whole Docker
+# state, which would pull the ground out from under a second job running
+# concurrently against the same daemon.
+
 on:
-  # schedule:
-  #   - cron: '0 0 * * *' # midnight UTC
-  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *' # midnight UTC
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: >-
+          Runner label every job runs on. Defaults to the self-hosted VM;
+          set it to e.g. ubuntu-latest to fall back to GitHub-hosted for a
+          single run without editing this file.
+        required: false
+        default: self-hosted
+        type: string
 
 concurrency:
   group: nightly
@@ -20,10 +45,33 @@ jobs:
   # Compute the dated version string once; all jobs consume it via needs.
   compute-version:
     name: Compute Version
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 5
     outputs:
       dev-version: ${{ steps.version.outputs.dev-version }}
     steps:
+      # First job on the VM, and the only place git can be installed before
+      # anything checks out — a local composite action is unavailable until
+      # after actions/checkout, and checkout is what needs git.
+      #
+      # This matters more than it looks. Without git on PATH, actions/checkout
+      # does not fail: it quietly downloads a REST tarball instead, leaving a
+      # working tree with no .git directory. Everything that only reads files
+      # still works, so the breakage surfaces much later and somewhere else —
+      # dorny/test-reporter shells out to `git ls-files -z` and dies, and
+      # fetch-depth/tag pushes have nothing to operate on.
+      #
+      # Later jobs re-assert this for themselves where a real repository is
+      # required, since job-to-runner assignment is not guaranteed if a second
+      # runner is ever registered.
+      - name: Bootstrap git
+        run: |
+          command -v git >/dev/null && { git --version; exit 0; }
+          sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+          echo "✅ Installed $(git --version)"
+
       - name: Compute dev version
         id: version
         run: |
@@ -36,7 +84,8 @@ jobs:
   cleanup-images:
     name: Cleanup Previous Nightly Images
     needs: compute-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 30
     permissions:
       packages: write
     strategy:
@@ -55,6 +104,13 @@ jobs:
           - wso2-amp-evaluation-extension
           - wso2-amp-api-platform-gateway-extension
     steps:
+      # `gh` is preinstalled on GitHub-hosted images but not on the VM, and
+      # the package probe below is pure `gh api`.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-self-hosted-tools
+        with:
+          tools: gh
+
       # The package may not exist yet (e.g. right after an image is renamed,
       # before its first build/push creates the GHCR package), in which case
       # ghcr-cleanup-action 404s and fails the job. Probe existence first so
@@ -116,10 +172,21 @@ jobs:
   cleanup-git-tag:
     name: Cleanup Previous Nightly Git Tag
     needs: compute-version
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
+      # See compute-version for why this is inline. Here specifically: without
+      # a real clone there is no history for fetch-depth: 0 and no way to push
+      # the tag deletions below.
+      - name: Bootstrap git
+        run: |
+          command -v git >/dev/null && { git --version; exit 0; }
+          sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -144,12 +211,16 @@ jobs:
   # Load release-config.json and emit job matrices (mirrors release.yml pattern).
   load-config:
     name: Load Config
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 10
     outputs:
       images: ${{ steps.set-matrix.outputs.images }}
       charts: ${{ steps.set-matrix.outputs.charts }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # The matrix below is built entirely with jq.
+      - uses: ./.github/actions/setup-self-hosted-tools
 
       - name: Load configuration and set matrix
         id: set-matrix
@@ -176,7 +247,8 @@ jobs:
   build-images:
     name: Build ${{ matrix.image.name }}
     needs: [compute-version, cleanup-images, load-config]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -186,6 +258,17 @@ jobs:
         image: ${{ fromJson(needs.load-config.outputs.images) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-self-hosted-tools
+        with:
+          tools: docker
+
+      # build-docker-image pushes a linux/amd64 + linux/arm64 manifest. The
+      # GitHub-hosted images come with qemu-user-static binfmt handlers already
+      # registered, so the arm64 half "just worked" there; a bare VM has no
+      # handler and the arm64 build fails with "exec format error".
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -208,10 +291,23 @@ jobs:
           tag: ${{ needs.compute-version.outputs.dev-version }}
           context: ${{ matrix.image.context }}
 
+      # Drops the builder, its cache and the registry credentials that
+      # docker/login-action wrote into the runner user's home directory.
+      # prune-images stays off here so the matrix entries that run after this
+      # one on the same VM keep their base-image layers; the cleanup-runner
+      # job at the end of the workflow does the full prune.
+      - name: Teardown
+        if: always()
+        uses: ./.github/actions/teardown-self-hosted
+        with:
+          registry: ${{ env.REGISTRY }}
+          prune-images: 'false'
+
   package-charts:
     name: Package ${{ matrix.chart.name }}
     needs: [compute-version, build-images, load-config]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -222,10 +318,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v4
+      # Replaces azure/setup-helm: the same 3.14.0 pin, but installed from the
+      # single place the VM's helm version is now defined, so this job and the
+      # e2e job below cannot drift apart.
+      - uses: ./.github/actions/setup-self-hosted-tools
         with:
-          version: '3.14.0'
+          tools: helm
 
       - name: Cache Helm chart dependencies
         if: hashFiles(format('{0}/Chart.lock', matrix.chart.path)) != ''
@@ -260,13 +358,32 @@ jobs:
           HELM_REGISTRY: ${{ env.HELM_REGISTRY }}
           HELM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Clears the OCI credentials package-helm-chart.sh's `helm registry
+      # login` leaves in the runner user's home directory.
+      - name: Teardown
+        if: always()
+        uses: ./.github/actions/teardown-self-hosted
+        with:
+          registry: ${{ env.REGISTRY }}
+          prune-images: 'false'
+
   update-dev-tag:
     name: Update Nightly Git Tag
     needs: [compute-version, cleanup-git-tag]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
+      # Same as cleanup-git-tag: this job creates and pushes a tag, so it needs
+      # a real clone, not checkout's tarball fallback.
+      - name: Bootstrap git
+        run: |
+          command -v git >/dev/null && { git --version; exit 0; }
+          sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -297,7 +414,7 @@ jobs:
   e2e:
     name: E2E
     needs: [compute-version, package-charts, update-dev-tag]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
     # Bumped from 60 to accommodate the reduced test parallelism below: with
     # --procs=1 (was -p, i.e. one proc per vCPU) suites run serially, so
     # wall-clock grows even though no suite thrashes on CPU any more.
@@ -308,29 +425,39 @@ jobs:
     outputs:
       summary: ${{ steps.test-summary.outputs.summary }}
     steps:
+      # Needed before checkout: the "Publish test results" step below runs
+      # `git ls-files -z` against the working tree, which only exists if
+      # checkout produced a real clone rather than its tarball fallback.
+      - name: Bootstrap git
+        run: |
+          command -v git >/dev/null && { git --version; exit 0; }
+          sudo -n true 2>/dev/null || { echo "::error::git is not installed and this runner has no passwordless sudo. Install git once on the VM."; exit 1; }
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get update -qq
+          sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # kubectl and helm were preinstalled on ubuntu-24.04 and only k3d and yq
+      # had to be fetched; on the VM all four come from here, at the same pins.
+      # `sysctl` raises vm.max_map_count and the inotify limits, without which
+      # the observability plane's OpenSearch fails its bootstrap check and
+      # controllers start reporting "too many open files".
+      - uses: ./.github/actions/setup-self-hosted-tools
+        with:
+          tools: docker,k3d,yq,kubectl,helm,sysctl
 
       - name: Setup Go
         uses: ./.github/actions/setup-go
 
-      - name: Install k3d
-        env:
-          K3D_VERSION: v5.8.3
-          K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
-        run: |
-          curl -fsSL -o /tmp/k3d "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
-          echo "${K3D_SHA256}  /tmp/k3d" | sha256sum -c -
-          sudo install /tmp/k3d /usr/local/bin/k3d
-          k3d version
+      # A previous run that was cancelled or timed out leaves its cluster and
+      # published ports behind, and quick-start/install.sh would silently adopt
+      # that cluster instead of building a fresh one. Clear it first so the
+      # nightly always tests a from-scratch install.
+      - name: Clean any leftover state from a previous run
+        uses: ./.github/actions/teardown-self-hosted
 
-      - name: Install yq
-        env:
-          YQ_VERSION: v4.45.4
-          YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
-        run: |
-          curl -fsSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
-          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
-          sudo install /tmp/yq /usr/local/bin/yq
+      - name: Preflight
+        uses: ./.github/actions/preflight-k3d
 
       - name: Install platform
         env:
@@ -424,6 +551,15 @@ jobs:
           path: /tmp/pod-logs/
           retention-days: 7
 
+      # fail-on-error/fail-on-empty are off (both default to true) because this
+      # step only *publishes* a result someone else already decided. With them
+      # on it fails twice over for reasons that are not its own: once because
+      # the report contains failed tests — which "Run e2e tests" above has
+      # already failed the job for — and once when there is no report.xml at
+      # all, which is the normal outcome when the platform install dies before
+      # ginkgo ever starts. Both showed up in run 31572576550, where the second
+      # red step masked the fact that the only real failure was upstream.
+      # "Build test summary" below reports the missing-report case explicitly.
       - name: Publish test results
         if: always()
         uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
@@ -431,6 +567,8 @@ jobs:
           name: Nightly E2E Test Results
           path: test/e2e/report.xml
           reporter: java-junit
+          fail-on-error: 'false'
+          fail-on-empty: 'false'
 
       - name: Upload test logs
         if: always()
@@ -467,12 +605,25 @@ jobs:
           echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
           echo "Test summary: $SUMMARY"
 
+      # Last step in the job, deliberately: everything above — the pod-log
+      # dump, the artifact uploads, the JUnit report — reads from the live
+      # cluster. Deleting it here is what frees the published host ports and
+      # guarantees tomorrow's run installs from scratch.
+      - name: Teardown
+        if: always()
+        uses: ./.github/actions/teardown-self-hosted
+
   notify-google-chat:
     name: Notify Google Chat
     needs: [compute-version, e2e]
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 10
     if: ${{ !cancelled() && needs.e2e.result == 'failure' }}
     steps:
+      # The alert payload is assembled with jq and posted with curl.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-self-hosted-tools
+
       - name: Post failure alert
         env:
           GCHAT_WEBHOOK_URL: ${{ secrets.GCHAT_WEBHOOK_URL }}
@@ -494,3 +645,32 @@ jobs:
           curl -s -X POST "${GCHAT_WEBHOOK_URL}" \
             -H 'Content-Type: application/json' \
             -d "${PAYLOAD}"
+
+  # Final sweep of the VM. Individual jobs clean up after themselves, but only
+  # for the paths they took: a job cancelled mid-step, or one that failed
+  # before its own teardown was reached, can still leave a cluster or an image
+  # set behind. This runs unconditionally after every other job and does the
+  # deep prune, so the disk state at the end of a nightly does not depend on
+  # how that nightly went.
+  cleanup-runner:
+    name: Cleanup Runner
+    needs:
+      - compute-version
+      - cleanup-images
+      - cleanup-git-tag
+      - load-config
+      - build-images
+      - package-charts
+      - update-dev-tag
+      - e2e
+      - notify-google-chat
+    if: always()
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Teardown
+        uses: ./.github/actions/teardown-self-hosted
+        with:
+          registry: ${{ env.REGISTRY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,24 +43,27 @@ env:
 
 jobs:
   # ==========================================================================
-  # TEMPORARY — REMOVE BEFORE MERGE
+  # Unconditional sweep of the VM before anything else starts.
   #
-  # Run 31620869475 was cancelled on the job timeout before its Teardown could
-  # run, leaving a live k3d cluster and the full AMP stack on the VM. Both
-  # teardown paths that would normally recover from that were themselves
-  # skipped, so the box needs one unconditional sweep before the next run can
-  # get past its port-availability check.
+  # Every other cleanup in this workflow runs at the *end* of a job, which
+  # makes all of it best-effort: run 31620869475 was cancelled on its job
+  # timeout before Teardown could run, and cleanup-runner — the safety net —
+  # then hit its own timeout, so the VM sat with a live k3d cluster holding
+  # port 8080 for eleven hours. Cleaning up first is the only guarantee that
+  # survives that, because the previous run is already over and cannot
+  # pre-empt this.
   #
-  # Deliberately does NOT check out the repo or use the composite action: on a
-  # thrashing VM the checkout is exactly what hung last time. Raw commands
-  # against the tools already installed on the host are the one thing that
-  # still works when everything else is stuck.
+  # Costs nothing when there is nothing to do: measured at 0s on an already
+  # clean VM, and 1s on one with no docker or k3d installed at all.
   #
-  # Once a run completes with its Teardown intact, delete this job and the
-  # `needs: prepare-runner` lines on compute-version and load-config.
+  # Deliberately checks out nothing and uses no composite action. On a
+  # thrashing VM the checkout is exactly what hung, so the recovery path must
+  # not depend on one. That is why this duplicates a little of
+  # teardown-self-hosted: this one has to work when nothing else does, so it
+  # stays minimal and raw, and the composite action remains the thorough one.
   # ==========================================================================
   prepare-runner:
-    name: Prepare Runner (temporary)
+    name: Prepare Runner
     runs-on: ${{ inputs.runner || 'self-hosted' }}
     timeout-minutes: 20
     steps:
@@ -269,7 +272,7 @@ jobs:
   # Load release-config.json and emit job matrices (mirrors release.yml pattern).
   load-config:
     name: Load Config
-    needs: prepare-runner  # TEMPORARY — remove with the prepare-runner job
+    needs: prepare-runner
     runs-on: ${{ inputs.runner || 'self-hosted' }}
     timeout-minutes: 10
     outputs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,9 +42,62 @@ env:
   HELM_REGISTRY: oci://ghcr.io/wso2
 
 jobs:
+  # ==========================================================================
+  # TEMPORARY — REMOVE BEFORE MERGE
+  #
+  # Run 31620869475 was cancelled on the job timeout before its Teardown could
+  # run, leaving a live k3d cluster and the full AMP stack on the VM. Both
+  # teardown paths that would normally recover from that were themselves
+  # skipped, so the box needs one unconditional sweep before the next run can
+  # get past its port-availability check.
+  #
+  # Deliberately does NOT check out the repo or use the composite action: on a
+  # thrashing VM the checkout is exactly what hung last time. Raw commands
+  # against the tools already installed on the host are the one thing that
+  # still works when everything else is stuck.
+  #
+  # Once a run completes with its Teardown intact, delete this job and the
+  # `needs: prepare-runner` lines on compute-version and load-config.
+  # ==========================================================================
+  prepare-runner:
+    name: Prepare Runner (temporary)
+    runs-on: ${{ inputs.runner || 'self-hosted' }}
+    timeout-minutes: 20
+    steps:
+      - name: Sweep leftover state
+        run: |
+          export PATH="${HOME}/.local/share/amp-ci/bin:${PATH}"
+          bounded() { timeout --kill-after=10s "$@" || echo "  (timed out or failed, continuing)"; }
+
+          echo "::group::Before"
+          bounded 60 k3d cluster list || true
+          bounded 60 docker ps -a || true
+          df -h / || true
+          echo "::endgroup::"
+
+          echo "::group::Sweeping"
+          bounded 300 k3d cluster delete --all || true
+          leftover="$(bounded 60 docker ps -aq 2>/dev/null | grep -E '^[0-9a-f]+$' || true)"
+          for c in ${leftover}; do bounded 60 docker rm -f "${c}" >/dev/null 2>&1 || true; done
+          bounded 120 docker buildx prune -af >/dev/null 2>&1 || true
+          bounded 600 docker system prune -af --volumes >/dev/null 2>&1 || true
+          pkill -f 'kubectl.*port-forward' >/dev/null 2>&1 || true
+          rm -f "${HOME}/.docker/config.json" "${HOME}/.config/helm/registry/config.json" || true
+          echo "::endgroup::"
+
+          echo "::group::After"
+          bounded 60 k3d cluster list || true
+          bounded 60 docker ps -a || true
+          bounded 60 docker system df || true
+          df -h / || true
+          echo "::endgroup::"
+
+          echo "✅ Runner swept"
+
   # Compute the dated version string once; all jobs consume it via needs.
   compute-version:
     name: Compute Version
+    needs: prepare-runner
     runs-on: ${{ inputs.runner || 'self-hosted' }}
     timeout-minutes: 5
     outputs:
@@ -216,6 +269,7 @@ jobs:
   # Load release-config.json and emit job matrices (mirrors release.yml pattern).
   load-config:
     name: Load Config
+    needs: prepare-runner  # TEMPORARY — remove with the prepare-runner job
     runs-on: ${{ inputs.runner || 'self-hosted' }}
     timeout-minutes: 10
     outputs:


### PR DESCRIPTION
## Purpose

The nightly dev build runs entirely on GitHub-hosted runners. This moves it to a dedicated, long-lived self-hosted VM.

A hosted runner image ships a large preinstalled toolchain and is discarded after every job. The VM does neither, and both differences reach into every job: nothing is installed to start with, and nothing is cleaned up at the end. A nightly that assumes a pristine host will pass once and then degrade — reusing a half-built cluster from the previous run, failing its port-availability check, or filling the disk with a fresh image set every night.

There is also a known trap. [#1233](https://github.com/wso2/agent-manager/pull/1233) had to move the instrumentation matrix's heavy tier *back* to GitHub-hosted runners because k3d could not work on the CodeBuild self-hosted runners: the daemon publishes the API server's host port into its own network namespace, so the cluster reports "created successfully" and then every `kubectl` call hangs until the readiness wait times out. The same topology would break this workflow the same way, and it is worth detecting rather than rediscovering.

Related to #1233

## Goals

Run the nightly on the VM with no manual provisioning beyond a working runner agent and passwordless sudo, leave the VM in the same state after every run regardless of how that run went, and fail fast and legibly when the VM's Docker topology cannot host k3d.

## Approach

Three new composite actions, plus the workflow changes that use them.

**`setup-self-hosted-tools`** installs only what is missing, at pinned versions, so the first run provisions the host and every later run is a handful of `command -v` calls. Covers docker (engine, buildx plugin and socket access for the runner user), k3d, yq, kubectl, helm, gh, and the base packages the workflow and `deployments/` scripts shell out to. Every download is checksum-verified: k3d and yq against digests pinned in the script and matching `amp-dev-stack`, kubectl, helm and gh against the digest each project publishes alongside the release. Pinned binaries land in a per-user bin dir added to `$GITHUB_PATH`; only the Docker engine and OS packages need root. Bumping a pin replaces an already-installed binary, since each tool is reinstalled when its reported version does not contain the pin.

It also raises `vm.max_map_count` and the inotify limits and persists them to `/etc/sysctl.d/`. Without the first, the observability plane's OpenSearch fails its bootstrap check and CrashLoopBackOffs with nothing in the pod's own logs pointing at a host sysctl.

**`teardown-self-hosted`** returns the VM to "tools installed, nothing else": deletes every k3d cluster, sweeps leftover containers, volumes, networks and buildx builders, prunes images, and drops the registry credentials `docker/login-action` and `helm registry login` leave in the runner user's home. Every command is best-effort and it always exits 0, so a cleanup hiccup cannot turn a green nightly red. It is invoked with `if: always()` by each job that touches Docker or Kubernetes, and a final `cleanup-runner` job runs it after everything, so end-of-run disk state does not depend on which job failed or where. The e2e job also runs it *before* installing — `quick-start/install.sh` is idempotent and adopts an existing `amp-local` cluster rather than rebuilding it, so a cancelled previous run would otherwise be silently reused instead of the from-scratch install the nightly is supposed to be testing.

**`preflight-k3d`** is the #1233 guard. It publishes a throwaway container port on `127.0.0.1` and curls it; if the daemon is in another namespace this fails in seconds with the diagnosis and the fix, instead of timing out several minutes into the install. It also verifies the k3d host ports are free — naming the process holding them, which `install.sh`'s own check does not — and reports vCPU, memory and disk, warning below what the full platform needs.

Three fixes fall out of the move:

- `build-images` gained `docker/setup-qemu-action`. It pushes a linux/amd64 + linux/arm64 manifest, which only worked because the hosted images come with binfmt handlers already registered; a bare VM fails the arm64 half with "exec format error".
- git is bootstrapped before checkout in the jobs that need a real clone. Without git on PATH `actions/checkout` does not fail — it quietly downloads a REST tarball, leaving a tree with no `.git`. Everything that only reads files still works, so the breakage surfaces later and elsewhere: tag pushes have nothing to operate on, and `dorny/test-reporter` shells out to `git ls-files -z` and dies at the very end of a two-hour e2e job.
- That reporter no longer fails on error or on an empty report. Both default to true, which makes it go red for reasons that are not its own — once because the report contains failures that "Run e2e tests" has already failed the job for, and once when there is no `report.xml` at all, the normal outcome when the install dies before ginkgo starts. Both happened in [run 31572576550](https://github.com/wso2/agent-manager/actions/runs/31572576550), where the second red step obscured that the only real failure was upstream. "Build test summary" already reports the missing-report case.

Every job carries an explicit timeout, since a hung job on a single runner blocks everything behind it with no hosted-runner quota to absorb it. A `runner` dispatch input, defaulting to `self-hosted`, allows a one-off run on `ubuntu-latest` to isolate whether a failure is the VM or the code. The midnight schedule is re-enabled.

## User stories

N/A — CI infrastructure change.

## Release note

N/A — CI-only change, no user-facing impact.

## Documentation

N/A — no product behavior change. The VM's one-time requirements and the #1233 topology constraint are documented in comments in the workflow and the actions.

## Training

N/A — no training impact.

## Certification

N/A — no certification impact.

## Marketing

N/A — no marketing impact.

## Automation tests

 - Unit tests
   > N/A — the change is CI workflow and shell tooling; there is no unit-testable product code.
 - Integration tests
   > The nightly itself is the test. Validated ahead of that by dispatching it against the VM (see Test environment). The individual pieces were also exercised directly: the installer was run twice in a clean `ubuntu:24.04` amd64 container, installing all six tools with checksums verified on the first pass and downloading nothing on the second; the teardown was run against mocked `docker`/`k3d` to confirm cluster deletion, self-container exclusion, keep-list handling, builder removal and its always-zero exit; the preflight probe was run against both a sibling-daemon topology, where it correctly failed with the #1233 diagnosis, and a real Docker host, where it passed in four seconds with no false alarm.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no application code changed.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Two things worth a reviewer's attention. Docker is installed via the official `get.docker.com` script when absent, which runs a downloaded script as root — standard for provisioning a CI host, and it only runs when `docker` is missing. And if `setfacl` cannot grant the runner user socket access, the setup falls back to `chmod 0666` on the socket with an explicit warning; that is acceptable on a dedicated CI VM but does grant every local user root-equivalent access through Docker.

## Samples

N/A

## Related PRs

- #1233 — pinned the instrumentation heavy tier back to GitHub-hosted after k3d failed on self-hosted runners. The preflight added here detects that topology up front rather than reverting away from it.

## Migrations (if applicable)

N/A

## Test environment

Ubuntu x86_64 VM with the runner agent installed as a systemd service against a local Docker Engine, and passwordless sudo for the runner user. The tooling scripts were exercised in `ubuntu:24.04` and `docker:28-cli` containers on linux/amd64 as described above; `actionlint` and `shellcheck` are clean.

To verify on the VM: dispatch the workflow with `runner` left at `self-hosted`. The first run should install the toolchain from scratch, the preflight should pass, and the VM should hold no clusters, containers or unused images afterwards. Dispatching again should skip every tool install.

## Learning

The instructive part was how quietly this class of failure degrades. `actions/checkout` without git does not error, it downloads a tarball — so the missing tool surfaces two hours later inside a test reporter, in a step that has nothing to do with checkout. #1233 has the same shape: k3d reports "Cluster created successfully" and only the readiness wait knows something is wrong. Both argued for the same thing, which is most of what this PR does: assert the environment up front, where the error message can still name the cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable preflight checks for Docker access, required ports, and host resources before k3d setup.
  - Added automated setup for self-hosted runner tools, including Kubernetes, Helm, and container utilities.
  - Added configurable teardown to clean test environments while optionally preserving selected containers.

- **Chores**
  - Improved nightly workflows with scheduled or manual execution, selectable runners, multi-architecture builds, and automated cleanup.
  - Added clearer validation results and remediation messages for unsupported runner environments.

- **Documentation**
  - Added guidance for configuring and operating self-hosted runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->