### PR TITLE
Upgrade ThunderID to v1.0.0 (GA) and configure CSP for branding assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-colima setup-k3d setup-openchoreo setup-default-env-thunder setup-sandbox setup-gvisor setup-kata setup-platform setup-gateway setup-console-local setup-console-local-force setup-amp teardown-amp reset-amp dev-up dev-down dev-restart dev-rebuild dev-logs dev-migrate openchoreo-up openchoreo-down openchoreo-status teardown db-connect db-logs service-logs service-shell console-logs port-forward stop-port-forward gen-eval-artifacts gen-instrumentation-contract check-contract-drift check-matrix-manifest e2e-test
+.PHONY: help setup setup-colima setup-k3d setup-openchoreo setup-default-env-thunder setup-sandbox setup-gvisor setup-kata setup-platform setup-gateway setup-console-local setup-console-local-force setup-amp teardown-amp reset-amp dev-up dev-down dev-restart dev-rebuild dev-logs dev-migrate openchoreo-up openchoreo-down openchoreo-status thunder-up thunder-down thunder-restart thunder-reset teardown db-connect db-logs service-logs service-shell console-logs port-forward stop-port-forward gen-eval-artifacts gen-instrumentation-contract check-contract-drift check-matrix-manifest e2e-test
 
 # Absolute path to the console directory on the host. Passed to docker-compose
 # so the container mounts and builds at the same path, keeping rush/pnpm
@@ -36,6 +36,12 @@ help:
 	@echo "  make openchoreo-status  - Check OpenChoreo cluster status"
 	@echo "  make port-forward       - Stop and restart all port-forwards (interactive)"
 	@echo "  make stop-port-forward  - Stop all active port-forwards"
+	@echo ""
+	@echo "⚡ Platform Thunder (Control Plane IDP):"
+	@echo "  make thunder-up         - Install or upgrade Platform Thunder"
+	@echo "  make thunder-down       - Uninstall Platform Thunder"
+	@echo "  make thunder-restart    - Restart Platform Thunder pods"
+	@echo "  make thunder-reset      - Reset Platform Thunder (uninstall + PVC wipe + reinstall)"
 	@echo ""
 	@echo "🗄️  Database:"
 	@echo "  make db-connect         - Connect to PostgreSQL"
@@ -265,6 +271,37 @@ openchoreo-status:
 	@echo ""
 	@echo "OpenChoreo Pods:"
 	@kubectl get pods -n openchoreo-system --context kind-openchoreo-local 2>/dev/null || echo "Cluster not accessible"
+
+# Platform Thunder management
+thunder-up:
+	@echo "📦 Installing/Upgrading Platform Thunder (amp-thunder-extension)..."
+	@helm dependency update deployments/helm-charts/wso2-amp-thunder-extension
+	@helm upgrade --install amp-thunder-extension deployments/helm-charts/wso2-amp-thunder-extension \
+		--namespace amp-thunder --create-namespace \
+		--set thunder.bootstrap.agentManagerMcpDevBaseUrl=http://localhost:9000
+	@echo "⏳ Waiting for Platform Thunder deployment..."
+	@kubectl rollout status deployment -n amp-thunder -l app.kubernetes.io/instance=amp-thunder-extension --timeout=120s 2>/dev/null || true
+	@echo "✅ Platform Thunder is up and running!"
+
+thunder-down:
+	@echo "🛑 Uninstalling Platform Thunder (amp-thunder-extension)..."
+	@helm uninstall amp-thunder-extension -n amp-thunder 2>/dev/null || true
+	@kubectl delete job -n amp-thunder -l app.kubernetes.io/instance=amp-thunder-extension --wait --timeout=60s 2>/dev/null || true
+	@echo "✅ Platform Thunder uninstalled"
+
+thunder-restart:
+	@echo "🔄 Restarting Platform Thunder deployment..."
+	@kubectl rollout restart deployment -n amp-thunder -l app.kubernetes.io/instance=amp-thunder-extension 2>/dev/null || true
+	@kubectl rollout status deployment -n amp-thunder -l app.kubernetes.io/instance=amp-thunder-extension --timeout=120s 2>/dev/null || true
+	@echo "✅ Platform Thunder restarted"
+
+thunder-reset:
+	@echo "🧹 Resetting Platform Thunder (uninstall + job/PVC delete + reinstall)..."
+	@helm uninstall amp-thunder-extension -n amp-thunder --wait --timeout=2m 2>/dev/null || true
+	@kubectl delete job -n amp-thunder -l app.kubernetes.io/instance=amp-thunder-extension --wait --timeout=60s 2>/dev/null || true
+	@kubectl delete pvc -n amp-thunder -l app.kubernetes.io/instance=amp-thunder-extension --wait --timeout=60s 2>/dev/null || true
+	@$(MAKE) thunder-up
+	@echo "✅ Platform Thunder reset complete!"
 
 # Port forwarding for OpenChoreo
 PLATFORM   ?=

