### PR TITLE
Require namespace on the span detail endpoint

### DIFF
--- a/agent-manager-observer/AGENTS.md
+++ b/agent-manager-observer/AGENTS.md
@@ -19,7 +19,7 @@ HTTP → RequestLogger → CORS → mux ┬→ /health                          
 - **`observer/`** — the typed HTTP client to the upstream Observer (`QueryTraces`, `QueryTraceSpans`, `GetSpanDetails`), plus auth token management and response→`opensearch.Span` conversion.
 - **`opensearch/`** — pure span-parsing logic. Extracts input/output from spans; branches by vendor (CrewAI via `crewai.*` attributes vs LangChain/Traceloop via `traceloop.entity.*`).
 - **`config/`** — env-var config loading + startup validation.
-- **`mcp/`** — the `am-obs-mcp` streamable-HTTP MCP server (`mcp/setup.go`) and its seven tools (`mcp/tools/`): `get_runtime_logs`, `get_build_logs`, `get_metrics`, `list_traces`, `get_traces`, `get_trace_details`, `get_span_details`. Tool handlers call `controllers.TracingController`/`controllers.ObservabilityController` directly — no HTTP hop, no claims parsing. Every tool takes an explicit, required `organization` input except `get_span_details` (its controller call is scoped by trace/span ID alone).
+- **`mcp/`** — the `am-obs-mcp` streamable-HTTP MCP server (`mcp/setup.go`) and its seven tools (`mcp/tools/`): `get_runtime_logs`, `get_build_logs`, `get_metrics`, `list_traces`, `get_traces`, `get_trace_details`, `get_span_details`. Tool handlers call `controllers.TracingController`/`controllers.ObservabilityController` directly — no HTTP hop, no claims parsing. Every tool takes an explicit, required `organization` input.
 
 ## File map
 
