### PR TITLE
Fix/agent route path stutter

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/builds_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/builds_test.go
@@ -46,7 +46,7 @@ const legacyComponentJSON = `{
 func TestUpdateComponentBuildParameters_DoesNotIntroduceRoutePath(t *testing.T) {
 	var putParameters map[string]any
 
-	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(legacyComponentJSON))
@@ -67,7 +67,7 @@ func TestUpdateComponentBuildParameters_DoesNotIntroduceRoutePath(t *testing.T) 
 		require.NoError(t, err)
 	}))
 
-	err := srv.UpdateComponentBuildParameters(context.Background(), "acme", "proj", "legacy-agent",
+	err := client.UpdateComponentBuildParameters(context.Background(), "acme", "proj", "legacy-agent",
 		UpdateComponentBuildParametersRequest{
 			AgentType:      AgentTypeConfig{Type: "agent-api", SubType: "custom-api"},
 			InputInterface: &InputInterfaceConfig{Type: "HTTP", Port: 9090, BasePath: "/new"},

--- a/agent-manager-service/clients/openchoreosvc/client/builds_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/builds_test.go
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A component created before routePath existed: spec.parameters carries the
+// build-time keys and nothing else.
+const legacyComponentJSON = `{
+  "metadata": {"name": "legacy-agent"},
+  "spec": {
+    "componentType": {"name": "internal-agent/agent-api"},
+    "owner": {"projectName": "proj"},
+    "parameters": {"exposed": true, "basePath": "/old", "port": 8080},
+    "workflow": {"parameters": {}}
+  }
+}`
+
+// UpdateComponentBuildParameters must never introduce routePath. A component
+// without it renders the legacy "<component>-<endpoint>" path, which is the URL
+// its owners already have; adding the parameter here would mean the first
+// build-parameters edit silently re-points a live agent's public URL.
+func TestUpdateComponentBuildParameters_DoesNotIntroduceRoutePath(t *testing.T) {
+	var putParameters map[string]any
+
+	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(legacyComponentJSON))
+			require.NoError(t, err)
+			return
+		}
+
+		var sent struct {
+			Spec struct {
+				Parameters map[string]any `json:"parameters"`
+			} `json:"spec"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&sent))
+		putParameters = sent.Spec.Parameters
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(legacyComponentJSON))
+		require.NoError(t, err)
+	}))
+
+	err := srv.UpdateComponentBuildParameters(context.Background(), "acme", "proj", "legacy-agent",
+		UpdateComponentBuildParametersRequest{
+			AgentType:      AgentTypeConfig{Type: "agent-api", SubType: "custom-api"},
+			InputInterface: &InputInterfaceConfig{Type: "HTTP", Port: 9090, BasePath: "/new"},
+		})
+
+	require.NoError(t, err)
+	require.NotNil(t, putParameters, "expected the update to PUT the component back")
+	// The build-parameter writes we do expect, so a passing test can't be a
+	// false negative from the update silently doing nothing.
+	assert.Equal(t, "/new", putParameters["basePath"])
+	assert.NotContains(t, putParameters, "routePath")
+}

--- a/agent-manager-service/clients/openchoreosvc/client/component_labels_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/component_labels_test.go
@@ -201,3 +201,50 @@ func TestConvertComponentFromTyped_Labels(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"env": "prod", "team": "ml"}, agent.Labels)
 }
