### PR TITLE
Allow MCP proxy scopes to exist with no tool bindings

### DIFF
--- a/agent-manager-service/controllers/mcp_proxy_scope_controller_unit_test.go
+++ b/agent-manager-service/controllers/mcp_proxy_scope_controller_unit_test.go
@@ -46,23 +46,13 @@ func (noopScopeRedeployer) RedeployMCPProxy(context.Context, *models.MCPProxy, s
 // scopeUpdateTestController wires the real scope service behind the controller so
 // the tests below exercise the whole decode -> validate -> persist path, which is
 // where the nil-vs-empty distinction for "tools" lives.
-func scopeUpdateTestController(
-	scopeRepo *repomocks.MCPProxyScopeRepositoryMock,
-	tools ...string,
-) MCPProxyScopeController {
-	toolMaps := make([]map[string]interface{}, 0, len(tools))
-	for _, tl := range tools {
-		toolMaps = append(toolMaps, map[string]interface{}{"name": tl})
-	}
+func scopeUpdateTestController(scopeRepo *repomocks.MCPProxyScopeRepositoryMock) MCPProxyScopeController {
 	proxy := &models.MCPProxy{
 		UUID:     uuid.New(),
 		Artifact: &models.Artifact{Handle: "t4-deepwiki"},
 		Endpoints: []models.MCPProxyEndpoint{{
 			UUID:   uuid.New(),
 			Handle: "primary",
-			Configuration: models.MCPEndpointConfig{
-				Capabilities: &models.MCPProxyCapabilities{Tools: &toolMaps},
-			},
 		}},
 	}
 	proxyRepo := &repomocks.MCPProxyRepositoryMock{
@@ -96,7 +86,7 @@ func TestUpdateMCPProxyScope_EmptyToolsClearsBindings(t *testing.T) {
 		},
 		UpdateFunc: func(_ context.Context, s *models.MCPProxyScope) error { persisted = s; return nil },
 	}
-	ctrl := scopeUpdateTestController(scopeRepo, "ask_question")
+	ctrl := scopeUpdateTestController(scopeRepo)
 
 	w := httptest.NewRecorder()
 	ctrl.UpdateMCPProxyScope(w, updateScopeRequest(t, `{"tools":[]}`))
@@ -119,7 +109,7 @@ func TestUpdateMCPProxyScope_OmittedToolsKeepsBindings(t *testing.T) {
 		},
 		UpdateFunc: func(_ context.Context, s *models.MCPProxyScope) error { persisted = s; return nil },
 	}
-	ctrl := scopeUpdateTestController(scopeRepo, "ask_question")
+	ctrl := scopeUpdateTestController(scopeRepo)
 
 	w := httptest.NewRecorder()
 	ctrl.UpdateMCPProxyScope(w, updateScopeRequest(t, `{"description":"write access"}`))

--- a/agent-manager-service/controllers/mcp_proxy_scope_controller_unit_test.go
+++ b/agent-manager-service/controllers/mcp_proxy_scope_controller_unit_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controllers
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/middleware"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// noopScopeRedeployer stands in for the gateway re-emission the scope service
+// performs after every write; these tests only assert the HTTP contract.
+type noopScopeRedeployer struct{}
+
+func (noopScopeRedeployer) RedeployMCPProxy(context.Context, *models.MCPProxy, string) error {
+	return nil
+}
+
+// scopeUpdateTestController wires the real scope service behind the controller so
+// the tests below exercise the whole decode -> validate -> persist path, which is
+// where the nil-vs-empty distinction for "tools" lives.
+func scopeUpdateTestController(
+	scopeRepo *repomocks.MCPProxyScopeRepositoryMock,
+	tools ...string,
+) MCPProxyScopeController {
+	toolMaps := make([]map[string]interface{}, 0, len(tools))
+	for _, tl := range tools {
+		toolMaps = append(toolMaps, map[string]interface{}{"name": tl})
+	}
+	proxy := &models.MCPProxy{
+		UUID:     uuid.New(),
+		Artifact: &models.Artifact{Handle: "t4-deepwiki"},
+		Endpoints: []models.MCPProxyEndpoint{{
+			UUID:   uuid.New(),
+			Handle: "primary",
+			Configuration: models.MCPEndpointConfig{
+				Capabilities: &models.MCPProxyCapabilities{Tools: &toolMaps},
+			},
+		}},
+	}
+	proxyRepo := &repomocks.MCPProxyRepositoryMock{
+		GetByHandleFunc: func(_ context.Context, _, _ string) (*models.MCPProxy, error) {
+			return proxy, nil
+		},
+	}
+	svc := services.NewMCPProxyScopeService(scopeRepo, proxyRepo, nil, nil, noopScopeRedeployer{}, slog.Default())
+	return NewMCPProxyScopeController(svc)
+}
+
+func updateScopeRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut,
+		"/orgs/default/mcp-proxies/t4-deepwiki/scopes/write-only", strings.NewReader(body))
+	req.SetPathValue(utils.PathParamOrgName, "default")
+	req.SetPathValue(utils.PathParamProxyId, "t4-deepwiki")
+	req.SetPathValue(utils.PathParamScopeAction, "write-only")
+	return req.WithContext(middleware.WithResolvedOrg(req.Context(), middleware.ResolvedOrg{OUID: "ou-org"}))
+}
+
+// Regression for the reported 400 on unbinding a scope's last tool: PUT
+// {"tools":[]} must succeed and persist an empty list.
+func TestUpdateMCPProxyScope_EmptyToolsClearsBindings(t *testing.T) {
+	var persisted *models.MCPProxyScope
+	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
+		GetFunc: func(_ context.Context, proxyUUID uuid.UUID, action string) (*models.MCPProxyScope, error) {
+			return &models.MCPProxyScope{
+				MCPProxyUUID: proxyUUID, Action: action, Tools: []string{"ask_question"},
+			}, nil
+		},
+		UpdateFunc: func(_ context.Context, s *models.MCPProxyScope) error { persisted = s; return nil },
+	}
+	ctrl := scopeUpdateTestController(scopeRepo, "ask_question")
+
+	w := httptest.NewRecorder()
+	ctrl.UpdateMCPProxyScope(w, updateScopeRequest(t, `{"tools":[]}`))
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"tools":[]`)
+	require.NotNil(t, persisted)
+	assert.Empty(t, persisted.Tools)
+}
+
+// A description-only PUT omits "tools" entirely, which must leave the existing
+// bindings alone rather than clearing them now that empty is a legal value.
+func TestUpdateMCPProxyScope_OmittedToolsKeepsBindings(t *testing.T) {
+	var persisted *models.MCPProxyScope
+	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
+		GetFunc: func(_ context.Context, proxyUUID uuid.UUID, action string) (*models.MCPProxyScope, error) {
+			return &models.MCPProxyScope{
+				MCPProxyUUID: proxyUUID, Action: action, Tools: []string{"ask_question"},
+			}, nil
+		},
+		UpdateFunc: func(_ context.Context, s *models.MCPProxyScope) error { persisted = s; return nil },
+	}
+	ctrl := scopeUpdateTestController(scopeRepo, "ask_question")
+
+	w := httptest.NewRecorder()
+	ctrl.UpdateMCPProxyScope(w, updateScopeRequest(t, `{"description":"write access"}`))
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.NotNil(t, persisted)
+	assert.Equal(t, []string{"ask_question"}, persisted.Tools)
+	assert.Equal(t, "write access", persisted.Description)
+}

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -10986,7 +10986,7 @@ components:
   schemas:
     MCPProxyScopeRequest:
       type: object
-      required: [action, tools]
+      required: [action]
       properties:
         action:
           type: string
@@ -10998,10 +10998,12 @@ components:
           example: Read access to repository tools
         tools:
           type: array
-          minItems: 1
           items:
             type: string
-          description: MCP tool names this scope authorizes.
+          description: >-
+            MCP tool names this scope authorizes. May be omitted or empty to declare a
+            scope before binding it to any tool; such a scope is grantable to roles but
+            enforced on no tool.
     MCPProxyScopeUpdateRequest:
       type: object
       properties:
@@ -11009,9 +11011,11 @@ components:
           type: string
         tools:
           type: array
-          minItems: 1
           items:
             type: string
+          description: >-
+            Replaces the scope's tool list. Omit to leave it unchanged; send an empty
+            array to unbind the scope from every tool.
     MCPProxyScopeResponse:
       type: object
       required: [action, scope, tools]

--- a/agent-manager-service/services/mcp_proxy_deployment_test.go
+++ b/agent-manager-service/services/mcp_proxy_deployment_test.go
@@ -741,8 +741,7 @@ func TestGenerateMCPProxyDeploymentYAML_UpstreamURLPassthrough(t *testing.T) {
 // policy emission: mcp-auth (pinned issuer, no requiredScopes — jwt-auth would enforce
 // all of them) plus one mcp-authz rule per tool, inverted from the proxy's scope->tools rows.
 func TestAppendMCPIdentityAuthPolicies_InvertsScopesToPerToolRules(t *testing.T) {
-	on := true
-	sec := &models.SecurityConfig{Enabled: &on, Identity: &models.IdentitySecurity{Enabled: &on}}
+	sec := identityEnabledSecurity()
 	scopes := []models.MCPProxyScope{
 		{Action: "read", Tools: []string{"get_repo", "list_repos"}},
 		{Action: "admin", Tools: []string{"delete_repo", "get_repo"}},
@@ -766,9 +765,7 @@ func TestAppendMCPIdentityAuthPolicies_InvertsScopesToPerToolRules(t *testing.T)
 }
 
 func TestAppendMCPIdentityAuthPolicies_NoScopesEmitsAuthOnly(t *testing.T) {
-	on := true
-	sec := &models.SecurityConfig{Enabled: &on, Identity: &models.IdentitySecurity{Enabled: &on}}
-	out := appendMCPIdentityAuthPolicies(nil, sec, "gh-proxy", nil)
+	out := appendMCPIdentityAuthPolicies(nil, identityEnabledSecurity(), "gh-proxy", nil)
 	assert.Len(t, out, 1)
 	assert.Equal(t, "mcp-auth", out[0].Name)
 	_, hasScopes := out[0].Params["requiredScopes"]
@@ -825,9 +822,7 @@ func TestMCPProxyEnvArtifactHandleDistinguishesEndpoints(t *testing.T) {
 // scope, mcp-authz is omitted entirely and the endpoint degrades to
 // authenticated-only rather than emitting an empty rule set.
 func TestAppendMCPIdentityAuthPolicies_ScopeWithNoToolsEmitsAuthOnly(t *testing.T) {
-	on := true
-	sec := &models.SecurityConfig{Enabled: &on, Identity: &models.IdentitySecurity{Enabled: &on}}
-	out := appendMCPIdentityAuthPolicies(nil, sec, "gh-proxy", []models.MCPProxyScope{
+	out := appendMCPIdentityAuthPolicies(nil, identityEnabledSecurity(), "gh-proxy", []models.MCPProxyScope{
 		{Action: "read", Tools: []string{}},
 	})
 	assert.Len(t, out, 1)

--- a/agent-manager-service/services/mcp_proxy_deployment_test.go
+++ b/agent-manager-service/services/mcp_proxy_deployment_test.go
@@ -820,3 +820,16 @@ func TestMCPProxyEnvArtifactHandleDistinguishesEndpoints(t *testing.T) {
 		t.Fatalf("expected distinct handles for different endpoints in the same environment")
 	}
 }
+
+// A scope bound to no tools contributes no mcp-authz rule; when it is the only
+// scope, mcp-authz is omitted entirely and the endpoint degrades to
+// authenticated-only rather than emitting an empty rule set.
+func TestAppendMCPIdentityAuthPolicies_ScopeWithNoToolsEmitsAuthOnly(t *testing.T) {
+	on := true
+	sec := &models.SecurityConfig{Enabled: &on, Identity: &models.IdentitySecurity{Enabled: &on}}
+	out := appendMCPIdentityAuthPolicies(nil, sec, "gh-proxy", []models.MCPProxyScope{
+		{Action: "read", Tools: []string{}},
+	})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "mcp-auth", out[0].Name)
+}

--- a/agent-manager-service/services/mcp_proxy_scope_service.go
+++ b/agent-manager-service/services/mcp_proxy_scope_service.go
@@ -126,13 +126,13 @@ func proxyToolUnion(proxy *models.MCPProxy) map[string]struct{} {
 	return union
 }
 
-// validateScopeTools normalizes a scope's tool list: trimmed, de-duplicated,
-// sorted, and — when the proxy's capabilities are known — restricted to tools it
-// actually discovered. An empty list is legal and yields an empty (never nil)
-// slice: a scope bound to no tools is a declared-but-unbound catalog entry,
-// still grantable to a role and still projected into Thunder on that grant, but
-// enforced on nothing (appendMCPIdentityAuthPolicies emits no rule for it).
-// Non-nil matters — tools is a jsonb column, and nil would persist as null.
+// validateScopeTools normalizes a scope's tool list and, when the proxy's
+// capabilities are known, restricts it to tools the proxy actually discovered.
+// An empty list is legal and yields an empty (never nil) slice: a scope bound to
+// no tools is a declared-but-unbound catalog entry, grantable to a role but
+// enforced on nothing — see
+// TestAppendMCPIdentityAuthPolicies_ScopeWithNoToolsEmitsAuthOnly. Non-nil
+// matters — tools is a jsonb column, and nil would persist as null.
 func validateScopeTools(tools []string, union map[string]struct{}) ([]string, error) {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(tools))

--- a/agent-manager-service/services/mcp_proxy_scope_service.go
+++ b/agent-manager-service/services/mcp_proxy_scope_service.go
@@ -126,10 +126,14 @@ func proxyToolUnion(proxy *models.MCPProxy) map[string]struct{} {
 	return union
 }
 
+// validateScopeTools normalizes a scope's tool list: trimmed, de-duplicated,
+// sorted, and — when the proxy's capabilities are known — restricted to tools it
+// actually discovered. An empty list is legal and yields an empty (never nil)
+// slice: a scope bound to no tools is a declared-but-unbound catalog entry,
+// still grantable to a role and still projected into Thunder on that grant, but
+// enforced on nothing (appendMCPIdentityAuthPolicies emits no rule for it).
+// Non-nil matters — tools is a jsonb column, and nil would persist as null.
 func validateScopeTools(tools []string, union map[string]struct{}) ([]string, error) {
-	if len(tools) == 0 {
-		return nil, fmt.Errorf("%w: a scope must authorize at least one tool", utils.ErrInvalidInput)
-	}
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(tools))
 	for _, tl := range tools {

--- a/agent-manager-service/services/mcp_proxy_scope_service_unit_test.go
+++ b/agent-manager-service/services/mcp_proxy_scope_service_unit_test.go
@@ -427,3 +427,67 @@ func TestListEnvironmentScopes_IncludesUndeployedIdentityProxies(t *testing.T) {
 		{Scope: "idle:read", Description: "d", MCPProxyID: "idle", MCPProxyName: "Idle"},
 	}, entries)
 }
+
+// A scope with no tools is a declared-but-unbound catalog entry: still grantable
+// to a role (and still projected into Thunder on that grant), but enforced on no
+// tool. Clearing the last tool must therefore persist as an empty list rather
+// than being rejected — see validateScopeTools.
+func TestMCPProxyScopeUpdate_ClearingAllToolsIsAllowed(t *testing.T) {
+	proxy := scopeTestProxy("gh-proxy", "list_repos")
+	var updated *models.MCPProxyScope
+	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
+		GetFunc: func(_ context.Context, _ uuid.UUID, action string) (*models.MCPProxyScope, error) {
+			return &models.MCPProxyScope{Action: action, Tools: []string{"list_repos"}}, nil
+		},
+		UpdateFunc: func(_ context.Context, s *models.MCPProxyScope) error { updated = s; return nil },
+	}
+	redeployer := &recordingRedeployer{}
+	svc := newScopeSvcForTestWithRedeployer(scopeRepo, proxy, redeployer)
+
+	res, err := svc.Update(context.Background(), "org-uuid", "org", "gh-proxy", "read",
+		models.MCPProxyScopeUpdateInput{Tools: []string{}})
+
+	assert.NoError(t, err)
+	// Empty, not nil: the jsonb column must hold [] rather than null.
+	assert.NotNil(t, updated.Tools)
+	assert.Empty(t, updated.Tools)
+	assert.Empty(t, res.Scope.Tools)
+	assert.Len(t, redeployer.calls, 1, "clearing tools must still re-emit the gateway policies")
+}
+
+// nil Tools means "leave unchanged" (models.MCPProxyScopeUpdateInput), so a
+// description-only PUT must not clear the tool list now that empty is legal.
+func TestMCPProxyScopeUpdate_OmittedToolsLeavesToolsUnchanged(t *testing.T) {
+	var updated *models.MCPProxyScope
+	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
+		GetFunc: func(_ context.Context, _ uuid.UUID, action string) (*models.MCPProxyScope, error) {
+			return &models.MCPProxyScope{Action: action, Tools: []string{"list_repos"}}, nil
+		},
+		UpdateFunc: func(_ context.Context, s *models.MCPProxyScope) error { updated = s; return nil },
+	}
+	svc := newScopeSvcForTest(scopeRepo, scopeTestProxy("gh-proxy", "list_repos"))
+
+	desc := "updated"
+	_, err := svc.Update(context.Background(), "org-uuid", "org", "gh-proxy", "read",
+		models.MCPProxyScopeUpdateInput{Description: &desc})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"list_repos"}, updated.Tools)
+}
+
+// A scope can be declared before any tool is wired to it.
+func TestMCPProxyScopeCreate_AllowsScopeWithNoTools(t *testing.T) {
+	var created *models.MCPProxyScope
+	scopeRepo := &repomocks.MCPProxyScopeRepositoryMock{
+		CreateFunc: func(_ context.Context, s *models.MCPProxyScope) error { created = s; return nil },
+	}
+	svc := newScopeSvcForTest(scopeRepo, scopeTestProxy("gh-proxy", "list_repos"))
+
+	res, err := svc.Create(context.Background(), "org-uuid", "org", "gh-proxy",
+		models.MCPProxyScopeInput{Action: "read"})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, created.Tools)
+	assert.Empty(t, created.Tools)
+	assert.Equal(t, "read", res.Scope.Action)
+}

--- a/agent-manager-service/spec/model_mcp_proxy_scope_request.go
+++ b/agent-manager-service/spec/model_mcp_proxy_scope_request.go
@@ -22,18 +22,17 @@ type MCPProxyScopeRequest struct {
 	// Action name on the proxy's resource server; the token scope is \"<proxy-handle>:<action>\".
 	Action      string  `json:"action"`
 	Description *string `json:"description,omitempty"`
-	// MCP tool names this scope authorizes.
-	Tools []string `json:"tools"`
+	// MCP tool names this scope authorizes. May be omitted or empty to declare a scope before binding it to any tool; such a scope is grantable to roles but enforced on no tool.
+	Tools []string `json:"tools,omitempty"`
 }
 
 // NewMCPProxyScopeRequest instantiates a new MCPProxyScopeRequest object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMCPProxyScopeRequest(action string, tools []string) *MCPProxyScopeRequest {
+func NewMCPProxyScopeRequest(action string) *MCPProxyScopeRequest {
 	this := MCPProxyScopeRequest{}
 	this.Action = action
-	this.Tools = tools
 	return &this
 }
 
@@ -101,26 +100,34 @@ func (o *MCPProxyScopeRequest) SetDescription(v string) {
 	o.Description = &v
 }
 
-// GetTools returns the Tools field value
+// GetTools returns the Tools field value if set, zero value otherwise.
 func (o *MCPProxyScopeRequest) GetTools() []string {
-	if o == nil {
+	if o == nil || IsNil(o.Tools) {
 		var ret []string
 		return ret
 	}
-
 	return o.Tools
 }
 
-// GetToolsOk returns a tuple with the Tools field value
+// GetToolsOk returns a tuple with the Tools field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *MCPProxyScopeRequest) GetToolsOk() ([]string, bool) {
-	if o == nil {
+	if o == nil || IsNil(o.Tools) {
 		return nil, false
 	}
 	return o.Tools, true
 }
 
-// SetTools sets field value
+// HasTools returns a boolean if a field has been set.
+func (o *MCPProxyScopeRequest) HasTools() bool {
+	if o != nil && !IsNil(o.Tools) {
+		return true
+	}
+
+	return false
+}
+
+// SetTools gets a reference to the given []string and assigns it to the Tools field.
 func (o *MCPProxyScopeRequest) SetTools(v []string) {
 	o.Tools = v
 }
@@ -139,7 +146,9 @@ func (o MCPProxyScopeRequest) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Description) {
 		toSerialize["description"] = o.Description
 	}
-	toSerialize["tools"] = o.Tools
+	if !IsNil(o.Tools) {
+		toSerialize["tools"] = o.Tools
+	}
 	return toSerialize, nil
 }
 

--- a/agent-manager-service/spec/model_mcp_proxy_scope_update_request.go
+++ b/agent-manager-service/spec/model_mcp_proxy_scope_update_request.go
@@ -19,8 +19,9 @@ var _ MappedNullable = &MCPProxyScopeUpdateRequest{}
 
 // MCPProxyScopeUpdateRequest struct for MCPProxyScopeUpdateRequest
 type MCPProxyScopeUpdateRequest struct {
-	Description *string  `json:"description,omitempty"`
-	Tools       []string `json:"tools,omitempty"`
+	Description *string `json:"description,omitempty"`
+	// Replaces the scope's tool list. Omit to leave it unchanged; send an empty array to unbind the scope from every tool.
+	Tools []string `json:"tools,omitempty"`
 }
 
 // NewMCPProxyScopeUpdateRequest instantiates a new MCPProxyScopeUpdateRequest object

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -4031,8 +4031,8 @@ type MCPProxyScopeRequest struct {
 	Action      string  `json:"action"`
 	Description *string `json:"description,omitempty"`
 
-	// Tools MCP tool names this scope authorizes.
-	Tools []string `json:"tools"`
+	// Tools MCP tool names this scope authorizes. May be omitted or empty to declare a scope before binding it to any tool; such a scope is grantable to roles but enforced on no tool.
+	Tools *[]string `json:"tools,omitempty"`
 }
 
 // MCPProxyScopeResponse defines model for MCPProxyScopeResponse.
@@ -4049,8 +4049,10 @@ type MCPProxyScopeResponse struct {
 
 // MCPProxyScopeUpdateRequest defines model for MCPProxyScopeUpdateRequest.
 type MCPProxyScopeUpdateRequest struct {
-	Description *string   `json:"description,omitempty"`
-	Tools       *[]string `json:"tools,omitempty"`
+	Description *string `json:"description,omitempty"`
+
+	// Tools Replaces the scope's tool list. Omit to leave it unchanged; send an empty array to unbind the scope from every tool.
+	Tools *[]string `json:"tools,omitempty"`
 }
 
 // MCPServerInfoFetchRequest defines model for MCPServerInfoFetchRequest.

--- a/console/workspaces/libs/types/src/api/mcp-proxy-scopes.ts
+++ b/console/workspaces/libs/types/src/api/mcp-proxy-scopes.ts
@@ -25,7 +25,7 @@ import type { OrgPathParams } from './common';
 export interface MCPProxyScopeRequest {
   action: string;
   description?: string;
-  tools: string[];
+  tools?: string[];
 }
 
 export interface MCPProxyScopeUpdateRequest {

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/CreateScopeDrawer.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/CreateScopeDrawer.tsx
@@ -93,7 +93,7 @@ interface CreateScopeDrawerProps {
   proxyId: string;
   /** Environments the current endpoint is deployed to with identity security enabled. */
   environments: Environment[];
-  /** Tool identifiers discovered on the current endpoint — a scope must authorize at least one. */
+  /** Tool identifiers discovered on the current endpoint, offered as scope bindings. */
   tools: string[];
 }
 
@@ -107,7 +107,6 @@ export function CreateScopeDrawer({
 }: CreateScopeDrawerProps) {
   const [formData, setFormData] = useState<CreateScopeFormValues>(DEFAULT_FORM);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
-  const [toolsError, setToolsError] = useState<string | null>(null);
   // Keyed by `env.name` (not position in `environments`) so a reorder or
   // refetch of the environments list can't silently misapply a selection to
   // the wrong environment. Roles are picked one environment at a time rather
@@ -129,7 +128,6 @@ export function CreateScopeDrawer({
     if (!open) return;
     setFormData(DEFAULT_FORM);
     setSelectedTools([]);
-    setToolsError(null);
     setSelectedRolesByEnv({});
     setSubmitError(null);
     clearErrors();
@@ -185,12 +183,7 @@ export function CreateScopeDrawer({
     async (e: React.FormEvent) => {
       e.preventDefault();
       const formValid = validateForm(formData);
-      // A scope must authorize at least one tool — enforced server-side too,
-      // but checked here so the failure surfaces next to the field instead of
-      // as a raw error after a round trip.
-      const toolsValid = selectedTools.length > 0;
-      setToolsError(toolsValid ? null : "Select at least one tool");
-      if (!formValid || !toolsValid) return;
+      if (!formValid) return;
 
       setSubmitError(null);
       let created: MCPProxyScopeResponse;
@@ -262,8 +255,7 @@ export function CreateScopeDrawer({
   );
 
   const isSubmitting = createScope.isPending || isAssigningRoles;
-  const isValid =
-    !errors.name && formData.name.trim().length > 0 && selectedTools.length > 0;
+  const isValid = !errors.name && formData.name.trim().length > 0;
 
   return (
     <DrawerWrapper open={open} onClose={onClose}>
@@ -279,7 +271,9 @@ export function CreateScopeDrawer({
 
             <Typography variant="body2" color="text.secondary">
               A scope is a named permission callers must hold to invoke the
-              tools it&apos;s attached to. It must authorize at least one tool.
+              tools it&apos;s attached to. Leave the tools empty to declare the
+              scope now and bind it later — until then it is grantable to roles
+              but required by no tool.
             </Typography>
 
             <FormControl fullWidth error={Boolean(errors.name)}>
@@ -311,38 +305,26 @@ export function CreateScopeDrawer({
               />
             </FormControl>
 
-            <FormControl fullWidth error={Boolean(toolsError)}>
-              <FormLabel required>Tools</FormLabel>
+            <FormControl fullWidth>
+              <FormLabel>Tools</FormLabel>
               <Autocomplete
                 multiple
                 size="small"
                 disableCloseOnSelect
                 options={tools}
                 value={selectedTools}
-                onChange={(_e, value) => {
-                  setSelectedTools(value);
-                  if (value.length > 0) setToolsError(null);
-                }}
+                onChange={(_e, value) => setSelectedTools(value)}
                 renderTags={(value, getTagProps) =>
                   value.map((tool, index) => (
                     <Chip {...getTagProps({ index })} key={tool} label={tool} size="small" />
                   ))
                 }
                 renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    placeholder="Search tools..."
-                    error={Boolean(toolsError)}
-                  />
+                  <TextField {...params} placeholder="Search tools..." />
                 )}
                 noOptionsText="No tools discovered on this endpoint"
                 disabled={isSubmitting}
               />
-              {toolsError && (
-                <Typography variant="caption" color="error">
-                  {toolsError}
-                </Typography>
-              )}
             </FormControl>
 
             <Stack spacing={1.5}>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
@@ -183,6 +183,10 @@ export function MCPProxySecurityTab({
     severity: "success" | "error";
   } | null>(null);
   const [fieldErrors, setFieldErrors] = useState<{ keyValue?: string }>({});
+  // Covers the whole of handleSave, unlike the isUpdating prop, which only
+  // tracks the endpoint-config mutation and goes idle again while the
+  // scope-update loop below it is still running.
+  const [isSaving, setIsSaving] = useState(false);
   const [createScopeDrawerOpen, setCreateScopeDrawerOpen] = useState(false);
   const [authorizationTab, setAuthorizationTab] = useState<"tools" | "scopes">("tools");
   const { addConfirmation } = useConfirmationDialog();
@@ -350,6 +354,9 @@ export function MCPProxySecurityTab({
   );
 
   const isDirty = authIsDirty || toolScopesDirty;
+  // Gates every control a save touches, so no edit or second Save can land
+  // while updates are still in flight.
+  const saveInProgress = isUpdating || isSaving;
 
   const handleDiscard = useCallback(() => {
     if (!config) return;
@@ -377,6 +384,7 @@ export function MCPProxySecurityTab({
     }
     setFieldErrors({});
 
+    setIsSaving(true);
     try {
       await onUpdate({
         security: {
@@ -440,6 +448,8 @@ export function MCPProxySecurityTab({
         message: "Failed to update security.",
         severity: "error",
       });
+    } finally {
+      setIsSaving(false);
     }
   }, [
     config,
@@ -613,7 +623,7 @@ export function MCPProxySecurityTab({
                             multiple
                             size="small"
                             disableCloseOnSelect
-                            disabled={isDisabled || isUpdating}
+                            disabled={isDisabled || saveInProgress}
                             options={catalogScopes}
                             value={row.scopes}
                             onChange={(_e, value) =>
@@ -741,7 +751,10 @@ export function MCPProxySecurityTab({
       )}
 
       <Stack spacing={1.5} width="100%">
-        <Collapse in={!!status && !isDirty} timeout={300}>
+        {/* Success messages hide as soon as the user edits again, but errors
+            must not: a failed save leaves the rows it couldn't commit dirty,
+            which would otherwise swallow the only report of the failure. */}
+        <Collapse in={!!status && (status.severity === "error" || !isDirty)} timeout={300}>
           {status && (
             <Alert
               severity={status.severity}
@@ -756,16 +769,16 @@ export function MCPProxySecurityTab({
           <Button
             variant="outlined"
             onClick={handleDiscard}
-            disabled={!isDirty || isUpdating}
+            disabled={!isDirty || saveInProgress}
           >
             Discard
           </Button>
           <Button
             variant="contained"
             onClick={() => void handleSave()}
-            disabled={isUpdating || !isDirty}
+            disabled={saveInProgress || !isDirty}
           >
-            {isUpdating ? "Saving..." : "Save"}
+            {saveInProgress ? "Saving..." : "Save"}
           </Button>
         </Stack>
       </Stack>

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
@@ -15,7 +15,7 @@
  * under the License.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useDeleteMCPProxyScope,
   useListMCPProxyScopes,
@@ -80,16 +80,22 @@ type ToolScopeRow = {
   scopes: MCPProxyScopeResponse[];
 };
 
+// One scope's replacement tool list, as sent by Save.
+type ScopeToolUpdate = { action: string; tools: string[] };
+
 // Builds one row per discovered tool, seeded with whichever scopes reference it.
-// Pure and parameterized on the catalog so a partially applied Save can derive
-// the rows the server now holds, not only the ones it last returned.
+// `appliedUpdates` overrides a scope's tool list, so a Save that committed only
+// some of its updates can derive the rows the server now holds rather than the
+// ones it last returned.
 function toolScopeRowsFor(
   toolEntries: string[],
   scopes: MCPProxyScopeResponse[],
+  appliedUpdates: ScopeToolUpdate[] = [],
 ): ToolScopeRow[] {
+  const toolsByAction = new Map(appliedUpdates.map((u) => [u.action, u.tools]));
   const toolToScopes = new Map<string, MCPProxyScopeResponse[]>();
   for (const scope of scopes) {
-    for (const tool of scope.tools) {
+    for (const tool of toolsByAction.get(scope.action) ?? scope.tools) {
       const scopesForTool = toolToScopes.get(tool) ?? [];
       scopesForTool.push(scope);
       toolToScopes.set(tool, scopesForTool);
@@ -101,26 +107,13 @@ function toolScopeRowsFor(
   }));
 }
 
-// The catalog with `updates` applied — the server's state after a Save that
-// committed only some of its scope updates.
-function applyScopeToolUpdates(
-  scopes: MCPProxyScopeResponse[],
-  updates: { action: string; tools: string[] }[],
-): MCPProxyScopeResponse[] {
-  const toolsByAction = new Map(updates.map((u) => [u.action, u.tools]));
-  return scopes.map((scope) => {
-    const tools = toolsByAction.get(scope.action);
-    return tools ? { ...scope, tools } : scope;
-  });
-}
-
 // Compares rows by tool and scope-action set only — the identity that Save
 // actually writes, ignoring incidental churn in the scope objects themselves.
 const serializeToolScopeRows = (rows: ToolScopeRow[]) =>
   JSON.stringify(
     rows.map((row) => ({
       tool: row.tool,
-      scopes: [...row.scopes.map((s) => s.action)].sort(),
+      scopes: row.scopes.map((s) => s.action).sort(),
     })),
   );
 
@@ -134,7 +127,7 @@ const serializeToolScopeRows = (rows: ToolScopeRow[]) =>
 function computeScopeToolUpdates(
   rows: ToolScopeRow[],
   catalogScopes: MCPProxyScopeResponse[],
-): { action: string; tools: string[] }[] {
+): ScopeToolUpdate[] {
   const desired = new Map<string, Set<string>>(
     catalogScopes.map((s) => [s.action, new Set<string>()]),
   );
@@ -146,7 +139,7 @@ function computeScopeToolUpdates(
   const setsEqual = (a: Set<string>, b: Set<string>) =>
     a.size === b.size && [...a].every((v) => b.has(v));
 
-  const updates: { action: string; tools: string[] }[] = [];
+  const updates: ScopeToolUpdate[] = [];
   for (const scope of catalogScopes) {
     const desiredTools = desired.get(scope.action) ?? new Set<string>();
     if (!setsEqual(desiredTools, new Set(scope.tools))) {
@@ -271,10 +264,20 @@ export function MCPProxySecurityTab({
   // step. Starts empty and is seeded by the effects below once the tool
   // list and scope catalog are both available.
   const [toolScopeRows, setToolScopeRows] = useState<ToolScopeRow[]>([]);
-  // State rather than a ref: toolScopesDirty below is memoized, and a ref write
-  // wouldn't recompute it — leaving the tab pinned as dirty after a save, which
-  // in turn keeps the reseed effect from ever adopting the refetched catalog.
+  // Must be state, not a ref: toolScopesDirty is memoized on it and the reseed
+  // effect below is gated on toolScopesDirty, so a ref write would leave the tab
+  // pinned as dirty and never adopt the refetched catalog. (lastSavedAuthRef
+  // above can stay a ref: authIsDirty already re-derives from the config prop,
+  // which the same refetch replaces.)
   const [lastSavedToolScopeRows, setLastSavedToolScopeRows] = useState<ToolScopeRow[]>([]);
+
+  // Rows and their saved snapshot move together whenever the server's state
+  // changes, as opposed to a user edit, which moves the rows alone. Missing the
+  // paired write is what pinned the tab as dirty before.
+  const resetToolScopeRows = useCallback((rows: SetStateAction<ToolScopeRow[]>) => {
+    setToolScopeRows(rows);
+    setLastSavedToolScopeRows(rows);
+  }, []);
 
   const toolScopesDirty = useMemo(
     () =>
@@ -283,11 +286,8 @@ export function MCPProxySecurityTab({
     [toolScopeRows, lastSavedToolScopeRows],
   );
 
-  // Rows are a view built from the discovered tool list, not a separately
-  // stored binding: every known tool always has a row, seeded with whichever
-  // scopes already reference it (empty if none). Memoized since both reseed
-  // effects below would otherwise rebuild this from scratch on every render
-  // they fire in, even when neither toolEntries nor catalogScopes changed.
+  // Memoized since both reseed effects below would otherwise rebuild this from
+  // scratch on every render they fire in, even when neither input changed.
   const derivedToolScopeRows = useMemo<ToolScopeRow[]>(
     () => toolScopeRowsFor(toolEntries, catalogScopes),
     [toolEntries, catalogScopes],
@@ -296,12 +296,9 @@ export function MCPProxySecurityTab({
   // Switching endpoint tabs discards unsaved row edits, consistent with the
   // auth-fields effect above — even though scopes are shared across every
   // endpoint of the proxy, this tab's Save/Discard state is still per endpoint.
-  // Reads derivedToolScopeRows without depending on it — the effect below
-  // owns reseeding on scope-list changes, so this one only reacts to the tab switch.
   useEffect(() => {
     if (!selectedEndpointId) return;
-    setToolScopeRows(derivedToolScopeRows);
-    setLastSavedToolScopeRows(derivedToolScopeRows);
+    resetToolScopeRows(derivedToolScopeRows);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- handled by the effect below
   }, [selectedEndpointId]);
 
@@ -313,8 +310,7 @@ export function MCPProxySecurityTab({
   // changes catalogScopes.
   useEffect(() => {
     if (!selectedEndpointId || toolScopesDirty) return;
-    setToolScopeRows(derivedToolScopeRows);
-    setLastSavedToolScopeRows(derivedToolScopeRows);
+    resetToolScopeRows(derivedToolScopeRows);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- guard, not a trigger dep
   }, [catalogScopes]);
 
@@ -415,27 +411,22 @@ export function MCPProxySecurityTab({
         // Sequential rather than Promise.all: a rejection must not leave the
         // remaining updates in flight, and the committed prefix has to be
         // knowable so the snapshot below can record what the server holds.
-        const committed: { action: string; tools: string[] }[] = [];
+        let committedCount = 0;
         try {
           for (const u of updates) {
             await updateMCPProxyScope.mutateAsync({
               params: { orgName, proxyId, scopeAction: u.action },
               body: { tools: u.tools },
             });
-            committed.push(u);
+            committedCount += 1;
           }
         } finally {
-          // Snapshot server truth: the requested rows when every update landed,
-          // otherwise the catalog with only the committed ones applied. Keeping
-          // the pre-save snapshot instead would leave Discard restoring a state
-          // the server no longer has.
+          // Keeping the pre-save snapshot instead would leave Discard restoring
+          // a state the server no longer has.
           setLastSavedToolScopeRows(
-            committed.length === updates.length
+            committedCount === updates.length
               ? toolScopeRows
-              : toolScopeRowsFor(
-                  toolEntries,
-                  applyScopeToolUpdates(catalogScopes, committed),
-                ),
+              : toolScopeRowsFor(toolEntries, catalogScopes, updates.slice(0, committedCount)),
           );
         }
       }
@@ -490,16 +481,15 @@ export function MCPProxySecurityTab({
               ...row,
               scopes: row.scopes.filter((s) => s.action !== scope.action),
             }));
-          setToolScopeRows(dropDeletedScope);
-          setLastSavedToolScopeRows(dropDeletedScope);
+          resetToolScopeRows(dropDeletedScope);
         },
       });
     },
-    [orgName, proxyId, addConfirmation, deleteMCPProxyScope],
+    [orgName, proxyId, addConfirmation, deleteMCPProxyScope, resetToolScopeRows],
   );
 
   const isDisabled = isLoading || !config;
-  const noToolsForRbac = !isLoading && !!config && toolEntries.length === 0;
+  const hasNoDiscoveredTools = !isLoading && !!config && toolEntries.length === 0;
 
   if (isLoading) {
     return (
@@ -579,7 +569,7 @@ export function MCPProxySecurityTab({
           </Tabs>
 
           {authorizationTab === "tools" &&
-            (noToolsForRbac ? (
+            (hasNoDiscoveredTools ? (
               <ListingTable.Container>
                 <ListingTable.EmptyState
                   illustration={<ShieldX size={64} />}

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
@@ -80,12 +80,57 @@ type ToolScopeRow = {
   scopes: MCPProxyScopeResponse[];
 };
 
+// Builds one row per discovered tool, seeded with whichever scopes reference it.
+// Pure and parameterized on the catalog so a partially applied Save can derive
+// the rows the server now holds, not only the ones it last returned.
+function toolScopeRowsFor(
+  toolEntries: string[],
+  scopes: MCPProxyScopeResponse[],
+): ToolScopeRow[] {
+  const toolToScopes = new Map<string, MCPProxyScopeResponse[]>();
+  for (const scope of scopes) {
+    for (const tool of scope.tools) {
+      const scopesForTool = toolToScopes.get(tool) ?? [];
+      scopesForTool.push(scope);
+      toolToScopes.set(tool, scopesForTool);
+    }
+  }
+  return toolEntries.map((tool) => ({
+    tool,
+    scopes: toolToScopes.get(tool) ?? [],
+  }));
+}
+
+// The catalog with `updates` applied — the server's state after a Save that
+// committed only some of its scope updates.
+function applyScopeToolUpdates(
+  scopes: MCPProxyScopeResponse[],
+  updates: { action: string; tools: string[] }[],
+): MCPProxyScopeResponse[] {
+  const toolsByAction = new Map(updates.map((u) => [u.action, u.tools]));
+  return scopes.map((scope) => {
+    const tools = toolsByAction.get(scope.action);
+    return tools ? { ...scope, tools } : scope;
+  });
+}
+
+// Compares rows by tool and scope-action set only — the identity that Save
+// actually writes, ignoring incidental churn in the scope objects themselves.
+const serializeToolScopeRows = (rows: ToolScopeRow[]) =>
+  JSON.stringify(
+    rows.map((row) => ({
+      tool: row.tool,
+      scopes: [...row.scopes.map((s) => s.action)].sort(),
+    })),
+  );
+
 // Diffs the desired (action -> tools) mapping built from the current rows
 // against the last-fetched scope list, producing only the tool-list updates
 // needed to bring the server in sync. Scopes themselves are created via the
 // Create Scope panel and deleted explicitly from the scopes list below — a
 // scope ending up with zero tools here is still a valid, saved state, not a
-// signal to delete it.
+// signal to delete it, and the server accepts the empty list (see
+// validateScopeTools in mcp_proxy_scope_service.go).
 function computeScopeToolUpdates(
   rows: ToolScopeRow[],
   catalogScopes: MCPProxyScopeResponse[],
@@ -226,42 +271,27 @@ export function MCPProxySecurityTab({
   // step. Starts empty and is seeded by the effects below once the tool
   // list and scope catalog are both available.
   const [toolScopeRows, setToolScopeRows] = useState<ToolScopeRow[]>([]);
-  const lastSavedToolScopeRowsRef = useRef<ToolScopeRow[]>([]);
+  // State rather than a ref: toolScopesDirty below is memoized, and a ref write
+  // wouldn't recompute it — leaving the tab pinned as dirty after a save, which
+  // in turn keeps the reseed effect from ever adopting the refetched catalog.
+  const [lastSavedToolScopeRows, setLastSavedToolScopeRows] = useState<ToolScopeRow[]>([]);
 
-  const serializeToolScopeRows = (rows: ToolScopeRow[]) =>
-    JSON.stringify(
-      rows.map((row) => ({
-        tool: row.tool,
-        scopes: [...row.scopes.map((s) => s.action)].sort(),
-      })),
-    );
-
-  const toolScopesDirty = useMemo(() => {
-    return (
+  const toolScopesDirty = useMemo(
+    () =>
       serializeToolScopeRows(toolScopeRows) !==
-      serializeToolScopeRows(lastSavedToolScopeRowsRef.current)
-    );
-  }, [toolScopeRows]);
+      serializeToolScopeRows(lastSavedToolScopeRows),
+    [toolScopeRows, lastSavedToolScopeRows],
+  );
 
   // Rows are a view built from the discovered tool list, not a separately
   // stored binding: every known tool always has a row, seeded with whichever
   // scopes already reference it (empty if none). Memoized since both reseed
   // effects below would otherwise rebuild this from scratch on every render
   // they fire in, even when neither toolEntries nor catalogScopes changed.
-  const derivedToolScopeRows = useMemo<ToolScopeRow[]>(() => {
-    const toolToScopes = new Map<string, MCPProxyScopeResponse[]>();
-    for (const scope of catalogScopes) {
-      for (const tool of scope.tools) {
-        const scopesForTool = toolToScopes.get(tool) ?? [];
-        scopesForTool.push(scope);
-        toolToScopes.set(tool, scopesForTool);
-      }
-    }
-    return toolEntries.map((tool) => ({
-      tool,
-      scopes: toolToScopes.get(tool) ?? [],
-    }));
-  }, [toolEntries, catalogScopes]);
+  const derivedToolScopeRows = useMemo<ToolScopeRow[]>(
+    () => toolScopeRowsFor(toolEntries, catalogScopes),
+    [toolEntries, catalogScopes],
+  );
 
   // Switching endpoint tabs discards unsaved row edits, consistent with the
   // auth-fields effect above — even though scopes are shared across every
@@ -271,7 +301,7 @@ export function MCPProxySecurityTab({
   useEffect(() => {
     if (!selectedEndpointId) return;
     setToolScopeRows(derivedToolScopeRows);
-    lastSavedToolScopeRowsRef.current = derivedToolScopeRows;
+    setLastSavedToolScopeRows(derivedToolScopeRows);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- handled by the effect below
   }, [selectedEndpointId]);
 
@@ -284,7 +314,7 @@ export function MCPProxySecurityTab({
   useEffect(() => {
     if (!selectedEndpointId || toolScopesDirty) return;
     setToolScopeRows(derivedToolScopeRows);
-    lastSavedToolScopeRowsRef.current = derivedToolScopeRows;
+    setLastSavedToolScopeRows(derivedToolScopeRows);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- guard, not a trigger dep
   }, [catalogScopes]);
 
@@ -337,8 +367,8 @@ export function MCPProxySecurityTab({
     setFieldErrors({});
     setStatus(null);
 
-    setToolScopeRows(lastSavedToolScopeRowsRef.current);
-  }, [config]);
+    setToolScopeRows(lastSavedToolScopeRows);
+  }, [config, lastSavedToolScopeRows]);
 
   const handleSave = useCallback(async () => {
     if (!config) return;
@@ -382,16 +412,32 @@ export function MCPProxySecurityTab({
       if (authenticationType === "identity" && toolScopesDirty && orgName && proxyId) {
         const updates = computeScopeToolUpdates(toolScopeRows, catalogScopes);
 
-        await Promise.all(
-          updates.map((u) =>
-            updateMCPProxyScope.mutateAsync({
+        // Sequential rather than Promise.all: a rejection must not leave the
+        // remaining updates in flight, and the committed prefix has to be
+        // knowable so the snapshot below can record what the server holds.
+        const committed: { action: string; tools: string[] }[] = [];
+        try {
+          for (const u of updates) {
+            await updateMCPProxyScope.mutateAsync({
               params: { orgName, proxyId, scopeAction: u.action },
               body: { tools: u.tools },
-            }),
-          ),
-        );
-
-        lastSavedToolScopeRowsRef.current = toolScopeRows;
+            });
+            committed.push(u);
+          }
+        } finally {
+          // Snapshot server truth: the requested rows when every update landed,
+          // otherwise the catalog with only the committed ones applied. Keeping
+          // the pre-save snapshot instead would leave Discard restoring a state
+          // the server no longer has.
+          setLastSavedToolScopeRows(
+            committed.length === updates.length
+              ? toolScopeRows
+              : toolScopeRowsFor(
+                  toolEntries,
+                  applyScopeToolUpdates(catalogScopes, committed),
+                ),
+          );
+        }
       }
 
       setStatus({
@@ -412,6 +458,7 @@ export function MCPProxySecurityTab({
     toolScopeRows,
     toolScopesDirty,
     catalogScopes,
+    toolEntries,
     orgName,
     proxyId,
     onUpdate,
@@ -444,9 +491,7 @@ export function MCPProxySecurityTab({
               scopes: row.scopes.filter((s) => s.action !== scope.action),
             }));
           setToolScopeRows(dropDeletedScope);
-          lastSavedToolScopeRowsRef.current = dropDeletedScope(
-            lastSavedToolScopeRowsRef.current,
-          );
+          setLastSavedToolScopeRows(dropDeletedScope);
         },
       });
     },
@@ -514,25 +559,14 @@ export function MCPProxySecurityTab({
           </Stack>
 
           <Stack direction="row" alignItems="center" justifyContent="flex-end">
-            <Tooltip
-              title={
-                noToolsForRbac
-                  ? "This MCP Server has no tools. A scope must authorize at least one."
-                  : ""
-              }
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<Plus size={16} />}
+              onClick={() => setCreateScopeDrawerOpen(true)}
             >
-              <span>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  startIcon={<Plus size={16} />}
-                  onClick={() => setCreateScopeDrawerOpen(true)}
-                  disabled={noToolsForRbac}
-                >
-                  Create Scope
-                </Button>
-              </span>
-            </Tooltip>
+              Create Scope
+            </Button>
           </Stack>
 
           <Tabs
@@ -550,7 +584,7 @@ export function MCPProxySecurityTab({
                 <ListingTable.EmptyState
                   illustration={<ShieldX size={64} />}
                   title="No Tools Available"
-                  description="This MCP Server has no tools. Scope bindings require at least one tool."
+                  description="This MCP Server has no tools to bind scopes to. Scopes can still be created and granted to roles."
                 />
               </ListingTable.Container>
             ) : (


### PR DESCRIPTION
## Purpose

Updating an identity-secured MCP proxy scope to remove its last tool assignment (`PUT /orgs/{org}/mcp-proxies/{proxy}/scopes/{action}` with `{"tools":[]}`) failed with:

```json
{ "code": "BAD_REQUEST", "message": "invalid input: a scope must authorize at least one tool" }
```

Since the Security tab's tool-scope table is the only way to unbind a scope, a scope's bindings could never be cleared through the product, and a batch save containing that scope left the console showing state the server did not hold.

Resolves https://github.com/wso2/agent-manager/issues/1661

**One correction to the issue's diagnosis:** the reported Thunder/DB drift is not caused by a partial Thunder mutation. No path reachable from a failed scope update writes to Thunder — `Update` validates before any write, `RedeployMCPProxy` only emits gateway artifacts, `DeleteProxyResourceServerAction` is called only from scope `Delete`, `DeleteProxyResourceServer` only from proxy `Delete`, and the endpoint-security PUT's `refreshAgentsBoundToProxy` only writes Kubernetes env vars. Thunder actions are created *lazily on role grant* (`agent_identity_controller.go` is the sole `EnsureProxyResourceServer` caller), so a scope never granted to a role has no Thunder action to begin with — the likeliest explanation for what was observed. The real inconsistency was console-side and is fixed here.

## Goals

1. A scope with no tools becomes a legal, first-class state: a declared-but-unbound catalog entry, grantable to a role (and projected into Thunder on that grant) but required by no tool.
2. A partially applied Save in the Security tab can no longer leave the console asserting state the server does not have.

## Approach

**Backend — remove the rule that nothing else shared**

`validateScopeTools` (`services/mcp_proxy_scope_service.go`) was the only component in the system treating zero tools as invalid:

- `appendMCPIdentityAuthPolicies` inverts scope→tools and emits no `mcp-authz` rule for a tool-less scope; if it is the proxy's only scope, `mcp-authz` is omitted entirely and the endpoint degrades to authenticated-only via `mcp-auth`.
- `resolveScopeGroups` only checks that the scope row exists, so the scope stays grantable and `EnsureProxyResourceServer` still creates its Thunder action on grant.
- `ListEnvironmentScopes` and `resolveAgentIdentityScopes` do not filter on tool count.
- The console's own `computeScopeToolUpdates` documents zero tools as "a valid, saved state, not a signal to delete it".

The empty-list branch is dropped. `Update`'s `if in.Tools != nil` gate is unchanged, so explicit `[]` still means "clear" and an omitted `tools` still means "leave unchanged" — the returned slice is empty-but-non-nil so the `tools` jsonb column holds `[]`, never `null`.

`MCPProxyScopeRequest`/`MCPProxyScopeUpdateRequest` lose `minItems: 1`, and `tools` is no longer required on create, so a scope can be declared before any tool is wired to it. Clients regenerated with `make spec` and `make amctl-gen-client`; the generated diff is confined to the two scope models and one CLI type.

**Console — stop half-applying the save**

`handleSave` fanned its per-scope updates out through `Promise.all`, so the rejected update never stopped its siblings from committing and the post-`await` snapshot assignment never ran. The updates are now sequential and record what actually committed, so the snapshot reflects server truth on a partial failure instead of the pre-edit state.

That snapshot also had to become state rather than a ref: `toolScopesDirty` is memoized, so a ref write left it stale and pinned the tab as dirty even after a *fully successful* save — which suppressed the success alert (gated on `!isDirty`), kept Save enabled, and permanently gated the reseed effect from ever adopting the refetched catalog. With it as state, Discard lands on truth and the tab recovers.

The Create Scope drawer no longer requires at least one tool, and the button is no longer disabled when the endpoint has no discovered tools.

## User stories

- As a platform user, I can remove a scope's last tool assignment without the save failing.
- As a platform user, I can declare a scope now and bind it to tools later.
- As a platform user, when a scope save partially fails, the Security tab shows me what the server actually holds rather than silently diverging from it.

## Release note

Fixed a validation error when removing every tool assignment from an identity-secured MCP proxy scope, and fixed the MCP proxy Security tab showing stale tool-scope bindings after a partially failed save. MCP proxy scopes may now be created without tool assignments.

## Documentation

N/A — no documented behaviour changes; this removes a validation restriction and fixes a UI sync bug. No pages describe the removed constraint.

## Training

N/A — no training content covers MCP proxy scope tool binding.

## Certification

N/A — no certification questions cover MCP proxy scope validation.

## Marketing

N/A — bug fix with no marketing impact.

## Automation tests

- **Unit tests**

  New, all in the no-DB unit tier:
  - `controllers/mcp_proxy_scope_controller_unit_test.go` — drives the issue's exact request (`PUT .../scopes/write-only` with `{"tools":[]}`) through decode → validate → persist and asserts `200` plus `"tools":[]`. Verified as a true regression test: it returns `400` with the check reinstated. A companion case pins that a description-only PUT (no `tools` key) leaves existing bindings intact.
  - `services/mcp_proxy_scope_service_unit_test.go` — clearing tools persists an empty, non-nil list and still triggers gateway re-emission; omitted tools leave the list unchanged; create succeeds with no tools.
  - `services/mcp_proxy_deployment_test.go` — a tool-less scope emits `mcp-auth` and no `mcp-authz`.

  Full unit tier passes (`make test-unit`); `golangci-lint` reports 0 issues on `services` and `controllers`; `gofumpt` clean. Console: `rush build` compiles the package and `eslint` is clean on both changed files.

- **Integration tests**

  None added — the change is a validation rule plus console state handling, both covered at the controller and service layers above.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** — Go/TypeScript change; FindSecurityBugs is a Java tool and does not apply.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

Worth noting for review: removing the constraint cannot widen access. A scope with no tools contributes no `requiredScopes` anywhere, so no tool becomes reachable that was not already reachable, and a proxy whose only scope is tool-less falls back to `mcp-auth` (authenticated-only) rather than emitting an empty rule set.

## Samples

N/A — no sample changes.

## Related PRs

None.

## Migrations (if applicable)

N/A — no schema change. Existing rows are unaffected; the `tools` jsonb column already holds a list and continues to be written as `[]` rather than `null` when empty.

## Test environment

Go 1.x toolchain in-repo; Node 20.20.2 for the console build (`rush.json` rejects Node 24, and `console/.nvmrc` pins 22.12.0 which is also outside its supported range — worth a separate look). Backend verified via the unit tier and lint; the console was verified by compile and lint only, not exercised against a running stack.

## Learning

The main lesson was that the reported symptom and the reported cause pointed at different layers. Tracing every Thunder-mutating call site ruled out the control-plane drift hypothesis and located the divergence in the console's `Promise.all` fan-out. The stale-memo-behind-a-ref bug surfaced only while reasoning about the recovery path, and it also affected the fully successful save — so it would have been missed by testing the failure case alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create MCP proxy scopes without assigning tools.
  * Create and manage scopes when no tools are available.
  * Omit tools during updates to preserve existing bindings.
  * Submit an empty tools list to clear all bindings.
  * Improved scope save progress and status tracking after partial updates.

* **Bug Fixes**
  * Corrected policy generation for scopes without tool bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->