### PR TITLE
Support native Docker on Linux in local setup scripts

### DIFF
--- a/deployments/setup/port-forward.sh
+++ b/deployments/setup/port-forward.sh
@@ -54,7 +54,25 @@ fi
 # Unset = kubectl default (127.0.0.1). CI sets 0.0.0.0 so the agent-manager
 # container (docker-compose) can reach them via the host/bridge gateway —
 # a 127.0.0.1-only forward is unreachable from inside the container on Linux.
+#
+# So on Linux, default to loopback *plus* the Docker bridge gateway: containers
+# reach the host through the address their `host-gateway` alias resolves to, and
+# binding it makes the forwards reachable from docker-compose without publishing
+# anything to the LAN, while loopback keeps http://localhost:<port> working for
+# the developer. macOS needs none of this — Docker Desktop already routes
+# host.docker.internal traffic to the host's loopback.
 PF_ADDRESS="${PORT_FORWARD_ADDRESS:-}"
+if [ -z "$PF_ADDRESS" ] && [ "$(uname -s)" = "Linux" ]; then
+    bridge_gateway=$(docker network inspect bridge \
+        --format '{{ (index .IPAM.Config 0).Gateway }}' 2>/dev/null)
+    if [ -n "$bridge_gateway" ]; then
+        PF_ADDRESS="127.0.0.1,$bridge_gateway"
+    else
+        echo "⚠️  Could not determine the Docker bridge gateway address."
+        echo "   Forwards will bind to localhost only, so containers cannot reach them."
+        echo "   Set PORT_FORWARD_ADDRESS explicitly to override."
+    fi
+fi
 
 start_forward() {
     local desc="$1"; shift

--- a/deployments/setup/setup-colima.sh
+++ b/deployments/setup/setup-colima.sh
@@ -7,7 +7,54 @@ source "$SCRIPT_DIR/env.sh"
 source "$SCRIPT_DIR/utils.sh"
 
 # ============================================================================
-# Configuration
+# Linux: skip the VM entirely
+# ============================================================================
+# Colima exists to give macOS a Linux Docker daemon. On Linux that daemon is
+# already native, and interposing a VM would strand k3d and docker-compose in a
+# daemon separate from the host's — bind mounts, published ports and
+# host.docker.internal all stop lining up. So on Linux we validate the native
+# daemon and hand straight over to the k3d setup.
+if [ "$(uname -s)" = "Linux" ]; then
+    echo "=== Checking prerequisites ==="
+    check_command docker
+    check_command k3d
+    check_command kubectl
+    check_command helm
+
+    echo ""
+    echo "=== Linux detected — using the native Docker daemon (no Colima VM) ==="
+
+    # Checked before reachability: a stale Colima context makes `docker info`
+    # fail too, and the honest diagnosis is the wrong context rather than a
+    # stopped daemon. Such a context silently points every later docker/k3d
+    # call at a VM daemon while the cluster and compose state live on the
+    # native one.
+    DOCKER_CONTEXT_NAME="$(docker context show)"
+    case "$DOCKER_CONTEXT_NAME" in
+        colima*)
+            echo "❌ Active Docker context is '$DOCKER_CONTEXT_NAME' (a Colima VM)."
+            echo "   On Linux this hides the native daemon from k3d and docker compose."
+            echo "   Switch back with:  docker context use default"
+            exit 1
+            ;;
+    esac
+
+    if ! docker info > /dev/null 2>&1; then
+        echo "❌ Cannot reach the Docker daemon."
+        echo "   Start it with:  sudo systemctl start docker"
+        echo "   If this user has never used Docker:"
+        echo "     sudo usermod -aG docker \$USER   (then log out and back in)"
+        exit 1
+    fi
+
+    echo "✅ Docker is running (context: $DOCKER_CONTEXT_NAME)"
+    echo ""
+    echo "✅ Setup complete! You can now proceed with k3d cluster setup."
+    exit 0
+fi
+
+# ============================================================================
+# Configuration (macOS)
 # ============================================================================
 PROFILE="${1:-dev}"
 COLIMA_CPU="${COLIMA_CPU:-8}"

