### PR TITLE
Fix shell quoting in generated Identity Provider commands

### DIFF
--- a/console/workspaces/pages/gateways/src/subComponents/ManageIdentityProviderDialog.tsx
+++ b/console/workspaces/pages/gateways/src/subComponents/ManageIdentityProviderDialog.tsx
@@ -47,15 +47,15 @@ import {
   useUpsertIdentityProvider,
 } from "@agent-management-platform/api-client";
 import {
-  getAgentManagerUrl,
-  getAmpVersionHelm,
-  getRawScriptUrl,
-} from "@agent-management-platform/shared-component";
-import {
   globalConfig,
   type GatewayEnvironmentResponse,
   type IdentityProvider,
 } from "@agent-management-platform/types";
+import {
+  getAgentManagerUrl,
+  getAmpVersionHelm,
+  getRawScriptUrl,
+} from "@agent-management-platform/shared-component";
 
 const SCRIPT_NAME = "manage-identity-provider.sh";
 const TOKEN_MASK = "•••••••••••••••";
@@ -81,7 +81,7 @@ interface ManageIdentityProviderDialogProps {
   } | null;
 }
 
-interface ScriptInputs {
+export interface ScriptInputs {
   orgId: string;
   envName: string;
   gatewayId: string;
@@ -89,11 +89,16 @@ interface ScriptInputs {
   issuer: string;
   jwksUri: string;
   skipTlsVerify: boolean;
-  mode: ManageIdentityProviderMode;
+  mode: "upsert" | "delete";
   token: string;
 }
 
-function buildScript(i: ScriptInputs): string {
+/** Quote a value as one POSIX shell word without evaluating metacharacters. */
+export function quoteShellWord(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+export function buildScript(i: ScriptInputs): string {
   // The dev-container quickstart and a real cluster both install the gateway
   // extension from the same OCI chart, so one command works for both: curl the
   // release-pinned script and upgrade the OCI chart at the deployed version.
@@ -101,19 +106,19 @@ function buildScript(i: ScriptInputs): string {
     i.mode === "delete"
       ? ["    ACTION=delete \\"]
       : [
-          `    IDP_ISSUER=${i.issuer || "<issuer>"} \\`,
-          `    IDP_JWKS_URI=${i.jwksUri || "<jwks-uri>"} \\`,
+          `    IDP_ISSUER=${quoteShellWord(i.issuer || "<issuer>")} \\`,
+          `    IDP_JWKS_URI=${quoteShellWord(i.jwksUri || "<jwks-uri>")} \\`,
           ...(i.skipTlsVerify ? ["    IDP_SKIP_TLS_VERIFY=true \\"] : []),
         ];
   const lines = [
-    `curl -fsSL ${getRawScriptUrl(SCRIPT_NAME)} \\`,
-    `  | ORG_NAME=${i.orgId || "<org>"} \\`,
-    `    ENV_NAME=${i.envName || "<env-name>"} \\`,
-    `    GATEWAY_ID=${i.gatewayId || "<gateway-id>"} \\`,
-    `    AGENT_MANAGER_TOKEN=${i.token} \\`,
-    `    AGENT_MANAGER_URL=${getAgentManagerUrl()} \\`,
-    `    CHART_VERSION=${getAmpVersionHelm()} \\`,
-    `    IDP_NAME=${i.name || "<identity-provider-name>"} \\`,
+    `curl -fsSL ${quoteShellWord(getRawScriptUrl(SCRIPT_NAME))} \\`,
+    `  | ORG_NAME=${quoteShellWord(i.orgId || "<org>")} \\`,
+    `    ENV_NAME=${quoteShellWord(i.envName || "<env-name>")} \\`,
+    `    GATEWAY_ID=${quoteShellWord(i.gatewayId || "<gateway-id>")} \\`,
+    `    AGENT_MANAGER_TOKEN=${quoteShellWord(i.token)} \\`,
+    `    AGENT_MANAGER_URL=${quoteShellWord(getAgentManagerUrl())} \\`,
+    `    CHART_VERSION=${quoteShellWord(getAmpVersionHelm())} \\`,
+    `    IDP_NAME=${quoteShellWord(i.name || "<identity-provider-name>")} \\`,
     ...actionEnvLines,
     "    bash",
   ];

--- a/console/workspaces/pages/gateways/src/subComponents/ManageIdentityProviderDialog.tsx
+++ b/console/workspaces/pages/gateways/src/subComponents/ManageIdentityProviderDialog.tsx
@@ -89,7 +89,7 @@ export interface ScriptInputs {
   issuer: string;
   jwksUri: string;
   skipTlsVerify: boolean;
-  mode: "upsert" | "delete";
+  mode: ManageIdentityProviderMode;
   token: string;
 }
 


### PR DESCRIPTION
## Purpose

The generated Identity Provider setup command failed when values such as `IDP_NAME` contained spaces or shell-special characters.
For example, `IDP_NAME=test auth0` caused the shell to interpret `auth0` as a separate command.

- Resolves : https://github.com/wso2/agent-manager/issues/1651

## Goals

Ensure generated Identity Provider setup commands work correctly and safely with spaces and shell-special characters.

## Approach

Added POSIX-compatible shell quoting to all dynamic values in the generated command, including:

- Identity Provider name
- Issuer and JWKS URI
- Organization and environment
- Gateway ID
- Agent Manager URL and token
- Chart version

The generated command now uses safely quoted values:

```bash
IDP_NAME='test auth0'
```
Embedded apostrophes and shell expressions such as `$()` are also handled safely.

## User stories

- As a user, I can create an Identity Provider with a name containing spaces.
- As a user, I can copy and run the generated setup command without manually correcting its values.

## Release note

N/A

## Documentation

N/A — fixes existing command-generation behavior without changing the documented workflow.

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

- Unit tests: none added
- Integration tests: N/A

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no
- Confirmed no keys, passwords, tokens, usernames, or other secrets committed: yes

## Samples

N/A

## Related PRs

N/A

## Migrations

N/A — no database or configuration migration required.

## Test environment

- Local development environment
- Gateway console package lint: passed
- TypeScript build: passed

## Learning
N/A