### PR TITLE
fix(console): suppress browser autofill blue background in dark theme…

### DIFF
--- a/console/apps/web-ui/src/index.css
+++ b/console/apps/web-ui/src/index.css
@@ -45,3 +45,30 @@ html[data-color-scheme="dark"] {
 .lucide:not(.lucide-logo) * {
   vector-effect: non-scaling-stroke;
 }
+
+/*
+ * Browser autofill background override (#1616)
+ *
+ * Chromium/WebKit apply a native UA background paint to autofilled inputs via
+ * an internal render layer that cannot be overridden with `background-color`.
+ * The only reliable approach is an inset `box-shadow` large enough to cover the
+ * autofill highlight, combined with `-webkit-text-fill-color` so text remains
+ * readable even when the browser also forces a text color.
+ *
+ * We reference the Oxygen UI CSS variables that `OxygenUIThemeProvider` already
+ * emits on `[data-color-scheme]` so this rule is theme-aware and does not
+ * hardcode any color — it uses exactly the same acrylic background and primary
+ * text color that `MuiOutlinedInput` uses in normal (non-autofilled) state.
+ *
+ * The four pseudo-class variants are needed because Chromium re-applies the
+ * autofill style on hover, focus, and active, not just on initial fill.
+ */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  box-shadow: 0 0 0 1000px var(--oxygen-palette-background-acrylic) inset !important;
+  -webkit-text-fill-color: var(--oxygen-palette-text-primary) !important;
+  /* Preserve the transition Oxygen UI sets on the input border/background */
+  transition: background-color 0s ease-in-out 0s;
+}


### PR DESCRIPTION
Purpose
Browser autofill in Chromium/WebKit overrides the native input background with a bright blue highlight in dark mode, visually breaking the Oxygen UI dark theme. This is reproducible on any form with browser-remembered fields (e.g. GitHub Repository, Branch, Project Path on the Add New Agent page).

Resolves #1616

Goals
Remove the bright blue/yellow autofill background in dark mode
Keep the autofilled input visually indistinguishable from a normal (non-autofilled) input in both dark and light themes
Preserve readable text color during autofill
Fix applies globally — not just to the three reported fields, but to every input in the application
Approach
Chromium and WebKit apply autofill styling through an internal UA render layer that cannot be overridden with background-color. The standard workaround is:

box-shadow: inset 0 0 0 1000px <color> — an inset shadow large enough to visually cover the entire input area, painting over the browser's autofill background without touching the UA layer itself.
-webkit-text-fill-color — overrides the browser-forced text color that Chromium applies during autofill.
Colors are sourced from the Oxygen UI CSS variables already emitted by OxygenUIThemeProvider:

--oxygen-palette-background-acrylic — matches the exact background MuiOutlinedInput uses in normal state (rgba(255,255,255,0.25) light / rgba(0,0,0,0.25) dark)
--oxygen-palette-text-primary — matches the theme's normal text color
These variables are scoped to [data-color-scheme] by the provider, so the fix adapts automatically to both themes without any hardcoded colors.

All four autofill pseudo-class variants are covered (:-webkit-autofill, :-webkit-autofill:hover, :-webkit-autofill:focus, :-webkit-autofill:active) because Chromium re-applies the autofill paint on each state transition.

File changed: console/apps/web-ui/src/index.css (+27 lines)

This is placed in the global stylesheet alongside the existing Oxygen UI icon stroke workaround — the same architectural pattern already used for other browser-level global overrides.

Before / After:

State	Before	After
Dark mode — autofilled	Bright blue background, potentially unreadable text	Matches dark Oxygen UI theme (rgba(0,0,0,0.25) background, #efefef text)
Light mode — autofilled	Yellow/blue highlight	Matches light Oxygen UI theme (rgba(255,255,255,0.25) background, #40404B text)
Normal (non-autofilled)	Unchanged	Unchanged
User stories
As a user filling in form fields (e.g. GitHub Repository, Branch, Project Path) using browser autofill in dark mode, the input should maintain the same appearance as manually typed text — no bright blue or yellow autofill highlight should break the dark theme.

Release note
Fixed an issue where browser autofill caused a bright blue background on input fields in dark mode. Autofilled inputs now match the dark Oxygen UI theme appearance.

Documentation
N/A — this is a pure visual bug fix with no user-facing behaviour change beyond the corrected styling.

Training
N/A

Certification
N/A — no functional behaviour change.

Marketing
N/A

Automation tests
Unit tests: N/A — CSS visual regression is not covered by the existing Vitest suite; this fix is validated manually via browser DevTools.
Integration tests: N/A
Security checks
Followed secure coding standards: yes
Ran FindSecurityBugs plugin: N/A (frontend CSS change only)
Confirmed no secrets committed: yes
Samples
N/A

Related PRs
None

Migrations
N/A

Test environment
Browser: Chrome 126+ (Chromium autofill behaviour)
OS: Windows 11
Theme: Dark mode (AcrylicOrangeTheme via OxygenUIThemeProvider)
Node.js: 20.17.0
Learning
Chromium's autofill paint is applied via an internal compositing layer separate from the element's own CSS paint order. Setting background-color — even with !important — has no effect on it. The box-shadow: inset technique works because box shadows are composited above the autofill layer. This is the established cross-browser workaround documented in the web community and referenced in the Chromium issue tracker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved browser autofill styling for inputs.
  * Autofilled fields now adapt to the selected theme across hover, focus, and active states while preserving readable text and smooth background transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->