--- a/deployments/helm-charts/wso2-amp-thunder-extension/Chart.lock
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: thunderid
   repository: oci://ghcr.io/thunder-id/helm-charts
-  version: 1.0.0-beta
-digest: sha256:bf97694e0f79a70659bc0d22fe532ac5b58112659aa0eb22edda33303479eea9
-generated: "2026-08-06T15:00:22.850401+05:30"
+  version: 1.0.0
+digest: sha256:7a3330fe398f37a06d616dd6288205ee28da18a7dbde6e7f3bb3510a81b943f1
+generated: "2026-08-16T23:58:47.639691+05:30"

--- a/deployments/helm-charts/wso2-amp-thunder-extension/Chart.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/Chart.yaml
@@ -21,4 +21,4 @@ dependencies:
     alias: thunder
     condition: thunder.enabled
     repository: oci://ghcr.io/thunder-id/helm-charts
-    version: "1.0.0-beta"
+    version: "1.0.0"

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -1044,6 +1044,59 @@ data:
     value:
       allowedOrigins: {{ .Values.thunder.configuration.cors.allowedOrigins | toJson }}
 
+  73-amp-csp-config.yaml: |
+    # Content Security Policy (CSP) server_config resource for ThunderID 1.0.0 GA.
+    # ThunderID 1.0.0 enforces a deny-first CSP policy with img-src 'self' data: by default.
+    # This bootstrap document relaxes img-src and font-src for /gate/ and /console/ paths
+    # to allow external branding assets (e.g. wso2.cachefly.net, gstatic, wikimedia).
+    resource_type: server_config
+    name: csp
+    value:
+      reportOnly: false
+      paths:
+        - location: "/gate/"
+          directives:
+            style-src-elem:
+              - "'self'"
+              - "'unsafe-inline'"
+            style-src-attr:
+              - "'self'"
+              - "'unsafe-inline'"
+            img-src:
+              - "'self'"
+              - "data:"
+              - "https://wso2.cachefly.net"
+              - "https://www.gstatic.com"
+              - "https://upload.wikimedia.org"
+            font-src:
+              - "'self'"
+              - "data:"
+              - "https://fonts.gstatic.com"
+        - location: "/console/"
+          directives:
+            style-src-elem:
+              - "'self'"
+              - "'unsafe-inline'"
+            style-src-attr:
+              - "'self'"
+              - "'unsafe-inline'"
+            img-src:
+              - "'self'"
+              - "data:"
+              - "https://wso2.cachefly.net"
+              - "https://www.gstatic.com"
+              - "https://upload.wikimedia.org"
+            font-src:
+              - "'self'"
+              - "data:"
+              - "https://fonts.gstatic.com"
+            connect-src:
+              - "'self'"
+              - "https://thunderid.dev"
+            worker-src:
+              - "'self'"
+              - "blob:"
+
   72-am-observer-client.yaml: |
     # No "scopes" key on purpose: this client's authority comes from its OpenChoreo
     # ClusterAuthzRoleBinding (amp-observer-reader-binding), not from AMP scopes.

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -19,7 +19,7 @@ thunder:
     image:
       registry: ghcr.io/thunder-id
       repository: thunderid
-      tag: "1.0.0-beta"
+      tag: "1.0.0"
       pullPolicy: Always
     container:
       port: 8090
@@ -354,6 +354,7 @@ thunder:
         - 71-amp-cors-config.yaml
         - 72-am-observer-client.yaml
         - 73-am-obs-mcp-client.yaml
