### PR TITLE
Support .env file upload and key-value paste parsing in Agent Kind "Create New Version"

### DIFF
--- a/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
+++ b/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React from "react";
+import React, { useRef } from "react";
 import {
     Box,
     Button,
@@ -240,13 +240,25 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
 
     const removeRow = (index: number) => onChange(rows.filter((_, i) => i !== index));
 
+    // FileReader resolves asynchronously, so by the time it fires, `rows` closed
+    // over at render time may be behind the latest edits — read from this ref instead.
+    const rowsRef = useRef(rows);
+    rowsRef.current = rows;
+
     const handleEnvFileParsed = (entries: ParsedEnvEntry[]) => {
-        const next = [...rows];
+        const next = [...rowsRef.current];
+        const indexByKey = new Map<string, number>();
+        next.forEach((row, i) => {
+            const trimmedKey = row.key.trim();
+            if (trimmedKey) indexByKey.set(trimmedKey, i);
+        });
+
         for (const { key, value } of entries) {
-            const existingIndex = next.findIndex((row) => row.key.trim() === key);
-            if (existingIndex !== -1) {
+            const existingIndex = indexByKey.get(key);
+            if (existingIndex !== undefined) {
                 next[existingIndex] = { ...next[existingIndex], defaultValue: value };
             } else {
+                indexByKey.set(key, next.length);
                 next.push(createRuntimeConfigRow({ key, defaultValue: value }));
             }
         }
@@ -269,11 +281,13 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
                 />
             ))}
             {!readonlyKey && (
-                <Box display="flex" flexDirection="row" gap={1}>
+                <Box display="flex" flexDirection="row" gap={1} alignItems="flex-start">
                     <Button size="small" variant="outlined" startIcon={<Plus />} onClick={addRow} disabled={isInvalid}>
                         Add Runtime Key
                     </Button>
-                    <EnvFileUploadButton onParsed={handleEnvFileParsed} label="Upload .env file" />
+                    <Box display="flex" flexDirection="column">
+                        <EnvFileUploadButton onParsed={handleEnvFileParsed} label="Upload .env file" />
+                    </Box>
                 </Box>
             )}
         </Stack>

--- a/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
+++ b/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
@@ -285,7 +285,7 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
                     <Button size="small" variant="outlined" startIcon={<Plus />} onClick={addRow} disabled={isInvalid}>
                         Add Runtime Key
                     </Button>
-                    <Box display="flex" flexDirection="column">
+                    <Box display="flex" flexDirection="column" alignItems="flex-start">
                         <EnvFileUploadButton onParsed={handleEnvFileParsed} label="Upload .env file" />
                     </Box>
                 </Box>

--- a/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
+++ b/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
@@ -27,7 +27,11 @@ import {
     Typography,
 } from "@wso2/oxygen-ui";
 import { Plus, Trash } from "@wso2/oxygen-ui-icons-react";
-import { TextInput } from "@agent-management-platform/views";
+import {
+    EnvFileUploadButton,
+    TextInput,
+    type ParsedEnvEntry,
+} from "@agent-management-platform/views";
 
 const KEY_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const KEY_MAX_LENGTH = 64;
@@ -39,6 +43,17 @@ const getKeyError = (key: string, keyCounts: Map<string, number>): string | null
     if (!KEY_REGEX.test(trimmed)) return "Key must start with a letter or underscore, and contain only letters, numbers, or underscores.";
     if ((keyCounts.get(trimmed) ?? 0) > 1) return "Key must be unique.";
     return null;
