### PR TITLE
Scope deploy-time env vars and file mounts to one environment

### DIFF
--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -21,6 +21,9 @@ import (
 //			AttachTraitsFunc: func(ctx context.Context, ouID string, projectName string, componentName string, traitRequests []client.TraitRequest) error {
 //				panic("mock out the AttachTraits method")
 //			},
+//			ClearComponentBaseWorkloadConfigFunc: func(ctx context.Context, ouID string, projectName string, componentName string) error {
+//				panic("mock out the ClearComponentBaseWorkloadConfig method")
+//			},
 //			ComponentExistsFunc: func(ctx context.Context, ouID string, projectName string, componentName string) (bool, error) {
 //				panic("mock out the ComponentExists method")
 //			},
@@ -252,6 +255,9 @@ import (
 type OpenChoreoClientMock struct {
 	// AttachTraitsFunc mocks the AttachTraits method.
 	AttachTraitsFunc func(ctx context.Context, ouID string, projectName string, componentName string, traitRequests []client.TraitRequest) error
+
+	// ClearComponentBaseWorkloadConfigFunc mocks the ClearComponentBaseWorkloadConfig method.
+	ClearComponentBaseWorkloadConfigFunc func(ctx context.Context, ouID string, projectName string, componentName string) error
 
 	// ComponentExistsFunc mocks the ComponentExists method.
 	ComponentExistsFunc func(ctx context.Context, ouID string, projectName string, componentName string) (bool, error)
@@ -489,6 +495,17 @@ type OpenChoreoClientMock struct {
 			ComponentName string
 			// TraitRequests is the traitRequests argument value.
 			TraitRequests []client.TraitRequest
+		}
+		// ClearComponentBaseWorkloadConfig holds details about calls to the ClearComponentBaseWorkloadConfig method.
+		ClearComponentBaseWorkloadConfig []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OuID is the ouID argument value.
+			OuID string
+			// ProjectName is the projectName argument value.
+			ProjectName string
+			// ComponentName is the componentName argument value.
+			ComponentName string
 		}
 		// ComponentExists holds details about calls to the ComponentExists method.
 		ComponentExists []struct {
@@ -1312,6 +1329,7 @@ type OpenChoreoClientMock struct {
 		}
 	}
 	lockAttachTraits                           sync.RWMutex
+	lockClearComponentBaseWorkloadConfig       sync.RWMutex
 	lockComponentExists                        sync.RWMutex
 	lockCreateComponent                        sync.RWMutex
 	lockCreateDeploymentPipeline               sync.RWMutex
@@ -1433,6 +1451,50 @@ func (mock *OpenChoreoClientMock) AttachTraitsCalls() []struct {
 	mock.lockAttachTraits.RLock()
 	calls = mock.calls.AttachTraits
 	mock.lockAttachTraits.RUnlock()
+	return calls
+}
+
+// ClearComponentBaseWorkloadConfig calls ClearComponentBaseWorkloadConfigFunc.
+func (mock *OpenChoreoClientMock) ClearComponentBaseWorkloadConfig(ctx context.Context, ouID string, projectName string, componentName string) error {
+	if mock.ClearComponentBaseWorkloadConfigFunc == nil {
+		panic("OpenChoreoClientMock.ClearComponentBaseWorkloadConfigFunc: method is nil but OpenChoreoClient.ClearComponentBaseWorkloadConfig was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		OuID          string
+		ProjectName   string
+		ComponentName string
+	}{
+		Ctx:           ctx,
+		OuID:          ouID,
+		ProjectName:   projectName,
+		ComponentName: componentName,
+	}
+	mock.lockClearComponentBaseWorkloadConfig.Lock()
+	mock.calls.ClearComponentBaseWorkloadConfig = append(mock.calls.ClearComponentBaseWorkloadConfig, callInfo)
+	mock.lockClearComponentBaseWorkloadConfig.Unlock()
+	return mock.ClearComponentBaseWorkloadConfigFunc(ctx, ouID, projectName, componentName)
+}
+
+// ClearComponentBaseWorkloadConfigCalls gets all the calls that were made to ClearComponentBaseWorkloadConfig.
+// Check the length with:
+//
+//	len(mockedOpenChoreoClient.ClearComponentBaseWorkloadConfigCalls())
+func (mock *OpenChoreoClientMock) ClearComponentBaseWorkloadConfigCalls() []struct {
+	Ctx           context.Context
+	OuID          string
+	ProjectName   string
+	ComponentName string
+} {
+	var calls []struct {
+		Ctx           context.Context
+		OuID          string
+		ProjectName   string
+		ComponentName string
+	}
+	mock.lockClearComponentBaseWorkloadConfig.RLock()
+	calls = mock.calls.ClearComponentBaseWorkloadConfig
+	mock.lockClearComponentBaseWorkloadConfig.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/clients/openchoreosvc/client/client.go
+++ b/agent-manager-service/clients/openchoreosvc/client/client.go
@@ -85,6 +85,7 @@ type OpenChoreoClient interface {
 	UpdateComponentEnvVars(ctx context.Context, ouID, projectName, componentName string, envVars []EnvVar) error
 	ReplaceComponentEnvVars(ctx context.Context, ouID, projectName, componentName string, envVars []EnvVar) error
 	ReplaceComponentFileMounts(ctx context.Context, ouID, projectName, componentName string, files []FileVar) error
+	ClearComponentBaseWorkloadConfig(ctx context.Context, ouID, projectName, componentName string) error
 	UpdateReleaseBindingEnvVars(ctx context.Context, ouID, projectName, componentName, envName string, envVars []EnvVar) error
 	RemoveComponentEnvironmentVariables(ctx context.Context, ouID, projectName, componentName string, envVarKeys []string) error
 	RemoveReleaseBindingEnvVars(ctx context.Context, ouID, projectName, componentName, envName string, envVarKeys []string) error

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -351,10 +351,18 @@ func getWorkflowName(build *BuildConfig) (string, error) {
 	return "", fmt.Errorf("invalid build configuration: unsupported build type '%s'", build.Type)
 }
 
+// Build workflow parameter names carrying the agent's runtime env vars and file mounts. They are
+// seeded once at agent creation and cleared on the first successful deploy — see
+// ClearComponentBaseWorkloadConfig for why they must not outlive that.
+const (
+	workflowParamEnvironmentVariables = "environmentVariables"
+	workflowParamFileMounts           = "fileMounts"
+)
+
 func buildWorkflowParameters(req CreateComponentRequest) (map[string]any, error) {
 	params := map[string]any{
-		"environmentVariables": buildEnvironmentVariables(req),
-		"fileMounts":           buildFileMounts(req),
+		workflowParamEnvironmentVariables: buildEnvironmentVariables(req),
+		workflowParamFileMounts:           buildFileMounts(req),
 	}
 
 	// Add repository details in nested format expected by ClusterWorkflow
@@ -1815,6 +1823,130 @@ func (c *openChoreoClient) ReplaceComponentFileMounts(ctx context.Context, ouID,
 		})
 	}
 
+	return nil
+}
+
+// ClearComponentBaseWorkloadConfig removes user-managed env vars and file mounts from the
+// component-wide base: the Component's build workflow parameters and the Workload's container spec.
+//
+// Runtime env vars and file mounts belong on each environment's ReleaseBinding workloadOverrides.
+// A copy left in the base leaks into every other environment (each environment renders
+// base + its own overrides) and makes removal impossible, because an override can never unset a
+// base key — mergeEnvConfigs/mergeFileConfigs fall back to the base whenever the override list
+// omits it, and return the base outright when the override list is empty.
+//
+// Both halves must be cleared. The build's generate-workload step rebuilds the Workload from the
+// workflow parameters and PUTs it wholesale, so clearing only the Workload would be undone by the
+// next build. Clearing the parameters leaves them to resolve to the workflow schema's `default: []`.
+//
+// Safe to call when there is nothing to clear, and when no Workload exists yet (never built).
+func (c *openChoreoClient) ClearComponentBaseWorkloadConfig(ctx context.Context, ouID, projectName, componentName string) error {
+	if err := c.clearComponentWorkflowConfigParams(ctx, ouID, componentName); err != nil {
+		return fmt.Errorf("failed to clear component workflow config parameters: %w", err)
+	}
+	if err := c.clearWorkloadContainerConfig(ctx, ouID, componentName); err != nil {
+		return fmt.Errorf("failed to clear workload container config: %w", err)
+	}
+	return nil
+}
+
+// clearComponentWorkflowConfigParams drops the environmentVariables and fileMounts build workflow
+// parameters from the Component CR. They are seeded once at agent creation (the only carrier for
+// create-time config, since no Workload or ReleaseBinding exists yet) and are dead weight once the
+// first deploy has copied them onto the environment's binding.
+func (c *openChoreoClient) clearComponentWorkflowConfigParams(ctx context.Context, ouID, componentName string) error {
+	namespaceName := c.NamespaceFor(ouID)
+	resp, err := c.ocClient.GetComponentWithResponse(ctx, namespaceName, componentName)
+	if err != nil {
+		return fmt.Errorf("failed to get component: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return handleErrorResponse(resp.StatusCode(), ErrorResponses{
+			JSON401: resp.JSON401,
+			JSON403: resp.JSON403,
+			JSON404: resp.JSON404,
+			JSON500: resp.JSON500,
+		})
+	}
+	if resp.JSON200 == nil || resp.JSON200.Spec == nil {
+		return fmt.Errorf("invalid component response")
+	}
+
+	component := resp.JSON200
+	if component.Spec.Workflow == nil || component.Spec.Workflow.Parameters == nil {
+		return nil
+	}
+	params := *component.Spec.Workflow.Parameters
+	_, hasEnvVars := params[workflowParamEnvironmentVariables]
+	_, hasFileMounts := params[workflowParamFileMounts]
+	if !hasEnvVars && !hasFileMounts {
+		return nil
+	}
+	delete(params, workflowParamEnvironmentVariables)
+	delete(params, workflowParamFileMounts)
+
+	component.Status = nil
+	updateResp, err := c.ocClient.UpdateComponentWithResponse(ctx, namespaceName, componentName, *component)
+	if err != nil {
+		return fmt.Errorf("failed to update component: %w", err)
+	}
+	if updateResp.StatusCode() != http.StatusOK {
+		return handleErrorResponse(updateResp.StatusCode(), ErrorResponses{
+			JSON401: updateResp.JSON401,
+			JSON403: updateResp.JSON403,
+			JSON404: updateResp.JSON404,
+			JSON500: updateResp.JSON500,
+		})
+	}
+	return nil
+}
+
+// clearWorkloadContainerConfig drops env vars and file mounts from the component's Workload, the
+// shared render base. Returns nil when no Workload exists yet — the agent has not been built, so
+// there is nothing to clear.
+func (c *openChoreoClient) clearWorkloadContainerConfig(ctx context.Context, ouID, componentName string) error {
+	namespaceName := c.NamespaceFor(ouID)
+	workloadResp, err := c.ocClient.ListWorkloadsWithResponse(ctx, namespaceName, &gen.ListWorkloadsParams{
+		Component: &componentName,
+		Limit:     &defaultListLimit,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list workloads: %w", err)
+	}
+	if workloadResp.StatusCode() != http.StatusOK {
+		return handleErrorResponse(workloadResp.StatusCode(), ErrorResponses{
+			JSON401: workloadResp.JSON401,
+			JSON403: workloadResp.JSON403,
+			JSON404: workloadResp.JSON404,
+			JSON500: workloadResp.JSON500,
+		})
+	}
+	if workloadResp.JSON200 == nil || len(workloadResp.JSON200.Items) == 0 {
+		return nil
+	}
+
+	workload := workloadResp.JSON200.Items[0]
+	if workload.Spec == nil || workload.Spec.Container == nil {
+		return nil
+	}
+	if workload.Spec.Container.Env == nil && workload.Spec.Container.Files == nil {
+		return nil
+	}
+	workload.Spec.Container.Env = nil
+	workload.Spec.Container.Files = nil
+
+	updateResp, err := c.ocClient.UpdateWorkloadWithResponse(ctx, namespaceName, workload.Metadata.Name, workload)
+	if err != nil {
+		return fmt.Errorf("failed to update workload: %w", err)
+	}
+	if updateResp.StatusCode() != http.StatusOK {
+		return handleErrorResponse(updateResp.StatusCode(), ErrorResponses{
+			JSON401: updateResp.JSON401,
+			JSON403: updateResp.JSON403,
+			JSON404: updateResp.JSON404,
+			JSON500: updateResp.JSON500,
+		})
+	}
 	return nil
 }
 

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -560,15 +560,17 @@ func (c *openChoreoClient) PromoteComponent(ctx context.Context, ouID, projectNa
 		return fmt.Errorf("failed to check target release binding: %w", err)
 	}
 
-	// Build workload overrides if env/file overrides are provided
+	// Build workload overrides if env/file overrides are provided.
+	// Nil means "the caller supplied nothing"; an empty slice means "this environment has none"
+	// and must still be written, so the target does not silently inherit the component-wide base.
 	var workloadOverrides *gen.WorkloadOverrides
-	if len(envOverrides) > 0 || len(fileOverrides) > 0 {
+	if envOverrides != nil || fileOverrides != nil {
 		container := &gen.ContainerOverride{}
-		if len(envOverrides) > 0 {
+		if envOverrides != nil {
 			envVars := toGenEnvVars(envOverrides)
 			container.Env = &envVars
 		}
-		if len(fileOverrides) > 0 {
+		if fileOverrides != nil {
 			fileVars := toGenFileVars(fileOverrides)
 			container.Files = &fileVars
 		}

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -1791,17 +1791,23 @@ func (s *agentConfigurationService) processEnvProviderChange(
 		oldProxyHandle = existingMapping.LLMProxy.Handle
 	}
 
-	// Internal-agent only: inject env vars into Component/ReleaseBinding.
+	// Internal-agent only: inject env vars into ReleaseBinding/Component.
 	// SecretReference is already created/updated by secretClient.CreateSecret above.
+	//
+	// The ReleaseBinding for THIS environment is the target — the proxy URL and API key ref are
+	// per-environment, and the Component CR is component-wide, so writing them there for anything
+	// but a bootstrap default is last-write-wins across environments. The Component CR write is
+	// therefore scoped to the first environment, matching every other injection site in this file.
 	if !isExternalAgent {
 		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context, true)
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
-		if uvErr := s.ocClient.UpdateComponentEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envVarsToInject); uvErr != nil {
-			s.logger.Error("failed to update Component CR env vars in Scenario A — Component CR in inconsistent state", "env", envName, "err", uvErr)
+		if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); rbErr != nil {
+			s.logger.Warn("failed to patch ReleaseBinding in Scenario A", "env", envName, "err", rbErr)
 		}
+		// Bootstrap default for agents with no ReleaseBinding yet.
 		if firstEnvName != "" && envName == firstEnvName {
-			if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, firstEnvName, envVarsToInject); rbErr != nil {
-				s.logger.Warn("failed to patch ReleaseBinding in Scenario A", "env", envName, "err", rbErr)
+			if uvErr := s.ocClient.UpdateComponentEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envVarsToInject); uvErr != nil {
+				s.logger.Error("failed to update Component CR env vars in Scenario A — Component CR in inconsistent state", "env", envName, "err", uvErr)
 			}
 		}
 	}

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -2819,25 +2819,32 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 
 	// Combine user-processed env vars with preserved system-managed env vars
 	// and freshly-derived AgentID credentials.
-	deployReq.Env = append(envVars, systemManagedEnvVars...)
-	deployReq.Env = append(deployReq.Env, identityEnvVars...)
+	//
+	// These are written to THIS environment's ReleaseBinding workloadOverrides after Deploy, not
+	// to the Workload: the Workload is a single component-wide base that every environment merges
+	// into its render, so config written there leaks into every other environment and can never be
+	// unset by an override. Deploy() itself only updates the image.
+	overrideEnvVars := append(envVars, systemManagedEnvVars...)
+	overrideEnvVars = append(overrideEnvVars, identityEnvVars...)
 
-	// Ensure Env is always non-nil so Deploy() replaces the Workload env vars rather than
-	// skipping the update. A nil slice is a no-op in Deploy(); an empty slice clears all vars.
-	if deployReq.Env == nil {
-		deployReq.Env = []client.EnvVar{}
+	// Non-nil so the override write means "this is the full set" rather than "leave existing
+	// alone" — an empty slice clears the environment's env vars.
+	if overrideEnvVars == nil {
+		overrideEnvVars = []client.EnvVar{}
 	}
 
-	s.logger.Debug("Final deploy env vars", "agentName", agentName, "totalCount", len(deployReq.Env))
+	s.logger.Debug("Final deploy env vars", "agentName", agentName, "totalCount", len(overrideEnvVars))
 
 	// Process file mounts
-	fileVars, err := s.processFileVars(ctx, ouID, projectName, lowestEnv, agentName, req.Files)
+	overrideFileVars, err := s.processFileVars(ctx, ouID, projectName, lowestEnv, agentName, req.Files)
 	if err != nil {
 		s.logger.Error("Failed to process file mounts", "agentName", agentName, "error", err)
 		return "", fmt.Errorf("failed to process file mounts: %w", err)
 	}
-	deployReq.Files = fileVars
-	s.logger.Debug("Processed file mounts", "agentName", agentName, "count", len(fileVars))
+	if overrideFileVars == nil {
+		overrideFileVars = []client.FileVar{}
+	}
+	s.logger.Debug("Processed file mounts", "agentName", agentName, "count", len(overrideFileVars))
 
 	targetEnv, err := s.ocClient.GetEnvironment(ctx, ouID, lowestEnv)
 	if err != nil {
@@ -2937,20 +2944,9 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	}
 	deployTraitEnvConfigs := buildTraitEnvConfigs(agentName, policies, "", resilienceTimeoutSeconds, isPythonBuildpack, isBallerinaBuildpack, enableAutoInstrumentation, deployInstrumentationImage)
 
-	// Replace Component CR workflow parameters with env vars and file mounts from deploy request
-	// This replaces all existing env vars to ensure the component CR matches the deploy request
-	s.logger.Debug("Replacing component workflow parameters with environment variables", "agentName", agentName, "envVarCount", len(deployReq.Env))
-	if err := s.ocClient.ReplaceComponentEnvVars(ctx, ouID, projectName, agentName, deployReq.Env); err != nil {
-		s.logger.Warn("Failed to replace component workflow parameters with env vars", "agentName", agentName, "error", err)
-		// Continue with deploy even if this fails - env vars will still be applied to the workload
-	}
-
-	if deployReq.Files != nil {
-		s.logger.Debug("Replacing component workflow parameters with file mounts", "agentName", agentName, "fileMountCount", len(deployReq.Files))
-		if err := s.ocClient.ReplaceComponentFileMounts(ctx, ouID, projectName, agentName, deployReq.Files); err != nil {
-			s.logger.Warn("Failed to replace component workflow parameters with file mounts", "agentName", agentName, "error", err)
-		}
-	}
+	// Env vars and file mounts are NOT written to the Component's build workflow parameters here.
+	// Those are seeded once at agent creation and cleared below, once this deploy has copied the
+	// effective set onto the environment's ReleaseBinding — see ClearComponentBaseWorkloadConfig.
 
 	if isAPIAgent {
 		if targetEnv == nil {
@@ -2994,22 +2990,30 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 		s.logger.Info("Updated api-configuration trait", "agentName", agentName, "artifactID", artifactID, "enableApiKeySecurity", enableApiKeySecurity)
 	}
 
-	// Apply deploy-time Component CR changes in a single PUT. This replaces workflow env vars
-	// and also applies any trait changes needed for this deploy.
-	s.logger.Debug("Updating component deployment config", "agentName", agentName, "envVarCount", len(deployReq.Env),
+	// Apply deploy-time Component CR changes in a single PUT — trait changes needed for this deploy.
+	s.logger.Debug("Updating component deployment config", "agentName", agentName,
 		"traitsToAttach", len(componentDeployConfig.TraitsToAttach), "traitsToDetach", len(componentDeployConfig.TraitsToDetach))
 	if err := s.ocClient.UpdateComponentDeploymentConfig(ctx, ouID, projectName, agentName, componentDeployConfig); err != nil {
 		if requiresComponentConfig {
 			return "", fmt.Errorf("failed to update component deployment config: %w", err)
 		}
-		s.logger.Warn("Failed to replace component workflow parameters with env vars", "agentName", agentName, "error", err)
-		// Continue with deploy even if this fails - env vars will still be applied to the workload.
+		s.logger.Warn("Failed to update component deployment config", "agentName", agentName, "error", err)
+		// Continue with deploy even if this fails — the traits are not required for this agent type.
 	}
 
-	// Deploy agent component in OpenChoreo (after env vars and instrumentation are configured)
+	// Deploy agent component in OpenChoreo (after env vars and instrumentation are configured).
+	// This updates the Workload image only; env vars and file mounts are applied per-environment
+	// via the release binding below.
 	s.logger.Debug("Deploying agent component in OpenChoreo", "agentName", agentName, "ouID", ouID, "projectName", projectName, "imageId", req.ImageId)
 	if err := s.ocClient.Deploy(ctx, ouID, projectName, agentName, deployReq); err != nil {
 		s.logger.Error("Failed to deploy agent component in OpenChoreo", "agentName", agentName, "ouID", ouID, "projectName", projectName, "error", err)
+		return "", err
+	}
+
+	// Write this environment's env vars and file mounts to its release binding, then drop the
+	// component-wide copies. Both steps must succeed: the overrides are the only place the config
+	// now lives, and a base left populated leaks into every other environment.
+	if err := s.applyEnvScopedWorkloadConfig(ctx, ouID, projectName, agentName, lowestEnv, overrideEnvVars, overrideFileVars); err != nil {
 		return "", err
 	}
 
@@ -3065,6 +3069,69 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 
 	s.logger.Info("Agent deployed successfully to "+lowestEnv, "agentName", agentName, "ouID", org.Name, "projectName", projectName, "environment", lowestEnv)
 	return lowestEnv, nil
+}
+
+// releaseBindingWaitAttempts / releaseBindingWaitInterval bound how long a deploy waits for the
+// environment's ReleaseBinding to exist. On an agent's first deploy the binding is created by
+// OpenChoreo's component controller once the build's Release lands (ensureReleaseBinding), so it
+// can trail the Deploy call by a reconcile cycle.
+const (
+	releaseBindingWaitAttempts = 10
+	releaseBindingWaitInterval = 2 * time.Second
+)
+
+// applyEnvScopedWorkloadConfig writes the environment's full env var and file mount set to its
+// ReleaseBinding workloadOverrides, then clears the component-wide base (build workflow parameters
+// + Workload container spec).
+//
+// The base is shared by every environment — each one renders base merged with its own overrides —
+// so config left there leaks into environments it was never meant for, and can never be removed,
+// since an override cannot unset a base key. Clearing it after the override write is what keeps
+// deploy scoped to a single environment.
+//
+// Ordering matters: the override write must land before the base is cleared, or a failure between
+// the two would leave the environment with no config at all.
+func (s *agentManagerService) applyEnvScopedWorkloadConfig(
+	ctx context.Context,
+	ouID, projectName, agentName, environment string,
+	envVars []client.EnvVar,
+	fileVars []client.FileVar,
+) error {
+	var lastErr error
+	for attempt := 1; attempt <= releaseBindingWaitAttempts; attempt++ {
+		lastErr = s.ocClient.ReplaceReleaseBindingWorkloadOverrides(ctx, ouID, agentName, environment, envVars, fileVars)
+		if lastErr == nil {
+			break
+		}
+		if !errors.Is(lastErr, utils.ErrNotFound) {
+			s.logger.Error("Failed to write workload overrides to release binding",
+				"agentName", agentName, "environment", environment, "error", lastErr)
+			return fmt.Errorf("failed to apply environment configuration: %w", lastErr)
+		}
+		// Binding not created yet (first deploy) — wait for the controller and retry.
+		s.logger.Debug("Release binding not ready yet, retrying workload override write",
+			"agentName", agentName, "environment", environment, "attempt", attempt)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(releaseBindingWaitInterval):
+		}
+	}
+	if lastErr != nil {
+		s.logger.Error("Release binding never became available for workload overrides",
+			"agentName", agentName, "environment", environment, "error", lastErr)
+		return fmt.Errorf("failed to apply environment configuration: %w", lastErr)
+	}
+
+	if err := s.ocClient.ClearComponentBaseWorkloadConfig(ctx, ouID, projectName, agentName); err != nil {
+		s.logger.Error("Failed to clear component-wide workload config after deploy",
+			"agentName", agentName, "environment", environment, "error", err)
+		return fmt.Errorf("failed to clear component-wide configuration: %w", err)
+	}
+
+	s.logger.Debug("Applied environment-scoped workload config", "agentName", agentName,
+		"environment", environment, "envVarCount", len(envVars), "fileMountCount", len(fileVars))
+	return nil
 }
 
 // resolvedTracingConfig holds resolved instrumentation config values.
@@ -3865,7 +3932,15 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 				userEnv = append(userEnv, env)
 			}
 		}
-		if len(userEnv) > 0 {
+		// Nil (caller sent nothing) and empty (caller cleared the list) must stay distinguishable:
+		// an empty list is a deliberate "this environment has none", so it still has to be
+		// processed and written as an explicit override rather than skipped.
+		//
+		// processEnvVars is also the sole writer of file-mount secrets to the KV store (it handles
+		// env and file secrets together on one path), so it must run whenever the request carries
+		// files, even with no env vars — otherwise processFileVars emits a secretKeyRef to a secret
+		// that was never created.
+		if req.Env != nil || req.Files != nil {
 			processed, err := s.processEnvVars(ctx, ouID, projectName, req.TargetEnvironment, agentName, userEnv, req.Files)
 			if err != nil {
 				s.logger.Error("Failed to process environment variables for promotion", "agentName", agentName, "error", err)
@@ -3873,13 +3948,16 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			}
 			envOverrides = append(envOverrides, processed...)
 		}
-		if len(req.Files) > 0 {
+		if req.Files != nil {
 			processed, err := s.processFileVars(ctx, ouID, projectName, req.TargetEnvironment, agentName, req.Files)
 			if err != nil {
 				s.logger.Error("Failed to process file mounts for promotion", "agentName", agentName, "error", err)
 				return fmt.Errorf("failed to process file mounts: %w", err)
 			}
 			fileOverrides = processed
+			if fileOverrides == nil {
+				fileOverrides = []client.FileVar{}
+			}
 		}
 	}
 

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
@@ -120,6 +120,36 @@ spec:
                         type: string
                         description: "Key within the secret"
 
+        fileMounts:
+          type: array
+          default: []
+          description: "List of file mounts"
+          items:
+            type: object
+            required: [key, mountPath]
+            properties:
+              key:
+                type: string
+                description: "File mount key; also the ConfigMap/Secret data key"
+              mountPath:
+                type: string
+                description: "Absolute path the file is mounted at inside the container"
+              value:
+                type: string
+                description: "Inline file content (optional if valueFrom is set)"
+              valueFrom:
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: "Name of the K8s secret"
+                      key:
+                        type: string
+                        description: "Key within the secret"
+
   runTemplate:
     apiVersion: argoproj.io/v1alpha1
     kind: Workflow

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
@@ -147,6 +147,36 @@ spec:
                         type: string
                         description: "Key within the secret"
 
+        fileMounts:
+          type: array
+          default: []
+          description: "List of file mounts"
+          items:
+            type: object
+            required: [key, mountPath]
+            properties:
+              key:
+                type: string
+                description: "File mount key; also the ConfigMap/Secret data key"
+              mountPath:
+                type: string
+                description: "Absolute path the file is mounted at inside the container"
+              value:
+                type: string
+                description: "Inline file content (optional if valueFrom is set)"
+              valueFrom:
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: "Name of the K8s secret"
+                      key:
+                        type: string
+                        description: "Key within the secret"
+
   runTemplate:
     apiVersion: argoproj.io/v1alpha1
     kind: Workflow

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
@@ -120,6 +120,36 @@ spec:
                         type: string
                         description: "Key within the secret"
 
+        fileMounts:
+          type: array
+          default: []
+          description: "List of file mounts"
+          items:
+            type: object
+            required: [key, mountPath]
+            properties:
+              key:
+                type: string
+                description: "File mount key; also the ConfigMap/Secret data key"
+              mountPath:
+                type: string
+                description: "Absolute path the file is mounted at inside the container"
+              value:
+                type: string
+                description: "Inline file content (optional if valueFrom is set)"
+              valueFrom:
+                type: object
+                properties:
+                  secretKeyRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: "Name of the K8s secret"
+                      key:
+                        type: string
+                        description: "Key within the secret"
+
   runTemplate:
     apiVersion: argoproj.io/v1alpha1
     kind: Workflow


### PR DESCRIPTION
Deploy wrote env vars and file mounts to the Workload's container spec. There is one Workload per component and every environment renders base + its own ReleaseBinding overrides, so anything written there reached every environment. Adding a var in Development applied it in Stage and Production too.

It also made removal impossible: mergeEnvConfigs/mergeFileConfigs fall back to the base whenever the override list omits a key, and return the base outright when it is empty, so no override can unset a base value. Deleting a var via Configure left it set on the pod at any environment count.

Deploy now writes the effective set to the environment's ReleaseBinding workloadOverrides and clears the component-wide base: both the Workload container spec and the Component's build workflow parameters, which the build's generate-workload step would otherwise re-seed into the base. Create still seeds those parameters -- with no Workload or binding yet they are the only carrier for create-time config -- and the first deploy copies them onto the binding before clearing. Per-agent migration therefore happens on the next deploy; no backfill is needed.

Also:

- Promote distinguishes nil from empty for env and files, so "the caller cleared the list" is written as an explicit empty override instead of being skipped and silently inheriting the base.
- Promote runs processEnvVars whenever the request carries files. It is the sole writer of file-mount secrets to the KV store, so a files-only promote previously emitted a secretKeyRef to a secret never created.
- processEnvProviderChange wrote the Component CR unconditionally and the ReleaseBinding only for the first environment, inverted from the other nine injection sites, and passed firstEnvName where envName belonged. Changing an LLM provider for a non-first environment therefore wrote that config only to the shared base -- which the deploy clear above would now discard -- while patching the wrong environment's binding.
- Declare the fileMounts build parameter on the three AMP workflows in the platform-resources-extension chart. Their run templates already referenced ${parameters.fileMounts}; the schema default makes it resolve without depending on the caller always writing the key.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.