### PR TITLE
fix: derive MCP runtime variables from the proxy's actual security type

### DIFF
--- a/console/workspaces/libs/shared-component/src/components/EnvironmentVariablesReference/EnvironmentVariablesReference.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentVariablesReference/EnvironmentVariablesReference.tsx
@@ -18,15 +18,9 @@
 import { type ChangeEvent, type ReactNode } from "react";
 import { Alert, Box, ListingTable, Stack, Typography } from "@wso2/oxygen-ui";
 import { TextInput } from "@agent-management-platform/views";
+import type { EnvVarReferenceRow } from "../../utils/mcpEnvVarSpec";
 
-export interface EnvVarReferenceRow {
-  /** Canonical key identifying the variable. */
-  key: string;
-  /** The (possibly user-overridden) environment variable name. */
-  name: string;
-  /** Human-readable description of what the variable holds. */
-  description?: string;
-}
+export type { EnvVarReferenceRow };
 
 interface EnvironmentVariablesReferenceProps {
   /** Heading text; override when a page shows more than one of these blocks. */

--- a/console/workspaces/libs/shared-component/src/components/EnvironmentVariablesReference/EnvironmentVariablesReference.tsx
+++ b/console/workspaces/libs/shared-component/src/components/EnvironmentVariablesReference/EnvironmentVariablesReference.tsx
@@ -27,7 +27,7 @@ interface EnvironmentVariablesReferenceProps {
   title?: string;
   /** Explanatory text rendered under the heading. */
   description: ReactNode;
-  rows: EnvVarReferenceRow[];
+  rows: readonly EnvVarReferenceRow[];
   /** Render in an info alert by default, or as plain drawer/page content. */
   variant?: "alert" | "plain";
   /**

--- a/console/workspaces/libs/shared-component/src/components/index.ts
+++ b/console/workspaces/libs/shared-component/src/components/index.ts
@@ -98,3 +98,6 @@ export {
   type EnvironmentGatewaySelectorProps,
   type EnvironmentGatewaySelectorViewProps,
 } from "./EnvironmentGatewaySelector/EnvironmentGatewaySelector";
+// EnvVarReferenceRow is intentionally not re-exported here — it originates in
+// utils/mcpEnvVarSpec, which the package index already re-exports.
+export { EnvironmentVariablesReference } from "./EnvironmentVariablesReference/EnvironmentVariablesReference";

--- a/console/workspaces/libs/shared-component/src/index.ts
+++ b/console/workspaces/libs/shared-component/src/index.ts
@@ -26,3 +26,6 @@ export * from './utils/gatewayScripts';
 export * from './utils/clipboard';
 export * from './utils/openApiSpec';
 export * from './utils/githubUrl';
+export * from './utils/mcpEndpointSecurity';
+export * from './utils/mcpEnvVarSpec';
+export * from './utils/useMCPProxySecurity';

--- a/console/workspaces/libs/shared-component/src/utils/mcpEndpointSecurity.ts
+++ b/console/workspaces/libs/shared-component/src/utils/mcpEndpointSecurity.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { MCPEndpointConfig } from "@agent-management-platform/types";
+
+/** How one MCP endpoint is secured. `""` is the "None" option in the UI. */
+export type AuthenticationType = "apiKey" | "identity" | "";
+
+const AUTHENTICATION_TYPE_LABELS: Record<AuthenticationType, string> = {
+  "": "None",
+  apiKey: "API Key",
+  identity: "OAuth",
+};
+
+// Display label for an AuthenticationType, shared by the Security tab's method
+// selector and the Overview tab's Auth Type summary so both stay in sync.
+export function getAuthenticationTypeLabel(type: AuthenticationType): string {
+  return AUTHENTICATION_TYPE_LABELS[type];
+}
+
+export function isAPIKeySecurityEnabled(
+  config: MCPEndpointConfig | undefined,
+): boolean {
+  const apiKeyConfig = config?.security?.apiKey;
+  return (
+    config?.security?.enabled !== false &&
+    !!apiKeyConfig &&
+    apiKeyConfig.enabled !== false
+  );
+}
+
+// Used by resolveAuthenticationType below to derive the Security tab's
+// active auth method from the endpoint's security config.
+function isIdentitySecurityEnabled(
+  config: MCPEndpointConfig | undefined,
+): boolean {
+  return (
+    config?.security?.enabled !== false &&
+    config?.security?.identity?.enabled === true
+  );
+}
+
+/**
+ * Derives which authentication method is active from the endpoint's security
+ * config. The single rule behind the MCP Servers Security tab (method selector),
+ * the Overview tab (Auth Type summary), and the runtime variables the agent
+ * creation and configuration pages ask for.
+ *
+ * Note that "None" is not the absence of a security object: the Security tab
+ * saves it as `enabled: true` with both `apiKey.enabled` and `identity.enabled`
+ * false. Anything that infers "API key" from "not identity" therefore gets None
+ * wrong, which is what issue #1597 originally exposed for OAuth.
+ */
+export function resolveAuthenticationType(
+  config: MCPEndpointConfig | undefined,
+): AuthenticationType {
+  if (isAPIKeySecurityEnabled(config)) return "apiKey";
+  if (isIdentitySecurityEnabled(config)) return "identity";
+  return "";
+}

--- a/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.test.ts
+++ b/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.test.ts
@@ -23,6 +23,7 @@ import {
   resolveMCPEndpointForEnvironment,
   resolveMCPEnvVarSpec,
   resolveProxyAuthenticationType,
+  resolveProxyEnvVarSpec,
 } from "./mcpEnvVarSpec";
 
 // The three options the MCP Servers Security tab offers, in the exact shape it
@@ -128,6 +129,25 @@ describe("resolveMCPEnvVarSpec", () => {
       "AMP_AGENTID_SCOPES",
     ]);
   });
+
+  // The rows are frozen, not just re-spread per call: a shared row object one
+  // caller mutated would silently corrupt every other caller's constant. This
+  // is a stronger guarantee than cloning, which still leaves each clone open to
+  // drifting from the source independently.
+  it("freezes the AgentID rows so a returned row cannot be mutated", () => {
+    const [firstRow] = resolveMCPEnvVarSpec("identity").referenceRows;
+
+    expect(() => {
+      firstRow.name = "MUTATED";
+    }).toThrow();
+
+    expect(resolveMCPEnvVarSpec("identity").referenceRows[0]).toEqual(
+      AGENTID_ENV_VAR_ROWS[0],
+    );
+    expect(resolveMCPEnvVarSpec("identity").referenceRows[0].name).toBe(
+      "AMP_AGENTID_CLIENT_ID",
+    );
+  });
 });
 
 describe("resolveMCPEndpointForEnvironment", () => {
@@ -206,5 +226,66 @@ describe("resolveProxyAuthenticationType", () => {
     expect(resolveProxyAuthenticationType(proxyWith([]))).toBe("");
     expect(resolveProxyAuthenticationType(null)).toBe("");
     expect(resolveProxyAuthenticationType(undefined)).toBe("");
+  });
+});
+
+describe("resolveProxyEnvVarSpec", () => {
+  it("offers both keys and no reference rows when every endpoint is apiKey", () => {
+    const spec = resolveProxyEnvVarSpec(
+      proxyWith([{ id: "a", security: apiKey }, { id: "b", security: apiKey }]),
+    );
+    expect(spec.editableKeys).toEqual(["url", "apikey"]);
+    expect(spec.referenceRows).toEqual([]);
+  });
+
+  it("drops the api key and shows the AgentID rows when every endpoint is identity", () => {
+    const spec = resolveProxyEnvVarSpec(
+      proxyWith([{ id: "a", security: identity }, { id: "b", security: identity }]),
+    );
+    expect(spec.editableKeys).toEqual(["url"]);
+    expect(spec.referenceRows).toEqual(AGENTID_ENV_VAR_ROWS);
+  });
+
+  // The bug resolveProxyEnvVarSpec exists to fix: resolveProxyAuthenticationType
+  // collapses this same proxy to "apiKey" alone (so the field stays nameable),
+  // but the OAuth endpoint still needs its reference rows shown. Deriving the
+  // spec from that single collapsed label would silently drop them.
+  it("keeps both the api key field and the AgentID rows for a mixed apiKey+identity proxy", () => {
+    const spec = resolveProxyEnvVarSpec(
+      proxyWith([{ id: "a", security: apiKey }, { id: "b", security: identity }]),
+    );
+    expect(spec.editableKeys).toEqual(["url", "apikey"]);
+    expect(spec.referenceRows).toEqual(AGENTID_ENV_VAR_ROWS);
+  });
+
+  it("offers only the url when every endpoint is unsecured", () => {
+    const spec = resolveProxyEnvVarSpec(
+      proxyWith([{ id: "a", security: none }, { id: "b", security: none }]),
+    );
+    expect(spec.editableKeys).toEqual(["url"]);
+    expect(spec.referenceRows).toEqual([]);
+  });
+
+  it("shows the AgentID rows for a mix of unsecured and identity, with no api key field", () => {
+    const spec = resolveProxyEnvVarSpec(
+      proxyWith([{ id: "a", security: none }, { id: "b", security: identity }]),
+    );
+    expect(spec.editableKeys).toEqual(["url"]);
+    expect(spec.referenceRows).toEqual(AGENTID_ENV_VAR_ROWS);
+  });
+
+  it("offers only the url when the proxy has no endpoints", () => {
+    expect(resolveProxyEnvVarSpec(proxyWith([]))).toEqual({
+      editableKeys: ["url"],
+      referenceRows: [],
+    });
+    expect(resolveProxyEnvVarSpec(null)).toEqual({
+      editableKeys: ["url"],
+      referenceRows: [],
+    });
+    expect(resolveProxyEnvVarSpec(undefined)).toEqual({
+      editableKeys: ["url"],
+      referenceRows: [],
+    });
   });
 });

