### PR TITLE
Fix amctl agent build, agent create secret echo, LLM provider template defaults, and add amctl gateway

### DIFF
--- a/agent-manager-service/controllers/agent_build_response_test.go
+++ b/agent-manager-service/controllers/agent_build_response_test.go
@@ -17,10 +17,12 @@
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -97,5 +99,69 @@ func TestBuildAgent_ResponseMatchesSpec(t *testing.T) {
 	}
 	if got.BuildParameters.CommitId != "328efd0" {
 		t.Errorf("buildParameters.commitId = %q, want 328efd0", got.BuildParameters.CommitId)
+	}
+}
+
+// createOnlyAgentService satisfies AgentManagerService for the CreateAgent handler,
+// leaving every other method nil so an unexpected call panics.
+type createOnlyAgentService struct {
+	services.AgentManagerService
+}
+
+func (createOnlyAgentService) CreateAgent(
+	_ context.Context, _ string, _ string, _ *spec.CreateAgentRequest,
+) error {
+	return nil
+}
+
+// TestCreateAgent_DoesNotEchoSecretValues pins the 202 body to the contract's
+// promise that a value is "omitted for secrets in responses". The handler used to
+// copy the decoded payload straight back out, so every submitted secret — and, for
+// kind-based agents, the kind's stored secret defaults — crossed the wire in
+// plaintext.
+func TestCreateAgent_DoesNotEchoSecretValues(t *testing.T) {
+	body, err := json.Marshal(spec.CreateAgentRequest{
+		Name:        "yolo",
+		DisplayName: "Yolo",
+		Provisioning: spec.Provisioning{
+			Type:      "internal",
+			AgentKind: &spec.ProvisioningAgentKind{Name: "chatbot", Version: "v1"},
+		},
+		Configurations: &spec.Configurations{
+			Env: []spec.EnvironmentVariable{
+				{Key: "OPENAI_API_KEY", Value: spec.PtrString("sk-super-secret"), IsSensitive: spec.PtrBool(true)},
+				{Key: "LOG_LEVEL", Value: spec.PtrString("debug")},
+			},
+			Files: []spec.FileMount{
+				{
+					Key:         "creds.json",
+					MountPath:   "/etc/creds.json",
+					Value:       spec.PtrString("file-super-secret"),
+					IsSensitive: spec.PtrBool(true),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	ctrl := NewAgentController(createOnlyAgentService{}, nil)
+	req := httptest.NewRequest(http.MethodPost, "/orgs/o/projects/default/agents", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	ctrl.CreateAgent(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "sk-super-secret") {
+		t.Errorf("202 body echoes the submitted env secret; body=%s", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "file-super-secret") {
+		t.Errorf("202 body echoes the submitted file-mount secret; body=%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "debug") {
+		t.Errorf("202 body dropped a non-sensitive value; body=%s", w.Body.String())
 	}
 }

--- a/agent-manager-service/controllers/agent_build_response_test.go
+++ b/agent-manager-service/controllers/agent_build_response_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+)
+
+// buildOnlyAgentService satisfies AgentManagerService by embedding the interface,
+// so every method except BuildAgent is nil and panics if the handler reaches it.
+type buildOnlyAgentService struct {
+	services.AgentManagerService
+	build *models.BuildResponse
+}
+
+func (s buildOnlyAgentService) BuildAgent(
+	_ context.Context, _ string, _ string, _ string, _ string,
+) (*models.BuildResponse, error) {
+	return s.build, nil
+}
+
+// TestBuildAgent_ResponseMatchesSpec pins the 202 body to the published contract.
+// The handler used to serialize *models.BuildResponse, whose `name`/`uuid` tags do
+// not match the spec's required `buildName`/`buildId` — so a spec-typed client saw
+// an empty build name and a null build id. A service-layer test cannot catch this:
+// the defect lives entirely in the controller's choice of serialized type.
+func TestBuildAgent_ResponseMatchesSpec(t *testing.T) {
+	started := time.Now().UTC().Truncate(time.Second)
+	svc := buildOnlyAgentService{
+		build: &models.BuildResponse{
+			UUID:        "b6f0e1c2-0000-4000-8000-000000000001",
+			Name:        "build-yolo-1",
+			AgentName:   "yolo",
+			ProjectName: "default",
+			Status:      "BuildInitiated",
+			StartedAt:   started,
+			ImageId:     "registry.example/yolo:1",
+			BuildParameters: models.BuildParameters{
+				RepoUrl:  "https://github.com/acme/yolo",
+				Branch:   "main",
+				CommitID: "328efd0",
+				Language: "python",
+			},
+		},
+	}
+
+	ctrl := NewAgentController(svc, nil)
+	req := httptest.NewRequest(http.MethodPost, "/orgs/o/projects/default/agents/yolo/builds", nil)
+	w := httptest.NewRecorder()
+	ctrl.BuildAgent(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+
+	var got spec.BuildResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode into spec.BuildResponse: %v; body=%s", err, w.Body.String())
+	}
+	if got.BuildName != "build-yolo-1" {
+		t.Errorf("buildName = %q, want build-yolo-1; body=%s", got.BuildName, w.Body.String())
+	}
+	if got.BuildId == nil {
+		t.Fatalf("buildId is null; body=%s", w.Body.String())
+	}
+	if *got.BuildId != "b6f0e1c2-0000-4000-8000-000000000001" {
+		t.Errorf("buildId = %q, want b6f0e1c2-0000-4000-8000-000000000001", *got.BuildId)
+	}
+	if got.AgentName != "yolo" || got.ProjectName != "default" {
+		t.Errorf("agentName/projectName = %q/%q, want yolo/default", got.AgentName, got.ProjectName)
+	}
+	if got.Status == nil || *got.Status != "BuildInitiated" {
+		t.Errorf("status = %v, want BuildInitiated", got.Status)
+	}
+	if got.BuildParameters.CommitId != "328efd0" {
+		t.Errorf("buildParameters.commitId = %q, want 328efd0", got.BuildParameters.CommitId)
+	}
+}

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -516,7 +516,9 @@ func (c *agentController) BuildAgent(w http.ResponseWriter, r *http.Request) {
 		handleCommonErrors(w, err, "Failed to build agent")
 		return
 	}
-	utils.WriteSuccessResponse(w, http.StatusAccepted, build)
+
+	buildResponse := utils.ConvertToBuildResponse(build)
+	utils.WriteSuccessResponse(w, http.StatusAccepted, buildResponse)
 }
 
 func (c *agentController) DeployAgent(w http.ResponseWriter, r *http.Request) {

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -345,7 +345,7 @@ func (c *agentController) CreateAgent(w http.ResponseWriter, r *http.Request) {
 		ProjectName:    projName,
 		Provisioning:   payload.Provisioning,
 		AgentType:      agentType,
-		Configurations: payload.Configurations,
+		Configurations: utils.RedactSecretConfigValues(payload.Configurations),
 		Build:          payload.Build,
 		CreatedAt:      time.Now(),
 	}

--- a/agent-manager-service/controllers/gateway_controller.go
+++ b/agent-manager-service/controllers/gateway_controller.go
@@ -243,8 +243,9 @@ func (c *gatewayController) GetGateway(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get environments from DB
-	environments := c.getGatewayEnvironmentsFromDB(ctx, ouID, gatewayID)
+	// Key the mapping lookup off the resolved UUID: gatewayID may be a name, and
+	// environment mappings are indexed by UUID only.
+	environments := c.getGatewayEnvironmentsFromDB(ctx, ouID, gateway.ID)
 
 	response := convertGatewayToSpecResponse(gateway, ouID, environments)
 	utils.WriteSuccessResponse(w, http.StatusOK, response)
@@ -375,8 +376,8 @@ func (c *gatewayController) UpdateGateway(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Get environments from DB
-	environments := c.getGatewayEnvironmentsFromDB(ctx, ouID, gatewayID)
+	// Key the mapping lookup off the resolved UUID rather than the raw path value.
+	environments := c.getGatewayEnvironmentsFromDB(ctx, ouID, gateway.ID)
 
 	response := convertGatewayToSpecResponse(gateway, ouID, environments)
 	utils.WriteSuccessResponse(w, http.StatusOK, response)

--- a/agent-manager-service/controllers/gateway_controller.go
+++ b/agent-manager-service/controllers/gateway_controller.go
@@ -285,16 +285,25 @@ func (c *gatewayController) ListGateways(w http.ResponseWriter, r *http.Request)
 		filters.Status = &isActive
 	}
 
-	// Filter by environment
+	// Filter by environment. envParam may be a UUID or a name; an unresolvable one
+	// is a client error, not a reason to drop the filter — silently returning the
+	// unfiltered list makes a typo look like "every gateway matches".
 	if envParam := r.URL.Query().Get("environment"); envParam != "" {
-		// envParam could be UUID or name, we need to resolve it to UUID
 		envUUID, err := c.resolveEnvironmentUUID(ctx, ouID, envParam)
-		if err != nil {
-			log.Warn("ListGateways: failed to resolve environment", "environment", envParam, "error", err)
-			// Continue without environment filter if resolution fails
-		} else {
-			filters.EnvironmentID = &envUUID
+		switch {
+		case errors.Is(err, utils.ErrEnvironmentNotFound):
+			// A 400 rather than a 404: the collection exists, the filter value does
+			// not. listGateways declares 400 but no 404.
+			log.Error("ListGateways: unknown environment filter", "environment", envParam)
+			utils.WriteErrorResponse(w, http.StatusBadRequest,
+				fmt.Sprintf("Unknown environment %q in 'environment' filter", envParam))
+			return
+		case err != nil:
+			log.Error("ListGateways: failed to resolve environment", "environment", envParam, "error", err)
+			handleGatewayErrors(w, err, "Failed to resolve environment filter")
+			return
 		}
+		filters.EnvironmentID = &envUUID
 	}
 
 	// Get gateways from local service with filters and DB-level pagination

--- a/agent-manager-service/controllers/gateway_controller.go
+++ b/agent-manager-service/controllers/gateway_controller.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/uuid"
 	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/audit"
@@ -86,23 +85,19 @@ func NewGatewayController(
 	}
 }
 
-// resolveEnvironmentUUID resolves environment name or UUID to UUID
+// resolveEnvironmentUUID resolves an environment name or UUID to the UUID of an
+// environment in ouID. A UUID is looked up like any other identifier rather than
+// trusted on shape: a well-formed UUID belonging to another organization is as
+// unknown to this caller as a typo, and returning it unchecked let a cross-org
+// value through as a list filter and as the target of an environment assignment.
 func (c *gatewayController) resolveEnvironmentUUID(ctx context.Context, ouID, envIdentifier string) (string, error) {
-	// First try to parse as UUID
-	if _, err := uuid.Parse(envIdentifier); err == nil {
-		// It's a valid UUID, return it
-		return envIdentifier, nil
-	}
-
-	// Not a UUID, try to resolve by name using OpenChoreo client
 	environments, err := c.ocClient.ListEnvironments(ctx, ouID)
 	if err != nil {
 		return "", fmt.Errorf("failed to list environments: %w", err)
 	}
 
-	// Find environment by name
 	for _, env := range environments {
-		if env.Name == envIdentifier {
+		if env.Name == envIdentifier || strings.EqualFold(env.UUID, envIdentifier) {
 			return env.UUID, nil
 		}
 	}

--- a/agent-manager-service/controllers/gateway_controller_env_filter_test.go
+++ b/agent-manager-service/controllers/gateway_controller_env_filter_test.go
@@ -97,6 +97,42 @@ func TestListGateways_KnownEnvironmentNameResolvesToItsUUID(t *testing.T) {
 	}
 }
 
+func TestListGateways_KnownEnvironmentUUIDResolvesToItself(t *testing.T) {
+	var filters repositories.GatewayFilterOptions
+	ctrl, w, req := listGatewaysRequest(t, "environment="+defaultEnvUUID, emptyGatewayRepo(&filters))
+
+	ctrl.ListGateways(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if filters.EnvironmentID == nil {
+		t.Fatal("environment filter was dropped")
+	}
+	if *filters.EnvironmentID != defaultEnvUUID {
+		t.Errorf("EnvironmentID = %q, want %q", *filters.EnvironmentID, defaultEnvUUID)
+	}
+}
+
+// A UUID used to be accepted on syntactic validity alone, so an environment from
+// another organization passed straight through as a filter and the caller saw an
+// empty list instead of being told the value is unknown to them.
+func TestListGateways_ForeignEnvironmentUUIDIsRejected(t *testing.T) {
+	const foreignEnvUUID = "11111111-2222-3333-4444-555555555555"
+	// Every repository func is nil: the filter must be rejected before the service
+	// is ever asked for gateways.
+	ctrl, w, req := listGatewaysRequest(t, "environment="+foreignEnvUUID, &repomocks.GatewayRepositoryMock{})
+
+	ctrl.ListGateways(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), foreignEnvUUID) {
+		t.Errorf("body = %s, want the rejected environment named", w.Body.String())
+	}
+}
+
 func TestListGateways_NoEnvironmentFilterLeavesItUnset(t *testing.T) {
 	var filters repositories.GatewayFilterOptions
 	ctrl, w, req := listGatewaysRequest(t, "", emptyGatewayRepo(&filters))

--- a/agent-manager-service/controllers/gateway_controller_env_filter_test.go
+++ b/agent-manager-service/controllers/gateway_controller_env_filter_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/services"
+)
+
+const defaultEnvUUID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+func listGatewaysRequest(
+	t *testing.T, query string, repo *repomocks.GatewayRepositoryMock,
+) (*gatewayController, *httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		ListEnvironmentsFunc: func(_ context.Context, _ string) ([]*models.EnvironmentResponse, error) {
+			return []*models.EnvironmentResponse{{UUID: defaultEnvUUID, Name: "default"}}, nil
+		},
+	}
+	svc := services.NewPlatformGatewayService(repo, nil)
+	ctrl := &gatewayController{gatewayService: svc, ocClient: ocClient}
+
+	req := httptest.NewRequest(http.MethodGet, "/orgs/acme/gateways?"+query, nil)
+	return ctrl, httptest.NewRecorder(), req
+}
+
+// emptyGatewayRepo answers the two list queries with nothing, so a test can assert
+// on the filters the controller built rather than on any rows.
+func emptyGatewayRepo(recordFilters *repositories.GatewayFilterOptions) *repomocks.GatewayRepositoryMock {
+	return &repomocks.GatewayRepositoryMock{
+		ListWithFiltersFunc: func(filters repositories.GatewayFilterOptions) ([]*models.Gateway, error) {
+			*recordFilters = filters
+			return []*models.Gateway{}, nil
+		},
+		CountWithFiltersFunc: func(_ repositories.GatewayFilterOptions) (int64, error) {
+			return 0, nil
+		},
+	}
+}
+
+// The controller used to log a warning and drop an unresolvable environment filter,
+// so `--env typo` returned every gateway in the org — a filter that fails open reads
+// as "everything matches".
+func TestListGateways_UnknownEnvironmentFilterIsRejected(t *testing.T) {
+	// Every repository func is nil: the filter must be rejected before the service
+	// is ever asked for gateways.
+	ctrl, w, req := listGatewaysRequest(t, "environment=nonexistent", &repomocks.GatewayRepositoryMock{})
+
+	ctrl.ListGateways(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "nonexistent") {
+		t.Errorf("body = %s, want the rejected environment named", w.Body.String())
+	}
+}
+
+func TestListGateways_KnownEnvironmentNameResolvesToItsUUID(t *testing.T) {
+	var filters repositories.GatewayFilterOptions
+	ctrl, w, req := listGatewaysRequest(t, "environment=default", emptyGatewayRepo(&filters))
+
+	ctrl.ListGateways(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if filters.EnvironmentID == nil {
+		t.Fatal("environment filter was dropped")
+	}
+	if *filters.EnvironmentID != defaultEnvUUID {
+		t.Errorf("EnvironmentID = %q, want %q", *filters.EnvironmentID, defaultEnvUUID)
+	}
+}
+
+func TestListGateways_NoEnvironmentFilterLeavesItUnset(t *testing.T) {
+	var filters repositories.GatewayFilterOptions
+	ctrl, w, req := listGatewaysRequest(t, "", emptyGatewayRepo(&filters))
+
+	ctrl.ListGateways(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if filters.EnvironmentID != nil {
+		t.Errorf("EnvironmentID = %q, want unset", *filters.EnvironmentID)
+	}
+}

--- a/agent-manager-service/controllers/llm_controller.go
+++ b/agent-manager-service/controllers/llm_controller.go
@@ -721,6 +721,10 @@ func (c *llmController) DeleteLLMProvider(w http.ResponseWriter, r *http.Request
 			log.Warn("DeleteLLMProvider: provider has associated proxies", "ouID", ouID, "providerID", providerID)
 			utils.WriteErrorResponse(w, http.StatusConflict, utils.ErrLLMProviderHasProxies.Error())
 			return
+		case errors.Is(err, utils.ErrLLMProviderUndeployFailed):
+			log.Error("DeleteLLMProvider: undeployment failed", "ouID", ouID, "providerID", providerID, "error", err)
+			utils.WriteErrorResponse(w, http.StatusConflict, utils.ErrLLMProviderUndeployFailed.Error())
+			return
 		default:
 			log.Error("DeleteLLMProvider: failed to delete provider", "ouID", ouID, "providerID", providerID, "error", err)
 			utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to delete LLM provider")

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -5712,7 +5712,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /orgs/{orgName}/llm-providers/{id}:
+  /orgs/{orgName}/llm-providers/{providerId}:
     parameters:
       - name: orgName
         in: path
@@ -5720,7 +5720,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID
@@ -5813,7 +5813,12 @@ paths:
       tags:
         - LLM Providers
       summary: Delete LLM provider
-      description: Delete an LLM provider
+      description: |
+        Delete an LLM provider.
+
+        The provider is undeployed from every gateway it is deployed to before it is
+        removed. Deletion is refused with a 409 while anything still references the
+        provider — an LLM proxy, or an agent's LLM configuration.
       operationId: deleteLLMProvider
       responses:
         "204":
@@ -5830,8 +5835,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Caller lacks the llm-provider:delete permission
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Provider not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: |
+            Provider still has dependents (LLM proxies or agent LLM configurations),
+            or undeploying it from its gateways failed. The message names the blocker.
           content:
             application/json:
               schema:
@@ -5843,7 +5862,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /orgs/{orgName}/llm-providers/{id}/catalog:
+  /orgs/{orgName}/llm-providers/{providerId}/catalog:
     parameters:
       - name: orgName
         in: path
@@ -5851,7 +5870,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID
@@ -5909,7 +5928,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /orgs/{orgName}/llm-providers/{id}/llm-proxies:
+  /orgs/{orgName}/llm-providers/{providerId}/llm-proxies:
     parameters:
       - name: orgName
         in: path
@@ -5917,7 +5936,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID
@@ -5980,7 +5999,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /orgs/{orgName}/llm-providers/{id}/consumers:
+  /orgs/{orgName}/llm-providers/{providerId}/consumers:
     parameters:
       - name: orgName
         in: path
@@ -5988,7 +6007,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID or handle
@@ -6752,7 +6771,7 @@ paths:
   # LLM DEPLOYMENT ENDPOINTS
   # ============================================
 
-  /orgs/{orgName}/llm-providers/{id}/deployments:
+  /orgs/{orgName}/llm-providers/{providerId}/deployments:
     parameters:
       - name: orgName
         in: path
@@ -6760,7 +6779,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID
@@ -6866,7 +6885,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /orgs/{orgName}/llm-providers/{id}/deployments/undeploy:
+  /orgs/{orgName}/llm-providers/{providerId}/deployments/undeploy:
     parameters:
       - name: orgName
         in: path
@@ -6874,7 +6893,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID
@@ -6942,7 +6961,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /orgs/{orgName}/llm-providers/{id}/deployments/restore:
+  /orgs/{orgName}/llm-providers/{providerId}/deployments/restore:
     parameters:
       - name: orgName
         in: path
@@ -6950,7 +6969,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID
@@ -7014,7 +7033,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
-  /orgs/{orgName}/llm-providers/{id}/deployments/{deploymentId}:
+  /orgs/{orgName}/llm-providers/{providerId}/deployments/{deploymentId}:
     parameters:
       - name: orgName
         in: path
@@ -7022,7 +7041,7 @@ paths:
         description: Organization name/handle
         schema:
           type: string
-      - name: id
+      - name: providerId
         in: path
         required: true
         description: Provider UUID

--- a/agent-manager-service/services/llm_provider_rollback_test.go
+++ b/agent-manager-service/services/llm_provider_rollback_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+)
+
+// serviceForRollback wires the three repository calls a rollback Delete makes for a
+// provider with no deployed gateways: resolve the provider, list its deployed
+// gateways, delete the row. deleteErr is what the final delete reports.
+func serviceForRollback(
+	created *models.LLMProvider, deleteErr error,
+) (*LLMProviderService, *LLMProviderDeploymentService) {
+	providerRepo := &repomocks.LLMProviderRepositoryMock{
+		GetByUUIDFunc: func(_, _ string) (*models.LLMProvider, error) { return created, nil },
+		DeleteFunc:    func(_, _ string) error { return deleteErr },
+	}
+	deploymentRepo := &repomocks.DeploymentRepositoryMock{
+		GetDeployedGatewaysByProviderFunc: func(_ uuid.UUID, _ string) ([]string, error) {
+			return []string{}, nil
+		},
+	}
+	return &LLMProviderService{providerRepo: providerRepo},
+		&LLMProviderDeploymentService{deploymentRepo: deploymentRepo}
+}
+
+func createdProvider() *models.LLMProvider {
+	return &models.LLMProvider{
+		UUID:          uuid.New(),
+		Configuration: models.LLMProviderConfig{Handle: "acme-openai"},
+	}
+}
+
+// A rollback that fails leaves behind the provider the rollback exists to remove.
+// Swallowing that into a log meant the caller saw only "all deployments failed",
+// retried the same handle, and was rejected by a provider it did not know existed.
+func TestRollbackCreatedProvider_ReturnsTheRollbackFailure(t *testing.T) {
+	boom := errors.New("connection refused")
+	created := createdProvider()
+	svc, deploymentSvc := serviceForRollback(created, boom)
+
+	err := svc.rollbackCreatedProvider(context.Background(), created, "ou-acme", deploymentSvc)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, boom)
+	assert.Contains(t, err.Error(), created.UUID.String())
+}
+
+func TestRollbackCreatedProvider_ReportsNoErrorWhenTheProviderIsRemoved(t *testing.T) {
+	created := createdProvider()
+	svc, deploymentSvc := serviceForRollback(created, nil)
+
+	err := svc.rollbackCreatedProvider(context.Background(), created, "ou-acme", deploymentSvc)
+
+	assert.NoError(t, err)
+}

--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -100,6 +102,121 @@ func NewLLMProviderService(
 	}
 }
 
+// providerVersionPattern mirrors the spec's `version` pattern. The endpoint used to
+// accept anything, so a client sending "v1" persisted a version its own generated
+// types declare as invalid.
+var providerVersionPattern = regexp.MustCompile(`^v\d+\.\d+$`)
+
+func validateProviderVersion(version string) error {
+	if !providerVersionPattern.MatchString(version) {
+		return fmt.Errorf("%w: version must match %s, e.g. v1.0", utils.ErrInvalidInput, providerVersionPattern)
+	}
+	return nil
+}
+
+// rollbackCreatedProvider removes a provider whose every gateway deployment failed,
+// so a failed CreateAndDeploy leaves nothing behind. A rollback failure is logged
+// rather than returned: the caller needs the deployment error, which is the one that
+// explains what went wrong.
+func (s *LLMProviderService) rollbackCreatedProvider(
+	ctx context.Context, created *models.LLMProvider, ouID string,
+	deploymentService *LLMProviderDeploymentService,
+) {
+	if err := s.Delete(ctx, created.UUID.String(), ouID, deploymentService); err != nil {
+		slog.Error("LLMProviderService.CreateAndDeploy: failed to roll back provider after deployment failure",
+			"ouID", ouID, "providerUUID", created.UUID, "error", err)
+		return
+	}
+	slog.Info("LLMProviderService.CreateAndDeploy: rolled back provider after deployment failure",
+		"ouID", ouID, "providerUUID", created.UUID)
+}
+
+// summarizeDeploymentFailures joins the per-gateway errors so the caller learns why
+// the deployments failed instead of only that they did.
+func summarizeDeploymentFailures(results []DeploymentResult) string {
+	reasons := make([]string, 0, len(results))
+	for _, result := range results {
+		if !result.Success {
+			reasons = append(reasons, fmt.Sprintf("%s: %s", result.GatewayID, result.Error))
+		}
+	}
+	return strings.Join(reasons, "; ")
+}
+
+// resolveTemplate returns the built-in or org-owned template behind handle.
+func (s *LLMProviderService) resolveTemplate(handle, ouID string) (*models.LLMProviderTemplate, error) {
+	if builtin := s.templateStore.Get(handle); builtin != nil {
+		return builtin, nil
+	}
+
+	userTemplate, err := s.templateRepo.GetByHandle(handle, ouID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, utils.ErrLLMProviderTemplateNotFound
+		}
+		return nil, fmt.Errorf("failed to validate template: %w", err)
+	}
+	if userTemplate == nil {
+		return nil, utils.ErrLLMProviderTemplateNotFound
+	}
+	return userTemplate, nil
+}
+
+// applyTemplateUpstreamDefaults fills the upstream URL and auth scheme from the
+// template's metadata wherever the caller left them unset. Every client documents
+// these as inherited from the template, but no layer applied them: a provider
+// created without an explicit --upstream-url deployed a proxy whose upstream URL was
+// empty and was silently dropped from the gateway config.
+//
+// Caller-supplied values always win, and this must run before the credential is
+// encrypted so the template's value prefix lands inside the ciphertext.
+func applyTemplateUpstreamDefaults(provider *models.LLMProvider, template *models.LLMProviderTemplate) {
+	if template.Metadata == nil {
+		return
+	}
+	meta := template.Metadata
+	if meta.EndpointURL == "" && meta.Auth == nil {
+		return
+	}
+
+	if provider.Configuration.Upstream == nil {
+		provider.Configuration.Upstream = &models.UpstreamConfig{}
+	}
+	if provider.Configuration.Upstream.Main == nil {
+		provider.Configuration.Upstream.Main = &models.UpstreamEndpoint{}
+	}
+	main := provider.Configuration.Upstream.Main
+
+	if main.URL == "" {
+		main.URL = meta.EndpointURL
+	}
+	if meta.Auth != nil {
+		main.Auth = applyTemplateAuthDefaults(main.Auth, meta.Auth)
+	}
+}
+
+// applyTemplateAuthDefaults fills in the auth type, header and value prefix the
+// template declares. An endpoint that has a URL but no auth block still gets the
+// template's scheme, so `--upstream-url` without a credential no longer produces a
+// provider that cannot authenticate.
+func applyTemplateAuthDefaults(auth *models.UpstreamAuth, templateAuth *models.LLMProviderTemplateAuth) *models.UpstreamAuth {
+	if auth == nil {
+		auth = &models.UpstreamAuth{}
+	}
+	if utils.StrPointerAsStr(auth.Type, "") == "" && templateAuth.Type != "" {
+		auth.Type = &templateAuth.Type
+	}
+	if utils.StrPointerAsStr(auth.Header, "") == "" && templateAuth.Header != "" {
+		auth.Header = &templateAuth.Header
+	}
+	if templateAuth.ValuePrefix != "" && auth.Value != nil &&
+		!strings.HasPrefix(*auth.Value, templateAuth.ValuePrefix) {
+		prefixed := templateAuth.ValuePrefix + *auth.Value
+		auth.Value = &prefixed
+	}
+	return auth
+}
+
 // resolveProvider looks up a provider by UUID or handle.
 func (s *LLMProviderService) resolveProvider(identifier, ouID string) (*models.LLMProvider, error) {
 	if _, err := uuid.Parse(identifier); err == nil {
@@ -165,24 +282,25 @@ func (s *LLMProviderService) Create(ctx context.Context, ouID, createdBy string,
 		provider.ModelList = string(modelListBytes)
 	}
 
-	// Validate template exists (check both built-in and user templates)
-	slog.Info("LLMProviderService.Create: validating template", "ouID", ouID, "handle", handle, "template", template)
-	templateExists := s.templateStore.Exists(template)
-	if !templateExists {
-		// Check user templates in database
-		userTemplateExists, err := s.templateRepo.Exists(template, ouID)
-		if err != nil {
-			slog.Error("LLMProviderService.Create: failed to validate user template", "ouID", ouID, "handle", handle, "template", template, "error", err)
-			return nil, fmt.Errorf("failed to validate template: %w", err)
-		}
-		if !userTemplateExists {
-			slog.Warn("LLMProviderService.Create: template not found", "ouID", ouID, "handle", handle, "template", template)
-			return nil, utils.ErrLLMProviderTemplateNotFound
-		}
+	// Resolve the template (built-in or org-owned) rather than merely checking that
+	// it exists: the upstream endpoint and auth scheme every client documents as
+	// "inherited from the template" live in its metadata.
+	slog.Info("LLMProviderService.Create: resolving template", "ouID", ouID, "handle", handle, "template", template)
+	resolvedTemplate, err := s.resolveTemplate(template, ouID)
+	if err != nil {
+		slog.Warn("LLMProviderService.Create: template unusable", "ouID", ouID, "handle", handle, "template", template, "error", err)
+		return nil, err
 	}
 
 	// Set template handle in provider
 	provider.TemplateHandle = template
+
+	applyTemplateUpstreamDefaults(provider, resolvedTemplate)
+
+	if err := validateProviderVersion(version); err != nil {
+		slog.Warn("LLMProviderService.Create: invalid version", "ouID", ouID, "handle", handle, "version", version)
+		return nil, err
+	}
 
 	// Validate mutual exclusivity of Auth.Value and Auth.SecretRef
 	if provider.Configuration.Upstream != nil &&
@@ -221,7 +339,7 @@ func (s *LLMProviderService) Create(ctx context.Context, ouID, createdBy string,
 
 	// Create provider in transaction with validation
 	slog.Info("LLMProviderService.Create: creating provider in database", "ouID", ouID, "handle", handle, "name", name, "version", version)
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err = s.db.Transaction(func(tx *gorm.DB) error {
 		// Create provider - uniqueness enforced by DB constraint
 		return s.providerRepo.Create(tx, provider, handle, name, version, ouID)
 	})
@@ -588,10 +706,13 @@ func (s *LLMProviderService) Delete(ctx context.Context, providerID, ouID string
 
 		slog.Info("LLMProviderService.Delete: undeployment results", "ouID", ouID, "providerID", providerID, "successfulUndeployments", successfulUndeployments, "totalGateways", len(gatewayIDs), "errorCount", len(undeploymentErrors))
 
-		// If all undeployments failed, return error
+		// If all undeployments failed, return error. Wrapped in a sentinel so the
+		// controller can report an actionable 409 instead of flattening a
+		// caller-fixable condition into an opaque 500.
 		if len(undeploymentErrors) > 0 && successfulUndeployments == 0 {
 			slog.Error("LLMProviderService.Delete: all undeployments failed", "ouID", ouID, "providerID", providerID, "errors", undeploymentErrors)
-			return fmt.Errorf("failed to undeploy from all %d gateways: %v", len(gatewayIDs), undeploymentErrors)
+			return fmt.Errorf("%w: %d of %d gateways: %s", utils.ErrLLMProviderUndeployFailed,
+				len(undeploymentErrors), len(gatewayIDs), strings.Join(undeploymentErrors, "; "))
 		}
 
 		// If some undeployments failed, log warning but continue with deletion
@@ -1018,10 +1139,14 @@ func (s *LLMProviderService) CreateAndDeploy(ctx context.Context, ouID, createdB
 		})
 	}
 
-	// Fail if ALL deployments failed (but only if we had valid gateways to deploy to)
+	// Fail if ALL deployments failed (but only if we had valid gateways to deploy to).
+	// The provider row is rolled back first: leaving it behind meant the caller saw a
+	// failure and got an undeployed provider anyway, invisible until the next list.
 	if len(validGatewayIDs) > 0 && successfulDeployments == 0 {
 		slog.Error("LLMProviderService.CreateAndDeploy: all deployments failed", "ouID", ouID, "providerUUID", created.UUID, "attempted", len(validGatewayIDs))
-		return nil, fmt.Errorf("all %d gateway deployments failed", len(validGatewayIDs))
+		s.rollbackCreatedProvider(ctx, created, ouID, deploymentService)
+		return nil, fmt.Errorf("all %d gateway deployments failed: %s",
+			len(validGatewayIDs), summarizeDeploymentFailures(deploymentResults))
 	}
 
 	slog.Info("LLMProviderService.CreateAndDeploy: completed", "ouID", ouID, "providerUUID", created.UUID, "successfulDeployments", successfulDeployments, "totalAttempted", len(validGatewayIDs))

--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -115,20 +115,23 @@ func validateProviderVersion(version string) error {
 }
 
 // rollbackCreatedProvider removes a provider whose every gateway deployment failed,
-// so a failed CreateAndDeploy leaves nothing behind. A rollback failure is logged
-// rather than returned: the caller needs the deployment error, which is the one that
-// explains what went wrong.
+// so a failed CreateAndDeploy leaves nothing behind. The rollback error is returned
+// as well as logged: it is not the error the caller reports — the deployment failure
+// explains what went wrong — but a rollback that failed means the provider survived,
+// and a caller told only "deployments failed" would retry the same handle and be
+// rejected with ErrLLMProviderExists by a provider it does not know exists.
 func (s *LLMProviderService) rollbackCreatedProvider(
 	ctx context.Context, created *models.LLMProvider, ouID string,
 	deploymentService *LLMProviderDeploymentService,
-) {
+) error {
 	if err := s.Delete(ctx, created.UUID.String(), ouID, deploymentService); err != nil {
 		slog.Error("LLMProviderService.CreateAndDeploy: failed to roll back provider after deployment failure",
 			"ouID", ouID, "providerUUID", created.UUID, "error", err)
-		return
+		return fmt.Errorf("failed to roll back provider %s: %w", created.UUID, err)
 	}
 	slog.Info("LLMProviderService.CreateAndDeploy: rolled back provider after deployment failure",
 		"ouID", ouID, "providerUUID", created.UUID)
+	return nil
 }
 
 // summarizeDeploymentFailures joins the per-gateway errors so the caller learns why
@@ -1147,9 +1150,17 @@ func (s *LLMProviderService) CreateAndDeploy(ctx context.Context, ouID, createdB
 	// failure and got an undeployed provider anyway, invisible until the next list.
 	if len(validGatewayIDs) > 0 && successfulDeployments == 0 {
 		slog.Error("LLMProviderService.CreateAndDeploy: all deployments failed", "ouID", ouID, "providerUUID", created.UUID, "attempted", len(validGatewayIDs))
-		s.rollbackCreatedProvider(ctx, created, ouID, deploymentService)
-		return nil, fmt.Errorf("all %d gateway deployments failed: %s",
+		failure := fmt.Sprintf("all %d gateway deployments failed: %s",
 			len(validGatewayIDs), summarizeDeploymentFailures(deploymentResults))
+
+		// The rollback error is carried as text rather than wrapped: the caller maps
+		// the HTTP status off this error, and a Delete sentinel in the chain would let
+		// an unrelated rollback sub-failure choose the status for a failed create.
+		if rollbackErr := s.rollbackCreatedProvider(ctx, created, ouID, deploymentService); rollbackErr != nil {
+			return nil, fmt.Errorf("%s (provider %q was created and could not be rolled back, delete it manually: %s)",
+				failure, created.Configuration.Handle, rollbackErr.Error())
+		}
+		return nil, errors.New(failure)
 	}
 
 	slog.Info("LLMProviderService.CreateAndDeploy: completed", "ouID", ouID, "providerUUID", created.UUID, "successfulDeployments", successfulDeployments, "totalAttempted", len(validGatewayIDs))

--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -171,11 +171,9 @@ func (s *LLMProviderService) resolveTemplate(handle, ouID string) (*models.LLMPr
 // Caller-supplied values always win, and this must run before the credential is
 // encrypted so the template's value prefix lands inside the ciphertext.
 func applyTemplateUpstreamDefaults(provider *models.LLMProvider, template *models.LLMProviderTemplate) {
-	if template.Metadata == nil {
-		return
-	}
 	meta := template.Metadata
-	if meta.EndpointURL == "" && meta.Auth == nil {
+	hasInheritableDefaults := meta != nil && (meta.EndpointURL != "" || meta.Auth != nil)
+	if !hasInheritableDefaults {
 		return
 	}
 
@@ -203,11 +201,16 @@ func applyTemplateAuthDefaults(auth *models.UpstreamAuth, templateAuth *models.L
 	if auth == nil {
 		auth = &models.UpstreamAuth{}
 	}
+	// Copied rather than aliased: for a built-in handle templateAuth points into the
+	// process-wide template store, so handing out &templateAuth.Type would let a write
+	// through the provider corrupt the template for every organization.
 	if utils.StrPointerAsStr(auth.Type, "") == "" && templateAuth.Type != "" {
-		auth.Type = &templateAuth.Type
+		authType := templateAuth.Type
+		auth.Type = &authType
 	}
 	if utils.StrPointerAsStr(auth.Header, "") == "" && templateAuth.Header != "" {
-		auth.Header = &templateAuth.Header
+		header := templateAuth.Header
+		auth.Header = &header
 	}
 	if templateAuth.ValuePrefix != "" && auth.Value != nil &&
 		!strings.HasPrefix(*auth.Value, templateAuth.ValuePrefix) {

--- a/agent-manager-service/services/llm_provider_template_defaults_test.go
+++ b/agent-manager-service/services/llm_provider_template_defaults_test.go
@@ -225,6 +225,41 @@ func TestResolveTemplate_RepositoryErrorIsNotMaskedAsNotFound(t *testing.T) {
 	assert.NotErrorIs(t, err, utils.ErrLLMProviderTemplateNotFound)
 }
 
+// The built-in templates live in one process-wide store whose Get copies only one
+// level deep: Metadata is cloned, but Metadata.Auth is a pointer the clone shares with
+// the store. Handing those fields to a provider by reference would let one
+// organization's create rewrite the template every other organization then resolves,
+// so the defaults must be copied in.
+func TestApplyTemplateUpstreamDefaults_LeavesTheSharedStoreTemplateIntact(t *testing.T) {
+	store := NewLLMTemplateStore()
+	store.Load([]*models.LLMProviderTemplate{mistralaiLikeTemplate()})
+	svc := &LLMProviderService{templateStore: store}
+
+	resolved, err := svc.resolveTemplate("mistralai", "ou-acme")
+	require.NoError(t, err)
+
+	provider := providerWithUpstream(&models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{
+			Auth: &models.UpstreamAuth{Value: strPtr("sk-caller-key")},
+		},
+	})
+	applyTemplateUpstreamDefaults(provider, resolved)
+
+	// Write through every pointer the provider now holds. Aliased defaults would
+	// carry these writes back into the store.
+	auth := provider.Configuration.Upstream.Main.Auth
+	*auth.Type = "tampered-type"
+	*auth.Header = "X-Tampered"
+	*auth.Value = "tampered-value"
+
+	stored := store.Get("mistralai")
+	require.NotNil(t, stored.Metadata.Auth)
+	assert.Equal(t, "api-key", stored.Metadata.Auth.Type)
+	assert.Equal(t, "Authorization", stored.Metadata.Auth.Header)
+	assert.Equal(t, "Bearer ", stored.Metadata.Auth.ValuePrefix)
+	assert.Equal(t, "https://api.mistral.ai", stored.Metadata.EndpointURL)
+}
+
 func TestSummarizeDeploymentFailures_NamesEachGateway(t *testing.T) {
 	summary := summarizeDeploymentFailures([]DeploymentResult{
 		{GatewayID: "gw-1", Success: false, Error: "upstream url is required"},

--- a/agent-manager-service/services/llm_provider_template_defaults_test.go
+++ b/agent-manager-service/services/llm_provider_template_defaults_test.go
@@ -161,6 +161,19 @@ func TestValidateProviderVersion(t *testing.T) {
 	}
 }
 
+// serviceWithTemplateRepo builds a service whose built-in store is empty, so
+// resolveTemplate always falls through to the org-template repository.
+func serviceWithTemplateRepo(
+	getByHandle func(handle, ouID string) (*models.LLMProviderTemplate, error),
+) *LLMProviderService {
+	return &LLMProviderService{
+		templateStore: NewLLMTemplateStore(),
+		templateRepo: &repomocks.LLMProviderTemplateRepositoryMock{
+			GetByHandleFunc: getByHandle,
+		},
+	}
+}
+
 func TestResolveTemplate_PrefersBuiltIn(t *testing.T) {
 	store := NewLLMTemplateStore()
 	store.Load([]*models.LLMProviderTemplate{mistralaiLikeTemplate()})
@@ -178,16 +191,11 @@ func TestResolveTemplate_FallsBackToOrgTemplate(t *testing.T) {
 		Handle:   "inhouse",
 		Metadata: &models.LLMProviderTemplateMetadata{EndpointURL: "https://llm.internal"},
 	}
-	svc := &LLMProviderService{
-		templateStore: NewLLMTemplateStore(),
-		templateRepo: &repomocks.LLMProviderTemplateRepositoryMock{
-			GetByHandleFunc: func(handle, ouID string) (*models.LLMProviderTemplate, error) {
-				assert.Equal(t, "inhouse", handle)
-				assert.Equal(t, "ou-acme", ouID)
-				return custom, nil
-			},
-		},
-	}
+	svc := serviceWithTemplateRepo(func(handle, ouID string) (*models.LLMProviderTemplate, error) {
+		assert.Equal(t, "inhouse", handle)
+		assert.Equal(t, "ou-acme", ouID)
+		return custom, nil
+	})
 
 	resolved, err := svc.resolveTemplate("inhouse", "ou-acme")
 
@@ -196,14 +204,9 @@ func TestResolveTemplate_FallsBackToOrgTemplate(t *testing.T) {
 }
 
 func TestResolveTemplate_UnknownHandleIsTemplateNotFound(t *testing.T) {
-	svc := &LLMProviderService{
-		templateStore: NewLLMTemplateStore(),
-		templateRepo: &repomocks.LLMProviderTemplateRepositoryMock{
-			GetByHandleFunc: func(_, _ string) (*models.LLMProviderTemplate, error) {
-				return nil, gorm.ErrRecordNotFound
-			},
-		},
-	}
+	svc := serviceWithTemplateRepo(func(_, _ string) (*models.LLMProviderTemplate, error) {
+		return nil, gorm.ErrRecordNotFound
+	})
 
 	_, err := svc.resolveTemplate("ghost", "ou-acme")
 
@@ -212,14 +215,9 @@ func TestResolveTemplate_UnknownHandleIsTemplateNotFound(t *testing.T) {
 
 func TestResolveTemplate_RepositoryErrorIsNotMaskedAsNotFound(t *testing.T) {
 	boom := errors.New("connection refused")
-	svc := &LLMProviderService{
-		templateStore: NewLLMTemplateStore(),
-		templateRepo: &repomocks.LLMProviderTemplateRepositoryMock{
-			GetByHandleFunc: func(_, _ string) (*models.LLMProviderTemplate, error) {
-				return nil, boom
-			},
-		},
-	}
+	svc := serviceWithTemplateRepo(func(_, _ string) (*models.LLMProviderTemplate, error) {
+		return nil, boom
+	})
 
 	_, err := svc.resolveTemplate("inhouse", "ou-acme")
 

--- a/agent-manager-service/services/llm_provider_template_defaults_test.go
+++ b/agent-manager-service/services/llm_provider_template_defaults_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// mistralaiLikeTemplate mirrors the shape the built-in templates actually serve, as
+// observed live: an endpoint URL plus an api-key auth block with a "Bearer " prefix.
+func mistralaiLikeTemplate() *models.LLMProviderTemplate {
+	return &models.LLMProviderTemplate{
+		Handle: "mistralai",
+		Metadata: &models.LLMProviderTemplateMetadata{
+			EndpointURL: "https://api.mistral.ai",
+			Auth: &models.LLMProviderTemplateAuth{
+				Type:        "api-key",
+				Header:      "Authorization",
+				ValuePrefix: "Bearer ",
+			},
+		},
+	}
+}
+
+func providerWithUpstream(upstream *models.UpstreamConfig) *models.LLMProvider {
+	return &models.LLMProvider{
+		Configuration: models.LLMProviderConfig{
+			Handle:   "diag",
+			Name:     "Diag",
+			Version:  "v1.0",
+			Template: "mistralai",
+			Upstream: upstream,
+		},
+	}
+}
+
+// The core of #1667: every client documents the endpoint URL as inherited from the
+// template, but no layer filled it in, so the deployed proxy had no upstream URL and
+// the empty value was silently dropped from the gateway config.
+func TestApplyTemplateUpstreamDefaults_FillsURLAndAuthWhenAbsent(t *testing.T) {
+	provider := providerWithUpstream(nil)
+
+	applyTemplateUpstreamDefaults(provider, mistralaiLikeTemplate())
+
+	main := provider.Configuration.Upstream.Main
+	require.NotNil(t, main)
+	assert.Equal(t, "https://api.mistral.ai", main.URL)
+	require.NotNil(t, main.Auth)
+	assert.Equal(t, "api-key", *main.Auth.Type)
+	assert.Equal(t, "Authorization", *main.Auth.Header)
+}
+
+// Live evidence showed a created provider carrying auth with a type and a value but
+// no header at all, so even a provider with a URL could not authenticate upstream.
+func TestApplyTemplateUpstreamDefaults_FillsHeaderOnCallerSuppliedAuth(t *testing.T) {
+	provider := providerWithUpstream(&models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{
+			Auth: &models.UpstreamAuth{
+				Type:  strPtr("api-key"),
+				Value: strPtr("sk-caller-key"),
+			},
+		},
+	})
+
+	applyTemplateUpstreamDefaults(provider, mistralaiLikeTemplate())
+
+	main := provider.Configuration.Upstream.Main
+	assert.Equal(t, "https://api.mistral.ai", main.URL)
+	assert.Equal(t, "Authorization", *main.Auth.Header)
+	assert.Equal(t, "Bearer sk-caller-key", *main.Auth.Value,
+		"the template's value prefix must be applied to the credential")
+}
+
+func TestApplyTemplateUpstreamDefaults_DoesNotDoublePrefix(t *testing.T) {
+	provider := providerWithUpstream(&models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{
+			Auth: &models.UpstreamAuth{Value: strPtr("Bearer sk-already-prefixed")},
+		},
+	})
+
+	applyTemplateUpstreamDefaults(provider, mistralaiLikeTemplate())
+
+	assert.Equal(t, "Bearer sk-already-prefixed", *provider.Configuration.Upstream.Main.Auth.Value)
+}
+
+func TestApplyTemplateUpstreamDefaults_CallerValuesWin(t *testing.T) {
+	provider := providerWithUpstream(&models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{
+			URL: "https://proxy.internal/mistral",
+			Auth: &models.UpstreamAuth{
+				Type:   strPtr("none"),
+				Header: strPtr("X-Custom-Key"),
+			},
+		},
+	})
+
+	applyTemplateUpstreamDefaults(provider, mistralaiLikeTemplate())
+
+	main := provider.Configuration.Upstream.Main
+	assert.Equal(t, "https://proxy.internal/mistral", main.URL)
+	assert.Equal(t, "none", *main.Auth.Type)
+	assert.Equal(t, "X-Custom-Key", *main.Auth.Header)
+}
+
+// A URL with no credential used to leave auth omitted entirely; the template's
+// scheme now applies so the provider is at least coherent.
+func TestApplyTemplateUpstreamDefaults_URLOnlyStillGetsTheAuthScheme(t *testing.T) {
+	provider := providerWithUpstream(&models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{URL: "https://proxy.internal/mistral"},
+	})
+
+	applyTemplateUpstreamDefaults(provider, mistralaiLikeTemplate())
+
+	auth := provider.Configuration.Upstream.Main.Auth
+	require.NotNil(t, auth)
+	assert.Equal(t, "api-key", *auth.Type)
+	assert.Equal(t, "Authorization", *auth.Header)
+	assert.Nil(t, auth.Value)
+}
+
+func TestApplyTemplateUpstreamDefaults_TemplateWithoutMetadataChangesNothing(t *testing.T) {
+	provider := providerWithUpstream(nil)
+
+	applyTemplateUpstreamDefaults(provider, &models.LLMProviderTemplate{Handle: "bare"})
+
+	assert.Nil(t, provider.Configuration.Upstream)
+}
+
+func TestValidateProviderVersion(t *testing.T) {
+	for _, valid := range []string{"v1.0", "v2.11", "v10.0"} {
+		assert.NoError(t, validateProviderVersion(valid), "version %q should be accepted", valid)
+	}
+	// "v1" is what the CLI sent by default and the server accepted without complaint,
+	// despite the spec pattern.
+	for _, invalid := range []string{"v1", "1.0", "v1.0.0", "", "latest"} {
+		err := validateProviderVersion(invalid)
+		assert.ErrorIs(t, err, utils.ErrInvalidInput, "version %q should be rejected", invalid)
+	}
+}
+
+func TestResolveTemplate_PrefersBuiltIn(t *testing.T) {
+	store := NewLLMTemplateStore()
+	store.Load([]*models.LLMProviderTemplate{mistralaiLikeTemplate()})
+	// templateRepo left nil: a built-in hit must not reach the database.
+	svc := &LLMProviderService{templateStore: store}
+
+	resolved, err := svc.resolveTemplate("mistralai", "ou-acme")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.mistral.ai", resolved.Metadata.EndpointURL)
+}
+
+func TestResolveTemplate_FallsBackToOrgTemplate(t *testing.T) {
+	custom := &models.LLMProviderTemplate{
+		Handle:   "inhouse",
+		Metadata: &models.LLMProviderTemplateMetadata{EndpointURL: "https://llm.internal"},
+	}
+	svc := &LLMProviderService{
+		templateStore: NewLLMTemplateStore(),
+		templateRepo: &repomocks.LLMProviderTemplateRepositoryMock{
+			GetByHandleFunc: func(handle, ouID string) (*models.LLMProviderTemplate, error) {
+				assert.Equal(t, "inhouse", handle)
+				assert.Equal(t, "ou-acme", ouID)
+				return custom, nil
+			},
+		},
+	}
+
+	resolved, err := svc.resolveTemplate("inhouse", "ou-acme")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://llm.internal", resolved.Metadata.EndpointURL)
+}
+
+func TestResolveTemplate_UnknownHandleIsTemplateNotFound(t *testing.T) {
+	svc := &LLMProviderService{
+		templateStore: NewLLMTemplateStore(),
+		templateRepo: &repomocks.LLMProviderTemplateRepositoryMock{
+			GetByHandleFunc: func(_, _ string) (*models.LLMProviderTemplate, error) {
+				return nil, gorm.ErrRecordNotFound
+			},
+		},
+	}
+
+	_, err := svc.resolveTemplate("ghost", "ou-acme")
+
+	assert.ErrorIs(t, err, utils.ErrLLMProviderTemplateNotFound)
+}
+
+func TestResolveTemplate_RepositoryErrorIsNotMaskedAsNotFound(t *testing.T) {
+	boom := errors.New("connection refused")
+	svc := &LLMProviderService{
+		templateStore: NewLLMTemplateStore(),
+		templateRepo: &repomocks.LLMProviderTemplateRepositoryMock{
+			GetByHandleFunc: func(_, _ string) (*models.LLMProviderTemplate, error) {
+				return nil, boom
+			},
+		},
+	}
+
+	_, err := svc.resolveTemplate("inhouse", "ou-acme")
+
+	assert.ErrorIs(t, err, boom)
+	assert.NotErrorIs(t, err, utils.ErrLLMProviderTemplateNotFound)
+}
+
+func TestSummarizeDeploymentFailures_NamesEachGateway(t *testing.T) {
+	summary := summarizeDeploymentFailures([]DeploymentResult{
+		{GatewayID: "gw-1", Success: false, Error: "upstream url is required"},
+		{GatewayID: "gw-2", Success: true},
+		{GatewayID: "gw-3", Success: false, Error: "gateway offline"},
+	})
+
+	assert.Contains(t, summary, "gw-1: upstream url is required")
+	assert.Contains(t, summary, "gw-3: gateway offline")
+	assert.NotContains(t, summary, "gw-2")
+}

--- a/agent-manager-service/services/mcp_proxy_service.go
+++ b/agent-manager-service/services/mcp_proxy_service.go
@@ -996,6 +996,9 @@ func sanitizeMCPUpstreamAuthForResponse(auth *models.UpstreamAuth) *models.Upstr
 	}
 	sanitized := *auth
 	sanitized.Value = nil
+	// SecretRef is the AES-256-GCM ciphertext of the same credential and is not
+	// declared on the spec's UpstreamAuth, so it must not reach a response body.
+	sanitized.SecretRef = nil
 	return &sanitized
 }
 

--- a/agent-manager-service/services/mcp_proxy_service_unit_test.go
+++ b/agent-manager-service/services/mcp_proxy_service_unit_test.go
@@ -614,3 +614,59 @@ func TestMapMCPProxyWriteError_NonPgErrorReturnsNil(t *testing.T) {
 	svc := &MCPProxyService{}
 	assert.Nil(t, svc.mapMCPProxyWriteError(errors.New("plain error"), "some-handle", "org-uuid"))
 }
+
+// TestSanitizeMCPUpstreamAuthForResponse_StripsSecretRef pins the sanitizer to the
+// contract its caller documents. SecretRef holds the AES-256-GCM ciphertext of the
+// upstream credential and is not declared on the spec's UpstreamAuth, so leaving it
+// populated shipped that ciphertext to every caller with MCP proxy read permission.
+func TestSanitizeMCPUpstreamAuthForResponse_StripsSecretRef(t *testing.T) {
+	sanitized := sanitizeMCPUpstreamAuthForResponse(&models.UpstreamAuth{
+		Type:      strPtr("api-key"),
+		Header:    strPtr("Authorization"),
+		Value:     strPtr("plaintext-upstream-key"),
+		SecretRef: strPtr("BASE64-AES-GCM-CIPHERTEXT"),
+	})
+
+	assert.Nil(t, sanitized.Value)
+	assert.Nil(t, sanitized.SecretRef)
+	assert.Equal(t, "api-key", *sanitized.Type)
+	assert.Equal(t, "Authorization", *sanitized.Header)
+}
+
+// TestSanitizeMCPUpstreamAuthForResponse_LeavesCallerIntact guards the copy: the
+// sanitizer runs on the persisted configuration, which the write path still needs.
+func TestSanitizeMCPUpstreamAuthForResponse_LeavesCallerIntact(t *testing.T) {
+	auth := &models.UpstreamAuth{
+		Type:      strPtr("api-key"),
+		SecretRef: strPtr("BASE64-AES-GCM-CIPHERTEXT"),
+	}
+
+	sanitizeMCPUpstreamAuthForResponse(auth)
+
+	assert.NotNil(t, auth.SecretRef)
+	assert.Equal(t, "BASE64-AES-GCM-CIPHERTEXT", *auth.SecretRef)
+}
+
+// TestBuildMCPEndpointDTOsForResponse_StripsUpstreamCredentials exercises the path
+// the proxy handlers actually serialize, not just the sanitizer in isolation.
+func TestBuildMCPEndpointDTOsForResponse_StripsUpstreamCredentials(t *testing.T) {
+	dtos := buildMCPEndpointDTOsForResponse([]models.MCPProxyEndpoint{
+		{
+			Handle: "primary",
+			Name:   "Primary",
+			Configuration: models.MCPEndpointConfig{
+				Upstream: &models.UpstreamEndpoint{
+					URL: "https://upstream.example",
+					Auth: &models.UpstreamAuth{
+						Type:      strPtr("api-key"),
+						SecretRef: strPtr("BASE64-AES-GCM-CIPHERTEXT"),
+					},
+				},
+			},
+		},
+	})
+
+	assert.Len(t, dtos, 1)
+	assert.Nil(t, dtos[0].Upstream.Main.Auth.Value)
+	assert.Nil(t, dtos[0].Upstream.Main.Auth.SecretRef)
+}

--- a/agent-manager-service/services/platform_gateway_service.go
+++ b/agent-manager-service/services/platform_gateway_service.go
@@ -339,12 +339,20 @@ func (s *PlatformGatewayService) ListGateways(ouID *string, filters *GatewayList
 // matched no case in handleGatewayErrors and surfaced as HTTP 500.
 func (s *PlatformGatewayService) resolveGateway(identifier, ouID string) (*models.Gateway, error) {
 	if _, err := uuid.Parse(identifier); err != nil {
-		return s.gatewayRepo.GetByNameAndOrgID(identifier, ouID)
+		return normalizeGatewayLookup(s.gatewayRepo.GetByNameAndOrgID(identifier, ouID))
 	}
+	return normalizeGatewayLookup(s.gatewayRepo.GetByUUID(identifier))
+}
 
-	gateway, err := s.gatewayRepo.GetByUUID(identifier)
+// normalizeGatewayLookup reduces either repository lookup's "no such row" shapes — a
+// gorm not-found error, the repository's own sentinel, or a nil gateway with no error
+// — to ErrGatewayNotFound, and wraps anything else with context. Both branches of
+// resolveGateway need this: a raw repository error matches no case in
+// handleGatewayErrors and surfaces as a 500, and a nil gateway returned without an
+// error is dereferenced by GetGateway.
+func normalizeGatewayLookup(gateway *models.Gateway, err error) (*models.Gateway, error) {
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, utils.ErrGatewayNotFound) {
 			return nil, utils.ErrGatewayNotFound
 		}
 		return nil, fmt.Errorf("failed to get gateway: %w", err)

--- a/agent-manager-service/services/platform_gateway_service.go
+++ b/agent-manager-service/services/platform_gateway_service.go
@@ -334,20 +334,33 @@ func (s *PlatformGatewayService) ListGateways(ouID *string, filters *GatewayList
 	return listResponse, nil
 }
 
-// GetGateway retrieves a gateway by ID
-func (s *PlatformGatewayService) GetGateway(gatewayID, ouID string) (*GatewayResponse, error) {
-	// Validate UUID format
-	if _, err := uuid.Parse(gatewayID); err != nil {
-		return nil, errors.New("invalid UUID format")
+// resolveGateway looks the identifier up as a UUID, falling back to a name lookup
+// within the org. A non-UUID identifier used to be rejected with a bare error that
+// matched no case in handleGatewayErrors and surfaced as HTTP 500.
+func (s *PlatformGatewayService) resolveGateway(identifier, ouID string) (*models.Gateway, error) {
+	if _, err := uuid.Parse(identifier); err != nil {
+		return s.gatewayRepo.GetByNameAndOrgID(identifier, ouID)
 	}
 
-	gateway, err := s.gatewayRepo.GetByUUID(gatewayID)
+	gateway, err := s.gatewayRepo.GetByUUID(identifier)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, utils.ErrGatewayNotFound
+		}
 		return nil, fmt.Errorf("failed to get gateway: %w", err)
 	}
-
 	if gateway == nil {
 		return nil, utils.ErrGatewayNotFound
+	}
+	return gateway, nil
+}
+
+// GetGateway retrieves a gateway by UUID or by name, matching what the spec
+// advertises for the path parameter ("Gateway UUID or name").
+func (s *PlatformGatewayService) GetGateway(gatewayID, ouID string) (*GatewayResponse, error) {
+	gateway, err := s.resolveGateway(gatewayID, ouID)
+	if err != nil {
+		return nil, err
 	}
 
 	if gateway.OUID != ouID {

--- a/agent-manager-service/services/platform_gateway_service_unit_test.go
+++ b/agent-manager-service/services/platform_gateway_service_unit_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+const gatewayTestOUID = "ou-acme"
+
+func gatewayFixture(name string) *models.Gateway {
+	return &models.Gateway{
+		UUID:        uuid.New(),
+		Name:        name,
+		DisplayName: name,
+		OUID:        gatewayTestOUID,
+		Vhost:       name + ".example.com",
+	}
+}
+
+// The spec advertises the path param as "Gateway UUID or name", and a name used to
+// be rejected with a bare error that matched no case in handleGatewayErrors and
+// surfaced as HTTP 500.
+func TestGetGateway_ResolvesByName(t *testing.T) {
+	gateway := gatewayFixture("edge")
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByNameAndOrgIDFunc: func(name, ouID string) (*models.Gateway, error) {
+			assert.Equal(t, "edge", name)
+			assert.Equal(t, gatewayTestOUID, ouID)
+			return gateway, nil
+		},
+		// GetByUUIDFunc nil: a name must not be looked up as a UUID.
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	resp, err := svc.GetGateway("edge", gatewayTestOUID)
+
+	require.NoError(t, err)
+	assert.Equal(t, gateway.UUID.String(), resp.ID)
+	assert.Equal(t, "edge", resp.Name)
+}
+
+func TestGetGateway_ResolvesByUUID(t *testing.T) {
+	gateway := gatewayFixture("edge")
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByUUIDFunc: func(gatewayID string) (*models.Gateway, error) {
+			assert.Equal(t, gateway.UUID.String(), gatewayID)
+			return gateway, nil
+		},
+		// GetByNameAndOrgIDFunc nil: a UUID must not fall through to a name lookup.
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	resp, err := svc.GetGateway(gateway.UUID.String(), gatewayTestOUID)
+
+	require.NoError(t, err)
+	assert.Equal(t, gateway.UUID.String(), resp.ID)
+}
+
+func TestGetGateway_UnknownNameIsNotFound(t *testing.T) {
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByNameAndOrgIDFunc: func(_, _ string) (*models.Gateway, error) {
+			return nil, utils.ErrGatewayNotFound
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	_, err := svc.GetGateway("ghost", gatewayTestOUID)
+
+	assert.ErrorIs(t, err, utils.ErrGatewayNotFound)
+}
+
+func TestGetGateway_UnknownUUIDIsNotFound(t *testing.T) {
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByUUIDFunc: func(_ string) (*models.Gateway, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	_, err := svc.GetGateway(uuid.New().String(), gatewayTestOUID)
+
+	assert.ErrorIs(t, err, utils.ErrGatewayNotFound)
+}
+
+// A real repository failure must not be flattened into not-found.
+func TestGetGateway_RepositoryErrorIsNotMaskedAsNotFound(t *testing.T) {
+	boom := errors.New("connection refused")
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByUUIDFunc: func(_ string) (*models.Gateway, error) {
+			return nil, boom
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	_, err := svc.GetGateway(uuid.New().String(), gatewayTestOUID)
+
+	assert.ErrorIs(t, err, boom)
+	assert.NotErrorIs(t, err, utils.ErrGatewayNotFound)
+}
+
+// Org isolation: a gateway UUID from another org reads as absent, not forbidden.
+func TestGetGateway_OtherOrgGatewayIsNotFound(t *testing.T) {
+	gateway := gatewayFixture("edge")
+	gateway.OUID = "ou-other"
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByUUIDFunc: func(_ string) (*models.Gateway, error) {
+			return gateway, nil
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	_, err := svc.GetGateway(gateway.UUID.String(), gatewayTestOUID)
+
+	assert.ErrorIs(t, err, utils.ErrGatewayNotFound)
+}

--- a/agent-manager-service/services/platform_gateway_service_unit_test.go
+++ b/agent-manager-service/services/platform_gateway_service_unit_test.go
@@ -107,6 +107,35 @@ func TestGetGateway_UnknownUUIDIsNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, utils.ErrGatewayNotFound)
 }
 
+// The name branch used to return the repository error verbatim, so a bare failure
+// matched no case in handleGatewayErrors and surfaced as a 500 instead of a 404.
+func TestGetGateway_UnknownNameFromGormIsNotFound(t *testing.T) {
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByNameAndOrgIDFunc: func(_, _ string) (*models.Gateway, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	_, err := svc.GetGateway("ghost", gatewayTestOUID)
+
+	assert.ErrorIs(t, err, utils.ErrGatewayNotFound)
+}
+
+// A nil gateway with no error reached GetGateway's OUID check and panicked.
+func TestGetGateway_NilGatewayWithoutErrorIsNotFound(t *testing.T) {
+	repo := &repomocks.GatewayRepositoryMock{
+		GetByNameAndOrgIDFunc: func(_, _ string) (*models.Gateway, error) {
+			return nil, nil //nolint:nilnil // the shape under test
+		},
+	}
+	svc := NewPlatformGatewayService(repo, nil)
+
+	_, err := svc.GetGateway("ghost", gatewayTestOUID)
+
+	assert.ErrorIs(t, err, utils.ErrGatewayNotFound)
+}
+
 // A real repository failure must not be flattened into not-found.
 func TestGetGateway_RepositoryErrorIsNotMaskedAsNotFound(t *testing.T) {
 	boom := errors.New("connection refused")

--- a/agent-manager-service/spec/api_llm_deployments.go
+++ b/agent-manager-service/spec/api_llm_deployments.go
@@ -26,7 +26,7 @@ type ApiDeleteLLMProviderDeploymentRequest struct {
 	ctx          context.Context
 	ApiService   *LLMDeploymentsAPIService
 	orgName      string
-	id           string
+	providerId   string
 	deploymentId string
 }
 
@@ -41,16 +41,16 @@ Delete a deployment (must be undeployed first)
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@param deploymentId Deployment UUID
 	@return ApiDeleteLLMProviderDeploymentRequest
 */
-func (a *LLMDeploymentsAPIService) DeleteLLMProviderDeployment(ctx context.Context, orgName string, id string, deploymentId string) ApiDeleteLLMProviderDeploymentRequest {
+func (a *LLMDeploymentsAPIService) DeleteLLMProviderDeployment(ctx context.Context, orgName string, providerId string, deploymentId string) ApiDeleteLLMProviderDeploymentRequest {
 	return ApiDeleteLLMProviderDeploymentRequest{
 		ApiService:   a,
 		ctx:          ctx,
 		orgName:      orgName,
-		id:           id,
+		providerId:   providerId,
 		deploymentId: deploymentId,
 	}
 }
@@ -68,9 +68,9 @@ func (a *LLMDeploymentsAPIService) DeleteLLMProviderDeploymentExecute(r ApiDelet
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/deployments/{deploymentId}"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/deployments/{deploymentId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"deploymentId"+"}", url.PathEscape(parameterValueToString(r.deploymentId, "deploymentId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -180,7 +180,7 @@ type ApiDeployLLMProviderRequest struct {
 	ctx                context.Context
 	ApiService         *LLMDeploymentsAPIService
 	orgName            string
-	id                 string
+	providerId         string
 	deployAgentRequest *DeployAgentRequest
 }
 
@@ -200,15 +200,15 @@ Deploy an LLM provider to a gateway
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiDeployLLMProviderRequest
 */
-func (a *LLMDeploymentsAPIService) DeployLLMProvider(ctx context.Context, orgName string, id string) ApiDeployLLMProviderRequest {
+func (a *LLMDeploymentsAPIService) DeployLLMProvider(ctx context.Context, orgName string, providerId string) ApiDeployLLMProviderRequest {
 	return ApiDeployLLMProviderRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -228,9 +228,9 @@ func (a *LLMDeploymentsAPIService) DeployLLMProviderExecute(r ApiDeployLLMProvid
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/deployments"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/deployments"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -342,7 +342,7 @@ type ApiGetLLMProviderDeploymentRequest struct {
 	ctx          context.Context
 	ApiService   *LLMDeploymentsAPIService
 	orgName      string
-	id           string
+	providerId   string
 	deploymentId string
 }
 
@@ -357,16 +357,16 @@ Retrieve detailed information about a specific deployment
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@param deploymentId Deployment UUID
 	@return ApiGetLLMProviderDeploymentRequest
 */
-func (a *LLMDeploymentsAPIService) GetLLMProviderDeployment(ctx context.Context, orgName string, id string, deploymentId string) ApiGetLLMProviderDeploymentRequest {
+func (a *LLMDeploymentsAPIService) GetLLMProviderDeployment(ctx context.Context, orgName string, providerId string, deploymentId string) ApiGetLLMProviderDeploymentRequest {
 	return ApiGetLLMProviderDeploymentRequest{
 		ApiService:   a,
 		ctx:          ctx,
 		orgName:      orgName,
-		id:           id,
+		providerId:   providerId,
 		deploymentId: deploymentId,
 	}
 }
@@ -387,9 +387,9 @@ func (a *LLMDeploymentsAPIService) GetLLMProviderDeploymentExecute(r ApiGetLLMPr
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/deployments/{deploymentId}"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/deployments/{deploymentId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"deploymentId"+"}", url.PathEscape(parameterValueToString(r.deploymentId, "deploymentId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
@@ -497,7 +497,7 @@ type ApiGetLLMProviderDeploymentsRequest struct {
 	ctx        context.Context
 	ApiService *LLMDeploymentsAPIService
 	orgName    string
-	id         string
+	providerId string
 	gatewayId  *string
 	status     *string
 }
@@ -525,15 +525,15 @@ Retrieve all deployments for an LLM provider
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiGetLLMProviderDeploymentsRequest
 */
-func (a *LLMDeploymentsAPIService) GetLLMProviderDeployments(ctx context.Context, orgName string, id string) ApiGetLLMProviderDeploymentsRequest {
+func (a *LLMDeploymentsAPIService) GetLLMProviderDeployments(ctx context.Context, orgName string, providerId string) ApiGetLLMProviderDeploymentsRequest {
 	return ApiGetLLMProviderDeploymentsRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -553,9 +553,9 @@ func (a *LLMDeploymentsAPIService) GetLLMProviderDeploymentsExecute(r ApiGetLLMP
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/deployments"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/deployments"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -668,7 +668,7 @@ type ApiRestoreLLMProviderDeploymentRequest struct {
 	ctx          context.Context
 	ApiService   *LLMDeploymentsAPIService
 	orgName      string
-	id           string
+	providerId   string
 	deploymentId *string
 	gatewayId    *string
 }
@@ -696,15 +696,15 @@ Restore a previously undeployed deployment
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiRestoreLLMProviderDeploymentRequest
 */
-func (a *LLMDeploymentsAPIService) RestoreLLMProviderDeployment(ctx context.Context, orgName string, id string) ApiRestoreLLMProviderDeploymentRequest {
+func (a *LLMDeploymentsAPIService) RestoreLLMProviderDeployment(ctx context.Context, orgName string, providerId string) ApiRestoreLLMProviderDeploymentRequest {
 	return ApiRestoreLLMProviderDeploymentRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -724,9 +724,9 @@ func (a *LLMDeploymentsAPIService) RestoreLLMProviderDeploymentExecute(r ApiRest
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/deployments/restore"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/deployments/restore"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -852,7 +852,7 @@ type ApiUndeployLLMProviderDeploymentRequest struct {
 	ctx          context.Context
 	ApiService   *LLMDeploymentsAPIService
 	orgName      string
-	id           string
+	providerId   string
 	deploymentId *string
 	gatewayId    *string
 }
@@ -880,15 +880,15 @@ Undeploy a specific deployment of an LLM provider
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiUndeployLLMProviderDeploymentRequest
 */
-func (a *LLMDeploymentsAPIService) UndeployLLMProviderDeployment(ctx context.Context, orgName string, id string) ApiUndeployLLMProviderDeploymentRequest {
+func (a *LLMDeploymentsAPIService) UndeployLLMProviderDeployment(ctx context.Context, orgName string, providerId string) ApiUndeployLLMProviderDeploymentRequest {
 	return ApiUndeployLLMProviderDeploymentRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -908,9 +908,9 @@ func (a *LLMDeploymentsAPIService) UndeployLLMProviderDeploymentExecute(r ApiUnd
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/deployments/undeploy"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/deployments/undeploy"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/agent-manager-service/spec/api_llm_providers.go
+++ b/agent-manager-service/spec/api_llm_providers.go
@@ -184,7 +184,7 @@ type ApiDeleteLLMProviderRequest struct {
 	ctx        context.Context
 	ApiService *LLMProvidersAPIService
 	orgName    string
-	id         string
+	providerId string
 }
 
 func (r ApiDeleteLLMProviderRequest) Execute() (*http.Response, error) {
@@ -194,19 +194,23 @@ func (r ApiDeleteLLMProviderRequest) Execute() (*http.Response, error) {
 /*
 DeleteLLMProvider Delete LLM provider
 
-Delete an LLM provider
+Delete an LLM provider.
+
+The provider is undeployed from every gateway it is deployed to before it is
+removed. Deletion is refused with a 409 while anything still references the
+provider — an LLM proxy, or an agent's LLM configuration.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiDeleteLLMProviderRequest
 */
-func (a *LLMProvidersAPIService) DeleteLLMProvider(ctx context.Context, orgName string, id string) ApiDeleteLLMProviderRequest {
+func (a *LLMProvidersAPIService) DeleteLLMProvider(ctx context.Context, orgName string, providerId string) ApiDeleteLLMProviderRequest {
 	return ApiDeleteLLMProviderRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -223,9 +227,9 @@ func (a *LLMProvidersAPIService) DeleteLLMProviderExecute(r ApiDeleteLLMProvider
 		return nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -292,7 +296,29 @@ func (a *LLMProvidersAPIService) DeleteLLMProviderExecute(r ApiDeleteLLMProvider
 			newErr.model = v
 			return localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 403 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 404 {
+			var v ErrorResponse
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 409 {
 			var v ErrorResponse
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
@@ -323,7 +349,7 @@ type ApiGetLLMProviderRequest struct {
 	ctx        context.Context
 	ApiService *LLMProvidersAPIService
 	orgName    string
-	id         string
+	providerId string
 }
 
 func (r ApiGetLLMProviderRequest) Execute() (*LLMProviderResponse, *http.Response, error) {
@@ -337,15 +363,15 @@ Retrieve detailed information about a specific provider
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiGetLLMProviderRequest
 */
-func (a *LLMProvidersAPIService) GetLLMProvider(ctx context.Context, orgName string, id string) ApiGetLLMProviderRequest {
+func (a *LLMProvidersAPIService) GetLLMProvider(ctx context.Context, orgName string, providerId string) ApiGetLLMProviderRequest {
 	return ApiGetLLMProviderRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -365,9 +391,9 @@ func (a *LLMProvidersAPIService) GetLLMProviderExecute(r ApiGetLLMProviderReques
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -620,7 +646,7 @@ type ApiListLLMProviderConsumersRequest struct {
 	ctx        context.Context
 	ApiService *LLMProvidersAPIService
 	orgName    string
-	id         string
+	providerId string
 }
 
 func (r ApiListLLMProviderConsumersRequest) Execute() (*LLMProviderConsumerListResponse, *http.Response, error) {
@@ -634,15 +660,15 @@ Returns a flat list of agents and monitors that consume any LLM proxy pointing t
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID or handle
+	@param providerId Provider UUID or handle
 	@return ApiListLLMProviderConsumersRequest
 */
-func (a *LLMProvidersAPIService) ListLLMProviderConsumers(ctx context.Context, orgName string, id string) ApiListLLMProviderConsumersRequest {
+func (a *LLMProvidersAPIService) ListLLMProviderConsumers(ctx context.Context, orgName string, providerId string) ApiListLLMProviderConsumersRequest {
 	return ApiListLLMProviderConsumersRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -662,9 +688,9 @@ func (a *LLMProvidersAPIService) ListLLMProviderConsumersExecute(r ApiListLLMPro
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/consumers"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/consumers"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -927,7 +953,7 @@ type ApiListLLMProxiesByProviderRequest struct {
 	ctx        context.Context
 	ApiService *LLMProvidersAPIService
 	orgName    string
-	id         string
+	providerId string
 	limit      *int32
 	offset     *int32
 }
@@ -955,15 +981,15 @@ Retrieve all proxies associated with a specific provider
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiListLLMProxiesByProviderRequest
 */
-func (a *LLMProvidersAPIService) ListLLMProxiesByProvider(ctx context.Context, orgName string, id string) ApiListLLMProxiesByProviderRequest {
+func (a *LLMProvidersAPIService) ListLLMProxiesByProvider(ctx context.Context, orgName string, providerId string) ApiListLLMProxiesByProviderRequest {
 	return ApiListLLMProxiesByProviderRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -983,9 +1009,9 @@ func (a *LLMProvidersAPIService) ListLLMProxiesByProviderExecute(r ApiListLLMPro
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/llm-proxies"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/llm-proxies"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1098,7 +1124,7 @@ type ApiUpdateLLMProviderRequest struct {
 	ctx                      context.Context
 	ApiService               *LLMProvidersAPIService
 	orgName                  string
-	id                       string
+	providerId               string
 	updateLLMProviderRequest *UpdateLLMProviderRequest
 }
 
@@ -1118,15 +1144,15 @@ Update an existing LLM provider
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiUpdateLLMProviderRequest
 */
-func (a *LLMProvidersAPIService) UpdateLLMProvider(ctx context.Context, orgName string, id string) ApiUpdateLLMProviderRequest {
+func (a *LLMProvidersAPIService) UpdateLLMProvider(ctx context.Context, orgName string, providerId string) ApiUpdateLLMProviderRequest {
 	return ApiUpdateLLMProviderRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -1146,9 +1172,9 @@ func (a *LLMProvidersAPIService) UpdateLLMProviderExecute(r ApiUpdateLLMProvider
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -1260,7 +1286,7 @@ type ApiUpdateLLMProviderCatalogStatusRequest struct {
 	ctx                             context.Context
 	ApiService                      *LLMProvidersAPIService
 	orgName                         string
-	id                              string
+	providerId                      string
 	updateLLMProviderCatalogRequest *UpdateLLMProviderCatalogRequest
 }
 
@@ -1286,15 +1312,15 @@ and will not appear in catalog queries.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
-	@param id Provider UUID
+	@param providerId Provider UUID
 	@return ApiUpdateLLMProviderCatalogStatusRequest
 */
-func (a *LLMProvidersAPIService) UpdateLLMProviderCatalogStatus(ctx context.Context, orgName string, id string) ApiUpdateLLMProviderCatalogStatusRequest {
+func (a *LLMProvidersAPIService) UpdateLLMProviderCatalogStatus(ctx context.Context, orgName string, providerId string) ApiUpdateLLMProviderCatalogStatusRequest {
 	return ApiUpdateLLMProviderCatalogStatusRequest{
 		ApiService: a,
 		ctx:        ctx,
 		orgName:    orgName,
-		id:         id,
+		providerId: providerId,
 	}
 }
 
@@ -1314,9 +1340,9 @@ func (a *LLMProvidersAPIService) UpdateLLMProviderCatalogStatusExecute(r ApiUpda
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{id}/catalog"
+	localVarPath := localBasePath + "/orgs/{orgName}/llm-providers/{providerId}/catalog"
 	localVarPath = strings.Replace(localVarPath, "{"+"orgName"+"}", url.PathEscape(parameterValueToString(r.orgName, "orgName")), -1)
-	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterValueToString(r.id, "id")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"providerId"+"}", url.PathEscape(parameterValueToString(r.providerId, "providerId")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/agent-manager-service/tests/build_agent_test.go
+++ b/agent-manager-service/tests/build_agent_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/wiring"
@@ -75,16 +76,20 @@ func TestBuildAgent(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("response body: %s", string(b))
 
-		var build models.BuildResponse
+		// Decode into the spec type, not the internal model: the 202 body is a
+		// wire contract, and decoding into models.BuildResponse is what let the
+		// buildName/buildId omission ship unnoticed.
+		var build spec.BuildResponse
 		require.NoError(t, json.Unmarshal(b, &build))
 
 		// Validate response fields
 		require.Equal(t, buildTestAgentName, build.AgentName)
 		require.Equal(t, buildTestProjName, build.ProjectName)
-		require.Equal(t, commitId, build.BuildParameters.CommitID)
-		require.Equal(t, "BuildInitiated", build.Status)
-		require.NotEmpty(t, build.Name)
-		require.NotEmpty(t, build.UUID)
+		require.Equal(t, commitId, build.BuildParameters.CommitId)
+		require.Equal(t, "BuildInitiated", *build.Status)
+		require.NotEmpty(t, build.BuildName)
+		require.NotNil(t, build.BuildId)
+		require.NotEmpty(t, *build.BuildId)
 		require.NotZero(t, build.StartedAt)
 
 		// Validate service calls
@@ -124,15 +129,16 @@ func TestBuildAgent(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("response body: %s", string(b))
 
-		var build models.BuildResponse
+		var build spec.BuildResponse
 		require.NoError(t, json.Unmarshal(b, &build))
 
 		// Validate response fields
 		require.Equal(t, buildTestAgentName, build.AgentName)
 		require.Equal(t, buildTestProjName, build.ProjectName)
-		require.Equal(t, "BuildInitiated", build.Status)
-		require.NotEmpty(t, build.Name)
-		require.NotEmpty(t, build.UUID)
+		require.Equal(t, "BuildInitiated", *build.Status)
+		require.NotEmpty(t, build.BuildName)
+		require.NotNil(t, build.BuildId)
+		require.NotEmpty(t, *build.BuildId)
 		require.NotZero(t, build.StartedAt)
 
 		// Validate service calls

--- a/agent-manager-service/tests/create_agent_test.go
+++ b/agent-manager-service/tests/create_agent_test.go
@@ -1088,6 +1088,9 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 
 		require.Equal(t, http.StatusAccepted, rr.Code, rr.Body.String())
 
+		require.NotContains(t, rr.Body.String(), "sk-kind-default-secret",
+			"the 202 body must not echo the kind's stored secret default, which the caller never supplied and is not entitled to")
+
 		require.Len(t, secretMgmtClient.CreateSecretCalls(), 1)
 		require.Equal(t, "sk-kind-default-secret", secretMgmtClient.CreateSecretCalls()[0].Data["OPENAI_API_KEY"])
 
@@ -1144,6 +1147,9 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 		app.ServeHTTP(rr, req)
 
 		require.Equal(t, http.StatusAccepted, rr.Code, rr.Body.String())
+
+		require.NotContains(t, rr.Body.String(), "my-own-api-key",
+			"the 202 body must not echo a submitted secret value back to the caller")
 
 		require.Len(t, secretMgmtClient.CreateSecretCalls(), 1)
 		require.Equal(t, "my-own-api-key", secretMgmtClient.CreateSecretCalls()[0].Data["OPENAI_API_KEY"])

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -164,6 +164,7 @@ var (
 	ErrLLMProviderNotFound         = errors.New("LLM provider not found")
 	ErrLLMProviderExists           = errors.New("LLM provider already exists")
 	ErrLLMProviderHasProxies       = errors.New("cannot delete LLM provider: it has associated LLM proxies. Please delete all proxies before deleting the provider")
+	ErrLLMProviderUndeployFailed   = errors.New("cannot delete LLM provider: undeploying it from its gateways failed. Retry, or undeploy manually before deleting")
 	ErrLLMProxyNotFound            = errors.New("LLM proxy not found")
 	ErrLLMProxyExists              = errors.New("LLM proxy already exists")
 	ErrMCPProxyNotFound            = errors.New("MCP proxy not found")

--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -17,6 +17,8 @@
 package utils
 
 import (
+	"slices"
+
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
@@ -1107,29 +1109,21 @@ func RedactSecretConfigValues(cfg *spec.Configurations) *spec.Configurations {
 }
 
 func redactSensitiveEnvValues(env []spec.EnvironmentVariable) []spec.EnvironmentVariable {
-	if len(env) == 0 {
-		return env
-	}
-	redacted := make([]spec.EnvironmentVariable, len(env))
-	for i, variable := range env {
-		if BoolPointerAsBool(variable.IsSensitive, false) {
-			variable.Value = nil
+	redacted := slices.Clone(env)
+	for i := range redacted {
+		if BoolPointerAsBool(redacted[i].IsSensitive, false) {
+			redacted[i].Value = nil
 		}
-		redacted[i] = variable
 	}
 	return redacted
 }
 
 func redactSensitiveFileValues(files []spec.FileMount) []spec.FileMount {
-	if len(files) == 0 {
-		return files
-	}
-	redacted := make([]spec.FileMount, len(files))
-	for i, file := range files {
-		if BoolPointerAsBool(file.IsSensitive, false) {
-			file.Value = nil
+	redacted := slices.Clone(files)
+	for i := range redacted {
+		if BoolPointerAsBool(redacted[i].IsSensitive, false) {
+			redacted[i].Value = nil
 		}
-		redacted[i] = file
 	}
 	return redacted
 }

--- a/agent-manager-service/utils/makeresults.go
+++ b/agent-manager-service/utils/makeresults.go
@@ -1086,3 +1086,50 @@ func convertTraceEvaluatorScores(evals []models.TraceEvaluatorScore) []spec.Trac
 	}
 	return result
 }
+
+// RedactSecretConfigValues returns a copy of cfg with the value of every sensitive
+// env var and file mount omitted, so a secret submitted on create is never
+// serialized back out. Mirrors the read path in GetAgentConfigurations, which
+// blanks the same fields.
+//
+// The copy is not incidental: cfg points into the decoded request body, and for
+// kind-based agents ApplySecretConfigDefaults has already written the kind's stored
+// secret defaults into the backing slices. Redacting in place would make
+// correctness depend on the order in which the service and the handler run.
+func RedactSecretConfigValues(cfg *spec.Configurations) *spec.Configurations {
+	if cfg == nil {
+		return nil
+	}
+	redacted := *cfg
+	redacted.Env = redactSensitiveEnvValues(cfg.Env)
+	redacted.Files = redactSensitiveFileValues(cfg.Files)
+	return &redacted
+}
+
+func redactSensitiveEnvValues(env []spec.EnvironmentVariable) []spec.EnvironmentVariable {
+	if len(env) == 0 {
+		return env
+	}
+	redacted := make([]spec.EnvironmentVariable, len(env))
+	for i, variable := range env {
+		if BoolPointerAsBool(variable.IsSensitive, false) {
+			variable.Value = nil
+		}
+		redacted[i] = variable
+	}
+	return redacted
+}
+
+func redactSensitiveFileValues(files []spec.FileMount) []spec.FileMount {
+	if len(files) == 0 {
+		return files
+	}
+	redacted := make([]spec.FileMount, len(files))
+	for i, file := range files {
+		if BoolPointerAsBool(file.IsSensitive, false) {
+			file.Value = nil
+		}
+		redacted[i] = file
+	}
+	return redacted
+}

--- a/agent-manager-service/utils/makeresults_redact_test.go
+++ b/agent-manager-service/utils/makeresults_redact_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+)
+
+func TestRedactSecretConfigValues(t *testing.T) {
+	t.Run("nil configurations stay nil", func(t *testing.T) {
+		require.Nil(t, RedactSecretConfigValues(nil))
+	})
+
+	t.Run("sensitive values are omitted and plain ones survive", func(t *testing.T) {
+		cfg := &spec.Configurations{
+			Env: []spec.EnvironmentVariable{
+				{Key: "OPENAI_API_KEY", Value: spec.PtrString("sk-super-secret"), IsSensitive: spec.PtrBool(true)},
+				{Key: "LOG_LEVEL", Value: spec.PtrString("debug")},
+			},
+			Files: []spec.FileMount{
+				{Key: "creds.json", MountPath: "/etc/creds.json", Value: spec.PtrString("file-super-secret"), IsSensitive: spec.PtrBool(true)},
+				{Key: "app.conf", MountPath: "/etc/app.conf", Value: spec.PtrString("plain=1")},
+			},
+		}
+
+		redacted := RedactSecretConfigValues(cfg)
+
+		require.Nil(t, redacted.Env[0].Value)
+		require.Equal(t, "debug", *redacted.Env[1].Value)
+		require.Nil(t, redacted.Files[0].Value)
+		require.Equal(t, "plain=1", *redacted.Files[1].Value)
+
+		// A nil *string with json:"value,omitempty" must drop the key entirely,
+		// not serialize as an empty string.
+		body, err := json.Marshal(redacted)
+		require.NoError(t, err)
+		require.NotContains(t, string(body), "sk-super-secret")
+		require.NotContains(t, string(body), "file-super-secret")
+		require.Contains(t, string(body), "debug")
+	})
+
+	t.Run("the caller's configurations are left intact", func(t *testing.T) {
+		// The handler redacts a pointer into the decoded request body, which the
+		// service still holds; redacting in place would corrupt it.
+		cfg := &spec.Configurations{
+			Env: []spec.EnvironmentVariable{
+				{Key: "OPENAI_API_KEY", Value: spec.PtrString("sk-super-secret"), IsSensitive: spec.PtrBool(true)},
+			},
+		}
+
+		RedactSecretConfigValues(cfg)
+
+		require.NotNil(t, cfg.Env[0].Value)
+		require.Equal(t, "sk-super-secret", *cfg.Env[0].Value)
+	})
+
+	t.Run("unrelated configuration fields are carried through", func(t *testing.T) {
+		cfg := &spec.Configurations{
+			EnableAutoInstrumentation: spec.PtrBool(true),
+			EnableApiKeySecurity:      spec.PtrBool(false),
+			ResilienceTimeoutSeconds:  spec.PtrInt32(45),
+		}
+
+		redacted := RedactSecretConfigValues(cfg)
+
+		require.True(t, *redacted.EnableAutoInstrumentation)
+		require.False(t, *redacted.EnableApiKeySecurity)
+		require.Equal(t, int32(45), *redacted.ResilienceTimeoutSeconds)
+	})
+}

--- a/agent-manager-service/utils/spec_converter.go
+++ b/agent-manager-service/utils/spec_converter.go
@@ -577,11 +577,11 @@ func ConvertModelToSpecUpstreamConfig(config models.UpstreamConfig) spec.Upstrea
 // to read its header from config.Main.Auth, which panics for a provider that has a
 // sandbox credential and no main one.
 func maskedSpecUpstreamAuth(auth *models.UpstreamAuth) *spec.UpstreamAuth {
-	maskedValue := "***REDACTED***"
+	masked := redactedMarker
 	return &spec.UpstreamAuth{
 		Type:   StrPointerAsStr(auth.Type, ""),
 		Header: auth.Header,
-		Value:  &maskedValue,
+		Value:  &masked,
 	}
 }
 

--- a/agent-manager-service/utils/spec_converter.go
+++ b/agent-manager-service/utils/spec_converter.go
@@ -553,13 +553,7 @@ func ConvertModelToSpecUpstreamConfig(config models.UpstreamConfig) spec.Upstrea
 			Ref: stringToPtr(config.Main.Ref),
 		}
 		if config.Main.Auth != nil {
-			// Mask credential value in API responses for security
-			maskedValue := "***REDACTED***"
-			main.Auth = &spec.UpstreamAuth{
-				Type:   *config.Main.Auth.Type,
-				Header: config.Main.Auth.Header,
-				Value:  &maskedValue,
-			}
+			main.Auth = maskedSpecUpstreamAuth(config.Main.Auth)
 		}
 		specConfig.Main = &main
 	}
@@ -570,18 +564,25 @@ func ConvertModelToSpecUpstreamConfig(config models.UpstreamConfig) spec.Upstrea
 			Ref: stringToPtr(config.Sandbox.Ref),
 		}
 		if config.Sandbox.Auth != nil {
-			// Mask credential value in API responses for security
-			maskedValue := "***REDACTED***"
-			sandbox.Auth = &spec.UpstreamAuth{
-				Type:   *config.Sandbox.Auth.Type,
-				Header: config.Main.Auth.Header,
-				Value:  &maskedValue,
-			}
+			sandbox.Auth = maskedSpecUpstreamAuth(config.Sandbox.Auth)
 		}
 		specConfig.Sandbox = &sandbox
 	}
 
 	return specConfig
+}
+
+// maskedSpecUpstreamAuth converts an upstream auth block for a response, replacing
+// the credential with a fixed mask. Both endpoints share it: the sandbox branch used
+// to read its header from config.Main.Auth, which panics for a provider that has a
+// sandbox credential and no main one.
+func maskedSpecUpstreamAuth(auth *models.UpstreamAuth) *spec.UpstreamAuth {
+	maskedValue := "***REDACTED***"
+	return &spec.UpstreamAuth{
+		Type:   StrPointerAsStr(auth.Type, ""),
+		Header: auth.Header,
+		Value:  &maskedValue,
+	}
 }
 
 // ConvertSpecToModelLLMAccessControl converts spec to model LLMAccessControl

--- a/agent-manager-service/utils/spec_converter_upstream_test.go
+++ b/agent-manager-service/utils/spec_converter_upstream_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+)
+
+func upstreamStrPtr(s string) *string { return &s }
+
+// The sandbox branch used to read its header from config.Main.Auth, so a provider
+// with a sandbox credential and no main auth panicked on every read.
+func TestConvertModelToSpecUpstream_SandboxAuthWithoutMainAuth(t *testing.T) {
+	converted := ConvertModelToSpecUpstreamConfig(models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{URL: "https://api.example"},
+		Sandbox: &models.UpstreamEndpoint{
+			URL: "https://sandbox.example",
+			Auth: &models.UpstreamAuth{
+				Type:   upstreamStrPtr("api-key"),
+				Header: upstreamStrPtr("X-Sandbox-Key"),
+				Value:  upstreamStrPtr("sk-sandbox-secret"),
+			},
+		},
+	})
+
+	require.NotNil(t, converted.Sandbox)
+	require.NotNil(t, converted.Sandbox.Auth)
+	assert.Equal(t, "api-key", converted.Sandbox.Auth.Type)
+	assert.Equal(t, "X-Sandbox-Key", *converted.Sandbox.Auth.Header,
+		"the sandbox header must come from the sandbox endpoint, not from main")
+	assert.Equal(t, "***REDACTED***", *converted.Sandbox.Auth.Value)
+	assert.Nil(t, converted.Main.Auth)
+}
+
+// Type is a *string on the model and a plain string on the wire, so a decoded
+// request that omitted it used to panic on the way back out.
+func TestConvertModelToSpecUpstream_AuthWithoutType(t *testing.T) {
+	converted := ConvertModelToSpecUpstreamConfig(models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{
+			URL:  "https://api.example",
+			Auth: &models.UpstreamAuth{Value: upstreamStrPtr("sk-secret")},
+		},
+	})
+
+	require.NotNil(t, converted.Main.Auth)
+	assert.Equal(t, "", converted.Main.Auth.Type)
+	assert.Equal(t, "***REDACTED***", *converted.Main.Auth.Value)
+}
+
+func TestConvertModelToSpecUpstream_MasksBothEndpoints(t *testing.T) {
+	converted := ConvertModelToSpecUpstreamConfig(models.UpstreamConfig{
+		Main: &models.UpstreamEndpoint{
+			URL:  "https://api.example",
+			Auth: &models.UpstreamAuth{Type: upstreamStrPtr("api-key"), Value: upstreamStrPtr("sk-main")},
+		},
+		Sandbox: &models.UpstreamEndpoint{
+			URL:  "https://sandbox.example",
+			Auth: &models.UpstreamAuth{Type: upstreamStrPtr("api-key"), Value: upstreamStrPtr("sk-sandbox")},
+		},
+	})
+
+	assert.Equal(t, "***REDACTED***", *converted.Main.Auth.Value)
+	assert.Equal(t, "***REDACTED***", *converted.Sandbox.Auth.Value)
+}

--- a/cli/pkg/clients/amsvc/gen/client.gen.go
+++ b/cli/pkg/clients/amsvc/gen/client.gen.go
@@ -467,17 +467,6 @@ type ClientInterface interface {
 	// ListAvailableLLMPolicies request
 	ListAvailableLLMPolicies(ctx context.Context, orgName string, params *ListAvailableLLMPoliciesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// DeleteLLMProvider request
-	DeleteLLMProvider(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// GetLLMProvider request
-	GetLLMProvider(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// UpdateLLMProviderWithBody request with any body
-	UpdateLLMProviderWithBody(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	UpdateLLMProvider(ctx context.Context, orgName string, id string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// ListLLMProviderAPIKeys request
 	ListLLMProviderAPIKeys(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -494,36 +483,47 @@ type ClientInterface interface {
 
 	RotateLLMProviderAPIKey(ctx context.Context, orgName string, id string, keyName string, body RotateLLMProviderAPIKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UpdateLLMProviderCatalogStatusWithBody request with any body
-	UpdateLLMProviderCatalogStatusWithBody(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// DeleteLLMProvider request
+	DeleteLLMProvider(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	UpdateLLMProviderCatalogStatus(ctx context.Context, orgName string, id string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetLLMProvider request
+	GetLLMProvider(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateLLMProviderWithBody request with any body
+	UpdateLLMProviderWithBody(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateLLMProvider(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateLLMProviderCatalogStatusWithBody request with any body
+	UpdateLLMProviderCatalogStatusWithBody(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateLLMProviderCatalogStatus(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListLLMProviderConsumers request
-	ListLLMProviderConsumers(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListLLMProviderConsumers(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetLLMProviderDeployments request
-	GetLLMProviderDeployments(ctx context.Context, orgName string, id string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetLLMProviderDeployments(ctx context.Context, orgName string, providerId string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeployLLMProviderWithBody request with any body
-	DeployLLMProviderWithBody(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeployLLMProviderWithBody(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	DeployLLMProvider(ctx context.Context, orgName string, id string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeployLLMProvider(ctx context.Context, orgName string, providerId string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RestoreLLMProviderDeployment request
-	RestoreLLMProviderDeployment(ctx context.Context, orgName string, id string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	RestoreLLMProviderDeployment(ctx context.Context, orgName string, providerId string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UndeployLLMProviderDeployment request
-	UndeployLLMProviderDeployment(ctx context.Context, orgName string, id string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UndeployLLMProviderDeployment(ctx context.Context, orgName string, providerId string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteLLMProviderDeployment request
-	DeleteLLMProviderDeployment(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	DeleteLLMProviderDeployment(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetLLMProviderDeployment request
-	GetLLMProviderDeployment(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetLLMProviderDeployment(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListLLMProxiesByProvider request
-	ListLLMProxiesByProvider(ctx context.Context, orgName string, id string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListLLMProxiesByProvider(ctx context.Context, orgName string, providerId string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListMCPProxies request
 	ListMCPProxies(ctx context.Context, orgName string, params *ListMCPProxiesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2544,54 +2544,6 @@ func (c *Client) ListAvailableLLMPolicies(ctx context.Context, orgName string, p
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteLLMProvider(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteLLMProviderRequest(c.Server, orgName, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) GetLLMProvider(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetLLMProviderRequest(c.Server, orgName, id)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateLLMProviderWithBody(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateLLMProviderRequestWithBody(c.Server, orgName, id, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) UpdateLLMProvider(ctx context.Context, orgName string, id string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateLLMProviderRequest(c.Server, orgName, id, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) ListLLMProviderAPIKeys(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListLLMProviderAPIKeysRequest(c.Server, orgName, id)
 	if err != nil {
@@ -2664,8 +2616,8 @@ func (c *Client) RotateLLMProviderAPIKey(ctx context.Context, orgName string, id
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateLLMProviderCatalogStatusWithBody(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateLLMProviderCatalogStatusRequestWithBody(c.Server, orgName, id, contentType, body)
+func (c *Client) DeleteLLMProvider(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteLLMProviderRequest(c.Server, orgName, providerId)
 	if err != nil {
 		return nil, err
 	}
@@ -2676,8 +2628,8 @@ func (c *Client) UpdateLLMProviderCatalogStatusWithBody(ctx context.Context, org
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateLLMProviderCatalogStatus(ctx context.Context, orgName string, id string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateLLMProviderCatalogStatusRequest(c.Server, orgName, id, body)
+func (c *Client) GetLLMProvider(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetLLMProviderRequest(c.Server, orgName, providerId)
 	if err != nil {
 		return nil, err
 	}
@@ -2688,8 +2640,8 @@ func (c *Client) UpdateLLMProviderCatalogStatus(ctx context.Context, orgName str
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListLLMProviderConsumers(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListLLMProviderConsumersRequest(c.Server, orgName, id)
+func (c *Client) UpdateLLMProviderWithBody(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateLLMProviderRequestWithBody(c.Server, orgName, providerId, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2700,8 +2652,8 @@ func (c *Client) ListLLMProviderConsumers(ctx context.Context, orgName string, i
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetLLMProviderDeployments(ctx context.Context, orgName string, id string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetLLMProviderDeploymentsRequest(c.Server, orgName, id, params)
+func (c *Client) UpdateLLMProvider(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateLLMProviderRequest(c.Server, orgName, providerId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2712,8 +2664,8 @@ func (c *Client) GetLLMProviderDeployments(ctx context.Context, orgName string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeployLLMProviderWithBody(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeployLLMProviderRequestWithBody(c.Server, orgName, id, contentType, body)
+func (c *Client) UpdateLLMProviderCatalogStatusWithBody(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateLLMProviderCatalogStatusRequestWithBody(c.Server, orgName, providerId, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2724,8 +2676,8 @@ func (c *Client) DeployLLMProviderWithBody(ctx context.Context, orgName string, 
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeployLLMProvider(ctx context.Context, orgName string, id string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeployLLMProviderRequest(c.Server, orgName, id, body)
+func (c *Client) UpdateLLMProviderCatalogStatus(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateLLMProviderCatalogStatusRequest(c.Server, orgName, providerId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2736,8 +2688,8 @@ func (c *Client) DeployLLMProvider(ctx context.Context, orgName string, id strin
 	return c.Client.Do(req)
 }
 
-func (c *Client) RestoreLLMProviderDeployment(ctx context.Context, orgName string, id string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewRestoreLLMProviderDeploymentRequest(c.Server, orgName, id, params)
+func (c *Client) ListLLMProviderConsumers(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListLLMProviderConsumersRequest(c.Server, orgName, providerId)
 	if err != nil {
 		return nil, err
 	}
@@ -2748,8 +2700,8 @@ func (c *Client) RestoreLLMProviderDeployment(ctx context.Context, orgName strin
 	return c.Client.Do(req)
 }
 
-func (c *Client) UndeployLLMProviderDeployment(ctx context.Context, orgName string, id string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUndeployLLMProviderDeploymentRequest(c.Server, orgName, id, params)
+func (c *Client) GetLLMProviderDeployments(ctx context.Context, orgName string, providerId string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetLLMProviderDeploymentsRequest(c.Server, orgName, providerId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -2760,8 +2712,8 @@ func (c *Client) UndeployLLMProviderDeployment(ctx context.Context, orgName stri
 	return c.Client.Do(req)
 }
 
-func (c *Client) DeleteLLMProviderDeployment(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewDeleteLLMProviderDeploymentRequest(c.Server, orgName, id, deploymentId)
+func (c *Client) DeployLLMProviderWithBody(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeployLLMProviderRequestWithBody(c.Server, orgName, providerId, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2772,8 +2724,8 @@ func (c *Client) DeleteLLMProviderDeployment(ctx context.Context, orgName string
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetLLMProviderDeployment(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetLLMProviderDeploymentRequest(c.Server, orgName, id, deploymentId)
+func (c *Client) DeployLLMProvider(ctx context.Context, orgName string, providerId string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeployLLMProviderRequest(c.Server, orgName, providerId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2784,8 +2736,56 @@ func (c *Client) GetLLMProviderDeployment(ctx context.Context, orgName string, i
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListLLMProxiesByProvider(ctx context.Context, orgName string, id string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListLLMProxiesByProviderRequest(c.Server, orgName, id, params)
+func (c *Client) RestoreLLMProviderDeployment(ctx context.Context, orgName string, providerId string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRestoreLLMProviderDeploymentRequest(c.Server, orgName, providerId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UndeployLLMProviderDeployment(ctx context.Context, orgName string, providerId string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUndeployLLMProviderDeploymentRequest(c.Server, orgName, providerId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteLLMProviderDeployment(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteLLMProviderDeploymentRequest(c.Server, orgName, providerId, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetLLMProviderDeployment(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetLLMProviderDeploymentRequest(c.Server, orgName, providerId, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListLLMProxiesByProvider(ctx context.Context, orgName string, providerId string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListLLMProxiesByProviderRequest(c.Server, orgName, providerId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -9704,142 +9704,6 @@ func NewListAvailableLLMPoliciesRequest(server string, orgName string, params *L
 	return req, nil
 }
 
-// NewDeleteLLMProviderRequest generates requests for DeleteLLMProvider
-func NewDeleteLLMProviderRequest(server string, orgName string, id string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/orgs/%s/llm-providers/%s", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewGetLLMProviderRequest generates requests for GetLLMProvider
-func NewGetLLMProviderRequest(server string, orgName string, id string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/orgs/%s/llm-providers/%s", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewUpdateLLMProviderRequest calls the generic UpdateLLMProvider builder with application/json body
-func NewUpdateLLMProviderRequest(server string, orgName string, id string, body UpdateLLMProviderJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewUpdateLLMProviderRequestWithBody(server, orgName, id, "application/json", bodyReader)
-}
-
-// NewUpdateLLMProviderRequestWithBody generates requests for UpdateLLMProvider with any type of body
-func NewUpdateLLMProviderRequestWithBody(server string, orgName string, id string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/orgs/%s/llm-providers/%s", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("PUT", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
 // NewListLLMProviderAPIKeysRequest generates requests for ListLLMProviderAPIKeys
 func NewListLLMProviderAPIKeysRequest(server string, orgName string, id string) (*http.Request, error) {
 	var err error
@@ -10044,19 +9908,8 @@ func NewRotateLLMProviderAPIKeyRequestWithBody(server string, orgName string, id
 	return req, nil
 }
 
-// NewUpdateLLMProviderCatalogStatusRequest calls the generic UpdateLLMProviderCatalogStatus builder with application/json body
-func NewUpdateLLMProviderCatalogStatusRequest(server string, orgName string, id string, body UpdateLLMProviderCatalogStatusJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewUpdateLLMProviderCatalogStatusRequestWithBody(server, orgName, id, "application/json", bodyReader)
-}
-
-// NewUpdateLLMProviderCatalogStatusRequestWithBody generates requests for UpdateLLMProviderCatalogStatus with any type of body
-func NewUpdateLLMProviderCatalogStatusRequestWithBody(server string, orgName string, id string, contentType string, body io.Reader) (*http.Request, error) {
+// NewDeleteLLMProviderRequest generates requests for DeleteLLMProvider
+func NewDeleteLLMProviderRequest(server string, orgName string, providerId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10068,7 +9921,154 @@ func NewUpdateLLMProviderCatalogStatusRequestWithBody(server string, orgName str
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/orgs/%s/llm-providers/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetLLMProviderRequest generates requests for GetLLMProvider
+func NewGetLLMProviderRequest(server string, orgName string, providerId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/orgs/%s/llm-providers/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateLLMProviderRequest calls the generic UpdateLLMProvider builder with application/json body
+func NewUpdateLLMProviderRequest(server string, orgName string, providerId string, body UpdateLLMProviderJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateLLMProviderRequestWithBody(server, orgName, providerId, "application/json", bodyReader)
+}
+
+// NewUpdateLLMProviderRequestWithBody generates requests for UpdateLLMProvider with any type of body
+func NewUpdateLLMProviderRequestWithBody(server string, orgName string, providerId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/orgs/%s/llm-providers/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUpdateLLMProviderCatalogStatusRequest calls the generic UpdateLLMProviderCatalogStatus builder with application/json body
+func NewUpdateLLMProviderCatalogStatusRequest(server string, orgName string, providerId string, body UpdateLLMProviderCatalogStatusJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateLLMProviderCatalogStatusRequestWithBody(server, orgName, providerId, "application/json", bodyReader)
+}
+
+// NewUpdateLLMProviderCatalogStatusRequestWithBody generates requests for UpdateLLMProviderCatalogStatus with any type of body
+func NewUpdateLLMProviderCatalogStatusRequestWithBody(server string, orgName string, providerId string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "orgName", orgName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10099,7 +10099,7 @@ func NewUpdateLLMProviderCatalogStatusRequestWithBody(server string, orgName str
 }
 
 // NewListLLMProviderConsumersRequest generates requests for ListLLMProviderConsumers
-func NewListLLMProviderConsumersRequest(server string, orgName string, id string) (*http.Request, error) {
+func NewListLLMProviderConsumersRequest(server string, orgName string, providerId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10111,7 +10111,7 @@ func NewListLLMProviderConsumersRequest(server string, orgName string, id string
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10140,7 +10140,7 @@ func NewListLLMProviderConsumersRequest(server string, orgName string, id string
 }
 
 // NewGetLLMProviderDeploymentsRequest generates requests for GetLLMProviderDeployments
-func NewGetLLMProviderDeploymentsRequest(server string, orgName string, id string, params *GetLLMProviderDeploymentsParams) (*http.Request, error) {
+func NewGetLLMProviderDeploymentsRequest(server string, orgName string, providerId string, params *GetLLMProviderDeploymentsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10152,7 +10152,7 @@ func NewGetLLMProviderDeploymentsRequest(server string, orgName string, id strin
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10219,18 +10219,18 @@ func NewGetLLMProviderDeploymentsRequest(server string, orgName string, id strin
 }
 
 // NewDeployLLMProviderRequest calls the generic DeployLLMProvider builder with application/json body
-func NewDeployLLMProviderRequest(server string, orgName string, id string, body DeployLLMProviderJSONRequestBody) (*http.Request, error) {
+func NewDeployLLMProviderRequest(server string, orgName string, providerId string, body DeployLLMProviderJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewDeployLLMProviderRequestWithBody(server, orgName, id, "application/json", bodyReader)
+	return NewDeployLLMProviderRequestWithBody(server, orgName, providerId, "application/json", bodyReader)
 }
 
 // NewDeployLLMProviderRequestWithBody generates requests for DeployLLMProvider with any type of body
-func NewDeployLLMProviderRequestWithBody(server string, orgName string, id string, contentType string, body io.Reader) (*http.Request, error) {
+func NewDeployLLMProviderRequestWithBody(server string, orgName string, providerId string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10242,7 +10242,7 @@ func NewDeployLLMProviderRequestWithBody(server string, orgName string, id strin
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10273,7 +10273,7 @@ func NewDeployLLMProviderRequestWithBody(server string, orgName string, id strin
 }
 
 // NewRestoreLLMProviderDeploymentRequest generates requests for RestoreLLMProviderDeployment
-func NewRestoreLLMProviderDeploymentRequest(server string, orgName string, id string, params *RestoreLLMProviderDeploymentParams) (*http.Request, error) {
+func NewRestoreLLMProviderDeploymentRequest(server string, orgName string, providerId string, params *RestoreLLMProviderDeploymentParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10285,7 +10285,7 @@ func NewRestoreLLMProviderDeploymentRequest(server string, orgName string, id st
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10344,7 +10344,7 @@ func NewRestoreLLMProviderDeploymentRequest(server string, orgName string, id st
 }
 
 // NewUndeployLLMProviderDeploymentRequest generates requests for UndeployLLMProviderDeployment
-func NewUndeployLLMProviderDeploymentRequest(server string, orgName string, id string, params *UndeployLLMProviderDeploymentParams) (*http.Request, error) {
+func NewUndeployLLMProviderDeploymentRequest(server string, orgName string, providerId string, params *UndeployLLMProviderDeploymentParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10356,7 +10356,7 @@ func NewUndeployLLMProviderDeploymentRequest(server string, orgName string, id s
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10415,7 +10415,7 @@ func NewUndeployLLMProviderDeploymentRequest(server string, orgName string, id s
 }
 
 // NewDeleteLLMProviderDeploymentRequest generates requests for DeleteLLMProviderDeployment
-func NewDeleteLLMProviderDeploymentRequest(server string, orgName string, id string, deploymentId string) (*http.Request, error) {
+func NewDeleteLLMProviderDeploymentRequest(server string, orgName string, providerId string, deploymentId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10427,7 +10427,7 @@ func NewDeleteLLMProviderDeploymentRequest(server string, orgName string, id str
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10463,7 +10463,7 @@ func NewDeleteLLMProviderDeploymentRequest(server string, orgName string, id str
 }
 
 // NewGetLLMProviderDeploymentRequest generates requests for GetLLMProviderDeployment
-func NewGetLLMProviderDeploymentRequest(server string, orgName string, id string, deploymentId string) (*http.Request, error) {
+func NewGetLLMProviderDeploymentRequest(server string, orgName string, providerId string, deploymentId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10475,7 +10475,7 @@ func NewGetLLMProviderDeploymentRequest(server string, orgName string, id string
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -10511,7 +10511,7 @@ func NewGetLLMProviderDeploymentRequest(server string, orgName string, id string
 }
 
 // NewListLLMProxiesByProviderRequest generates requests for ListLLMProxiesByProvider
-func NewListLLMProxiesByProviderRequest(server string, orgName string, id string, params *ListLLMProxiesByProviderParams) (*http.Request, error) {
+func NewListLLMProxiesByProviderRequest(server string, orgName string, providerId string, params *ListLLMProxiesByProviderParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10523,7 +10523,7 @@ func NewListLLMProxiesByProviderRequest(server string, orgName string, id string
 
 	var pathParam1 string
 
-	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "providerId", providerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
@@ -17260,17 +17260,6 @@ type ClientWithResponsesInterface interface {
 	// ListAvailableLLMPoliciesWithResponse request
 	ListAvailableLLMPoliciesWithResponse(ctx context.Context, orgName string, params *ListAvailableLLMPoliciesParams, reqEditors ...RequestEditorFn) (*ListAvailableLLMPoliciesResp, error)
 
-	// DeleteLLMProviderWithResponse request
-	DeleteLLMProviderWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderResp, error)
-
-	// GetLLMProviderWithResponse request
-	GetLLMProviderWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*GetLLMProviderResp, error)
-
-	// UpdateLLMProviderWithBodyWithResponse request with any body
-	UpdateLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error)
-
-	UpdateLLMProviderWithResponse(ctx context.Context, orgName string, id string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error)
-
 	// ListLLMProviderAPIKeysWithResponse request
 	ListLLMProviderAPIKeysWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*ListLLMProviderAPIKeysResp, error)
 
@@ -17287,36 +17276,47 @@ type ClientWithResponsesInterface interface {
 
 	RotateLLMProviderAPIKeyWithResponse(ctx context.Context, orgName string, id string, keyName string, body RotateLLMProviderAPIKeyJSONRequestBody, reqEditors ...RequestEditorFn) (*RotateLLMProviderAPIKeyResp, error)
 
-	// UpdateLLMProviderCatalogStatusWithBodyWithResponse request with any body
-	UpdateLLMProviderCatalogStatusWithBodyWithResponse(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error)
+	// DeleteLLMProviderWithResponse request
+	DeleteLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderResp, error)
 
-	UpdateLLMProviderCatalogStatusWithResponse(ctx context.Context, orgName string, id string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error)
+	// GetLLMProviderWithResponse request
+	GetLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*GetLLMProviderResp, error)
+
+	// UpdateLLMProviderWithBodyWithResponse request with any body
+	UpdateLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error)
+
+	UpdateLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error)
+
+	// UpdateLLMProviderCatalogStatusWithBodyWithResponse request with any body
+	UpdateLLMProviderCatalogStatusWithBodyWithResponse(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error)
+
+	UpdateLLMProviderCatalogStatusWithResponse(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error)
 
 	// ListLLMProviderConsumersWithResponse request
-	ListLLMProviderConsumersWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*ListLLMProviderConsumersResp, error)
+	ListLLMProviderConsumersWithResponse(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*ListLLMProviderConsumersResp, error)
 
 	// GetLLMProviderDeploymentsWithResponse request
-	GetLLMProviderDeploymentsWithResponse(ctx context.Context, orgName string, id string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentsResp, error)
+	GetLLMProviderDeploymentsWithResponse(ctx context.Context, orgName string, providerId string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentsResp, error)
 
 	// DeployLLMProviderWithBodyWithResponse request with any body
-	DeployLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error)
+	DeployLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error)
 
-	DeployLLMProviderWithResponse(ctx context.Context, orgName string, id string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error)
+	DeployLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error)
 
 	// RestoreLLMProviderDeploymentWithResponse request
-	RestoreLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*RestoreLLMProviderDeploymentResp, error)
+	RestoreLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*RestoreLLMProviderDeploymentResp, error)
 
 	// UndeployLLMProviderDeploymentWithResponse request
-	UndeployLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*UndeployLLMProviderDeploymentResp, error)
+	UndeployLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*UndeployLLMProviderDeploymentResp, error)
 
 	// DeleteLLMProviderDeploymentWithResponse request
-	DeleteLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderDeploymentResp, error)
+	DeleteLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderDeploymentResp, error)
 
 	// GetLLMProviderDeploymentWithResponse request
-	GetLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentResp, error)
+	GetLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentResp, error)
 
 	// ListLLMProxiesByProviderWithResponse request
-	ListLLMProxiesByProviderWithResponse(ctx context.Context, orgName string, id string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*ListLLMProxiesByProviderResp, error)
+	ListLLMProxiesByProviderWithResponse(ctx context.Context, orgName string, providerId string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*ListLLMProxiesByProviderResp, error)
 
 	// ListMCPProxiesWithResponse request
 	ListMCPProxiesWithResponse(ctx context.Context, orgName string, params *ListMCPProxiesParams, reqEditors ...RequestEditorFn) (*ListMCPProxiesResp, error)
@@ -20237,83 +20237,6 @@ func (r ListAvailableLLMPoliciesResp) StatusCode() int {
 	return 0
 }
 
-type DeleteLLMProviderResp struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON400      *ErrorResponse
-	JSON401      *ErrorResponse
-	JSON404      *ErrorResponse
-	JSON500      *ErrorResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r DeleteLLMProviderResp) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r DeleteLLMProviderResp) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type GetLLMProviderResp struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *LLMProviderResponse
-	JSON400      *ErrorResponse
-	JSON401      *ErrorResponse
-	JSON404      *ErrorResponse
-	JSON500      *ErrorResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r GetLLMProviderResp) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r GetLLMProviderResp) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type UpdateLLMProviderResp struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *LLMProviderResponse
-	JSON400      *ErrorResponse
-	JSON401      *ErrorResponse
-	JSON404      *ErrorResponse
-	JSON500      *ErrorResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r UpdateLLMProviderResp) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r UpdateLLMProviderResp) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type ListLLMProviderAPIKeysResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -20412,6 +20335,85 @@ func (r RotateLLMProviderAPIKeyResp) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RotateLLMProviderAPIKeyResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteLLMProviderResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON403      *ErrorResponse
+	JSON404      *ErrorResponse
+	JSON409      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteLLMProviderResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteLLMProviderResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetLLMProviderResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *LLMProviderResponse
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON404      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetLLMProviderResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetLLMProviderResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateLLMProviderResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *LLMProviderResponse
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON404      *ErrorResponse
+	JSON500      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateLLMProviderResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateLLMProviderResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -24303,41 +24305,6 @@ func (c *ClientWithResponses) ListAvailableLLMPoliciesWithResponse(ctx context.C
 	return ParseListAvailableLLMPoliciesResp(rsp)
 }
 
-// DeleteLLMProviderWithResponse request returning *DeleteLLMProviderResp
-func (c *ClientWithResponses) DeleteLLMProviderWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderResp, error) {
-	rsp, err := c.DeleteLLMProvider(ctx, orgName, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseDeleteLLMProviderResp(rsp)
-}
-
-// GetLLMProviderWithResponse request returning *GetLLMProviderResp
-func (c *ClientWithResponses) GetLLMProviderWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*GetLLMProviderResp, error) {
-	rsp, err := c.GetLLMProvider(ctx, orgName, id, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseGetLLMProviderResp(rsp)
-}
-
-// UpdateLLMProviderWithBodyWithResponse request with arbitrary body returning *UpdateLLMProviderResp
-func (c *ClientWithResponses) UpdateLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error) {
-	rsp, err := c.UpdateLLMProviderWithBody(ctx, orgName, id, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateLLMProviderResp(rsp)
-}
-
-func (c *ClientWithResponses) UpdateLLMProviderWithResponse(ctx context.Context, orgName string, id string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error) {
-	rsp, err := c.UpdateLLMProvider(ctx, orgName, id, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseUpdateLLMProviderResp(rsp)
-}
-
 // ListLLMProviderAPIKeysWithResponse request returning *ListLLMProviderAPIKeysResp
 func (c *ClientWithResponses) ListLLMProviderAPIKeysWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*ListLLMProviderAPIKeysResp, error) {
 	rsp, err := c.ListLLMProviderAPIKeys(ctx, orgName, id, reqEditors...)
@@ -24390,17 +24357,52 @@ func (c *ClientWithResponses) RotateLLMProviderAPIKeyWithResponse(ctx context.Co
 	return ParseRotateLLMProviderAPIKeyResp(rsp)
 }
 
+// DeleteLLMProviderWithResponse request returning *DeleteLLMProviderResp
+func (c *ClientWithResponses) DeleteLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderResp, error) {
+	rsp, err := c.DeleteLLMProvider(ctx, orgName, providerId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteLLMProviderResp(rsp)
+}
+
+// GetLLMProviderWithResponse request returning *GetLLMProviderResp
+func (c *ClientWithResponses) GetLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*GetLLMProviderResp, error) {
+	rsp, err := c.GetLLMProvider(ctx, orgName, providerId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetLLMProviderResp(rsp)
+}
+
+// UpdateLLMProviderWithBodyWithResponse request with arbitrary body returning *UpdateLLMProviderResp
+func (c *ClientWithResponses) UpdateLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error) {
+	rsp, err := c.UpdateLLMProviderWithBody(ctx, orgName, providerId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateLLMProviderResp(rsp)
+}
+
+func (c *ClientWithResponses) UpdateLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderResp, error) {
+	rsp, err := c.UpdateLLMProvider(ctx, orgName, providerId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateLLMProviderResp(rsp)
+}
+
 // UpdateLLMProviderCatalogStatusWithBodyWithResponse request with arbitrary body returning *UpdateLLMProviderCatalogStatusResp
-func (c *ClientWithResponses) UpdateLLMProviderCatalogStatusWithBodyWithResponse(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error) {
-	rsp, err := c.UpdateLLMProviderCatalogStatusWithBody(ctx, orgName, id, contentType, body, reqEditors...)
+func (c *ClientWithResponses) UpdateLLMProviderCatalogStatusWithBodyWithResponse(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error) {
+	rsp, err := c.UpdateLLMProviderCatalogStatusWithBody(ctx, orgName, providerId, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseUpdateLLMProviderCatalogStatusResp(rsp)
 }
 
-func (c *ClientWithResponses) UpdateLLMProviderCatalogStatusWithResponse(ctx context.Context, orgName string, id string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error) {
-	rsp, err := c.UpdateLLMProviderCatalogStatus(ctx, orgName, id, body, reqEditors...)
+func (c *ClientWithResponses) UpdateLLMProviderCatalogStatusWithResponse(ctx context.Context, orgName string, providerId string, body UpdateLLMProviderCatalogStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateLLMProviderCatalogStatusResp, error) {
+	rsp, err := c.UpdateLLMProviderCatalogStatus(ctx, orgName, providerId, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24408,8 +24410,8 @@ func (c *ClientWithResponses) UpdateLLMProviderCatalogStatusWithResponse(ctx con
 }
 
 // ListLLMProviderConsumersWithResponse request returning *ListLLMProviderConsumersResp
-func (c *ClientWithResponses) ListLLMProviderConsumersWithResponse(ctx context.Context, orgName string, id string, reqEditors ...RequestEditorFn) (*ListLLMProviderConsumersResp, error) {
-	rsp, err := c.ListLLMProviderConsumers(ctx, orgName, id, reqEditors...)
+func (c *ClientWithResponses) ListLLMProviderConsumersWithResponse(ctx context.Context, orgName string, providerId string, reqEditors ...RequestEditorFn) (*ListLLMProviderConsumersResp, error) {
+	rsp, err := c.ListLLMProviderConsumers(ctx, orgName, providerId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24417,8 +24419,8 @@ func (c *ClientWithResponses) ListLLMProviderConsumersWithResponse(ctx context.C
 }
 
 // GetLLMProviderDeploymentsWithResponse request returning *GetLLMProviderDeploymentsResp
-func (c *ClientWithResponses) GetLLMProviderDeploymentsWithResponse(ctx context.Context, orgName string, id string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentsResp, error) {
-	rsp, err := c.GetLLMProviderDeployments(ctx, orgName, id, params, reqEditors...)
+func (c *ClientWithResponses) GetLLMProviderDeploymentsWithResponse(ctx context.Context, orgName string, providerId string, params *GetLLMProviderDeploymentsParams, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentsResp, error) {
+	rsp, err := c.GetLLMProviderDeployments(ctx, orgName, providerId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24426,16 +24428,16 @@ func (c *ClientWithResponses) GetLLMProviderDeploymentsWithResponse(ctx context.
 }
 
 // DeployLLMProviderWithBodyWithResponse request with arbitrary body returning *DeployLLMProviderResp
-func (c *ClientWithResponses) DeployLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, id string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error) {
-	rsp, err := c.DeployLLMProviderWithBody(ctx, orgName, id, contentType, body, reqEditors...)
+func (c *ClientWithResponses) DeployLLMProviderWithBodyWithResponse(ctx context.Context, orgName string, providerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error) {
+	rsp, err := c.DeployLLMProviderWithBody(ctx, orgName, providerId, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseDeployLLMProviderResp(rsp)
 }
 
-func (c *ClientWithResponses) DeployLLMProviderWithResponse(ctx context.Context, orgName string, id string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error) {
-	rsp, err := c.DeployLLMProvider(ctx, orgName, id, body, reqEditors...)
+func (c *ClientWithResponses) DeployLLMProviderWithResponse(ctx context.Context, orgName string, providerId string, body DeployLLMProviderJSONRequestBody, reqEditors ...RequestEditorFn) (*DeployLLMProviderResp, error) {
+	rsp, err := c.DeployLLMProvider(ctx, orgName, providerId, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24443,8 +24445,8 @@ func (c *ClientWithResponses) DeployLLMProviderWithResponse(ctx context.Context,
 }
 
 // RestoreLLMProviderDeploymentWithResponse request returning *RestoreLLMProviderDeploymentResp
-func (c *ClientWithResponses) RestoreLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*RestoreLLMProviderDeploymentResp, error) {
-	rsp, err := c.RestoreLLMProviderDeployment(ctx, orgName, id, params, reqEditors...)
+func (c *ClientWithResponses) RestoreLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, params *RestoreLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*RestoreLLMProviderDeploymentResp, error) {
+	rsp, err := c.RestoreLLMProviderDeployment(ctx, orgName, providerId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24452,8 +24454,8 @@ func (c *ClientWithResponses) RestoreLLMProviderDeploymentWithResponse(ctx conte
 }
 
 // UndeployLLMProviderDeploymentWithResponse request returning *UndeployLLMProviderDeploymentResp
-func (c *ClientWithResponses) UndeployLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*UndeployLLMProviderDeploymentResp, error) {
-	rsp, err := c.UndeployLLMProviderDeployment(ctx, orgName, id, params, reqEditors...)
+func (c *ClientWithResponses) UndeployLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, params *UndeployLLMProviderDeploymentParams, reqEditors ...RequestEditorFn) (*UndeployLLMProviderDeploymentResp, error) {
+	rsp, err := c.UndeployLLMProviderDeployment(ctx, orgName, providerId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24461,8 +24463,8 @@ func (c *ClientWithResponses) UndeployLLMProviderDeploymentWithResponse(ctx cont
 }
 
 // DeleteLLMProviderDeploymentWithResponse request returning *DeleteLLMProviderDeploymentResp
-func (c *ClientWithResponses) DeleteLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderDeploymentResp, error) {
-	rsp, err := c.DeleteLLMProviderDeployment(ctx, orgName, id, deploymentId, reqEditors...)
+func (c *ClientWithResponses) DeleteLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*DeleteLLMProviderDeploymentResp, error) {
+	rsp, err := c.DeleteLLMProviderDeployment(ctx, orgName, providerId, deploymentId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24470,8 +24472,8 @@ func (c *ClientWithResponses) DeleteLLMProviderDeploymentWithResponse(ctx contex
 }
 
 // GetLLMProviderDeploymentWithResponse request returning *GetLLMProviderDeploymentResp
-func (c *ClientWithResponses) GetLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, id string, deploymentId string, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentResp, error) {
-	rsp, err := c.GetLLMProviderDeployment(ctx, orgName, id, deploymentId, reqEditors...)
+func (c *ClientWithResponses) GetLLMProviderDeploymentWithResponse(ctx context.Context, orgName string, providerId string, deploymentId string, reqEditors ...RequestEditorFn) (*GetLLMProviderDeploymentResp, error) {
+	rsp, err := c.GetLLMProviderDeployment(ctx, orgName, providerId, deploymentId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -24479,8 +24481,8 @@ func (c *ClientWithResponses) GetLLMProviderDeploymentWithResponse(ctx context.C
 }
 
 // ListLLMProxiesByProviderWithResponse request returning *ListLLMProxiesByProviderResp
-func (c *ClientWithResponses) ListLLMProxiesByProviderWithResponse(ctx context.Context, orgName string, id string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*ListLLMProxiesByProviderResp, error) {
-	rsp, err := c.ListLLMProxiesByProvider(ctx, orgName, id, params, reqEditors...)
+func (c *ClientWithResponses) ListLLMProxiesByProviderWithResponse(ctx context.Context, orgName string, providerId string, params *ListLLMProxiesByProviderParams, reqEditors ...RequestEditorFn) (*ListLLMProxiesByProviderResp, error) {
+	rsp, err := c.ListLLMProxiesByProvider(ctx, orgName, providerId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -30289,161 +30291,6 @@ func ParseListAvailableLLMPoliciesResp(rsp *http.Response) (*ListAvailableLLMPol
 	return response, nil
 }
 
-// ParseDeleteLLMProviderResp parses an HTTP response from a DeleteLLMProviderWithResponse call
-func ParseDeleteLLMProviderResp(rsp *http.Response) (*DeleteLLMProviderResp, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &DeleteLLMProviderResp{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseGetLLMProviderResp parses an HTTP response from a GetLLMProviderWithResponse call
-func ParseGetLLMProviderResp(rsp *http.Response) (*GetLLMProviderResp, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &GetLLMProviderResp{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest LLMProviderResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseUpdateLLMProviderResp parses an HTTP response from a UpdateLLMProviderWithResponse call
-func ParseUpdateLLMProviderResp(rsp *http.Response) (*UpdateLLMProviderResp, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &UpdateLLMProviderResp{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest LLMProviderResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest ErrorResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON500 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseListLLMProviderAPIKeysResp parses an HTTP response from a ListLLMProviderAPIKeysWithResponse call
 func ParseListLLMProviderAPIKeysResp(rsp *http.Response) (*ListLLMProviderAPIKeysResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -30654,6 +30501,175 @@ func ParseRotateLLMProviderAPIKeyResp(rsp *http.Response) (*RotateLLMProviderAPI
 			return nil, err
 		}
 		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteLLMProviderResp parses an HTTP response from a DeleteLLMProviderWithResponse call
+func ParseDeleteLLMProviderResp(rsp *http.Response) (*DeleteLLMProviderResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteLLMProviderResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetLLMProviderResp parses an HTTP response from a GetLLMProviderWithResponse call
+func ParseGetLLMProviderResp(rsp *http.Response) (*GetLLMProviderResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetLLMProviderResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest LLMProviderResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateLLMProviderResp parses an HTTP response from a UpdateLLMProviderWithResponse call
+func ParseUpdateLLMProviderResp(rsp *http.Response) (*UpdateLLMProviderResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateLLMProviderResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest LLMProviderResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
 
 	}
 

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -5985,14 +5985,14 @@ type UpdateLLMProviderTemplateJSONRequestBody = UpdateLLMProviderTemplateRequest
 // CreateLLMProviderJSONRequestBody defines body for CreateLLMProvider for application/json ContentType.
 type CreateLLMProviderJSONRequestBody = CreateLLMProviderRequest
 
-// UpdateLLMProviderJSONRequestBody defines body for UpdateLLMProvider for application/json ContentType.
-type UpdateLLMProviderJSONRequestBody = UpdateLLMProviderRequest
-
 // CreateLLMProviderAPIKeyJSONRequestBody defines body for CreateLLMProviderAPIKey for application/json ContentType.
 type CreateLLMProviderAPIKeyJSONRequestBody = CreateLLMAPIKeyRequest
 
 // RotateLLMProviderAPIKeyJSONRequestBody defines body for RotateLLMProviderAPIKey for application/json ContentType.
 type RotateLLMProviderAPIKeyJSONRequestBody = RotateLLMAPIKeyRequest
+
+// UpdateLLMProviderJSONRequestBody defines body for UpdateLLMProvider for application/json ContentType.
+type UpdateLLMProviderJSONRequestBody = UpdateLLMProviderRequest
 
 // UpdateLLMProviderCatalogStatusJSONRequestBody defines body for UpdateLLMProviderCatalogStatus for application/json ContentType.
 type UpdateLLMProviderCatalogStatusJSONRequestBody = UpdateLLMProviderCatalogRequest

--- a/cli/pkg/cmd/gateway/gateway.go
+++ b/cli/pkg/cmd/gateway/gateway.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gateway
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+)
+
+// NewGatewayCmd builds the `gateway` command group. Gateways are org-scoped and
+// shared by LLM providers, MCP proxies and IdP config, so this is a top-level noun
+// rather than a subcommand of any one consumer.
+func NewGatewayCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "gateway",
+		Short:   "List and inspect gateways in an organization",
+		Aliases: []string{"gateways"},
+	}
+	cmd.AddCommand(NewListCmd(f))
+	cmd.AddCommand(NewGetCmd(f))
+	return cmd
+}

--- a/cli/pkg/cmd/gateway/get.go
+++ b/cli/pkg/cmd/gateway/get.go
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package llmprovider
+package gateway
 
 import (
 	"context"
@@ -27,33 +27,30 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
 	"github.com/wso2/agent-manager/cli/pkg/iostreams"
 	"github.com/wso2/agent-manager/cli/pkg/render"
-	"github.com/wso2/agent-manager/cli/pkg/tableprinter"
 )
 
-// defaultListLimit is the page size requested by `list`, matching `project list`.
-const defaultListLimit = 50
-
-type ListOptions struct {
+type GetOptions struct {
 	IO           *iostreams.IOStreams
 	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
 	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
 	MakeScope    func(org, proj string) render.Scope
 
-	Org   string
-	Scope render.Scope
+	Org     string
+	Scope   render.Scope
+	Gateway string
 }
 
-func NewListCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &ListOptions{
+func NewGetCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &GetOptions{
 		IO:           f.IOStreams,
 		Client:       f.AgentManager,
 		ResolveScope: f.ResolveOrgProject,
 		MakeScope:    f.Scope,
 	}
-	return &cobra.Command{
-		Use:   "list",
-		Short: "List LLM providers in an organization",
-		Args:  cobra.NoArgs,
+	cmd := &cobra.Command{
+		Use:   "get <gateway>",
+		Short: "Get details of a gateway by name or UUID",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org, _, err := opts.ResolveScope(cmd, true, false)
 			scope := opts.MakeScope(org, "")
@@ -61,49 +58,60 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 				return render.Error(opts.IO, scope, err)
 			}
 			opts.Org, opts.Scope = org, scope
-			return runList(cmd.Context(), opts)
+			opts.Gateway = args[0]
+			return runGet(cmd.Context(), opts)
 		},
 	}
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return cmdutil.CompleteGateways(cmd, f), cobra.ShellCompDirectiveNoFileComp
+	}
+	return cmd
 }
 
-func runList(ctx context.Context, o *ListOptions) error {
+func runGet(ctx context.Context, o *GetOptions) error {
+	if err := cmdutil.ValidatePathParam("gateway", o.Gateway); err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
 	client, err := o.Client(ctx)
 	if err != nil {
 		return render.Error(o.IO, o.Scope, err)
 	}
 
-	// Request a 50-item page to match `project list`; --limit/--offset paging
-	// is not exposed yet.
-	limit := int32(defaultListLimit)
-	resp, err := client.ListLLMProvidersWithResponse(ctx, o.Org, &amsvc.ListLLMProvidersParams{Limit: &limit})
+	resp, err := client.GetGatewayWithResponse(ctx, o.Org, o.Gateway)
 	if err != nil {
 		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
 	}
 	if resp.JSON200 == nil {
-		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON500)))
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse,
+			cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON404, resp.JSON500)))
 	}
 
 	if o.IO.JSON {
 		return render.JSONSuccess(o.IO, o.Scope, resp.JSON200)
 	}
 
-	if len(resp.JSON200.Providers) == 0 {
-		return render.EmptyList(o.IO, fmt.Sprintf("No LLM providers found in organization %q.", o.Org))
-	}
-
-	tp := tableprinter.New(o.IO, "id", "name", "template", "status", "created")
+	g := resp.JSON200
+	w := o.IO.Out
 	cs := o.IO.ColorScheme()
-	for _, p := range resp.JSON200.Providers {
-		tp.AddField(p.Id, tableprinter.WithColor(cs.Bold))
-		tp.AddField(p.Name)
-		tp.AddField(p.Template)
-		tp.AddField(string(p.Status))
-		created := ""
-		if p.CreatedAt != nil {
-			created = p.CreatedAt.Format("2006-01-02")
-		}
-		tp.AddField(created, tableprinter.WithColor(cs.Gray))
-		tp.EndRow()
+	fmt.Fprintf(w, "name:          %s\n", cs.Bold(g.Name))
+	fmt.Fprintf(w, "display name:  %s\n", g.DisplayName)
+	fmt.Fprintf(w, "uuid:          %s\n", g.Uuid)
+	fmt.Fprintf(w, "type:          %s\n", string(g.GatewayType))
+	fmt.Fprintf(w, "status:        %s\n", string(g.Status))
+	fmt.Fprintf(w, "environment:   %s\n", environmentNames(*g))
+	fmt.Fprintf(w, "vhost:         %s\n", g.Vhost)
+	if g.Region != nil && *g.Region != "" {
+		fmt.Fprintf(w, "region:        %s\n", *g.Region)
 	}
-	return tp.Render()
+	if g.RuntimeUrl != nil && *g.RuntimeUrl != "" {
+		fmt.Fprintf(w, "runtime url:   %s\n", *g.RuntimeUrl)
+	}
+	fmt.Fprintf(w, "critical:      %t\n", g.IsCritical)
+	fmt.Fprintf(w, "org:           %s\n", o.Org)
+	fmt.Fprintf(w, "created:       %s\n", cs.Gray(g.CreatedAt.Format("2006-01-02T15:04:05Z07:00")))
+	return nil
 }

--- a/cli/pkg/cmd/gateway/get_test.go
+++ b/cli/pkg/cmd/gateway/get_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+func TestGet_SuccessJSON(t *testing.T) {
+	io, out, _ := newTestIO()
+	gw := sampleGateway("edge", "11111111-1111-1111-1111-111111111111", amsvc.GatewayTypeBOTH, "default")
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, gw)
+	defer closeFn()
+
+	err := runGet(context.Background(), &GetOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(), Gateway: "edge",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.path != "/orgs/acme/gateways/edge" {
+		t.Errorf("path = %q, want /orgs/acme/gateways/edge", captured.path)
+	}
+	env := decodeEnvelope(t, out.String())
+	if env["data"].(map[string]any)["uuid"] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("uuid = %v", env["data"].(map[string]any)["uuid"])
+	}
+}
+
+// The command takes a name or a UUID and sends it as-is; resolving either form is
+// the server's job, and it must not answer a bad identifier with a 500.
+func TestGet_AcceptsUUIDAndName(t *testing.T) {
+	for _, identifier := range []string{"edge", "11111111-1111-1111-1111-111111111111"} {
+		io, _, _ := newTestIO()
+		clientFn, captured, closeFn := newTestClient(t, http.StatusOK,
+			sampleGateway("edge", "11111111-1111-1111-1111-111111111111", amsvc.GatewayTypeBOTH))
+
+		err := runGet(context.Background(), &GetOptions{
+			IO: io, Client: clientFn, Org: "acme", Scope: baseScope(), Gateway: identifier,
+		})
+		closeFn()
+		if err != nil {
+			t.Fatalf("runGet(%q): %v", identifier, err)
+		}
+		if want := "/orgs/acme/gateways/" + identifier; captured.path != want {
+			t.Errorf("path = %q, want %q", captured.path, want)
+		}
+	}
+}
+
+func TestGet_TextOutputShowsUUIDAndType(t *testing.T) {
+	io, out, _ := newTextTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusOK,
+		sampleGateway("edge", "11111111-1111-1111-1111-111111111111", amsvc.GatewayTypeEGRESS, "default"))
+	defer closeFn()
+
+	if err := runGet(context.Background(), &GetOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(), Gateway: "edge",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"11111111-1111-1111-1111-111111111111", "EGRESS", "default", "edge.example.com"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q; got:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestGet_RejectsEmptyIdentifierWithoutCallingServer(t *testing.T) {
+	io, _, _ := newTestIO()
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, nil)
+	defer closeFn()
+
+	err := runGet(context.Background(), &GetOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(), Gateway: "  ",
+	})
+	if err == nil {
+		t.Fatal("expected an error for an empty gateway identifier")
+	}
+	if captured.called {
+		t.Error("server was called despite an empty identifier")
+	}
+}
+
+func TestGet_NotFoundSurfacesServerMessage(t *testing.T) {
+	io, out, _ := newTestIO()
+	clientFn, _, closeFn := newTestClient(t, http.StatusNotFound,
+		map[string]string{"code": "NOT_FOUND", "message": "gateway not found"})
+	defer closeFn()
+
+	err := runGet(context.Background(), &GetOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(), Gateway: "ghost",
+	})
+	if err == nil {
+		t.Fatal("expected an error on 404")
+	}
+	if !strings.Contains(out.String(), "gateway not found") {
+		t.Errorf("envelope = %q, want the server message", out.String())
+	}
+}

--- a/cli/pkg/cmd/gateway/helpers_test.go
+++ b/cli/pkg/cmd/gateway/helpers_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/config"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+)
+
+type capturedRequest struct {
+	called   bool
+	method   string
+	path     string
+	rawQuery string
+}
+
+func newTestClient(t *testing.T, status int, body any) (func(context.Context) (*amsvc.ClientWithResponses, error), *capturedRequest, func()) {
+	t.Helper()
+	captured := &capturedRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.called = true
+		captured.method = r.Method
+		captured.path = r.URL.Path
+		captured.rawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if body != nil {
+			if err := json.NewEncoder(w).Encode(body); err != nil {
+				t.Errorf("encode response: %v", err)
+			}
+		}
+	}))
+	client, err := amsvc.NewClientWithResponses(server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("new client: %v", err)
+	}
+	return func(context.Context) (*amsvc.ClientWithResponses, error) { return client, nil }, captured, server.Close
+}
+
+// newTestIO returns streams in JSON mode, where assertions read the envelope.
+func newTestIO() (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	io, _, out, errOut := iostreams.Test()
+	io.SetTerminal(true, true, true)
+	io.JSON = true
+	return io, out, errOut
+}
+
+// newTextTestIO returns streams in text mode with stdout marked as a terminal,
+// which is what the empty-list notice keys off.
+func newTextTestIO(stdoutTTY bool) (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	io, _, out, errOut := iostreams.Test()
+	io.SetTerminal(stdoutTTY, stdoutTTY, stdoutTTY)
+	return io, out, errOut
+}
+
+func decodeEnvelope(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		t.Fatalf("decode envelope: %v\nbody=%q", err, raw)
+	}
+	return m
+}
+
+func baseScope() render.Scope {
+	return render.Scope{Instance: "default", Org: "acme"}
+}
+
+// testGatewayCmd builds a root → gateway cobra tree for tests that exercise flag
+// parsing and validation through the RunE path.
+func testGatewayCmd(t *testing.T, ios *iostreams.IOStreams, clientFn func(context.Context) (*amsvc.ClientWithResponses, error)) *cobra.Command {
+	t.Helper()
+	f := &cmdutil.Factory{
+		IOStreams:    ios,
+		AgentManager: clientFn,
+		Config: func() (*config.Config, error) {
+			return &config.Config{
+				CurrentInstance: "default",
+				Instances: map[string]config.Instance{
+					"default": {URL: "http://test", CurrentOrg: "acme"},
+				},
+			}, nil
+		},
+	}
+	root := &cobra.Command{Use: "amctl", SilenceErrors: true, SilenceUsage: true}
+	cmdutil.EnableOrgOverride(root, f)
+	root.AddCommand(NewGatewayCmd(f))
+	return root
+}

--- a/cli/pkg/cmd/gateway/list.go
+++ b/cli/pkg/cmd/gateway/list.go
@@ -19,6 +19,7 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -77,16 +78,21 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 			opts.Org, opts.Scope = org, scope
 
+			// Both bounds are checked before the int32 conversion the wire type needs:
+			// on a 64-bit host `--limit 4294967297` truncates to 1, so an unchecked
+			// upper bound silently sends a page size nobody asked for.
 			if cmd.Flags().Changed("limit") {
-				if limit < 1 {
-					return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--limit must be >= 1"))
+				if limit < 1 || limit > math.MaxInt32 {
+					return render.Error(opts.IO, scope,
+						cmdutil.FlagErrorf("--limit must be between 1 and %d", math.MaxInt32))
 				}
 				v := int32(limit)
 				opts.Limit = &v
 			}
 			if cmd.Flags().Changed("offset") {
-				if offset < 0 {
-					return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--offset must be >= 0"))
+				if offset < 0 || offset > math.MaxInt32 {
+					return render.Error(opts.IO, scope,
+						cmdutil.FlagErrorf("--offset must be between 0 and %d", math.MaxInt32))
 				}
 				v := int32(offset)
 				opts.Offset = &v

--- a/cli/pkg/cmd/gateway/list.go
+++ b/cli/pkg/cmd/gateway/list.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+	"github.com/wso2/agent-manager/cli/pkg/cmdutil"
+	"github.com/wso2/agent-manager/cli/pkg/iostreams"
+	"github.com/wso2/agent-manager/cli/pkg/render"
+	"github.com/wso2/agent-manager/cli/pkg/tableprinter"
+)
+
+// gatewayTypes are the canonical placement roles accepted by --type. The server
+// also takes the deprecated REGULAR/AI aliases, which the CLI deliberately does not
+// advertise.
+var gatewayTypes = []string{"INGRESS", "EGRESS", "BOTH"}
+
+type ListOptions struct {
+	IO           *iostreams.IOStreams
+	Client       func(context.Context) (*amsvc.ClientWithResponses, error)
+	ResolveScope func(*cobra.Command, bool, bool) (string, string, error)
+	MakeScope    func(org, proj string) render.Scope
+
+	Org   string
+	Scope render.Scope
+
+	Type        string
+	Environment string
+	Limit       *int32
+	Offset      *int32
+}
+
+func NewListCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &ListOptions{
+		IO:           f.IOStreams,
+		Client:       f.AgentManager,
+		ResolveScope: f.ResolveOrgProject,
+		MakeScope:    f.Scope,
+	}
+	var limit, offset int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List gateways in an organization",
+		Long: "List gateways in an organization.\n\n" +
+			"The uuid column is the value to pass to 'amctl llm-provider create --gateways'.\n" +
+			"Only EGRESS and BOTH gateways can host an LLM proxy, and no two of a\n" +
+			"provider's gateways may share an environment.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org, _, err := opts.ResolveScope(cmd, true, false)
+			scope := opts.MakeScope(org, "")
+			if err != nil {
+				return render.Error(opts.IO, scope, err)
+			}
+			if cmd.Flags().Changed("limit") && limit < 1 {
+				return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--limit must be >= 1"))
+			}
+			if cmd.Flags().Changed("offset") && offset < 0 {
+				return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--offset must be >= 0"))
+			}
+			opts.Org, opts.Scope = org, scope
+			if cmd.Flags().Changed("limit") {
+				v := int32(limit)
+				opts.Limit = &v
+			}
+			if cmd.Flags().Changed("offset") {
+				v := int32(offset)
+				opts.Offset = &v
+			}
+			return runList(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Type, "type", "",
+		fmt.Sprintf("Filter by placement role (%s)", strings.Join(gatewayTypes, "|")))
+	// A plain string flag, not cmdutil.AddEnvFlag: that resolver defaults from the
+	// linked project's environment, which would silently narrow an org-wide listing.
+	cmd.Flags().StringVar(&opts.Environment, "env", "", "Filter by environment name")
+	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of results to return")
+	cmd.Flags().IntVar(&offset, "offset", 0, "Number of results to skip")
+	_ = cmd.RegisterFlagCompletionFunc("type",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return gatewayTypes, cobra.ShellCompDirectiveNoFileComp
+		})
+	return cmd
+}
+
+// normalizeGatewayType upper-cases the --type value and rejects anything outside
+// the canonical roles, so a typo fails locally instead of being sent as a filter
+// the server may not honour.
+func normalizeGatewayType(value string) (amsvc.GatewayTypeInput, error) {
+	normalized := strings.ToUpper(strings.TrimSpace(value))
+	for _, known := range gatewayTypes {
+		if normalized == known {
+			return amsvc.GatewayTypeInput(normalized), nil
+		}
+	}
+	return "", cmdutil.FlagErrorf("--type must be one of %s", strings.Join(gatewayTypes, ", "))
+}
+
+func runList(ctx context.Context, o *ListOptions) error {
+	params := &amsvc.ListGatewaysParams{
+		Limit:  o.Limit,
+		Offset: o.Offset,
+	}
+	if o.Type != "" {
+		gatewayType, err := normalizeGatewayType(o.Type)
+		if err != nil {
+			return render.Error(o.IO, o.Scope, err)
+		}
+		params.Type = &gatewayType
+	}
+	if o.Environment != "" {
+		params.Environment = &o.Environment
+	}
+	// Status is deliberately never filtered: the server's candidate set for
+	// placement is not liveness-filtered, so an ACTIVE-only view would offer a
+	// narrower set than the server actually accepts.
+
+	client, err := o.Client(ctx)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	resp, err := client.ListGatewaysWithResponse(ctx, o.Org, params)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
+	}
+	if resp.JSON200 == nil {
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse,
+			cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON500)))
+	}
+
+	if o.IO.JSON {
+		return render.JSONSuccess(o.IO, o.Scope, resp.JSON200)
+	}
+
+	if len(resp.JSON200.Gateways) == 0 {
+		return render.EmptyList(o.IO, o.emptyMessage())
+	}
+
+	tp := tableprinter.New(o.IO, "name", "uuid", "type", "status", "environment", "vhost")
+	cs := o.IO.ColorScheme()
+	for _, g := range resp.JSON200.Gateways {
+		tp.AddField(g.Name, tableprinter.WithColor(cs.Bold))
+		tp.AddField(g.Uuid)
+		tp.AddField(string(g.GatewayType))
+		tp.AddField(string(g.Status))
+		tp.AddField(environmentNames(g))
+		tp.AddField(g.Vhost, tableprinter.WithColor(cs.Gray))
+		tp.EndRow()
+	}
+	return tp.Render()
+}
+
+// emptyMessage names the active filters, so a user who mistyped --env sees why
+// the result is empty rather than concluding the org has no gateways.
+func (o *ListOptions) emptyMessage() string {
+	filters := []string{}
+	if o.Type != "" {
+		filters = append(filters, fmt.Sprintf("type %s", strings.ToUpper(o.Type)))
+	}
+	if o.Environment != "" {
+		filters = append(filters, fmt.Sprintf("environment %q", o.Environment))
+	}
+	if len(filters) == 0 {
+		return fmt.Sprintf("No gateways found in organization %q.", o.Org)
+	}
+	return fmt.Sprintf("No gateways in organization %q match %s.",
+		o.Org, strings.Join(filters, " and "))
+}
+
+// environmentNames renders the eagerly-included environment bindings as one cell.
+// A gateway with no binding cannot host an artifact, so the empty case is worth
+// showing rather than blanking.
+func environmentNames(g amsvc.GatewayResponse) string {
+	if g.Environments == nil || len(*g.Environments) == 0 {
+		return "-"
+	}
+	names := make([]string, 0, len(*g.Environments))
+	for _, env := range *g.Environments {
+		names = append(names, env.Name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}

--- a/cli/pkg/cmd/gateway/list.go
+++ b/cli/pkg/cmd/gateway/list.go
@@ -75,18 +75,19 @@ func NewListCmd(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return render.Error(opts.IO, scope, err)
 			}
-			if cmd.Flags().Changed("limit") && limit < 1 {
-				return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--limit must be >= 1"))
-			}
-			if cmd.Flags().Changed("offset") && offset < 0 {
-				return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--offset must be >= 0"))
-			}
 			opts.Org, opts.Scope = org, scope
+
 			if cmd.Flags().Changed("limit") {
+				if limit < 1 {
+					return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--limit must be >= 1"))
+				}
 				v := int32(limit)
 				opts.Limit = &v
 			}
 			if cmd.Flags().Changed("offset") {
+				if offset < 0 {
+					return render.Error(opts.IO, scope, cmdutil.FlagErrorf("--offset must be >= 0"))
+				}
 				v := int32(offset)
 				opts.Offset = &v
 			}
@@ -175,8 +176,8 @@ func runList(ctx context.Context, o *ListOptions) error {
 	return tp.Render()
 }
 
-// emptyMessage names the active filters, so a user who mistyped --env sees why
-// the result is empty rather than concluding the org has no gateways.
+// emptyMessage names the active filters, so a filter that matches nothing reads as
+// such rather than as an org with no gateways.
 func (o *ListOptions) emptyMessage() string {
 	filters := []string{}
 	if o.Type != "" {

--- a/cli/pkg/cmd/gateway/list_test.go
+++ b/cli/pkg/cmd/gateway/list_test.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+func sampleGateway(name, uuid string, gwType amsvc.GatewayType, envs ...string) amsvc.GatewayResponse {
+	g := amsvc.GatewayResponse{
+		Name:        name,
+		DisplayName: strings.ToUpper(name),
+		Uuid:        uuid,
+		GatewayType: gwType,
+		Status:      amsvc.GatewayStatus("ACTIVE"),
+		Vhost:       name + ".example.com",
+		CreatedAt:   time.Unix(0, 0).UTC(),
+		UpdatedAt:   time.Unix(0, 0).UTC(),
+	}
+	if len(envs) > 0 {
+		bindings := make([]amsvc.GatewayEnvironmentResponse, 0, len(envs))
+		for _, env := range envs {
+			bindings = append(bindings, amsvc.GatewayEnvironmentResponse{Name: env})
+		}
+		g.Environments = &bindings
+	}
+	return g
+}
+
+func sampleListResponse(gateways ...amsvc.GatewayResponse) amsvc.GatewayListResponse {
+	return amsvc.GatewayListResponse{
+		Gateways: gateways,
+		Total:    int32(len(gateways)),
+		Limit:    100,
+		Offset:   0,
+	}
+}
+
+func TestList_SuccessJSON(t *testing.T) {
+	io, out, _ := newTestIO()
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse(
+		sampleGateway("edge", "11111111-1111-1111-1111-111111111111", amsvc.GatewayTypeBOTH, "default"),
+	))
+	defer closeFn()
+
+	err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.method != "GET" {
+		t.Errorf("method = %q, want GET", captured.method)
+	}
+	if captured.path != "/orgs/acme/gateways" {
+		t.Errorf("path = %q, want /orgs/acme/gateways", captured.path)
+	}
+	env := decodeEnvelope(t, out.String())
+	gateways := env["data"].(map[string]any)["gateways"].([]any)
+	if len(gateways) != 1 {
+		t.Fatalf("gateways len = %d, want 1", len(gateways))
+	}
+	if gateways[0].(map[string]any)["uuid"] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("uuid = %v", gateways[0].(map[string]any)["uuid"])
+	}
+}
+
+// A list must not hide rows by default: the whole point of the command is showing
+// which gateways exist, and the placement rules are explained by the type column.
+func TestList_SendsNoFiltersByDefault(t *testing.T) {
+	io, _, _ := newTestIO()
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	if err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured.rawQuery != "" {
+		t.Errorf("rawQuery = %q, want empty (no implicit type or status filter)", captured.rawQuery)
+	}
+}
+
+func TestList_SendsTypeAndEnvironmentFilters(t *testing.T) {
+	io, _, _ := newTestIO()
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	if err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+		Type: "egress", Environment: "staging",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(captured.rawQuery, "type=EGRESS") {
+		t.Errorf("rawQuery = %q, want type=EGRESS (upper-cased)", captured.rawQuery)
+	}
+	if !strings.Contains(captured.rawQuery, "environment=staging") {
+		t.Errorf("rawQuery = %q, want environment=staging", captured.rawQuery)
+	}
+}
+
+func TestList_SendsPagination(t *testing.T) {
+	io, _, _ := newTestIO()
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	limit, offset := int32(5), int32(10)
+	if err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+		Limit: &limit, Offset: &offset,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(captured.rawQuery, "limit=5") || !strings.Contains(captured.rawQuery, "offset=10") {
+		t.Errorf("rawQuery = %q, want limit=5 and offset=10", captured.rawQuery)
+	}
+}
+
+func TestList_RejectsUnknownTypeWithoutCallingServer(t *testing.T) {
+	io, _, _ := newTestIO()
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(), Type: "AI-GATEWAY",
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown --type")
+	}
+	if captured.called {
+		t.Error("server was called despite an invalid --type")
+	}
+}
+
+func TestList_EmptyPrintsNoticeOnTTY(t *testing.T) {
+	io, out, errOut := newTextTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	if err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "No gateways found") {
+		t.Errorf("errOut = %q, want an empty-list notice", errOut.String())
+	}
+	if out.String() != "" {
+		t.Errorf("stdout = %q, want empty so the notice cannot be piped into a parser", out.String())
+	}
+}
+
+// The notice names the filters, so a mistyped --env does not read as "this org has
+// no gateways" — which matters because the server drops a filter it cannot resolve.
+func TestList_EmptyNoticeNamesActiveFilters(t *testing.T) {
+	io, _, errOut := newTextTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	if err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+		Type: "egress", Environment: "staging",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "type EGRESS") || !strings.Contains(errOut.String(), `environment "staging"`) {
+		t.Errorf("errOut = %q, want both filters named", errOut.String())
+	}
+}
+
+func TestList_EmptyStaysSilentWhenPiped(t *testing.T) {
+	io, out, errOut := newTextTestIO(false)
+	clientFn, _, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	if err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.String() != "" || errOut.String() != "" {
+		t.Errorf("piped output must stay empty; stdout=%q stderr=%q", out.String(), errOut.String())
+	}
+}
+
+func TestList_TableShowsUUIDAndEnvironments(t *testing.T) {
+	io, out, _ := newTextTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusOK, sampleListResponse(
+		sampleGateway("edge", "11111111-1111-1111-1111-111111111111", amsvc.GatewayTypeBOTH, "prod", "default"),
+		sampleGateway("inbound", "22222222-2222-2222-2222-222222222222", amsvc.GatewayTypeINGRESS),
+	))
+	defer closeFn()
+
+	if err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rendered := out.String()
+	for _, want := range []string{"UUID", "11111111-1111-1111-1111-111111111111", "BOTH", "default,prod", "INGRESS"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("table missing %q; got:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestList_ServerErrorIsSurfaced(t *testing.T) {
+	io, out, _ := newTestIO()
+	clientFn, _, closeFn := newTestClient(t, http.StatusInternalServerError,
+		map[string]string{"code": "INTERNAL_ERROR", "message": "boom"})
+	defer closeFn()
+
+	err := runList(context.Background(), &ListOptions{
+		IO: io, Client: clientFn, Org: "acme", Scope: baseScope(),
+	})
+	if err == nil {
+		t.Fatal("expected an error on 500")
+	}
+	if !strings.Contains(out.String(), "boom") {
+		t.Errorf("envelope = %q, want the server message", out.String())
+	}
+}
+
+func TestListCmd_RejectsZeroLimit(t *testing.T) {
+	io, _, _ := newTestIO()
+	clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+	defer closeFn()
+
+	root := testGatewayCmd(t, io, clientFn)
+	root.SetArgs([]string{"gateway", "list", "--limit", "0"})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected an error for --limit 0")
+	}
+	if captured.called {
+		t.Error("server was called despite an invalid --limit")
+	}
+}
+
+func TestNormalizeGatewayType(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    amsvc.GatewayTypeInput
+		wantErr bool
+	}{
+		{in: "EGRESS", want: amsvc.GatewayTypeInputEGRESS},
+		{in: "egress", want: amsvc.GatewayTypeInputEGRESS},
+		{in: " both ", want: amsvc.GatewayTypeInputBOTH},
+		{in: "INGRESS", want: amsvc.GatewayTypeInputINGRESS},
+		// Deprecated server-side aliases are deliberately not advertised.
+		{in: "REGULAR", wantErr: true},
+		{in: "AI", wantErr: true},
+		{in: "nonsense", wantErr: true},
+	} {
+		got, err := normalizeGatewayType(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("normalizeGatewayType(%q) = %q, want an error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeGatewayType(%q): %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("normalizeGatewayType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEnvironmentNames(t *testing.T) {
+	withNone := sampleGateway("a", "id", amsvc.GatewayTypeBOTH)
+	if got := environmentNames(withNone); got != "-" {
+		t.Errorf("environmentNames(no bindings) = %q, want -", got)
+	}
+	withTwo := sampleGateway("a", "id", amsvc.GatewayTypeBOTH, "prod", "default")
+	if got := environmentNames(withTwo); got != "default,prod" {
+		t.Errorf("environmentNames = %q, want default,prod (sorted)", got)
+	}
+}

--- a/cli/pkg/cmd/gateway/list_test.go
+++ b/cli/pkg/cmd/gateway/list_test.go
@@ -172,8 +172,8 @@ func TestList_EmptyPrintsNoticeOnTTY(t *testing.T) {
 	}
 }
 
-// The notice names the filters, so a mistyped --env does not read as "this org has
-// no gateways" — which matters because the server drops a filter it cannot resolve.
+// The notice names the filters, so a filter that matches nothing does not read as
+// "this org has no gateways".
 func TestList_EmptyNoticeNamesActiveFilters(t *testing.T) {
 	io, _, errOut := newTextTestIO(true)
 	clientFn, _, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())

--- a/cli/pkg/cmd/gateway/list_test.go
+++ b/cli/pkg/cmd/gateway/list_test.go
@@ -258,6 +258,32 @@ func TestListCmd_RejectsZeroLimit(t *testing.T) {
 	}
 }
 
+// The flags are ints narrowed to the wire's int32. Without an upper bound
+// `--limit 4294967297` truncated to 1 and `--offset 4294967296` to 0, so the command
+// quietly requested a page nobody asked for instead of rejecting the value.
+func TestListCmd_RejectsOutOfRangePagination(t *testing.T) {
+	for _, tc := range []struct{ flag, value string }{
+		{flag: "--limit", value: "4294967297"},  // truncates to 1
+		{flag: "--limit", value: "2147483648"},  // MaxInt32 + 1
+		{flag: "--offset", value: "4294967296"}, // truncates to 0
+	} {
+		t.Run(tc.flag+"="+tc.value, func(t *testing.T) {
+			io, _, _ := newTestIO()
+			clientFn, captured, closeFn := newTestClient(t, http.StatusOK, sampleListResponse())
+			defer closeFn()
+
+			root := testGatewayCmd(t, io, clientFn)
+			root.SetArgs([]string{"gateway", "list", tc.flag, tc.value})
+			if err := root.Execute(); err == nil {
+				t.Fatalf("expected an error for %s %s", tc.flag, tc.value)
+			}
+			if captured.called {
+				t.Errorf("server was called despite an invalid %s", tc.flag)
+			}
+		})
+	}
+}
+
 func TestNormalizeGatewayType(t *testing.T) {
 	for _, tc := range []struct {
 		in      string

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -140,11 +140,8 @@ func validateCreate(opts *CreateOptions) error {
 	if opts.keyRequested() && opts.AuthType == "none" {
 		v = append(v, "an API key cannot be used with --auth-type none")
 	}
-	for _, g := range opts.Gateways {
-		if strings.TrimSpace(g) == "" {
-			v = append(v, "--gateways must not contain a blank value")
-			break
-		}
+	if slices.ContainsFunc(opts.Gateways, func(g string) bool { return strings.TrimSpace(g) == "" }) {
+		v = append(v, "--gateways must not contain a blank value")
 	}
 
 	if len(v) == 0 {
@@ -189,9 +186,9 @@ func contextViolation(ctx string) string {
 }
 
 // gatewayNames returns the --gateways values that are not UUIDs, in order and
-// deduplicated. Kept pure so validateCreate can reject blanks without a client.
+// deduplicated. Kept separate so a UUID-only --gateways can skip the lookup that
+// resolving names would otherwise cost.
 func gatewayNames(raw []string) []string {
-	seen := map[string]bool{}
 	names := []string{}
 	for _, g := range raw {
 		trimmed := strings.TrimSpace(g)
@@ -201,8 +198,7 @@ func gatewayNames(raw []string) []string {
 		if _, err := uuid.Parse(trimmed); err == nil {
 			continue
 		}
-		if !seen[trimmed] {
-			seen[trimmed] = true
+		if !slices.Contains(names, trimmed) {
 			names = append(names, trimmed)
 		}
 	}

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -36,16 +36,28 @@ import (
 )
 
 const (
-	defaultVersion = "v1"
+	// defaultVersion must satisfy the spec's `^v\d+\.\d+$` pattern. "v1" does not,
+	// and was accepted only because the server did not validate it.
+	defaultVersion = "v1.0"
 	defaultContext = "/"
 	// defaultAuthType matches the auth scheme of the built-in templates that
 	// require a credential (openai, anthropic, mistralai, …). It is only sent
 	// when the user also supplies a key or an explicit auth override.
 	defaultAuthType = "api-key"
+	// defaultAccessMode matches what the console sends. A deployed proxy defaults
+	// to deny_all server-side and is then unreachable, so a provider created
+	// without an explicit mode would be created correctly and still not work.
+	defaultAccessMode = "allow_all"
 )
 
 // validAuthTypes are the upstream auth schemes accepted by the service.
 var validAuthTypes = []string{"api-key", "none"}
+
+// validAccessModes are the access control modes accepted by the service.
+var validAccessModes = []string{"allow_all", "deny_all"}
+
+// versionRegex mirrors the spec's `version` pattern.
+var versionRegex = regexp.MustCompile(`^v\d+\.\d+$`)
 
 type CreateOptions struct {
 	IO           *iostreams.IOStreams
@@ -74,13 +86,23 @@ type CreateOptions struct {
 	APIKey      string
 	APIKeyStdin bool
 
-	Gateways []string
+	AccessMode string
+	Gateways   []string
 }
 
 // keyRequested reports whether the user asked to attach a credential, without
 // reading stdin (so it is safe to call during validation).
 func (o *CreateOptions) keyRequested() bool {
 	return o.APIKey != "" || o.APIKeyStdin
+}
+
+// accessMode falls back to the default so a caller that builds CreateOptions
+// directly cannot send an empty mode, which the service would reject.
+func (o *CreateOptions) accessMode() string {
+	if o.AccessMode == "" {
+		return defaultAccessMode
+	}
+	return o.AccessMode
 }
 
 func validateCreate(opts *CreateOptions) error {
@@ -100,8 +122,14 @@ func validateCreate(opts *CreateOptions) error {
 	if msg := contextViolation(opts.Context); msg != "" {
 		v = append(v, msg)
 	}
+	if !versionRegex.MatchString(opts.Version) {
+		v = append(v, fmt.Sprintf("--version must match %s, e.g. %s", versionRegex, defaultVersion))
+	}
 	if !isValidAuthType(opts.AuthType) {
 		v = append(v, fmt.Sprintf("--auth-type must be one of: %s", strings.Join(validAuthTypes, ", ")))
+	}
+	if !slices.Contains(validAccessModes, opts.accessMode()) {
+		v = append(v, fmt.Sprintf("--access-mode must be one of: %s", strings.Join(validAccessModes, ", ")))
 	}
 	if opts.APIKey != "" && opts.APIKeyStdin {
 		v = append(v, "--api-key and --api-key-stdin are mutually exclusive")
@@ -112,8 +140,11 @@ func validateCreate(opts *CreateOptions) error {
 	if opts.keyRequested() && opts.AuthType == "none" {
 		v = append(v, "an API key cannot be used with --auth-type none")
 	}
-	if _, err := parseGateways(opts.Gateways); err != nil {
-		v = append(v, err.Error())
+	for _, g := range opts.Gateways {
+		if strings.TrimSpace(g) == "" {
+			v = append(v, "--gateways must not contain a blank value")
+			break
+		}
 	}
 
 	if len(v) == 0 {
@@ -157,19 +188,50 @@ func contextViolation(ctx string) string {
 	return ""
 }
 
-// parseGateways converts the raw --gateways values into typed UUIDs, reporting
-// the first malformed value.
-func parseGateways(raw []string) ([]openapi_types.UUID, error) {
+// gatewayNames returns the --gateways values that are not UUIDs, in order and
+// deduplicated. Kept pure so validateCreate can reject blanks without a client.
+func gatewayNames(raw []string) []string {
+	seen := map[string]bool{}
+	names := []string{}
+	for _, g := range raw {
+		trimmed := strings.TrimSpace(g)
+		if trimmed == "" {
+			continue
+		}
+		if _, err := uuid.Parse(trimmed); err == nil {
+			continue
+		}
+		if !seen[trimmed] {
+			seen[trimmed] = true
+			names = append(names, trimmed)
+		}
+	}
+	return names
+}
+
+// parseGateways converts the raw --gateways values into typed UUIDs, resolving any
+// that are names through nameToUUID. A nil nameToUUID means names are rejected,
+// which is what validateCreate uses to check shape without reaching the server.
+func parseGateways(raw []string, nameToUUID map[string]openapi_types.UUID) ([]openapi_types.UUID, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
 	out := make([]openapi_types.UUID, 0, len(raw))
 	for _, g := range raw {
-		id, err := uuid.Parse(strings.TrimSpace(g))
-		if err != nil {
-			return nil, fmt.Errorf("invalid gateway id %q: must be a UUID", g)
+		trimmed := strings.TrimSpace(g)
+		if trimmed == "" {
+			return nil, fmt.Errorf("--gateways must not contain a blank value")
 		}
-		out = append(out, id)
+		id, err := uuid.Parse(trimmed)
+		if err == nil {
+			out = append(out, id)
+			continue
+		}
+		resolved, ok := nameToUUID[trimmed]
+		if !ok {
+			return nil, fmt.Errorf("unknown gateway %q: pass a gateway name or UUID from 'amctl gateway list'", trimmed)
+		}
+		out = append(out, resolved)
 	}
 	return out, nil
 }
@@ -222,10 +284,15 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.AuthHeader, "auth-header", "", "Override the template's auth header name")
 	cmd.Flags().StringVar(&opts.APIKey, "api-key", "", "Provider API key (leaks into shell history; prefer --api-key-stdin)")
 	cmd.Flags().BoolVar(&opts.APIKeyStdin, "api-key-stdin", false, "Read the provider API key from stdin")
-	cmd.Flags().StringSliceVar(&opts.Gateways, "gateways", nil, "Gateway UUIDs to deploy the provider to (repeatable)")
+	cmd.Flags().StringVar(&opts.AccessMode, "access-mode", defaultAccessMode,
+		fmt.Sprintf("Route access control for the deployed proxy: %s", strings.Join(validAccessModes, " or ")))
+	cmd.Flags().StringSliceVar(&opts.Gateways, "gateways", nil, "Gateway names or UUIDs to deploy the provider to (repeatable)")
 
 	_ = cmd.RegisterFlagCompletionFunc("auth-type", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return validAuthTypes, cobra.ShellCompDirectiveNoFileComp
+	})
+	_ = cmd.RegisterFlagCompletionFunc("access-mode", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return validAccessModes, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("template", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.CompleteLLMProviderTemplates(cmd, f), cobra.ShellCompDirectiveNoFileComp
@@ -250,12 +317,17 @@ func runCreate(ctx context.Context, o *CreateOptions) error {
 		}
 	}
 
-	req, err := buildCreateRequest(o, key)
+	client, err := o.Client(ctx)
 	if err != nil {
 		return render.Error(o.IO, o.Scope, err)
 	}
 
-	client, err := o.Client(ctx)
+	gatewayUUIDs, err := resolveGatewayNames(ctx, client, o.Org, o.Gateways)
+	if err != nil {
+		return render.Error(o.IO, o.Scope, err)
+	}
+
+	req, err := buildCreateRequest(o, key, gatewayUUIDs)
 	if err != nil {
 		return render.Error(o.IO, o.Scope, err)
 	}
@@ -276,10 +348,43 @@ func runCreate(ctx context.Context, o *CreateOptions) error {
 	return nil
 }
 
+// resolveGatewayNames maps any non-UUID --gateways values to their UUIDs by listing
+// the org's gateways. Returns nil without calling the server when every value is
+// already a UUID, so the common scripted case costs no extra request.
+func resolveGatewayNames(
+	ctx context.Context, client *amsvc.ClientWithResponses, org string, raw []string,
+) (map[string]openapi_types.UUID, error) {
+	names := gatewayNames(raw)
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	resp, err := client.ListGatewaysWithResponse(ctx, org, &amsvc.ListGatewaysParams{})
+	if err != nil {
+		return nil, clierr.Newf(clierr.Transport, "look up gateways by name: %v", err)
+	}
+	if resp.JSON200 == nil {
+		return nil, cmdutil.ErrorFromServer(resp.HTTPResponse,
+			cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON500))
+	}
+
+	byName := make(map[string]openapi_types.UUID, len(resp.JSON200.Gateways))
+	for _, g := range resp.JSON200.Gateways {
+		id, err := uuid.Parse(g.Uuid)
+		if err != nil {
+			continue
+		}
+		byName[g.Name] = id
+	}
+	return byName, nil
+}
+
 // buildCreateRequest maps the resolved options into the create payload. The
 // upstream block is attached only when the user supplies a URL or an auth input,
 // so a bare `create <id> --display-name --template` defers entirely to the template.
-func buildCreateRequest(o *CreateOptions, key string) (amsvc.CreateLLMProviderRequest, error) {
+func buildCreateRequest(
+	o *CreateOptions, key string, gatewayUUIDs map[string]openapi_types.UUID,
+) (amsvc.CreateLLMProviderRequest, error) {
 	req := amsvc.CreateLLMProviderRequest{
 		Id:       o.ID,
 		Name:     o.DisplayName,
@@ -311,12 +416,19 @@ func buildCreateRequest(o *CreateOptions, key string) (amsvc.CreateLLMProviderRe
 		req.Upstream = amsvc.UpstreamConfig{Main: main}
 	}
 
-	gws, err := parseGateways(o.Gateways)
+	gws, err := parseGateways(o.Gateways, gatewayUUIDs)
 	if err != nil {
 		return req, cmdutil.FlagErrors([]string{err.Error()})
 	}
 	if len(gws) > 0 {
 		req.Gateways = &gws
+	}
+
+	// Sent unconditionally: a deployed proxy defaults to deny_all server-side, so a
+	// provider created without an access control block is unreachable.
+	req.AccessControl = &amsvc.LLMAccessControl{
+		Mode:       amsvc.LLMAccessControlMode(o.accessMode()),
+		Exceptions: &[]amsvc.RouteException{},
 	}
 
 	return req, nil

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -140,8 +141,11 @@ func validateCreate(opts *CreateOptions) error {
 	if opts.keyRequested() && opts.AuthType == "none" {
 		v = append(v, "an API key cannot be used with --auth-type none")
 	}
-	if slices.ContainsFunc(opts.Gateways, func(g string) bool { return strings.TrimSpace(g) == "" }) {
-		v = append(v, "--gateways must not contain a blank value")
+	for _, g := range opts.Gateways {
+		// Identical messages collapse: three blank values are one mistake.
+		if msg := gatewayViolation(g); msg != "" && !slices.Contains(v, msg) {
+			v = append(v, msg)
+		}
 	}
 
 	if len(v) == 0 {
@@ -152,6 +156,40 @@ func validateCreate(opts *CreateOptions) error {
 
 func isValidAuthType(t string) bool {
 	return slices.Contains(validAuthTypes, t)
+}
+
+// gatewayNameMaxLen mirrors the spec's maxLength on GatewayResponse.name.
+const gatewayNameMaxLen = 64
+
+// gatewayViolation returns a validation message when value can be neither a gateway
+// UUID nor a gateway name, or "" when it could be either. Rejecting the impossible
+// shapes here keeps them from costing a paginated walk of every gateway in the org
+// before resolution fails.
+//
+// It stops short of the spec's `^[a-z0-9-]+$` name pattern on purpose: a plausible
+// name still has to be resolved against the server, so mirroring the pattern buys
+// nothing beyond these checks and makes the CLI reject valid input the day the server
+// relaxes the rule. The checks kept are the ones cmdutil.ValidatePathParam already
+// applies to the gateway passed to `amctl gateway get`, plus the length bound.
+func gatewayViolation(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "--gateways must not contain a blank value"
+	}
+	if _, err := uuid.Parse(trimmed); err == nil {
+		return ""
+	}
+	if strings.Contains(trimmed, "/") {
+		return fmt.Sprintf("--gateways value %q must not contain '/'", trimmed)
+	}
+	if strings.ContainsFunc(trimmed, unicode.IsSpace) {
+		return fmt.Sprintf("--gateways value %q must not contain whitespace", trimmed)
+	}
+	if len(trimmed) > gatewayNameMaxLen {
+		return fmt.Sprintf("--gateways value %q is longer than a gateway name can be (at most %d characters)",
+			trimmed, gatewayNameMaxLen)
+	}
+	return ""
 }
 
 // handleRegex matches a valid resource handle: letters, digits, '-' and '_'.
@@ -206,8 +244,8 @@ func gatewayNames(raw []string) []string {
 }
 
 // parseGateways converts the raw --gateways values into typed UUIDs, resolving any
-// that are names through nameToUUID. A nil nameToUUID means names are rejected,
-// which is what validateCreate uses to check shape without reaching the server.
+// that are names through nameToUUID. A nil nameToUUID rejects every name, which is
+// what a UUID-only --gateways gets: resolveGatewayNames skips the lookup entirely.
 //
 // Duplicates are dropped after resolution, keeping the first occurrence and the
 // caller's order: a gateway named twice — or named once by name and once by UUID —

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -208,26 +208,35 @@ func gatewayNames(raw []string) []string {
 // parseGateways converts the raw --gateways values into typed UUIDs, resolving any
 // that are names through nameToUUID. A nil nameToUUID means names are rejected,
 // which is what validateCreate uses to check shape without reaching the server.
+//
+// Duplicates are dropped after resolution, keeping the first occurrence and the
+// caller's order: a gateway named twice — or named once by name and once by UUID —
+// is one placement, and sending it twice draws a confusing rejection from the
+// server's "no two gateways may share an environment" check.
 func parseGateways(raw []string, nameToUUID map[string]openapi_types.UUID) ([]openapi_types.UUID, error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
 	out := make([]openapi_types.UUID, 0, len(raw))
+	seen := make(map[openapi_types.UUID]struct{}, len(raw))
 	for _, g := range raw {
 		trimmed := strings.TrimSpace(g)
 		if trimmed == "" {
 			return nil, fmt.Errorf("--gateways must not contain a blank value")
 		}
 		id, err := uuid.Parse(trimmed)
-		if err == nil {
-			out = append(out, id)
+		if err != nil {
+			resolved, ok := nameToUUID[trimmed]
+			if !ok {
+				return nil, fmt.Errorf("unknown gateway %q: pass a gateway name or UUID from 'amctl gateway list'", trimmed)
+			}
+			id = resolved
+		}
+		if _, duplicate := seen[id]; duplicate {
 			continue
 		}
-		resolved, ok := nameToUUID[trimmed]
-		if !ok {
-			return nil, fmt.Errorf("unknown gateway %q: pass a gateway name or UUID from 'amctl gateway list'", trimmed)
-		}
-		out = append(out, resolved)
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
 	return out, nil
 }
@@ -355,20 +364,19 @@ func resolveGatewayNames(
 		return nil, nil
 	}
 
-	resp, err := client.ListGatewaysWithResponse(ctx, org, &amsvc.ListGatewaysParams{})
+	gateways, err := cmdutil.ListAllGateways(ctx, client, org)
 	if err != nil {
-		return nil, clierr.Newf(clierr.Transport, "look up gateways by name: %v", err)
-	}
-	if resp.JSON200 == nil {
-		return nil, cmdutil.ErrorFromServer(resp.HTTPResponse,
-			cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON500))
+		return nil, err
 	}
 
-	byName := make(map[string]openapi_types.UUID, len(resp.JSON200.Gateways))
-	for _, g := range resp.JSON200.Gateways {
+	byName := make(map[string]openapi_types.UUID, len(gateways))
+	for _, g := range gateways {
 		id, err := uuid.Parse(g.Uuid)
 		if err != nil {
-			continue
+			// Skipping the entry would report the gateway as unknown, blaming the
+			// user's input for a malformed UUID the server sent.
+			return nil, clierr.Newf(clierr.Internal,
+				"server returned gateway %q with an unparseable uuid %q", g.Name, g.Uuid)
 		}
 		byName[g.Name] = id
 	}

--- a/cli/pkg/cmd/llmprovider/create.go
+++ b/cli/pkg/cmd/llmprovider/create.go
@@ -230,6 +230,9 @@ func NewCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("template", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.CompleteLLMProviderTemplates(cmd, f), cobra.ShellCompDirectiveNoFileComp
 	})
+	_ = cmd.RegisterFlagCompletionFunc("gateways", func(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return cmdutil.CompleteGateways(cmd, f), cobra.ShellCompDirectiveNoFileComp
+	})
 
 	return cmd
 }

--- a/cli/pkg/cmd/llmprovider/create_payload_test.go
+++ b/cli/pkg/cmd/llmprovider/create_payload_test.go
@@ -140,6 +140,26 @@ func TestParseGateways_MixesNamesAndUUIDs(t *testing.T) {
 	}
 }
 
+// One gateway named twice is one placement. Sending it twice drew a rejection from
+// the server's "no two gateways may share an environment" check, which reads as a
+// conflict between two gateways rather than as a repeated value.
+func TestParseGateways_DropsDuplicatesKeepingFirstOccurrence(t *testing.T) {
+	edge := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	other := "11111111-1111-1111-1111-111111111111"
+
+	got, err := parseGateways(
+		[]string{"edge", other, " edge ", edge.String(), other},
+		map[string]openapi_types.UUID{"edge": edge},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "edge", " edge " and the bare UUID are all the same gateway.
+	if len(got) != 2 || got[0] != edge || got[1].String() != other {
+		t.Errorf("parseGateways = %v, want [%s %s]", got, edge, other)
+	}
+}
+
 // newRoutingTestClient answers each path with its own body, so a test can exercise
 // the gateway lookup followed by the create call. Any request to an undeclared path
 // fails the test, which is how the "no extra round trip" case is asserted.

--- a/cli/pkg/cmd/llmprovider/create_payload_test.go
+++ b/cli/pkg/cmd/llmprovider/create_payload_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+// accessControlMode digs out accessControl.mode from a captured create body.
+func accessControlMode(t *testing.T, raw []byte) (string, bool) {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal body: %v\nbody=%s", err, raw)
+	}
+	ac, ok := body["accessControl"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	mode, ok := ac["mode"].(string)
+	return mode, ok
+}
+
+// A deployed proxy defaults to deny_all server-side, so a create that omits the
+// access control block yields a provider that is configured correctly and still
+// unreachable.
+func TestCreate_SendsAllowAllAccessControlByDefault(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusCreated, sampleProviderResponse())
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: ios, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: defaultVersion, Context: "/",
+		Template: "openai", AuthType: "api-key",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mode, ok := accessControlMode(t, captured.body)
+	if !ok {
+		t.Fatalf("no accessControl block in body=%s", captured.body)
+	}
+	if mode != "allow_all" {
+		t.Errorf("accessControl.mode = %q, want allow_all", mode)
+	}
+}
+
+func TestCreate_HonoursExplicitAccessMode(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	clientFn, captured, closeFn := newTestClient(t, http.StatusCreated, sampleProviderResponse())
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: ios, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: defaultVersion, Context: "/",
+		Template: "openai", AuthType: "api-key", AccessMode: "deny_all",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	mode, _ := accessControlMode(t, captured.body)
+	if mode != "deny_all" {
+		t.Errorf("accessControl.mode = %q, want deny_all", mode)
+	}
+}
+
+// The spec pins version to ^v\d+\.\d+$. The old default "v1" cannot satisfy it and
+// was accepted only because the server did not validate the pattern.
+func TestDefaultVersionMatchesTheSpecPattern(t *testing.T) {
+	if !versionRegex.MatchString(defaultVersion) {
+		t.Errorf("defaultVersion %q does not match %s", defaultVersion, versionRegex)
+	}
+}
+
+func TestGatewayNames_KeepsOnlyNonUUIDs(t *testing.T) {
+	got := gatewayNames([]string{
+		"11111111-1111-1111-1111-111111111111",
+		"edge",
+		" edge ",
+		"  ",
+		"inbound",
+	})
+	want := []string{"edge", "inbound"}
+	if len(got) != len(want) {
+		t.Fatalf("gatewayNames = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("gatewayNames[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseGateways_RejectsUnknownName(t *testing.T) {
+	_, err := parseGateways([]string{"ghost"}, map[string]openapi_types.UUID{})
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable gateway name")
+	}
+	if !strings.Contains(err.Error(), "unknown gateway") {
+		t.Errorf("error = %v, want it to name the unknown gateway", err)
+	}
+}
+
+func TestParseGateways_MixesNamesAndUUIDs(t *testing.T) {
+	edge := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	explicit := "11111111-1111-1111-1111-111111111111"
+
+	got, err := parseGateways([]string{explicit, "edge"}, map[string]openapi_types.UUID{"edge": edge})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0].String() != explicit || got[1] != edge {
+		t.Errorf("parseGateways = %v, want [%s %s]", got, explicit, edge)
+	}
+}
+
+// newRoutingTestClient answers each path with its own body, so a test can exercise
+// the gateway lookup followed by the create call. Any request to an undeclared path
+// fails the test, which is how the "no extra round trip" case is asserted.
+func newRoutingTestClient(
+	t *testing.T, routes map[string]any,
+) (func(context.Context) (*amsvc.ClientWithResponses, error), *capturedRequest, func()) {
+	t.Helper()
+	captured := &capturedRequest{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := routes[r.URL.Path]
+		if !ok {
+			t.Errorf("unexpected request to %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		status := http.StatusOK
+		if r.Method == http.MethodPost {
+			captured.called = true
+			captured.method = r.Method
+			captured.path = r.URL.Path
+			raw, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read request body: %v", err)
+			}
+			captured.body = raw
+			status = http.StatusCreated
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	client, err := amsvc.NewClientWithResponses(server.URL)
+	if err != nil {
+		server.Close()
+		t.Fatalf("new client: %v", err)
+	}
+	return func(context.Context) (*amsvc.ClientWithResponses, error) { return client, nil }, captured, server.Close
+}
+
+func TestCreate_ResolvesGatewayNameToUUID(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	const edgeUUID = "22222222-2222-2222-2222-222222222222"
+	clientFn, captured, closeFn := newRoutingTestClient(t, map[string]any{
+		"/orgs/acme/gateways": amsvc.GatewayListResponse{
+			Gateways: []amsvc.GatewayResponse{{Name: "edge", Uuid: edgeUUID}},
+			Total:    1,
+		},
+		"/orgs/acme/llm-providers": sampleProviderResponse(),
+	})
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: ios, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: defaultVersion, Context: "/",
+		Template: "openai", AuthType: "api-key", Gateways: []string{"edge"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(captured.body), edgeUUID) {
+		t.Errorf("create body does not carry the resolved gateway UUID; body=%s", captured.body)
+	}
+}
+
+func TestCreate_UnknownGatewayNameFailsBeforeCreating(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	clientFn, captured, closeFn := newRoutingTestClient(t, map[string]any{
+		"/orgs/acme/gateways": amsvc.GatewayListResponse{Gateways: []amsvc.GatewayResponse{}},
+	})
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: ios, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: defaultVersion, Context: "/",
+		Template: "openai", AuthType: "api-key", Gateways: []string{"ghost"},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable gateway name")
+	}
+	if captured.called {
+		t.Error("provider was created despite an unresolvable gateway name")
+	}
+}
+
+// A UUID-only --gateways must not cost an extra round trip: the gateway list route
+// is absent here, so reaching it fails the test.
+func TestCreate_UUIDGatewaysSkipTheLookup(t *testing.T) {
+	ios, _, _ := newTestIO(true)
+	const explicit = "11111111-1111-1111-1111-111111111111"
+	clientFn, captured, closeFn := newRoutingTestClient(t, map[string]any{
+		"/orgs/acme/llm-providers": sampleProviderResponse(),
+	})
+	defer closeFn()
+
+	err := runCreate(context.Background(), &CreateOptions{
+		IO: ios, Client: clientFn, Org: "acme", Scope: baseScope(),
+		ID: "openai", DisplayName: "OpenAI", Version: defaultVersion, Context: "/",
+		Template: "openai", AuthType: "api-key", Gateways: []string{explicit},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(captured.body), explicit) {
+		t.Errorf("create body missing the gateway UUID; body=%s", captured.body)
+	}
+}

--- a/cli/pkg/cmd/llmprovider/create_test.go
+++ b/cli/pkg/cmd/llmprovider/create_test.go
@@ -264,6 +264,41 @@ func TestCreate_BlankGateway(t *testing.T) {
 		"--gateways must not contain a blank value")
 }
 
+// A value that can be neither a UUID nor a gateway name is rejected here rather
+// than after resolveGatewayNames has paged through every gateway in the org. The
+// command tree is built with a nil client factory, so reaching the server at all
+// would fail differently than a flag violation.
+func TestCreate_MalformedGatewayFailsBeforeTheLookup(t *testing.T) {
+	base := []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai"}
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"slash", "acme/edge", "must not contain '/'"},
+		{"whitespace", "ai gateway", "must not contain whitespace"},
+		{"too long", strings.Repeat("g", gatewayNameMaxLen+1), "longer than a gateway name can be"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runTreeExpectViolation(t, append(append([]string{}, base...), "--gateways", tc.value), tc.want)
+		})
+	}
+}
+
+// The shape gate must not take over resolution: a value that looks like a gateway
+// name is still the server's to accept or reject, because only the server knows
+// which names exist.
+func TestValidateCreate_PlausibleGatewayNameIsNotRejectedLocally(t *testing.T) {
+	err := validateCreate(&CreateOptions{
+		ID: "openai", DisplayName: "OpenAI", Template: "openai",
+		Context: "/", AuthType: "api-key", Version: defaultVersion,
+		Gateways: []string{"not-a-uuid-or-a-name", "22222222-2222-2222-2222-222222222222"},
+	})
+	if err != nil {
+		t.Fatalf("expected valid options, got %v", err)
+	}
+}
+
 func TestCreate_BadVersion(t *testing.T) {
 	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--version", "v1"},
 		"--version must match")

--- a/cli/pkg/cmd/llmprovider/create_test.go
+++ b/cli/pkg/cmd/llmprovider/create_test.go
@@ -232,7 +232,7 @@ func TestCreate_ContextTrailingSlash(t *testing.T) {
 func TestValidateCreate_RootContextOK(t *testing.T) {
 	err := validateCreate(&CreateOptions{
 		ID: "openai", DisplayName: "OpenAI", Template: "openai",
-		Context: "/", AuthType: "api-key",
+		Context: "/", AuthType: "api-key", Version: defaultVersion,
 	})
 	if err != nil {
 		t.Fatalf("expected valid options, got %v", err)
@@ -259,7 +259,17 @@ func TestCreate_BlankAPIKey(t *testing.T) {
 		"--api-key must not be blank")
 }
 
-func TestCreate_BadGateway(t *testing.T) {
-	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--gateways", "not-a-uuid"},
-		"invalid gateway id")
+func TestCreate_BlankGateway(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--gateways", "  "},
+		"--gateways must not contain a blank value")
+}
+
+func TestCreate_BadVersion(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--version", "v1"},
+		"--version must match")
+}
+
+func TestCreate_BadAccessMode(t *testing.T) {
+	runTreeExpectViolation(t, []string{"llm-provider", "create", "p", "--display-name", "X", "--template", "openai", "--access-mode", "everyone"},
+		"--access-mode must be one of")
 }

--- a/cli/pkg/cmd/llmprovider/delete.go
+++ b/cli/pkg/cmd/llmprovider/delete.go
@@ -105,7 +105,8 @@ func runDelete(ctx context.Context, o *DeleteOptions) error {
 		return render.Error(o.IO, o.Scope, clierr.Newf(clierr.Transport, "%v", err))
 	}
 	if resp.HTTPResponse == nil || resp.HTTPResponse.StatusCode != http.StatusNoContent {
-		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse, cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON404, resp.JSON500)))
+		return render.Error(o.IO, o.Scope, cmdutil.ErrorFromServer(resp.HTTPResponse,
+			cmdutil.FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON403, resp.JSON404, resp.JSON409, resp.JSON500)))
 	}
 
 	if o.IO.JSON {

--- a/cli/pkg/cmd/llmprovider/delete_conflict_test.go
+++ b/cli/pkg/cmd/llmprovider/delete_conflict_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package llmprovider
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+// TestDelete_ConflictSurfacesServerMessage is the regression test for "the provider
+// cannot be deleted". The server has always answered a blocked delete with a 409 and
+// an actionable message, but deleteLLMProvider declared no 409 in the spec, so the
+// generated client had no field to decode it into and the CLI printed the flatly
+// untrue "server returned 409 with no JSON body".
+func TestDelete_ConflictSurfacesServerMessage(t *testing.T) {
+	ios, out, _ := newTestIO(true)
+	const serverMessage = "cannot delete LLM provider: it has associated LLM proxies. " +
+		"Please delete all proxies before deleting the provider"
+	clientFn, _, closeFn := newTestClient(t, http.StatusConflict, amsvc.ErrorResponse{
+		Code:    "CONFLICT",
+		Message: serverMessage,
+	})
+	defer closeFn()
+
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: ios, Prompter: &fakePrompter{}, Client: clientFn, Scope: baseScope(),
+		Org: "acme", Provider: "openai", Yes: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error for 409")
+	}
+
+	rendered := out.String()
+	if strings.Contains(rendered, "no JSON body") {
+		t.Errorf("the 409 body was discarded; envelope=%s", rendered)
+	}
+	env := decodeEnvelope(t, rendered)
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != "CONFLICT" {
+		t.Errorf("code = %v, want CONFLICT", errBody["code"])
+	}
+	if msg, _ := errBody["message"].(string); !strings.Contains(msg, "delete all proxies") {
+		t.Errorf("message = %q, want the server's actionable text", msg)
+	}
+}
+
+// A 403 masked identically before the spec declared it.
+func TestDelete_ForbiddenSurfacesServerMessage(t *testing.T) {
+	ios, out, _ := newTestIO(true)
+	clientFn, _, closeFn := newTestClient(t, http.StatusForbidden, amsvc.ErrorResponse{
+		Code:    "FORBIDDEN",
+		Message: "missing llm-provider:delete permission",
+	})
+	defer closeFn()
+
+	err := runDelete(context.Background(), &DeleteOptions{
+		IO: ios, Prompter: &fakePrompter{}, Client: clientFn, Scope: baseScope(),
+		Org: "acme", Provider: "openai", Yes: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error for 403")
+	}
+	env := decodeEnvelope(t, out.String())
+	errBody := env["error"].(map[string]any)
+	if errBody["code"] != "FORBIDDEN" {
+		t.Errorf("code = %v, want FORBIDDEN; envelope=%s", errBody["code"], out.String())
+	}
+}

--- a/cli/pkg/cmd/root.go
+++ b/cli/pkg/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/wso2/agent-manager/cli/pkg/cmd/agent"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/api"
 	amcontext "github.com/wso2/agent-manager/cli/pkg/cmd/context"
+	"github.com/wso2/agent-manager/cli/pkg/cmd/gateway"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/llmprovider"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/project"
 	"github.com/wso2/agent-manager/cli/pkg/cmd/skills"
@@ -48,6 +49,7 @@ func NewRootCmd(f *cmdutil.Factory) (*cobra.Command, error) {
 	cmd.AddCommand(agent.NewAgentCmd(f))
 	cmd.AddCommand(api.NewAPICmd(f))
 	cmd.AddCommand(amcontext.NewContextCmd(f))
+	cmd.AddCommand(gateway.NewGatewayCmd(f))
 	cmd.AddCommand(llmprovider.NewLLMProviderCmd(f))
 	cmd.AddCommand(project.NewProjectCmd(f))
 	cmd.AddCommand(NewVersionCmd())

--- a/cli/pkg/cmdutil/completion.go
+++ b/cli/pkg/cmdutil/completion.go
@@ -313,6 +313,47 @@ func CompleteLLMProviderTemplates(cmd *cobra.Command, f *Factory) []string {
 	return out
 }
 
+// CompleteGateways returns sorted gateway names in the resolved org, each
+// annotated with its UUID and placement role. Org resolution follows
+// ResolveOrgProject(cmd, true, false). Returns nil if org cannot be resolved or on
+// any API error.
+//
+// Status is not filtered: the server's placement candidate set is not
+// liveness-filtered, so completing only ACTIVE gateways would hide values the
+// server accepts.
+func CompleteGateways(cmd *cobra.Command, f *Factory) []string {
+	const op = "CompleteGateways"
+	org, _, err := f.ResolveOrgProject(cmd, true, false)
+	if err != nil {
+		logCompletionErr(op, nil, err)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	client, err := f.AgentManager(ctx)
+	if err != nil {
+		logCompletionErr(op, map[string]string{"org": org}, err)
+		return nil
+	}
+	resp, err := client.ListGatewaysWithResponse(ctx, org, &amsvc.ListGatewaysParams{})
+	if err != nil {
+		logCompletionErr(op, map[string]string{"org": org}, err)
+		return nil
+	}
+	if resp.JSON200 == nil {
+		logCompletionErr(op, map[string]string{"org": org}, fmt.Errorf("status %d", resp.StatusCode()))
+		return nil
+	}
+	out := make([]string, 0, len(resp.JSON200.Gateways))
+	for _, g := range resp.JSON200.Gateways {
+		out = append(out, fmt.Sprintf("%s\t%s (%s)", g.Name, g.Uuid, g.GatewayType))
+	}
+	sort.Strings(out)
+	return out
+}
+
 // CompleteOrgs returns sorted organization names. Returns nil on any error
 // (no instance, network, server). Times out at 2s.
 func CompleteOrgs(cmd *cobra.Command, f *Factory) []string {

--- a/cli/pkg/cmdutil/completion.go
+++ b/cli/pkg/cmdutil/completion.go
@@ -337,17 +337,17 @@ func CompleteGateways(cmd *cobra.Command, f *Factory) []string {
 		logCompletionErr(op, map[string]string{"org": org}, err)
 		return nil
 	}
-	resp, err := client.ListGatewaysWithResponse(ctx, org, &amsvc.ListGatewaysParams{})
+	// A partial result is kept: paging the whole org can outrun completionTimeout,
+	// and the gateways already gathered complete better than an empty list.
+	gateways, err := ListAllGateways(ctx, client, org)
 	if err != nil {
 		logCompletionErr(op, map[string]string{"org": org}, err)
-		return nil
+		if len(gateways) == 0 {
+			return nil
+		}
 	}
-	if resp.JSON200 == nil {
-		logCompletionErr(op, map[string]string{"org": org}, fmt.Errorf("status %d", resp.StatusCode()))
-		return nil
-	}
-	out := make([]string, 0, len(resp.JSON200.Gateways))
-	for _, g := range resp.JSON200.Gateways {
+	out := make([]string, 0, len(gateways))
+	for _, g := range gateways {
 		out = append(out, fmt.Sprintf("%s\t%s (%s)", g.Name, g.Uuid, g.GatewayType))
 	}
 	sort.Strings(out)

--- a/cli/pkg/cmdutil/gateways.go
+++ b/cli/pkg/cmdutil/gateways.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdutil
+
+import (
+	"context"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+	"github.com/wso2/agent-manager/cli/pkg/clierr"
+)
+
+// gatewayPageLimit is the page size ListAllGateways requests. The server defaults
+// to 100 per page and caps a page at 1000.
+const gatewayPageLimit = int32(200)
+
+// ListAllGateways returns every gateway in the org, following the response's
+// pagination metadata rather than trusting one page. A single unpaginated request
+// reads as the whole set but is capped at the server's default page size, which
+// made a gateway past that boundary invisible: resolving it by name failed as
+// "unknown gateway", and completion offered a silently truncated list.
+//
+// Returns a clierr on transport failure or a non-2xx response, along with the pages
+// gathered before it. Callers that need the complete set must treat a non-nil error
+// as fatal; a best-effort caller such as shell completion can still use the partial
+// result, which beats offering nothing when a later page times out.
+func ListAllGateways(ctx context.Context, client *amsvc.ClientWithResponses, org string) ([]amsvc.GatewayResponse, error) {
+	var all []amsvc.GatewayResponse
+	for {
+		limit, offset := gatewayPageLimit, int32(len(all))
+		resp, err := client.ListGatewaysWithResponse(ctx, org, &amsvc.ListGatewaysParams{
+			Limit:  &limit,
+			Offset: &offset,
+		})
+		if err != nil {
+			return all, clierr.Newf(clierr.Transport, "list gateways: %v", err)
+		}
+		if resp.JSON200 == nil {
+			return all, ErrorFromServer(resp.HTTPResponse,
+				FirstNonNil(resp.JSON400, resp.JSON401, resp.JSON500))
+		}
+		all = append(all, resp.JSON200.Gateways...)
+		// An empty page terminates regardless of Total: a Total the server
+		// over-reports would otherwise loop forever.
+		if len(resp.JSON200.Gateways) == 0 || int32(len(all)) >= resp.JSON200.Total {
+			return all, nil
+		}
+	}
+}

--- a/cli/pkg/cmdutil/gateways_test.go
+++ b/cli/pkg/cmdutil/gateways_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// Licensed under the Apache License, Version 2.0.
+package cmdutil
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	amsvc "github.com/wso2/agent-manager/cli/pkg/clients/amsvc/gen"
+)
+
+// pagedGatewayServer serves `total` synthetic gateways, honouring the limit and
+// offset the client asks for, and records each offset it was called with.
+func pagedGatewayServer(t *testing.T, total int) (*amsvc.ClientWithResponses, *[]string) {
+	t.Helper()
+	var offsets []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		offsets = append(offsets, query.Get("offset"))
+		offset, _ := strconv.Atoi(query.Get("offset"))
+		limit, _ := strconv.Atoi(query.Get("limit"))
+
+		page := []amsvc.GatewayResponse{}
+		for i := offset; i < offset+limit && i < total; i++ {
+			page = append(page, amsvc.GatewayResponse{
+				Name: "gw-" + strconv.Itoa(i),
+				Uuid: "id-" + strconv.Itoa(i),
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(amsvc.GatewayListResponse{
+			Gateways: page,
+			Total:    int32(total),
+			Limit:    int32(limit),
+			Offset:   int32(offset),
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := amsvc.NewClientWithResponses(srv.URL)
+	if err != nil {
+		t.Fatalf("NewClientWithResponses: %v", err)
+	}
+	return client, &offsets
+}
+
+// A single unpaginated request stopped at the server's page size, so a gateway past
+// that boundary was invisible to both name resolution and completion.
+func TestListAllGateways_FollowsEveryPage(t *testing.T) {
+	const total = 450 // more than two pages at gatewayPageLimit
+	client, offsets := pagedGatewayServer(t, total)
+
+	got, err := ListAllGateways(context.Background(), client, "acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != total {
+		t.Fatalf("len = %d, want %d", len(got), total)
+	}
+	if got[0].Name != "gw-0" || got[total-1].Name != "gw-"+strconv.Itoa(total-1) {
+		t.Errorf("bounds = %q..%q, want gw-0..gw-%d", got[0].Name, got[total-1].Name, total-1)
+	}
+	want := []string{"0", "200", "400"}
+	if len(*offsets) != len(want) {
+		t.Fatalf("offsets = %v, want %v", *offsets, want)
+	}
+	for i := range want {
+		if (*offsets)[i] != want[i] {
+			t.Errorf("offsets[%d] = %q, want %q", i, (*offsets)[i], want[i])
+		}
+	}
+}
+
+func TestListAllGateways_SinglePageMakesOneRequest(t *testing.T) {
+	client, offsets := pagedGatewayServer(t, 3)
+
+	got, err := ListAllGateways(context.Background(), client, "acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("len = %d, want 3", len(got))
+	}
+	if len(*offsets) != 1 {
+		t.Errorf("made %d requests, want 1", len(*offsets))
+	}
+}
+
+func TestListAllGateways_EmptyOrgMakesOneRequest(t *testing.T) {
+	client, offsets := pagedGatewayServer(t, 0)
+
+	got, err := ListAllGateways(context.Background(), client, "acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+	if len(*offsets) != 1 {
+		t.Errorf("made %d requests, want 1", len(*offsets))
+	}
+}
+
+// A Total the server over-reports must not spin the loop forever: an empty page
+// terminates on its own.
+func TestListAllGateways_StopsOnEmptyPageDespiteOverstatedTotal(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(amsvc.GatewayListResponse{
+			Gateways: []amsvc.GatewayResponse{},
+			Total:    99,
+		})
+	}))
+	defer srv.Close()
+
+	client, err := amsvc.NewClientWithResponses(srv.URL)
+	if err != nil {
+		t.Fatalf("NewClientWithResponses: %v", err)
+	}
+
+	got, err := ListAllGateways(context.Background(), client, "acme")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len = %d, want 0", len(got))
+	}
+	if calls != 1 {
+		t.Errorf("made %d requests, want 1", calls)
+	}
+}
+
+// Shell completion runs under a 2s timeout that paging a large org can outrun. The
+// pages already gathered are returned alongside the error so a best-effort caller can
+// offer a truncated list instead of nothing.
+func TestListAllGateways_ReturnsPagesGatheredBeforeAFailure(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls > 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		page := make([]amsvc.GatewayResponse, 0, int(gatewayPageLimit))
+		for i := range int(gatewayPageLimit) {
+			page = append(page, amsvc.GatewayResponse{Name: "gw-" + strconv.Itoa(i)})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(amsvc.GatewayListResponse{
+			Gateways: page,
+			Total:    gatewayPageLimit * 2,
+		})
+	}))
+	defer srv.Close()
+
+	client, err := amsvc.NewClientWithResponses(srv.URL)
+	if err != nil {
+		t.Fatalf("NewClientWithResponses: %v", err)
+	}
+
+	got, err := ListAllGateways(context.Background(), client, "acme")
+	if err == nil {
+		t.Fatal("expected an error from the second page")
+	}
+	if len(got) != int(gatewayPageLimit) {
+		t.Errorf("len = %d, want the %d gateways from the first page", len(got), gatewayPageLimit)
+	}
+}
+
+func TestListAllGateways_ServerErrorIsSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"code": "INTERNAL_ERROR", "message": "boom"})
+	}))
+	defer srv.Close()
+
+	client, err := amsvc.NewClientWithResponses(srv.URL)
+	if err != nil {
+		t.Fatalf("NewClientWithResponses: %v", err)
+	}
+
+	if _, err := ListAllGateways(context.Background(), client, "acme"); err == nil {
+		t.Fatal("expected an error on 500")
+	}
+}

--- a/cli/pkg/render/render.go
+++ b/cli/pkg/render/render.go
@@ -64,6 +64,19 @@ func JSONSuccess(ios *iostreams.IOStreams, scope Scope, data any) error {
 	return writeJSON(ios.Out, successEnvelope{Scope: scope, Data: data})
 }
 
+// EmptyList tells an interactive user that a list command matched nothing, which
+// a table of bare headers does not. Piped output stays silent so a caller can
+// still count lines, and --json is handled by JSONSuccess instead.
+//
+// Call it only after the --json branch, in place of rendering an empty table.
+func EmptyList(ios *iostreams.IOStreams, message string) error {
+	if !ios.IsStdoutTTY() {
+		return nil
+	}
+	_, err := fmt.Fprintln(ios.ErrOut, message)
+	return err
+}
+
 // JSONError writes the error JSON envelope to io.Out and returns a sentinel
 // that signals the envelope has already been written.
 func JSONError(ios *iostreams.IOStreams, scope Scope, err error) error {

--- a/documentation/docs/reference/cli/gateway.mdx
+++ b/documentation/docs/reference/cli/gateway.mdx
@@ -1,0 +1,138 @@
+---
+sidebar_position: 6
+sidebar_label: Gateway
+---
+
+# amctl gateway
+
+List and inspect the gateways registered in an organization.
+
+```
+amctl gateway [command]
+```
+
+Gateways are **organization-level** resources. Each one carries a placement role that decides what it can host, and is mapped to one or more environments. LLM providers and MCP proxies are deployed onto gateways, so this command group is how you find the UUID that [`amctl llm-provider create --gateways`](./llm-provider.mdx#amctl-llm-provider-create) expects. The group is also available under the `gateways` alias.
+
+Gateways are registered by a platform engineer, not by this CLI — `amctl gateway` is read-only.
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| [`list`](#amctl-gateway-list) | List gateways in an organization |
+| [`get`](#amctl-gateway-get) | Get details of one gateway |
+
+## Options inherited from parent commands
+
+| Name | Description |
+|------|-------------|
+| `--org` | Override the active organization. |
+| `--json` | Output as JSON envelopes. |
+
+## Placement roles
+
+The `type` column is a placement policy, not a capability — every gateway has identical runtime capabilities regardless of role.
+
+| Type | Meaning |
+|------|---------|
+| `INGRESS` | Handles inbound agent traffic. At most one per environment. |
+| `EGRESS` | Hosts outbound LLM and MCP artifacts. Uncapped per environment. |
+| `BOTH` | Does both. Counts against the ingress cap. |
+
+Only `EGRESS` and `BOTH` gateways can host an LLM proxy, and no two gateways passed to a single provider may share an environment. Picking a gateway that breaks either rule fails the deployment, which is why `list` shows type and environment next to the UUID.
+
+---
+
+## amctl gateway list
+
+List the gateways in the active organization.
+
+```
+amctl gateway list [flags]
+```
+
+The default text output is a table with `name`, `uuid`, `type`, `status`, `environment`, and `vhost` columns; `--json` returns the raw response with pagination metadata.
+
+All gateways are listed by default, including `INGRESS` ones that cannot host an LLM proxy — narrow the view with `--type` rather than relying on an implicit filter.
+
+### Flags
+
+| Name | Description |
+|------|-------------|
+| `--type` | Filter by placement role: `INGRESS`, `EGRESS`, or `BOTH`. Case-insensitive. |
+| `--env` | Filter by environment name. An unknown name is an error, not an empty filter. |
+| `--limit` | Maximum number of results to return. |
+| `--offset` | Number of results to skip. |
+
+### Examples
+
+```bash
+# Every gateway in the active organization
+amctl gateway list
+
+# Only the gateways that can host an LLM proxy
+amctl gateway list --type EGRESS
+amctl gateway list --type BOTH
+
+# Gateways mapped to one environment
+amctl gateway list --env production
+
+# Pipe the UUID of the first egress-capable gateway into a provider
+echo "$OPENAI_API_KEY" | amctl llm-provider create prod-openai \
+  --display-name "Production OpenAI" \
+  --template openai \
+  --api-key-stdin \
+  --gateways "$(amctl gateway list --type BOTH --limit 1 --json | jq -r '.data.gateways[0].uuid')"
+```
+
+Sample output:
+
+```
+NAME                          UUID                                  TYPE  STATUS  ENVIRONMENT  VHOST
+api-platform-default-default  51854841-2350-49a2-ab2b-829d3809bf45  BOTH  ACTIVE  default      default.gw.example.com
+```
+
+:::note
+`status` is shown for information only and is never used as a filter. A gateway's registered placement candidacy is independent of its liveness, so filtering on `ACTIVE` would hide gateways the server still accepts.
+:::
+
+When nothing matches, `list` says so on a terminal and names the active filters. Piped output stays empty so a script can count lines.
+
+---
+
+## amctl gateway get
+
+Get the details of one gateway by name or UUID.
+
+```
+amctl gateway get <gateway>
+```
+
+### Arguments
+
+| Name | Description |
+|------|-------------|
+| `<gateway>` | The gateway's name or its UUID. Tab completion lists the gateways in the active organization, annotated with UUID and type. |
+
+### Examples
+
+```bash
+amctl gateway get api-platform-default-default
+amctl gateway get 51854841-2350-49a2-ab2b-829d3809bf45
+amctl gateway get api-platform-default-default --json
+```
+
+Sample output:
+
+```
+name:          api-platform-default-default
+display name:  Default Gateway
+uuid:          51854841-2350-49a2-ab2b-829d3809bf45
+type:          BOTH
+status:        ACTIVE
+environment:   default
+vhost:         default.gw.example.com
+critical:      false
+org:           default
+created:       2026-08-01T09:14:02Z
+```

--- a/documentation/docs/reference/cli/llm-provider.mdx
+++ b/documentation/docs/reference/cli/llm-provider.mdx
@@ -62,7 +62,13 @@ amctl llm-provider create prod-anthropic \
   --upstream-url https://api.anthropic.com \
   --api-key-stdin < anthropic-key.txt
 
-# Deploy the provider to specific AI Gateways at creation time
+# Deploy the provider to specific AI Gateways at creation time, by name or UUID
+echo "$OPENAI_API_KEY" | amctl llm-provider create shared-openai \
+  --display-name "Shared OpenAI" \
+  --template openai \
+  --api-key-stdin \
+  --gateways api-platform-default-default
+
 echo "$OPENAI_API_KEY" | amctl llm-provider create shared-openai \
   --display-name "Shared OpenAI" \
   --template openai \
@@ -83,7 +89,7 @@ amctl llm-provider create internal-proxy \
 |------|------|---------|-------------|
 | `--display-name` | string | _required_ | Human-readable display name. |
 | `--template` | string | _required_ | Provider template handle, e.g. `openai`, `anthropic`, `mistralai`. Tab-completes the live set for your org. |
-| `--version` | string | `v1` | Provider version. |
+| `--version` | string | `v1.0` | Provider version. Must match `^v\d+\.\d+$`. |
 | `--context` | string | `/` | API context path. Must start with `/` and must not end with `/` (except the root path). |
 | `--description` | string | (none) | Provider description. |
 | `--upstream-url` | string | (template default) | Override the template's upstream endpoint URL. |
@@ -91,7 +97,8 @@ amctl llm-provider create internal-proxy \
 | `--auth-header` | string | (template default) | Override the template's auth header name. |
 | `--api-key` | string | (none) | Provider API key. Leaks into shell history — prefer `--api-key-stdin`. |
 | `--api-key-stdin` | bool | `false` | Read the provider API key from stdin. |
-| `--gateways` | strings | (none) | AI Gateway UUIDs to deploy the provider to. Repeatable, or comma-separated. |
+| `--access-mode` | string | `allow_all` | Route access control for the deployed proxy: `allow_all` or `deny_all`. A proxy deployed with `deny_all` accepts no requests. |
+| `--gateways` | strings | (none) | AI Gateway names or UUIDs to deploy the provider to. Repeatable, or comma-separated. Tab-completes from [`amctl gateway list`](./gateway.mdx). |
 
 ### Built-in templates
 
@@ -166,7 +173,20 @@ amctl llm-provider delete prod-openai
 amctl llm-provider delete prod-openai --yes
 ```
 
+### When deletion is refused
+
+The provider is undeployed from each of its gateways first, then removed. Deletion is refused while anything still references the provider — an LLM proxy, or an agent's LLM configuration:
+
+```
+X cannot delete LLM provider: it has associated LLM proxies. Please delete all proxies
+  before deleting the provider
+```
+
+Remove the dependents first. For an agent binding, that is [`amctl agent llm unset`](./agent.mdx).
+
 ## See Also
+
+- [`amctl gateway list`](./gateway.mdx#amctl-gateway-list) — find the gateway names and UUIDs `--gateways` accepts
 
 - [`amctl agent create`](./agent.mdx#amctl-agent-create) — attach a provider to an agent with `--llm-provider`
 - [Register an LLM Service Provider](../../guides/register-llm-service-provider.mdx) — console walkthrough and per-provider settings

--- a/documentation/docs/reference/cli/llm-provider.mdx
+++ b/documentation/docs/reference/cli/llm-provider.mdx
@@ -106,7 +106,8 @@ Tab completion on `--template` lists the live set — built-in handles plus any 
 - A provider inherits the template's upstream URL, auth scheme, and auth header. The upstream block is sent only when you supply `--upstream-url`, `--auth-type`, or `--auth-header`, or a credential — otherwise creation defers entirely to the template.
 - `--api-key` and `--api-key-stdin` are mutually exclusive.
 - An API key cannot be combined with `--auth-type none`.
-- A provider must be associated with at least one AI Gateway to be callable by agents. Pass `--gateways` at creation, or associate gateways later from the console (see [Register an LLM Service Provider](../../guides/register-llm-service-provider.mdx)).
+- A provider must be associated with at least one AI Gateway to be callable by agents. Pass `--gateways` at creation with gateway names or UUIDs — [`amctl gateway list`](./gateway.mdx#amctl-gateway-list) shows both, along with the placement role and environment each gateway carries, and tab completion on `--gateways` lists them. Gateways can also be associated later from the console (see [Register an LLM Service Provider](../../guides/register-llm-service-provider.mdx)).
+- Only `EGRESS` and `BOTH` gateways can host an LLM proxy, and no two gateways passed to one provider may share an environment.
 
 :::tip
 Reading the key from stdin keeps it out of your shell history and process list. `--api-key-stdin` accepts a piped value (`echo "$KEY" | …`) or a redirected file (`… < key.txt`).

--- a/documentation/sidebars.ts
+++ b/documentation/sidebars.ts
@@ -156,6 +156,7 @@ const sidebars: SidebarsConfig = {
             'reference/cli/project',
             'reference/cli/agent',
             'reference/cli/llm-provider',
+            'reference/cli/gateway',
             'reference/cli/skills',
             'reference/cli/version',
             'reference/cli/api',


### PR DESCRIPTION
## Purpose

Four `amctl` issues were filed against the CLI. Three of them are actually server-side: `agent-manager-service` breaks its own published OpenAPI contract, and the CLI is faithfully rendering what it is handed. Fixing them in the CLI would have papered over the contract violation, so they are fixed where they live.

Resolves #1669, resolves #1668, resolves #1667, resolves #1666

While reproducing #1668 an **unreported plaintext-credential-reference leak in the MCP proxy response path** turned up — same defect class, so it is fixed in the same commit.

## Goals

| Issue | Defect | Fixed in |
|---|---|---|
| #1669 | `amctl agent build` prints an empty `buildName` and a null `buildId` | `agent-manager-service` |
| #1668 | `amctl agent create` echoes sensitive config values back in plaintext | `agent-manager-service` |
| (unfiled) | MCP proxy responses echo the AES-256-GCM `secretRef` ciphertext, which is not a declared field on the spec's `UpstreamAuth` | `agent-manager-service` |
| #1667 | An LLM provider created from a template gets no upstream URL and no auth header, so the deployed proxy cannot reach upstream; a fully-failed create leaves a dead provider behind; a refused delete reports `server returned 409 with no JSON body` | both |
| #1666 | No way to discover AI Gateways from the CLI, so `--gateways` had to be given a UUID copied from the console; `gateway get <name>` returned HTTP 500 | both |
| — | Nil dereference converting an upstream config whose sandbox endpoint has auth but whose main endpoint does not | `agent-manager-service` |

## Approach

One commit per defect, each reproduced before the fix and re-verified after against a local dev stack.

**`b2ec8bd` — #1669, empty `buildName`.** `BuildAgent` serialized `*models.BuildResponse`, whose field tag is `json:"name"`, while `buildAgent` in the spec declares `buildName`. The handler now writes `utils.ConvertToBuildResponse(build)`, the spec type. This also fixes the null `buildId` in the same response.

The test lives at the **controller layer** on purpose. A service-layer test cannot catch this: the service returns the right model, and the defect is entirely in what the controller chooses to serialize. That is a deliberate departure from where the usual service-unit-test convention would put it.

**`fd5fe12` — #1668 and the MCP `secretRef` leak.** `CreateAgent` echoed `payload.Configurations` verbatim, so every value marked `isSensitive` came back in plaintext — into terminal scrollback, `--json` output, and CI logs. New `utils.RedactSecretConfigValues` nils `Env[].Value` and `Files[].Value` where `IsSensitive` is set. It **deep-copies** rather than redacting in place: for kind agents `ApplySecretConfigDefaults` has already mutated the backing slice, so in-place redaction would make correctness depend on call ordering. No spec change — `value` is already optional.

`sanitizeMCPUpstreamAuthForResponse` nil'd `Value` but left `SecretRef`, which is the base64 AES-256-GCM ciphertext of the same credential and is not a declared field on the spec's `UpstreamAuth`. It is now nil'd too.

Both are tested at the HTTP boundary (`require.NotContains(t, rr.Body.String(), "<secret>")`) rather than on a struct field, so a re-introduction through a different field still fails the test.

**`52b38c4` — #1666, `amctl gateway`.** New org-scoped `gateway list` / `gateway get` command group. Columns are `name | uuid | type | status | environment | vhost`; `--type`, `--env`, `--limit`, `--offset` filters. There is deliberately **no status filter** — hiding gateways by status is how a user ends up unable to find the gateway they were told to use.

`gateway get <name>` returned HTTP 500 because `PlatformGatewayService` called `uuid.Parse` and turned the failure into a bare `errors.New("invalid UUID format")`, which the controller could not classify. A new `resolveGateway` falls back to name lookup, maps `gorm.ErrRecordNotFound` to `utils.ErrGatewayNotFound`, and the controller returns 404. Org ownership is checked after resolution.

`ListGateways` also silently ignored an unresolvable `--env` filter and returned every gateway in the org — a filter that fails open. It now returns 400 (`listGateways` declares 400 but no 404).

Added `cmdutil.CompleteGateways`, registered on `gateway get` and on `llm-provider create --gateways`, and folded in the `llm-provider list` empty-case convention as a shared `render.EmptyList`.

**`80dd262` — nil dereference.** The sandbox branch of `ConvertModelToSpecUpstreamConfig` read its header from `config.Main.Auth.Header`, so a provider with a sandbox credential and no main auth panicked on every read. Extracted `maskedSpecUpstreamAuth` and pointed both branches at it, which also fixes a second nil deref on the `*Auth.Type` pointer — reachable once the #1667 template defaulting starts populating auth blocks.

**`cba0320e` — #1667, LLM provider.** Four parts:

- *Template defaulting moved server-side* (`LLMProviderService.Create`): `upstream.main.url` is filled from `metadata.endpointUrl`, `auth.header` from `metadata.auth.header`, and `metadata.auth.valuePrefix` is applied to the credential. Every client documents these as inherited from the template, but no layer was filling them in, so the deployed proxy had an empty upstream URL that the gateway config silently dropped. Server-side rather than in the CLI so the console and any direct API caller get the same behavior.
- *Create is now atomic*: when `successfulDeployments == 0` the provider is deleted, and the error names each gateway and its failure. Previously a fully-failed deploy left an undeployed provider that the user then had to find and delete.
- *A refused delete now says why*: `deleteLLMProvider` gained 403 and 409 in the spec (client regenerated with `make amctl-gen-client`), the undeploy-failure path is wrapped in a new `utils.ErrLLMProviderUndeployFailed` sentinel mapped to 409, and the CLI's `FirstNonNil` chain was extended. The CLI used to print `server returned 409 with no JSON body`, which was simply false — the body was there, the spec just never declared the status.
- *CLI collateral*: `accessControl` is now always sent (new `--access-mode` flag, default `allow_all`); `--gateways` accepts names as well as UUIDs; `--version` defaults to `v1.0` and is validated against the spec pattern, **and the same validation was added server-side** — see the compatibility note below.

Also normalized a spec/implementation divergence: eight `llm-providers/{id}` paths were declared with `{id}` but implemented as `{providerId}`. The API-key paths keep `{id}`, because `api/llm_provider_apikey_routes.go` and `audit/policy.go` key off that exact spelling.

**`5d91444`** — `GetGatewayEnvironments` was passed the raw path value, so after name resolution a name reached a UUID-keyed lookup and every environment came back as `-`. It now takes the resolved `gateway.ID`.

**`00f77bc`** — a clarity pass over the six commits above, no behavior change. The one substantive item: `applyTemplateAuthDefaults` was handing the provider `&templateAuth.Type` / `&templateAuth.Header`, which for a built-in handle are fields of the process-wide template store, so a future write through the provider would have corrupted the template for every organization. Those are copied now.

**`7081bfa` — regenerated `spec/`.** `scripts/gen_client.sh` deletes the generated `spec/api` *directory*, but the generated service files live at `spec/api_*.go` in the package root and survive, so the path-parameter rename and the new 403/409 responses do change generated Go. `make spec` output for `api_llm_providers.go` and `api_llm_deployments.go` is committed here; without it `make codegenfmt-check` fails in CI.

**`ab181b0` — two gateway-lookup defects found while hardening the above.** `resolveEnvironmentUUID` accepted any *syntactically* valid UUID without checking it belongs to the caller's organization, so a foreign environment UUID passed straight through as a list filter and as an assignment target; it is now resolved against the org's environments like any other identifier. And the name branch of `resolveGateway` returned the repository error verbatim, so a bare failure matched no case in `handleGatewayErrors` and surfaced as a 500 instead of a 404 — while a nil gateway returned with no error was dereferenced. Both shapes now funnel through `normalizeGatewayLookup`.

**`ce83599`** — a test pinning the template-store fix from `00f77bc`: `LLMTemplateStore.Get` clones `Metadata` but not `Metadata.Auth`, so the test writes through every pointer the created provider holds and asserts the shared store is unchanged.

**`b007d2b` — the CLI paged only once.** `CompleteGateways` and the `--gateways` name resolution each made a single unpaginated `ListGateways` call, which reads as "the whole set" but is capped at the server's default page size — a gateway past that boundary was invisible, so resolving it by name failed as "unknown gateway" and completion silently offered a truncated list. New `cmdutil.ListAllGateways` follows the response's pagination metadata, terminating on an empty page so an over-reported `Total` cannot spin forever; completion keeps a partial result rather than offering nothing when a later page times out. Also in this commit: `parseGateways` drops duplicates *after* resolution (one gateway named twice — or once by name and once by UUID — is one placement, and sending it twice drew a confusing "no two gateways may share an environment" rejection); a gateway whose UUID the server sends unparseable is now an internal error rather than being skipped and reported as the user's unknown gateway; and `--limit`/`--offset` are bounded above as well as below, since on a 64-bit host `--limit 4294967297` truncated to 1 through the `int32` wire type.

### Compatibility note

Server-side `--version` validation is a **behavior change for older `amctl` clients**. The spec has always declared `^v\d+\.\d+$`, but the server never enforced it, and older CLI builds default to `v1`. Those clients now get a 400 on create until they upgrade or pass `v1.0`. That is the point of the fix — the previously-accepted values produced providers that did not match the contract — but it belongs in the release note.

### Left alone deliberately

- **The LLM deployment contract mismatch** (`models.Deployment` vs `spec.DeploymentResponse`). Real, but out of scope for this batch and larger than any fix here.
- **`GetGatewayEnvironments` is still name-unaware** (`gateway_controller.go`). `gateway get` no longer reaches it with a name, but the route itself would still fail on one. Separate fix.
- **A structural guard in `WriteSuccessResponse`** that would catch the whole #1669 class — a handler serializing an internal model where the spec declares a generated type — at review time rather than one instance at a time. Worth doing; sequenced after this batch.

## User stories

- As a platform engineer, `amctl agent build --json` gives me a build name and id I can poll on, instead of `""` and `null`.
- As a platform engineer, creating an agent with a sensitive config value does not print that value back at me, or into my CI logs.
- As a platform engineer, I can find an AI Gateway with `amctl gateway list` and pass it to `--gateways` by name, without opening the console to copy a UUID.
- As a platform engineer, an LLM provider I create from the `openai` template can actually reach OpenAI.
- As a platform engineer, when a delete is refused I am told what still references the provider.

## Release note

- Fixed `amctl agent build` returning an empty `buildName` and a null `buildId`.
- Fixed sensitive configuration values being echoed in plaintext in agent-create responses, and the encrypted credential reference being echoed in MCP proxy responses.
- Added `amctl gateway list` and `amctl gateway get`; `amctl llm-provider create --gateways` now accepts gateway names as well as UUIDs.
- Fixed `GET /gateways/{id}` returning HTTP 500 for a gateway name, and `GET /gateways` silently ignoring an unknown `environment` filter instead of rejecting it.
- LLM providers created from a template now inherit the template's upstream URL and auth header, so the deployed proxy can reach upstream. A create whose gateway deployments all fail no longer leaves the provider behind, and a refused delete now reports the reason instead of `409 with no JSON body`.
- Fixed `GET /gateways` and the environment-assignment path accepting an environment UUID from another organization without checking it, and `GET /gateways/{id}` returning a 500 rather than a 404 when a gateway name lookup failed.
- Fixed `amctl gateway` completion and `--gateways` name resolution seeing only the first page of gateways, so a gateway past the server's default page size could not be resolved by name.
- LLM provider `version` is now validated against the documented `^v\d+\.\d+$` pattern. Older `amctl` builds that default to `v1` must upgrade or pass `--version v1.0`.

## Documentation

- New `documentation/docs/reference/cli/gateway.mdx`, registered in `documentation/sidebars.ts`.
- `documentation/docs/reference/cli/llm-provider.mdx`: `--version` default corrected to `v1.0` with its pattern, new `--access-mode` row, `--gateways` documented as accepting names, a name-based example, a "When deletion is refused" section, and a See Also link to `gateway list`.

## Training

N/A — bug fixes plus one CLI command group; no training content covers `amctl` gateway discovery.

## Certification

N/A — no certification exam covers the `amctl` CLI surface.

## Marketing

N/A — bug fixes.

## Automation tests

- Unit tests

  New: `controllers/agent_build_response_test.go`, `controllers/gateway_controller_env_filter_test.go`, `services/platform_gateway_service_unit_test.go`, `services/llm_provider_template_defaults_test.go`, `services/mcp_proxy_service_unit_test.go`, `utils/makeresults_redact_test.go`, `utils/spec_converter_upstream_test.go`, `cli/pkg/cmd/gateway/{helpers,list,get}_test.go`, `cli/pkg/cmd/llmprovider/{create_payload,delete_conflict}_test.go`, `cli/pkg/cmdutil/gateways_test.go`. Extended: `tests/build_agent_test.go`, `tests/create_agent_test.go`, `cli/pkg/cmd/llmprovider/create_test.go`.

  Each was written against a reproduced defect rather than after the fact, so each fails on the pre-fix code. The two credential-leak tests assert at the HTTP boundary (`require.NotContains` on the response body) so a re-introduction through any field fails.

  The unit tier and the CLI's `go test ./...` are green; `make codegenfmt-check`'s generator steps (`wire`, `spec`, `codegen`, `fmt`) leave no `.go` drift; `golangci-lint` with the CI config reports 0 issues, including the `goheader` pass. `TestEveryMutatingRouteIsAudited` still passes after the spec path-parameter rename.

- Integration tests

  No new ones. The database-backed tier is unchanged by this batch — the two defects that touch persistence (`resolveGateway`, provider rollback) are covered by mock-based unit tests, and the end-to-end behavior was verified by hand against a running dev stack (see Test environment).

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **no** — FindSecurityBugs is a Java/SpotBugs plugin and does not apply to these Go modules. `golangci-lint` with the repo's CI config runs clean.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

Two of the fixes here are credential leaks, so one note for whoever owns security comms: secrets already submitted through the #1668 path have been echoed into terminal scrollback and CI job logs. **If any pipeline creates agents with sensitive config values and `--json`, those values are in build logs now, and a rotation notice may be warranted.** The MCP `secretRef` leak is ciphertext rather than plaintext, so its risk profile differs. Flagging it — it is not something this PR can fix.

Checked and cleared: `models.SecurityConfig.APIKey.Key` is the header *name* (`X-API-Key`, with `In: "header"`), not a credential. It is not a third leak.

## Samples

N/A — no sample apps affected.

## Related PRs

None.

## Migrations (if applicable)

N/A — no schema changes.

## Test environment

- Go 1.26.6 toolchain (both modules declare `go 1.25.7`), Linux
- Local `docker compose` dev stack: `agent-manager-service` on `localhost:9000` with PostgreSQL, org `default`
- `amctl` built from this branch

Verified live end to end: a provider created from the `openai` template reports `url: https://api.openai.com/v1`, `header: Authorization`, `version: v1.0`, `accessControl: {mode: allow_all}`; `--gateways <name>` resolves and deploys; deleting a bound provider prints the real CONFLICT message; `gateway get <name>` returns the gateway with its environment instead of a 500; creating an agent with a sensitive config value no longer echoes it; `agent build --json` returns a populated `buildName` and `buildId`.

## Learning

The useful lesson is about where these bugs were filed. Three of the four came in against `amctl`, because that is where the user saw them, and each was a server-side contract violation the CLI was faithfully rendering.

#1669 in particular is a shape the type system permits and no test caught: a handler serializing the internal model where the spec declares the generated type. The two field sets overlap enough to look right and differ exactly where it matters. That is why its test sits at the controller layer against the JSON body rather than at the service layer against a struct, and why both credential-leak tests assert on the response body rather than on a field — the field is not the contract, the wire format is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `amctl gateway list` and `get` commands with filtering, pagination, and JSON/table output.
  - LLM provider creation now supports gateway names, access modes, and validated versions.
  - Gateway lookup supports organization-scoped names and UUIDs.

- **Bug Fixes**
  - Sensitive configuration and authentication values are no longer exposed in responses.
  - Invalid or cross-organization environments and gateways are rejected.
  - Deployment failures now roll back safely and report actionable errors.
  - Empty CLI results and provider deletion errors display clearer messages.

- **Documentation**
  - Updated API and CLI documentation for gateway usage, provider parameters, and deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->