### PR TITLE
Add retry support for failed AgentID provisioning

### DIFF
--- a/agent-manager-service/api/agent_routes.go
+++ b/agent-manager-service/api/agent_routes.go
@@ -50,6 +50,7 @@ func registerAgentRoutes(rr *middleware.RouteRegistrar, ctrl controllers.AgentCo
 	rr.HandleFuncWithValidationAndAuthz("PUT /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities", rbac.AgentUpdate, ctrl.ProvisionAgentIdentity)
 	rr.HandleFuncWithValidationAndAuthz("POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities", rbac.AgentUpdate, ctrl.RegenerateAgentIdentitySecret)
 	rr.HandleFuncWithValidationAndAuthz("DELETE /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities", rbac.AgentUpdate, ctrl.RevokeAgentIdentitySecret)
+	rr.HandleFuncWithValidationAndAuthz("POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities/retry", rbac.AgentUpdate, ctrl.RetryAgentIdentityProvisioning)
 	rr.HandleFuncWithValidationAndAuthz("GET /orgs/{orgName}/projects/{projName}/agents/{agentName}/roles", rbac.AgentUpdate, ctrl.GetAgentRoles)
 	rr.HandleFuncWithValidationAndAuthz("GET /orgs/{orgName}/projects/{projName}/agents/{agentName}/groups", rbac.AgentUpdate, ctrl.GetAgentGroups)
 }