+
+func TestBuildInternalAgentFromKindComponentRequestBody_RoutePath(t *testing.T) {
+	req := CreateComponentRequest{
+		Name:        "agent-1",
+		DisplayName: "Agent 1",
+		AgentType:   AgentTypeConfig{Type: "agent-api", SubType: "chat-api"},
+		AgentKind:   &AgentKindRef{Name: "kind-1", Version: "v1"},
+		Build:       &BuildConfig{Type: "buildpack", Buildpack: &BuildpackConfig{Language: "python"}},
+	}
+	body, err := buildInternalAgentFromKindComponentRequestBody("ns", "proj", req)
+	require.NoError(t, err)
+	require.NotNil(t, body.Spec)
+	require.NotNil(t, body.Spec.Parameters)
+	// The chart prefixes the slash, so the parameter carries a bare segment.
+	assert.Equal(t, "agent-1", (*body.Spec.Parameters)["routePath"])
+}
+
+func TestBuildInternalAgentFromSourceComponentRequestBody_RoutePath(t *testing.T) {
+	req := CreateComponentRequest{
+		Name:             "agent-1",
+		DisplayName:      "Agent 1",
+		ProvisioningType: "internal",
+		AgentType:        AgentTypeConfig{Type: "agent-api", SubType: "chat-api"},
+		Build:            &BuildConfig{Type: "buildpack", Buildpack: &BuildpackConfig{Language: "python", LanguageVersion: "3.11"}},
+		InputInterface:   &InputInterfaceConfig{BasePath: "/"},
+	}
+	body, err := buildInternalAgentFromSourceComponentRequestBody("ns", "proj", req)
+	require.NoError(t, err)
+	require.NotNil(t, body.Spec)
+	require.NotNil(t, body.Spec.Parameters)
+	assert.Equal(t, "agent-1", (*body.Spec.Parameters)["routePath"])
+}
+
+func TestBuildExternalAgentComponentRequestBody_NoRoutePath(t *testing.T) {
+	// External agents render no HTTPRoute at all (external-agent-api.yaml), so a
+	// routePath would be a parameter nothing reads.
+	req := CreateComponentRequest{
+		Name:             "agent-1",
+		DisplayName:      "Agent 1",
+		ProvisioningType: "external",
+		AgentType:        AgentTypeConfig{Type: "external-agent-api", SubType: "custom-api"},
+	}
+	body, err := buildExternalAgentComponentRequestBody("ns", "proj", req)
+	require.NoError(t, err)
+	require.NotNil(t, body.Spec)
+	assert.Nil(t, body.Spec.Parameters)
+}

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -106,6 +106,7 @@ func buildInternalAgentFromKindComponentRequestBody(namespaceName, projectName s
 	defaultParams := ComponentParameters{
 		Exposed:   true,
 		Resources: resourceParams,
+		RoutePath: req.Name,
 	}
 	parameters, err := structToMap(defaultParams)
 	if err != nil {
@@ -224,6 +225,7 @@ func buildInternalAgentFromSourceComponentRequestBody(namespaceName, projectName
 	defaultParams := ComponentParameters{
 		Exposed:   true,
 		Resources: resourceParams,
+		RoutePath: req.Name,
 	}
 
 	// Convert struct to map for OpenChoreo API

--- a/agent-manager-service/clients/openchoreosvc/client/types.go
+++ b/agent-manager-service/clients/openchoreosvc/client/types.go
@@ -189,6 +189,7 @@ type AutoScalingConfig struct {
 type ComponentParameters struct {
 	Exposed   bool            `json:"exposed"`
 	Resources *ResourceConfig `json:"resources,omitempty"`
+	RoutePath string          `json:"routePath,omitempty"`
 }
 
 // EnvOverrideParameters represents environment-specific overrides (must match agent-api.yaml envOverrides schema)

--- a/agent-manager-service/clients/openchoreosvc/client/types.go
+++ b/agent-manager-service/clients/openchoreosvc/client/types.go
@@ -189,7 +189,9 @@ type AutoScalingConfig struct {
 type ComponentParameters struct {
 	Exposed   bool            `json:"exposed"`
 	Resources *ResourceConfig `json:"resources,omitempty"`
-	RoutePath string          `json:"routePath,omitempty"`
+	// RoutePath is a bare path segment with no leading slash: the chart template
+	// supplies the "/" when it renders the HTTPRoute path from this parameter.
+	RoutePath string `json:"routePath,omitempty"`
 }
 
 // EnvOverrideParameters represents environment-specific overrides (must match agent-api.yaml envOverrides schema)

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
@@ -57,6 +57,13 @@ spec:
       properties:
         resources:
           $ref: "#/$defs/ResourceRequirements"
+        routePath:
+          type: string
+          description: >-
+            Public URL path segment for this agent's external route, without a
+            leading slash. Absent or empty preserves the legacy
+            "<componentName>-<endpointName>" path, so agents created before this
+            field existed keep the URLs they were deployed with.
 
   environmentConfigs:
     openAPIV3Schema:
@@ -333,7 +340,7 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
-                value: /${metadata.componentName}-${endpoint}
+                value: '${has(parameters.routePath) && parameters.routePath != "" ? "/" + parameters.routePath : "/" + metadata.componentName + "-" + endpoint}'
             filters:
               - type: URLRewrite
                 urlRewrite:
@@ -369,7 +376,7 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
-                value: /${metadata.componentName}-${endpoint}
+                value: '${has(parameters.routePath) && parameters.routePath != "" ? "/" + parameters.routePath : "/" + metadata.componentName + "-" + endpoint}'
             filters:
               - type: URLRewrite
                 urlRewrite:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
@@ -60,10 +60,16 @@ spec:
         routePath:
           type: string
           description: >-
-            Public URL path segment for this agent's external route, without a
-            leading slash. Absent or empty preserves the legacy
-            "<componentName>-<endpointName>" path, so agents created before this
-            field existed keep the URLs they were deployed with.
+            Public URL path segment for this agent's external and internal
+            routes alike, without a leading slash. Absent or empty preserves
+            the legacy "<componentName>-<endpointName>" path, so agents
+            created before this field existed keep the URLs they were
+            deployed with. This parameter is component-scoped while the
+            HTTPRoute rendering is per-endpoint, so a component with more than
+            one exposed HTTP endpoint would render duplicate hostname+path
+            routes instead of the distinct paths the legacy expression gave
+            each; today every code path produces exactly one endpoint, so this
+            is unreachable in practice.
 
   environmentConfigs:
     openAPIV3Schema:
@@ -340,6 +346,10 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
+                # The false branch is load-bearing, not a defensive default: agents created
+                # before routePath existed have no such parameter, and must keep resolving to
+                # the exact "<componentName>-<endpoint>" path they were deployed with. Do not
+                # simplify this ternary to the routePath expression alone.
                 value: '${has(parameters.routePath) && parameters.routePath != "" ? "/" + parameters.routePath : "/" + metadata.componentName + "-" + endpoint}'
             filters:
               - type: URLRewrite
@@ -376,6 +386,10 @@ spec:
           - matches:
             - path:
                 type: PathPrefix
+                # The false branch is load-bearing, not a defensive default: agents created
+                # before routePath existed have no such parameter, and must keep resolving to
+                # the exact "<componentName>-<endpoint>" path they were deployed with. Do not
+                # simplify this ternary to the routePath expression alone.
                 value: '${has(parameters.routePath) && parameters.routePath != "" ? "/" + parameters.routePath : "/" + metadata.componentName + "-" + endpoint}'
             filters:
               - type: URLRewrite

--- a/documentation/docs/guides/_partials/_amp-installation.mdx
+++ b/documentation/docs/guides/_partials/_amp-installation.mdx
@@ -32,6 +32,10 @@ Thunder (identity provider) must be installed before proceeding — see the Thun
 
 Install these in order — each depends on the one before it.
 
+:::warning Upgrading an existing installation? Reverse Steps 2 and 4
+The order above is for a fresh install, where no agents exist yet and the order is harmless. When upgrading an already-running platform, upgrade `wso2-amp-platform-resources-extension` (Step 4) at or before `wso2-agent-manager` (Step 2), not after: the service writes component parameters that the chart must already know how to read, so an agent created in the window between the two upgrades can have its live invoke URL change on the later chart upgrade.
+:::
+
 #### Step 1: Gateway Operator
 
 Manages API Gateway resources and enables secure, authenticated trace ingestion into the Observability Plane.

--- a/test/e2e/tests/agent/internal_agent_test.go
+++ b/test/e2e/tests/agent/internal_agent_test.go
@@ -106,6 +106,10 @@ var _ = Describe("Internal chat agent in default environment:", Label("agent", "
 		// The path is the agent name alone. It used to be
 		// "<agent>-<agent>-endpoint", because the ComponentType prefixed the
 		// component name onto an endpoint name that already carried it.
+		// This assumes the shared agent above was created (not merely reused)
+		// by a service version that writes routePath at create time; against a
+		// long-lived local environment whose shared agent predates that change,
+		// this assertion fails even though the code under test is correct.
 		parsed, err := url.Parse(endpointURL)
 		Expect(err).NotTo(HaveOccurred(), "endpoint URL should parse")
 		Expect(parsed.Path).To(Equal("/"+agentName),

--- a/test/e2e/tests/agent/internal_agent_test.go
+++ b/test/e2e/tests/agent/internal_agent_test.go
@@ -25,6 +25,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -101,6 +102,14 @@ var _ = Describe("Internal chat agent in default environment:", Label("agent", "
 			Cfg.DefaultOrg, projectName, agentName, Cfg.DefaultEnv)
 		endpointURL = deployment.FirstEndpointURL(endpoints)
 		Expect(endpointURL).NotTo(BeEmpty(), "agent endpoint URL should not be empty")
+
+		// The path is the agent name alone. It used to be
+		// "<agent>-<agent>-endpoint", because the ComponentType prefixed the
+		// component name onto an endpoint name that already carried it.
+		parsed, err := url.Parse(endpointURL)
+		Expect(err).NotTo(HaveOccurred(), "endpoint URL should parse")
+		Expect(parsed.Path).To(Equal("/"+agentName),
+			"expected the invoke path to be the agent name alone, got %q", parsed.Path)
 
 		invokeReq = framework.DefaultInvokeRequest()
 		GinkgoWriter.Printf("Agent ready: endpoint=%s\n", endpointURL)


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/agent-manager/issues/1532

A deployed agent's public invoke URL repeats the agent name:

```
https://{env}-{project}.{gateway-host}/foo-agent-foo-agent-endpoint
```

The `agent-api` ComponentType renders the path segment as `{componentName}-{endpoint}`, and
`{endpoint}` — the workload endpoint name — is itself always constructed as `{componentName}-endpoint`
by the control plane. Two layers independently prefix the agent name, so the stutter is
unconditional and no user input can avoid it.

## Goals

For `componentName = foo`:

| | Path |
|---|---|
| Today | `/foo-foo-endpoint` |
| With this fix (new agents) | `/foo` |
| With this fix (existing agents) | `/foo-foo-endpoint`, unchanged |

Making the path user-definable — the issue's broader ask — is deliberately **not** in this PR. See
Deferred scope below.

## Approach

New agents are given an explicit `routePath` component parameter equal to their name, written at
create time. The ComponentType renders `/{routePath}` when the parameter is present and non-empty,
and **falls back to the exact legacy expression** otherwise:

```yaml
value: '${has(parameters.routePath) && parameters.routePath != "" ? "/" + parameters.routePath : "/" + metadata.componentName + "-" + endpoint}'
```

That fallback is the whole backward-compatibility guarantee: a component created before this change
has no `routePath`, so it keeps rendering the path it was deployed with. Both the external and
internal HTTPRoutes get the same expression, even though agents only render the external one today,
so the two cannot silently diverge.

`routePath` is written by the two internal-agent create builders and by nothing else.
`UpdateComponentBuildParameters` rewrites `spec.parameters` on every build-parameters edit — if
`routePath` ever joined `basePath` and `port` there, the first build edit on any pre-existing agent
would silently re-point its live URL. There is a regression test pinning that.

### Why this is safe

The `api-configuration` trait patches the same HTTPRoute, replacing `filters` wholesale with a
rewrite to `/{env}-{project}-{component}` and swapping the backendRef to the API Platform router.
**The trait patch never reads the match path**, and `ReplacePrefixMatch` substitutes whatever prefix
matched. The external path is therefore fully decoupled from the APIM context: changing it churns no
`RestApi`, artifact id, API key, or subscription.

URL reporting needs no change either — `extractEndpointsFromBinding` reads the URL out of the
ReleaseBinding status, which OpenChoreo derives from the rendered HTTPRoute, so Console, CLI, and
e2e follow automatically. Nothing in Go, TypeScript, or the charts constructs the public path
client-side.

The HTTPRoute *resource name* is intentionally left deriving from `oc_generate_name(componentName, endpoint)`.
Had it been derived from `routePath`, a chart upgrade would delete and recreate every route.

## Migrations

**Deploy `wso2-amp-platform-resources-extension` at or before `wso2-agent-manager`.**

`routePath` is written at create time, so "new agent" is defined by *service* version. If the
service ships first, agents created in that window carry `routePath` under a chart that still
ignores it: they render and advertise the legacy stuttered path, and the later chart upgrade then
changes their live URL. Shipping the chart first closes the window entirely.

The repo's installation guide previously numbered the service (Step 2) before the chart (Step 4),
which is harmless for a fresh install but is the wrong order for an upgrade. This PR adds upgrade
ordering guidance to `documentation/docs/guides/_partials/_amp-installation.mdx`.

## Automation tests

- **Unit tests** — three new tests asserting both internal create builders emit
  `parameters["routePath"]` equal to the component name, and that the external-agent builder emits
  none (external agents render no HTTPRoute at all).
- **Regression test** — `TestUpdateComponentBuildParameters_DoesNotIntroduceRoutePath` verifies that
  a build-parameters update on a component lacking `routePath` leaves it absent. It also asserts
  `basePath` *was* written, so it cannot pass as a false negative from the update silently doing
  nothing. It was validated by deliberately breaking the invariant and confirming the test fails.
- **E2E** — `internal_agent_test.go` now asserts the advertised path is the agent name alone. It
  compiles clean but **has not been executed**; see Test environment.

Note that `helm template` never evaluates CEL, so no chart test can exercise either branch of the
conditional. A chart render test here is a typo-catcher only.

## Test environment

k3d / OpenChoreo local setup, chart installed from this branch.

| Check | Result |
|---|---|
| `routePath` survives admission | Component CR carries `"routePath":"routepath-check"` |
| Forward branch (parameter present) | rendered path `/routepath-check` |
| Fallback branch (parameter absent) | rendered path `/routepath-check-routepath-check-endpoint` |
| Reversible | restoring the parameter flips the path back; deterministic both ways |
| Live traffic via `gateway-default` | `/routepath-check/chat` → 401 (routed, auth rejected unkeyed request); `/routepath-check-routepath-check-endpoint/chat` → 404 |

**What was not verified, stated plainly:**

- **The literal chart-upgrade transition.** The verification environment was reinstalled with this
  branch's chart before testing began, so no pre-branch agent existed to upgrade underneath. The
  fallback branch was instead exercised by removing `spec.parameters.routePath` from a live
  component — an agent that predates this change is, to the renderer, exactly a component whose
  parameters lack `routePath`, so the branch itself is genuinely proven. The upgrade mechanics
  around it are not. Reviewers wanting the literal check: create an agent on the current chart,
  upgrade, and confirm its rendered HTTPRoute path is unchanged.
- **The e2e assertion**, which compiles but has never run.
- **Invocation with a valid API key** — only the 401/404 routing distinction was probed.

## Known edge case

An agent named literally `foo-foo-endpoint` would claim `/foo-foo-endpoint`, colliding with legacy
agent `foo`'s derived path. Negligible, and exactly what the deferred uniqueness validation would
catch.

## Deferred scope

Explicitly out of scope, for a separate discussion:

- exposing `routePath` in the public API, OpenAPI spec, CLI, Console, or MCP tools
- project-scoped uniqueness validation
- path aliasing / retaining previous paths on rename
- APIM-style `context` + `version` exposure, or unifying the external path with the `RestApi` context
- custom hostnames

`routePath` stays an internal component parameter written only by the control plane — no API surface
change, therefore no codegen, no RBAC, no Console work. It is deliberately the same field a
user-definable-path feature would later expose, so this is a strict subset of that work rather than
throwaway.

## Documentation

`documentation/docs/guides/_partials/_amp-installation.mdx` — upgrade ordering guidance (see
Migrations).

## Release note

Newly created agents are exposed at `/<agent-name>` instead of
`/<agent-name>-<agent-name>-endpoint`. Existing agents keep their current URLs.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java in this change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## User stories

N/A — defect fix.

## Training

N/A

## Certification

N/A — no certification impact; this changes a generated URL path, not product concepts under exam.

## Marketing

N/A

## Samples

N/A

## Related PRs

None.