--- a/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.test.ts
+++ b/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { MCPProxy, SecurityConfig } from "@agent-management-platform/types";
+import { resolveAuthenticationType } from "./mcpEndpointSecurity";
+import {
+  AGENTID_ENV_VAR_ROWS,
+  resolveMCPEndpointForEnvironment,
+  resolveMCPEnvVarSpec,
+  resolveProxyAuthenticationType,
+} from "./mcpEnvVarSpec";
+
+// The three options the MCP Servers Security tab offers, in the exact shape it
+// saves them (MCPProxySecurityTab always writes enabled: true and flips only the
+// two sub-flags — so "none" is NOT the absence of a security object).
+const apiKey: SecurityConfig = {
+  enabled: true,
+  apiKey: { enabled: true, key: "X-API-Key", in: "header" },
+  identity: { enabled: false },
+};
+const identity: SecurityConfig = {
+  enabled: true,
+  apiKey: { enabled: false, key: "", in: "header" },
+  identity: { enabled: true },
+};
+const none: SecurityConfig = {
+  enabled: true,
+  apiKey: { enabled: false, key: "", in: "header" },
+  identity: { enabled: false },
+};
+
+function proxyWith(
+  endpoints: { id: string; security?: SecurityConfig; envs?: string[] }[],
+): Pick<MCPProxy, "endpoints"> {
+  return {
+    endpoints: endpoints.map((endpoint) => ({
+      id: endpoint.id,
+      security: endpoint.security,
+      environments: (endpoint.envs ?? []).map((environmentUuid) => ({
+        environmentUuid,
+      })),
+    })),
+  };
+}
+
+describe("resolveAuthenticationType", () => {
+  it("reads the three Security tab options back correctly", () => {
+    expect(resolveAuthenticationType({ security: apiKey })).toBe("apiKey");
+    expect(resolveAuthenticationType({ security: identity })).toBe("identity");
+    expect(resolveAuthenticationType({ security: none })).toBe("");
+  });
+
+  it("treats a missing security object as none", () => {
+    expect(resolveAuthenticationType({})).toBe("");
+    expect(resolveAuthenticationType(undefined)).toBe("");
+  });
+
+  it("treats security.enabled false as none whatever the sub-flags say", () => {
+    expect(
+      resolveAuthenticationType({
+        security: { enabled: false, apiKey: { enabled: true } },
+      }),
+    ).toBe("");
+    expect(
+      resolveAuthenticationType({
+        security: { enabled: false, identity: { enabled: true } },
+      }),
+    ).toBe("");
+  });
+});
+
+describe("resolveMCPEnvVarSpec", () => {
+  it("offers both keys and no reference rows for an API-key endpoint", () => {
+    const spec = resolveMCPEnvVarSpec("apiKey");
+    expect(spec.editableKeys).toEqual(["url", "apikey"]);
+    expect(spec.referenceRows).toEqual([]);
+  });
+
+  it("drops the api key and shows the AgentID rows for OAuth", () => {
+    const spec = resolveMCPEnvVarSpec("identity");
+    expect(spec.editableKeys).toEqual(["url"]);
+    expect(spec.referenceRows).toEqual(AGENTID_ENV_VAR_ROWS);
+  });
+
+  // An unsecured endpoint has no credential of any kind, so the URL is the whole
+  // contract — an API key field here would produce a permanently empty env var.
+  it("offers only the url and no reference rows when security is none", () => {
+    const spec = resolveMCPEnvVarSpec("");
+    expect(spec.editableKeys).toEqual(["url"]);
+    expect(spec.referenceRows).toEqual([]);
+  });
+
+  it("always offers the url, whatever the security", () => {
+    for (const type of ["apiKey", "identity", ""] as const) {
+      expect(resolveMCPEnvVarSpec(type).editableKeys).toContain("url");
+    }
+  });
+
+  it("returns a fresh editableKeys array so callers cannot mutate the constant", () => {
+    resolveMCPEnvVarSpec("apiKey").editableKeys.push("url");
+    expect(resolveMCPEnvVarSpec("apiKey").editableKeys).toEqual(["url", "apikey"]);
+  });
+
+  it("names exactly the four AgentID variables the platform injects", () => {
+    expect(AGENTID_ENV_VAR_ROWS.map((row) => row.name)).toEqual([
+      "AMP_AGENTID_CLIENT_ID",
+      "AMP_AGENTID_CLIENT_SECRET",
+      "AMP_AGENTID_TOKEN_ENDPOINT",
+      "AMP_AGENTID_SCOPES",
+    ]);
+  });
+});
+
+describe("resolveMCPEndpointForEnvironment", () => {
+  it("picks the endpoint bound to the requested environment", () => {
+    const proxy = proxyWith([
+      { id: "e1", security: apiKey, envs: ["dev-uuid"] },
+      { id: "e2", security: identity, envs: ["prod-uuid"] },
+    ]);
+    expect(resolveMCPEndpointForEnvironment(proxy, "prod-uuid")?.id).toBe("e2");
+    expect(resolveMCPEndpointForEnvironment(proxy, "dev-uuid")?.id).toBe("e1");
+  });
+
+  it("is undefined when no endpoint is bound to that environment", () => {
+    const proxy = proxyWith([{ id: "e1", security: identity, envs: ["dev-uuid"] }]);
+    expect(resolveMCPEndpointForEnvironment(proxy, "staging-uuid")).toBeUndefined();
+  });
+
+  it("is undefined without an environment uuid", () => {
+    const proxy = proxyWith([{ id: "e1", security: identity, envs: ["dev-uuid"] }]);
+    expect(resolveMCPEndpointForEnvironment(proxy, undefined)).toBeUndefined();
+  });
+
+  it("is undefined for a missing or endpointless proxy", () => {
+    expect(resolveMCPEndpointForEnvironment(null, "dev-uuid")).toBeUndefined();
+    expect(resolveMCPEndpointForEnvironment(undefined, "dev-uuid")).toBeUndefined();
+    expect(resolveMCPEndpointForEnvironment(proxyWith([]), "dev-uuid")).toBeUndefined();
+  });
+
+  // The reason this resolver returns the endpoint rather than its security: an
+  // unsecured bound endpoint must read as "none", not as "look elsewhere".
+  it("finds an endpoint that carries no security config at all", () => {
+    const proxy = proxyWith([
+      { id: "bare", envs: ["dev-uuid"] },
+      { id: "oauth", security: identity, envs: ["prod-uuid"] },
+    ]);
+    const endpoint = resolveMCPEndpointForEnvironment(proxy, "dev-uuid");
+    expect(endpoint?.id).toBe("bare");
+    expect(resolveAuthenticationType(endpoint)).toBe("");
+  });
+});
+
+describe("resolveProxyAuthenticationType", () => {
+  it("is identity only when every endpoint uses identity", () => {
+    expect(
+      resolveProxyAuthenticationType(
+        proxyWith([{ id: "a", security: identity }, { id: "b", security: identity }]),
+      ),
+    ).toBe("identity");
+  });
+
+  it("is apiKey when any endpoint needs a key, so mixed security keeps the field", () => {
+    expect(
+      resolveProxyAuthenticationType(
+        proxyWith([{ id: "a", security: identity }, { id: "b", security: apiKey }]),
+      ),
+    ).toBe("apiKey");
+  });
+
+  it("is none when every endpoint is unsecured", () => {
+    expect(
+      resolveProxyAuthenticationType(
+        proxyWith([{ id: "a", security: none }, { id: "b", security: none }]),
+      ),
+    ).toBe("");
+  });
+
+  it("is none for a mix of unsecured and OAuth, since neither needs a key", () => {
+    expect(
+      resolveProxyAuthenticationType(
+        proxyWith([{ id: "a", security: none }, { id: "b", security: identity }]),
+      ),
+    ).toBe("");
+  });
+
+  it("is none when the proxy has no endpoints", () => {
+    expect(resolveProxyAuthenticationType(proxyWith([]))).toBe("");
+    expect(resolveProxyAuthenticationType(null)).toBe("");
+    expect(resolveProxyAuthenticationType(undefined)).toBe("");
+  });
+});

--- a/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.test.ts
+++ b/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.test.ts
@@ -111,9 +111,13 @@ describe("resolveMCPEnvVarSpec", () => {
     }
   });
 