+};
+
+const stripQuotes = (value: string): string => {
+    if (
+        value.length >= 2 &&
+        ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'")))
+    ) {
+        return value.slice(1, -1);
+    }
+    return value;
 };
 
 const createRowId = (): string => {
@@ -81,6 +96,7 @@ interface ConfigRowProps {
     readonlyKey?: boolean;
     canRemove: boolean;
     onUpdate: <K extends keyof RuntimeConfigRow>(field: K, value: RuntimeConfigRow[K]) => void;
+    onUpdateMany: (updates: Partial<RuntimeConfigRow>) => void;
     onRemove: () => void;
 }
 
@@ -90,6 +106,7 @@ const ConfigRow: React.FC<ConfigRowProps> = ({
     readonlyKey,
     canRemove,
     onUpdate,
+    onUpdateMany,
     onRemove,
 }) => (
     <Stack key={row.id} direction="row" spacing={1} alignItems="top" justifyContent="flex-start">
@@ -102,6 +119,19 @@ const ConfigRow: React.FC<ConfigRowProps> = ({
                         placeholder="Key"
                         value={row.key}
                         onChange={(e) => onUpdate("key", e.target.value.replace(/\s/g, "_"))}
+                        onPaste={(e) => {
+                            const pasted = e.clipboardData.getData("text");
+                            const equalsIdx = pasted.indexOf("=");
+                            if (equalsIdx === -1) return;
+                            const pastedKey = pasted.slice(0, equalsIdx).trim();
+                            const pastedValue = stripQuotes(pasted.slice(equalsIdx + 1).trim());
+                            if (!pastedKey) return;
+                            e.preventDefault();
+                            onUpdateMany({
+                                key: pastedKey.replace(/\s/g, "_"),
+                                defaultValue: pastedValue,
+                            });
+                        }}
                         fullWidth
                         size="small"
                         error={!!keyError}
@@ -195,6 +225,12 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
         onChange(next);
     };
 
+    const updateRowMany = (index: number, updates: Partial<RuntimeConfigRow>) => {
+        const next = [...rows];
+        next[index] = { ...next[index], ...updates };
+        onChange(next);
+    };
+
     const addRow = () => {
         if (isInvalid) {
             return;
@@ -203,6 +239,20 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
     };
 
     const removeRow = (index: number) => onChange(rows.filter((_, i) => i !== index));
+
+    const handleEnvFileParsed = (entries: ParsedEnvEntry[]) => {
+        const next = [...rows];
+        for (const { key, value } of entries) {
+            const existingIndex = next.findIndex((row) => row.key.trim() === key);
+            if (existingIndex !== -1) {
+                next[existingIndex] = { ...next[existingIndex], defaultValue: value };
+            } else {
+                next.push(createRuntimeConfigRow({ key, defaultValue: value }));
+            }
+        }
+        const withoutBlankRow = next.filter((row) => row.key.trim() !== "" || row.defaultValue?.trim());
+        onChange(withoutBlankRow.length > 0 ? withoutBlankRow : next);
+    };
 
     return (
         <Stack spacing={1} pt={1}>
@@ -214,14 +264,16 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
                     readonlyKey={readonlyKey}
                     canRemove={rows.length > 1}
                     onUpdate={(field, value) => updateRow(i, field, value)}
+                    onUpdateMany={(updates) => updateRowMany(i, updates)}
                     onRemove={() => removeRow(i)}
                 />
             ))}
             {!readonlyKey && (
-                <Box>
+                <Box display="flex" flexDirection="row" gap={1}>
                     <Button size="small" variant="outlined" startIcon={<Plus />} onClick={addRow} disabled={isInvalid}>
                         Add Runtime Key
                     </Button>
+                    <EnvFileUploadButton onParsed={handleEnvFileParsed} label="Upload .env file" />
                 </Box>
             )}
         </Stack>


### PR DESCRIPTION
## Purpose
On the Agent Kind "Create New Version" page, users could only add environment/runtime config variables one at a time via manual Key/Value input fields. This is tedious and error-prone when releasing a new version with many variables, especially since this same friction was already solved elsewhere in the console (standard Agent configuration flow) but never carried over to this page.

Resolves [#1606](https://github.com/wso2/agent-manager/issues/1606)

## Goals
- Let users bulk-import runtime config variables from a `.env` file instead of typing each key/value pair manually.
- Let users paste a `KEY=VALUE` string directly into the Key field and have both the key and default value auto-fill.
- Keep behavior consistent with the existing `.env` upload/paste experience already used in the standard Agent configuration flow.

## Approach
Reused the existing shared `EnvFileUploadButton` / `parseEnvFileContent` utilities from `@agent-management-platform/views` (already powering `.env` upload in the standard Agent configuration and deploy flows) and wired them into `RuntimeConfigEditor.tsx`:

- Added an "Upload .env file" button next to "Add Runtime Key". Uploaded entries merge into existing rows, matching keys update the default value, new keys append as new rows.
- Added paste-handling on the Key field: pasting `KEY=VALUE` (or quoted variants) splits on the first `=`, strips quotes, and fills both fields in one state update.
- Hidden in `readonlyKey` mode (viewing already-published version schemas) — only active in the editable "Create New Version" flow.

**Screen captures**

https://github.com/user-attachments/assets/37d87d91-065b-4499-bcfe-02e708e0bbd3

## User stories
- As a developer publishing a new Agent Kind version, I want to upload a `.env` file so I don't have to manually retype every runtime config variable.
- As a developer publishing a new Agent Kind version, I want to paste a `KEY=VALUE` line into the key field and have it auto-split.

## Release note
Added `.env` file upload and `KEY=VALUE` paste support to the Agent Kind "Create New Version" page, allowing bulk import of runtime configuration variables instead of manual key-by-key entry.

## Documentation
N/A — UI convenience enhancement to an existing form; no new concepts requiring doc updates.

## Training
N/A

## Certification
N/A — minor UX enhancement, no certification content impact.

## Marketing
N/A — internal UX improvement.

## Automation tests
- Unit tests
     N/A
- Integration tests
    N/A

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (frontend TypeScript, no Java)
- Confirmed no keys/passwords/tokens/secrets committed: yes

## Samples
N/A

## Related PRs
None

## Migrations
N/A

## Test environment
dev build

## Learning
Reused the existing `.env` upload/parse pattern from `EnvironmentVariable.tsx` and `EnvVariableEditor.tsx` rather than reinventing parsing logic, keeping the interaction consistent across the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for uploading `.env` files in the runtime configuration editor.
  - Pasted `KEY=VALUE` content is now parsed into configuration entries automatically.
  - Matching quote wrappers are removed from pasted values.
  - Imported settings can update existing entries or create new ones.
  - Blank placeholder rows are removed when configuration data is imported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->