### PR TITLE
Fix installer completion hints on wrapper installs

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1733,7 +1733,11 @@ if [[ "${ENV_THUNDER_PROVISIONED}" == "true" ]]; then
     -n "${default_ns}" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d 2>/dev/null || true)"
   if [[ -n "${ENV_THUNDER_ADMIN_PASSWORD}" ]]; then
     log_step "Default Environment Thunder ID Console"
-    log_info "URL:      http://${default_org}-${default_env}.thunder.amp.localhost:8080/console"
+    # thunder_issuer() honours THUNDER_HOST_BASE_DOMAIN/TLS_ENABLED, which is what
+    # env-Thunder was actually provisioned with — a hardcoded amp.localhost:8080
+    # printed an unreachable host on wrapper installs (the VM installers export both
+    # of those, so the instance answers on https://<org>-<env>.thunder.<base>).
+    log_info "URL:      $(thunder_issuer "${default_org}" "${default_env}")/console"
     log_info "Username: admin"
     log_info "Password: ${ENV_THUNDER_ADMIN_PASSWORD}"
   fi
@@ -1742,9 +1746,18 @@ fi
 echo ""
 echo ""
 log_info "To check status: kubectl get pods -A"
-echo ""
-log_step "Uninstall Options"
-log_info "Uninstall platform (keep cluster):       ./uninstall.sh"
-log_info "Uninstall and delete k3d cluster:        ./uninstall.sh --delete-cluster"
-log_info "Full cleanup (including Colima profile):  ./uninstall.sh --delete-cluster --delete-colima"
+
+# These hints point at ./uninstall.sh, a sibling of this script in the repo
+# checkout. Wrappers that source install.sh from a bundle (e.g. the VM installer)
+# have no such sibling left on disk — bootstrap.sh deletes the unpacked bundle on
+# exit — and tear down extra host state of their own, so they suppress these lines
+# and document their own teardown. Defaults to SHOW_LOCALHOST_URLS: both answer
+# "is this the plain local quick-start?".
+if [[ "${SHOW_UNINSTALL_HINTS:-${SHOW_LOCALHOST_URLS:-true}}" == "true" ]]; then
+  echo ""
+  log_step "Uninstall Options"
+  log_info "Uninstall platform (keep cluster):       ./uninstall.sh"
+  log_info "Uninstall and delete k3d cluster:        ./uninstall.sh --delete-cluster"
+  log_info "Full cleanup (including Colima profile):  ./uninstall.sh --delete-cluster --delete-colima"
+fi
 echo ""


### PR DESCRIPTION
## Purpose

The quick-start installer's completion summary prints two things that are wrong whenever `install.sh` is sourced by a wrapper rather than run from a repo checkout — which is exactly what both VM installers do (`deployments/vm/install-vm.sh`, `deployments/vm/install-advanced.sh`).

1. **Uninstall hints point at a script that no longer exists.** The summary advertises `./uninstall.sh`, `./uninstall.sh --delete-cluster` and `./uninstall.sh --delete-cluster --delete-colima`. On a VM install, `bootstrap.sh` unpacks the release bundle into a `mktemp -d` and deletes it via an `EXIT` trap, so by the time the operator reads those lines there is no `uninstall.sh` anywhere on the host. `--delete-colima` targets a local macOS Colima profile and is meaningless on a VM, and the script knows nothing about the `amp-caddy` container the VM installer starts, so following the hint would leave the proxy running.
2. **The default env-Thunder console URL is hardcoded to `amp.localhost`.** It ignored the `THUNDER_HOST_BASE_DOMAIN` / `TLS_ENABLED` pair the VM installers export when provisioning env-Thunder, so an unreachable host was printed right next to the admin password, which is otherwise the most useful line in that block.

Both lines sit outside the existing `SHOW_LOCALHOST_URLS` guard that wrappers already use to suppress unreachable localhost URLs.

## Goals

Make the completion summary correct on every install flavour, without changing what the plain local quick-start prints and without requiring edits in the wrapper installers.