-  it("returns a fresh editableKeys array so callers cannot mutate the constant", () => {
+  it("returns fresh arrays so callers cannot mutate the shared constants", () => {
     resolveMCPEnvVarSpec("apiKey").editableKeys.push("url");
     expect(resolveMCPEnvVarSpec("apiKey").editableKeys).toEqual(["url", "apikey"]);
+
+    resolveMCPEnvVarSpec("identity").referenceRows.pop();
+    expect(resolveMCPEnvVarSpec("identity").referenceRows).toEqual(AGENTID_ENV_VAR_ROWS);
+    expect(AGENTID_ENV_VAR_ROWS).toHaveLength(4);
   });
 
   it("names exactly the four AgentID variables the platform injects", () => {

--- a/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.ts
+++ b/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { MCPProxy, MCPProxyEndpoint } from "@agent-management-platform/types";
+import {
+  resolveAuthenticationType,
+  type AuthenticationType,
+} from "./mcpEndpointSecurity";
+
+/**
+ * One row in an "Environment Variables References" table: a variable the
+ * platform injects into the agent deployment, with the (possibly
+ * user-overridden) name the agent code reads.
+ */
+export interface EnvVarReferenceRow {
+  /** Canonical key identifying the variable. */
+  key: string;
+  /** The (possibly user-overridden) environment variable name. */
+  name: string;
+  /** Human-readable description of what the variable holds. */
+  description?: string;
+}
+
+/**
+ * The env var keys a user can name for a tool binding. `apikey` only applies to
+ * API-key-secured endpoints — see {@link resolveMCPEnvVarSpec}.
+ */
+export const ENV_VAR_KEYS = ["url", "apikey"] as const;
+
+export type EnvVarKey = (typeof ENV_VAR_KEYS)[number];
+
+/**
+ * The OAuth (AgentID) variables the platform injects for an identity-secured MCP
+ * endpoint. Their names are fixed — only their values vary per environment — so
+ * they are reference-only and never user-editable.
+ */
+export const AGENTID_ENV_VAR_ROWS: EnvVarReferenceRow[] = [
+  {
+    key: "clientId",
+    name: "AMP_AGENTID_CLIENT_ID",
+    description: "This agent's OAuth2 client ID for this environment",
+  },
+  {
+    key: "clientSecret",
+    name: "AMP_AGENTID_CLIENT_SECRET",
+    description: "This agent's OAuth2 client secret for this environment",
+  },
+  {
+    key: "tokenEndpoint",
+    name: "AMP_AGENTID_TOKEN_ENDPOINT",
+    description: "Token endpoint to call with a client_credentials grant",
+  },
+  {
+    key: "scopes",
+    name: "AMP_AGENTID_SCOPES",
+    description: "Space-separated scopes to request for this tool's actions",
+  },
+];
+
+/**
+ * The endpoint bound to `environmentUuid`, or undefined when the proxy has none.
+ * Mirrors the server's per-environment resolution (`resolveMCPEndpointForEnv`),
+ * which is the model the agent-creation flow follows because it targets exactly
+ * one environment.
+ *
+ * Callers must branch on the *endpoint* rather than on its `security`, because a
+ * bound endpoint with no security config means "unsecured", which is a different
+ * answer from "no endpoint here".
+ */
+export function resolveMCPEndpointForEnvironment(
+  proxy: Pick<MCPProxy, "endpoints"> | null | undefined,
+  environmentUuid: string | undefined,
+): MCPProxyEndpoint | undefined {
+  if (!proxy?.endpoints?.length || !environmentUuid) return undefined;
+  return proxy.endpoints.find((candidate) =>
+    (candidate.environments ?? []).some(
+      (binding) => binding.environmentUuid === environmentUuid,
+    ),
+  );
+}
+
+/**
+ * The proxy's authentication type collapsed across all of its endpoints. This is
+ * the environment-agnostic rule, used when a single binding maps every
+ * environment to one proxy at once (the agent-configuration flow).
+ *
+ * A proxy counts as OAuth only when every endpoint is; otherwise any endpoint
+ * needing an API key keeps the API key field available, since a mixed-security
+ * proxy must still be nameable. A proxy whose endpoints are all unsecured (or a
+ * mix of unsecured and OAuth) needs no API key at all.
+ */
+export function resolveProxyAuthenticationType(
+  proxy: Pick<MCPProxy, "endpoints"> | null | undefined,
+): AuthenticationType {
+  const endpoints = proxy?.endpoints ?? [];
+  if (endpoints.length === 0) return "";
+  const types = endpoints.map((endpoint) => resolveAuthenticationType(endpoint));
+  if (types.every((type) => type === "identity")) return "identity";
+  if (types.some((type) => type === "apiKey")) return "apiKey";
+  return "";
+}
+
+/** Which env vars a tool binding exposes, given how the endpoint is secured. */
+export interface MCPEnvVarSpec {
+  /** Keys the user can name. OAuth endpoints still need the URL. */
+  editableKeys: EnvVarKey[];
+  /** Fixed, platform-injected variables to show for reference only. */
+  referenceRows: EnvVarReferenceRow[];
+}
+
+/**
+ * The single source of truth for "which runtime variables does this MCP tool
+ * binding need?". Both the agent-creation and agent-configuration flows derive
+ * their field set from here so the two cannot drift apart again (issue #1597).
+ *
+ * Only an API-key endpoint has a key for the user to name. An OAuth (AgentID)
+ * endpoint mints its credentials server-side and gets the fixed AMP_AGENTID_*
+ * variables instead; an unsecured endpoint needs no credential at all. Offering
+ * the API key field in either case produces an environment variable the platform
+ * injects permanently empty. The URL is needed in all three cases.
+ */
+export function resolveMCPEnvVarSpec(
+  authenticationType: AuthenticationType,
+): MCPEnvVarSpec {
+  switch (authenticationType) {
+    case "apiKey":
+      return { editableKeys: [...ENV_VAR_KEYS], referenceRows: [] };
+    case "identity":
+      return { editableKeys: ["url"], referenceRows: AGENTID_ENV_VAR_ROWS };
+    default:
+      return { editableKeys: ["url"], referenceRows: [] };
+  }
+}

--- a/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.ts
+++ b/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.ts
@@ -48,28 +48,29 @@ export type EnvVarKey = (typeof ENV_VAR_KEYS)[number];
  * endpoint. Their names are fixed — only their values vary per environment — so
  * they are reference-only and never user-editable.
  */
-export const AGENTID_ENV_VAR_ROWS: EnvVarReferenceRow[] = [
-  {
+export const AGENTID_ENV_VAR_ROWS: readonly EnvVarReferenceRow[] = [
+  Object.freeze({
     key: "clientId",
     name: "AMP_AGENTID_CLIENT_ID",
     description: "This agent's OAuth2 client ID for this environment",
-  },
-  {
+  }),
+  Object.freeze({
     key: "clientSecret",
     name: "AMP_AGENTID_CLIENT_SECRET",
     description: "This agent's OAuth2 client secret for this environment",
-  },
-  {
+  }),
+  Object.freeze({
     key: "tokenEndpoint",
     name: "AMP_AGENTID_TOKEN_ENDPOINT",
     description: "Token endpoint to call with a client_credentials grant",
-  },
-  {
+  }),
+  Object.freeze({
     key: "scopes",
     name: "AMP_AGENTID_SCOPES",
     description: "Space-separated scopes to request for this tool's actions",
-  },
+  }),
 ];
+Object.freeze(AGENTID_ENV_VAR_ROWS);
 
 /**
  * The endpoint bound to `environmentUuid`, or undefined when the proxy has none.
@@ -144,4 +145,33 @@ export function resolveMCPEnvVarSpec(
     default:
       return { editableKeys: ["url"], referenceRows: [] };
   }
+}
+
+/**
+ * The env var spec for a proxy considered across *all* of its endpoints at
+ * once — used by the agent-configuration flow, which binds every environment
+ * to the same proxy in a single call.
+ *
+ * Deriving this from {@link resolveProxyAuthenticationType} would collapse a
+ * mixed proxy to one label first and lose information: a proxy with one
+ * API-key endpoint and one OAuth endpoint resolves to `"apiKey"` (so the field
+ * stays nameable), but feeding that single label into
+ * {@link resolveMCPEnvVarSpec} would then drop the AgentID reference rows the
+ * OAuth endpoint still needs. This resolver unions each endpoint's actual
+ * requirement instead: the API key field is offered if any endpoint needs one,
+ * and the AgentID rows are shown if any endpoint uses OAuth — independently of
+ * each other.
+ */
+export function resolveProxyEnvVarSpec(
+  proxy: Pick<MCPProxy, "endpoints"> | null | undefined,
+): MCPEnvVarSpec {
+  const types = (proxy?.endpoints ?? []).map((endpoint) =>
+    resolveAuthenticationType(endpoint),
+  );
+  const needsAPIKey = types.some((type) => type === "apiKey");
+  const needsIdentity = types.some((type) => type === "identity");
+  return {
+    editableKeys: needsAPIKey ? [...ENV_VAR_KEYS] : ["url"],
+    referenceRows: needsIdentity ? [...AGENTID_ENV_VAR_ROWS] : [],
+  };
 }

--- a/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.ts
+++ b/console/workspaces/libs/shared-component/src/utils/mcpEnvVarSpec.ts
@@ -140,7 +140,7 @@ export function resolveMCPEnvVarSpec(
     case "apiKey":
       return { editableKeys: [...ENV_VAR_KEYS], referenceRows: [] };
     case "identity":
-      return { editableKeys: ["url"], referenceRows: AGENTID_ENV_VAR_ROWS };
+      return { editableKeys: ["url"], referenceRows: [...AGENTID_ENV_VAR_ROWS] };
     default:
       return { editableKeys: ["url"], referenceRows: [] };
   }

--- a/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.test.ts
+++ b/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { MCPProxy, SecurityConfig } from "@agent-management-platform/types";
+
+const useGetMCPProxy = vi.fn();
+vi.mock("@agent-management-platform/api-client", () => ({
+  useGetMCPProxy: (...args: unknown[]) => useGetMCPProxy(...args),
+}));
+
+const { useMCPProxySecurity } = await import("./useMCPProxySecurity");
+
+const apiKey: SecurityConfig = {
+  enabled: true,
+  apiKey: { enabled: true, key: "X-API-Key", in: "header" },
+  identity: { enabled: false },
+};
+const identity: SecurityConfig = {
+  enabled: true,
+  apiKey: { enabled: false, key: "", in: "header" },
+  identity: { enabled: true },
+};
+const none: SecurityConfig = {
+  enabled: true,
+  apiKey: { enabled: false, key: "", in: "header" },
+  identity: { enabled: false },
+};
+
+function proxy(
+  endpoints: { id: string; security?: SecurityConfig; envs?: string[] }[],
+): MCPProxy {
+  return {
+    id: "proxy-1",
+    name: "weather",
+    version: "1.0.0",
+    endpoints: endpoints.map((endpoint) => ({
+      id: endpoint.id,
+      security: endpoint.security,
+      environments: (endpoint.envs ?? []).map((environmentUuid) => ({
+        environmentUuid,
+      })),
+    })),
+  };
+}
+
+/** Shape react-query returns in the states this hook branches on. */
+function query({
+  data,
+  isLoading = false,
+  isError = false,
+}: {
+  data?: MCPProxy;
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  useGetMCPProxy.mockReturnValue({ data, isLoading, isError });
+}
+
+beforeEach(() => {
+  useGetMCPProxy.mockReset();
+});
+
+describe("useMCPProxySecurity", () => {
+  it("scopes the answer to the selected environment's endpoint", () => {
+    query({
+      data: proxy([
+        { id: "dev", security: apiKey, envs: ["dev-uuid"] },
+        { id: "prod", security: identity, envs: ["prod-uuid"] },
+      ]),
+    });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({
+        orgName: "acme",
+        proxyId: "proxy-1",
+        environmentUuid: "prod-uuid",
+      }),
+    );
+
+    expect(result.current.authenticationType).toBe("identity");
+    expect(result.current.usesIdentitySecurity).toBe(true);
+    expect(result.current.spec.editableKeys).toEqual(["url"]);
+    expect(result.current.isResolved).toBe(true);
+  });
+
+  it("falls back to the every-endpoint rule when the environment has no uuid", () => {
+    query({
+      data: proxy([
+        { id: "a", security: identity, envs: ["dev-uuid"] },
+        { id: "b", security: apiKey, envs: ["prod-uuid"] },
+      ]),
+    });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({ orgName: "acme", proxyId: "proxy-1" }),
+    );
+
+    // Mixed security keeps the API key field available.
+    expect(result.current.authenticationType).toBe("apiKey");
+    expect(result.current.spec.editableKeys).toEqual(["url", "apikey"]);
+  });
+
+  it("reports none for an unsecured endpoint, with no api key and no reference rows", () => {
+    query({ data: proxy([{ id: "a", security: none, envs: ["dev-uuid"] }]) });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({
+        orgName: "acme",
+        proxyId: "proxy-1",
+        environmentUuid: "dev-uuid",
+      }),
+    );
+
+    expect(result.current.authenticationType).toBe("");
+    expect(result.current.spec.editableKeys).toEqual(["url"]);
+    expect(result.current.spec.referenceRows).toEqual([]);
+    expect(result.current.isResolved).toBe(true);
+  });
+
+  it("is not resolved while the fetch is in flight", () => {
+    query({ isLoading: true });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({ orgName: "acme", proxyId: "proxy-1" }),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isResolved).toBe(false);
+  });
+
+  // The regression this guards: react-query reports isLoading false once a fetch
+  // errors, so a failed load looks exactly like a genuinely unsecured endpoint.
+  // Callers that trusted authenticationType would hide the API key field and drop
+  // the variable from the payload — issue #1597 with the polarity reversed.
+  it("is not resolved when the fetch failed, even though it reports none", () => {
+    query({ isError: true });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({ orgName: "acme", proxyId: "proxy-1" }),
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isResolved).toBe(false);
+    expect(result.current.authenticationType).toBe("");
+  });
+
+  it("is resolved with nothing pending when no proxy is selected", () => {
+    query({ isLoading: true });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({ orgName: "acme", proxyId: null }),
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isResolved).toBe(true);
+  });
+
+  it("is not resolved when the proxy came back with no endpoints to judge", () => {
+    query({ data: undefined });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({ orgName: "acme", proxyId: "proxy-1" }),
+    );
+
+    expect(result.current.isResolved).toBe(false);
+  });
+});

--- a/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.test.ts
+++ b/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.test.ts
@@ -173,7 +173,7 @@ describe("useMCPProxySecurity", () => {
     expect(result.current.isResolved).toBe(true);
   });
 