--- a/deployments/setup/setup-platform.sh
+++ b/deployments/setup/setup-platform.sh
@@ -14,8 +14,13 @@ echo "=== Setting up Agent Manager Core Platform ==="
 
 # Check prerequisites
 if ! docker info &> /dev/null; then
-    echo "❌ Docker is not running. Please start Colima first:"
-    echo "   ./setup-colima.sh"
+    if [ "$(uname -s)" = "Linux" ]; then
+        echo "❌ Docker is not running. Start the daemon first:"
+        echo "   sudo systemctl start docker"
+    else
+        echo "❌ Docker is not running. Please start Colima first:"
+        echo "   ./setup-colima.sh"
+    fi
     exit 1
 fi
 
@@ -30,6 +35,11 @@ if ! docker buildx version &> /dev/null; then
     echo "   Please install Docker Buildx plugin."
     exit 1
 fi
+
+# Checked up front rather than at first use: the migration step below shells out
+# to `go run`, and it only runs after images are built and Postgres is up — so a
+# missing toolchain would otherwise surface many minutes into the setup.
+check_command go
 
 if ! command -v node &> /dev/null; then
     echo "❌ Node.js is not installed."
@@ -76,6 +86,15 @@ echo "2️⃣  Start platform services"
 # Export console host path so docker-compose can align WORKDIR with the host,
 # preventing Rush temp-file / node_modules path mismatches.
 export CONSOLE_HOST_PATH="$(cd "$SCRIPT_DIR/../../console" && pwd)"
+
+# The console service mounts named volumes at these two paths inside the
+# bind-mounted console directory. Any that do not exist yet, Docker creates as
+# the container's user — root — and on Linux that ownership lands on the host
+# verbatim, so the later host-side `rush install` gets EACCES. (macOS remaps
+# bind-mount ownership to the invoking user, which is why it only bites here.)
+# Creating them first leaves them owned by this user; Docker never re-chowns an
+# existing mountpoint.
+mkdir -p "$CONSOLE_HOST_PATH/node_modules" "$CONSOLE_HOST_PATH/common/temp"
 
 # Must migrate before agent-manager-service starts: it crashes on a fresh volume
 # (missing tables), and Air never auto-restarts a crash — only rebuilds on file changes.

--- a/deployments/setup/teardown.sh
+++ b/deployments/setup/teardown.sh
@@ -41,9 +41,13 @@ fi
 # ============================================================================
 # Step 3: Delete Colima dev profile
 # ============================================================================
+# Linux never created a Colima VM (see setup-colima.sh), and any profile found
+# here belongs to the user's other work — leave it alone.
 echo ""
 echo "3️⃣  Delete Colima dev profile"
-if command -v colima &> /dev/null; then
+if [ "$(uname -s)" = "Linux" ]; then
+    echo "⏭️  Linux uses the native Docker daemon, no Colima profile to delete"
+elif command -v colima &> /dev/null; then
     if colima list 2>/dev/null | grep -q "dev"; then
         echo "🛑 Deleting Colima dev profile..."
         colima stop dev 2>/dev/null || true
@@ -57,7 +61,9 @@ else
 fi
 
 echo ""
-echo "ℹ️  Note: Colima default profile may still be running."
-echo "   To completely remove Colima: colima delete"
-echo ""
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "ℹ️  Note: Colima default profile may still be running."
+    echo "   To completely remove Colima: colima delete"
+    echo ""
+fi
 echo "✅ Teardown complete!"

--- a/deployments/setup/utils.sh
+++ b/deployments/setup/utils.sh
@@ -1,10 +1,34 @@
 # Util: Check if a port is in use
+#
+# On Linux a published container port is held by a root-owned docker-proxy,
+# which lsof hides from an unprivileged caller — the port reads as free and the
+# cluster only fails much later, at bind time. ss reads /proc/net/tcp and sees
+# every listener regardless of owner. macOS ships no ss, but there the listener
+# belongs to the invoking user, so lsof is accurate.
 is_port_in_use() {
     local port="$1"
-    if lsof -i :"$port" -sTCP:LISTEN &>/dev/null; then
-        return 0
+    if command -v ss &> /dev/null; then
+        [ -n "$(ss -ltnH "sport = :$port" 2>/dev/null)" ]
+        return
     fi
-    return 1
+    lsof -i :"$port" -sTCP:LISTEN &> /dev/null
+}
+
+# Util: Name the Docker containers publishing a port, so a conflict report says
+# what to stop instead of only which port is taken.
+containers_publishing_port() {
+    docker ps --filter "publish=$1" --format '{{.Names}}' 2>/dev/null \
+        | tr '\n' ' ' \
+        | sed 's/ *$//'
+}
+
+# Util: The command that shows which process owns a listening port, per platform.
+port_owner_command() {
+    if command -v ss &> /dev/null; then
+        echo "ss -ltnp 'sport = :<port>'"
+    else
+        echo "lsof -i :<port>"
+    fi
 }
 
 # Util: Check all required ports for k3d cluster are available
