### PR TITLE
Fix Thunder admin API invalid_target and connectivity for in-cluster deployments

### DIFF
--- a/agent-manager-service/clients/thundersvc/client.go
+++ b/agent-manager-service/clients/thundersvc/client.go
@@ -108,12 +108,12 @@ type thunderClient struct {
 
 const httpClientTimeout = 30 * time.Second
 
-// systemResourceIdentifier returns the System resource server identifier ("<issuer>/mcp")
+// SystemResourceIdentifier returns the System resource server identifier ("<issuer>/mcp")
 // for a Thunder instance reachable at the given public/issuer URL. This mirrors the
 // identifier set by the bootstrap resource (deployments/.../70-fix-thunder-system-rs-identifier.yaml
 // and add-environment-thunder.sh's render_system_rs_identifier_fix), both of which use
 // "<publicUrl>/mcp".
-func systemResourceIdentifier(issuerURL string) string {
+func SystemResourceIdentifier(issuerURL string) string {
 	return strings.TrimRight(issuerURL, "/") + "/mcp"
 }
 
@@ -127,24 +127,26 @@ func NewThunderClient(baseURL, clientID, clientSecret string) ThunderClient {
 		baseURL:        baseURL,
 		clientID:       clientID,
 		clientSecret:   clientSecret,
-		systemResource: systemResourceIdentifier(baseURL),
+		systemResource: SystemResourceIdentifier(baseURL),
 		httpClient:     &http.Client{Timeout: httpClientTimeout},
 	}
 }
 
-// newThunderClientWithDialOverride creates a Thunder API client that connects to
+// NewThunderClientWithDialOverride creates a Thunder API client that connects to
 // resolveToHost instead of baseURL's own host, while every request still carries
 // baseURL's host as the HTTP Host header — so Kgateway's host-based routing still
 // selects the right env-Thunder backend. Used by EnvThunderResolver when the
 // direct base URL (cluster-internal DNS or the public ingress hostname) isn't
 // dialable from the caller's network, e.g. a docker-compose container that can't
-// resolve either. An empty resolveToHost behaves exactly like NewThunderClient.
+// resolve either — and, for platform Thunder, when agent-manager-service itself
+// runs in-cluster while Thunder's public/issuer URL only resolves on the host
+// machine. An empty resolveToHost behaves exactly like NewThunderClient.
 //
 // systemResource is passed explicitly (rather than derived from baseURL) because the
-// selected baseURL may be the cluster-internal DNS name, which differs from the
+// selected baseURL may be a cluster-internal DNS name, which differs from the
 // instance's issuer. The System RS identifier is always "<issuer>/mcp", so callers
-// derive it from the env-Thunder issuer URL, not the dialable base URL.
-func newThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource string) ThunderClient {
+// derive it from the instance's issuer URL, not the dialable base URL.
+func NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource string) ThunderClient {
 	httpClient := &http.Client{Timeout: httpClientTimeout}
 	if resolveToHost != "" {
 		httpClient.Transport = &http.Transport{
@@ -153,6 +155,16 @@ func newThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveTo
 				return d.DialContext(ctx, network, resolveToHost)
 			},
 		}
+		// Thunder never terminates TLS itself — it always runs its own listener
+		// plain HTTP and relies on whatever fronts it publicly (Caddy, an
+		// HTTPRoute, ...) to add TLS. baseURL may still be an https:// public/
+		// issuer URL (required for the resource-identifier derivation above), but
+		// the dialed connection itself must speak plain HTTP, or the TLS
+		// handshake this client attempts gets rejected by the plain-HTTP backend
+		// ("server gave HTTP response to HTTPS client"). Only the scheme changes
+		// here — baseURL's host is untouched, so the Host header Kgateway's
+		// host-based routing relies on is unaffected.
+		baseURL = "http://" + strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
 	}
 	return &thunderClient{
 		baseURL:        baseURL,

--- a/agent-manager-service/clients/thundersvc/client_test.go
+++ b/agent-manager-service/clients/thundersvc/client_test.go
@@ -46,7 +46,7 @@ func TestNewThunderClientWithDialOverride_UsesOverrideAddress(t *testing.T) {
 	defer server.Close()
 
 	overrideHost := strings.TrimPrefix(server.URL, "http://")
-	client := newThunderClientWithDialOverride("http://unreachable.invalid:9999", "cid", "secret", overrideHost, "http://unreachable.invalid:9999/mcp")
+	client := NewThunderClientWithDialOverride("http://unreachable.invalid:9999", "cid", "secret", overrideHost, "http://unreachable.invalid:9999/mcp")
 
 	tc, ok := client.(*thunderClient)
 	require.True(t, ok)
@@ -69,7 +69,7 @@ func TestNewThunderClientWithDialOverride_EmptyOverrideDialsBaseURLDirectly(t *t
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	client := newThunderClientWithDialOverride(server.URL, "cid", "secret", "", server.URL+"/mcp")
+	client := NewThunderClientWithDialOverride(server.URL, "cid", "secret", "", server.URL+"/mcp")
 
 	tc, ok := client.(*thunderClient)
 	require.True(t, ok)

--- a/agent-manager-service/clients/thundersvc/env_resolver.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver.go
@@ -162,8 +162,8 @@ func (r *envThunderResolver) Resolve(ctx context.Context, ouID, orgNamespace, en
 		}
 		// The System RS identifier is "<issuer>/mcp", derived from the env-Thunder issuer
 		// URL — not the (possibly cluster-internal) dialable base URL selected above.
-		systemResource := systemResourceIdentifier(ThunderIssuerURL(orgNamespace, envName))
-		client := newThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource)
+		systemResource := SystemResourceIdentifier(ThunderIssuerURL(orgNamespace, envName))
+		client := NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource)
 
 		r.mu.Lock()
 		r.cache[cacheKey] = cachedThunderClient{client: client, cachedAt: r.now()}

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -139,9 +139,23 @@ func NewIdentityClient(baseURL, clientID, clientSecret string) IdentityClient {
 		baseURL:        baseURL,
 		clientID:       clientID,
 		clientSecret:   clientSecret,
-		systemResource: systemResourceIdentifier(baseURL),
+		systemResource: SystemResourceIdentifier(baseURL),
 		httpClient:     &http.Client{Timeout: httpClientTimeout},
 	}
+}
+
+// NewIdentityClientWithDialOverride creates a Thunder identity client that dials
+// resolveToHost instead of baseURL's own host, while still using baseURL for the
+// HTTP Host header and to derive the System resource server identifier (see
+// SystemResourceIdentifier). Needed when baseURL is Thunder's public/issuer URL
+// (required, since that's the only identifier Thunder's System resource server is
+// registered under) but that hostname isn't directly dialable from this process —
+// e.g. agent-manager-service running in-cluster while Thunder's public URL only
+// resolves via the host machine's own DNS/hosts setup. An empty resolveToHost
+// behaves exactly like NewIdentityClient.
+func NewIdentityClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost string) IdentityClient {
+	c := NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, SystemResourceIdentifier(baseURL))
+	return c.(IdentityClient)
 }
 
 // --- Users ---

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -358,12 +358,24 @@ type InternalServerConfig struct {
 
 // ThunderConfig holds Thunder admin API configuration for provisioning OAuth apps
 type ThunderConfig struct {
-	// BaseURL is the Thunder API base URL (if empty, provisioner uses static defaults)
+	// BaseURL is the Thunder API base URL (if empty, provisioner uses static defaults).
+	// Must be Thunder's public/issuer URL: it also derives the System resource server
+	// identifier (RFC 8707) admin API tokens are scoped to — see
+	// thundersvc.systemResourceIdentifier. It does NOT need to be directly dialable
+	// from this process; see ResolveToHost below.
 	BaseURL string
 	// ClientID is the OAuth2 client ID of the system app (with Administrator role)
 	ClientID string
 	// ClientSecret is the OAuth2 client secret of the system app
 	ClientSecret string `json:"-"`
+	// ResolveToHost, if set, is the host:port this process actually dials for every
+	// Thunder request, while requests still carry BaseURL's host as the HTTP Host
+	// header and BaseURL still derives the System resource server identifier. Set
+	// this when BaseURL isn't directly dialable from here — e.g. agent-manager-service
+	// running in-cluster while Thunder's public URL only resolves via the host
+	// machine's own DNS/hosts setup (typically the in-cluster Thunder service's own
+	// cluster-DNS address). Leave empty when BaseURL is already directly dialable.
+	ResolveToHost string
 }
 
 // WebSocketConfig holds WebSocket-specific configuration

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -234,9 +234,10 @@ func loadEnvs() {
 
 	// Thunder admin API configuration for provisioning per-org OAuth apps
 	config.Thunder = ThunderConfig{
-		BaseURL:      r.readOptionalString("THUNDER_BASE_URL", ""),
-		ClientID:     r.readOptionalString("THUNDER_CLIENT_ID", ""),
-		ClientSecret: r.readOptionalString("THUNDER_CLIENT_SECRET", ""),
+		BaseURL:       r.readOptionalString("THUNDER_BASE_URL", ""),
+		ClientID:      r.readOptionalString("THUNDER_CLIENT_ID", ""),
+		ClientSecret:  r.readOptionalString("THUNDER_CLIENT_SECRET", ""),
+		ResolveToHost: r.readOptionalString("THUNDER_RESOLVE_TO_HOST", ""),
 	}
 	if config.Thunder.BaseURL != "" && (config.Thunder.ClientID == "" || config.Thunder.ClientSecret == "") {
 		r.errors = append(r.errors, fmt.Errorf("THUNDER_BASE_URL is set but THUNDER_CLIENT_ID and/or THUNDER_CLIENT_SECRET are missing"))

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -241,6 +242,16 @@ func loadEnvs() {
 	}
 	if config.Thunder.BaseURL != "" && (config.Thunder.ClientID == "" || config.Thunder.ClientSecret == "") {
 		r.errors = append(r.errors, fmt.Errorf("THUNDER_BASE_URL is set but THUNDER_CLIENT_ID and/or THUNDER_CLIENT_SECRET are missing"))
+	}
+	if config.Thunder.ResolveToHost != "" {
+		if config.Thunder.BaseURL == "" {
+			r.errors = append(r.errors, fmt.Errorf("THUNDER_RESOLVE_TO_HOST requires THUNDER_BASE_URL"))
+		}
+		if host, port, err := net.SplitHostPort(config.Thunder.ResolveToHost); err != nil {
+			r.errors = append(r.errors, fmt.Errorf("THUNDER_RESOLVE_TO_HOST must be host:port: %w", err))
+		} else if host == "" || port == "" {
+			r.errors = append(r.errors, fmt.Errorf("THUNDER_RESOLVE_TO_HOST must contain a non-empty host and port"))
+		}
 	}
 
 	config.TLSConfig = TLSConfig{

--- a/agent-manager-service/services/publisher_credential_provisioner.go
+++ b/agent-manager-service/services/publisher_credential_provisioner.go
@@ -144,11 +144,22 @@ func NewPublisherCredentialProvisioner(
 		}, nil
 	}
 
-	thunderCl := thundersvc.NewThunderClient(
-		cfg.Thunder.BaseURL,
-		cfg.Thunder.ClientID,
-		cfg.Thunder.ClientSecret,
-	)
+	var thunderCl thundersvc.ThunderClient
+	if cfg.Thunder.ResolveToHost != "" {
+		thunderCl = thundersvc.NewThunderClientWithDialOverride(
+			cfg.Thunder.BaseURL,
+			cfg.Thunder.ClientID,
+			cfg.Thunder.ClientSecret,
+			cfg.Thunder.ResolveToHost,
+			thundersvc.SystemResourceIdentifier(cfg.Thunder.BaseURL),
+		)
+	} else {
+		thunderCl = thundersvc.NewThunderClient(
+			cfg.Thunder.BaseURL,
+			cfg.Thunder.ClientID,
+			cfg.Thunder.ClientSecret,
+		)
+	}
 
 	logger.Info(
 		"Publisher credential provisioner initialized with Thunder",

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -540,6 +540,9 @@ func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {
 
 // ProvideIdentityClient creates a Thunder identity client using the Thunder system app credentials.
 func ProvideIdentityClient(cfg config.ThunderConfig) thundersvc.IdentityClient {
+	if cfg.ResolveToHost != "" {
+		return thundersvc.NewIdentityClientWithDialOverride(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret, cfg.ResolveToHost)
+	}
 	return thundersvc.NewIdentityClient(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret)
 }
 

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -8,6 +8,9 @@ package wiring
 
 import (
 	"fmt"
+	"log/slog"
+	"time"
+
 	"github.com/google/wire"
 	"github.com/wso2/agent-manager/agent-manager-service/audit"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/observersvc"
@@ -25,8 +28,6 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 	"gorm.io/gorm"
-	"log/slog"
-	"time"
 )
 
 // Injectors from wire.go:

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -8,9 +8,6 @@ package wiring
 
 import (
 	"fmt"
-	"log/slog"
-	"time"
-
 	"github.com/google/wire"
 	"github.com/wso2/agent-manager/agent-manager-service/audit"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/observersvc"
@@ -28,6 +25,8 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 	"gorm.io/gorm"
+	"log/slog"
+	"time"
 )
 
 // Injectors from wire.go:
@@ -807,6 +806,9 @@ func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {
 
 // ProvideIdentityClient creates a Thunder identity client using the Thunder system app credentials.
 func ProvideIdentityClient(cfg config.ThunderConfig) thundersvc.IdentityClient {
+	if cfg.ResolveToHost != "" {
+		return thundersvc.NewIdentityClientWithDialOverride(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret, cfg.ResolveToHost)
+	}
 	return thundersvc.NewIdentityClient(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret)
 }
 

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -75,8 +75,12 @@ data:
   # Workflow Plane OpenBao configuration (for Git Secrets)
   WORKFLOW_PLANE_OPENBAO_URL: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.url | default "" | quote }}
   WORKFLOW_PLANE_OPENBAO_PATH: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.path | default "secret" | quote }}
-  # Thunder admin API configuration (for per-org publisher credentials)
+  # Thunder admin API configuration (for per-org publisher credentials and the
+  # identity APIs). resolveToHost lets baseURL stay Thunder's public URL (required
+  # for the System resource server identifier) even when that hostname isn't
+  # directly dialable from this pod — see values.yaml's thunder.resolveToHost.
   THUNDER_BASE_URL: {{ .Values.agentManagerService.config.thunder.baseURL | default "" | quote }}
+  THUNDER_RESOLVE_TO_HOST: {{ .Values.agentManagerService.config.thunder.resolveToHost | default "" | quote }}
   THUNDER_CLIENT_ID: {{ .Values.agentManagerService.config.thunder.clientId | default "" | quote }}
   # Agent resource limits (per-agent upper bounds)
   RESOURCE_MAX_REPLICAS: {{ .Values.agentManagerService.config.perAgentResourceLimits.maxReplicas | default 10 | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -336,11 +336,26 @@ agentManagerService:
       maxCPU: "500m"
       maxMemory: "512Mi"
 
-    # Thunder admin API configuration (for per-org publisher credential provisioning)
-    # When baseURL is empty, the static amp-publisher-client credentials are used.
+    # Thunder admin API configuration (for per-org publisher credential provisioning
+    # and the identity APIs: users, roles, groups). When baseURL is empty, the
+    # static amp-publisher-client credentials are used instead for publisher
+    # provisioning, and the identity APIs are unavailable.
     thunder:
-      # Thunder API base URL
-      baseURL: "http://amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090"
+      # Must be the PUBLIC URL, same as keyManager.issuer above. Every admin API
+      # request asks for a token scoped to Thunder's System resource server via an
+      # RFC 8707 "resource" parameter derived from this value (client.go's
+      # SystemResourceIdentifier), and Thunder only recognizes the public URL as
+      # that resource server's registered identifier — any other value fails with
+      # invalid_target. This does NOT need to be directly dialable from the pod;
+      # see resolveToHost below for that.
+      baseURL: "http://thunder.amp.localhost:8080"
+      # The host:port this service actually connects to for every Thunder request
+      # (baseURL's host is still sent as the HTTP Host header, and still drives the
+      # resource-identifier above). Needed here because baseURL is a *.localhost
+      # hostname that only resolves via the host machine's own DNS/hosts setup —
+      # it doesn't resolve from inside this pod. Leave empty only if baseURL is
+      # itself directly dialable from the pod (e.g. a real in-cluster DNS name).
+      resolveToHost: "amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090"
       # OAuth2 client ID of the system app (with Administrator role)
       clientId: "amp-system-client"
       # OAuth2 client secret of the system app

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -42,6 +42,14 @@ vm_host() {
 # 60-amp-resource-server.yaml in the Thunder extension chart. If a future
 # AMP_VERSION changes that identifier again, this value needs to move with it,
 # same as the hostnames above.
+#
+# thunder.baseURL must be the public Thunder URL (same as keyManager.issuer),
+# not the in-cluster service address, because it also derives the RFC 8707
+# resource identifier admin API tokens are scoped to. thunder.resolveToHost
+# points the actual connection at the in-cluster service instead, since the
+# public hostname doesn't resolve from inside the cluster. Leaving either
+# unset reproduces AUTH-4030/invalid_target failures on every admin identity
+# call (users/roles/groups).
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
   local k
@@ -51,6 +59,8 @@ amp_helm_args() {
       "--set" "${k}.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
       "--set" "${k}.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
       "--set" "${k}.config.keyManager.audience=urn:wso2:amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/" \
+      "--set" "${k}.config.thunder.baseURL=https://${AMP_HOST_THUNDER}" \
+      "--set" "${k}.config.thunder.resolveToHost=amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090" \
       "--set" "${k}.config.tlsEnabled=true" \
       "--set" "${k}.config.thunderHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
       "--set" "${k}.config.agentsBaseDomain=${AMP_AGENTS_BASE}" \

--- a/documentation/docs/guides/_partials/_amp-installation.mdx
+++ b/documentation/docs/guides/_partials/_amp-installation.mdx
@@ -163,6 +163,8 @@ helm install amp \
   --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
+  --set agentManagerService.config.thunder.baseURL="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.thunder.resolveToHost="${THUNDER_INTERNAL_URL#http://}" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --timeout 1800s
 ```
@@ -217,6 +219,8 @@ helm install amp \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set agentManagerService.config.oidc.clientSecret="${AMP_API_CLIENT_SECRET}" \
+  --set agentManagerService.config.thunder.baseURL="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.thunder.resolveToHost="${THUNDER_INTERNAL_URL#http://}" \
   --set agentManagerService.config.thunder.clientSecret="${AMP_SYSTEM_CLIENT_SECRET}" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --set agentManagerService.config.tlsEnabled=true \
@@ -285,6 +289,20 @@ resource metadata is derived from it, so
 must differ. Likewise the MCP audience entry is derived from
 `serverPublicURL` above, so `keyManager.audience` only needs setting to change
 the accepted client IDs.
+
+`thunder.baseURL` must also be the public Thunder URL, for a related but
+separate reason: every admin identity call (users, roles, groups) requests a
+token scoped to Thunder's System resource server via an RFC 8707 `resource`
+parameter derived from this value, and Thunder only recognizes the public URL
+as that resource server's registered identifier — anything else fails with
+`invalid_target`. Since the API runs in-cluster and the public hostname often
+doesn't resolve there, `thunder.resolveToHost` tells it which address to
+actually connect to while still presenting `thunder.baseURL` on the wire; set
+it to the in-cluster Thunder service (as above) whenever the public hostname
+isn't directly dialable from this cluster. Leaving `thunder.baseURL` at the
+chart default (or omitting `resolveToHost` when the public hostname can't
+resolve in-cluster) breaks every admin identity call with `invalid_target` or
+a DNS lookup failure, while the rest of the platform looks healthy.
 :::
 
 :::tip Verify

--- a/documentation/versioned_docs/version-v1.0.0-beta/guides/_partials/_amp-installation.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-beta/guides/_partials/_amp-installation.mdx
@@ -163,6 +163,8 @@ helm install amp \
   --set agentManagerService.config.keyManager.issuer="${THUNDER_PUBLIC_URL}" \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
+  --set agentManagerService.config.thunder.baseURL="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.thunder.resolveToHost="${THUNDER_INTERNAL_URL#http://}" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --timeout 1800s
 ```
@@ -217,6 +219,8 @@ helm install amp \
   --set agentManagerService.config.keyManager.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set agentManagerService.config.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
   --set agentManagerService.config.oidc.clientSecret="${AMP_API_CLIENT_SECRET}" \
+  --set agentManagerService.config.thunder.baseURL="${THUNDER_PUBLIC_URL}" \
+  --set agentManagerService.config.thunder.resolveToHost="${THUNDER_INTERNAL_URL#http://}" \
   --set agentManagerService.config.thunder.clientSecret="${AMP_SYSTEM_CLIENT_SECRET}" \
   --set agentManagerService.config.openChoreo.baseURL="http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080" \
   --set agentManagerService.config.tlsEnabled=true \
@@ -285,6 +289,20 @@ resource metadata is derived from it, so
 must differ. Likewise the MCP audience entry is derived from
 `serverPublicURL` above, so `keyManager.audience` only needs setting to change
 the accepted client IDs.
+
+`thunder.baseURL` must also be the public Thunder URL, for a related but
+separate reason: every admin identity call (users, roles, groups) requests a
+token scoped to Thunder's System resource server via an RFC 8707 `resource`
+parameter derived from this value, and Thunder only recognizes the public URL
+as that resource server's registered identifier — anything else fails with
+`invalid_target`. Since the API runs in-cluster and the public hostname often
+doesn't resolve there, `thunder.resolveToHost` tells it which address to
+actually connect to while still presenting `thunder.baseURL` on the wire; set
+it to the in-cluster Thunder service (as above) whenever the public hostname
+isn't directly dialable from this cluster. Leaving `thunder.baseURL` at the
+chart default (or omitting `resolveToHost` when the public hostname can't
+resolve in-cluster) breaks every admin identity call with `invalid_target` or
+a DNS lookup failure, while the rest of the platform looks healthy.
 :::
 
 :::tip Verify


### PR DESCRIPTION
## Purpose
Agent Manager used a single config value (`THUNDER_BASE_URL`) for two things that need different values once Agent Manager runs *inside* the same cluster as Thunder: the resource identifier sent when requesting an admin-scoped token (must be Thunder's public URL), and the actual address the HTTP client connects to (must be reachable from inside the cluster). One value can't satisfy both, so every admin identity call (users/roles/groups) failed on the quick-setup and VM install paths, either with `invalid_target` or a DNS lookup failure.
- Resolves : https://github.com/wso2/agent-manager/issues/1609

## Goals
- Fix `invalid_target` on every admin identity API call (list/invite users, roles, groups) when Agent Manager runs in-cluster or on a VM.
- Do it without changing behavior for local docker-compose dev, where this was never broken (Agent Manager runs outside the cluster and only the public URL is ever used).
- Fix a second, related connectivity failure the above surfaced during live VM testing: Thunder's admin API never terminates TLS itself, so the fix must dial it as plain HTTP even though the public URL is `https://`.

## Approach
- Split `THUNDER_BASE_URL` into two config values: `BaseURL` stays Thunder's public/issuer URL (used for the Host header and the RFC 8707 resource identifier); a new `ResolveToHost` is the address actually dialed. Added `NewThunderClientWithDialOverride` / `NewIdentityClientWithDialOverride` to carry this split through a custom `DialContext`.
- Wired `THUNDER_RESOLVE_TO_HOST` through config loading, Wire DI (`ProvideIdentityClient`), the publisher-credential provisioner, Helm chart defaults/ConfigMap, and the VM installer (`lib-vm.sh`).
- Fixed a second bug found via live VM verification: the dial-override client tried to speak TLS to `ResolveToHost` because `BaseURL`'s scheme is `https://`, but Thunder's in-cluster listener is always plain HTTP (TLS is only ever added by whatever fronts it publicly). The client now dials plain HTTP whenever `ResolveToHost` is set, while the resource identifier and Host header are unaffected.
- Updated both published installation guides with the new Helm values and why both are required.

## Release note
N/A

## Documentation
Updated `_amp-installation.mdx` (next + the frozen `v1.0.0-beta` snapshot) and `on-your-environment.mdx` with `thunder.baseURL` / `thunder.resolveToHost` and the failure mode each one prevents.

## Automation tests
- Unit tests: `go test ./clients/thundersvc/...` — passing.
- Integration tests: live-verified against Thunder v1.0.0-beta on local k3d quick-setup and a GCP VM install — token mint + real admin API calls (users/roles/groups) returning `200`.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (Go service, not JVM)
- Confirmed no keys/passwords/tokens/secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Local k3d quick-setup (Colima) and a GCP Compute Engine VM (Ubuntu 24.04, k3d), both running ThunderID v1.0.0-beta.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separate public Thunder URLs and internal host resolution.
  * Added optional `THUNDER_RESOLVE_TO_HOST` configuration for deployments where the public hostname is not internally reachable.
  * Preserved public resource identity while routing network requests through an internal address.

* **Documentation**
  * Updated Helm, VM, and installation documentation with the new Thunder configuration requirements and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->