-  it("is not resolved when the proxy came back with no endpoints to judge", () => {
+  it("is not resolved when the fetch returned no data at all", () => {
     query({ data: undefined });
 
     const { result } = renderHook(() =>
@@ -181,5 +181,21 @@ describe("useMCPProxySecurity", () => {
     );
 
     expect(result.current.isResolved).toBe(false);
+  });
+
+  // A proxy record that fetched successfully but has zero endpoints is not a
+  // state this hook can make a security determination from — a truthy `proxy`
+  // alone is not proof the answer is real.
+  it("is not resolved when the proxy fetched successfully but has no endpoints", () => {
+    query({ data: proxy([]) });
+
+    const { result } = renderHook(() =>
+      useMCPProxySecurity({ orgName: "acme", proxyId: "proxy-1" }),
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isResolved).toBe(false);
+    expect(result.current.authenticationType).toBe("");
   });
 });

--- a/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.ts
+++ b/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.ts
@@ -21,6 +21,7 @@ import {
   resolveMCPEndpointForEnvironment,
   resolveMCPEnvVarSpec,
   resolveProxyAuthenticationType,
+  resolveProxyEnvVarSpec,
   type MCPEnvVarSpec,
 } from "./mcpEnvVarSpec";
 import {
@@ -87,22 +88,39 @@ export function useMCPProxySecurity({
     proxyId: proxyId ?? "",
   });
 
+  // Resolved once, then reused: authenticationType needs it to derive one
+  // label, and — for the fallback case — spec needs the whole proxy anyway to
+  // union each endpoint's requirement rather than derive from that one label.
+  const scopedEndpoint = useMemo(
+    () =>
+      proxyId && proxy
+        ? resolveMCPEndpointForEnvironment(proxy, environmentUuid)
+        : undefined,
+    [proxy, proxyId, environmentUuid],
+  );
+
   const authenticationType = useMemo<AuthenticationType>(() => {
     if (!proxyId || !proxy) return "";
-    const scopedEndpoint = resolveMCPEndpointForEnvironment(proxy, environmentUuid);
-    if (scopedEndpoint) {
-      return resolveAuthenticationType(scopedEndpoint);
-    }
+    if (scopedEndpoint) return resolveAuthenticationType(scopedEndpoint);
     return resolveProxyAuthenticationType(proxy);
-  }, [proxy, proxyId, environmentUuid]);
+  }, [proxy, proxyId, scopedEndpoint]);
 
-  const spec = useMemo(
-    () => resolveMCPEnvVarSpec(authenticationType),
-    [authenticationType],
-  );
+  const spec = useMemo<MCPEnvVarSpec>(() => {
+    if (!proxyId || !proxy) return resolveMCPEnvVarSpec("");
+    // Scoped to one endpoint: a single label is the whole answer.
+    if (scopedEndpoint) return resolveMCPEnvVarSpec(authenticationType);
+    // Environment-agnostic: union every endpoint's requirement instead of
+    // collapsing to one label first, or a proxy mixing an API-key endpoint
+    // with an OAuth endpoint would lose the OAuth reference rows.
+    return resolveProxyEnvVarSpec(proxy);
+  }, [proxy, proxyId, scopedEndpoint, authenticationType]);
 
   // No proxy selected yet means nothing to wait for, whatever the query says.
   const hasProxy = Boolean(proxyId);
+  // A proxy that fetched successfully but reports zero endpoints is not a
+  // state this hook can make a security determination from — treat it the
+  // same as an unresolved fetch rather than silently defaulting to None.
+  const hasEndpoints = Boolean(proxy?.endpoints?.length);
 
   return {
     authenticationType,
@@ -111,7 +129,8 @@ export function useMCPProxySecurity({
     isLoading: hasProxy && isLoading,
     isError: hasProxy && isError,
     // React Query reports isLoading false once a fetch errors, so `proxy` being
-    // present is the only thing that proves the answer is real.
-    isResolved: !hasProxy || Boolean(proxy),
+    // present (with endpoints to judge) is the only thing that proves the
+    // answer is real.
+    isResolved: !hasProxy || hasEndpoints,
   };
 }

--- a/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.ts
+++ b/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.ts
@@ -49,6 +49,21 @@ export interface UseMCPProxySecurityResult {
   spec: MCPEnvVarSpec;
   /** The proxy fetch is still in flight, so `spec` is not yet trustworthy. */
   isLoading: boolean;
+  /** The proxy fetch failed, so the security kind is unknown. */
+  isError: boolean;
+  /**
+   * `spec` reflects the proxy's real security. False while loading, on a failed
+   * fetch, and when the proxy came back empty.
+   *
+   * Callers MUST gate on this rather than reading `authenticationType`
+   * directly. An unresolved fetch yields `""`, which is indistinguishable from a
+   * genuinely unsecured endpoint — and acting on it hides the API key field and
+   * drops the variable from the payload, the same silent-empty-credential
+   * failure as issue #1597 with the polarity reversed. There is no safe guess
+   * here: assuming "apiKey" reintroduces #1597 for OAuth proxies. Surface the
+   * error instead.
+   */
+  isResolved: boolean;
 }
 
 /**
@@ -67,7 +82,7 @@ export function useMCPProxySecurity({
   proxyId,
   environmentUuid,
 }: UseMCPProxySecurityParams): UseMCPProxySecurityResult {
-  const { data: proxy, isLoading } = useGetMCPProxy({
+  const { data: proxy, isLoading, isError } = useGetMCPProxy({
     orgName,
     proxyId: proxyId ?? "",
   });
@@ -86,11 +101,17 @@ export function useMCPProxySecurity({
     [authenticationType],
   );
 
+  // No proxy selected yet means nothing to wait for, whatever the query says.
+  const hasProxy = Boolean(proxyId);
+
   return {
     authenticationType,
     usesIdentitySecurity: authenticationType === "identity",
     spec,
-    // No proxy selected yet means nothing to wait for, whatever the query says.
-    isLoading: Boolean(proxyId) && isLoading,
+    isLoading: hasProxy && isLoading,
+    isError: hasProxy && isError,
+    // React Query reports isLoading false once a fetch errors, so `proxy` being
+    // present is the only thing that proves the answer is real.
+    isResolved: !hasProxy || Boolean(proxy),
   };
 }

--- a/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.ts
+++ b/console/workspaces/libs/shared-component/src/utils/useMCPProxySecurity.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useMemo } from "react";
+import { useGetMCPProxy } from "@agent-management-platform/api-client";
+import {
+  resolveMCPEndpointForEnvironment,
+  resolveMCPEnvVarSpec,
+  resolveProxyAuthenticationType,
+  type MCPEnvVarSpec,
+} from "./mcpEnvVarSpec";
+import {
+  resolveAuthenticationType,
+  type AuthenticationType,
+} from "./mcpEndpointSecurity";
+
+export interface UseMCPProxySecurityParams {
+  orgName?: string;
+  /** The MCP proxy the tool binding points at. Empty disables the fetch. */
+  proxyId?: string | null;
+  /**
+   * Scope the answer to one environment's endpoint. Omit (or pass undefined,
+   * which happens when the environment carries no uuid) to fall back to the
+   * environment-agnostic every-endpoint rule.
+   */
+  environmentUuid?: string;
+}
+
+export interface UseMCPProxySecurityResult {
+  /** How the resolved endpoint is secured: API key, OAuth, or none. */
+  authenticationType: AuthenticationType;
+  /** True when the resolved endpoint is secured with OAuth (AgentID). */
+  usesIdentitySecurity: boolean;
+  /** Which env vars to offer and which to show for reference. */
+  spec: MCPEnvVarSpec;
+  /** The proxy fetch is still in flight, so `spec` is not yet trustworthy. */
+  isLoading: boolean;
+}
+
+/**
+ * Resolves how an MCP proxy's endpoint is secured and, from that, which runtime
+ * variables a tool binding needs. `MCPProxyListItem` carries no security data, so
+ * the full proxy has to be fetched — this hook is the one place that does it.
+ *
+ * When `environmentUuid` is supplied and the proxy has an endpoint bound to it,
+ * the answer is that endpoint's security, matching the server's per-environment
+ * resolution. Otherwise it falls back to "every endpoint uses OAuth", which is
+ * the sound answer when one binding covers all environments at once, and also
+ * the safe answer when the environment simply has no uuid to match on.
+ */
+export function useMCPProxySecurity({
+  orgName,
+  proxyId,
+  environmentUuid,
+}: UseMCPProxySecurityParams): UseMCPProxySecurityResult {
+  const { data: proxy, isLoading } = useGetMCPProxy({
+    orgName,
+    proxyId: proxyId ?? "",
+  });
+
+  const authenticationType = useMemo<AuthenticationType>(() => {
+    if (!proxyId || !proxy) return "";
+    const scopedEndpoint = resolveMCPEndpointForEnvironment(proxy, environmentUuid);
+    if (scopedEndpoint) {
+      return resolveAuthenticationType(scopedEndpoint);
+    }
+    return resolveProxyAuthenticationType(proxy);
+  }, [proxy, proxyId, environmentUuid]);
+
+  const spec = useMemo(
+    () => resolveMCPEnvVarSpec(authenticationType),
+    [authenticationType],
+  );
+
+  return {
+    authenticationType,
+    usesIdentitySecurity: authenticationType === "identity",
+    spec,
+    // No proxy selected yet means nothing to wait for, whatever the query says.
+    isLoading: Boolean(proxyId) && isLoading,
+  };
+}

--- a/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
@@ -35,6 +35,7 @@ import { LLMProviderSection } from "./LLMProviderSection";
 import { MCPProxySection } from "./MCPProxySection";
 import { EnvironmentVariable } from "./EnvironmentVariable";
 import { FileMount } from "./FileMount";
+import { mcpEntryVarNames } from "../utils/mcpEnvVarNames";
 
 export const CatalogAgentFlow: React.FC = () => {
   const navigate = useNavigate();
@@ -163,10 +164,9 @@ export const CatalogAgentFlow: React.FC = () => {
         entry.urlVarName ?? `${agentNameUpper}_${index + 1}_URL`,
         entry.apikeyVarName ?? `${agentNameUpper}_${index + 1}_API_KEY`,
       ]),
-      ...mcpProxies.flatMap((entry, index) => [
-        entry.urlVarName ?? `${agentNameUpper}_MCP_${index + 1}_URL`,
-        entry.apikeyVarName ?? `${agentNameUpper}_MCP_${index + 1}_API_KEY`,
-      ]),
+      ...mcpProxies.flatMap((entry, index) =>
+        mcpEntryVarNames(entry, index, agentNameUpper),
+      ),
     ];
   }, [formData.displayName, llmProviders, mcpProxies]);
 
@@ -311,10 +311,7 @@ export const CatalogAgentFlow: React.FC = () => {
               : "AGENT";
             return new Set([
               ...(formData.env ?? []).map((e) => e.key).filter((k): k is string => !!k),
-              ...mcpProxies.flatMap((e, i) => [
-                e.urlVarName ?? `${agentNameUpper}_MCP_${i + 1}_URL`,
-                e.apikeyVarName ?? `${agentNameUpper}_MCP_${i + 1}_API_KEY`,
-              ]),
+              ...mcpProxies.flatMap((e, i) => mcpEntryVarNames(e, i, agentNameUpper)),
             ]);
           })()}
         />

--- a/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/CatalogAgentFlow.tsx
@@ -35,7 +35,10 @@ import { LLMProviderSection } from "./LLMProviderSection";
 import { MCPProxySection } from "./MCPProxySection";
 import { EnvironmentVariable } from "./EnvironmentVariable";
 import { FileMount } from "./FileMount";
