### PR TITLE
Remove unused configurations and fix fallback logic in environment selection

### DIFF
--- a/console/workspaces/pages/overview/src/AgentOverview/EnvCapabilitiesSection.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvCapabilitiesSection.tsx
@@ -19,13 +19,13 @@
 import { useState } from "react";
 import { Box, Button, Chip, Tooltip, Typography } from "@wso2/oxygen-ui";
 import { Plug } from "@wso2/oxygen-ui-icons-react";
+import { useGetAgentConfigurations } from "@agent-management-platform/api-client";
 import {
     CollapsibleSection,
     DeploymentStatus,
     getAgentDeploymentPath,
     OverviewSectionCard,
 } from "@agent-management-platform/shared-component";
-import { type Configurations } from "@agent-management-platform/types";
 import { TextInput } from "@agent-management-platform/views";
 import { ConsumerConfigDrawer, type AuthMode } from "./ConsumerConfigDrawer";
 import { useAgentEndpointResources } from "./useAgentEndpointResources";
@@ -35,7 +35,6 @@ interface EnvCapabilitiesSectionProps {
     projectId: string;
     agentId: string;
     envId: string;
-    configurations?: Configurations;
     external?: boolean;
     deploymentStatus?: DeploymentStatus;
 }
@@ -104,13 +103,22 @@ const StatusPill: React.FC<StatusPillProps> = ({ label, value, tooltip }) => (
  * aren't deployed through this platform, so there's nothing to fetch).
  */
 export const EnvCapabilitiesSection: React.FC<EnvCapabilitiesSectionProps> = ({
-    orgId, projectId, agentId, envId, configurations, external, deploymentStatus,
+    orgId, projectId, agentId, envId, external, deploymentStatus,
 }) => {
     const [consumerConfigOpen, setConsumerConfigOpen] = useState(false);
 
     const { invokeUrl, isLoading, isError } = useAgentEndpointResources({
         orgId, projectId, agentId, envId, external,
     });
+
+    // Auth/CORS are per-environment settings, fetched keyed on envId — GetAgent
+    // only returns the lowest pipeline environment's configuration, so every
+    // env's card would otherwise show the same values regardless of which
+    // environment tab is selected (mirrors DeployCard.tsx's envConfig fetch).
+    const { data: configurations } = useGetAgentConfigurations(
+        { orgName: orgId, projName: projectId, agentName: agentId },
+        { environment: envId },
+    );
 
     // Mirrors DeployCard.tsx's authMode derivation so the wording matches the
     // Deploy page's own security summary.

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvCapabilitiesSection.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvCapabilitiesSection.tsx
@@ -107,7 +107,11 @@ export const EnvCapabilitiesSection: React.FC<EnvCapabilitiesSectionProps> = ({
 }) => {
     const [consumerConfigOpen, setConsumerConfigOpen] = useState(false);
 
-    const { invokeUrl, isLoading, isError } = useAgentEndpointResources({
+    const {
+        invokeUrl,
+        isLoading: isEndpointLoading,
+        isError: isEndpointError,
+    } = useAgentEndpointResources({
         orgId, projectId, agentId, envId, external,
     });
 
@@ -115,10 +119,22 @@ export const EnvCapabilitiesSection: React.FC<EnvCapabilitiesSectionProps> = ({
     // only returns the lowest pipeline environment's configuration, so every
     // env's card would otherwise show the same values regardless of which
     // environment tab is selected (mirrors DeployCard.tsx's envConfig fetch).
-    const { data: configurations } = useGetAgentConfigurations(
-        { orgName: orgId, projName: projectId, agentName: agentId },
+    // orgName is withheld for external agents (nothing to fetch), matching
+    // useAgentEndpointResources' own skip pattern above.
+    const {
+        data: configurations,
+        isLoading: isConfigLoading,
+        isError: isConfigError,
+    } = useGetAgentConfigurations(
+        { orgName: external ? "" : orgId, projName: projectId, agentName: agentId },
         { environment: envId },
     );
+
+    // Combined so the card never renders a stale/default "None · Disabled"
+    // security summary while the per-env config is still loading, or silently
+    // shows the wrong posture if that fetch fails outright.
+    const isLoading = isEndpointLoading || isConfigLoading;
+    const isError = isEndpointError || isConfigError;
 
     // Mirrors DeployCard.tsx's authMode derivation so the wording matches the
     // Deploy page's own security summary.

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvironmentSectionsContent.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvironmentSectionsContent.tsx
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import type { Configurations } from "@agent-management-platform/types";
 import type { DeploymentStatus } from "@agent-management-platform/shared-component";
 import { EnvAgentInterfaceCard } from "./EnvAgentInterfaceCard";
 import { EnvAgentRolesGroupsSection } from "./EnvAgentRolesGroupsSection";
@@ -31,7 +30,6 @@ interface EnvironmentSectionsContentProps {
     projectId: string;
     agentId: string;
     envId: string;
-    configurations?: Configurations;
     external?: boolean;
     deploymentStatus?: DeploymentStatus;
 }
@@ -45,7 +43,7 @@ interface EnvironmentSectionsContentProps {
  * since both are compact per-environment identity/interface summaries.
  */
 export function EnvironmentSectionsContent({
-    orgId, projectId, agentId, envId, configurations, external, deploymentStatus,
+    orgId, projectId, agentId, envId, external, deploymentStatus,
 }: EnvironmentSectionsContentProps) {
     return (
         <>
@@ -55,7 +53,6 @@ export function EnvironmentSectionsContent({
                 projectId={projectId}
                 agentId={agentId}
                 envId={envId}
-                configurations={configurations}
                 external={external}
                 deploymentStatus={deploymentStatus}
             />

--- a/console/workspaces/pages/overview/src/AgentOverview/ExternalAgentOverview.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/ExternalAgentOverview.tsx
@@ -165,7 +165,6 @@ export const ExternalAgentOverview = () => {
                   projectId={projectId}
                   agentId={agentId}
                   envId={selectedEnvironment.name}
-                  configurations={agent?.configurations}
                   external
                 />
               }

--- a/console/workspaces/pages/overview/src/AgentOverview/InternalAgentOverview.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/InternalAgentOverview.tsx
@@ -151,7 +151,6 @@ export const InternalAgentOverview = () => {
                                 projectId={projectId}
                                 agentId={agentId}
                                 envId={selectedEnvironment.name}
-                                configurations={agent?.configurations}
                                 deploymentStatus={selectedEnvironmentStatus}
                             />
                         }

--- a/console/workspaces/pages/overview/src/AgentOverview/useSelectedEnvironmentParam.ts
+++ b/console/workspaces/pages/overview/src/AgentOverview/useSelectedEnvironmentParam.ts
@@ -28,9 +28,10 @@ export const ENV_SEARCH_PARAM = "env";
  * an environment outside the current list — the rightmost (most-promoted)
  * environment that `isDeployed` reports as deployed, so users land on
  * whatever's furthest along the pipeline instead of always Dev. Falls back
- * further to the first environment when none are deployed yet, or when no
+ * further to the first environment when none are deployed yet. When no
  * `isDeployed` predicate is given (e.g. external agents, which have no
- * platform-managed deployment concept).
+ * platform-managed deployment concept to check), there's nothing to filter
+ * on, so it defaults straight to the rightmost (most-promoted) environment.
  */
 export function useSelectedEnvironmentParam(
   environments: Environment[],
@@ -43,8 +44,9 @@ export function useSelectedEnvironmentParam(
   // case, once a selection is in the URL, skips it entirely.
   const selectedEnvironment =
     environments.find((env) => env.name === requestedName) ??
-    (isDeployed ? [...environments].reverse().find(isDeployed) : undefined) ??
-    environments[0];
+    (isDeployed
+      ? [...environments].reverse().find(isDeployed) ?? environments[0]
+      : environments[environments.length - 1]);
 
   const selectEnvironment = (name: string) => {
     setSearchParams(


### PR DESCRIPTION
## Purpose
This pull request updates the way environment-specific agent configurations are fetched and passed through the Agent Overview pages, ensuring that each environment displays its correct configuration rather than sharing a single configuration across all environments. It also improves the logic for selecting the default environment tab, especially for external agents.

**Environment-specific configuration fetching:**
- [`EnvCapabilitiesSection.tsx`](diffhunk://#diff-fb2bc95c7f7549bb8a32824ffccc23332a763f3e8dbb5cc0ab83ca939a6a0a44R22-L28): Replaces the `configurations` prop with an internal call to `useGetAgentConfigurations`, fetching configuration data keyed by `envId` to ensure each environment tab displays its own settings. [[1]](diffhunk://#diff-fb2bc95c7f7549bb8a32824ffccc23332a763f3e8dbb5cc0ab83ca939a6a0a44R22-L28) [[2]](diffhunk://#diff-fb2bc95c7f7549bb8a32824ffccc23332a763f3e8dbb5cc0ab83ca939a6a0a44L107-R122)
- Removes the now-unnecessary `configurations` prop from component interfaces and usage in `EnvCapabilitiesSection`, `EnvironmentSectionsContent`, `ExternalAgentOverview`, and `InternalAgentOverview`, streamlining prop passing and preventing stale/incorrect configuration data. [[1]](diffhunk://#diff-fb2bc95c7f7549bb8a32824ffccc23332a763f3e8dbb5cc0ab83ca939a6a0a44L38) [[2]](diffhunk://#diff-eb29252fc746bfbe4b85efb237e46846bc36174f44683170b748de7401e3b34fL34) [[3]](diffhunk://#diff-eb29252fc746bfbe4b85efb237e46846bc36174f44683170b748de7401e3b34fL48-R46) [[4]](diffhunk://#diff-eb29252fc746bfbe4b85efb237e46846bc36174f44683170b748de7401e3b34fL58) [[5]](diffhunk://#diff-10a36b80241aca73315f78ca3c551a7cd62a03a02e90b072eeddb3629e3fbb7dL168) [[6]](diffhunk://#diff-f746d9acefa13680b4f296b9d176443274f852eb8c83ee5386c62409631d12e2L154) [[7]](diffhunk://#diff-eb29252fc746bfbe4b85efb237e46846bc36174f44683170b748de7401e3b34fL19)

**Default environment selection logic:**
- [`useSelectedEnvironmentParam.ts`](diffhunk://#diff-1d6ceed03ab5392a199b5fddc84f5dfadc24a74d9e479db3f6d1180964b15a09L31-R34): Refines the logic for selecting the default environment tab. For external agents (which lack deployment state), the default is now the rightmost (most-promoted) environment, rather than always the first. For internal agents, it still prefers the most-promoted deployed environment, falling back to the first if none are deployed. [[1]](diffhunk://#diff-1d6ceed03ab5392a199b5fddc84f5dfadc24a74d9e479db3f6d1180964b15a09L31-R34) [[2]](diffhunk://#diff-1d6ceed03ab5392a199b5fddc84f5dfadc24a74d9e479db3f6d1180964b15a09L46-R49)

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Environment capability details now load configuration data specific to the selected environment.
  - Environment selection defaults to the most-promoted environment when no environment is specified.

- **Bug Fixes**
  - Improved accuracy of authentication, CORS, and consumer details by using environment-specific configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->