--- a/agent-manager-service/audit/actions_domain.go
+++ b/agent-manager-service/audit/actions_domain.go
@@ -44,9 +44,10 @@ const (
 	ActionAgentTokenMint              Action = "agent-token:mint"
 	ActionAgentTokenRegenerateTracing Action = "agent-token:regenerate-tracing"
 
-	ActionAgentIdentityProvision        Action = "agent-identity:provision"
-	ActionAgentIdentityRegenerateSecret Action = "agent-identity:regenerate-secret"
-	ActionAgentIdentityRevokeSecret     Action = "agent-identity:revoke-secret"
+	ActionAgentIdentityProvision         Action = "agent-identity:provision"
+	ActionAgentIdentityRegenerateSecret  Action = "agent-identity:regenerate-secret"
+	ActionAgentIdentityRevokeSecret      Action = "agent-identity:revoke-secret"
+	ActionAgentIdentityRetryProvisioning Action = "agent-identity:retry-provisioning"
 
 	ActionServiceAccountConfigure Action = "service-account:configure"
 	ActionServiceAccountRemove    Action = "service-account:remove"
@@ -228,6 +229,10 @@ func init() {
 		"agentName":   KindName,
 		"environment": KindName,
 		"clientId":    KindIdentifier,
+	})
+	registerCredential(ActionAgentIdentityRetryProvisioning, map[string]FieldKind{
+		"agentName":   KindName,
+		"environment": KindName,
 	})
 
 	registerCredential(ActionServiceAccountConfigure, map[string]FieldKind{

--- a/agent-manager-service/audit/actions_domain_test.go
+++ b/agent-manager-service/audit/actions_domain_test.go
@@ -63,6 +63,10 @@ func TestDomainActionsMatchRouteDerivedActions(t *testing.T) {
 			"DELETE /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities",
 			nil, ActionAgentIdentityRevokeSecret,
 		},
+		{
+			"POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities/retry",
+			nil, ActionAgentIdentityRetryProvisioning,
+		},
 		{"PUT /orgs/{orgName}/environments/{envID}/thunder-system-client", nil, ActionServiceAccountConfigure},
 		{"DELETE /orgs/{orgName}/environments/{envID}/thunder-system-client", nil, ActionServiceAccountRemove},
 		{"POST /orgs/{orgName}/identities/roles/{roleID}/permissions/add", nil, ActionRoleGrantPermission},
@@ -113,6 +117,7 @@ func TestCredentialAndIdentityActionsAreCritical(t *testing.T) {
 		ActionGatewayTokenRotate, ActionGatewayTokenRevoke,
 		ActionAgentTokenMint, ActionAgentTokenRegenerateTracing,
 		ActionAgentIdentityProvision, ActionAgentIdentityRegenerateSecret, ActionAgentIdentityRevokeSecret,
+		ActionAgentIdentityRetryProvisioning,
 		ActionServiceAccountConfigure, ActionServiceAccountRemove,
 		ActionRoleGrantPermission, ActionRoleRevokePermission,
 		ActionRoleAssign, ActionRoleUnassign,

--- a/agent-manager-service/audit/policy.go
+++ b/agent-manager-service/audit/policy.go
@@ -218,9 +218,10 @@ var actionOverrides = map[string]Action{
 	"DELETE /orgs/{orgName}/projects/{projName}/llm-proxies/{id}/deployments/{deploymentId}": "llm-proxy:delete-deployment",
 
 	// One permission, several operations — agent OAuth identity.
-	"PUT /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities":    "agent-identity:provision",
-	"POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities":   "agent-identity:regenerate-secret",
-	"DELETE /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities": "agent-identity:revoke-secret",
+	"PUT /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities":        "agent-identity:provision",
+	"POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities":       "agent-identity:regenerate-secret",
+	"DELETE /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities":     "agent-identity:revoke-secret",
+	"POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities/retry": "agent-identity:retry-provisioning",
 
 	// One permission, several operations — agent tokens.
 	"POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/token":                    "agent-token:mint",

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -62,6 +62,7 @@ type AgentController interface {
 	RegenerateAgentIdentitySecret(w http.ResponseWriter, r *http.Request)
 	RevokeAgentIdentitySecret(w http.ResponseWriter, r *http.Request)
 	ProvisionAgentIdentity(w http.ResponseWriter, r *http.Request)
+	RetryAgentIdentityProvisioning(w http.ResponseWriter, r *http.Request)
 	GetAgentRoles(w http.ResponseWriter, r *http.Request)
 	GetAgentGroups(w http.ResponseWriter, r *http.Request)
 }
@@ -1263,6 +1264,72 @@ func (c *agentController) ProvisionAgentIdentity(w http.ResponseWriter, r *http.
 	}
 	log.Info("ProvisionAgentIdentity: completed", "orgName", orgName, "agentName", agentName, "envID", envID, "alreadyExisted", alreadyExisted)
 	utils.WriteSuccessResponse(w, status, view)
+}
+
+// RetryAgentIdentityProvisioning handles
+// POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities/retry
+//
+// Resets a FAILED AgentID binding back to PENDING and re-attempts
+// provisioning, for both Internal and External agents. The target
+// environment is passed in the request body, matching
+// RegenerateAgentIdentitySecret's convention for POST identity actions.
+func (c *agentController) RetryAgentIdentityProvisioning(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := logger.GetLogger(ctx)
+
+	orgName := middleware.OrgHandleFromRequest(r)
+	ouID := middleware.OUIDFromRequest(r)
+	projName := r.PathValue(utils.PathParamProjName)
+	agentName := r.PathValue(utils.PathParamAgentName)
+
+	var payload models.AgentIdentityActionRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		log.Error("RetryAgentIdentityProvisioning: failed to decode request body", "error", err)
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	envID := payload.Environment
+	if envID == "" {
+		utils.WriteErrorResponse(w, http.StatusBadRequest, "environment is required in the request body")
+		return
+	}
+
+	log.Info("RetryAgentIdentityProvisioning: starting", "orgName", orgName, "agentName", agentName, "envID", envID)
+
+	attempt, ok := beginAuditOrFail(
+		w, r, "RetryAgentIdentityProvisioning", "Failed to retry agent identity provisioning", audit.ActionAgentIdentityRetryProvisioning,
+		audit.Org(ouID),
+		audit.ResourceNamed(audit.ResourceAgentIdentity, agentName, agentName),
+		audit.Project(projName),
+		audit.Environment(envID),
+		audit.Detail("agentName", agentName),
+		audit.Detail("environment", envID),
+	)
+	if !ok {
+		return
+	}
+
+	view, err := c.agentService.RetryAgentIdentityProvisioning(ctx, ouID, projName, agentName, envID)
+	if err != nil {
+		attempt.Complete(ctx, err)
+		if errors.Is(err, utils.ErrAgentIdentityNotProvisioned) {
+			log.Warn("RetryAgentIdentityProvisioning: identity not yet provisioned", "orgName", orgName, "agentName", agentName, "envID", envID)
+			utils.WriteErrorResponse(w, http.StatusNotFound, "Agent identity not yet provisioned for this environment")
+			return
+		}
+		if errors.Is(err, utils.ErrAgentIdentityRetryNotAllowed) {
+			log.Warn("RetryAgentIdentityProvisioning: binding not in a failed state", "orgName", orgName, "agentName", agentName, "envID", envID)
+			utils.WriteErrorResponse(w, http.StatusConflict, "Agent identity binding is not in a failed state and cannot be retried")
+			return
+		}
+		log.Error("RetryAgentIdentityProvisioning: failed to retry provisioning", "orgName", orgName, "agentName", agentName, "envID", envID, "error", err)
+		handleCommonErrors(w, err, "Failed to retry agent identity provisioning")
+		return
+	}
+
+	attempt.Complete(ctx, nil)
+	log.Info("RetryAgentIdentityProvisioning: retry scheduled", "orgName", orgName, "agentName", agentName, "envID", envID)
+	utils.WriteSuccessResponse(w, http.StatusAccepted, view)
 }
 
 // GetAgentRoles handles

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -3565,6 +3565,85 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities/retry:
+    post:
+      tags:
+        - Agent Identity
+      summary: Retry a failed AgentID provisioning attempt
+      description: |
+        Resets a binding stuck in `failed` status back to `pending` — clearing
+        its attempt budget and last error — and re-attempts provisioning in
+        the background, for both platform-hosted and externally hosted
+        agents.
+
+        Only a binding whose current status is `failed` can be retried this
+        way: `completed`, `pending`, and `in_progress` bindings already have
+        their own path forward (nothing to reset, or already retrying) and
+        are rejected with `409`.
+      operationId: retryAgentIdentityProvisioning
+      parameters:
+        - name: orgName
+          in: path
+          required: true
+          description: Organization name
+          schema:
+            type: string
+        - name: projName
+          in: path
+          required: true
+          description: Project name
+          schema:
+            type: string
+        - name: agentName
+          in: path
+          required: true
+          description: Agent name
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentIdentityActionRequest"
+      responses:
+        "202":
+          description: The binding was reset and provisioning was scheduled again
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentIdentityEnvironmentView"
+        "400":
+          description: Missing or invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: Agent identity not yet provisioned for this environment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: The binding exists but is not currently in `failed` status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /orgs/{orgName}/projects/{projName}/agents/{agentName}/roles:
     parameters:
       - name: orgName

--- a/agent-manager-service/repositories/agent_thunder_client_repository.go
+++ b/agent-manager-service/repositories/agent_thunder_client_repository.go
@@ -67,6 +67,17 @@ type AgentThunderClientRepository interface {
 	// pending/stale) — the caller must skip the attempt.
 	ClaimForAttempt(ctx context.Context, id uuid.UUID) (claimed bool, err error)
 
+	// ResetFailedForRetry atomically transitions a binding from FAILED back to
+	// PENDING for a manual retry — clearing attempt_count, last_error, and
+	// last_attempted_at so it starts a fresh attempt budget, and setting
+	// next_retry_at to now so the reconciler's sweep is a safety net even if
+	// the caller's own inline attempt never runs. Conditioned on the row's
+	// CURRENT status being FAILED, so two concurrent retry calls (e.g. a
+	// double click) can only ever reset it once; reset=false means it already
+	// changed state (a concurrent retry won, or the reconciler got there
+	// first) and the caller must treat that as a conflict, not a silent no-op.
+	ResetFailedForRetry(ctx context.Context, id uuid.UUID) (reset bool, err error)
+
 	// UpdateAfterAttempt records the outcome of a provisioning attempt: the resolved
 	// Thunder identity (on success), status, attempt bookkeeping, and the next retry
 	// time (nil once the binding is COMPLETED or FAILED).
@@ -223,6 +234,23 @@ func (r *AgentThunderClientRepo) ClaimForAttempt(ctx context.Context, id uuid.UU
 		})
 	if result.Error != nil {
 		return false, fmt.Errorf("claim agent thunder client for attempt: %w", result.Error)
+	}
+	return result.RowsAffected > 0, nil
+}
+
+func (r *AgentThunderClientRepo) ResetFailedForRetry(ctx context.Context, id uuid.UUID) (bool, error) {
+	result := r.db.WithContext(ctx).Model(&models.AgentThunderClient{}).
+		Where("id = ? AND status = ?", id, models.AgentThunderStatusFailed).
+		Updates(map[string]interface{}{
+			"status":            models.AgentThunderStatusPending,
+			"attempt_count":     0,
+			"last_error":        "",
+			"last_attempted_at": nil,
+			"next_retry_at":     clause.Expr{SQL: "NOW()"},
+			"updated_at":        clause.Expr{SQL: "NOW()"},
+		})
+	if result.Error != nil {
+		return false, fmt.Errorf("reset failed agent thunder client for retry: %w", result.Error)
 	}
 	return result.RowsAffected > 0, nil
 }

--- a/agent-manager-service/repositories/repomocks/agent_thunder_client_repository_mock.go
+++ b/agent-manager-service/repositories/repomocks/agent_thunder_client_repository_mock.go
@@ -43,6 +43,9 @@ import (
 //			GetFunc: func(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (*models.AgentThunderClient, error) {
 //				panic("mock out the Get method")
 //			},
+//			ResetFailedForRetryFunc: func(ctx context.Context, id uuid.UUID) (bool, error) {
+//				panic("mock out the ResetFailedForRetry method")
+//			},
 //			UpdateAfterAttemptFunc: func(ctx context.Context, id uuid.UUID, fields repositories.AgentThunderAttemptUpdate) error {
 //				panic("mock out the UpdateAfterAttempt method")
 //			},
@@ -82,6 +85,9 @@ type AgentThunderClientRepositoryMock struct {
 
 	// GetFunc mocks the Get method.
 	GetFunc func(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (*models.AgentThunderClient, error)
+
+	// ResetFailedForRetryFunc mocks the ResetFailedForRetry method.
+	ResetFailedForRetryFunc func(ctx context.Context, id uuid.UUID) (bool, error)
 
 	// UpdateAfterAttemptFunc mocks the UpdateAfterAttempt method.
 	UpdateAfterAttemptFunc func(ctx context.Context, id uuid.UUID, fields repositories.AgentThunderAttemptUpdate) error
@@ -172,6 +178,13 @@ type AgentThunderClientRepositoryMock struct {
 			// EnvironmentName is the environmentName argument value.
 			EnvironmentName string
 		}
+		// ResetFailedForRetry holds details about calls to the ResetFailedForRetry method.
+		ResetFailedForRetry []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ID is the id argument value.
+			ID uuid.UUID
+		}
 		// UpdateAfterAttempt holds details about calls to the UpdateAfterAttempt method.
 		UpdateAfterAttempt []struct {
 			// Ctx is the ctx argument value.
@@ -206,6 +219,7 @@ type AgentThunderClientRepositoryMock struct {
 	lockFindDue                       sync.RWMutex
 	lockFindRecentlyCompletedInternal sync.RWMutex
 	lockGet                           sync.RWMutex
+	lockResetFailedForRetry           sync.RWMutex
 	lockUpdateAfterAttempt            sync.RWMutex
 	lockUpdateSecretRef               sync.RWMutex
 	lockUpsert                        sync.RWMutex
@@ -540,6 +554,42 @@ func (mock *AgentThunderClientRepositoryMock) GetCalls() []struct {
 	mock.lockGet.RLock()
 	calls = mock.calls.Get
 	mock.lockGet.RUnlock()
+	return calls
+}
+
+// ResetFailedForRetry calls ResetFailedForRetryFunc.
+func (mock *AgentThunderClientRepositoryMock) ResetFailedForRetry(ctx context.Context, id uuid.UUID) (bool, error) {
+	if mock.ResetFailedForRetryFunc == nil {
+		panic("AgentThunderClientRepositoryMock.ResetFailedForRetryFunc: method is nil but AgentThunderClientRepository.ResetFailedForRetry was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+		ID  uuid.UUID
+	}{
+		Ctx: ctx,
+		ID:  id,
+	}
+	mock.lockResetFailedForRetry.Lock()
+	mock.calls.ResetFailedForRetry = append(mock.calls.ResetFailedForRetry, callInfo)
+	mock.lockResetFailedForRetry.Unlock()
+	return mock.ResetFailedForRetryFunc(ctx, id)
+}
+
+// ResetFailedForRetryCalls gets all the calls that were made to ResetFailedForRetry.
+// Check the length with:
+//
+//	len(mockedAgentThunderClientRepository.ResetFailedForRetryCalls())
+func (mock *AgentThunderClientRepositoryMock) ResetFailedForRetryCalls() []struct {
+	Ctx context.Context
+	ID  uuid.UUID
+} {
+	var calls []struct {
+		Ctx context.Context
+		ID  uuid.UUID
+	}
+	mock.lockResetFailedForRetry.RLock()
+	calls = mock.calls.ResetFailedForRetry
+	mock.lockResetFailedForRetry.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -72,6 +72,7 @@ type AgentManagerService interface {
 	RegenerateAgentIdentitySecret(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (*models.AgentRegenerateSecretResponse, error)
 	RevokeAgentIdentitySecret(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (models.AgentRevokeSecretResponse, error)
 	ProvisionAgentIdentity(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (view models.AgentIdentityEnvironmentView, alreadyExisted bool, err error)
+	RetryAgentIdentityProvisioning(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (models.AgentIdentityEnvironmentView, error)
 	GetAgentRoles(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) ([]thundersvc.ThunderRole, error)
 	GetAgentGroups(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) ([]thundersvc.ThunderGroup, error)
 }
@@ -3693,6 +3694,15 @@ func (s *agentManagerService) ProvisionAgentIdentity(ctx context.Context, ouID s
 	// Upsert inside ProvisionForEnvironmentIfMissing is synchronous, so the row
 	// (at minimum PENDING) must already be visible to this read.
 	return models.AgentIdentityEnvironmentView{}, alreadyExisted, fmt.Errorf("agent thunder binding for %s/%s vanished immediately after being provisioned", agentName, environmentName)
+}
+
+// RetryAgentIdentityProvisioning resets a failed AgentID binding and
+// re-attempts provisioning, for both Internal and External agents.
+func (s *agentManagerService) RetryAgentIdentityProvisioning(ctx context.Context, ouID string, projectName string, agentName string, environmentName string) (models.AgentIdentityEnvironmentView, error) {
+	if s.agentThunderProvisioning == nil {
+		return models.AgentIdentityEnvironmentView{}, utils.ErrAgentIdentityNotProvisioned
+	}
+	return s.agentThunderProvisioning.RetryProvisioning(ctx, ouID, projectName, agentName, environmentName)
 }
 
 // PromoteAgent promotes an agent from one environment to another.

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -103,6 +103,16 @@ type AgentThunderProvisioningService interface {
 	// best-effort background attempt.
 	ProvisionForEnvironmentIfMissing(ctx context.Context, ouID, projectName, agentName, envName string, ownership models.AgentProvisioningType, requestedBy string) (alreadyExisted bool, err error)
 
+	// RetryProvisioning resets a FAILED binding back to PENDING — clearing its
+	// attempt budget and last error — and re-attempts provisioning in the
+	// background, for both Internal and External agents. Returns
+	// utils.ErrAgentIdentityNotProvisioned if no binding exists for this agent
+	// in this environment, or utils.ErrAgentIdentityRetryNotAllowed if the
+	// binding exists but its current status is not FAILED — completed,
+	// pending, and in-progress bindings already have their own path forward
+	// and are rejected rather than silently no-oped.
+	RetryProvisioning(ctx context.Context, ouID, projectName, agentName, envName string) (models.AgentIdentityEnvironmentView, error)
+
 	// RegenerateSecret rotates the secret for one binding and returns the
 	// binding's ownership type, client ID, and the new secret. The caller (the
 	// HTTP layer) decides whether to expose the secret in the response based on
@@ -623,6 +633,49 @@ func (s *agentThunderProvisioningService) ProvisionForEnvironmentIfMissing(
 
 	s.ProvisionForAgent(ctx, ouID, projectName, agentName, ownership, []string{envName}, requestedBy)
 	return false, nil
+}
+
+func (s *agentThunderProvisioningService) RetryProvisioning(ctx context.Context, ouID, projectName, agentName, envName string) (models.AgentIdentityEnvironmentView, error) {
+	binding, err := s.repo.Get(ctx, ouID, projectName, agentName, envName)
+	if err != nil {
+		if errors.Is(err, repositories.ErrAgentThunderClientNotFound) {
+			return models.AgentIdentityEnvironmentView{}, fmt.Errorf("%w: %s in %s", utils.ErrAgentIdentityNotProvisioned, agentName, envName)
+		}
+		return models.AgentIdentityEnvironmentView{}, err
+	}
+	if binding.Status != models.AgentThunderStatusFailed {
+		return models.AgentIdentityEnvironmentView{}, fmt.Errorf("%w: %s in %s is %s", utils.ErrAgentIdentityRetryNotAllowed, agentName, envName, binding.Status)
+	}
+
+	reset, err := s.repo.ResetFailedForRetry(ctx, binding.ID)
+	if err != nil {
+		return models.AgentIdentityEnvironmentView{}, fmt.Errorf("reset agent thunder binding for retry: %w", err)
+	}
+	if !reset {
+		// Lost a race with something else that moved the binding out of FAILED
+		// between the read above and this conditional update (another retry,
+		// or the reconciler) — same outward signal as "not currently failed."
+		return models.AgentIdentityEnvironmentView{}, fmt.Errorf("%w: %s in %s changed state concurrently", utils.ErrAgentIdentityRetryNotAllowed, agentName, envName)
+	}
+
+	binding.Status = models.AgentThunderStatusPending
+	binding.AttemptCount = 0
+	binding.LastError = ""
+	binding.LastAttemptedAt = nil
+	binding.NextRetryAt = nil
+
+	// Detach from the request context so the background attempt survives the
+	// HTTP handler returning, mirroring ProvisionForAgent's own attemptAll call.
+	go s.AttemptProvision(context.WithoutCancel(ctx), *binding)
+
+	return models.AgentIdentityEnvironmentView{
+		EnvironmentName:  binding.EnvironmentName,
+		ProvisioningType: binding.ProvisioningType,
+		Status:           models.AgentThunderStatusPending,
+		AgentID:          binding.ThunderAgentID,
+		ClientID:         binding.ThunderClientID,
+		RequestedBy:      binding.RequestedBy,
+	}, nil
 }
 
 func (s *agentThunderProvisioningService) AttemptProvision(ctx context.Context, binding models.AgentThunderClient) {

--- a/agent-manager-service/services/agent_thunder_reconciler_test.go
+++ b/agent-manager-service/services/agent_thunder_reconciler_test.go
@@ -481,6 +481,10 @@ func (f *fakeProvisioningService) RegenerateSecret(context.Context, string, stri
 	return "", "", "", nil
 }
 
+func (f *fakeProvisioningService) RetryProvisioning(context.Context, string, string, string, string) (models.AgentIdentityEnvironmentView, error) {
+	return models.AgentIdentityEnvironmentView{}, nil
+}
+
 func (f *fakeProvisioningService) RevokeSecret(context.Context, string, string, string, string) (string, error) {
 	return "", nil
 }

--- a/agent-manager-service/spec/api_agent_identity.go
+++ b/agent-manager-service/spec/api_agent_identity.go
@@ -3022,6 +3022,191 @@ func (a *AgentIdentityAPIService) RemoveAgentIdentityRoleAssigneesExecute(r ApiR
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type ApiRetryAgentIdentityProvisioningRequest struct {
+	ctx                        context.Context
+	ApiService                 *AgentIdentityAPIService
+	orgName                    string
+	projName                   string
+	agentName                  string
+	agentIdentityActionRequest *AgentIdentityActionRequest
+}
+
+func (r ApiRetryAgentIdentityProvisioningRequest) AgentIdentityActionRequest(agentIdentityActionRequest AgentIdentityActionRequest) ApiRetryAgentIdentityProvisioningRequest {
+	r.agentIdentityActionRequest = &agentIdentityActionRequest
+	return r
+}
+
+func (r ApiRetryAgentIdentityProvisioningRequest) Execute() (*AgentIdentityEnvironmentView, *http.Response, error) {
+	return r.ApiService.RetryAgentIdentityProvisioningExecute(r)
+}
+
+/*
+RetryAgentIdentityProvisioning Retry a failed AgentID provisioning attempt
+
+Resets a binding stuck in `failed` status back to `pending` — clearing
+its attempt budget and last error — and re-attempts provisioning in
+the background, for both platform-hosted and externally hosted
+agents.
+
+Only a binding whose current status is `failed` can be retried this
+way: `completed`, `pending`, and `in_progress` bindings already have
+their own path forward (nothing to reset, or already retrying) and
+are rejected with `409`.
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@param orgName Organization name
+	@param projName Project name
+	@param agentName Agent name
+	@return ApiRetryAgentIdentityProvisioningRequest
+*/
+func (a *AgentIdentityAPIService) RetryAgentIdentityProvisioning(ctx context.Context, orgName string, projName string, agentName string) ApiRetryAgentIdentityProvisioningRequest {
+	return ApiRetryAgentIdentityProvisioningRequest{
+		ApiService: a,
+		ctx:        ctx,
+		orgName:    orgName,
+		projName:   projName,
+		agentName:  agentName,
+	}
+}
+
+// Execute executes the request
+//
+//	@return AgentIdentityEnvironmentView
+func (a *AgentIdentityAPIService) RetryAgentIdentityProvisioningExecute(r ApiRetryAgentIdentityProvisioningRequest) (*AgentIdentityEnvironmentView, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodPost
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *AgentIdentityEnvironmentView
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AgentIdentityAPIService.RetryAgentIdentityProvisioning")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/orgs/{orgName}/projects/{projName}/agents/{agentName}/identities/retry"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"projName"+"}", url.PathEscape(parameterValueToString(r.projName, "projName")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"agentName"+"}", url.PathEscape(parameterValueToString(r.agentName, "agentName")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.agentIdentityActionRequest == nil {
+		return localVarReturnValue, nil, reportError("agentIdentityActionRequest is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.agentIdentityActionRequest
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 404 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type ApiRevokeAgentIdentitySecretRequest struct {
 	ctx         context.Context
 	ApiService  *AgentIdentityAPIService

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -69,14 +69,17 @@ func IsValidationError(err error) *ValidationError {
 
 var (
 	// Resource not found errors
-	ErrProjectNotFound                = errors.New("project not found")
-	ErrAgentAlreadyExists             = errors.New("agent already exists")
-	ErrAgentNotFound                  = errors.New("agent not found")
-	ErrTraitNotFound                  = errors.New("trait not found")
-	ErrOrganizationNotFound           = errors.New("organization not found")
-	ErrBuildNotFound                  = errors.New("build not found")
-	ErrEnvironmentNotFound            = errors.New("environment not found")
-	ErrAgentIdentityNotProvisioned    = errors.New("agent identity not yet provisioned for this environment")
+	ErrProjectNotFound             = errors.New("project not found")
+	ErrAgentAlreadyExists          = errors.New("agent already exists")
+	ErrAgentNotFound               = errors.New("agent not found")
+	ErrTraitNotFound               = errors.New("trait not found")
+	ErrOrganizationNotFound        = errors.New("organization not found")
+	ErrBuildNotFound               = errors.New("build not found")
+	ErrEnvironmentNotFound         = errors.New("environment not found")
+	ErrAgentIdentityNotProvisioned = errors.New("agent identity not yet provisioned for this environment")
+	// ErrAgentIdentityRetryNotAllowed is returned when a retry is requested for
+	// a binding whose current status is not failed. Maps to 409.
+	ErrAgentIdentityRetryNotAllowed   = errors.New("agent identity binding is not in a failed state and cannot be retried")
 	ErrOrganizationAlreadyExists      = errors.New("organization already exists")
 	ErrProjectAlreadyExists           = errors.New("project already exists")
 	ErrDeploymentPipelineNotFound     = errors.New("deployment pipeline not found")

--- a/cli/pkg/clients/amsvc/gen/client.gen.go
+++ b/cli/pkg/clients/amsvc/gen/client.gen.go
@@ -674,6 +674,11 @@ type ClientInterface interface {
 	// ProvisionAgentIdentity request
 	ProvisionAgentIdentity(ctx context.Context, orgName string, projName string, agentName string, params *ProvisionAgentIdentityParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RetryAgentIdentityProvisioningWithBody request with any body
+	RetryAgentIdentityProvisioningWithBody(ctx context.Context, orgName string, projName string, agentName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RetryAgentIdentityProvisioning(ctx context.Context, orgName string, projName string, agentName string, body RetryAgentIdentityProvisioningJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListAgentMCPConfigs request
 	ListAgentMCPConfigs(ctx context.Context, orgName string, projName string, agentName string, params *ListAgentMCPConfigsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3427,6 +3432,30 @@ func (c *Client) RegenerateAgentIdentitySecret(ctx context.Context, orgName stri
 
 func (c *Client) ProvisionAgentIdentity(ctx context.Context, orgName string, projName string, agentName string, params *ProvisionAgentIdentityParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewProvisionAgentIdentityRequest(c.Server, orgName, projName, agentName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetryAgentIdentityProvisioningWithBody(ctx context.Context, orgName string, projName string, agentName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetryAgentIdentityProvisioningRequestWithBody(c.Server, orgName, projName, agentName, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RetryAgentIdentityProvisioning(ctx context.Context, orgName string, projName string, agentName string, body RetryAgentIdentityProvisioningJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRetryAgentIdentityProvisioningRequest(c.Server, orgName, projName, agentName, body)
 	if err != nil {
 		return nil, err
 	}
@@ -12791,6 +12820,67 @@ func NewProvisionAgentIdentityRequest(server string, orgName string, projName st
 	return req, nil
 }
 
+// NewRetryAgentIdentityProvisioningRequest calls the generic RetryAgentIdentityProvisioning builder with application/json body
+func NewRetryAgentIdentityProvisioningRequest(server string, orgName string, projName string, agentName string, body RetryAgentIdentityProvisioningJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRetryAgentIdentityProvisioningRequestWithBody(server, orgName, projName, agentName, "application/json", bodyReader)
+}
+
+// NewRetryAgentIdentityProvisioningRequestWithBody generates requests for RetryAgentIdentityProvisioning with any type of body
+func NewRetryAgentIdentityProvisioningRequestWithBody(server string, orgName string, projName string, agentName string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "projName", projName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "agentName", agentName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/orgs/%s/projects/%s/agents/%s/identities/retry", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewListAgentMCPConfigsRequest generates requests for ListAgentMCPConfigs
 func NewListAgentMCPConfigsRequest(server string, orgName string, projName string, agentName string, params *ListAgentMCPConfigsParams) (*http.Request, error) {
 	var err error
@@ -17115,6 +17205,11 @@ type ClientWithResponsesInterface interface {
 	// ProvisionAgentIdentityWithResponse request
 	ProvisionAgentIdentityWithResponse(ctx context.Context, orgName string, projName string, agentName string, params *ProvisionAgentIdentityParams, reqEditors ...RequestEditorFn) (*ProvisionAgentIdentityResp, error)
 
+	// RetryAgentIdentityProvisioningWithBodyWithResponse request with any body
+	RetryAgentIdentityProvisioningWithBodyWithResponse(ctx context.Context, orgName string, projName string, agentName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetryAgentIdentityProvisioningResp, error)
+
+	RetryAgentIdentityProvisioningWithResponse(ctx context.Context, orgName string, projName string, agentName string, body RetryAgentIdentityProvisioningJSONRequestBody, reqEditors ...RequestEditorFn) (*RetryAgentIdentityProvisioningResp, error)
+
 	// ListAgentMCPConfigsWithResponse request
 	ListAgentMCPConfigsWithResponse(ctx context.Context, orgName string, projName string, agentName string, params *ListAgentMCPConfigsParams, reqEditors ...RequestEditorFn) (*ListAgentMCPConfigsResp, error)
 
@@ -21247,6 +21342,33 @@ func (r ProvisionAgentIdentityResp) StatusCode() int {
 	return 0
 }
 
+type RetryAgentIdentityProvisioningResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *AgentIdentityEnvironmentView
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON404      *ErrorResponse
+	JSON409      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RetryAgentIdentityProvisioningResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RetryAgentIdentityProvisioningResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListAgentMCPConfigsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -24463,6 +24585,23 @@ func (c *ClientWithResponses) ProvisionAgentIdentityWithResponse(ctx context.Con
 		return nil, err
 	}
 	return ParseProvisionAgentIdentityResp(rsp)
+}
+
+// RetryAgentIdentityProvisioningWithBodyWithResponse request with arbitrary body returning *RetryAgentIdentityProvisioningResp
+func (c *ClientWithResponses) RetryAgentIdentityProvisioningWithBodyWithResponse(ctx context.Context, orgName string, projName string, agentName string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RetryAgentIdentityProvisioningResp, error) {
+	rsp, err := c.RetryAgentIdentityProvisioningWithBody(ctx, orgName, projName, agentName, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetryAgentIdentityProvisioningResp(rsp)
+}
+
+func (c *ClientWithResponses) RetryAgentIdentityProvisioningWithResponse(ctx context.Context, orgName string, projName string, agentName string, body RetryAgentIdentityProvisioningJSONRequestBody, reqEditors ...RequestEditorFn) (*RetryAgentIdentityProvisioningResp, error) {
+	rsp, err := c.RetryAgentIdentityProvisioning(ctx, orgName, projName, agentName, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRetryAgentIdentityProvisioningResp(rsp)
 }
 
 // ListAgentMCPConfigsWithResponse request returning *ListAgentMCPConfigsResp
@@ -32326,6 +32465,67 @@ func ParseProvisionAgentIdentityResp(rsp *http.Response) (*ProvisionAgentIdentit
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRetryAgentIdentityProvisioningResp parses an HTTP response from a RetryAgentIdentityProvisioningWithResponse call
+func ParseRetryAgentIdentityProvisioningResp(rsp *http.Response) (*RetryAgentIdentityProvisioningResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RetryAgentIdentityProvisioningResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest AgentIdentityEnvironmentView
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ErrorResponse

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -6014,6 +6014,9 @@ type RotateAgentAPIKeyJSONRequestBody = RotateLLMAPIKeyRequest
 // RegenerateAgentIdentitySecretJSONRequestBody defines body for RegenerateAgentIdentitySecret for application/json ContentType.
 type RegenerateAgentIdentitySecretJSONRequestBody = AgentIdentityActionRequest
 
+// RetryAgentIdentityProvisioningJSONRequestBody defines body for RetryAgentIdentityProvisioning for application/json ContentType.
+type RetryAgentIdentityProvisioningJSONRequestBody = AgentIdentityActionRequest
+
 // CreateAgentMCPConfigJSONRequestBody defines body for CreateAgentMCPConfig for application/json ContentType.
 type CreateAgentMCPConfigJSONRequestBody = CreateAgentModelConfigRequest
 

--- a/console/workspaces/libs/api-client/src/apis/agents.ts
+++ b/console/workspaces/libs/api-client/src/apis/agents.ts
@@ -49,6 +49,7 @@ import type {
   ProvisionAgentIdentityPathParams,
   ProvisionAgentIdentityQuery,
   RegenerateAgentIdentitySecretPathParams,
+  RetryAgentIdentityProvisioningPathParams,
   AgentIdentityActionRequest,
   AgentRegenerateSecretResponse,
   RevokeAgentIdentitySecretPathParams,
@@ -323,6 +324,22 @@ export async function regenerateAgentIdentitySecret(
   const { orgName = "default", projName = "default", agentName } = params;
   const token = getToken ? await getToken() : undefined;
   const res = await httpPOST(identityBase(orgName, projName, agentName ?? ""), body, { token });
+  if (!res.ok) throw await res.json();
+  return res.json();
+}
+
+// Resets a binding stuck in "failed" status back to "pending" and
+// re-attempts provisioning. Only valid while the binding is currently
+// failed — a 409 means it moved on (or was never failed) before this call
+// landed.
+export async function retryAgentIdentityProvisioning(
+  params: RetryAgentIdentityProvisioningPathParams,
+  body: AgentIdentityActionRequest,
+  getToken?: () => Promise<string>,
+): Promise<AgentIdentityEnvironmentView> {
+  const { orgName = "default", projName = "default", agentName } = params;
+  const token = getToken ? await getToken() : undefined;
+  const res = await httpPOST(`${identityBase(orgName, projName, agentName ?? "")}/retry`, body, { token });
   if (!res.ok) throw await res.json();
   return res.json();
 }

--- a/console/workspaces/libs/api-client/src/hooks/agents.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agents.ts
@@ -21,7 +21,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   createAgent, deleteAgent, getAgent, listAgents, listOrgAgents, generateAgentToken, updateAgent,
   updateAgentBuildParameters, getAgentRoles, getAgentGroups, getAgentIdentity,
-  provisionAgentIdentity, regenerateAgentIdentitySecret, revokeAgentIdentitySecret,
+  provisionAgentIdentity, regenerateAgentIdentitySecret, retryAgentIdentityProvisioning,
+  revokeAgentIdentitySecret,
 } from "../apis";
 import { SLOW_POLL_INTERVAL } from "../utils";
 import type {
@@ -56,6 +57,7 @@ import type {
   ProvisionAgentIdentityPathParams,
   ProvisionAgentIdentityQuery,
   RegenerateAgentIdentitySecretPathParams,
+  RetryAgentIdentityProvisioningPathParams,
   AgentIdentityActionRequest,
   AgentRegenerateSecretResponse,
   RevokeAgentIdentitySecretPathParams,
@@ -340,6 +342,22 @@ export function useRegenerateAgentIdentitySecret() {
   >({
     action: { verb: 'rotate', target: 'agent identity secret' },
     mutationFn: ({ params, body }) => regenerateAgentIdentitySecret(params, body, getToken),
+    onSuccess: (_data, { params }) => {
+      queryClient.invalidateQueries({ queryKey: ['agent-identity', params] });
+    },
+  });
+}
+
+export function useRetryAgentIdentityProvisioning() {
+  const { getToken } = useAuthHooks();
+  const queryClient = useQueryClient();
+  return useApiMutation<
+    AgentIdentityEnvironmentView,
+    unknown,
+    { params: RetryAgentIdentityProvisioningPathParams; body: AgentIdentityActionRequest }
+  >({
+    action: { verb: 'rerun', target: 'agent identity provisioning' },
+    mutationFn: ({ params, body }) => retryAgentIdentityProvisioning(params, body, getToken),
     onSuccess: (_data, { params }) => {
       queryClient.invalidateQueries({ queryKey: ['agent-identity', params] });
     },

--- a/console/workspaces/libs/types/src/api/agents.ts
+++ b/console/workspaces/libs/types/src/api/agents.ts
@@ -240,6 +240,8 @@ export interface ProvisionAgentIdentityQuery {
 
 export type RegenerateAgentIdentitySecretPathParams = AgentPathParams;
 
+export type RetryAgentIdentityProvisioningPathParams = AgentPathParams;
+
 export type RevokeAgentIdentitySecretPathParams = AgentPathParams;
 export interface RevokeAgentIdentitySecretQuery {
   environment: string;

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
@@ -16,11 +16,12 @@
  */
 
 import { useMemo, useState } from "react";
-import { Avatar, Box, IconButton, Skeleton, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { Copy, Fingerprint } from "@wso2/oxygen-ui-icons-react";
+import { Alert, Avatar, Box, Button, CircularProgress, IconButton, Skeleton, Tooltip, Typography } from "@wso2/oxygen-ui";
+import { AlertTriangle, Copy, Fingerprint, RefreshCw } from "@wso2/oxygen-ui-icons-react";
 import {
   useAgentIdentityBinding,
   useListAgentIdentityAgents,
+  useRetryAgentIdentityProvisioning,
 } from "@agent-management-platform/api-client";
 import {
   OverviewSectionCard,
@@ -48,9 +49,18 @@ interface EnvAgentRolesGroupsSectionProps {
 export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProps> = ({
   orgId, projectId, agentId, envId,
 }) => {
-  const { provisioned, isLoading: isLoadingIdentity } = useAgentIdentityBinding({
+  const { binding, provisioned, isLoading: isLoadingIdentity } = useAgentIdentityBinding({
     orgId, projectId, agentId, envId,
   });
+  const isFailed = binding?.status === "failed";
+
+  const { mutate: retryProvisioning, isPending: isRetrying } = useRetryAgentIdentityProvisioning();
+  const handleRetry = () => {
+    retryProvisioning({
+      params: { orgName: orgId, projName: projectId, agentName: agentId },
+      body: { environment: envId },
+    });
+  };
 
   const { roles, groups, isLoading, isError: isRolesGroupsError } = useAgentRolesAndGroups({
     orgId, projectId, agentId, envId, enabled: provisioned,
@@ -97,10 +107,15 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
         >
           <Fingerprint size={24} />
         </Avatar>
+        {isLoadingIdentity ? (
+          <Skeleton variant="text" width={160} height={20} />
+        ) : isFailed ? (
+          <Typography variant="body2" color="error" fontWeight={600}>
+            Provisioning Status : Failed
+          </Typography>
+        ) : (
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          {isLoadingIdentity ? (
-            <Skeleton variant="text" width={160} height={20} />
-          ) : thunderAgentId ? (
+          {thunderAgentId ? (
             <Box display="flex" alignItems="center" gap={0.5} minWidth={0}>
               <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}>
                 Agent ID:
@@ -159,7 +174,29 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
             )}
           </Box>
         </Box>
+        )}
       </Box>
+      {isFailed && !isLoadingIdentity && (
+        <Alert
+          severity="error"
+          icon={<AlertTriangle size={18} />}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={handleRetry}
+              disabled={isRetrying}
+              startIcon={isRetrying ? <CircularProgress size={14} color="inherit" /> : <RefreshCw size={14} />}
+              sx={{ whiteSpace: "nowrap" }}
+            >
+              {isRetrying ? "Retrying..." : "Retry"}
+            </Button>
+          }
+          sx={{ mt: 1.5, flexWrap: "wrap", "& .MuiAlert-action": { flexShrink: 0 } }}
+        >
+          Provisioning failed{binding?.lastError ? `: ${binding.lastError}` : ""}
+        </Alert>
+      )}
     </OverviewSectionCard>
   );
 };


### PR DESCRIPTION
## Purpose

AgentID provisioning could not be retried after reaching the `failed` state, leaving users blocked even after the identity provider recovered.

- Resolves : https://github.com/wso2/agent-manager/issues/1637

## Goals

- Allow failed AgentID provisioning to be retried for both external and platform-hosted agents.
- Provide a retry control in the Agent ID overview.
- Prevent duplicate retries.

## Approach

- Added `POST /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities/retry`.
- Atomically resets a failed binding to `pending`, clears its previous error and attempt count, and starts provisioning again.
- Returns `409 Conflict` when the binding is not failed.
- Added a retry button using existing console components and the `RefreshCw` icon.
- Added audit logging and updated the OpenAPI contract.

- UI Update
<img width="1916" height="992" alt="image" src="https://github.com/user-attachments/assets/1329665c-275e-4de3-9b6b-c31e586016c6" />


## User stories

- As a user, I can retry failed AgentID provisioning after the environment identity provider becomes available again.
- As a user, I can see the provisioning failure and retry it from the Agent ID overview.

## Release note

Added support for retrying failed AgentID provisioning for external and platform-hosted agents.

## Documentation

The API contract is documented in the updated OpenAPI specification. No separate product documentation changes are included.

## Training

N/A 

## Certification

N/A 

## Marketing

N/A

## Automation tests

- Unit tests
  - Updated audit action and repository mock coverage for the new retry operation.
- Integration tests
  - N/A — no new integration tests were added.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? Yes
- Ran FindSecurityBugs plugin and verified report? No
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

Local development environment.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a retry option for failed Agent ID provisioning.
  * Added a retry API endpoint and client support.
  * The agent overview now displays provisioning failures with the reason and a retry button.
  * Successful retries show an in-progress state while provisioning resumes.
* **Bug Fixes**
  * Failed provisioning can now be reset and rescheduled without manual intervention.
* **Documentation**
  * Documented the new retry endpoint, request format, responses, and error conditions.
* **Audit**
  * Added critical audit tracking for provisioning retry actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->