### PR TITLE
Fix browser autofill overriding input background in dark theme

### DIFF
--- a/console/apps/web-ui/src/index.css
+++ b/console/apps/web-ui/src/index.css
@@ -45,3 +45,45 @@ html[data-color-scheme="dark"] {
 .lucide:not(.lucide-logo) * {
   vector-effect: non-scaling-stroke;
 }
+
+/* Browser autofill background override.
+   WebKit/Blink paint an internal light-blue background (and dark text) on
+   autofilled fields with a UA !important rule that ordinary background-color
+   declarations cannot beat. An inset box-shadow is not part of that rule, so
+   it is the one way to repaint the field. Two stacked shadows reproduce the
+   real input surface: the translucent acrylic layer composited over the page
+   background, matching a non-autofilled input in both colour schemes. */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+textarea:-webkit-autofill:hover,
+textarea:-webkit-autofill:focus,
+textarea:-webkit-autofill:active,
+select:-webkit-autofill,
+select:-webkit-autofill:hover,
+select:-webkit-autofill:focus,
+select:-webkit-autofill:active {
+  -webkit-box-shadow:
+    0 0 0 1000px var(--oxygen-palette-background-acrylic) inset,
+    0 0 0 1000px var(--oxygen-palette-background-default) inset !important;
+  box-shadow:
+    0 0 0 1000px var(--oxygen-palette-background-acrylic) inset,
+    0 0 0 1000px var(--oxygen-palette-background-default) inset !important;
+  -webkit-text-fill-color: var(--oxygen-palette-text-primary) !important;
+  caret-color: var(--oxygen-palette-text-primary);
+  /* Chrome animates the autofill background in on focus; parking the
+     transition far in the future keeps the shadow from flashing blue. */
+  transition: background-color 5000s ease-in-out 0s;
+}
+
+/* Chrome also forces its own font onto the first line of an autofilled
+   field, which breaks the theme typography. */
+input:-webkit-autofill::first-line,
+textarea:-webkit-autofill::first-line,
+select:-webkit-autofill::first-line {
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+}

--- a/console/apps/web-ui/src/index.css
+++ b/console/apps/web-ui/src/index.css
@@ -46,13 +46,34 @@ html[data-color-scheme="dark"] {
   vector-effect: non-scaling-stroke;
 }
 
+/* Opaque stand-in for the translucent input surface, used only by the autofill
+   override below.
+
+   Blink paints the autofill background as its own layer, so it cannot be made
+   transparent — neither `background-color` nor `background-clip: text` removes
+   it, and an inset box-shadow is the only thing that covers it. That forces an
+   opaque colour, but the real surface is not opaque: background.acrylic (25%
+   alpha) over a Card over a page gradient that shifts warm near the top-left.
+   These two values approximate that surface mid-page. They are the only thing
+   to retune if the theme's palette or body gradient changes.
+
+   To resample after a theme change, autofill a field and run in DevTools:
+     getComputedStyle(document.querySelector('.MuiOutlinedInput-root')).backgroundColor
+   composited over its parent, or just eyedrop a non-autofilled input. */
+:root {
+  --am-autofill-surface: #f7f6f5;
+}
+
+html[data-color-scheme="dark"] {
+  --am-autofill-surface: #26211f;
+}
+
 /* Browser autofill background override.
    WebKit/Blink paint an internal light-blue background (and dark text) on
    autofilled fields with a UA !important rule that ordinary background-color
-   declarations cannot beat. An inset box-shadow is not part of that rule, so
-   it is the one way to repaint the field. Two stacked shadows reproduce the
-   real input surface: the translucent acrylic layer composited over the page
-   background, matching a non-autofilled input in both colour schemes. */
+   declarations cannot beat. The inset box-shadow is not part of that rule, so
+   it is the one way to repaint the field. Text and caret still come from the
+   theme, so only the surface is an approximation. */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
@@ -65,16 +86,12 @@ select:-webkit-autofill,
 select:-webkit-autofill:hover,
 select:-webkit-autofill:focus,
 select:-webkit-autofill:active {
-  -webkit-box-shadow:
-    0 0 0 1000px var(--oxygen-palette-background-acrylic) inset,
-    0 0 0 1000px var(--oxygen-palette-background-default) inset !important;
-  box-shadow:
-    0 0 0 1000px var(--oxygen-palette-background-acrylic) inset,
-    0 0 0 1000px var(--oxygen-palette-background-default) inset !important;
+  -webkit-box-shadow: 0 0 0 1000px var(--am-autofill-surface) inset !important;
+  box-shadow: 0 0 0 1000px var(--am-autofill-surface) inset !important;
   -webkit-text-fill-color: var(--oxygen-palette-text-primary) !important;
   caret-color: var(--oxygen-palette-text-primary);
   /* Chrome animates the autofill background in on focus; parking the
-     transition far in the future keeps the shadow from flashing blue. */
+     transition far in the future keeps it from flashing blue. */
   transition: background-color 5000s ease-in-out 0s;
 }
 

--- a/console/apps/web-ui/src/index.css
+++ b/console/apps/web-ui/src/index.css
@@ -1,5 +1,6 @@
 /* CSS Reset for proper viewport handling */
-html, body {
+html,
+body {
   margin: 0;
   padding: 0;
   height: 100%;
@@ -10,7 +11,9 @@ html {
   box-sizing: border-box;
 }
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: inherit;
 }
 
@@ -46,20 +49,6 @@ html[data-color-scheme="dark"] {
   vector-effect: non-scaling-stroke;
 }
 
-/* Opaque stand-in for the translucent input surface, used only by the autofill
-   override below.
-
-   Blink paints the autofill background as its own layer, so it cannot be made
-   transparent — neither `background-color` nor `background-clip: text` removes
-   it, and an inset box-shadow is the only thing that covers it. That forces an
-   opaque colour, but the real surface is not opaque: background.acrylic (25%
-   alpha) over a Card over a page gradient that shifts warm near the top-left.
-   These two values approximate that surface mid-page. They are the only thing
-   to retune if the theme's palette or body gradient changes.
-
-   To resample after a theme change, autofill a field and run in DevTools:
-     getComputedStyle(document.querySelector('.MuiOutlinedInput-root')).backgroundColor
-   composited over its parent, or just eyedrop a non-autofilled input. */
 :root {
   --am-autofill-surface: #f7f6f5;
 }
@@ -68,12 +57,6 @@ html[data-color-scheme="dark"] {
   --am-autofill-surface: #26211f;
 }
 
-/* Browser autofill background override.
-   WebKit/Blink paint an internal light-blue background (and dark text) on
-   autofilled fields with a UA !important rule that ordinary background-color
-   declarations cannot beat. The inset box-shadow is not part of that rule, so
-   it is the one way to repaint the field. Text and caret still come from the
-   theme, so only the surface is an approximation. */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,


### PR DESCRIPTION
## Purpose
Autofilled inputs render with the browser's blue background and dark text instead of the theme surface. 

Resolves #1616

## Goals
Autofilled fields match the surrounding input styling in both dark and light themes.

## Approach
Browsers force their own default background color on autofilled fields and ignore standard styling rules. Fixed this in index.css by covering the input with a matching shadow layer so it seamlessly keeps the dark theme's background and text colors.

https://github.com/user-attachments/assets/b70f123d-c242-4737-ae98-e57d57f088f8

https://github.com/user-attachments/assets/6fd8c7b3-053c-4d7f-91ef-cdafb124e9e7

## User stories
As a user filling the Agent Creation form, I want autofilled fields to look like the rest of the form.

## Release note
Fixed browser autofill applying a light background to input fields in dark theme.

## Documentation
N/A 

## Training
N/A

## Certification
N/A 

## Marketing
N/A

## Automation tests
 - Unit tests
   > None.
 - Integration tests
   > None

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? N/A 
 - Confirmed no keys/passwords/tokens/secrets committed? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
dev build

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved autofill appearance to match light and dark themes.
  * Preserved themed text, caret colors, and typography in autofilled fields.
  * Reduced unwanted browser autofill background animations.
  * Reformatted CSS reset selectors for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->