### PR TITLE
Fixes/Improvements related to Agent Kind

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/component_labels_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/component_labels_test.go
@@ -18,6 +18,7 @@
 package client
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -134,7 +135,7 @@ func TestBuildInternalAgentFromKindComponentRequestBody_UserLabels(t *testing.T)
 	assert.Equal(t, "ml", labels["team"])
 	assert.Equal(t, "kind-1", labels[string(LabelKeyAgentKindName)])
 	// System keys plus the one user key, no collision.
-	assert.Len(t, labels, 6)
+	assert.Len(t, labels, 7)
 }
 
 func TestBuildExternalAgentComponentRequestBody_UserLabels(t *testing.T) {
@@ -247,4 +248,83 @@ func TestBuildExternalAgentComponentRequestBody_NoRoutePath(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, body.Spec)
 	assert.Nil(t, body.Spec.Parameters)
+}
+
+func TestBuildInternalAgentFromKindComponentRequestBody_KindVersion(t *testing.T) {
+	req := CreateComponentRequest{
+		Name:        "agent-1",
+		DisplayName: "Agent 1",
+		AgentType:   AgentTypeConfig{Type: "agent-api", SubType: "chat-api"},
+		AgentKind:   &AgentKindRef{Name: "kind-1", Version: "v1.2.0"},
+		Build:       &BuildConfig{Type: "buildpack", Buildpack: &BuildpackConfig{Language: "python"}},
+	}
+	body, err := buildInternalAgentFromKindComponentRequestBody("ns", "proj", req)
+	require.NoError(t, err)
+	require.NotNil(t, body.Metadata.Labels)
+	labels := *body.Metadata.Labels
+	assert.Equal(t, "kind-1", labels[string(LabelKeyAgentKindName)])
+	assert.Equal(t, "v1.2.0", labels[string(LabelKeyAgentKindVersion)])
+}
+
+// A version tag that can't be a label value must fail loudly. Creating the agent
+// without the version label would leave an incomplete provenance record that
+// nothing downstream could distinguish from a pre-label agent.
+func TestBuildInternalAgentFromKindComponentRequestBody_RejectsUnlabelableVersion(t *testing.T) {
+	for _, version := range []string{"1.0 (beta)", "v1.0.0+build.1", "-v1", strings.Repeat("v", 64)} {
+		t.Run(version, func(t *testing.T) {
+			req := CreateComponentRequest{
+				Name:        "agent-1",
+				DisplayName: "Agent 1",
+				AgentType:   AgentTypeConfig{Type: "agent-api", SubType: "chat-api"},
+				AgentKind:   &AgentKindRef{Name: "kind-1", Version: version},
+				Build:       &BuildConfig{Type: "buildpack", Buildpack: &BuildpackConfig{Language: "python"}},
+			}
+			_, err := buildInternalAgentFromKindComponentRequestBody("ns", "proj", req)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), version)
+		})
+	}
+}
+
+func TestConvertComponentFromTyped_KindVersion(t *testing.T) {
+	newComp := func(labels map[string]string) *gen.Component {
+		return &gen.Component{
+			Metadata: gen.ObjectMeta{
+				Name:   "agent-1",
+				Labels: &labels,
+			},
+			Spec: &gen.ComponentSpec{
+				ComponentType: struct {
+					Kind *gen.ComponentSpecComponentTypeKind `json:"kind,omitempty"`
+					Name string                              `json:"name"`
+				}{Name: "internal-agent/agent-api"},
+				Owner: struct {
+					ProjectName string `json:"projectName"`
+				}{ProjectName: "proj"},
+			},
+		}
+	}
+
+	t.Run("reads name and version from labels", func(t *testing.T) {
+		agent, err := convertComponentFromTyped(newComp(map[string]string{
+			string(LabelKeyProvisioningType): "internal",
+			string(LabelKeyBuildSource):      BuildSourceKind,
+			string(LabelKeyAgentKindName):    "kind-1",
+			string(LabelKeyAgentKindVersion): "v1.2.0",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "kind-1", agent.KindName)
+		assert.Equal(t, "v1.2.0", agent.KindVersion)
+	})
+
+	t.Run("agent created before the version label still resolves its kind", func(t *testing.T) {
+		agent, err := convertComponentFromTyped(newComp(map[string]string{
+			string(LabelKeyProvisioningType): "internal",
+			string(LabelKeyBuildSource):      BuildSourceKind,
+			string(LabelKeyAgentKindName):    "kind-1",
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "kind-1", agent.KindName)
+		assert.Empty(t, agent.KindVersion)
+	})
 }

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -76,11 +76,21 @@ func buildInternalAgentFromKindComponentRequestBody(namespaceName, projectName s
 		string(AnnotationKeyDisplayName): req.DisplayName,
 		string(AnnotationKeyDescription): req.Description,
 	}
+	// Both the kind name and version are recorded so an agent can be traced back to
+	// the exact published kind version it was instantiated from. Version tags are
+	// free-form, and a tag that isn't a legal label value would be rejected by the
+	// API server with an opaque error — so it's checked here and reported as a
+	// validation error naming the tag, never dropped to make creation succeed with
+	// an incomplete provenance record.
+	if err := utils.ValidateLabelValue(req.AgentKind.Version, "agent kind version"); err != nil {
+		return gen.CreateComponentJSONRequestBody{}, err
+	}
 	labels := map[string]string{
 		string(LabelKeyProvisioningType): string(ProvisioningInternal),
 		string(LabelKeyAgentSubType):     req.AgentType.SubType,
 		string(LabelKeyBuildSource):      BuildSourceKind,
 		string(LabelKeyAgentKindName):    req.AgentKind.Name,
+		string(LabelKeyAgentKindVersion): req.AgentKind.Version,
 	}
 
 	// Mirror the same language label logic as buildInternalAgentFromSourceComponentRequestBody
@@ -2905,6 +2915,8 @@ func convertComponentFromTyped(comp *gen.Component) (*models.AgentResponse, erro
 
 	if getLabel(comp.Metadata.Labels, string(LabelKeyBuildSource)) == BuildSourceKind {
 		agent.KindName = getLabel(comp.Metadata.Labels, string(LabelKeyAgentKindName))
+		// Empty for agents created before the version label existed.
+		agent.KindVersion = getLabel(comp.Metadata.Labels, string(LabelKeyAgentKindVersion))
 		// Enrich agent.Build from labels — kind agents have no workflow, so extractBuildParams
 		// is never called above, but the build source info is stored in labels at creation time.
 		language := getLabel(comp.Metadata.Labels, string(LabelKeyAgentLanguage))

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -83,7 +83,7 @@ func buildInternalAgentFromKindComponentRequestBody(namespaceName, projectName s
 	// validation error naming the tag, never dropped to make creation succeed with
 	// an incomplete provenance record.
 	if err := utils.ValidateLabelValue(req.AgentKind.Version, "agent kind version"); err != nil {
-		return gen.CreateComponentJSONRequestBody{}, err
+		return gen.CreateComponentJSONRequestBody{}, fmt.Errorf("invalid agent kind version: %w", err)
 	}
 	labels := map[string]string{
 		string(LabelKeyProvisioningType): string(ProvisioningInternal),

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -84,6 +84,13 @@ func NewAgentController(agentService services.AgentManagerService, agentKindServ
 // If no common error matches, writes an internal server error with the provided fallback message.
 func handleCommonErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 	switch {
+	// A ValidationError raised below the controller (e.g. a stored agent kind
+	// version that can't be written as a label) is still a client-side problem —
+	// report it as a 400 naming the offending value instead of letting it reach
+	// the generic 500 fallback.
+	case utils.IsValidationError(err) != nil:
+		utils.WriteValidationErrorResponse(w, err)
+
 	// Not found errors
 	case errors.Is(err, utils.ErrOrganizationNotFound):
 		utils.WriteErrorResponseWithReason(w, http.StatusNotFound,
@@ -1027,6 +1034,14 @@ func (c *agentController) PublishKind(w http.ResponseWriter, r *http.Request) {
 
 	if payload.GetKindName() == "" || payload.GetVersion() == "" || payload.GetBuildName() == "" {
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "kindName, version, and buildName are required")
+		return
+	}
+
+	// The tag is stamped onto every agent created from this version as a label,
+	// so reject an unusable one here rather than at agent-creation time.
+	if err := utils.ValidateLabelValue(payload.GetVersion(), "version"); err != nil {
+		log.Debug("PublishKind: invalid version tag", "error", err)
+		utils.WriteValidationErrorResponse(w, err)
 		return
 	}
 

--- a/agent-manager-service/controllers/agent_kind_controller.go
+++ b/agent-manager-service/controllers/agent_kind_controller.go
@@ -171,6 +171,13 @@ func (c *agentKindController) AddVersion(w http.ResponseWriter, r *http.Request)
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "version, buildName, sourceAgentName, and sourceProjectName are required")
 		return
 	}
+	// The tag is stamped onto every agent created from this version as a label,
+	// so reject an unusable one here rather than at agent-creation time.
+	if err := utils.ValidateLabelValue(payload.GetVersion(), "version"); err != nil {
+		log.Debug("AddVersion: invalid version tag", "error", err)
+		utils.WriteValidationErrorResponse(w, err)
+		return
+	}
 
 	result, err := c.kindService.AddVersion(ctx, ouID, kindName, &payload)
 	if err != nil {

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -11831,6 +11831,9 @@ components:
         kindName:
           type: string
           description: Name of the Agent Kind this agent was instantiated from (absent for source-built agents)
+        kindVersion:
+          type: string
+          description: Version tag of the Agent Kind this agent was instantiated from (absent for source-built agents, and for kind-sourced agents created before the version was recorded)
         labels:
           $ref: "#/components/schemas/Labels"
         createdBy:
@@ -17947,7 +17950,13 @@ components:
       properties:
         version:
           type: string
-          description: Version tag for this release
+          description: >-
+            Version tag for this release. Stored as a Kubernetes label on every
+            agent created from this version, so it must be at most 63 characters
+            of letters, digits, '.', '_' or '-', starting and ending with a
+            letter or digit.
+          maxLength: 63
+          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$"
           example: "v1.0.0"
         buildName:
           type: string
@@ -17995,7 +18004,13 @@ components:
           $ref: "#/components/schemas/Labels"
         version:
           type: string
-          description: Version tag for this release
+          description: >-
+            Version tag for this release. Stored as a Kubernetes label on every
+            agent created from this version, so it must be at most 63 characters
+            of letters, digits, '.', '_' or '-', starting and ending with a
+            letter or digit.
+          maxLength: 63
+          pattern: "^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$"
           example: "v1.0.0"
         buildName:
           type: string

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -12396,6 +12396,13 @@ components:
         imageId:
           type: string
           description: Container image ID
+        kindVersion:
+          type: string
+          description: >-
+            Agent Kind version this deployment runs, resolved from the deployed
+            image. Per-environment, so it reflects what is actually deployed
+            rather than the version the agent was created from. Absent for
+            source-built agents and when the image matches no published version.
         status:
           type: string
           description: Deployment status

--- a/agent-manager-service/models/agent.go
+++ b/agent-manager-service/models/agent.go
@@ -25,20 +25,22 @@ import (
 )
 
 type AgentResponse struct {
-	UUID           string            `json:"uuid"`
-	Name           string            `json:"name"`
-	DisplayName    string            `json:"displayName,omitempty"`
-	Description    string            `json:"description,omitempty"`
-	ProjectName    string            `json:"projectName"`
-	CreatedAt      time.Time         `json:"createdAt"`
-	Status         string            `json:"status,omitempty"`
-	Provisioning   Provisioning      `json:"provisioning,omitempty"`
-	Type           AgentType         `json:"type,omitempty"`
-	Build          *Build            `json:"build,omitempty"`
-	InputInterface *InputInterface   `json:"inputInterface,omitempty"`
-	Configurations *Configurations   `json:"configurations,omitempty"`
-	KindName       string            `json:"kindName,omitempty"`
-	Labels         map[string]string `json:"labels,omitempty"`
+	UUID           string          `json:"uuid"`
+	Name           string          `json:"name"`
+	DisplayName    string          `json:"displayName,omitempty"`
+	Description    string          `json:"description,omitempty"`
+	ProjectName    string          `json:"projectName"`
+	CreatedAt      time.Time       `json:"createdAt"`
+	Status         string          `json:"status,omitempty"`
+	Provisioning   Provisioning    `json:"provisioning,omitempty"`
+	Type           AgentType       `json:"type,omitempty"`
+	Build          *Build          `json:"build,omitempty"`
+	InputInterface *InputInterface `json:"inputInterface,omitempty"`
+	Configurations *Configurations `json:"configurations,omitempty"`
+	KindName       string          `json:"kindName,omitempty"`
+	// KindVersion is empty for agents created before the version was recorded.
+	KindVersion string            `json:"kindVersion,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
 	// CreatedBy is best-effort: resolved from the audit-only requester id
 	// captured at agent-creation time (see AgentThunderClient.RequestedBy).
 	// Nil when unknown — pre-existing agents, deployments without AgentID

--- a/agent-manager-service/models/build_deployment.go
+++ b/agent-manager-service/models/build_deployment.go
@@ -29,6 +29,12 @@ type DeploymentResponse struct {
 	PromotionTargetEnvironment *PromotionTargetEnvironment `json:"promotionTargetEnvironment,omitempty"`
 	LastDeployedAt             *time.Time                  `json:"lastDeployedAt,omitempty"`
 	Endpoints                  []Endpoint                  `json:"endpoints"`
+	// KindVersion is the published Agent Kind version whose image this deployment
+	// runs, resolved from ImageId. It is per-environment and reflects what is
+	// actually deployed, unlike the component's creation-time kind-version label,
+	// which does not move when an agent is redeployed on a newer version. Empty
+	// for source-built agents and when the image matches no published version.
+	KindVersion string `json:"kindVersion,omitempty"`
 }
 
 // PromotionTargetEnvironment represents environment promotion targets

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -507,6 +507,86 @@ func (s *agentManagerService) buildCreateTraitRequests(ctx context.Context, ouID
 	return traits, nil
 }
 
+// effectiveUpstreamInterface returns the port and base path the API gateway must
+// dial to reach this agent's container, for the api-configuration trait.
+//
+// A source-built agent carries them on its component's workflow parameters, so
+// they read straight off the component. A kind-sourced agent has no workflow —
+// its endpoint lives only on the Workload — so convertComponentFromTyped leaves
+// InputInterface nil, and falling through to the chat-API defaults would point the
+// gateway at a port nothing listens on (a 503 on every request to a custom-api
+// agent). Resolve those from the build its kind version was published from.
+//
+// The chat-API defaults remain the last resort: a chat agent genuinely serves on
+// them, and they are the only sane guess when nothing else resolves
+func (s *agentManagerService) effectiveUpstreamInterface(ctx context.Context, ouID string, agent *models.AgentResponse) (int32, string) {
+	port := config.GetConfig().DefaultChatAPI.DefaultHTTPPort
+	basePath := config.GetConfig().DefaultChatAPI.DefaultBasePath
+
+	iface := agent.InputInterface
+	if agent.KindName != "" {
+		if resolved := s.kindVersionInputInterface(ctx, ouID, agent.KindName, agent.KindVersion); resolved != nil {
+			iface = resolved
+		}
+	}
+	if iface != nil {
+		if iface.Port > 0 {
+			port = iface.Port
+		}
+		if iface.BasePath != "" {
+			basePath = iface.BasePath
+		}
+	}
+	return port, basePath
+}
+
+// kindVersionInputInterface reads the input interface a kind version was published
+// with, off the build (workflow run) that produced its image.
+//
+// The build is read rather than the kind's source agent because a source agent goes
+// on living: change its port or base path after publishing, and reading the
+// component would describe an interface the published image never served. A
+// WorkflowRun is a finished record of one build, so its parameters still describe
+// the image this agent actually runs — the same reason the agent catalogue reads a
+// version's API spec from there.
+//
+// Returns nil on any failure so callers fall back to their defaults rather than
+// failing a deploy over it.
+func (s *agentManagerService) kindVersionInputInterface(ctx context.Context, ouID, kindName, versionTag string) *models.InputInterface {
+	if versionTag == "" {
+		s.logger.Warn("Agent has no recorded kind version; cannot resolve its published upstream interface",
+			"kindName", kindName)
+		return nil
+	}
+	kindVersion, err := s.agentKindService.GetKindVersion(ctx, ouID, kindName, versionTag)
+	if err != nil {
+		s.logger.Warn("Failed to read kind version while resolving upstream interface",
+			"kindName", kindName, "kindVersion", versionTag, "error", err)
+		return nil
+	}
+	return s.kindBuildInputInterface(ctx, ouID, kindVersion)
+}
+
+// kindBuildInputInterface reads the input interface off the build that produced a
+// kind version's image. Returns nil when the version has no build, or the build can
+// no longer be read, so callers fall back rather than failing over it.
+func (s *agentManagerService) kindBuildInputInterface(ctx context.Context, ouID string, kindVersion *models.AgentKindVersion) *models.InputInterface {
+	if kindVersion == nil || kindVersion.Kind == nil || kindVersion.BuildName == "" {
+		return nil
+	}
+	build, err := s.ocClient.GetBuild(ctx, ouID, kindVersion.Kind.ProjectName, kindVersion.Kind.AgentName, kindVersion.BuildName)
+	if err != nil {
+		s.logger.Warn("Failed to read a kind version's build while resolving its input interface",
+			"kindName", kindVersion.Kind.Name, "kindVersion", kindVersion.Version,
+			"buildName", kindVersion.BuildName, "error", err)
+		return nil
+	}
+	if build == nil {
+		return nil
+	}
+	return build.InputInterface
+}
+
 // ErrInstrumentationVersionNotPinned indicates an agent has no pinned AMP
 // instrumentation version: no row in agent_configs yet, no project pipeline,
 // or the column is NULL. Callers should treat it as "fall back to the platform
@@ -1282,30 +1362,27 @@ func (s *agentManagerService) CreateAgent(ctx context.Context, ouID string, proj
 			SubType: &subType,
 		}
 		req.Build = modelBuildToSpecBuild(sourceComponent.Build)
-		if sourceComponent.InputInterface != nil {
-			port := sourceComponent.InputInterface.Port
-			basePath := sourceComponent.InputInterface.BasePath
+		// Prefer the interface recorded on the build this version was published
+		// from: the source agent keeps living, so its component may describe a port
+		// or base path the published image never served. The component is the
+		// fallback for versions whose build is gone. This is what the created
+		// agent's api-configuration trait — and so the gateway's upstream URL — is
+		// built from, which is why a wrong value here is a 503 rather than a
+		// cosmetic slip.
+		iface := s.kindBuildInputInterface(ctx, ouID, kindVersion)
+		if iface == nil {
+			iface = sourceComponent.InputInterface
+		}
+		if iface != nil {
+			port := iface.Port
+			basePath := iface.BasePath
 			req.InputInterface = &spec.InputInterface{
-				Type:     sourceComponent.InputInterface.Type,
+				Type:     iface.Type,
 				Port:     &port,
 				BasePath: &basePath,
 			}
-			if sourceComponent.InputInterface.Schema != nil && sourceComponent.InputInterface.Schema.Path != "" {
-				req.InputInterface.Schema = &spec.InputInterfaceSchema{Path: &sourceComponent.InputInterface.Schema.Path}
-				// Kind-sourced agents deploy from a stored image with no git checkout/build step,
-				// so the schema path above can never be resolved into content for them. Resolve the
-				// source agent's already-built OpenAPI content here so the Swagger UI has something
-				// to render instead of "No API schema available for this endpoint".
-				if endpoints, epErr := s.ocClient.GetComponentEndpoints(ctx, ouID, kindVersion.Kind.ProjectName, kindVersion.Kind.AgentName, ""); epErr != nil {
-					s.logger.Warn("Failed to resolve source agent's OpenAPI schema content for kind instantiation",
-						"ouID", ouID, "sourceProject", kindVersion.Kind.ProjectName, "agentName", kindVersion.Kind.AgentName, "error", epErr)
-				} else if sourceEndpoint, ok := endpoints[kindVersion.Kind.AgentName+"-endpoint"]; ok && sourceEndpoint.Schema.Content != "" {
-					content := sourceEndpoint.Schema.Content
-					req.InputInterface.Schema.Content = &content
-				} else {
-					s.logger.Debug("No resolved OpenAPI schema content found for source agent's endpoint during kind instantiation",
-						"ouID", ouID, "sourceProject", kindVersion.Kind.ProjectName, "agentName", kindVersion.Kind.AgentName)
-				}
+			if iface.Schema != nil && iface.Schema.Path != "" {
+				req.InputInterface.Schema = &spec.InputInterfaceSchema{Path: &iface.Schema.Path}
 			}
 		}
 		imageID = kindVersion.ImageId
@@ -2984,18 +3061,11 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 		}
 		artifactID := apiArtifact.UUID.String()
 
+		upstreamPort, upstreamBasePath := s.effectiveUpstreamInterface(ctx, ouID, agent)
 		traitOpts := []client.TraitOption{
 			client.WithArtifactID(artifactID),
-		}
-		if agent.InputInterface != nil && agent.InputInterface.Port > 0 {
-			traitOpts = append(traitOpts, client.WithUpstreamPort(agent.InputInterface.Port))
-		} else {
-			traitOpts = append(traitOpts, client.WithUpstreamPort(config.GetConfig().DefaultChatAPI.DefaultHTTPPort))
-		}
-		if agent.InputInterface != nil && agent.InputInterface.BasePath != "" {
-			traitOpts = append(traitOpts, client.WithUpstreamBasePath(agent.InputInterface.BasePath))
-		} else {
-			traitOpts = append(traitOpts, client.WithUpstreamBasePath(config.GetConfig().DefaultChatAPI.DefaultBasePath))
+			client.WithUpstreamPort(upstreamPort),
+			client.WithUpstreamBasePath(upstreamBasePath),
 		}
 		if resilienceTimeoutSeconds > 0 {
 			traitOpts = append(traitOpts, client.WithResilienceTimeout(resilienceTimeoutSeconds))
@@ -5021,11 +5091,50 @@ func (s *agentManagerService) GetAgentDeployments(ctx context.Context, ouID stri
 	// for all-runc setups, and converges in a single write per binding.
 	if agent, err := s.ocClient.GetComponent(ctx, ouID, projectName, agentName); err != nil {
 		s.logger.Warn("isolation reconcile: failed to fetch agent for type gate", "agentName", agentName, "error", err)
-	} else if agent.Type.Type == string(utils.AgentTypeAPI) {
-		s.reconcileIsolationRuntimeClass(ctx, ouID, agentName, deployments)
+	} else {
+		if agent.Type.Type == string(utils.AgentTypeAPI) {
+			s.reconcileIsolationRuntimeClass(ctx, ouID, agentName, deployments)
+		}
+		s.resolveDeployedKindVersions(ctx, ouID, agent.KindName, deployments)
 	}
 
 	return deployments, nil
+}
+
+// resolveDeployedKindVersions stamps each deployment with the Agent Kind version
+// its image was published as, mutating deployments in place.
+//
+// The version an agent runs is a property of the deployment, not of the agent:
+// redeploying on a newer kind version — or promoting one environment and not
+// another — changes it per environment, while the component's kind-version label
+// records only what the agent was created from. The image is the link between the
+// two, since a published version's image is unique.
+//
+// Best-effort: a kind that can't be read leaves the versions empty rather than
+// failing the deployments read, which must keep working for the rest of its data.
+func (s *agentManagerService) resolveDeployedKindVersions(ctx context.Context, ouID, kindName string, deployments []*models.DeploymentResponse) {
+	if kindName == "" || len(deployments) == 0 {
+		return
+	}
+	kind, err := s.agentKindService.GetKind(ctx, ouID, kindName)
+	if err != nil {
+		s.logger.Warn("Failed to resolve deployed kind versions", "kindName", kindName, "error", err)
+		return
+	}
+	versionByImage := make(map[string]string, len(kind.Versions))
+	for _, v := range kind.Versions {
+		if v.ImageId != "" {
+			versionByImage[v.ImageId] = v.Version
+		}
+	}
+	for _, deployment := range deployments {
+		if deployment == nil {
+			continue
+		}
+		// No entry means the image predates the kind or its version was deleted;
+		// leaving it empty is the honest answer, and callers render nothing.
+		deployment.KindVersion = versionByImage[deployment.ImageId]
+	}
 }
 
 // reconcileIsolationRuntimeClass ensures every deployment whose environment has an isolation tier

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -517,15 +517,25 @@ func (s *agentManagerService) buildCreateTraitRequests(ctx context.Context, ouID
 // gateway at a port nothing listens on (a 503 on every request to a custom-api
 // agent). Resolve those from the build its kind version was published from.
 //
+// deployedImageID is the image this call is deploying. A deploy can select a kind
+// version other than the one the agent was created from, and the component's
+// kind-version label does not move when it does — so the image, not the label,
+// says which version's interface the gateway must be pointed at. Empty (or an
+// image matching no published version) falls back to the label.
+//
 // The chat-API defaults remain the last resort: a chat agent genuinely serves on
 // them, and they are the only sane guess when nothing else resolves
-func (s *agentManagerService) effectiveUpstreamInterface(ctx context.Context, ouID string, agent *models.AgentResponse) (int32, string) {
+func (s *agentManagerService) effectiveUpstreamInterface(ctx context.Context, ouID string, agent *models.AgentResponse, deployedImageID string) (int32, string) {
 	port := config.GetConfig().DefaultChatAPI.DefaultHTTPPort
 	basePath := config.GetConfig().DefaultChatAPI.DefaultBasePath
 
 	iface := agent.InputInterface
 	if agent.KindName != "" {
-		if resolved := s.kindVersionInputInterface(ctx, ouID, agent.KindName, agent.KindVersion); resolved != nil {
+		versionTag := agent.KindVersion
+		if deployed := s.kindVersionForImage(ctx, ouID, agent.KindName, deployedImageID); deployed != "" {
+			versionTag = deployed
+		}
+		if resolved := s.kindVersionInputInterface(ctx, ouID, agent.KindName, versionTag); resolved != nil {
 			iface = resolved
 		}
 	}
@@ -538,6 +548,27 @@ func (s *agentManagerService) effectiveUpstreamInterface(ctx context.Context, ou
 		}
 	}
 	return port, basePath
+}
+
+// kindVersionForImage returns the kind version published as the given image, or ""
+// when the image is empty, matches no published version, or the kind can't be read.
+// Published images are unique per version, so the mapping is unambiguous.
+func (s *agentManagerService) kindVersionForImage(ctx context.Context, ouID, kindName, imageID string) string {
+	if imageID == "" {
+		return ""
+	}
+	kind, err := s.agentKindService.GetKind(ctx, ouID, kindName)
+	if err != nil {
+		s.logger.Warn("Failed to read agent kind while resolving the deployed version",
+			"kindName", kindName, "error", err)
+		return ""
+	}
+	for _, v := range kind.Versions {
+		if v.ImageId == imageID {
+			return v.Version
+		}
+	}
+	return ""
 }
 
 // kindVersionInputInterface reads the input interface a kind version was published
@@ -3061,7 +3092,7 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 		}
 		artifactID := apiArtifact.UUID.String()
 
-		upstreamPort, upstreamBasePath := s.effectiveUpstreamInterface(ctx, ouID, agent)
+		upstreamPort, upstreamBasePath := s.effectiveUpstreamInterface(ctx, ouID, agent, req.ImageId)
 		traitOpts := []client.TraitOption{
 			client.WithArtifactID(artifactID),
 			client.WithUpstreamPort(upstreamPort),

--- a/agent-manager-service/services/upstream_interface_unit_test.go
+++ b/agent-manager-service/services/upstream_interface_unit_test.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// The api-configuration trait's upstream port and base path are what the API
+// gateway dials. Getting them wrong is not a cosmetic bug: the gateway reaches
+// nothing and every request to the agent returns 503. Kind-sourced agents have no
+// workflow parameters to read them from, which is exactly the case these cover.
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/google/uuid"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+)
+
+func TestEffectiveUpstreamInterface(t *testing.T) {
+	ctx := context.Background()
+	defaultPort := config.GetConfig().DefaultChatAPI.DefaultHTTPPort
+	defaultBasePath := config.GetConfig().DefaultChatAPI.DefaultBasePath
+
+	t.Run("reads the agent's own interface when it has one", func(t *testing.T) {
+		s := &agentManagerService{logger: discardLogger()}
+
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{
+			InputInterface: &models.InputInterface{Port: 8084, BasePath: "/tasks"},
+		})
+
+		assert.Equal(t, int32(8084), port)
+		assert.Equal(t, "/tasks", basePath)
+	})
+
+	// kindRepo returns a kind whose version 1.0.1 was built by build-1.
+	kindRepo := func() *repomocks.AgentKindRepositoryMock {
+		kindID := uuid.New()
+		return &repomocks.AgentKindRepositoryMock{
+			GetKindFunc: func(_ context.Context, _, kindName string) (*models.AgentKind, error) {
+				return &models.AgentKind{
+					ID: kindID, Name: kindName, ProjectName: "source-proj", AgentName: "source-agent",
+				}, nil
+			},
+			GetVersionFunc: func(_ context.Context, _ uuid.UUID, versionTag string) (*models.AgentKindVersion, error) {
+				return &models.AgentKindVersion{
+					Version:   versionTag,
+					BuildName: "build-1",
+					Kind: &models.AgentKind{
+						Name: "bal-task-assistant", ProjectName: "source-proj", AgentName: "source-agent",
+					},
+				}, nil
+			},
+		}
+	}
+
+	// The regression this exists for: a kind agent has no workflow parameters, so
+	// its component reports no interface and the defaults would point the gateway
+	// at a port nothing listens on. The build is the per-version record — reading
+	// the source component instead would report whatever its port is today, which
+	// the published image may never have served.
+	t.Run("falls back to the build its kind version was published from", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{
+			GetBuildFunc: func(_ context.Context, _, projectName, componentName, buildName string) (*models.BuildDetailsResponse, error) {
+				assert.Equal(t, "source-proj", projectName)
+				assert.Equal(t, "source-agent", componentName)
+				assert.Equal(t, "build-1", buildName)
+				return &models.BuildDetailsResponse{
+					InputInterface: &models.InputInterface{Port: 8084, BasePath: "/tasks"},
+				}, nil
+			},
+		}
+		repo := kindRepo()
+		s := &agentManagerService{
+			ocClient: oc, agentKindService: newKindService(repo, oc), logger: discardLogger(),
+		}
+
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{
+			KindName: "bal-task-assistant", KindVersion: "1.0.1",
+		})
+
+		assert.Equal(t, int32(8084), port)
+		assert.Equal(t, "/tasks", basePath)
+		require.Empty(t, oc.GetComponentCalls(), "the mutable source component must not be consulted")
+	})
+
+	t.Run("a build that can no longer be read leaves the defaults", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{
+			GetBuildFunc: func(_ context.Context, _, _, _, _ string) (*models.BuildDetailsResponse, error) {
+				return nil, errors.New("workflow run not found")
+			},
+		}
+		repo := kindRepo()
+		s := &agentManagerService{
+			ocClient: oc, agentKindService: newKindService(repo, oc), logger: discardLogger(),
+		}
+
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org",
+			&models.AgentResponse{KindName: "k", KindVersion: "1.0.1"})
+
+		assert.Equal(t, defaultPort, port)
+		assert.Equal(t, defaultBasePath, basePath)
+	})
+
+	// Agents created before the kind version was recorded have nothing to resolve
+	// against; guessing a version would risk describing a different image.
+	t.Run("a kind agent with no recorded version leaves the defaults", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{}
+		repo := kindRepo()
+		s := &agentManagerService{
+			ocClient: oc, agentKindService: newKindService(repo, oc), logger: discardLogger(),
+		}
+
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{KindName: "k"})
+
+		assert.Equal(t, defaultPort, port)
+		assert.Equal(t, defaultBasePath, basePath)
+		require.Empty(t, oc.GetBuildCalls())
+	})
+
+	// A source-built agent must never trigger a kind lookup.
+	t.Run("a non-kind agent with no interface uses the defaults without extra calls", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{}
+		s := &agentManagerService{ocClient: oc, logger: discardLogger()}
+
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{})
+
+		assert.Equal(t, defaultPort, port)
+		assert.Equal(t, defaultBasePath, basePath)
+		require.Empty(t, oc.GetBuildCalls())
+	})
+}

--- a/agent-manager-service/services/upstream_interface_unit_test.go
+++ b/agent-manager-service/services/upstream_interface_unit_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"gorm.io/gorm"
 )
 
 func TestEffectiveUpstreamInterface(t *testing.T) {
@@ -45,7 +46,7 @@ func TestEffectiveUpstreamInterface(t *testing.T) {
 
 		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{
 			InputInterface: &models.InputInterface{Port: 8084, BasePath: "/tasks"},
-		})
+		}, "")
 
 		assert.Equal(t, int32(8084), port)
 		assert.Equal(t, "/tasks", basePath)
@@ -54,20 +55,29 @@ func TestEffectiveUpstreamInterface(t *testing.T) {
 	// kindRepo returns a kind whose version 1.0.1 was built by build-1.
 	kindRepo := func() *repomocks.AgentKindRepositoryMock {
 		kindID := uuid.New()
+		sourceKind := &models.AgentKind{
+			ID: kindID, Name: "bal-task-assistant", ProjectName: "source-proj", AgentName: "source-agent",
+		}
+		// Each published version has its own image and its own build, which is what
+		// lets a deploy of 1.2.0's image be told apart from the agent's 1.0.1 label.
+		versions := []models.AgentKindVersion{
+			{Version: "1.0.1", BuildName: "build-1", ImageId: "registry/agent:v1", Kind: sourceKind},
+			{Version: "1.2.0", BuildName: "build-2", ImageId: "registry/agent:v2", Kind: sourceKind},
+		}
 		return &repomocks.AgentKindRepositoryMock{
 			GetKindFunc: func(_ context.Context, _, kindName string) (*models.AgentKind, error) {
-				return &models.AgentKind{
-					ID: kindID, Name: kindName, ProjectName: "source-proj", AgentName: "source-agent",
-				}, nil
+				kind := *sourceKind
+				kind.Name = kindName
+				kind.Versions = versions
+				return &kind, nil
 			},
 			GetVersionFunc: func(_ context.Context, _ uuid.UUID, versionTag string) (*models.AgentKindVersion, error) {
-				return &models.AgentKindVersion{
-					Version:   versionTag,
-					BuildName: "build-1",
-					Kind: &models.AgentKind{
-						Name: "bal-task-assistant", ProjectName: "source-proj", AgentName: "source-agent",
-					},
-				}, nil
+				for i := range versions {
+					if versions[i].Version == versionTag {
+						return &versions[i], nil
+					}
+				}
+				return nil, gorm.ErrRecordNotFound
 			},
 		}
 	}
@@ -95,11 +105,61 @@ func TestEffectiveUpstreamInterface(t *testing.T) {
 
 		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{
 			KindName: "bal-task-assistant", KindVersion: "1.0.1",
-		})
+		}, "")
 
 		assert.Equal(t, int32(8084), port)
 		assert.Equal(t, "/tasks", basePath)
 		require.Empty(t, oc.GetComponentCalls(), "the mutable source component must not be consulted")
+	})
+
+	// A deploy can select a version other than the one the agent was created from,
+	// and the component's kind-version label does not move when it does. Reading the
+	// label here would point the gateway at the old version's port — a 503 on every
+	// request whenever two versions serve different interfaces.
+	t.Run("uses the interface of the version being deployed, not the agent's label", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{
+			GetBuildFunc: func(_ context.Context, _, _, _, buildName string) (*models.BuildDetailsResponse, error) {
+				require.Equal(t, "build-2", buildName, "must read the deployed version's build")
+				return &models.BuildDetailsResponse{
+					InputInterface: &models.InputInterface{Port: 9090, BasePath: "/v2"},
+				}, nil
+			},
+		}
+		repo := kindRepo()
+		s := &agentManagerService{
+			ocClient: oc, agentKindService: newKindService(repo, oc), logger: discardLogger(),
+		}
+
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{
+			KindName: "bal-task-assistant", KindVersion: "1.0.1",
+		}, "registry/agent:v2")
+
+		assert.Equal(t, int32(9090), port)
+		assert.Equal(t, "/v2", basePath)
+	})
+
+	// An image the kind never published (a source-built image, or a version since
+	// deleted) leaves the label as the only thing left to go on.
+	t.Run("an unpublished image falls back to the agent's recorded version", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{
+			GetBuildFunc: func(_ context.Context, _, _, _, buildName string) (*models.BuildDetailsResponse, error) {
+				require.Equal(t, "build-1", buildName)
+				return &models.BuildDetailsResponse{
+					InputInterface: &models.InputInterface{Port: 8084, BasePath: "/tasks"},
+				}, nil
+			},
+		}
+		repo := kindRepo()
+		s := &agentManagerService{
+			ocClient: oc, agentKindService: newKindService(repo, oc), logger: discardLogger(),
+		}
+
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{
+			KindName: "bal-task-assistant", KindVersion: "1.0.1",
+		}, "registry/agent:unknown")
+
+		assert.Equal(t, int32(8084), port)
+		assert.Equal(t, "/tasks", basePath)
 	})
 
 	t.Run("a build that can no longer be read leaves the defaults", func(t *testing.T) {
@@ -114,7 +174,7 @@ func TestEffectiveUpstreamInterface(t *testing.T) {
 		}
 
 		port, basePath := s.effectiveUpstreamInterface(ctx, "org",
-			&models.AgentResponse{KindName: "k", KindVersion: "1.0.1"})
+			&models.AgentResponse{KindName: "k", KindVersion: "1.0.1"}, "")
 
 		assert.Equal(t, defaultPort, port)
 		assert.Equal(t, defaultBasePath, basePath)
@@ -129,7 +189,7 @@ func TestEffectiveUpstreamInterface(t *testing.T) {
 			ocClient: oc, agentKindService: newKindService(repo, oc), logger: discardLogger(),
 		}
 
-		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{KindName: "k"})
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{KindName: "k"}, "")
 
 		assert.Equal(t, defaultPort, port)
 		assert.Equal(t, defaultBasePath, basePath)
@@ -141,7 +201,7 @@ func TestEffectiveUpstreamInterface(t *testing.T) {
 		oc := &clientmocks.OpenChoreoClientMock{}
 		s := &agentManagerService{ocClient: oc, logger: discardLogger()}
 
-		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{})
+		port, basePath := s.effectiveUpstreamInterface(ctx, "org", &models.AgentResponse{}, "")
 
 		assert.Equal(t, defaultPort, port)
 		assert.Equal(t, defaultBasePath, basePath)

--- a/agent-manager-service/spec/model_add_agent_kind_version_request.go
+++ b/agent-manager-service/spec/model_add_agent_kind_version_request.go
@@ -19,7 +19,7 @@ var _ MappedNullable = &AddAgentKindVersionRequest{}
 
 // AddAgentKindVersionRequest struct for AddAgentKindVersionRequest
 type AddAgentKindVersionRequest struct {
-	// Version tag for this release
+	// Version tag for this release. Stored as a Kubernetes label on every agent created from this version, so it must be at most 63 characters of letters, digits, '.', '_' or '-', starting and ending with a letter or digit.
 	Version string `json:"version"`
 	// Build name from the source agent's build history
 	BuildName string `json:"buildName"`

--- a/agent-manager-service/spec/model_agent_response.go
+++ b/agent-manager-service/spec/model_agent_response.go
@@ -35,6 +35,8 @@ type AgentResponse struct {
 	Build          *Build          `json:"build,omitempty"`
 	// Name of the Agent Kind this agent was instantiated from (absent for source-built agents)
 	KindName *string `json:"kindName,omitempty"`
+	// Version tag of the Agent Kind this agent was instantiated from (absent for source-built agents, and for kind-sourced agents created before the version was recorded)
+	KindVersion *string `json:"kindVersion,omitempty"`
 	// User-defined key/value labels. Keys are 1-63 characters of [a-zA-Z0-9._-] starting and ending alphanumeric (not enforceable here as an OpenAPI 3.0 property-name pattern — validated server-side); values follow the same rules but may be empty. At most 10 labels per resource.
 	Labels    *map[string]string `json:"labels,omitempty"`
 	CreatedBy *AgentCreatedBy    `json:"createdBy,omitempty"`
@@ -417,6 +419,38 @@ func (o *AgentResponse) SetKindName(v string) {
 	o.KindName = &v
 }
 
+// GetKindVersion returns the KindVersion field value if set, zero value otherwise.
+func (o *AgentResponse) GetKindVersion() string {
+	if o == nil || IsNil(o.KindVersion) {
+		var ret string
+		return ret
+	}
+	return *o.KindVersion
+}
+
+// GetKindVersionOk returns a tuple with the KindVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AgentResponse) GetKindVersionOk() (*string, bool) {
+	if o == nil || IsNil(o.KindVersion) {
+		return nil, false
+	}
+	return o.KindVersion, true
+}
+
+// HasKindVersion returns a boolean if a field has been set.
+func (o *AgentResponse) HasKindVersion() bool {
+	if o != nil && !IsNil(o.KindVersion) {
+		return true
+	}
+
+	return false
+}
+
+// SetKindVersion gets a reference to the given string and assigns it to the KindVersion field.
+func (o *AgentResponse) SetKindVersion(v string) {
+	o.KindVersion = &v
+}
+
 // GetLabels returns the Labels field value if set, zero value otherwise.
 func (o *AgentResponse) GetLabels() map[string]string {
 	if o == nil || IsNil(o.Labels) {
@@ -513,6 +547,9 @@ func (o AgentResponse) ToMap() (map[string]interface{}, error) {
 	}
 	if !IsNil(o.KindName) {
 		toSerialize["kindName"] = o.KindName
+	}
+	if !IsNil(o.KindVersion) {
+		toSerialize["kindVersion"] = o.KindVersion
 	}
 	if !IsNil(o.Labels) {
 		toSerialize["labels"] = o.Labels

--- a/agent-manager-service/spec/model_deployment_details_response.go
+++ b/agent-manager-service/spec/model_deployment_details_response.go
@@ -22,6 +22,8 @@ var _ MappedNullable = &DeploymentDetailsResponse{}
 type DeploymentDetailsResponse struct {
 	// Container image ID
 	ImageId string `json:"imageId"`
+	// Agent Kind version this deployment runs, resolved from the deployed image. Per-environment, so it reflects what is actually deployed rather than the version the agent was created from. Absent for source-built agents and when the image matches no published version.
+	KindVersion *string `json:"kindVersion,omitempty"`
 	// Deployment status
 	Status string `json:"status"`
 	// Timestamp of last deployment
@@ -75,6 +77,38 @@ func (o *DeploymentDetailsResponse) GetImageIdOk() (*string, bool) {
 // SetImageId sets field value
 func (o *DeploymentDetailsResponse) SetImageId(v string) {
 	o.ImageId = v
+}
+
+// GetKindVersion returns the KindVersion field value if set, zero value otherwise.
+func (o *DeploymentDetailsResponse) GetKindVersion() string {
+	if o == nil || IsNil(o.KindVersion) {
+		var ret string
+		return ret
+	}
+	return *o.KindVersion
+}
+
+// GetKindVersionOk returns a tuple with the KindVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DeploymentDetailsResponse) GetKindVersionOk() (*string, bool) {
+	if o == nil || IsNil(o.KindVersion) {
+		return nil, false
+	}
+	return o.KindVersion, true
+}
+
+// HasKindVersion returns a boolean if a field has been set.
+func (o *DeploymentDetailsResponse) HasKindVersion() bool {
+	if o != nil && !IsNil(o.KindVersion) {
+		return true
+	}
+
+	return false
+}
+
+// SetKindVersion gets a reference to the given string and assigns it to the KindVersion field.
+func (o *DeploymentDetailsResponse) SetKindVersion(v string) {
+	o.KindVersion = &v
 }
 
 // GetStatus returns the Status field value
@@ -232,6 +266,9 @@ func (o DeploymentDetailsResponse) MarshalJSON() ([]byte, error) {
 func (o DeploymentDetailsResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	toSerialize["imageId"] = o.ImageId
+	if !IsNil(o.KindVersion) {
+		toSerialize["kindVersion"] = o.KindVersion
+	}
 	toSerialize["status"] = o.Status
 	if !IsNil(o.LastDeployed) {
 		toSerialize["lastDeployed"] = o.LastDeployed

--- a/agent-manager-service/spec/model_publish_agent_kind_request.go
+++ b/agent-manager-service/spec/model_publish_agent_kind_request.go
@@ -27,7 +27,7 @@ type PublishAgentKindRequest struct {
 	KindDescription *string `json:"kindDescription,omitempty"`
 	// User-defined key/value labels. Keys are 1-63 characters of [a-zA-Z0-9._-] starting and ending alphanumeric (not enforceable here as an OpenAPI 3.0 property-name pattern — validated server-side); values follow the same rules but may be empty. At most 10 labels per resource.
 	KindLabels *map[string]string `json:"kindLabels,omitempty"`
-	// Version tag for this release
+	// Version tag for this release. Stored as a Kubernetes label on every agent created from this version, so it must be at most 63 characters of letters, digits, '.', '_' or '-', starting and ending with a letter or digit.
 	Version string `json:"version"`
 	// Build name from this agent's build history
 	BuildName string `json:"buildName"`

--- a/agent-manager-service/utils/labels.go
+++ b/agent-manager-service/utils/labels.go
@@ -63,6 +63,21 @@ func ValidateLabels(labels map[string]string) error {
 	return nil
 }
 
+// ValidateLabelValue checks a single value against the Kubernetes label-value
+// rules, for values the platform stores as labels on OpenChoreo resources
+// rather than accepting from the user's label map. field names the offending
+// input in the detail message.
+func ValidateLabelValue(value, field string) error {
+	if len(value) > maxLabelLength || !labelValueRegex.MatchString(value) {
+		return NewValidationErrorf(
+			fmt.Sprintf("%s must be at most %d characters of letters, digits, '.', '_' or '-', starting and ending with a letter or digit",
+				field, maxLabelLength),
+			"%s: invalid value %q", field, value,
+		)
+	}
+	return nil
+}
+
 // ParseLabelSelectors parses repeated `label=key:value` query parameters into
 // a label map. Each entry is split on the first ':'; the key and value must
 // satisfy the same rules as stored labels. Repeating the same key with

--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -127,6 +127,14 @@ func convertToInternalAgentResponse(component *models.AgentResponse) spec.AgentR
 			}
 			return &component.KindName
 		}(),
+		// Absent for source-built agents, and for kind-sourced agents created
+		// before the version was recorded on the component.
+		KindVersion: func() *string {
+			if component.KindVersion == "" {
+				return nil
+			}
+			return &component.KindVersion
+		}(),
 		CreatedBy: convertToCreatedBy(component.CreatedBy),
 	}
 	if len(component.Labels) > 0 {
@@ -398,12 +406,18 @@ func ConvertToDeploymentDetailsResponse(deploymentDetails []*models.DeploymentRe
 			envDisplayName = &deployment.EnvironmentDisplayName
 		}
 
+		var kindVersion *string
+		if deployment.KindVersion != "" {
+			kindVersion = &deployment.KindVersion
+		}
+
 		deploymentResponse := spec.DeploymentDetailsResponse{
 			ImageId:                deployment.ImageId,
 			Status:                 deployment.Status,
 			LastDeployed:           deployment.LastDeployedAt,
 			Endpoints:              endpoints,
 			EnvironmentDisplayName: envDisplayName,
+			KindVersion:            kindVersion,
 		}
 
 		// Add to result map with environment name as key

--- a/agent-manager-service/utils/makeresults_test.go
+++ b/agent-manager-service/utils/makeresults_test.go
@@ -50,3 +50,58 @@ func TestConvertToConfigurations_UnpinnedIsOmitted(t *testing.T) {
 		t.Errorf("InstrumentationVersion should be unset when the agent has no pin")
 	}
 }
+
+// The kind name and version travel together: a response carrying one but not the
+// other leaves every consumer unable to say which published version an agent runs.
+func TestConvertToAgentResponse_SurfacesKindVersion(t *testing.T) {
+	kindAgent := func(kindName, kindVersion string) *models.AgentResponse {
+		return &models.AgentResponse{
+			Name:         "kind-agent",
+			Provisioning: models.Provisioning{Type: string(InternalAgent)},
+			KindName:     kindName,
+			KindVersion:  kindVersion,
+		}
+	}
+
+	got := ConvertToAgentResponse(kindAgent("bal-task-assistant", "1.0.1"))
+	if got.KindName == nil || *got.KindName != "bal-task-assistant" {
+		t.Errorf("KindName = %v, want bal-task-assistant", got.KindName)
+	}
+	if got.KindVersion == nil || *got.KindVersion != "1.0.1" {
+		t.Errorf("KindVersion = %v, want 1.0.1", got.KindVersion)
+	}
+
+	// Agents created before the version was recorded must omit the field rather
+	// than report an empty version.
+	got = ConvertToAgentResponse(kindAgent("bal-task-assistant", ""))
+	if got.KindVersion != nil {
+		t.Errorf("KindVersion = %v, want nil for an agent with no recorded version", *got.KindVersion)
+	}
+}
+
+// The deployed kind version is what the environment actually runs; dropping it in
+// the mapper would leave the console re-deriving it from image IDs.
+func TestConvertToDeploymentDetailsResponse_SurfacesKindVersion(t *testing.T) {
+	got := ConvertToDeploymentDetailsResponse([]*models.DeploymentResponse{
+		{Environment: "default", ImageId: "img:v1", KindVersion: "1.2.0"},
+		{Environment: "prod", ImageId: "img:v0"},
+	})
+
+	deployed, ok := got["default"]
+	if !ok {
+		t.Fatal("expected a response for the default environment")
+	}
+	if deployed.KindVersion == nil || *deployed.KindVersion != "1.2.0" {
+		t.Errorf("KindVersion = %v, want 1.2.0", deployed.KindVersion)
+	}
+
+	// An image matching no published version must omit the field rather than
+	// report an empty version.
+	unresolved, ok := got["prod"]
+	if !ok {
+		t.Fatal("expected a response for the prod environment")
+	}
+	if unresolved.KindVersion != nil {
+		t.Errorf("KindVersion = %v, want nil when the image matches no version", *unresolved.KindVersion)
+	}
+}

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -1220,7 +1220,7 @@ type AddAgentKindVersionRequest struct {
 	// SourceProjectName Project the source agent belongs to
 	SourceProjectName string `json:"sourceProjectName"`
 
-	// Version Version tag for this release
+	// Version Version tag for this release. Stored as a Kubernetes label on every agent created from this version, so it must be at most 63 characters of letters, digits, '.', '_' or '-', starting and ending with a letter or digit.
 	Version string `json:"version"`
 }
 
@@ -1602,6 +1602,9 @@ type AgentResponse struct {
 
 	// KindName Name of the Agent Kind this agent was instantiated from (absent for source-built agents)
 	KindName *string `json:"kindName,omitempty"`
+
+	// KindVersion Version tag of the Agent Kind this agent was instantiated from (absent for source-built agents, and for kind-sourced agents created before the version was recorded)
+	KindVersion *string `json:"kindVersion,omitempty"`
 
 	// Labels User-defined key/value labels. Keys are 1-63 characters of [a-zA-Z0-9._-] starting and ending alphanumeric (not enforceable here as an OpenAPI 3.0 property-name pattern — validated server-side); values follow the same rules but may be empty. At most 10 labels per resource.
 	Labels       *Labels      `json:"labels,omitempty"`
@@ -4524,7 +4527,7 @@ type PublishAgentKindRequest struct {
 	// Metadata Optional interface metadata (e.g. OpenAPI spec)
 	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 
-	// Version Version tag for this release
+	// Version Version tag for this release. Stored as a Kubernetes label on every agent created from this version, so it must be at most 63 characters of letters, digits, '.', '_' or '-', starting and ending with a letter or digit.
 	Version string `json:"version"`
 }
 

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -2550,6 +2550,9 @@ type DeploymentDetailsResponse struct {
 	// ImageId Container image ID
 	ImageId string `json:"imageId"`
 
+	// KindVersion Agent Kind version this deployment runs, resolved from the deployed image. Per-environment, so it reflects what is actually deployed rather than the version the agent was created from. Absent for source-built agents and when the image matches no published version.
+	KindVersion *string `json:"kindVersion,omitempty"`
+
 	// LastDeployed Timestamp of last deployment
 	LastDeployed *time.Time `json:"lastDeployed,omitempty"`
 

--- a/console/workspaces/libs/types/src/api/agents.ts
+++ b/console/workspaces/libs/types/src/api/agents.ts
@@ -119,6 +119,7 @@ export interface AgentResponse {
   inputInterface?: InputInterface;
   uuid?: string;
   kindName?: string;
+  kindVersion?: string;
   labels?: Record<string, string>;
   createdBy?: AgentCreatedBy;
 }

--- a/console/workspaces/libs/types/src/api/deployments.ts
+++ b/console/workspaces/libs/types/src/api/deployments.ts
@@ -99,6 +99,9 @@ export interface PromotionTargetEnvironment {
 
 export interface DeploymentDetailsResponse {
   imageId: string;
+  /** Agent Kind version running in this environment, resolved from the deployed
+   *  image. Absent for source-built agents and unmatched images. */
+  kindVersion?: string;
   status: string;
   lastDeployed: string; // ISO date-time
   endpoints: DeploymentEndpoint[];

--- a/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
+++ b/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
@@ -162,6 +162,8 @@ const ConfigRow: React.FC<ConfigRowProps> = ({
                 fullWidth
                 size="small"
                 disabled={readonlyKey && row.isSecret}
+                type={row.isSecret && !readonlyKey ? "password" : "text"}
+                showPasswordToggle={row.isSecret && !readonlyKey}
             />
         </Box>
         <Box display="flex" flexDirection="row" flexGrow={1} alignItems="start" pl={2} pt={0.5} gap={1}>

--- a/console/workspaces/pages/deploy/src/subComponent/BuildCard.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/BuildCard.tsx
@@ -130,11 +130,12 @@ export function BuildCard(props: BuildCardProps) {
   const selectedVersionFromParams = searchParams.get("selectedVersion");
   const isVersionSelectorOpen = searchParams.get("versionSelector") === "open";
 
-  const { data: deployments } = useListAgentDeployments({
-    orgName: orgId,
-    projName: projectId,
-    agentName: agentId,
-  });
+  const { data: deployments, isLoading: isDeploymentsLoading } =
+    useListAgentDeployments({
+      orgName: orgId,
+      projName: projectId,
+      agentName: agentId,
+    });
 
   // What the card opens on, in order: the version this environment already runs,
   // then the one the agent was created from, then the kind's newest. Defaulting to
@@ -154,12 +155,25 @@ export function BuildCard(props: BuildCardProps) {
   }, [deployments, initialEnvironment?.name, agent?.kindVersion, sortedKindVersions]);
 
   useEffect(() => {
+    // Writing the param pins the selection — the effect cannot correct it later,
+    // because selectedVersionFromParams is set from then on. So wait for the
+    // deployments query: pinning first would lock the card onto the fallback
+    // (the creation version, or the kind's newest) even though this environment
+    // runs something else.
+    if (isDeploymentsLoading) return;
     if (isKindAgent && !selectedVersionFromParams && defaultKindVersion) {
       const next = new URLSearchParams(searchParams);
       next.set("selectedVersion", defaultKindVersion);
       setSearchParams(next, { replace: true });
     }
-  }, [isKindAgent, selectedVersionFromParams, defaultKindVersion, searchParams, setSearchParams]);
+  }, [
+    isDeploymentsLoading,
+    isKindAgent,
+    selectedVersionFromParams,
+    defaultKindVersion,
+    searchParams,
+    setSearchParams,
+  ]);
 
   const selectedVersion = selectedVersionFromParams || defaultKindVersion;
 

--- a/console/workspaces/pages/deploy/src/subComponent/BuildCard.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/BuildCard.tsx
@@ -31,6 +31,7 @@ import {
   useGetAgent,
   useGetAgentBuilds,
   useGetAgentKind,
+  useListAgentDeployments,
 } from "@agent-management-platform/api-client";
 import { useMemo, useCallback, useEffect } from "react";
 import {
@@ -129,18 +130,38 @@ export function BuildCard(props: BuildCardProps) {
   const selectedVersionFromParams = searchParams.get("selectedVersion");
   const isVersionSelectorOpen = searchParams.get("versionSelector") === "open";
 
-  // Default selected version to latest kind version when no version is in params
+  const { data: deployments } = useListAgentDeployments({
+    orgName: orgId,
+    projName: projectId,
+    agentName: agentId,
+  });
+
+  // What the card opens on, in order: the version this environment already runs,
+  // then the one the agent was created from, then the kind's newest. Defaulting to
+  // newest — as this did — turns "Configure & Deploy" into an unannounced upgrade
+  // for anyone who just wanted to redeploy, and shows a version the agent has
+  // never run. Only versions the kind still publishes are offered, since a
+  // deleted one cannot be deployed.
+  const defaultKindVersion = useMemo(() => {
+    const published = (v?: string) =>
+      v && sortedKindVersions.some((kv) => kv.version === v) ? v : undefined;
+    return (
+      published(deployments?.[initialEnvironment?.name ?? ""]?.kindVersion) ??
+      published(agent?.kindVersion) ??
+      sortedKindVersions[0]?.version ??
+      ""
+    );
+  }, [deployments, initialEnvironment?.name, agent?.kindVersion, sortedKindVersions]);
+
   useEffect(() => {
-    if (isKindAgent && !selectedVersionFromParams && sortedKindVersions.length > 0) {
+    if (isKindAgent && !selectedVersionFromParams && defaultKindVersion) {
       const next = new URLSearchParams(searchParams);
-      next.set("selectedVersion", sortedKindVersions[0].version);
+      next.set("selectedVersion", defaultKindVersion);
       setSearchParams(next, { replace: true });
     }
-  }, [isKindAgent, selectedVersionFromParams, sortedKindVersions, searchParams, setSearchParams]);
+  }, [isKindAgent, selectedVersionFromParams, defaultKindVersion, searchParams, setSearchParams]);
 
-  const selectedVersion =
-    selectedVersionFromParams ||
-    (sortedKindVersions.length > 0 ? sortedKindVersions[0].version : "");
+  const selectedVersion = selectedVersionFromParams || defaultKindVersion;
 
   const currentKindVersion = sortedKindVersions.find(
     (v) => v.version === selectedVersion

--- a/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
@@ -23,7 +23,6 @@ import {
   useGetAgentResourceConfigs,
   useGetDeploymentPipeline,
   useListAgentDeployments,
-  useListAgentKindVersions,
   useUpdateDeploymentState,
 } from "@agent-management-platform/api-client";
 import { NoDataFound, TextInput } from "@agent-management-platform/views";
@@ -81,7 +80,6 @@ import {
   AgentResourceConfigsResponse,
   MetricsResponse,
   Environment,
-  AgentKindVersionResponse,
   TraceListTimeRange,
 } from "@agent-management-platform/types";
 import { extractBuildIdFromImageId } from "../utils/extractBuildIdFromImageId";
@@ -415,13 +413,11 @@ export function DeployCard(props: DeployCardProps) {
 
   const kindName = agent?.kindName;
 
-  const { data: kindVersions } = useListAgentKindVersions(
-    { orgName: orgId ?? "", kindName: kindName ?? "" },
-  );
-
-  const matchedKindVersion: AgentKindVersionResponse | undefined = kindVersions?.find(
-    (v) => v.imageId === currentDeployment?.imageId,
-  );
+  // The version running in THIS environment, resolved server-side from the image
+  // this environment's release is pinned to. Environments diverge between a deploy
+  // and its promotion, so this is per-deployment and not the agent's creation-time
+  // kind version. Absent when the image matches no published version.
+  const deployedKindVersion = currentDeployment?.kindVersion;
 
   const selectedBuildId = extractBuildIdFromImageId(currentDeployment?.imageId);
   const lastDeployedText = currentDeployment?.lastDeployed
@@ -543,13 +539,13 @@ export function DeployCard(props: DeployCardProps) {
                         absoluteRouteMap.children.org.children.catalog.children.kindDetails.path,
                         { orgId, kindId: kindName },
                       ) +
-                      (matchedKindVersion ? `?version=${matchedKindVersion.version}` : "")
+                      (deployedKindVersion ? `?version=${deployedKindVersion}` : "")
                     }
                   >
                     <ExternalLink size={16} />
                   </IconButton>
                 }
-                value={matchedKindVersion ? `v${matchedKindVersion.version}` : ""}
+                value={deployedKindVersion ? `v${deployedKindVersion}` : ""}
                 slotProps={{ input: { readOnly: true } }}
               />
             ) : (

--- a/console/workspaces/pages/overview/src/AgentOverview/InternalAgentOverview.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/InternalAgentOverview.tsx
@@ -87,6 +87,9 @@ export const InternalAgentOverview = () => {
     const isKindAgent = !!agent?.kindName;
     const hasMultipleEnvironments = sortedEnvironmentList.length > 1;
     const selectedEnvironmentStatus = statusOf(deployments, selectedEnvironment?.name ?? "");
+    // The kind version running in the selected environment, not the one the agent
+    // was created from — a redeploy moves the former and leaves the latter behind.
+    const deployedKindVersion = deployments?.[selectedEnvironment?.name ?? ""]?.kindVersion;
 
     return (
         <Box display="flex" flexDirection="column" gap={2}>
@@ -94,7 +97,7 @@ export const InternalAgentOverview = () => {
                 <KindInfoCard
                     orgId={orgId ?? ""}
                     kindName={agent!.kindName!}
-                    kindVersion={agent?.kindVersion}
+                    kindVersion={deployedKindVersion}
                     framework={agent?.agentType?.type}
                     model={agent?.agentType?.subType}
                 />

--- a/console/workspaces/pages/overview/src/AgentOverview/InternalAgentOverview.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/InternalAgentOverview.tsx
@@ -94,6 +94,7 @@ export const InternalAgentOverview = () => {
                 <KindInfoCard
                     orgId={orgId ?? ""}
                     kindName={agent!.kindName!}
+                    kindVersion={agent?.kindVersion}
                     framework={agent?.agentType?.type}
                     model={agent?.agentType?.subType}
                 />

--- a/console/workspaces/pages/overview/src/AgentOverview/KindInfoCard.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/KindInfoCard.tsx
@@ -38,8 +38,8 @@ import { UppercaseCaptionLabel } from "./SectionHeader";
 interface KindInfoCardProps {
     orgId: string;
     kindName: string;
-    /** The kind version this agent was created from. Absent for agents created
-     *  before the component recorded it. */
+    /** The kind version deployed in the selected environment. Absent when nothing
+     *  is deployed there, or when the deployed image matches no published version. */
     kindVersion?: string;
     framework?: string;
     model?: string;
@@ -55,12 +55,12 @@ export const KindInfoCard: React.FC<KindInfoCardProps> = ({
         { orgId, kindId: kindName },
     );
 
-    // The version shown is the one this agent actually runs — never the kind's
-    // newest, which diverges from it the moment the kind publishes again. An agent
-    // created before the version was recorded has nothing to show, so the chip is
-    // omitted rather than filled in with a version we can't attribute to it.
-    // versionData carries that version's own metadata (its publish date), and is
-    // absent when the version has since been deleted from the kind.
+    // The version shown is the one actually deployed — never the kind's newest,
+    // which diverges from it the moment the kind publishes again. An environment
+    // with nothing deployed has nothing to show, so the chip is omitted rather
+    // than filled in with a version we can't attribute to it. versionData carries
+    // that version's own metadata (its publish date), and is absent when the
+    // version has since been deleted from the kind.
     const versionData = kindVersion
         ? kind?.versions?.find((v) => v.version === kindVersion)
         : undefined;

--- a/console/workspaces/pages/overview/src/AgentOverview/KindInfoCard.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/KindInfoCard.tsx
@@ -102,7 +102,7 @@ export const KindInfoCard: React.FC<KindInfoCardProps> = ({
                                         <Box display="flex" alignItems="center" gap={0.5} sx={{ flexShrink: 0 }}>
                                             <Tag size={13} />
                                             <Typography variant="body2" color="text.secondary" noWrap>
-                                                v{kindVersion}
+                                                {kindVersion}
                                             </Typography>
                                         </Box>
                                     )}

--- a/console/workspaces/pages/overview/src/AgentOverview/KindInfoCard.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/KindInfoCard.tsx
@@ -38,12 +38,15 @@ import { UppercaseCaptionLabel } from "./SectionHeader";
 interface KindInfoCardProps {
     orgId: string;
     kindName: string;
+    /** The kind version this agent was created from. Absent for agents created
+     *  before the component recorded it. */
+    kindVersion?: string;
     framework?: string;
     model?: string;
 }
 
 export const KindInfoCard: React.FC<KindInfoCardProps> = ({
-    orgId, kindName, framework, model,
+    orgId, kindName, kindVersion, framework, model,
 }) => {
     const { data: kind, isLoading } = useGetAgentKind({ orgName: orgId, kindName });
 
@@ -52,8 +55,15 @@ export const KindInfoCard: React.FC<KindInfoCardProps> = ({
         { orgId, kindId: kindName },
     );
 
-    const latestVersionData = kind?.versions?.find((v) => v.version === kind.latestVersion)
-        ?? kind?.versions?.[0];
+    // The version shown is the one this agent actually runs — never the kind's
+    // newest, which diverges from it the moment the kind publishes again. An agent
+    // created before the version was recorded has nothing to show, so the chip is
+    // omitted rather than filled in with a version we can't attribute to it.
+    // versionData carries that version's own metadata (its publish date), and is
+    // absent when the version has since been deleted from the kind.
+    const versionData = kindVersion
+        ? kind?.versions?.find((v) => v.version === kindVersion)
+        : undefined;
 
     return (
         <Card variant="outlined">
@@ -86,20 +96,24 @@ export const KindInfoCard: React.FC<KindInfoCardProps> = ({
                                 </IconButton>
                             </Box>
 
-                            {latestVersionData && (
+                            {(kindVersion || framework || model) && (
                                 <Box display="flex" alignItems="center" gap={1.5} minWidth={0}>
-                                    <Box display="flex" alignItems="center" gap={0.5} sx={{ flexShrink: 0 }}>
-                                        <Tag size={13} />
+                                    {kindVersion && (
+                                        <Box display="flex" alignItems="center" gap={0.5} sx={{ flexShrink: 0 }}>
+                                            <Tag size={13} />
+                                            <Typography variant="body2" color="text.secondary" noWrap>
+                                                v{kindVersion}
+                                            </Typography>
+                                        </Box>
+                                    )}
+                                    {versionData && (
                                         <Typography variant="body2" color="text.secondary" noWrap>
-                                            v{latestVersionData.version}
+                                            {formatDistanceToNow(
+                                                new Date(versionData.createdAt),
+                                                { addSuffix: true },
+                                            )}
                                         </Typography>
-                                    </Box>
-                                    <Typography variant="body2" color="text.secondary" noWrap>
-                                        {formatDistanceToNow(
-                                            new Date(latestVersionData.createdAt),
-                                            { addSuffix: true },
-                                        )}
-                                    </Typography>
+                                    )}
                                     {(framework || model) && (
                                         <Typography variant="caption" color="text.secondary" noWrap sx={{ flexShrink: 0 }}>
                                             {`Agent Type: ${[framework, model].filter(Boolean).join("/")}`}

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -22,6 +22,7 @@ import {
   useGetAgentEndpoints,
   useGetAgentKindVersion,
   useGetBuild,
+  useListAgentDeployments,
   useTestAgentAPIKey,
 } from "@agent-management-platform/api-client";
 import { getErrorMessage } from "@agent-management-platform/shared-component";
@@ -100,14 +101,15 @@ export function Swagger() {
 
   // A kind-sourced agent runs no build of its own, so nothing ever writes an
   // OpenAPI document onto its deployed endpoint. Resolve the spec from the kind
-  // version it was created from instead — kind version -> its source build —
-  // which is how the agent catalogue renders a kind's API spec.
+  // version instead — kind version -> its source build — which is how the agent
+  // catalogue renders a kind's API spec.
   //
-  // kindName is set only for agents instantiated from a kind, so it — not an
-  // empty endpoint schema — is what decides which source to read: waiting for
-  // the endpoints response first would just delay the two lookups behind it.
-  // kindVersion is absent on agents created before it was recorded, and those
-  // can't be tied to a published version.
+  // The version read is the one deployed in THIS environment, not the agent's
+  // creation-time kindVersion: redeploying on a newer version changes what the
+  // endpoint actually serves, and each environment moves independently, so the
+  // creation version would render a spec that no longer matches the running API.
+  // kindName is what identifies a kind agent; waiting on the endpoints response
+  // to notice a missing schema would just delay the lookups behind it.
   const deployedSpec = data?.[endpoint]?.schema?.content;
   const {
     data: agent,
@@ -118,7 +120,14 @@ export function Swagger() {
     projName: projectId,
     agentName: agentId,
   });
-  const needsKindSpec = !!agent?.kindName && !!agent?.kindVersion;
+  const { data: deployments, isLoading: isDeploymentsLoading } =
+    useListAgentDeployments({
+      orgName: orgId,
+      projName: projectId,
+      agentName: agentId,
+    });
+  const deployedKindVersion = deployments?.[envId ?? ""]?.kindVersion;
+  const needsKindSpec = !!agent?.kindName && !!deployedKindVersion;
   const {
     data: kindVersion,
     isLoading: isKindVersionLoading,
@@ -126,7 +135,7 @@ export function Swagger() {
   } = useGetAgentKindVersion({
     orgName: needsKindSpec ? orgId ?? "" : "",
     kindName: needsKindSpec ? agent?.kindName ?? "" : "",
-    versionTag: needsKindSpec ? agent?.kindVersion ?? "" : "",
+    versionTag: needsKindSpec ? deployedKindVersion ?? "" : "",
   });
   const {
     data: kindBuild,
@@ -139,7 +148,8 @@ export function Swagger() {
     buildName: kindVersion?.buildName ?? "",
   });
   const isKindSpecLoading =
-    needsKindSpec && (isKindVersionLoading || isKindBuildLoading);
+    !!agent?.kindName &&
+    (isDeploymentsLoading || (needsKindSpec && (isKindVersionLoading || isKindBuildLoading)));
   // Reading the kind's spec goes through the kind's source project, which the
   // viewer may not have access to, so these can fail on their own.
   const specLookupError = agentError ?? (needsKindSpec ? kindVersionError ?? kindBuildError : null);

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -17,8 +17,11 @@
  */
 
 import {
+  useGetAgent,
   useGetAgentConfigurations,
   useGetAgentEndpoints,
+  useGetAgentKindVersion,
+  useGetBuild,
   useTestAgentAPIKey,
 } from "@agent-management-platform/api-client";
 import { getErrorMessage } from "@agent-management-platform/shared-component";
@@ -95,6 +98,40 @@ export function Swagger() {
 
   const endpoint = useMemo(() => Object.keys(data ?? {})?.[0] ?? "", [data]);
 
+  // A kind-sourced agent runs no build of its own, so nothing ever writes an
+  // OpenAPI document onto its deployed endpoint. Resolve the spec from the kind
+  // version it was created from instead — kind version -> its source build —
+  // which is how the agent catalogue renders a kind's API spec.
+  //
+  // kindName is set only for agents instantiated from a kind, so it — not an
+  // empty endpoint schema — is what decides which source to read: waiting for
+  // the endpoints response first would just delay the two lookups behind it.
+  // kindVersion is absent on agents created before it was recorded, and those
+  // can't be tied to a published version.
+  const deployedSpec = data?.[endpoint]?.schema?.content;
+  const { data: agent } = useGetAgent({
+    orgName: orgId,
+    projName: projectId,
+    agentName: agentId,
+  });
+  const needsKindSpec = !!agent?.kindName && !!agent?.kindVersion;
+  const { data: kindVersion, isLoading: isKindVersionLoading } =
+    useGetAgentKindVersion({
+      orgName: needsKindSpec ? orgId ?? "" : "",
+      kindName: needsKindSpec ? agent?.kindName ?? "" : "",
+      versionTag: needsKindSpec ? agent?.kindVersion ?? "" : "",
+    });
+  const { data: kindBuild, isLoading: isKindBuildLoading } = useGetBuild({
+    orgName: needsKindSpec ? orgId ?? "" : "",
+    projName: kindVersion?.sourceProjectName ?? "",
+    agentName: kindVersion?.sourceAgentName ?? "",
+    buildName: kindVersion?.buildName ?? "",
+  });
+  const isKindSpecLoading =
+    needsKindSpec && (isKindVersionLoading || isKindBuildLoading);
+  const specContent =
+    deployedSpec || kindBuild?.inputInterface?.schema?.content;
+
   // The gateway drops CORS headers on 401s, so a cross-origin 401 rejects
   // fetch with a TypeError before swagger-ui's responseInterceptor runs.
   // Inject a custom fetch (req.userFetch) instead: retry once to ride out key
@@ -169,7 +206,7 @@ export function Swagger() {
     }
   };
 
-  if (isLoading || (securityEnabled && isLoadingTestKey)) {
+  if (isLoading || isKindSpecLoading || (securityEnabled && isLoadingTestKey)) {
     return <Skeleton variant="rounded" height={500} />;
   }
 
@@ -185,7 +222,7 @@ export function Swagger() {
     );
   }
 
-  if (!data?.[endpoint]?.schema?.content) {
+  if (!specContent) {
     return (
       <Alert severity="warning">
         No API schema available for this endpoint.
@@ -240,7 +277,7 @@ export function Swagger() {
       )}
       <Box sx={{ "& .swagger-ui .wrapper": { padding: 0 } }}>
         <SwaggerUI
-          spec={data?.[endpoint].schema.content}
+          spec={specContent}
           layout="BaseLayout"
           plugins={[disableAuthorizeAndInfoPluginCustomSecuritySchema]}
           docExpansion="list"

--- a/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
+++ b/console/workspaces/pages/test/src/AgentTest/Swagger.tsx
@@ -109,19 +109,30 @@ export function Swagger() {
   // kindVersion is absent on agents created before it was recorded, and those
   // can't be tied to a published version.
   const deployedSpec = data?.[endpoint]?.schema?.content;
-  const { data: agent } = useGetAgent({
+  const {
+    data: agent,
+    isLoading: isAgentLoading,
+    error: agentError,
+  } = useGetAgent({
     orgName: orgId,
     projName: projectId,
     agentName: agentId,
   });
   const needsKindSpec = !!agent?.kindName && !!agent?.kindVersion;
-  const { data: kindVersion, isLoading: isKindVersionLoading } =
-    useGetAgentKindVersion({
-      orgName: needsKindSpec ? orgId ?? "" : "",
-      kindName: needsKindSpec ? agent?.kindName ?? "" : "",
-      versionTag: needsKindSpec ? agent?.kindVersion ?? "" : "",
-    });
-  const { data: kindBuild, isLoading: isKindBuildLoading } = useGetBuild({
+  const {
+    data: kindVersion,
+    isLoading: isKindVersionLoading,
+    error: kindVersionError,
+  } = useGetAgentKindVersion({
+    orgName: needsKindSpec ? orgId ?? "" : "",
+    kindName: needsKindSpec ? agent?.kindName ?? "" : "",
+    versionTag: needsKindSpec ? agent?.kindVersion ?? "" : "",
+  });
+  const {
+    data: kindBuild,
+    isLoading: isKindBuildLoading,
+    error: kindBuildError,
+  } = useGetBuild({
     orgName: needsKindSpec ? orgId ?? "" : "",
     projName: kindVersion?.sourceProjectName ?? "",
     agentName: kindVersion?.sourceAgentName ?? "",
@@ -129,6 +140,9 @@ export function Swagger() {
   });
   const isKindSpecLoading =
     needsKindSpec && (isKindVersionLoading || isKindBuildLoading);
+  // Reading the kind's spec goes through the kind's source project, which the
+  // viewer may not have access to, so these can fail on their own.
+  const specLookupError = agentError ?? (needsKindSpec ? kindVersionError ?? kindBuildError : null);
   const specContent =
     deployedSpec || kindBuild?.inputInterface?.schema?.content;
 
@@ -206,7 +220,12 @@ export function Swagger() {
     }
   };
 
-  if (isLoading || isKindSpecLoading || (securityEnabled && isLoadingTestKey)) {
+  if (
+    isLoading ||
+    isAgentLoading ||
+    isKindSpecLoading ||
+    (securityEnabled && isLoadingTestKey)
+  ) {
     return <Skeleton variant="rounded" height={500} />;
   }
 
@@ -218,6 +237,19 @@ export function Swagger() {
     return (
       <Alert severity="error">
         Failed to fetch test API key{testKeyError instanceof Error ? `: ${testKeyError.message}` : ""}.
+      </Alert>
+    );
+  }
+
+  // A failed lookup is not the same as an agent that has no schema, so only claim
+  // the latter once every lookup the spec could have come from has succeeded. A
+  // schema we already have still renders — an error resolving the kind's copy is
+  // irrelevant then.
+  if (!specContent && specLookupError) {
+    return (
+      <Alert severity="error">
+        Could not load the API schema for this agent:{" "}
+        {getErrorMessage(specLookupError)}
       </Alert>
     );
   }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.


This PR includes the following changes;
1. Save agent kind version along with the kind name from which the agent was created.
2. Render the api spec for kind-based agents when the source is published from a custom chat agent by fetching the build. The build contains the OpenAPI schema.
4. Show the correct agent kind version on the overview page
5.  Show the correct agent kind version on the environment card
6. Resolve a kind agent's upstream interface from its version's build do it carry forward the port, base path etc.
7. Mask sensitive values in UI when "Secret" toggle is enabled during Agent Kind version creation


Resolves https://github.com/wso2/agent-manager/issues/1585
Resolves https://github.com/wso2/agent-manager/issues/1584
Resolves https://github.com/wso2/agent-manager/issues/1593
Resolves https://github.com/wso2/agent-manager/issues/1652

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Agent and deployment responses now show the recorded Agent Kind version when available.
- Agent details display the deployed Kind version and publish date.
- Swagger schema resolution supports versioned Agent Kind APIs.
- Deployment workflows select and retain the relevant Kind version.

## Bug Fixes
- Invalid version values are rejected with clear validation errors.
- Existing agents without version metadata remain supported.
- API routing uses the appropriate published interface for Kind-based deployments.

## Documentation
- Version requirements document Kubernetes-compatible label formatting and length limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->