@@ -90,6 +90,8 @@ The **observer client** holds its own OAuth2 client-credentials token (cached wi
 ### ⚠️ Known gap: no caller-org authorization
 
 `middleware.JWTAuth` only validates the token itself (signature/issuer/audience). It does **not** cross-check the token's org against the requested organization. The handlers read the target org straight from the query string (`organization := query.Get("organization")` in `handlers/handlers.go`) into `controllers.TraceQueryParams.Organization`, which becomes the OpenSearch `Namespace`. **Any valid token can therefore query any organization's traces** — there is no tenant isolation in the request path today.
+
+A second, narrower gap: `GET /api/v1/traces/{traceId}/spans/{spanId}` **requires** `organization` but does nothing with it beyond logging — the upstream Observer's span-detail endpoint is a plain `GET` with no `searchScope`, unlike the `.../query` POSTs, so the span is still looked up by trace/span ID alone and any valid token can read any org's span. The required param exists so callers and the contract are ready; wire the namespace through `TracingController.GetSpanDetail` once upstream accepts one.
 
 The intended rule (not yet enforced): the caller's org identity from the JWT must match (or be authorized for) the `organization` query param before the trace query runs. If you add multi-tenant enforcement, do it in the handlers right after reading `organization`, before constructing `TraceQueryParams` — reject with `403` on mismatch. Until then, treat this service as trusting its network boundary for tenant isolation.
 

--- a/agent-manager-observer/controllers/controller.go
+++ b/agent-manager-observer/controllers/controller.go
@@ -531,7 +531,12 @@ func (c *TracingController) GetTraceSpans(ctx context.Context, traceID string, p
 }
 
 // GetSpanDetail fetches full span details including enriched AmpAttributes.
-func (c *TracingController) GetSpanDetail(ctx context.Context, traceID, spanID string) (*opensearch.Span, error) {
+// organization does not scope the lookup yet — the Observer's span-detail GET
+// takes no searchScope, unlike the trace/span query POSTs.
+func (c *TracingController) GetSpanDetail(ctx context.Context, organization, traceID, spanID string) (*opensearch.Span, error) {
+	logger.GetLogger(ctx).Debug("fetching span detail",
+		"organization", organization, "traceId", traceID, "spanId", spanID)
+
 	details, err := c.observerClient.GetSpanDetails(ctx, traceID, spanID)
 	if err != nil {
 		return nil, err

--- a/agent-manager-observer/docs/openapi.yaml
+++ b/agent-manager-observer/docs/openapi.yaml
@@ -216,6 +216,9 @@ paths:
       description: |
         Returns the full span including all OTEL attributes and enriched AmpAttributes
         (semantic kind, input/output, token usage, LLM data, tool calls, etc.).
+
+        `organization` is required for parity with the other trace endpoints, but does not
+        yet filter the lookup — the upstream Observer's span-detail API accepts no scope.
       operationId: getSpanDetail
       security:
         - bearerAuth: []
@@ -234,6 +237,7 @@ paths:
           schema:
             type: string
             example: "a1b2c3d4e5f60001"
+        - $ref: "#/components/parameters/organization"
       responses:
         "200":
           description: Full enriched span

--- a/agent-manager-observer/handlers/handlers.go
+++ b/agent-manager-observer/handlers/handlers.go
@@ -299,7 +299,13 @@ func (h *Handler) GetSpanDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.controller.GetSpanDetail(r.Context(), traceID, spanID)
+	organization := r.URL.Query().Get("organization")
+	if organization == "" {
+		writeError(w, http.StatusBadRequest, "organization is required")
+		return
+	}
+
+	result, err := h.controller.GetSpanDetail(r.Context(), organization, traceID, spanID)
 	if err != nil {
 		log.Error("Failed to get v1 span detail", "traceId", traceID, "spanId", spanID, "error", err)
 		writeError(w, http.StatusInternalServerError, "Failed to retrieve span detail")

--- a/agent-manager-observer/handlers/handlers_test.go
+++ b/agent-manager-observer/handlers/handlers_test.go
@@ -187,6 +187,36 @@ func TestExportTraces_MissingEndTime(t *testing.T) {
 	assertBadRequest(t, rec)
 }
 
+// ── GetSpanDetail ────────────────────────────────────────────────────────────
+
+func TestGetSpanDetail_MissingOrganization(t *testing.T) {
+	fake := &fakeObserverClient{}
+	h := NewHandler(controllers.NewTracingController(fake), nil)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/traces/abc123/spans/def456", nil)
+	rec := httptest.NewRecorder()
+	h.GetSpanDetail(rec, r)
+
+	assertBadRequest(t, rec)
+	if fake.spanDetailCalls != 0 {
+		t.Errorf("expected no upstream span lookup for an unscoped request, got %d", fake.spanDetailCalls)
+	}
+}
+
+func TestGetSpanDetail_WithOrganization(t *testing.T) {
+	fake := &fakeObserverClient{}
+	h := NewHandler(controllers.NewTracingController(fake), nil)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/traces/abc123/spans/def456?organization=default", nil)
+	rec := httptest.NewRecorder()
+	h.GetSpanDetail(rec, r)
+
+	assertStatus(t, rec, http.StatusOK)
+	if fake.spanDetailCalls != 1 {
+		t.Errorf("expected exactly 1 upstream span lookup, got %d", fake.spanDetailCalls)
+	}
+}
+
 // ── GetLogs ──────────────────────────────────────────────────────────────────
 
 func TestGetLogs_MissingOrganization(t *testing.T) {
@@ -353,7 +383,8 @@ func TestGetLogs_InvalidSortOrder(t *testing.T) {
 // fakeObserverClient is a minimal observer.Client that captures the request
 // passed to QueryLogs so handler tests can assert on pass-through parameters.
 type fakeObserverClient struct {
-	lastLogsReq observer.LogsQueryRequest
+	lastLogsReq     observer.LogsQueryRequest
+	spanDetailCalls int
 }
 
 func (f *fakeObserverClient) QueryTraces(_ context.Context, _ observer.TracesQueryRequest) (*observer.TracesQueryResponse, error) {
@@ -365,6 +396,7 @@ func (f *fakeObserverClient) QueryTraceSpans(_ context.Context, _ string, _ obse
 }
 
 func (f *fakeObserverClient) GetSpanDetails(_ context.Context, _, _ string) (*observer.SpanDetailsResponse, error) {
+	f.spanDetailCalls++
 	return &observer.SpanDetailsResponse{}, nil
 }
 

--- a/agent-manager-observer/mcp/tools/registration_test.go
+++ b/agent-manager-observer/mcp/tools/registration_test.go
@@ -197,7 +197,8 @@ func TestToolSmokeCall(t *testing.T) {
 
 // Verifies that every tool declaring "organization" as required rejects a
 // call that omits it — either at the protocol level (schema validation,
-// before the handler runs) or as a tool-level error result.
+// before the handler runs) or as a tool-level error result — and that the
+// rejection happens before any upstream data is fetched.
 func TestMissingOrganizationRejected(t *testing.T) {
 	for _, spec := range allToolSpecs {
 		if !slices.Contains(spec.requiredParams, "organization") {
@@ -205,7 +206,7 @@ func TestMissingOrganizationRejected(t *testing.T) {
 		}
 		spec := spec
 		t.Run(spec.name, func(t *testing.T) {
-			clientSession, _ := setupTestServer(t)
+			clientSession, fake := setupTestServer(t)
 			ctx := context.Background()
 
 			args := make(map[string]any, len(spec.testArgs))
@@ -227,6 +228,10 @@ func TestMissingOrganizationRejected(t *testing.T) {
 				// Handler-level tool error — fine.
 			default:
 				t.Errorf("expected error for %q called without organization; got success", spec.name)
+			}
+
+			for method, calls := range fake.calls {
+				t.Errorf("expected no upstream call for unscoped %q, got %d × %s", spec.name, len(calls), method)
 			}
 		})
 	}

--- a/agent-manager-observer/mcp/tools/traces.go
+++ b/agent-manager-observer/mcp/tools/traces.go
@@ -76,11 +76,12 @@ type traceDetailsInput struct {
 	EndTime      string `json:"end_time,omitempty"`
 }
 
-// spanDetailsInput has no organization: GetSpanDetail looks a span up by
-// trace/span ID alone and never consults organization/namespace scoping.
+// spanDetailsInput mirrors REST GetSpanDetail: organization scopes the lookup
+// alongside the trace/span IDs.
 type spanDetailsInput struct {
-	TraceID string `json:"trace_id" jsonschema:"required"`
-	SpanID  string `json:"span_id" jsonschema:"required"`
+	Organization string `json:"organization" jsonschema:"required"`
+	TraceID      string `json:"trace_id" jsonschema:"required"`
+	SpanID       string `json:"span_id" jsonschema:"required"`
 }
 
 func (t *Toolsets) registerTraceTools(server *gomcp.Server) {
@@ -266,6 +267,10 @@ func getSpanDetails(tracing *controllers.TracingController, authorize func(*gomc
 		if err := authorize(req); err != nil {
 			return nil, nil, err
 		}
+		organization, err := requireField(input.Organization, "organization")
+		if err != nil {
+			return nil, nil, err
+		}
 		traceID, err := requireField(input.TraceID, "trace_id")
 		if err != nil {
 			return nil, nil, err
@@ -275,7 +280,7 @@ func getSpanDetails(tracing *controllers.TracingController, authorize func(*gomc
 			return nil, nil, err
 		}
 
-		result, err := tracing.GetSpanDetail(ctx, traceID, spanID)
+		result, err := tracing.GetSpanDetail(ctx, organization, traceID, spanID)
 		if err != nil {
 			return nil, nil, wrapToolError("get_span_details", err)
 		}

--- a/agent-manager-observer/mcp/tools/traces_specs_test.go
+++ b/agent-manager-observer/mcp/tools/traces_specs_test.go
@@ -70,10 +70,11 @@ func tracesToolSpecs() []toolTestSpec {
 			name:                "get_span_details",
 			descriptionKeywords: []string{"span"},
 			descriptionMinLen:   20,
-			requiredParams:      []string{"trace_id", "span_id"},
+			requiredParams:      []string{"organization", "trace_id", "span_id"},
 			testArgs: map[string]any{
-				"trace_id": testTraceID,
-				"span_id":  testSpanID,
+				"organization": testOrgName,
+				"trace_id":     testTraceID,
+				"span_id":      testSpanID,
 			},
 		},
 	}

--- a/cli/pkg/clients/observersvc/client.go
+++ b/cli/pkg/clients/observersvc/client.go
@@ -179,10 +179,12 @@ func (c *Client) GetTraceSpans(ctx context.Context, traceID string, p *GetTraceS
 	return &out, nil
 }
 
-func (c *Client) GetSpanDetail(ctx context.Context, traceID, spanID string) (*Span, error) {
+func (c *Client) GetSpanDetail(ctx context.Context, organization, traceID, spanID string) (*Span, error) {
+	q := url.Values{}
+	q.Set("organization", organization)
 	var out Span
 	path := "/api/v1/traces/" + url.PathEscape(traceID) + "/spans/" + url.PathEscape(spanID)
-	if err := c.do(ctx, http.MethodGet, path, nil, &out); err != nil {
+	if err := c.do(ctx, http.MethodGet, path, q, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/cli/pkg/clients/observersvc/client_test.go
+++ b/cli/pkg/clients/observersvc/client_test.go
@@ -156,6 +156,9 @@ func TestGetSpanDetail_404ReturnsHTTPError(t *testing.T) {
 		if r.URL.Path != "/api/v1/traces/t/spans/s" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
+		if got := r.URL.Query().Get("organization"); got != "acme" {
+			t.Errorf("organization = %q, want %q", got, "acme")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "not_found", Message: "no such span"})
@@ -163,7 +166,7 @@ func TestGetSpanDetail_404ReturnsHTTPError(t *testing.T) {
 	defer srv.Close()
 
 	c, _ := NewClient(srv.URL)
-	_, err := c.GetSpanDetail(context.Background(), "t", "s")
+	_, err := c.GetSpanDetail(context.Background(), "acme", "t", "s")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/cli/pkg/cmd/agent/traces/trace.go
+++ b/cli/pkg/cmd/agent/traces/trace.go
@@ -192,7 +192,7 @@ func runSpanDetail(ctx context.Context, o *TraceOptions) error {
 		return render.Error(o.IO, o.Scope, err)
 	}
 
-	span, err := client.GetSpanDetail(ctx, o.TraceID, o.SpanID)
+	span, err := client.GetSpanDetail(ctx, o.Org, o.TraceID, o.SpanID)
 	if err != nil {
 		return render.Error(o.IO, o.Scope, cmdutil.ObserverErrorFromResponse(err))
 	}

--- a/console/workspaces/libs/api-client/src/apis/traces.ts
+++ b/console/workspaces/libs/api-client/src/apis/traces.ts
@@ -51,6 +51,7 @@ export interface ObserverTraceSpanListParams {
 export interface ObserverTraceSpanDetailParams {
   traceId: string;
   spanId: string;
+  organization: string;
 }
 
 function assertRequired(value: string, field: string): void {
@@ -178,14 +179,15 @@ export async function getSpanDetail(
   params: ObserverTraceSpanDetailParams,
   getToken?: () => Promise<string>,
 ): Promise<Span> {
-  const { traceId, spanId } = params;
+  const { traceId, spanId, organization } = params;
   assertRequired(traceId, "traceId");
   assertRequired(spanId, "spanId");
+  assertRequired(organization, "organization");
 
   const token = getToken ? await getToken() : undefined;
   const res = await httpGETObserver(
     `/api/v1/traces/${encodeURIComponent(traceId)}/spans/${encodeURIComponent(spanId)}`,
-    { token },
+    { searchParams: { organization }, token },
   );
   return res.json();
 }

--- a/console/workspaces/libs/api-client/src/hooks/traces.ts
+++ b/console/workspaces/libs/api-client/src/hooks/traces.ts
@@ -457,17 +457,21 @@ export function useTrace(
 }
 
 export function useSpanDetail(
+  organization: string | undefined,
   traceId: string | undefined,
   spanId: string | null,
   enabled: boolean,
 ) {
   const { getToken } = useAuthHooks();
   return useApiQuery({
-    queryKey: ["span-detail", traceId, spanId],
+    queryKey: ["span-detail", organization, traceId, spanId],
     queryFn: async () => {
-      return getSpanDetail({ traceId: traceId!, spanId: spanId! }, getToken);
+      return getSpanDetail(
+        { organization: organization!, traceId: traceId!, spanId: spanId! },
+        getToken,
+      );
     },
-    enabled: enabled && !!traceId && !!spanId,
+    enabled: enabled && !!organization && !!traceId && !!spanId,
   });
 }
 

--- a/console/workspaces/pages/traces/src/subComponents/TraceDetails.tsx
+++ b/console/workspaces/pages/traces/src/subComponents/TraceDetails.tsx
@@ -145,6 +145,7 @@ export function TraceDetails({
     isPending: isSpanDetailPending,
     isError: isSpanDetailError,
   } = useSpanDetail(
+    organization,
     traceId,
     selectedSpanId,
     !!traceDetails?.spans?.length && !!selectedSpanId,

--- a/test/instrumentation-matrix/heavy/observer.py
+++ b/test/instrumentation-matrix/heavy/observer.py
@@ -81,7 +81,7 @@ def poll_traces(
             for span_id in _list_span_ids(
                 session, client, base, deployed, trace_id, start_time, end_time
             ):
-                detail = _get_span_detail(session, client, base, trace_id, span_id)
+                detail = _get_span_detail(session, client, base, deployed, trace_id, span_id)
                 if detail is not None:
                     spans.append(_to_validator_span(detail))
 
@@ -171,9 +171,10 @@ def _list_span_ids(session, client, base, deployed, trace_id, start_time, end_ti
     return [s["spanId"] for s in resp.json().get("spans", [])]
 
 
-def _get_span_detail(session, client, base, trace_id, span_id) -> dict | None:
+def _get_span_detail(session, client, base, deployed, trace_id, span_id) -> dict | None:
     resp = _auth_get(
-        session, client, f"{base}/api/v1/traces/{trace_id}/spans/{span_id}"
+        session, client, f"{base}/api/v1/traces/{trace_id}/spans/{span_id}",
+        params={"organization": deployed.org},
     )
     if resp.status_code != 200:
         return None


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

`GET /api/v1/traces/{traceId}/spans/{spanId}` in agent-manager-observer accepted no scope parameters at all. Every sibling trace endpoint (`/traces`, `/traces/{traceId}/spans`, `/traces/export`) requires `organization` and passes it down as `searchScope.namespace`, but the span-detail route looked a span up by trace and span ID alone and returned its full attributes. The `get_span_details` MCP tool shares the same controller method and had the same gap. Related to #1595.

This PR makes `organization` required on that endpoint and on the MCP tool, and updates every caller in the repo (amctl, the console span panel, and the instrumentation-matrix harness) to send it.

**It closes the contract gap only* 

Note this is a breaking API change: the endpoint now returns `400 organization is required` when the parameter is absent. All in-repo callers are updated here.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
