### PR TITLE
Fix Environment Variables row misalignment and spacing on duplicate-key error

### DIFF
--- a/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
+++ b/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
@@ -185,9 +185,13 @@ export function EnvVariableEditor({
       </InputAdornment>
     ) : undefined;
 
+  // Extra breathing room below rows whose helper text would otherwise crowd
+  // the next row; compact rows (no error) keep the default tight spacing.
+  const hasError = !!keyError || !!valueError;
+
   return (
-    <Stack key={index} direction="column" gap={1}>
-      <Stack direction="row" gap={2} alignItems="end">
+    <Stack key={index} direction="column" gap={1} mb={hasError ? 0.5 : 0}>
+      <Stack direction="row" gap={2} alignItems="flex-start">
         <Box flex={1} minWidth={0}>
           <TextInput
             label={keyLabel}
@@ -222,6 +226,7 @@ export function EnvVariableEditor({
             the Key/Value column alignment across rows. */}
         <Box
           mr={4}
+          pt={1}
           sx={{
             visibility: onSensitiveChange ? 'visible' : 'hidden',
             pointerEvents: onSensitiveChange ? 'auto' : 'none',
@@ -240,7 +245,7 @@ export function EnvVariableEditor({
             sx={{ whiteSpace: 'nowrap', marginRight: 0 }}
           />
         </Box>
-        <Box pb={1} display="flex" alignItems="center">
+        <Box pt={1} display="flex" alignItems="center">
           {/* Always reserve this slot so the delete/lock icons stay aligned across
               rows. Existing secrets toggle between Edit (locked) and Cancel
               (editing); other fields keep the slot hidden. Cancel stays visible

--- a/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
+++ b/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
@@ -19,7 +19,9 @@
 import {
   Box,
   Checkbox,
+  FormControl,
   FormControlLabel,
+  FormLabel,
   IconButton,
   InputAdornment,
   Stack,
@@ -226,68 +228,83 @@ export function EnvVariableEditor({
             the Key/Value column alignment across rows. */}
         <Box
           mr={4}
-          pt={1}
           sx={{
             visibility: onSensitiveChange ? 'visible' : 'hidden',
             pointerEvents: onSensitiveChange ? 'auto' : 'none',
           }}
         >
-          <FormControlLabel
-            control={
-              <Checkbox
-                size="small"
-                checked={isSensitive}
-                disabled={isSystem}
-                onChange={(e) => onSensitiveChange?.(e.target.checked)}
-              />
-            }
-            label="Mark as Secret"
-            sx={{ whiteSpace: 'nowrap', marginRight: 0 }}
-          />
-        </Box>
-        <Box pt={1} display="flex" alignItems="center">
-          {/* Always reserve this slot so the delete/lock icons stay aligned across
-              rows. Existing secrets toggle between Edit (locked) and Cancel
-              (editing); other fields keep the slot hidden. Cancel stays visible
-              for the whole edit session even after typing clears the stored
-              secret flag upstream. System rows are excluded outright, even when
-              they happen to be an existing secret — they're never editable. */}
-          <Tooltip title={isEditing ? 'Cancel edit' : 'Edit value'}>
-            <IconButton
-              size="small"
-              aria-label={isEditing ? 'Cancel edit' : 'Edit value'}
-              onClick={isEditing ? handleCancelEdit : handleStartEdit}
-              sx={
-                isEditing
-                  ? undefined
-                  : {
-                      visibility: isSecretLocked && !isSystem ? 'visible' : 'hidden',
-                      pointerEvents: isSecretLocked && !isSystem ? 'auto' : 'none',
-                    }
+          {/* The Key/Value labels are static FormLabels stacked above their
+              TextInput, not MUI's floating label, so their input boxes start
+              below a full label's height. An invisible FormLabel of the same
+              height (rather than a guessed padding value) is what keeps this
+              checkbox's top edge flush with the Key/Value inputs' top edge. */}
+          <FormControl>
+            <FormLabel sx={{ visibility: 'hidden' }}>{' '}</FormLabel>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  size="small"
+                  checked={isSensitive}
+                  disabled={isSystem}
+                  onChange={(e) => onSensitiveChange?.(e.target.checked)}
+                />
               }
-            >
-              {isEditing ? <X size={16} /> : <Edit size={16} />}
-            </IconButton>
-          </Tooltip>
-          {isSystem ? (
-            // Same slot/size as the delete button below, so system rows line up
-            // pixel-for-pixel with editable rows instead of drifting left.
-            <Tooltip title="System-injected variable — managed by the platform, not editable">
-              <IconButton
-                size="small"
-                disableRipple
-                tabIndex={-1}
-                aria-label="System-injected variable — managed by the platform, not editable"
-                sx={{ cursor: 'default' }}
-              >
-                <Lock size={16} />
-              </IconButton>
-            </Tooltip>
-          ) : (
-            <IconButton size="small" color="error" onClick={onRemove}>
-              <DeleteOutline size={16} />
-            </IconButton>
-          )}
+              label="Mark as Secret"
+              sx={{ whiteSpace: 'nowrap', marginRight: 0 }}
+            />
+          </FormControl>
+        </Box>
+        <Box>
+          {/* Same reasoning as the "Mark as Secret" slot above: an invisible
+              FormLabel matches the Key/Value labels' height so the icons'
+              top edge lines up with the inputs' top edge instead of the labels'. */}
+          <FormControl>
+            <FormLabel sx={{ visibility: 'hidden' }}>{' '}</FormLabel>
+            <Box display="flex" alignItems="center">
+              {/* Always reserve this slot so the delete/lock icons stay aligned across
+                  rows. Existing secrets toggle between Edit (locked) and Cancel
+                  (editing); other fields keep the slot hidden. Cancel stays visible
+                  for the whole edit session even after typing clears the stored
+                  secret flag upstream. System rows are excluded outright, even when
+                  they happen to be an existing secret — they're never editable. */}
+              <Tooltip title={isEditing ? 'Cancel edit' : 'Edit value'}>
+                <IconButton
+                  size="small"
+                  aria-label={isEditing ? 'Cancel edit' : 'Edit value'}
+                  onClick={isEditing ? handleCancelEdit : handleStartEdit}
+                  sx={
+                    isEditing
+                      ? undefined
+                      : {
+                          visibility: isSecretLocked && !isSystem ? 'visible' : 'hidden',
+                          pointerEvents: isSecretLocked && !isSystem ? 'auto' : 'none',
+                        }
+                  }
+                >
+                  {isEditing ? <X size={16} /> : <Edit size={16} />}
+                </IconButton>
+              </Tooltip>
+              {isSystem ? (
+                // Same slot/size as the delete button below, so system rows line up
+                // pixel-for-pixel with editable rows instead of drifting left.
+                <Tooltip title="System-injected variable — managed by the platform, not editable">
+                  <IconButton
+                    size="small"
+                    disableRipple
+                    tabIndex={-1}
+                    aria-label="System-injected variable — managed by the platform, not editable"
+                    sx={{ cursor: 'default' }}
+                  >
+                    <Lock size={16} />
+                  </IconButton>
+                </Tooltip>
+              ) : (
+                <IconButton size="small" color="error" onClick={onRemove}>
+                  <DeleteOutline size={16} />
+                </IconButton>
+              )}
+            </Box>
+          </FormControl>
         </Box>
       </Stack>
     </Stack>


### PR DESCRIPTION
## Purpose
Fixes UI row misalignment and spacing issues in Environment Variables when the "Duplicate key" validation error is triggered. Resolves #1479.

## Goals
- Keep Key, Value, Secret checkbox, and Delete icon top-aligned across a row, even when helper/error text appears.
- Add extra bottom spacing only to the specific errored row, without affecting compact non-errored rows.

## Approach
In `EnvVariableEditor.tsx`: switched the row's `alignItems` from `end` to `flex-start`, and added an invisible `FormLabel` spacer (matching the Key/Value label height) above the Secret checkbox and the icon buttons so they align with the input boxes' top edge instead of relying on guessed padding. Added a small conditional `mb` on the row when `keyError`/`valueError` is present.

**Before:**

https://github.com/user-attachments/assets/ce84693a-4c72-4b64-9f66-ca407f7a233a



**After:**

https://github.com/user-attachments/assets/1558eaf6-71d7-42a4-827a-06f59b3387e2



## User stories
As a user editing Environment Variables, when I enter a duplicate key, the row layout stays visually consistent instead of breaking alignment or crowding the next row.

## Release note
Fixed row misalignment and spacing issues in the Environment Variables editor when a duplicate key validation error is shown.

## Documentation
N/A — internal UI layout fix, no user-facing behavior/doc change.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests: None added (pre-existing gap in this component, not introduced by this change).
- Integration tests: Manually verified in-browser with duplicate-key scenarios across multiple rows.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (frontend-only CSS/layout change)
- Confirmed no secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
Manually verified in Chrome via the console dev server.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alignment of sensitive-variable checkboxes and edit/delete controls with their corresponding fields.
  - Preserved consistent row widths and spacing when validation errors appear.
  - Kept controls vertically aligned for clearer editing of environment variables.

- **Style**
  - Updated field layouts to provide a more consistent and polished environment-variable editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->