### PR TITLE
Resolve Swagger schema for agents instantiated from Agent Kinds

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/types.go
+++ b/agent-manager-service/clients/openchoreosvc/client/types.go
@@ -123,7 +123,11 @@ type InputInterfaceConfig struct {
 	Type       string
 	Port       int32
 	SchemaPath string
-	BasePath   string
+	// SchemaContent holds the resolved OpenAPI spec content, when available up front
+	// (e.g. copied from a source agent when instantiating from an Agent Kind, which
+	// has no git checkout/build step to resolve SchemaPath into content itself).
+	SchemaContent string
+	BasePath      string
 }
 
 // UpdateComponentRequest contains data for updating a component (patch operation)

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -331,6 +331,7 @@ func mapInputInterface(specInterface *spec.InputInterface) *client.InputInterfac
 	}
 	if specInterface.Schema != nil {
 		config.SchemaPath = utils.StrPointerAsStr(specInterface.Schema.Path, "")
+		config.SchemaContent = utils.StrPointerAsStr(specInterface.Schema.Content, "")
 	}
 
 	return config
@@ -1290,6 +1291,21 @@ func (s *agentManagerService) CreateAgent(ctx context.Context, ouID string, proj
 			}
 			if sourceComponent.InputInterface.Schema != nil && sourceComponent.InputInterface.Schema.Path != "" {
 				req.InputInterface.Schema = &spec.InputInterfaceSchema{Path: &sourceComponent.InputInterface.Schema.Path}
+				// Kind-sourced agents deploy from a stored image with no git checkout/build step,
+				// so the schema path above can never be resolved into content for them. Resolve the
+				// source agent's already-built OpenAPI content here so the Swagger UI has something
+				// to render instead of "No API schema available for this endpoint".
+				if endpoints, epErr := s.ocClient.GetComponentEndpoints(ctx, ouID, kindVersion.Kind.ProjectName, kindVersion.Kind.AgentName, ""); epErr != nil {
+					s.logger.Warn("Failed to resolve source agent's OpenAPI schema content for kind instantiation", "agentName", kindVersion.Kind.AgentName, "error", epErr)
+				} else {
+					for _, endpoint := range endpoints {
+						if endpoint.Schema.Content != "" {
+							content := endpoint.Schema.Content
+							req.InputInterface.Schema.Content = &content
+							break
+						}
+					}
+				}
 			}
 		}
 		imageID = kindVersion.ImageId
@@ -5229,9 +5245,9 @@ func modelBuildToSpecBuild(b *models.Build) *spec.Build {
 }
 
 // inputInterfaceToEndpoints converts an InputInterfaceConfig to the slice expected by CreateInternalAgentFromKindWorkload.
-// Note: Workload CRs require inline schema content, not a file path. Since the schema path originates
-// from the git repository of the source agent, schema is intentionally omitted here — it is already
-// configured at the Component level via CreateComponent.
+// Note: Workload CRs require inline schema content, not a file path. Kind-sourced agents have no git
+// checkout/build step to resolve a schema path into content themselves, so CreateAgent must resolve
+// the source agent's schema content up front and pass it in via cfg.SchemaContent.
 func inputInterfaceToEndpoints(cfg *client.InputInterfaceConfig, componentName string) []client.InputInterfaceEndpoint {
 	if cfg == nil {
 		return nil
@@ -5242,6 +5258,9 @@ func inputInterfaceToEndpoints(cfg *client.InputInterfaceConfig, componentName s
 		Type:       cfg.Type,
 		BasePath:   cfg.BasePath,
 		Visibility: []string{"external"},
+	}
+	if cfg.SchemaContent != "" {
+		ep.Schema = &client.EndpointSchema{Content: cfg.SchemaContent, Type: client.SchemaTypeOpenAPI}
 	}
 	return []client.InputInterfaceEndpoint{ep}
 }

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1296,15 +1296,14 @@ func (s *agentManagerService) CreateAgent(ctx context.Context, ouID string, proj
 				// source agent's already-built OpenAPI content here so the Swagger UI has something
 				// to render instead of "No API schema available for this endpoint".
 				if endpoints, epErr := s.ocClient.GetComponentEndpoints(ctx, ouID, kindVersion.Kind.ProjectName, kindVersion.Kind.AgentName, ""); epErr != nil {
-					s.logger.Warn("Failed to resolve source agent's OpenAPI schema content for kind instantiation", "agentName", kindVersion.Kind.AgentName, "error", epErr)
+					s.logger.Warn("Failed to resolve source agent's OpenAPI schema content for kind instantiation",
+						"ouID", ouID, "sourceProject", kindVersion.Kind.ProjectName, "agentName", kindVersion.Kind.AgentName, "error", epErr)
+				} else if sourceEndpoint, ok := endpoints[kindVersion.Kind.AgentName+"-endpoint"]; ok && sourceEndpoint.Schema.Content != "" {
+					content := sourceEndpoint.Schema.Content
+					req.InputInterface.Schema.Content = &content
 				} else {
-					for _, endpoint := range endpoints {
-						if endpoint.Schema.Content != "" {
-							content := endpoint.Schema.Content
-							req.InputInterface.Schema.Content = &content
-							break
-						}
-					}
+					s.logger.Debug("No resolved OpenAPI schema content found for source agent's endpoint during kind instantiation",
+						"ouID", ouID, "sourceProject", kindVersion.Kind.ProjectName, "agentName", kindVersion.Kind.AgentName)
 				}
 			}
 		}


### PR DESCRIPTION
## Purpose
When an Agent is instantiated from an Agent Kind, the OpenAPI/Swagger docs tab fails with "No API schema available for this endpoint." Original (non-Kind) Agents render their schema correctly.

Resolves #1593

## Goals
Kind-instantiated agents show their OpenAPI schema in the Swagger UI, identical to agents created the normal way.

## Approach
Kind-sourced agents deploy from a stored container image with no git checkout/build step, so the OpenAPI schema *path* copied from the source component was never being resolved into schema *content* on the Workload CR.

- `CreateAgent` now resolves the source component's already-built schema content via
  `GetComponentEndpoints` at instantiation time and carries it through as
  `InputInterfaceConfig.SchemaContent`.
- `inputInterfaceToEndpoints` inlines that content directly into the Workload CR's
  endpoint schema (mirroring what a normal build would produce), instead of leaving
  schema unset.

https://github.com/user-attachments/assets/a4fe9445-82ad-46dc-afb1-b09211182358



## User stories
As a user who created an Agent Kind and instantiated an agent from it, I can view and try out its OpenAPI/Swagger docs the same way I can for a regular agent.

## Release note
Fixed: OpenAPI/Swagger documentation now renders correctly for agents instantiated from an Agent Kind.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   Existing `services` and `clients/openchoreosvc/client` unit test suites pass. No new unit test added for the schema
 
 - Integration tests
   Manually verified: create Agent → publish Agent Kind → instantiate new Agent → Swagger tab renders schema identically to the source agent.

## Security checks
 - Followed secure coding standards: yes
 - Ran FindSecurityBugs plugin and verified report: no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
dev setup, mac os

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI schema content is now preserved when configuring input interfaces.
  * Agent endpoint definitions can include resolved inline OpenAPI specifications, improving compatibility with schema-based integrations.
* **Bug Fixes**
  * Improved handling of agents whose OpenAPI definitions are provided through a schema path, ensuring available schema details are retained during creation and deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->