-import { mcpEntryVarNames } from "../utils/mcpEnvVarNames";
+import {
+  hasUnresolvedMCPSecurity,
+  mcpEntryVarNames,
+} from "../utils/mcpEnvVarNames";
 
 export const CatalogAgentFlow: React.FC = () => {
   const navigate = useNavigate();
@@ -367,7 +370,8 @@ export const CatalogAgentFlow: React.FC = () => {
           onSubmit={handleDeploy}
           isNameEmpty={!formData.name.trim()}
           mode="deploy"
-          hasLLMVarConflicts={(() => {
+          hasUnresolvedMCPSecurity={hasUnresolvedMCPSecurity(mcpProxies)}
+        hasLLMVarConflicts={(() => {
             if (llmGeneratedNames.length !== llmReservedNames.size) return true;
             const envKeyList = (formData.env ?? [])
               .map((envEntry) => envEntry.key)

--- a/console/workspaces/pages/add-new-agent/src/components/CreateButtons.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/CreateButtons.tsx
@@ -27,10 +27,12 @@ interface SummaryPanelProps {
     mode?: 'deploy' | 'connect';
     isNameEmpty?: boolean;
     hasLLMVarConflicts?: boolean;
+    /** An MCP server's security is still loading or failed to load. */
+    hasUnresolvedMCPSecurity?: boolean;
 }
 
 export const CreateButtons = (
-    { lastSubmittedValidationErrors, isPending, onCancel, onSubmit, mode = 'deploy', isNameEmpty = false, hasLLMVarConflicts = false }: SummaryPanelProps
+    { lastSubmittedValidationErrors, isPending, onCancel, onSubmit, mode = 'deploy', isNameEmpty = false, hasLLMVarConflicts = false, hasUnresolvedMCPSecurity = false }: SummaryPanelProps
 ) => {
     const isConnectMode = mode === 'connect';
 
@@ -59,7 +61,10 @@ export const CreateButtons = (
                         <Link size={16} /> :
                         <RocketOutlined size={16} />}
                     onClick={onSubmit}
-                    disabled={isPending || isNameEmpty || hasLLMVarConflicts}
+                    disabled={
+                        isPending || isNameEmpty || hasLLMVarConflicts ||
+                        hasUnresolvedMCPSecurity
+                    }
                 >
                     {isConnectMode ? 'Register' : 'Deploy'}
                 </Button>

--- a/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
@@ -33,6 +33,7 @@ import {
   findLowestEnvironmentName,
   hasMultipleEnvironments,
 } from "../utils/buildAgentPayload";
+import { mcpEntryVarNames } from "../utils/mcpEnvVarNames";
 
 export const InternalAgentFlow: React.FC = () => {
   const navigate = useNavigate();
@@ -215,10 +216,7 @@ export const InternalAgentFlow: React.FC = () => {
                 e.urlVarName ?? `${agentNameUpper}_${i + 1}_URL`,
                 e.apikeyVarName ?? `${agentNameUpper}_${i + 1}_API_KEY`,
               ]),
-              ...mcpProxies.flatMap((e, i) => [
-                e.urlVarName ?? `${agentNameUpper}_MCP_${i + 1}_URL`,
-                e.apikeyVarName ?? `${agentNameUpper}_MCP_${i + 1}_API_KEY`,
-              ]),
+              ...mcpProxies.flatMap((e, i) => mcpEntryVarNames(e, i, agentNameUpper)),
             ];
             const llmNameSet = new Set(llmNames);
             // Duplicate LLM/MCP names

--- a/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/InternalAgentFlow.tsx
@@ -33,7 +33,10 @@ import {
   findLowestEnvironmentName,
   hasMultipleEnvironments,
 } from "../utils/buildAgentPayload";
-import { mcpEntryVarNames } from "../utils/mcpEnvVarNames";
+import {
+  hasUnresolvedMCPSecurity,
+  mcpEntryVarNames,
+} from "../utils/mcpEnvVarNames";
 
 export const InternalAgentFlow: React.FC = () => {
   const navigate = useNavigate();
@@ -207,7 +210,8 @@ export const InternalAgentFlow: React.FC = () => {
           onSubmit={handleDeploy}
           isNameEmpty={!formData.name.trim()}
           mode="deploy"
-          hasLLMVarConflicts={(() => {
+          hasUnresolvedMCPSecurity={hasUnresolvedMCPSecurity(mcpProxies)}
+        hasLLMVarConflicts={(() => {
             const agentNameUpper = formData.displayName
               ? formData.displayName.toUpperCase().replace(/[^A-Z0-9]/g, "_")
               : "AGENT";

--- a/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DrawerContent,
   DrawerHeader,
@@ -36,6 +36,7 @@ import {
   IconButton,
   ListingTable,
   SearchBar,
+  Skeleton,
   Stack,
   Tab,
   Tabs,
@@ -59,7 +60,16 @@ import {
   useListMCPProxies,
 } from "@agent-management-platform/api-client";
 import { absoluteRouteMap } from "@agent-management-platform/types";
+import {
+  EnvironmentVariablesReference,
+  useMCPProxySecurity,
+} from "@agent-management-platform/shared-component";
 import type { MCPProxyFormEntry } from "../form/schema";
+import {
+  defaultMCPApiKeyVarName,
+  defaultMCPUrlVarName,
+  mcpEntryVarNames,
+} from "../utils/mcpEnvVarNames";
 
 interface ProxyInfo {
   id: string;
@@ -119,8 +129,9 @@ interface EntryCardProps {
   entry: MCPProxyFormEntry;
   index: number;
   proxies: ProxyInfo[];
-  environments: { name: string; displayName?: string }[];
+  environments: { name: string; displayName?: string; id?: string }[];
   agentNameUpper: string;
+  orgId?: string;
   usedVarNames: Set<string>;
   onOpenDrawer: (index: number, envName: string) => void;
   onRemove: (index: number) => void;
@@ -133,6 +144,7 @@ const EntryCard: React.FC<EntryCardProps> = ({
   proxies,
   environments,
   agentNameUpper,
+  orgId,
   usedVarNames,
   onOpenDrawer,
   onRemove,
@@ -142,12 +154,57 @@ const EntryCard: React.FC<EntryCardProps> = ({
 
   const selectedEnvName = environments[selectedEnvIndex]?.name ?? "";
   const selectedEnvLabel = environments[selectedEnvIndex]?.displayName ?? selectedEnvName;
+  const selectedEnvUuid = environments[selectedEnvIndex]?.id;
   const currentEnvProxyId = entry.selectedProxyByEnv[selectedEnvName]?.id ?? null;
+
+  // Which runtime variables this binding actually needs. Scoped to the selected
+  // environment's endpoint, matching how the server resolves MCP security; falls
+  // back to the every-endpoint rule when the environment carries no uuid.
+  const { authenticationType, spec, isLoading: isSecurityLoading } =
+    useMCPProxySecurity({
+      orgName: orgId,
+      proxyId: currentEnvProxyId,
+      environmentUuid: selectedEnvUuid,
+    });
+  const showApiKeyField = spec.editableKeys.includes("apikey");
+
+  // The resolved security owns apikeyVarName: only an API-key endpoint gets a
+  // default name, and any other kind has it cleared. Keeping the name absent
+  // until the proxy resolves means a submit that races the fetch omits the
+  // variable rather than sending one the platform would inject empty.
+  useEffect(() => {
+    if (isSecurityLoading) return;
+    const nextApikeyVarName = showApiKeyField
+      ? (entry.apikeyVarName ?? defaultMCPApiKeyVarName(agentNameUpper, index))
+      : undefined;
+    if (
+      entry.authenticationType === authenticationType &&
+      entry.apikeyVarName === nextApikeyVarName
+    ) {
+      return;
+    }
+    onUpdateEntry(index, {
+      ...entry,
+      authenticationType,
+      apikeyVarName: nextApikeyVarName,
+    });
+  }, [
+    isSecurityLoading,
+    authenticationType,
+    showApiKeyField,
+    agentNameUpper,
+    entry,
+    index,
+    onUpdateEntry,
+  ]);
 
   // Flag when the URL and API key variable names within this same card are identical.
   // usedVarNames excludes the active entry, so this same-entry clash is checked separately.
+  // Only meaningful while both fields exist.
   const sameEntryNameCollision =
-    entry.urlVarName !== undefined && entry.urlVarName === entry.apikeyVarName;
+    showApiKeyField &&
+    entry.urlVarName !== undefined &&
+    entry.urlVarName === entry.apikeyVarName;
 
   const firstProxyEntry = Object.values(entry.selectedProxyByEnv).find(
     (e): e is { id: string; name: string } => e !== null && e !== undefined,
@@ -264,6 +321,15 @@ const EntryCard: React.FC<EntryCardProps> = ({
                   }
                 />
               </Form.ElementWrapper>
+              {/*
+                * Whether this slot is an API key input at all depends on the
+                * proxy's security — only an API-key endpoint has one — so hold it
+                * until that resolves rather than render a field we are about to
+                * remove. The URL variable is needed either way and never waits.
+                */}
+              {isSecurityLoading ? (
+                <Skeleton variant="rounded" height={40} sx={{ flex: 1 }} />
+              ) : !showApiKeyField ? null : (
               <Form.ElementWrapper label="API key variable name" name="apikeyVarName">
                 <TextField
                   size="small"
@@ -288,7 +354,15 @@ const EntryCard: React.FC<EntryCardProps> = ({
                   }
                 />
               </Form.ElementWrapper>
+              )}
             </Stack>
+            {!isSecurityLoading && spec.referenceRows.length > 0 && (
+              <EnvironmentVariablesReference
+                title="Injected at runtime"
+                description="This MCP server uses OAuth (AgentID) security, so there is no API key to name. These values are injected into the agent's pod at runtime alongside the URL above; their names are fixed, only their values change per environment."
+                rows={spec.referenceRows}
+              />
+            )}
           </Box>
         </Stack>
       </AccordionDetails>
@@ -404,8 +478,9 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
             ...prev,
             {
               selectedProxyByEnv,
-              urlVarName: `${agentNameUpper}_MCP_${newIndex + 1}_URL`,
-              apikeyVarName: `${agentNameUpper}_MCP_${newIndex + 1}_API_KEY`,
+              urlVarName: defaultMCPUrlVarName(agentNameUpper, newIndex),
+              // apikeyVarName is filled in by EntryCard once the proxy's security
+              // resolves, and only when the endpoint actually uses an API key.
             },
           ];
         } else {
@@ -467,10 +542,7 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
         {mcpProxies.map((entry, index) => {
           const usedVarNames = new Set([
             ...mcpProxies.flatMap((e, i) =>
-              i === index ? [] : [
-                e.urlVarName ?? `${agentNameUpper}_MCP_${i + 1}_URL`,
-                e.apikeyVarName ?? `${agentNameUpper}_MCP_${i + 1}_API_KEY`,
-              ],
+              i === index ? [] : mcpEntryVarNames(e, i, agentNameUpper),
             ),
             ...Array.from(externalEnvKeys),
           ]);
@@ -482,6 +554,7 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
               proxies={proxies}
               environments={targetEnvironments}
               agentNameUpper={agentNameUpper}
+              orgId={orgId}
               usedVarNames={usedVarNames}
               onOpenDrawer={handleOpenDrawer}
               onRemove={handleRemoveEntry}

--- a/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
@@ -26,6 +26,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Alert,
   Avatar,
   Box,
   Button,
@@ -160,20 +161,28 @@ const EntryCard: React.FC<EntryCardProps> = ({
   // Which runtime variables this binding actually needs. Scoped to the selected
   // environment's endpoint, matching how the server resolves MCP security; falls
   // back to the every-endpoint rule when the environment carries no uuid.
-  const { authenticationType, spec, isLoading: isSecurityLoading } =
-    useMCPProxySecurity({
-      orgName: orgId,
-      proxyId: currentEnvProxyId,
-      environmentUuid: selectedEnvUuid,
-    });
+  const {
+    authenticationType,
+    spec,
+    isLoading: isSecurityLoading,
+    isResolved: isSecurityResolved,
+  } = useMCPProxySecurity({
+    orgName: orgId,
+    proxyId: currentEnvProxyId,
+    environmentUuid: selectedEnvUuid,
+  });
   const showApiKeyField = spec.editableKeys.includes("apikey");
+  // A failed fetch reports "" (unsecured) just like a genuinely open endpoint.
+  // Acting on that would hide the API key field for a proxy that needs one, so
+  // treat unresolved as unknown and say so.
+  const isSecurityUnknown = !isSecurityLoading && !isSecurityResolved;
 
   // The resolved security owns apikeyVarName: only an API-key endpoint gets a
   // default name, and any other kind has it cleared. Keeping the name absent
   // until the proxy resolves means a submit that races the fetch omits the
   // variable rather than sending one the platform would inject empty.
   useEffect(() => {
-    if (isSecurityLoading) return;
+    if (isSecurityLoading || !isSecurityResolved) return;
     const nextApikeyVarName = showApiKeyField
       ? (entry.apikeyVarName ?? defaultMCPApiKeyVarName(agentNameUpper, index))
       : undefined;
@@ -190,6 +199,7 @@ const EntryCard: React.FC<EntryCardProps> = ({
     });
   }, [
     isSecurityLoading,
+    isSecurityResolved,
     authenticationType,
     showApiKeyField,
     agentNameUpper,
@@ -329,7 +339,7 @@ const EntryCard: React.FC<EntryCardProps> = ({
                 */}
               {isSecurityLoading ? (
                 <Skeleton variant="rounded" height={40} sx={{ flex: 1 }} />
-              ) : !showApiKeyField ? null : (
+              ) : isSecurityUnknown || !showApiKeyField ? null : (
               <Form.ElementWrapper label="API key variable name" name="apikeyVarName">
                 <TextField
                   size="small"
@@ -356,7 +366,15 @@ const EntryCard: React.FC<EntryCardProps> = ({
               </Form.ElementWrapper>
               )}
             </Stack>
-            {!isSecurityLoading && spec.referenceRows.length > 0 && (
+            {isSecurityUnknown && (
+              <Alert severity="error" sx={{ mt: 2 }}>
+                Couldn&apos;t load this MCP server&apos;s security settings, so the
+                runtime variables it needs are unknown. Reselect the server or
+                retry once it is reachable — saving now could leave the agent
+                without a credential it needs.
+              </Alert>
+            )}
+            {!isSecurityLoading && !isSecurityUnknown && spec.referenceRows.length > 0 && (
               <EnvironmentVariablesReference
                 title="Injected at runtime"
                 description="This MCP server uses OAuth (AgentID) security, so there is no API key to name. These values are injected into the agent's pod at runtime alongside the URL above; their names are fixed, only their values change per environment."

--- a/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/MCPProxySection.tsx
@@ -512,6 +512,15 @@ export const MCPProxySection: React.FC<MCPProxySectionProps> = ({
               ...entry.selectedProxyByEnv,
               [drawerEnvName]: { id: proxyId, name: proxyName },
             },
+            // The new proxy's security hasn't resolved yet. Carrying over the
+            // previous proxy's authenticationType/apikeyVarName would let
+            // hasUnresolvedMCPSecurity — which keys off authenticationType
+            // being undefined — miss this resolve window, and a submit during
+            // it could carry the old proxy's api key name onto a proxy that
+            // may not use one (issue #1597). EntryCard's effect repopulates
+            // both once the newly selected proxy's security resolves.
+            authenticationType: undefined,
+            apikeyVarName: undefined,
           };
           return updated;
         }

--- a/console/workspaces/pages/add-new-agent/src/form/schema.ts
+++ b/console/workspaces/pages/add-new-agent/src/form/schema.ts
@@ -18,6 +18,7 @@
 
 import { z } from 'zod';
 import type { InputInterfaceType } from '@agent-management-platform/types';
+import type { AuthenticationType } from '@agent-management-platform/shared-component';
 
 export type InterfaceType = InputInterfaceType;
 
@@ -37,6 +38,14 @@ export interface MCPProxyFormEntry {
   selectedProxyByEnv: Record<string, { id: string; name: string } | null>;
   urlVarName?: string;
   apikeyVarName?: string;
+  /**
+   * How the selected proxy's endpoint for the target environment is secured,
+   * resolved from the proxy once it loads (undefined until then). Only an
+   * "apiKey" endpoint has a user-named API key; for "identity" and "" (none),
+   * submitting one creates an env var the platform injects permanently empty
+   * (issue #1597).
+   */
+  authenticationType?: AuthenticationType;
 }
 
 // Base fields shared by both flows

--- a/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
+++ b/console/workspaces/pages/add-new-agent/src/forms/InternalAgentForm.tsx
@@ -35,6 +35,7 @@ import { MCPProxySection } from "../components/MCPProxySection";
 import { LabelsEditor, MarkdownEditor } from "@agent-management-platform/shared-component";
 import type { CreateAgentFormValues, LLMProviderFormEntry, MCPProxyFormEntry } from "../form/schema";
 import { BuildpackIcon } from "@agent-management-platform/views";
+import { mcpEntryVarNames } from "../utils/mcpEnvVarNames";
 
 interface InternalAgentFormProps {
   formData: CreateAgentFormValues;
@@ -698,10 +699,7 @@ export const InternalAgentForm = ({
             : "AGENT";
           return new Set([
             ...(formData.env ?? []).map((e) => e.key).filter((k): k is string => !!k),
-            ...mcpProxies.flatMap((e, i) => [
-              e.urlVarName ?? `${agentNameUpper}_MCP_${i + 1}_URL`,
-              e.apikeyVarName ?? `${agentNameUpper}_MCP_${i + 1}_API_KEY`,
-            ]),
+            ...mcpProxies.flatMap((e, i) => mcpEntryVarNames(e, i, agentNameUpper)),
           ]);
         })()}
       />
@@ -736,10 +734,7 @@ export const InternalAgentForm = ({
               e.urlVarName ?? `${agentNameUpper}_${i + 1}_URL`,
               e.apikeyVarName ?? `${agentNameUpper}_${i + 1}_API_KEY`,
             ]),
-            ...mcpProxies.flatMap((e, i) => [
-              e.urlVarName ?? `${agentNameUpper}_MCP_${i + 1}_URL`,
-              e.apikeyVarName ?? `${agentNameUpper}_MCP_${i + 1}_API_KEY`,
-            ]),
+            ...mcpProxies.flatMap((e, i) => mcpEntryVarNames(e, i, agentNameUpper)),
           ]);
         })()}
       />

--- a/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.test.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { buildModelConfig, findLowestEnvironmentName, buildCatalogAgentPayload, deriveCatalogEnvSeed } from "./buildAgentPayload";
-import type { CreateAgentFormValues, LLMProviderFormEntry } from "../form/schema";
+import { buildModelConfig, buildMCPConfig, findLowestEnvironmentName, buildCatalogAgentPayload, deriveCatalogEnvSeed } from "./buildAgentPayload";
+import { mcpEntryVarNames } from "./mcpEnvVarNames";
+import type { CreateAgentFormValues, LLMProviderFormEntry, MCPProxyFormEntry } from "../form/schema";
 import type { AgentKindConfigSchemaItem, OrgProjPathParams } from "@agent-management-platform/types";
 
 function entry(over: Partial<LLMProviderFormEntry> = {}): LLMProviderFormEntry {
@@ -204,5 +205,113 @@ describe("deriveCatalogEnvSeed", () => {
     expect(seed.env).toEqual([]);
     expect(seed.lockedEnvKeys.size).toBe(0);
     expect(seed.kindSecretKeysWithDefault.size).toBe(0);
+  });
+});
+
+function mcpEntry(over: Partial<MCPProxyFormEntry> = {}): MCPProxyFormEntry {
+  return {
+    selectedProxyByEnv: { Development: { id: "proxy-1", name: "weather" } },
+    urlVarName: "AGENT_MCP_1_URL",
+    apikeyVarName: "AGENT_MCP_1_API_KEY",
+    authenticationType: "apiKey",
+    ...over,
+  };
+}
+
+// Issue #1597: only an API-key endpoint has a key the user names. For OAuth and
+// for "None", submitting one makes ensureMCPEnvVarRows persist it with an empty
+// secret reference, which mcpProxyAPIKeySecurityEnabled then never fills — the
+// agent gets a variable that is empty forever, with no error at create or deploy.
+describe("buildMCPConfig", () => {
+  it("submits both url and apikey for an API-key-secured proxy", () => {
+    expect(buildMCPConfig([mcpEntry()], "Development")).toEqual([
+      {
+        proxyName: "proxy-1",
+        environmentVariables: [
+          { key: "url", name: "AGENT_MCP_1_URL" },
+          { key: "apikey", name: "AGENT_MCP_1_API_KEY" },
+        ],
+      },
+    ]);
+  });
+
+  it("omits apikey for an OAuth proxy even when a stale name is still in form state", () => {
+    expect(
+      buildMCPConfig([mcpEntry({ authenticationType: "identity" })], "Development"),
+    ).toEqual([
+      {
+        proxyName: "proxy-1",
+        environmentVariables: [{ key: "url", name: "AGENT_MCP_1_URL" }],
+      },
+    ]);
+  });
+
+  it("omits apikey for an unsecured proxy even when a stale name is still in form state", () => {
+    expect(
+      buildMCPConfig([mcpEntry({ authenticationType: "" })], "Development"),
+    ).toEqual([
+      {
+        proxyName: "proxy-1",
+        environmentVariables: [{ key: "url", name: "AGENT_MCP_1_URL" }],
+      },
+    ]);
+  });
+
+  // A submit that races the proxy fetch must fail safe: no resolved security
+  // means no API key variable, rather than one the platform injects empty.
+  it("omits apikey when the proxy's security has not resolved yet", () => {
+    expect(
+      buildMCPConfig([mcpEntry({ authenticationType: undefined })], "Development"),
+    ).toEqual([
+      {
+        proxyName: "proxy-1",
+        environmentVariables: [{ key: "url", name: "AGENT_MCP_1_URL" }],
+      },
+    ]);
+  });
+
+  it("still sends the url for every security kind, since the agent always needs it", () => {
+    for (const authenticationType of ["apiKey", "identity", ""] as const) {
+      const out = buildMCPConfig([mcpEntry({ authenticationType })], "Development");
+      expect(out?.[0]?.environmentVariables).toContainEqual({
+        key: "url",
+        name: "AGENT_MCP_1_URL",
+      });
+    }
+  });
+
+  it("builds nothing when the initial environment has no proxy selected", () => {
+    expect(buildMCPConfig([mcpEntry()], "Production")).toBeUndefined();
+  });
+});
+
+describe("mcpEntryVarNames", () => {
+  it("reserves both names for an API-key entry", () => {
+    expect(mcpEntryVarNames(mcpEntry(), 0, "AGENT")).toEqual([
+      "AGENT_MCP_1_URL",
+      "AGENT_MCP_1_API_KEY",
+    ]);
+  });
+
+  it("reserves only the url for an OAuth entry, freeing the api key name", () => {
+    expect(
+      mcpEntryVarNames(mcpEntry({ authenticationType: "identity" }), 0, "AGENT"),
+    ).toEqual(["AGENT_MCP_1_URL"]);
+  });
+
+  it("reserves only the url for an unsecured entry", () => {
+    expect(
+      mcpEntryVarNames(mcpEntry({ authenticationType: "" }), 0, "AGENT"),
+    ).toEqual(["AGENT_MCP_1_URL"]);
+  });
+
+  it("falls back to index-derived defaults when names are unset", () => {
+    expect(
+      mcpEntryVarNames(
+        mcpEntry({ urlVarName: undefined, apikeyVarName: undefined }),
+        1,
+        "MYAGENT",
+      ),
+    ).toEqual(["MYAGENT_MCP_2_URL", "MYAGENT_MCP_2_API_KEY"]);
   });
 });

--- a/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/buildAgentPayload.ts
@@ -30,6 +30,7 @@ import {
   LLMProviderFormEntry,
   MCPProxyFormEntry,
 } from "../form/schema";
+import { mcpEntryHasAPIKeyVar } from "./mcpEnvVarNames";
 
 export interface CatalogEnvSeed {
   env: { key: string; value: string; isSensitive: boolean }[];
@@ -139,9 +140,15 @@ function buildOneMCPConfig(
     : null;
   if (!proxy) return null;
 
+  // Only an API-key endpoint has an API key to name: OAuth mints credentials
+  // server-side and an unsecured endpoint needs none. Submitting one anyway
+  // creates an env var row the platform injects permanently empty, with no error
+  // at create or deploy (issue #1597).
+  const apikeyVarName = mcpEntryHasAPIKeyVar(entry) ? entry.apikeyVarName : undefined;
+
   const environmentVariables = [
     ...(entry.urlVarName ? [{ key: "url", name: entry.urlVarName }] : []),
-    ...(entry.apikeyVarName ? [{ key: "apikey", name: entry.apikeyVarName }] : []),
+    ...(apikeyVarName ? [{ key: "apikey", name: apikeyVarName }] : []),
   ];
 
   return {

--- a/console/workspaces/pages/add-new-agent/src/utils/mcpEnvVarNames.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/mcpEnvVarNames.ts
@@ -57,3 +57,17 @@ export function mcpEntryVarNames(
   }
   return names;
 }
+
+/**
+ * Whether any MCP entry has a proxy selected but its security still unresolved —
+ * the fetch is in flight or failed. Creating in that state would submit whichever
+ * env vars the unknown default happens to imply, so the flows block on it
+ * (issue #1597).
+ */
+export function hasUnresolvedMCPSecurity(entries: MCPProxyFormEntry[]): boolean {
+  return entries.some(
+    (entry) =>
+      entry.authenticationType === undefined &&
+      Object.values(entry.selectedProxyByEnv).some((proxy) => !!proxy),
+  );
+}

--- a/console/workspaces/pages/add-new-agent/src/utils/mcpEnvVarNames.ts
+++ b/console/workspaces/pages/add-new-agent/src/utils/mcpEnvVarNames.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { MCPProxyFormEntry } from "../form/schema";
+
+/** The default URL variable name for the nth MCP entry on the create form. */
+export function defaultMCPUrlVarName(agentNameUpper: string, index: number): string {
+  return `${agentNameUpper}_MCP_${index + 1}_URL`;
+}
+
+/** The default API key variable name for the nth MCP entry on the create form. */
+export function defaultMCPApiKeyVarName(agentNameUpper: string, index: number): string {
+  return `${agentNameUpper}_MCP_${index + 1}_API_KEY`;
+}
+
+/**
+ * Whether this entry's endpoint has an API key variable the user names. Only an
+ * "apiKey" endpoint does — OAuth mints credentials server-side and an unsecured
+ * endpoint needs none (issue #1597).
+ *
+ * Undefined authenticationType means the proxy's security has not resolved yet, so
+ * there is no API key variable to account for either.
+ */
+export function mcpEntryHasAPIKeyVar(entry: MCPProxyFormEntry): boolean {
+  return entry.authenticationType === "apiKey";
+}
+
+/**
+ * The environment variable names one MCP entry occupies, used to detect collisions
+ * against other configs on the form. An entry with no API key variable must not
+ * reserve that name, or it would block it for an unrelated config while never
+ * using it.
+ */
+export function mcpEntryVarNames(
+  entry: MCPProxyFormEntry,
+  index: number,
+  agentNameUpper: string,
+): string[] {
+  const names = [entry.urlVarName ?? defaultMCPUrlVarName(agentNameUpper, index)];
+  if (mcpEntryHasAPIKeyVar(entry)) {
+    names.push(entry.apikeyVarName ?? defaultMCPApiKeyVarName(agentNameUpper, index));
+  }
+  return names;
+}

--- a/console/workspaces/pages/configure-agent/src/Configure/subComponents/AddMCPToolConfigPanel.tsx
+++ b/console/workspaces/pages/configure-agent/src/Configure/subComponents/AddMCPToolConfigPanel.tsx
@@ -145,10 +145,21 @@ export function AddMCPToolConfigPanel({
   // environmentUuid is passed on purpose: this proxy maps to every environment at
   // once, so the hook's every-endpoint rule applies and a mixed-security proxy
   // keeps both fields.
-  const { authenticationType, usesIdentitySecurity, spec } = useMCPProxySecurity({
+  const {
+    authenticationType,
+    usesIdentitySecurity,
+    spec,
+    isLoading: isSecurityLoading,
+    isResolved: isSecurityResolved,
+  } = useMCPProxySecurity({
     orgName: orgId,
     proxyId: selectedProxyId,
   });
+  // A failed fetch reports "" (unsecured), which is indistinguishable from a
+  // genuinely open endpoint — acting on it would drop an API key variable the
+  // agent needs. Hold the section until the answer is real.
+  const isSecurityUnknown = !isSecurityLoading && !isSecurityResolved;
+  const isSecurityPending = isSecurityLoading || isSecurityUnknown;
   const relevantEnvVarKeys: EnvVarKey[] = spec.editableKeys;
 
   const filteredServers = useMemo(() => {
@@ -271,7 +282,11 @@ export function AddMCPToolConfigPanel({
     Boolean(selectedProxyId) &&
     !createConfig.isPending &&
     !isLoadingEnvironments &&
-    environments.length > 0;
+    environments.length > 0 &&
+    // Saving before the proxy's security resolves would write whichever env vars
+    // the unknown default implies (issue #1597). External agents get no env vars
+    // at all, so they are unaffected.
+    (isExternal || !isSecurityPending);
 
   return (
     <DrawerWrapper open={open} onClose={onClose} minWidth={740}>
@@ -411,7 +426,26 @@ export function AddMCPToolConfigPanel({
                 placeholder="my-mcp-configuration"
               />
 
-              {!isExternal ? (
+              {!isExternal && isSecurityUnknown ? (
+                <Form.Section>
+                  <Form.Subheader>Environment Variable Names</Form.Subheader>
+                  <Alert severity="error">
+                    Couldn&apos;t load this MCP server&apos;s security settings, so
+                    the runtime variables it needs are unknown. Reselect the server
+                    or retry once it is reachable — saving now could leave the agent
+                    without a credential it needs.
+                  </Alert>
+                </Form.Section>
+              ) : null}
+
+              {!isExternal && isSecurityLoading ? (
+                <Form.Section>
+                  <Form.Subheader>Environment Variable Names</Form.Subheader>
+                  <Skeleton variant="rounded" height={120} />
+                </Form.Section>
+              ) : null}
+
+              {!isExternal && !isSecurityPending ? (
                 <Form.Section>
                   <Form.Subheader>Environment Variable Names</Form.Subheader>
                   <Typography

--- a/console/workspaces/pages/configure-agent/src/Configure/subComponents/AddMCPToolConfigPanel.tsx
+++ b/console/workspaces/pages/configure-agent/src/Configure/subComponents/AddMCPToolConfigPanel.tsx
@@ -46,17 +46,18 @@ import { absoluteRouteMap } from "@agent-management-platform/types";
 import {
   useCreateAgentMCPConfig,
   useGetAgent,
-  useGetMCPProxy,
   useListAgentMCPConfigs,
   useListMCPProxies,
 } from "@agent-management-platform/api-client";
-import { usePipelineEnvironmentsState } from "@agent-management-platform/shared-component";
-import { ConfigNameSection } from "./ConfigNameSection";
-import { EnvironmentVariablesReference } from "./EnvironmentVariablesReference";
-import { MCPServerDisplay } from "./MCPServerDisplay";
-import { AGENTID_ENV_VAR_ROWS } from "../../ViewMCPServer.Component";
 import {
-  ENV_VAR_KEYS,
+  AGENTID_ENV_VAR_ROWS,
+  EnvironmentVariablesReference,
+  usePipelineEnvironmentsState,
+  useMCPProxySecurity,
+} from "@agent-management-platform/shared-component";
+import { ConfigNameSection } from "./ConfigNameSection";
+import { MCPServerDisplay } from "./MCPServerDisplay";
+import {
   generateEnvVarNames,
   generateUniqueConfigName,
   type EnvVarKey,
@@ -140,22 +141,15 @@ export function AddMCPToolConfigPanel({
     [servers, selectedProxyId],
   );
 
-  // The list item has no security info, so fetch the full proxy to get it.
-  const { data: selectedProxyDetails } = useGetMCPProxy({
+  // The list item has no security info, so the hook fetches the full proxy. No
+  // environmentUuid is passed on purpose: this proxy maps to every environment at
+  // once, so the hook's every-endpoint rule applies and a mixed-security proxy
+  // keeps both fields.
+  const { authenticationType, usesIdentitySecurity, spec } = useMCPProxySecurity({
     orgName: orgId,
-    proxyId: selectedProxyId ?? "",
+    proxyId: selectedProxyId,
   });
-
-  // No single environment to check security against (this proxy maps to all at once).
-  // Hide apikey only when every endpoint uses OAuth, so mixed security keeps both fields.
-  const proxyEndpoints = selectedProxyDetails?.endpoints ?? [];
-  const usesIdentitySecurity =
-    proxyEndpoints.length > 0 &&
-    proxyEndpoints.every((endpoint) => endpoint.security?.identity?.enabled === true);
-  const relevantEnvVarKeys: EnvVarKey[] = useMemo(
-    () => (usesIdentitySecurity ? ["url"] : [...ENV_VAR_KEYS]),
-    [usesIdentitySecurity],
-  );
+  const relevantEnvVarKeys: EnvVarKey[] = spec.editableKeys;
 
   const filteredServers = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -425,9 +419,11 @@ export function AddMCPToolConfigPanel({
                     color="text.secondary"
                     sx={{ mb: 2 }}
                   >
-                    {usesIdentitySecurity
+                    {authenticationType === "identity"
                       ? "Your agent still needs this tool's URL, even with OAuth. Shared across all environments; edit only if your code uses a different name."
-                      : "These names are shared across all environments. The platform injects the MCP server URL and API key values at runtime per environment (empty in environments the proxy is not configured for). Edit only if your code uses different names."}
+                      : authenticationType === ""
+                        ? "This MCP server is unsecured, so your agent needs only its URL. Shared across all environments; edit only if your code uses a different name."
+                        : "These names are shared across all environments. The platform injects the MCP server URL and API key values at runtime per environment (empty in environments the proxy is not configured for). Edit only if your code uses different names."}
                   </Typography>
                   <ListingTable.Container>
                     <ListingTable density="compact">

--- a/console/workspaces/pages/configure-agent/src/Configure/subComponents/EnvironmentVariablesGuideDrawer.tsx
+++ b/console/workspaces/pages/configure-agent/src/Configure/subComponents/EnvironmentVariablesGuideDrawer.tsx
@@ -26,7 +26,7 @@ import { AlertTriangle, BookOpen } from "@wso2/oxygen-ui-icons-react";
 import {
   EnvironmentVariablesReference,
   type EnvVarReferenceRow,
-} from "./EnvironmentVariablesReference";
+} from "@agent-management-platform/shared-component";
 
 interface EnvironmentVariablesGuideDrawerProps {
   open: boolean;

--- a/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
@@ -25,7 +25,9 @@ import {
 } from "@agent-management-platform/views";
 import {
   CodeBlock,
+  AGENTID_ENV_VAR_ROWS,
   copyToClipboard,
+  EnvironmentVariablesReference,
   getErrorMessage,
   monospaceInputSx,
   useAgentIdentityCredentials,
@@ -85,10 +87,6 @@ import {
   useParams,
 } from "react-router-dom";
 import { EnvironmentVariablesGuideDrawer } from "./Configure/subComponents/EnvironmentVariablesGuideDrawer";
-import {
-  EnvironmentVariablesReference,
-  type EnvVarReferenceRow,
-} from "./Configure/subComponents/EnvironmentVariablesReference";
 import { MCPServerDisplay } from "./Configure/subComponents/MCPServerDisplay";
 import { MCPProxyAPIKeysSection } from "./Configure/subComponents/MCPProxyAPIKeysSection";
 import { CONFIGURE_TAB_PARAM } from "./configureTabs";
@@ -102,29 +100,9 @@ type AuthInfoEntry = {
 
 // Fixed, never-renameable AMP_AGENTID_* names (client.EnvVarAgentID* in
 // constants.go) — kept as their own reference instead of folding into
-// envVarReferenceRows.
-export const AGENTID_ENV_VAR_ROWS: EnvVarReferenceRow[] = [
-  {
-    key: "clientId",
-    name: "AMP_AGENTID_CLIENT_ID",
-    description: "This agent's OAuth2 client ID for this environment",
-  },
-  {
-    key: "clientSecret",
-    name: "AMP_AGENTID_CLIENT_SECRET",
-    description: "This agent's OAuth2 client secret for this environment",
-  },
-  {
-    key: "tokenEndpoint",
-    name: "AMP_AGENTID_TOKEN_ENDPOINT",
-    description: "Token endpoint to call with a client_credentials grant",
-  },
-  {
-    key: "scopes",
-    name: "AMP_AGENTID_SCOPES",
-    description: "Space-separated scopes to request for this tool's actions",
-  },
-];
+// envVarReferenceRows. Now defined in shared-component so the agent-creation flow
+// shows the same variables; re-exported here for existing importers.
+export { AGENTID_ENV_VAR_ROWS };
 
 // Mirrors how buildMCPPythonSnippet resolves the (possibly renamed) URL var,
 // so both guides stay consistent if that name changes.

--- a/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
@@ -459,6 +459,13 @@ export const ViewMCPServerComponent = () => {
   const authenticationType = resolveAuthenticationType(sourceProxyEndpoint);
   const usesIdentitySecurity = authenticationType === "identity";
   const usesAPIKeySecurity = authenticationType === "apiKey";
+  // A failed or in-flight proxy fetch leaves sourceProxyEndpoint undefined,
+  // which resolveAuthenticationType reads as "None" — indistinguishable from a
+  // genuinely unsecured endpoint. Treating that as real would hide whichever
+  // fields/rows the endpoint's actual security needs and show misleading
+  // copy, the same #1597 failure mode with the polarity reversed. Callers must
+  // gate on this rather than trusting authenticationType directly while true.
+  const isMCPSecurityUnresolved = isLoadingProxyDetails || isProxyDetailsError;
 
   // Scopes are a proxy-level catalog (action -> tools it authorizes), not
   // per-endpoint, so this fetch doesn't depend on the selected environment.

--- a/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
@@ -30,6 +30,7 @@ import {
   EnvironmentVariablesReference,
   getErrorMessage,
   monospaceInputSx,
+  resolveAuthenticationType,
   useAgentIdentityCredentials,
   usePipelineEnvironmentsState,
   useThunderInstanceForEnv,
@@ -453,7 +454,11 @@ export const ViewMCPServerComponent = () => {
     selectedEnvUuid,
   );
   const apiKeyHeaderName = getMCPAPIKeyHeaderName(sourceProxyEndpoint?.security);
-  const usesIdentitySecurity = sourceProxyEndpoint?.security?.identity?.enabled === true;
+  // Same rule the MCP Servers Security tab renders and the creation flow derives
+  // its variables from, so all three surfaces agree on API key vs OAuth vs None.
+  const authenticationType = resolveAuthenticationType(sourceProxyEndpoint);
+  const usesIdentitySecurity = authenticationType === "identity";
+  const usesAPIKeySecurity = authenticationType === "apiKey";
 
   // Scopes are a proxy-level catalog (action -> tools it authorizes), not
   // per-endpoint, so this fetch doesn't depend on the selected environment.
@@ -508,14 +513,16 @@ export const ViewMCPServerComponent = () => {
     [config],
   );
 
-  // A config may still carry an apikey row from before the proxy's security
-  // was switched to OAuth; hide it rather than show a stale, irrelevant field.
+  // A config may still carry an apikey row from before the proxy's security was
+  // switched away from API key; hide it rather than show a stale, irrelevant
+  // field. Only an API-key endpoint has one — OAuth mints credentials
+  // server-side and an unsecured endpoint needs none (issue #1597).
   const visibleEnvVarRows = useMemo(
     () =>
-      usesIdentitySecurity
-        ? envVarRows.filter((envVar) => !isAPIKeyEnvVarKey(envVar.key))
-        : envVarRows,
-    [envVarRows, usesIdentitySecurity],
+      usesAPIKeySecurity
+        ? envVarRows
+        : envVarRows.filter((envVar) => !isAPIKeyEnvVarKey(envVar.key)),
+    [envVarRows, usesAPIKeySecurity],
   );
 
   useEffect(() => {
@@ -1028,7 +1035,7 @@ export const ViewMCPServerComponent = () => {
           )}
         </Form.Section>
 
-        {isExternal && providerConfig && !usesIdentitySecurity && (
+        {isExternal && providerConfig && usesAPIKeySecurity && (
           <MCPProxyAPIKeysSection
             orgName={orgId}
             projName={projectId}

--- a/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
@@ -553,7 +553,8 @@ export const ViewMCPServerComponent = () => {
       !projectId ||
       !agentId ||
       !decodedConfigId ||
-      hasEmptyEnvVarName
+      hasEmptyEnvVarName ||
+      isMCPSecurityUnresolved
     ) {
       return;
     }
@@ -829,7 +830,7 @@ export const ViewMCPServerComponent = () => {
         onSave={handleSave}
         isDirty={isDirty}
         isSaving={updateConfig.isPending}
-        hasInvalidNames={hasEmptyEnvVarName}
+        hasInvalidNames={hasEmptyEnvVarName || isMCPSecurityUnresolved}
         error={updateConfig.isError ? updateConfig.error : undefined}
         description={
           "These variable names are injected into the agent at runtime with environment-specific values. Rename them here if your code already uses different names, then save."
@@ -843,7 +844,20 @@ export const ViewMCPServerComponent = () => {
         }
       >
         <Divider sx={{ my: 2 }} />
-        {usesIdentitySecurity ? (
+        {isMCPSecurityUnresolved ? (
+          isLoadingProxyDetails ? (
+            <Skeleton variant="rounded" height={160} />
+          ) : (
+            <Alert severity="error" icon={<AlertTriangle size={18} />}>
+              <Typography variant="body2">
+                Couldn&apos;t load this MCP server&apos;s security settings, so
+                the fields and integration guide shown here may not match how
+                this tool is actually secured. Reload the page or try again
+                once the server is reachable before saving.
+              </Typography>
+            </Alert>
+          )
+        ) : usesIdentitySecurity ? (
           <Stack spacing={3}>
             <Alert severity="info">
               <Typography variant="body2">
@@ -878,8 +892,9 @@ export const ViewMCPServerComponent = () => {
           <Form.Section>
             <Form.Subheader>Integration Guide</Form.Subheader>
             <Typography variant="body2" color="text.secondary">
-              Copy this pattern into your agent code to load MCP tools
-              through the injected proxy URL and API key.
+              {usesAPIKeySecurity
+                ? "Copy this pattern into your agent code to load MCP tools through the injected proxy URL and API key."
+                : "Copy this pattern into your agent code to load MCP tools through the injected proxy URL. This server requires no API key."}
             </Typography>
             <CodeBlock
               language="python"
@@ -1106,9 +1121,33 @@ function isAPIKeyEnvVarKey(key: string): boolean {
 function buildMCPPythonSnippet(rows: { key: string; name: string }[]): string {
   const urlEnvVar =
     rows.find((row) => /url/i.test(row.key))?.name ?? "MCP_SERVER_URL";
-  const apiKeyEnvVar =
-    rows.find((row) => /api[-_]?key/i.test(row.key))?.name ??
-    "MCP_SERVER_API_KEY";
+  // The caller already filters the apikey row out of `rows` for anything but an
+  // API-key-secured endpoint (visibleEnvVarRows, issue #1597), so its absence
+  // here is the real signal — not something to paper over with a hardcoded
+  // fallback name. An unsecured endpoint has no key to read at all.
+  const apiKeyEnvVar = rows.find((row) => /api[-_]?key/i.test(row.key))?.name;
+
+  if (!apiKeyEnvVar) {
+    return [
+      "import os",
+      "from typing import Any",
+      "from langchain_mcp_adapters.client import MultiServerMCPClient",
+      "",
+      `raw_urls = os.environ.get("${urlEnvVar}", "")`,
+      'mcp_server_urls = [url.strip() for url in raw_urls.split(",") if url.strip()]',
+      "",
+      "server_configs: dict[str, dict[str, Any]] = {",
+      '    f"mcp_server_{i}": {',
+      '        "url": url,',
+      '        "transport": "streamable_http",',
+      "    }",
+      "    for i, url in enumerate(mcp_server_urls)",
+      "} if mcp_server_urls else {}",
+      "",
+      "mcp_client = MultiServerMCPClient(server_configs)",
+      "tools = await mcp_client.get_tools()",
+    ].join("\n");
+  }
 
   return [
     "import os",

--- a/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/ViewMCPServer.Component.tsx
@@ -666,7 +666,20 @@ export const ViewMCPServerComponent = () => {
           onClose={() => setPanelOpen(false)}
         />
         <DrawerContent>
-          {usesIdentitySecurity ? (
+          {isMCPSecurityUnresolved ? (
+            isLoadingProxyDetails ? (
+              <Skeleton variant="rounded" height={160} />
+            ) : (
+              <Alert severity="error" icon={<AlertTriangle size={18} />}>
+                <Typography variant="body2">
+                  Couldn&apos;t load this MCP server&apos;s security settings, so
+                  the connection details shown here may not match how this tool
+                  is actually secured. Reload the page or try again once the
+                  server is reachable.
+                </Typography>
+              </Alert>
+            )
+          ) : usesIdentitySecurity ? (
             <Stack spacing={3}>
               <Alert severity="info">
                 <Typography variant="body2">
@@ -739,7 +752,7 @@ export const ViewMCPServerComponent = () => {
                 </Form.Section>
               )}
             </Stack>
-          ) : (() => {
+          ) : usesAPIKeySecurity ? (() => {
             const authEntry =
               authInfoByEnv?.[selectedEnvName] ?? providerConfig.authInfo;
             const headerName = apiKeyHeaderName || authEntry?.name || "api-key";
@@ -816,7 +829,40 @@ export const ViewMCPServerComponent = () => {
                 </Form.Section>
               </Stack>
             );
-          })()}
+          })() : (
+            // Unsecured endpoint: no header, no key, and no "the key was only
+            // shown at creation" copy — that phrasing implies a credential that
+            // was never minted, since this server takes none (issue #1597).
+            <Stack spacing={3}>
+              <Alert severity="info">
+                <Typography variant="body2">
+                  This tool has no security configured. Call the endpoint
+                  directly — no header or API key is required.
+                </Typography>
+              </Alert>
+              <Form.Section>
+                <Form.Subheader>Connection</Form.Subheader>
+                {Boolean(providerConfig.url) && (
+                  <TextInput
+                    label="Endpoint URL"
+                    value={providerConfig.url ?? ""}
+                    copyable
+                    copyTooltipText="Copy Endpoint URL"
+                    slotProps={{ input: { readOnly: true } }}
+                    size="small"
+                  />
+                )}
+              </Form.Section>
+              <Form.Section>
+                <Form.Subheader>Example cURL</Form.Subheader>
+                <CodeBlock
+                  code={`curl -N ${providerConfig.url || "<endpoint-url>"}`}
+                  language="bash"
+                  fieldId="mcp-curl"
+                />
+              </Form.Section>
+            </Stack>
+          )}
         </DrawerContent>
       </DrawerWrapper>
     ) : (

--- a/console/workspaces/pages/configure-agent/src/utils/envConfig.ts
+++ b/console/workspaces/pages/configure-agent/src/utils/envConfig.ts
@@ -15,9 +15,15 @@
  * under the License.
  */
 
-export const ENV_VAR_KEYS = ["url", "apikey"] as const;
+import type { EnvVarKey } from "@agent-management-platform/shared-component";
 
-export type EnvVarKey = (typeof ENV_VAR_KEYS)[number];
+// The key list itself now lives in shared-component alongside resolveMCPEnvVarSpec,
+// which decides which of these keys a given endpoint's security actually needs.
+// Re-exported here so the LLM-provider and MCP pages keep their existing imports.
+export {
+  ENV_VAR_KEYS,
+  type EnvVarKey,
+} from "@agent-management-platform/shared-component";
 
 export function generateEnvVarNames(prefix: string): Record<EnvVarKey, string> {
   let sanitized = prefix.replace(/[^A-Za-z0-9_]/g, "_").toUpperCase();

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/mcpEndpoints.ts
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/mcpEndpoints.ts
@@ -50,52 +50,15 @@ export const DEFAULT_ENDPOINT_SECURITY = {
   },
 };
 
-export type AuthenticationType = "apiKey" | "identity" | "";
-
-const AUTHENTICATION_TYPE_LABELS: Record<AuthenticationType, string> = {
-  "": "None",
-  apiKey: "API Key",
-  identity: "OAuth",
-};
-
-// Display label for an AuthenticationType, shared by the Security tab's method
-// selector and the Overview tab's Auth Type summary so both stay in sync.
-export function getAuthenticationTypeLabel(type: AuthenticationType): string {
-  return AUTHENTICATION_TYPE_LABELS[type];
-}
-
-export function isAPIKeySecurityEnabled(
-  config: MCPEndpointConfig | undefined,
-): boolean {
-  const apiKeyConfig = config?.security?.apiKey;
-  return (
-    config?.security?.enabled !== false &&
-    !!apiKeyConfig &&
-    apiKeyConfig.enabled !== false
-  );
-}
-
-// Used by resolveAuthenticationType below to derive the Security tab's
-// active auth method from the endpoint's security config.
-function isIdentitySecurityEnabled(
-  config: MCPEndpointConfig | undefined,
-): boolean {
-  return (
-    config?.security?.enabled !== false &&
-    config?.security?.identity?.enabled === true
-  );
-}
-
-// Derives which authentication method is active from the endpoint's security
-// config, the same way both the Security tab (method selector) and the
-// Overview tab (Auth Type summary) need to.
-export function resolveAuthenticationType(
-  config: MCPEndpointConfig | undefined,
-): AuthenticationType {
-  if (isAPIKeySecurityEnabled(config)) return "apiKey";
-  if (isIdentitySecurityEnabled(config)) return "identity";
-  return "";
-}
+// The auth-type rule lives in shared-component so the agent creation and
+// configuration pages derive their runtime variables from the same definition
+// this page renders. Re-exported here for existing importers.
+export {
+  getAuthenticationTypeLabel,
+  isAPIKeySecurityEnabled,
+  resolveAuthenticationType,
+  type AuthenticationType,
+} from "@agent-management-platform/shared-component";
 
 // Backend identifier of a capability entry, matching the resolution used by the
 // Rewrite / Manage Tools tabs (resources key on uri, tools/prompts on name).


### PR DESCRIPTION
## Purpose

Fixes a critical bug where the Agent Creation page always requested legacy API-key runtime variables (`*_MCP_1_URL` and `*_MCP_1_API_KEY`), even when an MCP Server used **OAuth (AgentID)** or **None** (unsecured). This caused the backend to deploy agents with permanently empty, unpopulated API-key environment variables while hiding the actual `AMP_AGENTID_*` variables. (Resolves #1597)

## Goals

1. **Dynamic Inputs:** Update Agent Creation to request runtime variables matching the server’s actual security type (API Key, OAuth, or None).
2. **Prevent Stale Variables:** Stop submitting empty API key variables for non-API key endpoints.
3. **Show OAuth Vars:** Surface the 4 read-only `AMP_AGENTID_*` variables at creation time for OAuth servers.
4. **Single Source of Truth:** Eliminate cross-screen drift by unifying variable requirements under one definition.
5. **Fail-Safe Load:** Block submit and show an error if an MCP server's security configuration fails to load.

## Approach

* **Root Cause:** MCP Security is three-state (`apiKey`, `identity`/OAuth, or `""`/None). `MCPProxySection.tsx` previously had zero security awareness and rendered API-key fields unconditionally.
* **Unified Definition:** Moved `resolveAuthenticationType` into `libs/shared-component` and created shared helper modules (`mcpEndpointSecurity.ts`, `mcpEnvVarSpec.ts`, `useMCPProxySecurity.ts`) used across all screens.
* **Per-Environment Resolution:** Scoped security lookups to the target environment during creation, with mixed-security fallbacks for post-creation configurations.
* **UI Updates:**
* **Creation Page & Configuration Drawer:** Render fields dynamically based on auth type; show skeletons during loading; display clear errors on failure.
* **MCP Server View:** Cleaned up stale editable API key rows and credential sections for unsecured servers.

### Screen recordings



**Agent Creation page — attachment 1**



https://github.com/user-attachments/assets/952da2b7-745e-437a-bf65-27c668e31626



**Agent Configuration tab — attachment 2**



https://github.com/user-attachments/assets/91f0b8e3-94c8-44b5-accc-c54ef0f2ee08

## User Stories

* **OAuth Users:** See exact `AMP_AGENTID_*` runtime variables and are no longer prompted for unused API keys.
* **Unsecured Users:** Prompted only for URL variables.
* **API Key Users:** Retain existing experience.
* **All Developers:** Avoid silent auth failures caused by empty variables or failed security fetch states.
* **Maintainers:** Manage all MCP auth-type logic in a single shared function.

## Release Note

Fixed the Agent Creation page to request runtime variables matching the selected MCP Server's security type (OAuth, API Key, or None). OAuth servers now display injected `AMP_AGENTID_*` variables at creation time, preventing agents from being deployed with permanently empty API-key environment variables.
## Documentation

`documentation/docs/guides/configure-agent-mcp-proxies.mdx` is now stale:

## Training

N/A — no training content covers the MCP tool-configuration runtime variables.

## Certification

N/A

## Marketing

N/A

## Automation Tests

### Unit Tests

* **`mcpEnvVarSpec.test.ts` (19 tests):** Covers all 3 security tab options (`apiKey`, `identity`, None), disabled states, missing configs, per-environment lookups, and mixed-endpoint fallback aggregations.
* **`useMCPProxySecurity.test.ts` (7 tests):** Covers per-environment scoping, fallbacks, loading states, empty responses, and a regression guard asserting `isResolved: false` on fetch failure.
* **`buildAgentPayload.test.ts` (14 tests):** Asserts API key variables are present *only* for API-key proxies and omitted for OAuth, None, or unresolved states.

### Integration Tests

N/A
## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 
## Samples
N/A

## Related PRs

None.

## Migrations (if applicable)

N/A

## Test environment

- **OS:** macOS 26.6 (build 25G72)
- **Node.js:** v20.20.2

dev setup

## Learning

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-specific MCP endpoint security detection for API key, OAuth, identity-secured, and unsecured endpoints.
  * MCP configuration now displays the appropriate environment-variable fields and authentication guidance.
  * Added loading and error states while security settings are being resolved.
  * API-key variables are included only when required; OAuth and unsecured endpoints use the appropriate runtime configuration.
  * Agent creation and configuration saving are disabled until MCP security settings are resolved.

* **Bug Fixes**
  * Improved MCP environment-variable naming and conflict detection across agent creation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->