### PR TITLE
Enable AWS Bedrock setup from the LLM provider form

### DIFF
--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -15739,7 +15739,7 @@ components:
         type:
           type: string
           description: Authentication type
-          example: bearer
+          example: api-key
         header:
           type: string
           description: Header name for authentication
@@ -15801,10 +15801,8 @@ components:
           description: Authentication type
           enum:
             - api-key
-            - bearer
-            - basic
             - none
-          example: bearer
+          example: api-key
         header:
           type: string
           description: Authentication header name

--- a/agent-manager-service/resources/builtin_llm_templates.go
+++ b/agent-manager-service/resources/builtin_llm_templates.go
@@ -102,7 +102,13 @@ var BuiltInLLMProviderTemplates = []*models.LLMProviderTemplate{
 		IsSystem: true,
 		OUID:     "",
 		Metadata: &models.LLMProviderTemplateMetadata{
-			EndpointURL:    "https://bedrock-runtime.us-east-1.amazonaws.com",
+			EndpointURL: "https://bedrock-runtime.us-east-1.amazonaws.com",
+			// "bearer" is not a gateway upstream auth type; api-key sets the header verbatim.
+			Auth: &models.LLMProviderTemplateAuth{
+				Type:        "api-key",
+				Header:      "Authorization",
+				ValuePrefix: "Bearer ",
+			},
 			LogoURL:        "https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/icon.png",
 			OpenapiSpecURL: "https://raw.githubusercontent.com/nomadxd/openapi-connectors/main/openapi/aws.bedrock/openapi.yaml",
 		},

--- a/agent-manager-service/services/llm_template_seeder.go
+++ b/agent-manager-service/services/llm_template_seeder.go
@@ -93,6 +93,11 @@ func (s *LLMTemplateSeeder) SeedForOrg(ouID string) error {
 					current.Metadata.OpenapiSpecURL = tpl.Metadata.OpenapiSpecURL
 					updated = true
 				}
+				// Backfill only when absent, so an operator-set auth block survives re-seeding.
+				if current.Metadata.Auth == nil && tpl.Metadata.Auth != nil {
+					current.Metadata.Auth = tpl.Metadata.Auth
+					updated = true
+				}
 			}
 			if current.Name == "" && tpl.Name != "" {
 				current.Name = tpl.Name

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -368,13 +368,13 @@ func (e CreateEnvironmentRequestIsolationTier) Valid() bool {
 
 // Defines values for CreateGitSecretRequestType.
 const (
-	CreateGitSecretRequestTypeBasic CreateGitSecretRequestType = "basic"
+	Basic CreateGitSecretRequestType = "basic"
 )
 
 // Valid indicates whether the value is a known member of the CreateGitSecretRequestType enum.
 func (e CreateGitSecretRequestType) Valid() bool {
 	switch e {
-	case CreateGitSecretRequestTypeBasic:
+	case Basic:
 		return true
 	default:
 		return false
@@ -1025,22 +1025,16 @@ func (e UpdateDeploymentStateResponseState) Valid() bool {
 
 // Defines values for UpstreamAuthType.
 const (
-	UpstreamAuthTypeApiKey UpstreamAuthType = "api-key"
-	UpstreamAuthTypeBasic  UpstreamAuthType = "basic"
-	UpstreamAuthTypeBearer UpstreamAuthType = "bearer"
-	UpstreamAuthTypeNone   UpstreamAuthType = "none"
+	ApiKey UpstreamAuthType = "api-key"
+	None   UpstreamAuthType = "none"
 )
 
 // Valid indicates whether the value is a known member of the UpstreamAuthType enum.
 func (e UpstreamAuthType) Valid() bool {
 	switch e {
-	case UpstreamAuthTypeApiKey:
+	case ApiKey:
 		return true
-	case UpstreamAuthTypeBasic:
-		return true
-	case UpstreamAuthTypeBearer:
-		return true
-	case UpstreamAuthTypeNone:
+	case None:
 		return true
 	default:
 		return false

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -45,7 +45,7 @@ const (
 )
 
 // validAuthTypes are the upstream auth schemes accepted by the service.
-var validAuthTypes = []string{"api-key", "basic", "bearer", "none"}
+var validAuthTypes = []string{"api-key", "none"}
 
 type CreateOptions struct {
 	IO           *iostreams.IOStreams

--- a/console/workspaces/libs/types/src/api/llm-providers.ts
+++ b/console/workspaces/libs/types/src/api/llm-providers.ts
@@ -122,7 +122,7 @@ export interface LLMModel {
   description?: string;
 }
 
-export type UpstreamAuthType = "api-key" | "bearer" | "basic" | "none";
+export type UpstreamAuthType = "api-key" | "none";
 
 export interface UpstreamAuth {
   type: UpstreamAuthType;

--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -63,7 +63,7 @@ export type TemplateCard = {
   hasTemplateAuthType?: boolean;
   hasTemplateAuthHeader?: boolean;
   /**
-   * Auth type from template metadata (e.g., "bearer", "apiKey").
+   * Auth type from template metadata (e.g., "api-key").
    */
   authType?: string;
   /**

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderConnectionTab.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderConnectionTab.tsx
@@ -58,10 +58,9 @@ const resilienceTimeoutSchema = z
 
 const AUTH_TYPE_API_KEY = "api-key";
 
+// "bearer" and "basic" are absent from the gateway's upstream auth enum, so they never deploy.
 const AUTH_TYPE_OPTIONS: { value: UpstreamAuthType; label: string }[] = [
   { value: "api-key", label: "API Key" },
-  { value: "bearer", label: "Bearer" },
-  { value: "basic", label: "Basic" },
   { value: "none", label: "None" },
 ];
 

--- a/console/workspaces/pages/llm-providers/src/utils/llmProviderPayload.ts
+++ b/console/workspaces/pages/llm-providers/src/utils/llmProviderPayload.ts
@@ -84,15 +84,13 @@ export function buildCreateLLMProviderRequest(
   const contextPath = values.context?.trim() || ``;
 
   const authType: UpstreamAuthType =
-    (selectedTemplate?.authType as UpstreamAuthType) ?? "bearer";
+    (selectedTemplate?.authType as UpstreamAuthType) ?? "api-key";
   const authHeader = selectedTemplate?.authHeader ?? "Authorization";
   const apiKey = values.apiKey?.trim() ?? "";
   const authValue = apiKey
     ? selectedTemplate?.authValuePrefix
       ? `${selectedTemplate.authValuePrefix}${apiKey}`
-      : authType === "bearer"
-        ? `Bearer ${apiKey}`
-        : apiKey
+      : apiKey
     : "";
 
   return {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Resolves #1533

AWS Bedrock could not be set up from the LLM provider form. The built-in `awsbedrock` template declared no authentication, so the console fell back to an upstream auth type of `bearer` -- a value the gateway does not accept anymore. Bedrock was only usable by creating a provider and then editing its connection settings by hand, which in turn blocked LLM-judge monitors from using Bedrock as the judge model. 

Bedrock API keys are bearer tokens sent in the `Authorization` header, which is exactly what the existing `api-key` auth type produces together with a value prefix. The template now declares that, and organisations seeded before this change have the auth block backfilled when the seeder next runs.

While checking this against the gateway, `bearer` and `basic` turned out never to have been valid upstream auth types -- the gateway's enum is `api-key`, `none` and `other` -- so a provider storing either can never deploy. They are removed from our own contract and from the connection tab dropdown rather than left as choices that always fail.

SigV4 signing needs no change here. The gateway already accepts an upstream auth type of `none`, and the `aws-authentication` policy can be attached from the guardrails tab, so that path works without new code.


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.