## Approach

- Wrap the "Uninstall Options" block in `SHOW_UNINSTALL_HINTS`, defaulting to `SHOW_LOCALHOST_URLS` (itself defaulting to `true`). Both VM installers already export `SHOW_LOCALHOST_URLS=false`, so they inherit the suppression with no change of their own; the separate name leaves an independent override available if a future wrapper wants one behaviour without the other. VM teardown is already documented in the on-a-vm guide, so suppressing here leaves no gap.
- Derive the env-Thunder console URL from `thunder_issuer()` (`deployments/scripts/thunder-naming.sh`) instead of a hardcoded host. That helper is the single source of truth for this derivation, is already in scope at this point in the script, and honours the same `THUNDER_HOST_BASE_DOMAIN` / `TLS_ENABLED` config env-Thunder was actually provisioned with — so the reported URL can no longer diverge from the instance's real issuer.
- `To check status: kubectl get pods -A` stays unguarded (valid everywhere), as does the Thunder console block, which is now host-correct on every flavour.

Rendered output:

| Install | Env-Thunder console URL |
| --- | --- |
| Local quick-start | `http://default-default.thunder.amp.localhost:8080/console` (byte-identical to before) |
| VM (`TLS_ENABLED=true`) | `https://default-default.thunder.<base-domain>/console` |

## User stories

As an operator installing on a VM, the completion summary should only tell me things that are true for my install — so I don't run a teardown command for a script that isn't on the box, or open a console URL that can't resolve.

## Release note

Fixed the installer's completion summary printing uninstall instructions and a default environment Thunder ID console URL that were not applicable to VM installations.

## Documentation

N/A — no doc change needed. VM teardown is already documented in `documentation/docs/guides/on-a-vm.mdx`, which explains that the installer leaves no checkout on the VM and gives the correct `k3d cluster delete` / `docker rm -f amp-caddy` commands. This PR makes the installer output consistent with that page.

## Training

N/A — no training content covers installer console output.

## Certification

N/A — no impact on certification exams; this changes informational output only.

## Marketing

N/A — internal installer output fix with no promotable surface.

## Automation tests

- Unit tests
  > N/A — the change is in a bash installer's final summary block, which has no unit-test harness.
- Integration tests
  > Verified manually: `bash -n deployments/quick-start/install.sh` passes, and `shellcheck -S warning` reports only the pre-existing SC2034 at line 53 (no new findings). The guard was exercised across all four combinations — unset (prints), `SHOW_LOCALHOST_URLS=false` (suppressed), `SHOW_UNINSTALL_HINTS=true SHOW_LOCALHOST_URLS=false` (prints), `SHOW_UNINSTALL_HINTS=false` (suppressed). `thunder_issuer default default` was rendered with and without `THUNDER_HOST_BASE_DOMAIN`/`TLS_ENABLED` to confirm local output is unchanged and the TLS variant resolves to the wrapper's base domain.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no samples relate to installer console output.

## Related PRs

None.

## Migrations (if applicable)

N/A — output-only change; nothing to migrate, and existing installations are unaffected.

## Test environment

Static analysis and behavioural checks run on macOS (darwin 25.5.0) with GNU bash and shellcheck. The affected code paths are shell-only and platform-independent; the guard defaults preserve existing behaviour on the local k3d quick-start.

## Learning

Traced how the VM bootstrap composes the quick-start installer: `bootstrap.sh` downloads a single versioned bundle, and both VM installers `source` `install.sh` in a subshell with overrides. That pattern means any absolute or repo-relative assumption in the installer's output — a sibling script path, a hardcoded hostname — silently becomes wrong for wrapper flavours, which is what both bugs here have in common. Reusing the existing `SHOW_LOCALHOST_URLS` convention as the default kept the fix contained to one file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thunder Console URLs now reflect the configured host, domain, and TLS settings instead of defaulting to localhost.
  * Uninstall instructions are shown only when the relevant display option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->