### PR TITLE
Stop the monitor scheduler from provisioning credentials

### DIFF
--- a/agent-manager-service/services/monitor_scheduler.go
+++ b/agent-manager-service/services/monitor_scheduler.go
@@ -18,6 +18,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -159,6 +160,16 @@ func (s *monitorSchedulerService) triggerPendingMonitors(ctx context.Context) er
 
 	for _, monitor := range monitors {
 		if err := s.triggerMonitor(ctx, &monitor); err != nil {
+			// An org with no usable scheduler credential is an expected state, not a
+			// malfunction: credentials are provisioned on the request path, and this
+			// recurs every cycle until one is. Kept at Warn rather than Debug — the
+			// monitor genuinely is not running, and a condition nobody sees is how this
+			// class of failure stays invisible for weeks.
+			if errors.Is(err, ErrSchedulerCredentialNotFound) {
+				s.logger.Warn("Skipping monitor: organization has no usable scheduler credential",
+					"monitor", monitor.Name, "ouID", monitor.OUID)
+				continue
+			}
 			s.logger.Error("Failed to trigger monitor", "monitor", monitor.Name, "error", err)
 		}
 	}
@@ -239,6 +250,14 @@ func (s *monitorSchedulerService) syncRunStatus(ctx context.Context) error {
 
 	for _, run := range runs {
 		if err := s.syncSingleRunStatus(ctx, &run); err != nil {
+			// Debug rather than the Warn used when triggering: the org-level condition is
+			// already reported there once per cycle, and repeating it per pending run —
+			// up to the batch limit — would bury the message it duplicates.
+			if errors.Is(err, ErrSchedulerCredentialNotFound) {
+				s.logger.Debug("Skipping run status sync: organization has no usable scheduler credential",
+					"runID", run.ID)
+				continue
+			}
 			s.logger.Error("Failed to sync run status", "runID", run.ID, "error", err)
 		}
 	}

--- a/agent-manager-service/services/monitor_scheduler_unit_test.go
+++ b/agent-manager-service/services/monitor_scheduler_unit_test.go
@@ -39,6 +39,10 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -113,6 +117,50 @@ func newScheduler(
 	repo *repomocks.MonitorRepositoryMock,
 ) *monitorSchedulerService {
 	return NewMonitorSchedulerService(oc, prov, discardLogger(), exec, repo).(*monitorSchedulerService)
+}
+
+// recordingHandler captures emitted records so a test can assert the level a condition is
+// reported at. The scheduler survives every per-monitor error by design, so "the batch kept
+// going" proves nothing about whether an expected state is being shouted about once a minute.
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *recordingHandler) WithGroup(string) slog.Handler { return h }
+
+// levelsFor returns the levels of every record whose message contains substr.
+func (h *recordingHandler) levelsFor(substr string) []slog.Level {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var levels []slog.Level
+	for _, r := range h.records {
+		if strings.Contains(r.Message, substr) {
+			levels = append(levels, r.Level)
+		}
+	}
+	return levels
+}
+
+func newSchedulerWithLogger(
+	oc *clientmocks.OpenChoreoClientMock,
+	prov PublisherCredentialProvisioner,
+	exec MonitorExecutor,
+	repo *repomocks.MonitorRepositoryMock,
+	logger *slog.Logger,
+) *monitorSchedulerService {
+	return NewMonitorSchedulerService(oc, prov, logger, exec, repo).(*monitorSchedulerService)
 }
 
 func intPtrU(i int) *int { return &i }
@@ -398,6 +446,48 @@ func TestMonitorScheduler_triggerPendingMonitors(t *testing.T) {
 		require.NoError(t, s.triggerPendingMonitors(context.Background()))
 		// m1 succeeded; m2 failed before reaching the executor.
 		assert.Equal(t, 1, executed)
+	})
+
+	t.Run("skips an org with no usable scheduler credential without stalling the batch", func(t *testing.T) {
+		unprovisioned := futureMonitor("org-unprovisioned", 10, time.Now())
+		healthy := futureMonitor("org-healthy", 10, time.Now())
+
+		repo := &repomocks.MonitorRepositoryMock{
+			ListDueMonitorsFunc: func(_ string, _ time.Time) ([]models.Monitor, error) {
+				return []models.Monitor{unprovisioned, healthy}, nil
+			},
+		}
+		prov := &fakeProvisioner{
+			IsThunderModeFunc: func() bool { return true },
+			GetOCClientForOrgFunc: func(_ context.Context, ouID string) (client.OpenChoreoClient, error) {
+				if ouID == unprovisioned.OUID {
+					return nil, fmt.Errorf("%w for org %s", ErrSchedulerCredentialNotFound, ouID)
+				}
+				return &clientmocks.OpenChoreoClientMock{}, nil
+			},
+		}
+
+		executedFor := []string{}
+		exec := &fakeMonitorExecutor{
+			ExecuteMonitorRunFunc: func(_ context.Context, params ExecuteMonitorRunParams) (*ExecuteMonitorRunResult, error) {
+				executedFor = append(executedFor, params.OUID)
+				return &ExecuteMonitorRunResult{Name: "run"}, nil
+			},
+			UpdateNextRunTimeFunc: func(_ context.Context, _ uuid.UUID, _ time.Time) error { return nil },
+		}
+		handler := &recordingHandler{}
+		s := newSchedulerWithLogger(&clientmocks.OpenChoreoClientMock{}, prov, exec, repo, slog.New(handler))
+
+		require.NoError(t, s.triggerPendingMonitors(context.Background()))
+
+		// The unprovisioned org is skipped; the healthy one behind it still runs.
+		assert.Equal(t, []string{healthy.OUID}, executedFor)
+
+		// Reported once, as a skip. Logging it at Error would repeat every cycle for as
+		// long as the org stays unprovisioned, which is an expected state, not a fault.
+		assert.Equal(t, []slog.Level{slog.LevelWarn}, handler.levelsFor("Skipping monitor"))
+		assert.Empty(t, handler.levelsFor("Failed to trigger monitor"),
+			"a missing credential is not a trigger failure")
 	})
 }
 

