### PR TITLE
Improve Strands agent framework trace parsing

### DIFF
--- a/agent-manager-observer/controllers/controller.go
+++ b/agent-manager-observer/controllers/controller.go
@@ -472,8 +472,18 @@ func (c *TracingController) aggregateFromLeafLLMSpans(
 		tokens.Partial = true
 	}
 
-	// Input preview from the first leaf, output preview from the last.
-	input = opensearch.ExtractInputPreviewFromLeaf(&validLeaves[0])
+	// Input preview from the first leaf that actually carries messages. A
+	// framework that wraps the provider call in its own LLM span (Strands opens
+	// "chat" around "openai.chat") puts a content-free span first, and reading
+	// only validLeaves[0] leaves the trace list's Input column blank.
+	for i := range validLeaves {
+		if v := opensearch.ExtractInputPreviewFromLeaf(&validLeaves[i]); v != nil {
+			input = v
+			break
+		}
+	}
+	// Output stays pinned to the last leaf: it is the turn's final model call,
+	// and walking backwards would surface an earlier turn's answer instead.
 	output = opensearch.ExtractOutputPreviewFromLeaf(&validLeaves[len(validLeaves)-1])
 	return input, output, tokens
 }

--- a/agent-manager-observer/opensearch/process.go
+++ b/agent-manager-observer/opensearch/process.go
@@ -1900,8 +1900,12 @@ func ExtractEmbeddingDocuments(attrs map[string]interface{}) []string {
 
 // DetermineSpanType analyzes a span's attributes to determine its semantic type
 func DetermineSpanType(span Span) SpanType {
+	// Fall through to the name, not straight to unknown: a span can be
+	// classifiable by name alone, and returning unknown here made this disagree
+	// with DetermineSpanKindFromName, so the same span drew a different icon in
+	// the trace list than in the detail view.
 	if span.Attributes == nil {
-		return SpanTypeUnknown
+		return determineSpanTypeFromName(span.Name)
 	}
 
 	// Check for CrewAI Task operations (must come before generic task check)
@@ -1981,6 +1985,12 @@ func determineSpanTypeFromName(name string) SpanType {
 		return SpanTypeUnknown
 	}
 
+	// Strands opens one of these per agent reasoning iteration. Matched before the
+	// "."-segment switch below, which would otherwise see the whole undotted name.
+	if strings.HasPrefix(strings.ToLower(name), "execute_event_loop_cycle") {
+		return SpanTypeChain
+	}
+
 	// Split by "." and get the last segment
 	parts := strings.Split(name, ".")
 	if len(parts) == 0 {
@@ -2028,6 +2038,9 @@ func DetermineSpanKindFromName(name string) SpanType {
 	case strings.HasPrefix(lower, "execute_tool"):
 		return SpanTypeTool
 	case strings.HasPrefix(lower, "execute_task"):
+		return SpanTypeChain
+	// Strands opens one of these per agent reasoning iteration.
+	case strings.HasPrefix(lower, "execute_event_loop_cycle"):
 		return SpanTypeChain
 	}
 

--- a/agent-manager-observer/opensearch/process.go
+++ b/agent-manager-observer/opensearch/process.go
@@ -1046,9 +1046,21 @@ func ExtractTraceInputOutputWithFallback(rootSpan *Span, spans []Span) (input in
 	}
 	if len(leaves) > 0 {
 		slices.SortFunc(leaves, func(a, b *Span) int { return a.StartTime.Compare(b.StartTime) })
+		// Scan past content-free leaves rather than giving up on the first one.
+		// Frameworks that wrap the provider call in their own LLM span (Strands opens
+		// "chat" around "openai.chat") would otherwise lose the trace input preview
+		// to the empty wrapper, which sorts first.
 		if input == nil {
-			input = ExtractInputPreviewFromLeaf(leaves[0])
+			for _, leaf := range leaves {
+				if v := ExtractInputPreviewFromLeaf(leaf); v != nil {
+					input = v
+					break
+				}
+			}
 		}
+		// Not scanned backwards: the last leaf is the turn's final model call, and
+		// falling back to an earlier one would export a previous turn's answer as
+		// the trace response for evaluators to score.
 		if output == nil {
 			output = ExtractOutputPreviewFromLeaf(leaves[len(leaves)-1])
 		}

--- a/agent-manager-observer/opensearch/process.go
+++ b/agent-manager-observer/opensearch/process.go
@@ -609,11 +609,46 @@ func extractTokenUsageFromAttributes(attrs map[string]interface{}) *LLMTokenUsag
 func ExtractTokenUsage(spans []Span) *TokenUsage {
 	var inputTokens, outputTokens int
 
+	// Count a span only when no ancestor reports usage. Frameworks report the same
+	// tokens at several depths — Strands puts a turn's usage on its "chat" wrapper,
+	// Traceloop repeats it on the "openai.chat" beneath, and Strands repeats the
+	// turn total again on "invoke_agent" — so summing every reporting span trebles
+	// the trace. Preferring the outermost report also keeps aggregates whose
+	// children only partially report (streaming calls that carry no usage, or a
+	// truncated span set) from being under-counted.
+	reportsUsage := make(map[string]bool, len(spans))
+	parentOf := make(map[string]string, len(spans))
+	for i := range spans {
+		if spans[i].Attributes != nil && extractTokenUsageFromAttributes(spans[i].Attributes) != nil {
+			reportsUsage[spans[i].SpanID] = true
+		}
+		parentOf[spans[i].SpanID] = spans[i].ParentSpanID
+	}
+
+	// Walks up the parent chain; the seen set keeps malformed data (a parent cycle,
+	// or a span parented to itself) from looping forever.
+	hasReportingAncestor := func(id string) bool {
+		seen := map[string]bool{id: true}
+		for p := parentOf[id]; p != ""; p = parentOf[p] {
+			if seen[p] {
+				return false
+			}
+			seen[p] = true
+			if reportsUsage[p] {
+				return true
+			}
+		}
+		return false
+	}
+
 	for _, span := range spans {
 		// Check if this is a GenAI span by looking for gen_ai.* attributes
 		if span.Attributes != nil {
 			// Use the helper method to extract token usage from attributes
 			if usage := extractTokenUsageFromAttributes(span.Attributes); usage != nil {
+				if hasReportingAncestor(span.SpanID) {
+					continue
+				}
 				inputTokens += usage.InputTokens
 				outputTokens += usage.OutputTokens
 			}
@@ -1046,9 +1081,9 @@ func ExtractTraceInputOutputWithFallback(rootSpan *Span, spans []Span) (input in
 	}
 	if len(leaves) > 0 {
 		slices.SortFunc(leaves, func(a, b *Span) int { return a.StartTime.Compare(b.StartTime) })
-		// Scan past content-free leaves rather than giving up on the first one.
-		// Frameworks that wrap the provider call in their own LLM span (Strands opens
-		// "chat" around "openai.chat") would otherwise lose the trace input preview
+		// Scan outward past content-free leaves rather than giving up on the first
+		// one. Frameworks that wrap the provider call in their own LLM span (Strands
+		// opens "chat" around "openai.chat") would otherwise lose the trace preview
 		// to the empty wrapper, which sorts first.
 		if input == nil {
 			for _, leaf := range leaves {

--- a/agent-manager-observer/opensearch/process_test.go
+++ b/agent-manager-observer/opensearch/process_test.go
@@ -2086,3 +2086,57 @@ func TestExtractTraceInputOutputSkipsContentFreeLeaf(t *testing.T) {
 		t.Errorf("output = %v, want the final assistant turn", output)
 	}
 }
+
+func TestExtractTokenUsagePrefersOutermostReport(t *testing.T) {
+	usage := ExtractTokenUsage(strandsTrace(time.Date(2026, 8, 15, 9, 0, 0, 0, time.UTC)))
+	if usage == nil {
+		t.Fatal("expected token usage, got nil")
+	}
+	// Summing every reporting span would give 84+4*42 = 252 input tokens.
+	if usage.InputTokens != 84 || usage.OutputTokens != 24 {
+		t.Errorf("got %d/%d, want 84/24 (the turn total, counted once)",
+			usage.InputTokens, usage.OutputTokens)
+	}
+}
+
+func TestExtractTokenUsageKeepsAggregateWhenChildrenPartiallyReport(t *testing.T) {
+	base := time.Date(2026, 8, 15, 9, 0, 0, 0, time.UTC)
+	spans := []Span{
+		{
+			SpanID: "agent", Name: "invoke_agent Strands Agents", StartTime: base,
+			Attributes: map[string]interface{}{
+				"gen_ai.usage.input_tokens":  float64(100),
+				"gen_ai.usage.output_tokens": float64(40),
+			},
+		},
+		{
+			SpanID: "reported", ParentSpanID: "agent", Name: "openai.chat", StartTime: base.Add(time.Millisecond),
+			Attributes: map[string]interface{}{
+				"gen_ai.usage.input_tokens":  float64(40),
+				"gen_ai.usage.output_tokens": float64(15),
+			},
+		},
+		// A streamed call that never emitted gen_ai.usage.*.
+		{SpanID: "silent", ParentSpanID: "agent", Name: "openai.chat", StartTime: base.Add(2 * time.Millisecond)},
+	}
+	usage := ExtractTokenUsage(spans)
+	if usage == nil {
+		t.Fatal("expected token usage, got nil")
+	}
+	if usage.InputTokens != 100 || usage.OutputTokens != 40 {
+		t.Errorf("got %d/%d, want the agent aggregate 100/40 — dropping it would under-count the silent call",
+			usage.InputTokens, usage.OutputTokens)
+	}
+}
+
+func TestExtractTokenUsageSurvivesParentCycle(t *testing.T) {
+	spans := []Span{
+		{SpanID: "a", ParentSpanID: "b", Name: "openai.chat", Attributes: map[string]interface{}{
+			"gen_ai.usage.input_tokens": float64(10), "gen_ai.usage.output_tokens": float64(5),
+		}},
+		{SpanID: "b", ParentSpanID: "a", Name: "chat"},
+	}
+	if usage := ExtractTokenUsage(spans); usage == nil || usage.InputTokens != 10 {
+		t.Errorf("expected 10 input tokens without hanging, got %+v", usage)
+	}
+}

--- a/agent-manager-observer/opensearch/process_test.go
+++ b/agent-manager-observer/opensearch/process_test.go
@@ -18,6 +18,7 @@ package opensearch
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -2030,5 +2031,58 @@ func TestEventLoopCycleClassifiesAsChain(t *testing.T) {
 	cycle := Span{Name: "execute_event_loop_cycle", Attributes: map[string]interface{}{}}
 	if got := DetermineSpanType(cycle); got != SpanTypeChain {
 		t.Errorf("DetermineSpanType = %q, want %q", got, SpanTypeChain)
+	}
+}
+
+// strandsTrace mirrors a real Strands turn: two event-loop cycles, each with a
+// Strands "chat" span wrapping Traceloop's "openai.chat" and repeating its usage,
+// and an agent span carrying the whole turn's total again.
+func strandsTrace(base time.Time) []Span {
+	ms := func(n int) time.Time { return base.Add(time.Duration(n) * time.Millisecond) }
+	cycle := func(n int, ask, answer string) []Span {
+		c, w, prov := fmt.Sprintf("cycle%d", n), fmt.Sprintf("wrap%d", n), fmt.Sprintf("prov%d", n)
+		off := n * 10
+		return []Span{
+			{SpanID: c, ParentSpanID: "agent", Name: "execute_event_loop_cycle", StartTime: ms(off)},
+			{
+				SpanID: w, ParentSpanID: c, Name: "chat", StartTime: ms(off + 1),
+				Attributes: map[string]interface{}{
+					"gen_ai.usage.input_tokens":  float64(42),
+					"gen_ai.usage.output_tokens": float64(12),
+				},
+			},
+			{
+				SpanID: prov, ParentSpanID: w, Name: "openai.chat", StartTime: ms(off + 2),
+				Attributes: map[string]interface{}{
+					"gen_ai.usage.input_tokens":  float64(42),
+					"gen_ai.usage.output_tokens": float64(12),
+					"gen_ai.input.messages":      fmt.Sprintf(`[{"role":"user","content":%q}]`, ask),
+					"gen_ai.output.messages":     fmt.Sprintf(`[{"role":"assistant","content":%q}]`, answer),
+				},
+			},
+		}
+	}
+	spans := []Span{{
+		SpanID: "agent", Name: "invoke_agent Strands Agents", StartTime: base,
+		Attributes: map[string]interface{}{
+			"gen_ai.usage.input_tokens":  float64(84),
+			"gen_ai.usage.output_tokens": float64(24),
+		},
+	}}
+	spans = append(spans, cycle(1, "status of O2412?", "calling get_flight_status")...)
+	return append(spans, cycle(2, "tool said on time", "O2412 is on time.")...)
+}
+
+func TestExtractTraceInputOutputSkipsContentFreeLeaf(t *testing.T) {
+	spans := strandsTrace(time.Date(2026, 8, 15, 9, 0, 0, 0, time.UTC))
+	root := spans[0]
+	input, output := ExtractTraceInputOutputWithFallback(&root, spans)
+	// The "chat" wrapper sorts ahead of the provider span it wraps and carries no
+	// messages, so taking the first leaf verbatim used to yield a nil input.
+	if input != "status of O2412?" {
+		t.Errorf("input = %v, want the user turn from the first provider span", input)
+	}
+	if output != "O2412 is on time." {
+		t.Errorf("output = %v, want the final assistant turn", output)
 	}
 }

--- a/agent-manager-observer/opensearch/process_test.go
+++ b/agent-manager-observer/opensearch/process_test.go
@@ -2017,3 +2017,18 @@ func TestExtractTraceInputOutputWithFallback(t *testing.T) {
 		}
 	})
 }
+
+func TestEventLoopCycleClassifiesAsChain(t *testing.T) {
+	if got := DetermineSpanKindFromName("execute_event_loop_cycle"); got != SpanTypeChain {
+		t.Errorf("DetermineSpanKindFromName = %q, want %q", got, SpanTypeChain)
+	}
+	// Nil attributes, not an empty map: real event-loop spans can arrive without
+	// any, and an empty map would pass even while the nil path returned unknown.
+	if got := DetermineSpanType(Span{Name: "execute_event_loop_cycle"}); got != SpanTypeChain {
+		t.Errorf("DetermineSpanType with nil attributes = %q, want %q", got, SpanTypeChain)
+	}
+	cycle := Span{Name: "execute_event_loop_cycle", Attributes: map[string]interface{}{}}
+	if got := DetermineSpanType(cycle); got != SpanTypeChain {
+		t.Errorf("DetermineSpanType = %q, want %q", got, SpanTypeChain)
+	}
+}

--- a/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
+++ b/console/workspaces/libs/views/src/component/TraceExplorer/TraceExplorer.tsx
@@ -344,6 +344,12 @@ const SpanRow = memo(function SpanRow({
                     <XCircle size={16} />
                   </Stack>
                 )}
+                <Chip
+                  icon={<Clock size={16} />}
+                  label={formatDuration(node.span.durationInNanos)}
+                  size="small"
+                  variant="outlined"
+                />
                 {(() => {
                   const tokenUsage = getTokenUsage(node.span);
                   return (
@@ -361,12 +367,6 @@ const SpanRow = memo(function SpanRow({
                     )
                   );
                 })()}
-                <Chip
-                  icon={<Clock size={16} />}
-                  label={formatDuration(node.span.durationInNanos)}
-                  size="small"
-                  variant="outlined"
-                />
               </Stack>
             </Stack>
           </Stack>

--- a/console/workspaces/pages/traces/src/subComponents/TraceDetails.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/TraceDetails.tsx
@@ -153,16 +153,32 @@ export function TraceDetails({
   const panelSpan =
     spanDetail && spanDetail.spanId === selectedSpanId ? spanDetail : null;
 
+  // Span details arrive one selection at a time, but the summaries the tree falls
+  // back to carry no token usage. Without this the token chip of an already-loaded
+  // span disappears as soon as another span is selected.
+  const [loadedSpans, setLoadedSpans] = useState<Record<string, Span>>({});
+
+  useEffect(() => setLoadedSpans({}), [traceId]);
+
+  useEffect(() => {
+    if (!panelSpan) return;
+    setLoadedSpans((prev) =>
+      prev[panelSpan.spanId] === panelSpan
+        ? prev
+        : { ...prev, [panelSpan.spanId]: panelSpan },
+    );
+  }, [panelSpan]);
+
   const spansForExplorer = useMemo(() => {
     if (!traceDetails?.spans?.length) return [];
     return traceDetails.spans.map((s) => {
-      const base = panelSpan?.spanId === s.spanId ? panelSpan : traceSpanSummaryToSpan(s);
+      const base = loadedSpans[s.spanId] ?? traceSpanSummaryToSpan(s);
       // Pin the tree icon to the summary's name-based kind so it never flips on selection.
       return s.spanKind
         ? { ...base, ampAttributes: { ...base.ampAttributes, kind: s.spanKind } }
         : base;
     });
-  }, [traceDetails?.spans, panelSpan]);
+  }, [traceDetails?.spans, loadedSpans]);
 
   const displaySelectedSpan = useMemo(() => {
     if (!selectedSpanId) return null;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Resolves: #1618 

Traces from agents built on the Strands Agents SDK do not parse correctly in the Console. Strands nests its own `chat` span around the provider's `openai.chat` span and repeats the same token usage at several depths, and it emits an `execute_event_loop_cycle` span per reasoning iteration that we did not recognise.

Three problems followed. The trace list showed an empty Input column, because the input preview was taken from the first LLM leaf by start time — which is Strands' wrapper span, and it carries no messages. Token totals were roughly three times too high, because every span reporting usage was summed, so a wrapper and the turn aggregate were added on top of the real model call. And the event-loop span rendered with no type or icon.

This changes the observer to classify `execute_event_loop_cycle` as a chain span, to scan past content-free leaves when deriving the trace input preview, and to count token usage only from the outermost span that reports it. The last rule also protects aggregates whose children only partially report usage, such as streamed calls that emit no usage attributes. Two Console tweaks come with it: the span duration now shows before the token count, and token counts stay visible after switching spans instead of disappearing when a span falls back to its summary.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace previews by selecting the first span containing meaningful input or messages.
  * Corrected token usage totals, including partially reported nested usage.
  * Added safeguards against cyclic trace relationships to prevent processing hangs.
  * Improved recognition and display of event-loop cycle spans.

* **UI Improvements**
  * Preserved loaded span details when switching between spans.
  * Reordered span details so duration appears before token usage for easier scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->