### PR TITLE
open Add LLM Provider link in a new tab to prevent Create Agent form data loss and provider list refresh

### DIFF
--- a/console/workspaces/pages/add-new-agent/src/components/LLMProviderSection.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/LLMProviderSection.tsx
@@ -54,12 +54,13 @@ import {
   Info,
   Link,
   Plus,
+  RefreshCw,
   Search,
   Trash2,
   Zap,
 } from "@wso2/oxygen-ui-icons-react";
 import { formatDistanceToNow } from "date-fns";
-import { useParams, useNavigate, generatePath } from "react-router-dom";
+import { useParams, generatePath } from "react-router-dom";
 import {
   useListCatalogLLMProviders,
   useListEnvironments,
@@ -540,8 +541,6 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const navigate = useNavigate();
-
   const { data: environments = [], isLoading: envsLoading } =
     useListEnvironments({ orgName: orgId });
   const targetEnvironments = useMemo(
@@ -553,10 +552,31 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
   const drawerEnvironmentId = drawerEnvName
     ? environments.find((e) => e.name === drawerEnvName)?.id
     : undefined;
-  const { data: catalogData, isLoading: catalogLoading } = useListCatalogLLMProviders(
+  const {
+    data: catalogData,
+    isLoading: catalogLoading,
+    refetch: refetchCatalog,
+  } = useListCatalogLLMProviders(
     { orgName: orgId },
     { limit: 50, environmentId: drawerEnvironmentId },
   );
+
+  // The "Add LLM Provider" action opens in a new tab (see below) so the
+  // Create Agent form's state is never unmounted. Refetch the catalog when
+  // the user tabs back so a freshly created provider shows up without them
+  // having to manually refresh.
+  React.useEffect(() => {
+    if (!providerDrawerOpen) return;
+    const onFocus = () => {
+      if (document.visibilityState === "visible") refetchCatalog();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, [providerDrawerOpen, refetchCatalog]);
   const { data: templatesData, isLoading: templatesLoading } =
     useListLLMProviderTemplates({ orgName: orgId });
 
@@ -758,14 +778,25 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
                 ? "Select a provider for this LLM configuration."
                 : "Change the provider for this LLM configuration."}
             </Typography>
-            <SearchBar
-              placeholder="Search providers"
-              size="small"
-              fullWidth
-              value={providerSearchQuery}
-              onChange={handleSearchChange}
-              sx={{ mb: 1 }}
-            />
+            <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
+              <SearchBar
+                placeholder="Search providers"
+                size="small"
+                fullWidth
+                value={providerSearchQuery}
+                onChange={handleSearchChange}
+              />
+              <Tooltip title="Refresh provider list" placement="top" arrow>
+                <IconButton
+                  size="small"
+                  aria-label="Refresh provider list"
+                  onClick={() => refetchCatalog()}
+                  disabled={catalogLoading}
+                >
+                  <RefreshCw size={16} />
+                </IconButton>
+              </Tooltip>
+            </Stack>
             <Stack spacing={1} sx={{ flex: 1, overflowY: "auto" }}>
               {drawerLoading ? (
                 <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
@@ -797,15 +828,14 @@ export const LLMProviderSection: React.FC<LLMProviderSectionProps> = ({
                             variant="contained"
                             size="small"
                             startIcon={<Link size={16} />}
-                            onClick={() =>
-                              navigate(
-                                generatePath(
-                                  absoluteRouteMap.children.org.children.
-                                    llmProviders.children.add.path,
-                                  { orgId },
-                                ),
-                              )
-                            }
+                            component="a"
+                            href={generatePath(
+                              absoluteRouteMap.children.org.children.
+                                llmProviders.children.add.path,
+                              { orgId },
+                            )}
+                            target="_blank"
+                            rel="noopener noreferrer"
                           >
                             Add LLM Service Provider
                           </Button>


### PR DESCRIPTION
## Purpose
Resolves #1610. Clicking "Create New Provider" from the Create Agent page navigated in the same tab, unmounting the form and discarding all entered agent data (name, instructions, tools, etc.).

## Goals
- Preserve Create Agent form state when a user goes to create an LLM provider.
- Let the user pick up the newly created provider without reloading the page.

## Approach
The "Add LLM Provider" action (both the empty-state CTA and the persistent drawer link) now opens the provider creation route in a new tab (`target="_blank" rel="noopener noreferrer"`) instead of `navigate()`-ing the current tab. The provider catalog auto-refetches when the tab regains focus/visibility, and a manual refresh button was added to the provider drawer as a fallback.

**Demo — new tab behavior:**

https://github.com/user-attachments/assets/7edcaf04-34bc-43d7-a639-1703855f9776


**Demo — auto refresh/ refresh button:**

https://github.com/user-attachments/assets/2420f849-e65a-4ca8-bfea-ed9db8f91c6a



## User stories
As a user creating an agent, I can create a missing LLM provider without losing the form I've already filled in.

## Release note
Fixed an issue where clicking "Create New Provider" during agent creation could discard the in-progress form. The provider creation page now opens in a new tab.

## Documentation
N/A — no user-facing workflow documentation exists for this step; behavior change is self-explanatory in the UI.

## Training
N/A

## Certification
N/A — no exam impact.

## Marketing
N/A

## Automation tests
- Unit tests: N/A
- Integration tests: N/A

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no
- Confirmed no secrets committed: yes

## Samples
N/A

## Related PRs
N/A

## Migrations
N/A

## Test environment
Chrome (latest), local dev environment

## Learning
N/A