--- a/agent-manager-service/services/publisher_credential_provisioner.go
+++ b/agent-manager-service/services/publisher_credential_provisioner.go
@@ -218,8 +218,19 @@ func (p *publisherCredentialProvisioner) resolveSecretRef(ctx context.Context, o
 
 // EnsureCredentials provisions per-org publisher and scheduler credentials.
 // Uses singleflight to deduplicate concurrent provisioning calls for the same org.
+//
+// orgUUID is required. Thunder's EnsureApp falls back to the platform's default
+// organization unit when it is empty, and the OU is written once at application
+// creation: findApp then matches by name across all OUs, so a misparented app is found
+// forever after and its OU is never revisited. An empty value here would therefore mint
+// a per-org credential belonging to another organization, permanently and silently.
 func (p *publisherCredentialProvisioner) EnsureCredentials(ctx context.Context, ouID, orgUUID string) (*PublisherCredentials, error) {
 	p.logger.Debug("EnsureCredentials called", "ouID", ouID, "orgUUID", orgUUID)
+
+	if orgUUID == "" {
+		return nil, fmt.Errorf("cannot provision credentials for org %s: orgUUID is required, "+
+			"since an empty value would create the Thunder application under the default organization unit", ouID)
+	}
 
 	result, err, _ := p.sfg.Do("provision:"+ouID, func() (any, error) {
 		pubCreds, err := p.provisionPublisherCredentials(ctx, ouID, orgUUID)

--- a/agent-manager-service/services/publisher_credential_provisioner.go
+++ b/agent-manager-service/services/publisher_credential_provisioner.go
@@ -45,7 +45,9 @@ var ErrNotThunderMode = errors.New("not in Thunder mode")
 // Distinct from real DB errors so callers can decide whether to provision-on-demand vs retry.
 var ErrPublisherCredentialNotFound = errors.New("publisher credentials not found")
 
-// ErrSchedulerCredentialNotFound means a scheduler credential still wasn't found right after provisioning it.
+// ErrSchedulerCredentialNotFound means the org has no scheduler credential the scheduler can
+// use — either no row at all, or one carrying no usable secret. Both are repaired only on the
+// request path, so the scheduler reports this and moves on rather than trying to fix it.
 var ErrSchedulerCredentialNotFound = errors.New("scheduler credentials not found")
 
 // PublisherCredentials holds the provisioned OAuth2 credentials for publishing scores.
@@ -69,6 +71,9 @@ type PublisherCredentialProvisioner interface {
 	// Used by the scheduler which runs without a user request context and therefore has no
 	// user JWT in ctx. Decrypts the stored client secret and exchanges it for an access token
 	// via the IDP token endpoint.
+	// Strictly read-only with respect to credentials: it never provisions, because doing so
+	// needs the very JWT the scheduler lacks. Returns ErrSchedulerCredentialNotFound when the
+	// org has no usable credential yet; EnsureCredentials on the request path supplies one.
 	// In non-Thunder mode returns nil, ErrNotThunderMode — callers must fall back to the system OC client.
 	GetOCClientForOrg(ctx context.Context, ouID string) (client.OpenChoreoClient, error)
 }
@@ -330,14 +335,28 @@ func (p *publisherCredentialProvisioner) provisionPublisherCredentials(ctx conte
 }
 
 // provisionSchedulerCredentials provisions the scheduler-only credential, bound to schedulerRoleName; never injected into the eval-job pod.
+//
+// Request path only — it writes to the secret store, which authenticates with the caller's
+// JWT from the request context. See GetOCClientForOrg for why the scheduler cannot call it.
+//
+// Serialised per org, because the flow rotates the app's client secret in Thunder. That
+// rotation is destructive and not idempotent: two overlapping runs leave Thunder holding
+// the second rotation while the database records the first, which no later call repairs
+// because both paths treat a credential with a secret as already provisioned.
 func (p *publisherCredentialProvisioner) provisionSchedulerCredentials(ctx context.Context, ouID, orgUUID string) error {
-	existing, err := p.schedulerCredRepo.GetByOrgName(ouID)
-	if err != nil {
-		if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("failed to look up scheduler credentials for org %s: %w", ouID, err)
-		}
-		// ErrRecordNotFound: no credentials yet, fall through to provision.
-	} else {
+	_, err, _ := p.sfg.Do("schedulerCred:"+ouID, func() (any, error) {
+		return nil, p.doProvisionSchedulerCredentials(ctx, ouID, orgUUID)
+	})
+	return err
+}
+
+func (p *publisherCredentialProvisioner) doProvisionSchedulerCredentials(ctx context.Context, ouID, orgUUID string) error {
+	existing, lookupErr := p.schedulerCredRepo.GetByOrgName(ouID)
+	switch {
+	case lookupErr != nil && !errors.Is(lookupErr, gorm.ErrRecordNotFound):
+		return fmt.Errorf("failed to look up scheduler credentials for org %s: %w", ouID, lookupErr)
+
+	case lookupErr == nil && len(existing.ClientSecretEncrypted) > 0:
 		p.logger.Debug("Found existing scheduler credentials in DB",
 			"ouID", ouID, "clientID", existing.ClientID)
 
@@ -347,9 +366,17 @@ func (p *publisherCredentialProvisioner) provisionSchedulerCredentials(ctx conte
 				"ouID", ouID, "clientID", existing.ClientID, "error", bindErr)
 		}
 		return nil
-	}
 
-	p.logger.Info("No existing scheduler credentials, provisioning via Thunder", "ouID", ouID)
+	case lookupErr == nil:
+		// A row with no usable secret is not "already provisioned": the scheduler cannot mint
+		// a token from it and has no way to repair it, so re-provision rather than returning
+		// early and leaving the org stuck.
+		p.logger.Warn("Scheduler credentials exist without a usable secret, re-provisioning",
+			"ouID", ouID, "clientID", existing.ClientID)
+
+	default:
+		p.logger.Info("No existing scheduler credentials, provisioning via Thunder", "ouID", ouID)
+	}
 
 	appName := "amp-scheduler-" + ouID
 	clientID, clientSecret, created, err := p.thunderClient.EnsureApp(ctx, appName, orgUUID)
@@ -375,6 +402,29 @@ func (p *publisherCredentialProvisioner) provisionSchedulerCredentials(ctx conte
 		return fmt.Errorf("failed to provision scheduler credentials for org %s: no client secret available", ouID)
 	}
 
+	encryptedSecret, err := utils.EncryptBytes([]byte(clientSecret), p.encryptionKey)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt scheduler secret for org %s: %w", ouID, err)
+	}
+
+	// Record the secret Thunder now holds before attempting anything else that can fail.
+	// The rotation above is destructive and cannot be undone or replayed, so persisting at
+	// the end of the flow means any failure in between strands the org: Thunder has moved
+	// to a new secret that nothing holds a copy of, and the scheduler can no longer get a
+	// token. Writing here keeps the database and Thunder in agreement no matter where the
+	// rest of the flow gives out. The reference fields are filled in by the completing
+	// upsert below — nothing reads them for a scheduler credential, which is why they can
+	// lag the secret itself.
+	dbCred := &models.OrgSchedulerCredential{
+		OUID:                  ouID,
+		OrgUUID:               orgUUID,
+		ClientID:              clientID,
+		ClientSecretEncrypted: encryptedSecret,
+	}
+	if dbErr := p.schedulerCredRepo.Upsert(dbCred); dbErr != nil {
+		return fmt.Errorf("failed to persist scheduler credentials for org %s: %w", ouID, dbErr)
+	}
+
 	location := schedulerSecretLocation(ouID)
 	secretData := map[string]string{
 		"client-id":     clientID,
@@ -393,11 +443,6 @@ func (p *publisherCredentialProvisioner) provisionSchedulerCredentials(ctx conte
 		return fmt.Errorf("failed to resolve SecretReference for scheduler credentials of org %s: %w", ouID, resolveErr)
 	}
 
-	encryptedSecret, err := utils.EncryptBytes([]byte(clientSecret), p.encryptionKey)
-	if err != nil {
-		return fmt.Errorf("failed to encrypt scheduler secret for org %s: %w", ouID, err)
-	}
-
 	// ClusterAuthzRoleBindings are cluster-scoped; non-fatal if the role isn't installed yet.
 	if bindErr := p.ocClient.EnsureClusterRoleBinding(ctx, clientID, schedulerRoleName); bindErr != nil {
 		p.logger.Warn("Failed to ensure ClusterAuthzRoleBinding for new scheduler credentials",
@@ -407,16 +452,10 @@ func (p *publisherCredentialProvisioner) provisionSchedulerCredentials(ctx conte
 			"ouID", ouID, "clientID", clientID, "role", schedulerRoleName)
 	}
 
-	dbCred := &models.OrgSchedulerCredential{
-		OUID:                  ouID,
-		OrgUUID:               orgUUID,
-		ClientID:              clientID,
-		SecretKVPath:          resolvedKVPath,
-		SecretKey:             resolvedKey,
-		ClientSecretEncrypted: encryptedSecret,
-	}
+	dbCred.SecretKVPath = resolvedKVPath
+	dbCred.SecretKey = resolvedKey
 	if dbErr := p.schedulerCredRepo.Upsert(dbCred); dbErr != nil {
-		return fmt.Errorf("failed to persist scheduler credentials for org %s: %w", ouID, dbErr)
+		return fmt.Errorf("failed to persist scheduler credential references for org %s: %w", ouID, dbErr)
 	}
 
 	p.logger.Info("Provisioned new scheduler credentials",
@@ -449,49 +488,28 @@ func (p *publisherCredentialProvisioner) GetOCClientForOrg(ctx context.Context, 
 		}
 		p.orgOCMu.RUnlock()
 
-		// DB I/O and decrypt run with no lock held; singleflight already serializes
-		// concurrent callers for this ouID.
+		// Read-only by design. Provisioning writes to the secret store, and that write
+		// authenticates with the caller's JWT taken from the request context — which the
+		// scheduler, running on a timer with no inbound request, does not have. Attempting
+		// it here fails at the store write every single cycle, but only *after* the Thunder
+		// client secret has already been rotated, so each attempt silently invalidates the
+		// org's credential and persists nothing. Two overlapping attempts are worse still:
+		// whatever the request path just stored is rotated out from under it, leaving the
+		// database and Thunder permanently disagreeing.
+		//
+		// So report the absence and let the request path (monitor creation, which does carry
+		// a JWT) be the only thing that provisions or repairs.
 		cred, err := p.schedulerCredRepo.GetByOrgName(ouID)
 		if err != nil {
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil, fmt.Errorf("failed to look up scheduler credentials for org %s: %w", ouID, err)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, fmt.Errorf("%w for org %s: credentials are provisioned on the request path, "+
+					"so this resolves once a monitor is created in the org", ErrSchedulerCredentialNotFound, ouID)
 			}
-			// Provision on demand: the periodic scheduler calls this directly and never calls EnsureCredentials.
-			p.logger.Info("No scheduler credentials found for org, provisioning on demand", "ouID", ouID)
-			if provErr := p.provisionSchedulerCredentials(ctx, ouID, ""); provErr != nil {
-				return nil, fmt.Errorf("failed to provision scheduler credentials for org %s: %w", ouID, provErr)
-			}
-			cred, err = p.schedulerCredRepo.GetByOrgName(ouID)
-			if err != nil {
-				if errors.Is(err, gorm.ErrRecordNotFound) {
-					return nil, fmt.Errorf("%w: org %s — provisioned but still not found: %w", ErrSchedulerCredentialNotFound, ouID, err)
-				}
-				return nil, fmt.Errorf("failed to look up scheduler credentials for org %s after provisioning: %w", ouID, err)
-			}
+			return nil, fmt.Errorf("failed to look up scheduler credentials for org %s: %w", ouID, err)
 		}
 		if len(cred.ClientSecretEncrypted) == 0 {
-			// Record exists but has no encrypted secret — regenerate the Thunder client secret,
-			// push it to the secret store, and persist the encrypted copy to DB.
-			p.logger.Info("No encrypted secret for org, regenerating Thunder client secret",
-				"ouID", ouID, "clientID", cred.ClientID)
-			newSecret, backfillErr := p.thunderClient.RegenerateAppClientSecret(ctx, cred.ClientID)
-			if backfillErr != nil {
-				return nil, fmt.Errorf("failed to regenerate client secret for org %s: %w", ouID, backfillErr)
-			}
-			// Propagate the new secret to the secret store.
-			if _, backfillErr = p.secretClient.PatchSecret(ctx, schedulerSecretLocation(ouID),
-				map[string]string{"client-secret": newSecret}, nil); backfillErr != nil {
-				return nil, fmt.Errorf("failed to update secret store for org %s: %w", ouID, backfillErr)
-			}
-			encrypted, backfillErr := utils.EncryptBytes([]byte(newSecret), p.encryptionKey)
-			if backfillErr != nil {
-				return nil, fmt.Errorf("failed to encrypt regenerated client secret for org %s: %w", ouID, backfillErr)
-			}
-			cred.ClientSecretEncrypted = encrypted
-			if backfillErr = p.schedulerCredRepo.Upsert(cred); backfillErr != nil {
-				return nil, fmt.Errorf("failed to persist regenerated secret for org %s: %w", ouID, backfillErr)
-			}
-			p.logger.Info("Backfilled encrypted client secret", "ouID", ouID, "clientID", cred.ClientID)
+			return nil, fmt.Errorf("%w for org %s: the stored credential (client %s) has no usable secret "+
+				"and can only be repaired on the request path", ErrSchedulerCredentialNotFound, ouID, cred.ClientID)
 		}
 
 		secretBytes, err := utils.DecryptBytes(cred.ClientSecretEncrypted, p.encryptionKey)

--- a/agent-manager-service/services/publisher_credential_provisioner_test.go
+++ b/agent-manager-service/services/publisher_credential_provisioner_test.go
@@ -19,7 +19,9 @@ package services
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -115,8 +117,14 @@ func TestEnsureCredentials_NewOrg_BindsOnlySchedulerCredential(t *testing.T) {
 	require.Len(t, publisherUpserts, 1)
 	assert.Equal(t, "amp-publisher-acme", publisherUpserts[0].ClientID)
 
-	require.Len(t, schedulerUpserts, 1)
+	// Two upserts: the secret is recorded as soon as it is known, then the SecretReference
+	// fields are filled in once resolved. See provisionSchedulerCredentials for why.
+	require.Len(t, schedulerUpserts, 2)
 	assert.Equal(t, "amp-scheduler-acme", schedulerUpserts[0].ClientID)
+	assert.NotEmpty(t, schedulerUpserts[0].ClientSecretEncrypted,
+		"the first write must already carry the secret")
+	assert.NotEmpty(t, schedulerUpserts[1].SecretKVPath)
+	assert.NotEmpty(t, schedulerUpserts[1].SecretKey)
 
 	require.Len(t, boundClientIDs, 1, "EnsureClusterRoleBinding should be called exactly once")
 	assert.Equal(t, "amp-scheduler-acme", boundClientIDs[0])
@@ -127,6 +135,11 @@ func TestEnsureCredentials_NewOrg_BindsOnlySchedulerCredential(t *testing.T) {
 func TestEnsureCredentials_ExistingOrg_ReverifiesOnlySchedulerBinding(t *testing.T) {
 	var boundClientIDs []string
 
+	// A healthy row carries a usable secret; without one it would be re-provisioned instead.
+	schedulerSecret, err := utils.EncryptBytes([]byte("scheduler-secret-value"), testEncryptionKey)
+	require.NoError(t, err)
+
+	// Empty: re-verifying an existing credential must not touch Thunder.
 	thunderMock := &clientmocks.ThunderClientMock{}
 	ocMock := &clientmocks.OpenChoreoClientMock{
 		EnsureClusterRoleBindingFunc: func(_ context.Context, clientID string, _ string) error {
@@ -146,6 +159,7 @@ func TestEnsureCredentials_ExistingOrg_ReverifiesOnlySchedulerBinding(t *testing
 		GetByOrgNameFunc: func(_ string) (*models.OrgSchedulerCredential, error) {
 			return &models.OrgSchedulerCredential{
 				ClientID: "amp-scheduler-acme", SecretKVPath: "kv/scheduler", SecretKey: "client-secret",
+				ClientSecretEncrypted: schedulerSecret,
 			}, nil
 		},
 	}
@@ -199,46 +213,21 @@ func TestGetOCClientForOrg_ReadsFromSchedulerCredRepo(t *testing.T) {
 	assert.NotNil(t, ocClient)
 }
 
-// Orgs whose monitors predate the credential split have no scheduler credential yet —
-// GetOCClientForOrg must provision one on demand rather than fail permanently.
-func TestGetOCClientForOrg_ProvisionsOnDemand_WhenSchedulerCredMissing(t *testing.T) {
-	var upserted *models.OrgSchedulerCredential
-
+// Provisioning writes to the secret store, and that write authenticates with a JWT taken
+// from the request context. The scheduler has no request context, so provisioning from
+// here could only ever fail — after it had already rotated the org's Thunder secret. Fail
+// fast on a sentinel instead, and touch neither Thunder nor the secret store.
+func TestGetOCClientForOrg_MissingSchedulerCred_DoesNotProvision(t *testing.T) {
 	schedulerCredRepo := &repomocks.OrgSchedulerCredentialRepositoryMock{
-		GetByOrgNameFunc: func(ouID string) (*models.OrgSchedulerCredential, error) {
-			if upserted == nil {
-				return nil, gorm.ErrRecordNotFound
-			}
-			return upserted, nil
+		GetByOrgNameFunc: func(_ string) (*models.OrgSchedulerCredential, error) {
+			return nil, gorm.ErrRecordNotFound
 		},
-		UpsertFunc: func(cred *models.OrgSchedulerCredential) error {
-			upserted = cred
-			return nil
-		},
+		// No UpsertFunc: the mock panics if anything tries to persist from this path.
 	}
-
-	var boundClientID string
-	thunderMock := &clientmocks.ThunderClientMock{
-		EnsureAppFunc: func(_ context.Context, appName, _ string) (string, string, bool, error) {
-			assert.Equal(t, "amp-scheduler-acme", appName)
-			return appName, "scheduler-secret", true, nil
-		},
-	}
-	ocMock := &clientmocks.OpenChoreoClientMock{
-		EnsureClusterRoleBindingFunc: func(_ context.Context, clientID string, roleName string) error {
-			boundClientID = clientID
-			assert.Equal(t, schedulerRoleName, roleName)
-			return nil
-		},
-		GetSecretReferenceFunc: func(_ context.Context, _ string, secretRefName string) (*occlient.SecretReferenceInfo, error) {
-			return newTestSecretRef("kv/"+secretRefName, "client-secret"), nil
-		},
-	}
-	secretClient := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(_ context.Context, location secretmanagersvc.SecretLocation, _ map[string]string) (string, error) {
-			return "ref-" + location.EntityName, nil
-		},
-	}
+	// Every mock below is deliberately empty — any call panics the test.
+	thunderMock := &clientmocks.ThunderClientMock{}
+	secretClient := &clientmocks.SecretManagementClientMock{}
+	ocMock := &clientmocks.OpenChoreoClientMock{}
 
 	p := &publisherCredentialProvisioner{
 		thunderClient:     thunderMock,
@@ -252,32 +241,147 @@ func TestGetOCClientForOrg_ProvisionsOnDemand_WhenSchedulerCredMissing(t *testin
 		orgOCClients:      make(map[string]occlient.OpenChoreoClient),
 	}
 
-	ocClient, err := p.GetOCClientForOrg(context.Background(), "acme")
-	require.NoError(t, err)
-	assert.NotNil(t, ocClient)
-	require.NotNil(t, upserted, "the missing scheduler credential should have been provisioned")
-	assert.Equal(t, "amp-scheduler-acme", upserted.ClientID)
-	assert.Equal(t, "amp-scheduler-acme", boundClientID)
+	_, err := p.GetOCClientForOrg(context.Background(), "acme")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSchedulerCredentialNotFound)
+	assert.Empty(t, p.orgOCClients, "nothing should be cached for an unprovisioned org")
 }
 
-// A real DB error on the post-provisioning recheck must not be reported as "genuinely absent".
-func TestGetOCClientForOrg_RealDBErrorOnRecheck_NotMisreportedAsNotFound(t *testing.T) {
-	dbTimeout := errors.New("db timeout")
-	calls := 0
+// Same reasoning for a row that exists but carries no usable secret: repairing it means
+// rotating in Thunder and writing the secret store, so the scheduler must not attempt it.
+func TestGetOCClientForOrg_EmptyEncryptedSecret_DoesNotRepair(t *testing.T) {
 	schedulerCredRepo := &repomocks.OrgSchedulerCredentialRepositoryMock{
 		GetByOrgNameFunc: func(_ string) (*models.OrgSchedulerCredential, error) {
-			calls++
-			if calls == 1 {
-				return nil, gorm.ErrRecordNotFound
-			}
+			return &models.OrgSchedulerCredential{
+				ClientID:              "amp-scheduler-acme",
+				ClientSecretEncrypted: nil,
+			}, nil
+		},
+	}
+	thunderMock := &clientmocks.ThunderClientMock{}
+	secretClient := &clientmocks.SecretManagementClientMock{}
+
+	p := &publisherCredentialProvisioner{
+		thunderClient:     thunderMock,
+		secretClient:      secretClient,
+		schedulerCredRepo: schedulerCredRepo,
+		logger:            discardLogger(),
+		encryptionKey:     testEncryptionKey,
+		idpTokenURL:       "http://thunder.test/oauth2/token",
+		ocBaseURL:         "http://openchoreo.test",
+		orgOCClients:      make(map[string]occlient.OpenChoreoClient),
+	}
+
+	_, err := p.GetOCClientForOrg(context.Background(), "acme")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSchedulerCredentialNotFound)
+}
+
+// A real DB error must not be reported as "genuinely absent".
+func TestGetOCClientForOrg_RealDBError_NotMisreportedAsNotFound(t *testing.T) {
+	dbTimeout := errors.New("db timeout")
+	schedulerCredRepo := &repomocks.OrgSchedulerCredentialRepositoryMock{
+		GetByOrgNameFunc: func(_ string) (*models.OrgSchedulerCredential, error) {
 			return nil, dbTimeout
 		},
-		UpsertFunc: func(_ *models.OrgSchedulerCredential) error { return nil },
+	}
+
+	p := &publisherCredentialProvisioner{
+		schedulerCredRepo: schedulerCredRepo,
+		logger:            discardLogger(),
+		encryptionKey:     testEncryptionKey,
+		orgOCClients:      make(map[string]occlient.OpenChoreoClient),
+	}
+
+	_, err := p.GetOCClientForOrg(context.Background(), "acme")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrSchedulerCredentialNotFound),
+		"a real DB error must not be reported as the not-found sentinel")
+	assert.ErrorIs(t, err, dbTimeout)
+}
+
+// Rotating the Thunder secret is destructive and irreversible, while every step after it
+// can fail. If the encrypted secret were only persisted at the end, a failure in between
+// would leave Thunder holding a secret nothing has a record of — which is how an org ends
+// up permanently unable to mint a token.
+func TestProvisionSchedulerCredentials_PersistsSecretBeforeFallibleSteps(t *testing.T) {
+	storeDown := errors.New("no JWT token found in context")
+
+	var upserts []*models.OrgSchedulerCredential
+	schedulerCredRepo := &repomocks.OrgSchedulerCredentialRepositoryMock{
+		GetByOrgNameFunc: func(_ string) (*models.OrgSchedulerCredential, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+		UpsertFunc: func(cred *models.OrgSchedulerCredential) error {
+			upserts = append(upserts, cred)
+			return nil
+		},
 	}
 	thunderMock := &clientmocks.ThunderClientMock{
 		EnsureAppFunc: func(_ context.Context, appName, _ string) (string, string, bool, error) {
-			return appName, "scheduler-secret", true, nil
+			return appName, "", false, nil // app exists, secret unavailable → forces a rotation
 		},
+		RegenerateAppClientSecretFunc: func(_ context.Context, _ string) (string, error) {
+			return "rotated-secret", nil
+		},
+	}
+	secretClient := &clientmocks.SecretManagementClientMock{
+		CreateSecretFunc: func(_ context.Context, _ secretmanagersvc.SecretLocation, _ map[string]string) (string, error) {
+			return "", storeDown
+		},
+	}
+	ocMock := &clientmocks.OpenChoreoClientMock{}
+
+	p := &publisherCredentialProvisioner{
+		thunderClient:     thunderMock,
+		secretClient:      secretClient,
+		ocClient:          ocMock,
+		schedulerCredRepo: schedulerCredRepo,
+		logger:            discardLogger(),
+		encryptionKey:     testEncryptionKey,
+		orgOCClients:      make(map[string]occlient.OpenChoreoClient),
+	}
+
+	err := p.provisionSchedulerCredentials(context.Background(), "acme", "org-uuid-1")
+	require.Error(t, err, "the secret-store failure must still surface")
+	assert.ErrorIs(t, err, storeDown)
+
+	require.NotEmpty(t, upserts, "the rotated secret must be recorded before the store write")
+	decrypted, decErr := utils.DecryptBytes(upserts[0].ClientSecretEncrypted, testEncryptionKey)
+	require.NoError(t, decErr)
+	assert.Equal(t, "rotated-secret", string(decrypted),
+		"the persisted secret must match what Thunder now holds")
+}
+
+// Provisioning rotates a secret in Thunder, so running it twice over for one org leaves
+// Thunder holding the second rotation while the DB records the first. Whatever the entry
+// point, concurrent provisioning of the same org must collapse to a single run.
+func TestProvisionSchedulerCredentials_ConcurrentCallsForOneOrgCollapse(t *testing.T) {
+	var mu sync.Mutex
+	rotations := 0
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enterOnce sync.Once
+
+	thunderMock := &clientmocks.ThunderClientMock{
+		EnsureAppFunc: func(_ context.Context, appName, _ string) (string, string, bool, error) {
+			enterOnce.Do(func() { close(entered) })
+			<-release
+			return appName, "", false, nil // app exists, secret unavailable → forces a rotation
+		},
+		RegenerateAppClientSecretFunc: func(_ context.Context, _ string) (string, error) {
+			mu.Lock()
+			rotations++
+			mu.Unlock()
+			return "rotated-secret", nil
+		},
+	}
+	schedulerCredRepo := &repomocks.OrgSchedulerCredentialRepositoryMock{
+		GetByOrgNameFunc: func(_ string) (*models.OrgSchedulerCredential, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+		UpsertFunc: func(_ *models.OrgSchedulerCredential) error { return nil },
 	}
 	ocMock := &clientmocks.OpenChoreoClientMock{
 		EnsureClusterRoleBindingFunc: func(_ context.Context, _ string, _ string) error { return nil },
@@ -298,14 +402,31 @@ func TestGetOCClientForOrg_RealDBErrorOnRecheck_NotMisreportedAsNotFound(t *test
 		schedulerCredRepo: schedulerCredRepo,
 		logger:            discardLogger(),
 		encryptionKey:     testEncryptionKey,
-		idpTokenURL:       "http://thunder.test/oauth2/token",
-		ocBaseURL:         "http://openchoreo.test",
 		orgOCClients:      make(map[string]occlient.OpenChoreoClient),
 	}
 
-	_, err := p.GetOCClientForOrg(context.Background(), "acme")
-	require.Error(t, err)
-	assert.False(t, errors.Is(err, ErrSchedulerCredentialNotFound),
-		"a real DB error must not be reported as the not-found sentinel")
-	assert.ErrorIs(t, err, dbTimeout)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, p.provisionSchedulerCredentials(context.Background(), "acme", "org-uuid-1"))
+	}()
+
+	<-entered // the first call is inside the critical section and holds the org's slot
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, p.provisionSchedulerCredentials(context.Background(), "acme", "org-uuid-1"))
+	}()
+
+	// Give the second call time to reach the deduplication point. Generous margin: the
+	// assertion below is what fails on a regression, not this wait.
+	time.Sleep(200 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, rotations, "concurrent provisioning of one org must rotate its secret once")
 }

--- a/agent-manager-service/services/publisher_credential_provisioner_test.go
+++ b/agent-manager-service/services/publisher_credential_provisioner_test.go
@@ -82,13 +82,15 @@ func TestEnsureCredentials_NewOrg_BindsOnlySchedulerCredential(t *testing.T) {
 		},
 	}
 
-	var schedulerUpserts []*models.OrgSchedulerCredential
+	var schedulerUpserts []models.OrgSchedulerCredential
 	schedulerCredRepo := &repomocks.OrgSchedulerCredentialRepositoryMock{
 		GetByOrgNameFunc: func(_ string) (*models.OrgSchedulerCredential, error) {
 			return nil, gorm.ErrRecordNotFound
 		},
 		UpsertFunc: func(cred *models.OrgSchedulerCredential) error {
-			schedulerUpserts = append(schedulerUpserts, cred)
+			// Snapshot by value: the caller reuses one struct across both writes, so
+			// storing the pointer would make every assertion read post-mutation state.
+			schedulerUpserts = append(schedulerUpserts, *cred)
 			return nil
 		},
 	}
@@ -123,6 +125,8 @@ func TestEnsureCredentials_NewOrg_BindsOnlySchedulerCredential(t *testing.T) {
 	assert.Equal(t, "amp-scheduler-acme", schedulerUpserts[0].ClientID)
 	assert.NotEmpty(t, schedulerUpserts[0].ClientSecretEncrypted,
 		"the first write must already carry the secret")
+	assert.Empty(t, schedulerUpserts[0].SecretKVPath,
+		"the first write lands before the reference fields are resolved")
 	assert.NotEmpty(t, schedulerUpserts[1].SecretKVPath)
 	assert.NotEmpty(t, schedulerUpserts[1].SecretKey)
 
@@ -360,13 +364,16 @@ func TestProvisionSchedulerCredentials_ConcurrentCallsForOneOrgCollapse(t *testi
 	var mu sync.Mutex
 	rotations := 0
 
-	entered := make(chan struct{})
+	// EnsureApp signals on every entry and then parks, so while the first call is parked a
+	// second signal can only mean a second call got through. Waiting for that signal, rather
+	// than sleeping and hoping the second call got far enough, inverts the timing risk: a
+	// starved runner can make this test pass spuriously but never fail spuriously.
+	entries := make(chan struct{}, 4)
 	release := make(chan struct{})
-	var enterOnce sync.Once
 
 	thunderMock := &clientmocks.ThunderClientMock{
 		EnsureAppFunc: func(_ context.Context, appName, _ string) (string, string, bool, error) {
-			enterOnce.Do(func() { close(entered) })
+			entries <- struct{}{}
 			<-release
 			return appName, "", false, nil // app exists, secret unavailable → forces a rotation
 		},
@@ -412,7 +419,7 @@ func TestProvisionSchedulerCredentials_ConcurrentCallsForOneOrgCollapse(t *testi
 		assert.NoError(t, p.provisionSchedulerCredentials(context.Background(), "acme", "org-uuid-1"))
 	}()
 
-	<-entered // the first call is inside the critical section and holds the org's slot
+	<-entries // the first call is parked inside EnsureApp and holds the org's slot
 
 	wg.Add(1)
 	go func() {
@@ -420,13 +427,21 @@ func TestProvisionSchedulerCredentials_ConcurrentCallsForOneOrgCollapse(t *testi
 		assert.NoError(t, p.provisionSchedulerCredentials(context.Background(), "acme", "org-uuid-1"))
 	}()
 
-	// Give the second call time to reach the deduplication point. Generous margin: the
-	// assertion below is what fails on a regression, not this wait.
-	time.Sleep(200 * time.Millisecond)
+	select {
+	case <-entries:
+		close(release)
+		wg.Wait()
+		t.Fatal("the second call reached Thunder while the first was still in flight: " +
+			"provisioning for one org was not deduplicated")
+	case <-time.After(500 * time.Millisecond):
+		// No second entry while the first is parked — the second call was deduplicated.
+	}
+
 	close(release)
 	wg.Wait()
 
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, 1, rotations, "concurrent provisioning of one org must rotate its secret once")
+	assert.Empty(t, entries, "EnsureApp must be reached exactly once for one org")
 }

--- a/agent-manager-service/services/publisher_credential_provisioner_test.go
+++ b/agent-manager-service/services/publisher_credential_provisioner_test.go
@@ -186,6 +186,28 @@ func TestEnsureCredentials_ExistingOrg_ReverifiesOnlySchedulerBinding(t *testing
 	assert.Equal(t, "amp-scheduler-acme", boundClientIDs[0])
 }
 
+// An empty orgUUID makes Thunder create the application under the platform's default
+// organization unit. Because the OU is written once at creation and findApp matches by
+// name across all OUs, that misparenting is permanent and invisible — so refuse the input
+// rather than hand Thunder a value that silently means "somebody else's organization".
+func TestEnsureCredentials_EmptyOrgUUID_RefusesToProvision(t *testing.T) {
+	// Every collaborator is empty: the mocks panic if anything is provisioned.
+	p := &publisherCredentialProvisioner{
+		thunderClient:     &clientmocks.ThunderClientMock{},
+		secretClient:      &clientmocks.SecretManagementClientMock{},
+		ocClient:          &clientmocks.OpenChoreoClientMock{},
+		credRepo:          &repomocks.OrgPublisherCredentialRepositoryMock{},
+		schedulerCredRepo: &repomocks.OrgSchedulerCredentialRepositoryMock{},
+		logger:            discardLogger(),
+		encryptionKey:     testEncryptionKey,
+		orgOCClients:      make(map[string]occlient.OpenChoreoClient),
+	}
+
+	_, err := p.EnsureCredentials(context.Background(), "acme", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "orgUUID is required")
+}
+
 // credRepo has no GetByOrgNameFunc — the mock panics if GetOCClientForOrg ever touches it.
 func TestGetOCClientForOrg_ReadsFromSchedulerCredRepo(t *testing.T) {
 	encryptedSecret, err := utils.EncryptBytes([]byte("scheduler-secret-value"), testEncryptionKey)


### PR DESCRIPTION
## Purpose

Scheduled (`future`) monitors never run for an organization that has no scheduler credential yet, and the failure actively destroys the credential it is trying to create.

Every scheduler cycle calls `GetOCClientForOrg`, which provisioned a scheduler credential on demand when none was found. Provisioning writes to the secret store, and that write authenticates with the caller's JWT taken from the request context. The scheduler runs on a timer with no inbound request, so it has no JWT and the write always fails:

```
Failed to sync run status  error="failed to get OC client for org <ouid>:
  failed to provision scheduler credentials for org <ouid>:
    failed to store scheduler secret for org <ouid>:
      failed to upsert secret: no JWT token found in context"
```

`GetOCClientForOrg`'s own doc comment already stated the constraint — *"Used by the scheduler which runs without a user request context and therefore has no user JWT in ctx"* — and the on-demand provisioning added later did the one thing that requires exactly that JWT.

The failure is not inert. `provisionSchedulerCredentials` rotates the Thunder app's client secret **before** it writes the secret store, so each attempt rotated the secret and then persisted nothing, once a minute, indefinitely. That is also why creating a new monitor did not help: the request path provisions correctly and stores its secret, then the scheduler's concurrent attempt rotates it away moments later. The database and Thunder end up permanently disagreeing, and because both paths treat "a row with a secret" as already provisioned, nothing ever repairs either side.

Three defects compound here, and this PR addresses all three.

## Goals

Scheduled monitors run for organizations whose credentials exist, and an organization whose credentials do not exist fails with an accurate, actionable error instead of silently corrupting its own credential every minute.

## Approach

**Make the scheduler read-only with respect to credentials.** `GetOCClientForOrg` no longer provisions and no longer backfills. It returns `ErrSchedulerCredentialNotFound` — both when there is no row and when the row carries no usable secret — and leaves provisioning to the request path, which has the JWT the flow requires. This immediately stops the rotation loop, and once it stops, what the request path stores actually sticks. An organization with no usable credential still cannot run scheduled monitors until a monitor is created in it, but it now says so plainly rather than quietly destroying the credential.

**Persist the encrypted secret as soon as it is known.** The rotation is destructive and cannot be replayed, so persisting at the end of the flow let any later failure strand an organization: Thunder moved to a new secret that nothing held a copy of. The DB write now happens immediately after encryption, ahead of the secret-store write and reference resolution; the `SecretKVPath`/`SecretKey` fields follow in a completing upsert. Nothing reads those two fields for a scheduler credential, which is what makes it safe for them to lag the secret.

**Serialise provisioning per organization** with singleflight, so two overlapping runs cannot rotate the same app twice and record only the first.

Additionally, a credential row carrying no usable secret is no longer treated as already provisioned. The scheduler cannot mint a token from one and can no longer repair it, so the request path re-provisions instead of returning early and leaving the organization stuck.

Not changed: the `amp-monitor-scheduler` ClusterAuthzRole and its bindings. These were investigated and ruled out — installs run scheduled monitors correctly with no binding present, and the binding step sits after the secret-store write that fails, so it is never reached on the broken path.

## User stories

As an operator, a monitor I schedule to run on an interval either runs, or tells me exactly why it cannot — instead of sitting idle while the platform invalidates its own credentials in the background.

## Release note

Fixed scheduled evaluation monitors never running for an organization whose scheduler credentials had not yet been provisioned, and stopped the repeated provisioning attempts from invalidating that organization's credentials.

## Documentation

N/A — no user-facing configuration changes; this restores intended behavior of an existing feature.

## Training

N/A — no training content impact.

## Certification

N/A — no impact on certification exam content.

## Marketing

N/A — bug fix.

## Automation tests

- Unit tests
  > Six tests added and two updated in `services/publisher_credential_provisioner_test.go`, all in the unit tier (no database):
  > - `TestGetOCClientForOrg_MissingSchedulerCred_DoesNotProvision` — every Thunder / secret-store / OpenChoreo mock is left empty, so the test panics if the scheduler path touches any of them; asserts the sentinel and that nothing is cached.
  > - `TestGetOCClientForOrg_EmptyEncryptedSecret_DoesNotRepair` — same guarantee for the backfill path.
  > - `TestGetOCClientForOrg_RealDBError_NotMisreportedAsNotFound` — a real DB error must not surface as the not-found sentinel.
  > - `TestProvisionSchedulerCredentials_PersistsSecretBeforeFallibleSteps` — fails the secret-store write and asserts the rotated secret was already persisted and matches what Thunder holds.
  > - `TestProvisionSchedulerCredentials_ConcurrentCallsForOneOrgCollapse` — two concurrent provisioning calls for one org must rotate exactly once. Verified to fail (2 rotations) with the singleflight wrapper removed, so it genuinely guards the behavior.
  > - The two existing `TestEnsureCredentials_*` tests were updated for the two-phase upsert and for a healthy row now needing a usable secret.
  >
  > Full unit tier passes, including under `-race`. `gofumpt` clean, `go vet` clean.
- Integration tests
  > N/A — the affected paths are covered at the unit tier with mocked Thunder, secret-store and OpenChoreo clients. The integration tier does not exercise scheduler credential provisioning.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java sources touched.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Note: this narrows what the scheduler may do — it drops the ability to create OAuth applications and write the secret store from an unauthenticated background context. The client secret continues to be encrypted at rest with the existing key; no secret value is logged.

## Samples

N/A — no samples relate to this change.

## Related PRs

None.

## Migrations (if applicable)

None required — no schema change.

Operational note for an organization already wedged by this bug: its stored secret may no longer match Thunder, because earlier failed attempts rotated Thunder without persisting. Such an organization recovers when the request path next provisions it. Rows whose `client_secret_encrypted` is empty are re-provisioned automatically on that path as of this change.

## Test environment

macOS (darwin 25.5.0), Go toolchain per `agent-manager-service/go.mod`; unit tier run with and without `-race`.

## Learning

Two things worth carrying forward.

A background worker that shares a code path with a request handler silently inherits that path's authentication assumptions. The requirement here was documented in a comment on the very function involved, and the on-demand provisioning was still added to it. A context-carried credential is invisible in the call signature, so nothing at the call site suggests the path is unavailable.

Retry loops around non-idempotent operations need the destructive step ordered last. Rotating before persisting turned a recoverable failure into permanent credential drift, and re-running once a minute turned that into a race against the very path that could have repaired it. Ordering the irreversible step after everything that can fail — or recording its result before anything else runs — is what keeps a failed attempt merely failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler credential provisioning reliability during secret rotation.
  * Existing credentials with missing or unusable encrypted secrets are now repaired automatically.
  * Credential reads no longer trigger unexpected provisioning or repair operations.
  * Missing credentials now return a clear not-found error.
  * Concurrent provisioning requests are safely serialized to prevent duplicate work.

* **Tests**
  * Added coverage for credential reuse, rotation ordering, missing secrets, database errors, and concurrent provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->