### PR TITLE
Read file mounts from the environment's release binding

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -2991,25 +2991,75 @@ func (c *openChoreoClient) GetComponentFileMounts(ctx context.Context, ouID, pro
 		})
 	}
 
-	var fileMounts []models.FileMountEntry
+	// Base file mounts from the Workload, keyed so the environment's overrides can replace them.
+	// Order is tracked separately: a map alone would return the mounts in a different order on
+	// every call, which reshuffles the list the console renders.
+	fileMountMap := make(map[string]models.FileMountEntry)
+	var order []string
+	appendMount := func(f gen.FileVar) {
+		isSensitive := f.ValueFrom != nil && f.ValueFrom.SecretKeyRef != nil
+		secretRef := ""
+		if isSensitive && f.ValueFrom.SecretKeyRef.Name != nil {
+			secretRef = *f.ValueFrom.SecretKeyRef.Name
+		}
+		if _, seen := fileMountMap[f.Key]; !seen {
+			order = append(order, f.Key)
+		}
+		fileMountMap[f.Key] = models.FileMountEntry{
+			Key:         f.Key,
+			MountPath:   f.MountPath,
+			Value:       utils.StrPointerAsStr(f.Value, ""),
+			IsSensitive: isSensitive,
+			SecretRef:   secretRef,
+		}
+	}
+
 	if workloadResp.JSON200 != nil && len(workloadResp.JSON200.Items) > 0 {
 		workload := workloadResp.JSON200.Items[0]
 		if workload.Spec != nil && workload.Spec.Container != nil && workload.Spec.Container.Files != nil {
 			for _, f := range *workload.Spec.Container.Files {
-				isSensitive := f.ValueFrom != nil && f.ValueFrom.SecretKeyRef != nil
-				secretRef := ""
-				if isSensitive && f.ValueFrom.SecretKeyRef.Name != nil {
-					secretRef = *f.ValueFrom.SecretKeyRef.Name
-				}
-				fileMounts = append(fileMounts, models.FileMountEntry{
-					Key:         f.Key,
-					MountPath:   f.MountPath,
-					Value:       utils.StrPointerAsStr(f.Value, ""),
-					IsSensitive: isSensitive,
-					SecretRef:   secretRef,
-				})
+				appendMount(f)
 			}
 		}
+	}
+
+	// Overlay this environment's release binding overrides. Deploy writes the effective set here
+	// and clears the Workload base, so without this the mounts vanish from the console after the
+	// first deploy even though they are mounted on the pod. Mirrors GetComponentConfigurations.
+	releaseBindingResp, err := c.ocClient.ListReleaseBindingsWithResponse(ctx, namespaceName, &gen.ListReleaseBindingsParams{
+		Component: &componentName,
+		Limit:     &defaultListLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list release bindings: %w", err)
+	}
+	if releaseBindingResp.StatusCode() != http.StatusOK {
+		return nil, handleErrorResponse(releaseBindingResp.StatusCode(), ErrorResponses{
+			JSON401: releaseBindingResp.JSON401,
+			JSON403: releaseBindingResp.JSON403,
+			JSON404: releaseBindingResp.JSON404,
+			JSON500: releaseBindingResp.JSON500,
+		})
+	}
+
+	if releaseBindingResp.JSON200 != nil {
+		for _, binding := range releaseBindingResp.JSON200.Items {
+			if binding.Spec == nil || binding.Spec.Environment != environment {
+				continue
+			}
+			if binding.Spec.WorkloadOverrides != nil && binding.Spec.WorkloadOverrides.Container != nil &&
+				binding.Spec.WorkloadOverrides.Container.Files != nil {
+				for _, f := range *binding.Spec.WorkloadOverrides.Container.Files {
+					appendMount(f)
+				}
+			}
+			break
+		}
+	}
+
+	var fileMounts []models.FileMountEntry
+	for _, key := range order {
+		fileMounts = append(fileMounts, fileMountMap[key])
 	}
 
 	return fileMounts, nil


### PR DESCRIPTION
GetComponentFileMounts took an environment argument and ignored it, reading only the Workload's container spec. Deploy writes the effective set to that environment's ReleaseBinding workloadOverrides and then clears the component-wide base, so every agent past its first deploy read back an empty list: the mounts were on the pod but absent from the console and from GET .../file-mounts, and per-environment values never differed between environments.

Overlay the binding the way GetComponentConfigurations already does for env vars: seed from the Workload base, find the binding whose Spec.Environment matches, and apply its container.Files on top. Union semantics match how the render merges them -- mergeFileConfigs falls back to the base for keys an override omits -- so agents that have not yet migrated off the base still read correctly.

Entries are collected into a keyed map with the insertion order tracked separately. The env var twin returns map-iteration order, which reshuffles the list on every call; file mounts keep base order with override-only keys appended.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.