+        - 73-amp-csp-config.yaml
     # Observer Resource Reader Client configuration (for observability plane to read resources)
     observerResourceReaderClient:
       clientId: "openchoreo-observer-resource-reader-client" # clusterauthzrolebinding is already created with this clientId by openchoreo, so it should not be changed unless the corresponding ClusterAuthzRoleBinding is also updated

--- a/deployments/scripts/add-environment-thunder.sh
+++ b/deployments/scripts/add-environment-thunder.sh
@@ -39,7 +39,7 @@ set -euo pipefail
 #   - ORG_NAME (default: default)
 #   - THUNDER_CHART: override the chart ref (default: oci://ghcr.io/thunder-id/helm-charts/thunderid —
 #     the upstream ThunderID release chart, pulled directly, NOT the agent-manager chart)
-#   - CHART_VERSION: pin the chart version (default: 1.0.0-beta; OCI charts only)
+#   - CHART_VERSION: pin the chart version (default: 1.0.0; OCI charts only)
 #   - SYSTEM_CLIENT_SECRET (default: generated; reused if one already exists)
 #   - THUNDER_ADMIN_PASSWORD (default: generated 10-char password w/ letters, digits,
 #     and symbols; reused if one already exists) — native ThunderID superadmin password
@@ -696,7 +696,7 @@ main() {
   # whatever version platform Thunder happens to run.
   local version_args=()
   if printf '%s' "$chart" | grep -q '^oci://'; then
-    local chart_version="${CHART_VERSION:-1.0.0-beta}"
+    local chart_version="${CHART_VERSION:-1.0.0}"
     echo "📌 Using Thunder chart version: ${chart_version}"
     version_args=(--version "$chart_version")
   fi
@@ -758,7 +758,7 @@ main() {
     # AMP component assumes, e.g. agent-manager-service/clients/thundersvc/naming.go's
     # "<release>-service" convention) instead of the chart's default fullname suffix.
     --set-string "fullnameOverride=${release}"
-    --set-string "deployment.image.tag=${CHART_VERSION:-1.0.0-beta}"
+    --set-string "deployment.image.tag=${CHART_VERSION:-1.0.0}"
     # Single replica + writable root FS: required for SQLite (single-pod, local file DB).
     --set "deployment.replicaCount=1"
     --set "deployment.securityContext.readOnlyRootFilesystem=false"
@@ -979,7 +979,7 @@ ${ca_pem}"
   echo "  Environment:     ${ENV_NAME}"
   echo "  Namespace:       ${ns}"
   echo "  Release:         ${release}"
-  echo "  Chart:           ${chart} (${CHART_VERSION:-1.0.0-beta})"
+  echo "  Chart:           ${chart} (${CHART_VERSION:-1.0.0})"
   echo "  Issuer:          ${issuer}"
   echo "  JWKS:            ${issuer}/oauth2/jwks"
   echo "  Trusted issuer:  ${pt_issuer}"

--- a/deployments/scripts/add-environment.sh
+++ b/deployments/scripts/add-environment.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 #     release so an added env runs the same chart. Injected by the console.
 # Optional:
 #   - CHART_VERSION: gateway-extension chart version (e.g. 0.15.0). Injected by the console.
-#   - THUNDER_CHART_VERSION: ThunderID chart version for the per-env instance (default: 1.0.0-beta).
+#   - THUNDER_CHART_VERSION: ThunderID chart version for the per-env instance (default: 1.0.0).
 #   - GATEWAY_CHART: path to a local chart directory or tarball (e.g. ./deployments/helm-charts/wso2-amp-api-platform-gateway-extension).
 #     When set, CHART_VERSION is ignored and the local chart is used directly.
 #   - IS_PRODUCTION (default: false)

--- a/deployments/setup/setup-amp-extensions.sh
+++ b/deployments/setup/setup-amp-extensions.sh
@@ -30,7 +30,7 @@ install_thunder_extension() {
 
     # Detect an image mismatch and do a clean uninstall+install so the
     # pre-install setup job re-runs and re-bootstraps the database.
-    local target_image="ghcr.io/thunder-id/thunderid:1.0.0-beta"
+    local target_image="ghcr.io/thunder-id/thunderid:1.0.0"
     local selector="app.kubernetes.io/instance=amp-thunder-extension"
     if helm status amp-thunder-extension -n amp-thunder &>/dev/null; then
         local current_image

--- a/documentation/docs/_constants.md
+++ b/documentation/docs/_constants.md
@@ -2,5 +2,5 @@
 
 export const versions = {
   latestVersion: 'v1.0.0-beta',
-  quickStartDockerTag: 'v1.0.0-beta'
+  quickStartDockerTag: '1.0.0'
 };

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -591,7 +591,7 @@ The same applies to the Agent Manager database role in [Phase 2](#phase-2-agent-
 Load the schema first. The scripts ship inside the Thunder image, so copy them out of the version the chart pins and apply each to its database as the owning role:
 
 ```bash
-THUNDER_IMAGE="ghcr.io/thunder-id/thunderid:1.0.0-beta"
+THUNDER_IMAGE="ghcr.io/thunder-id/thunderid:1.0.0"
 docker create --name thunder-schema "${THUNDER_IMAGE}"
 for db in configdb entitydb runtime_transient runtime_persistent; do
   docker cp "thunder-schema:/opt/thunderid/dbscripts/${db}/postgres.sql" "./thunder-${db}.sql"


### PR DESCRIPTION
## Purpose
Upgrade ThunderID from **v1.0.0-beta to v1.0.0 (GA)** across Platform Thunder and Environment Thunder instances. ThunderID v1.0.0 GA introduced a deny-first Content Security Policy (CSP) engine and breaking schema changes (`subjectAttribute` and `LogoutEndpoint` removal). This PR bumps the ThunderID version, updates chart/script defaults, configures CSP for external branding assets, and adds Make commands for Platform Thunder lifecycle management.

> Resolved: https://github.com/wso2/agent-manager/issues/1636

## Goals
 - Upgrade ThunderID to `v1.0.0` (GA) across the platform.
 - Configure CSP server_config in Platform Thunder bootstrap to authorize external branding assets (`wso2.cachefly.net`, `gstatic.com`, etc.).
 - Add Makefile targets (`thunder-up`, `thunder-down`, `thunder-restart`, `thunder-reset`) for managing Platform Thunder instances locally.

## Approach
**What changed in ThunderID v1.0.0 (GA) upgrade and fixes made:**

**Extension Chart & Bootstrap (`wso2-amp-thunder-extension`)**
- **`Chart.yaml` / `Chart.lock` / `values.yaml`**: Bumped `thunderid` dependency version and deployment container image tag from `1.0.0-beta` to `1.0.0`.
- **`templates/amp-thunder-bootstrap.yaml`**: Added `73-amp-csp-config.yaml` declarative `server_config` resource for `csp`. Configured `img-src` and `font-src` for `/gate/` and `/console/` paths to explicitly authorize `https://wso2.cachefly.net`, `https://www.gstatic.com`, `https://upload.wikimedia.org`, and `https://fonts.gstatic.com` under ThunderID 1.0.0's deny-first CSP engine.

**Deployment Scripts & Documentation**
- **`deployments/scripts/add-environment-thunder.sh` & `add-environment.sh`**: Updated default `CHART_VERSION` fallbacks and output messages from `1.0.0-beta` to `1.0.0`.
- **`deployments/setup/setup-amp-extensions.sh`**: Updated target container image tag to `ghcr.io/thunder-id/thunderid:1.0.0`.
- **`documentation/docs/_constants.md` & `guides/on-your-environment.mdx`**: Updated `quickStartDockerTag` and default `THUNDER_IMAGE` constants to `1.0.0`.

**Makefile Lifecycle Management**
- **`Makefile`**: Added `thunder-up`, `thunder-down`, `thunder-restart`, and `thunder-reset` targets. Included explicit deletion of pre-install hook Jobs (`job.batch/amp-thunder-extension-setup`) and PVCs during teardown/reset to prevent Helm pre-install hook timeouts (`context deadline exceeded`).

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Ran `go test -mod=mod ./clients/thundersvc/...` — passed 100%.
 - Integration tests
   > Verified on local k3d cluster with `make thunder-reset` and `make thunder-up`. Verified token issuance, CSP header enforcement, and login page asset loading.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> macOS, k3d local cluster, ThunderID v1.0.0, Go 1.23
 
## Learning
> N/A