@@ -30,7 +54,13 @@ check_required_ports() {
         local port="${port_info%%:*}"
         local desc="${port_info#*:}"
         if is_port_in_use "$port"; then
-            blocked_ports+=("$port ($desc)")
+            local holders
+            holders=$(containers_publishing_port "$port")
+            if [ -n "$holders" ]; then
+                blocked_ports+=("$port ($desc) — held by container(s): $holders")
+            else
+                blocked_ports+=("$port ($desc)")
+            fi
         fi
     done
 
@@ -41,7 +71,7 @@ check_required_ports() {
         done
         echo ""
         echo "Please free these ports before creating the cluster."
-        echo "You can find processes using a port with: lsof -i :<port>"
+        echo "You can find processes using a port with: $(port_owner_command)"
         return 1
     fi
 
@@ -56,6 +86,7 @@ get_min_version() {
         k3d)     echo "5.8" ;;
         kubectl) echo "1.32" ;;
         helm)    echo "3.12" ;;
+        go)      echo "1.25" ;;
         *)       echo "" ;;
     esac
 }
@@ -73,12 +104,21 @@ get_version() {
     "$1" version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1
 }
 
+# Util: Suggest how to install a missing command on the current platform.
+install_hint() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        echo "brew install $1"
+    else
+        echo "install '$1' with your distribution's package manager"
+    fi
+}
+
 # Util: Check if a command is installed and version is compatible
 check_command() {
     local cmd="$1"
     if ! command -v "$cmd" &> /dev/null; then
         echo "❌ $cmd is not installed. Please install it first:"
-        echo "   brew install $cmd"
+        echo "   $(install_hint "$cmd")"
         exit 1
     fi
 


### PR DESCRIPTION
## Purpose

`make setup` cannot complete on a native Linux host. The local setup scripts assume macOS + Colima throughout, and four distinct problems block the run — three of them Linux-specific, one cross-platform:

1. **Colima is mandatory.** `setup-colima.sh` unconditionally requires the `colima` binary and starts a VM. On Linux the Docker daemon is already native; interposing a VM strands k3d and docker-compose in a daemon separate from the host's, so bind mounts, published ports and `host.docker.internal` all stop lining up.
2. **The port pre-flight check is blind on Linux.** `is_port_in_use()` uses `lsof`, but a published container port is held by a root-owned `docker-proxy`, which `lsof` hides from an unprivileged caller. The port reads as free and the cluster only fails much later, at bind time, with an error that doesn't name the conflict. Observed with unrelated containers holding 8080 and 5432: the check reported "All required ports are available" and the k3d cluster creation failed minutes later.
3. **`rush install` fails with EACCES.** The console service mounts named volumes at `console/node_modules` and `console/common/temp`. Docker creates missing mountpoints as the container's user (root), and on Linux that ownership lands on the host verbatim — so the host-side `rush install` later cannot write `common/temp/rush#<pid>.lock`. macOS remaps bind-mount ownership to the invoking user, which is why this only bites on Linux.
4. **The gateway bootstrap Job fails.** `kubectl port-forward` binds 127.0.0.1 only, but the agent-manager container reaches the host via its `host-gateway` alias (172.17.0.1 on the default bridge), so the forwards are unreachable from docker-compose. The bootstrap Job fails with `dial tcp 172.17.0.1:8195: connect: connection refused`. `port-forward.sh` already documents this for CI (which sets `PORT_FORWARD_ADDRESS=0.0.0.0`), but there is no local default.

Additionally, `go` is not pre-flighted even though `setup-platform.sh` shells out to `go run` for the DB migration — a missing toolchain surfaces ~20 minutes into the run, after images are built and Postgres is up.

## Goals

Let `make setup` run to completion unmodified on a native Linux host, while leaving the macOS/Colima path byte-for-byte unchanged in behaviour. Every change is gated on `uname -s` or is a strict improvement on both platforms.

## Approach

**`setup-colima.sh`** — added a Linux branch ahead of the macOS configuration block. It validates the prerequisites, checks the active Docker context, checks daemon reachability, and exits 0 so `make setup` proceeds to k3d. The context check deliberately runs *before* `docker info`: a stale `colima*` context makes `docker info` fail too, and the honest diagnosis is the wrong context rather than a stopped daemon. The macOS path below it is untouched.

**`utils.sh`** —
- `is_port_in_use()` now prefers `ss -ltnH "sport = :$port"`, which reads `/proc/net/tcp` and sees every listener regardless of owner. It falls back to `lsof` where `ss` is absent (macOS), where the listener belongs to the invoking user and `lsof` is accurate.
- Added `containers_publishing_port()` so a conflict report names the container to stop, not just the port that is taken.
- Added `port_owner_command()` so the "find the process using this port" hint is correct per platform.
- Added `install_hint()`, so `check_command` stops suggesting `brew install` on Linux.
- Added a `go` entry to `get_min_version` (1.25, matching `agent-manager-service/go.mod`).

**`setup-platform.sh`** —
- `check_command go` moved up front, so a missing toolchain fails in seconds instead of after the image builds.
- `mkdir -p` for `console/node_modules` and `console/common/temp` before `docker compose up`, so those mountpoints exist and are owned by the invoking user. Docker never re-chowns an existing mountpoint.
- The "Docker is not running" message now suggests `systemctl start docker` on Linux and `./setup-colima.sh` on macOS.

**`port-forward.sh`** — on Linux, `PORT_FORWARD_ADDRESS` now defaults to `127.0.0.1,<docker bridge gateway>` (the gateway is read from `docker network inspect bridge`). Containers reach the forwards through the address their `host-gateway` alias resolves to, and loopback keeps `http://localhost:<port>` working for the developer. Deliberately **not** `0.0.0.0` — that would publish the platform's control-plane ports to the LAN. An explicit `PORT_FORWARD_ADDRESS` still wins, so the CI override is unaffected. If the gateway cannot be determined the script warns and falls back to loopback rather than failing.

**`teardown.sh`** — skips the Colima profile deletion on Linux (no profile was ever created, and any profile found belongs to the user's other work), and drops the trailing Colima note there.

No UI changes, so no screenshots apply.

## User stories

As a developer on a Linux workstation, I can clone the repo and run `make setup` to get a working local Agent Manager environment, without hand-patching the setup scripts or installing Colima.

## Release note

Fixed local setup scripts failing on native Linux hosts; `make setup` now uses the host Docker daemon directly instead of requiring Colima.

## Documentation

N/A — no product documentation covers these developer setup scripts; the behaviour change is self-describing in the script output. Happy to add a Linux note to the local-setup README if maintainers point me at the right file.

## Training

N/A — developer tooling change, no training content impact.

## Certification

N/A — local developer setup scripts are not covered by certification exams.

## Marketing

N/A — internal developer tooling.

## Automation tests

- Unit tests
  > N/A — the repo has no test harness for the `deployments/setup` shell scripts, and adding one is out of scope for this fix.
- Integration tests
  > N/A automated. Verified manually end-to-end (see Test environment). All five modified scripts pass `bash -n`. Each Linux branch was exercised in both directions: the Colima-context guard was tested with `DOCKER_CONTEXT=colima-dev` set and unset, and the port check was verified before and after the fix — with unrelated containers holding 8080/5432 the old check reported all ports available, and the new one reports `8080 (Control Plane HTTP) — held by container(s): <name>`. The port-forward binding was confirmed to listen on 127.0.0.1 and the bridge gateway only, and reachable from inside a container both by IP and by the `host.docker.internal` alias.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** — FindSecurityBugs is a Java static-analysis tool; this PR only changes Bash scripts.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

One security-relevant note: the port-forward default binds the Docker bridge gateway rather than `0.0.0.0` specifically to avoid exposing the local control plane to the LAN.

## Samples

N/A — no samples relate to the local setup scripts.

## Related PRs

None.

## Migrations (if applicable)

N/A — no schema or data migrations. Existing macOS developers need no action; their code path is unchanged.

## Test environment

- OS: Linux 7.1.8 (CachyOS / Arch), x86_64
- Docker: native daemon (`default` context), Docker Compose v2, Buildx
- k3d cluster `openchoreo-local-setup` (k3s), OpenChoreo 1.2.0
- Go 1.26.6
- Node.js 20.20.2 (see note below)
- Verified: `make setup` exits 0 end to end; all pods Running/Completed; all 10 PVCs Bound; console returns HTTP 200 on :3000; agent-manager-service `/healthz` returns HTTP 200 on :9000.
- macOS path not re-tested — every change is gated behind `uname -s = Linux`, or (in `utils.sh`) falls back to the exact prior `lsof`/`brew` behaviour when `ss` is absent.

## Learning

The common thread is that Docker Desktop and Colima virtualize away a boundary that is real on native Linux, so each of these is invisible on macOS:

- `lsof` cannot see root-owned `docker-proxy` listeners for an unprivileged caller; `ss` reads `/proc/net/tcp` and sees them all. On macOS the listener belongs to the invoking user, so `lsof` happens to be correct there.
- Bind-mount UID passthrough is literal on Linux; osxfs/virtiofs remap ownership to the invoking user on macOS, which hides root-created mountpoints.
- `kubectl port-forward --address` accepts a comma-separated list, which is what makes "loopback *and* the bridge gateway" possible without resorting to `0.0.0.0`.

---

### Follow-ups found while testing — deliberately not in this PR

Flagging these for maintainers; each is independent and I'm happy to open separate PRs.

1. **Stale console image after the checkout moves.** `docker-compose.yml` passes `WORKDIR_PATH: ${CONSOLE_HOST_PATH}` as a *build arg*, baking the host path into the image as `WORKDIR`. If the checkout later moves — a git worktree, a rename, a second clone — Compose reuses the existing image tag, mounts the source at a path the image's `WORKDIR` does not point to, and silently serves the snapshot baked in at build time. The dev server comes up healthy on stale code; only `make dev-rebuild` clears it. This is **not** Linux-specific. A cheap guard in `setup-platform.sh` (compare `docker image inspect --format '{{.Config.WorkingDir}}'` against `CONSOLE_HOST_PATH`, rebuild on mismatch) fixes it; a fixed container path such as `WORKDIR /workspace` with `${CONSOLE_HOST_PATH}:/workspace` would remove the coupling entirely, but needs checking against Rush's absolute-path handling in `common/temp` first.
2. **Node version ranges disagree in three places.** `console/rush.json` sets `nodeSupportedVersionRange: ">=18.20.3 <19.0.0 || >=20.14.0 <21.0.0"`, `console/.nvmrc` pins `22.12.0` — which rush.json rejects — and `setup-platform.sh` checks for a third range (`>=20.19.0 || >=22.12.0`). Following `.nvmrc` makes `rush install` fail.
3. **`setup-openchoreo.sh` mutates the global kubectl context.** Line 21 runs `kubectl config use-context "$CLUSTER_CONTEXT"`, which changes the user's active context process-wide and persistently. During testing this caused a parallel session's `kubectl apply` (intended for a remote cluster) to land on the local k3d cluster, installing an incompatible default StorageClass and leaving every PVC Pending. Passing `--context` per command, or saving and restoring the previous context, would contain the blast radius.
4. **Makefile `openchoreo-up` / `openchoreo-down` / `openchoreo-status` reference kind, not k3d.** They use `kind-openchoreo-local` and `openchoreo-local-control-plane`, while the setup scripts create a k3d cluster named `openchoreo-local-setup`. These targets are dead as written.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Linux Docker setup support without requiring Colima.
  * Port forwarding on Linux now supports both localhost and the Docker bridge gateway when available.
  * Added clearer platform-specific setup, teardown, and installation guidance.
  * Port conflict messages now identify publishing containers and suggest ownership commands.

* **Bug Fixes**
  * Improved port detection reliability by preferring `ss` with `lsof` fallback.
  * Setup now validates required tools and prepares necessary directories before starting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->