### PR TITLE
Log full promotion-block detail and return a brief error to the UI

### DIFF
--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -88,6 +88,12 @@ func handleCommonErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 	// version that can't be written as a label) is still a client-side problem —
 	// report it as a 400 naming the offending value instead of letting it reach
 	// the generic 500 fallback.
+	//
+	// Keep this FIRST: a ValidationError may also match a classification
+	// sentinel (utils.NewInvalidInputError sets ErrInvalidInput), and the
+	// sentinel cases below relabel the response with a generic bucket message.
+	// Moving this case down silently replaces every such error's own
+	// user-facing Message with "Invalid input provided".
 	case utils.IsValidationError(err) != nil:
 		utils.WriteValidationErrorResponse(w, err)
 

--- a/agent-manager-service/controllers/error_mapping_unit_test.go
+++ b/agent-manager-service/controllers/error_mapping_unit_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// A service that returns its own short user-facing message (a ValidationError)
+// must have that message reach the wire — the generic "Invalid input provided"
+// bucket label belongs to errors that carry their whole story in the reason.
+// The ordering inside handleCommonErrors is what guarantees it: the sentinel
+// case below would otherwise win and relabel the response.
+func TestHandleCommonErrors_ValidationErrorWithSentinel_KeepsItsOwnMessage(t *testing.T) {
+	rr := httptest.NewRecorder()
+
+	handleCommonErrors(rr, utils.NewValidationErrorFor(utils.ErrInvalidInput,
+		"Promotion blocked: the agent identity for \"staging\" is still being provisioned",
+		"retry once provisioning completes"), "Failed to promote agent")
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	var body struct {
+		Message string `json:"message"`
+		Reason  string `json:"reason"`
+		Code    string `json:"code"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, "Promotion blocked: the agent identity for \"staging\" is still being provisioned", body.Message)
+	assert.Equal(t, "retry once provisioning completes", body.Reason)
+	assert.Equal(t, utils.ErrCodeValidation, body.Code)
+}

--- a/agent-manager-service/controllers/error_mapping_unit_test.go
+++ b/agent-manager-service/controllers/error_mapping_unit_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
@@ -36,18 +37,15 @@ import (
 func TestHandleCommonErrors_ValidationErrorWithSentinel_KeepsItsOwnMessage(t *testing.T) {
 	rr := httptest.NewRecorder()
 
-	handleCommonErrors(rr, utils.NewValidationErrorFor(utils.ErrInvalidInput,
+	handleCommonErrors(rr, utils.NewInvalidInputError(
 		"Promotion blocked: the agent identity for \"staging\" is still being provisioned",
 		"retry once provisioning completes"), "Failed to promote agent")
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
-	var body struct {
-		Message string `json:"message"`
-		Reason  string `json:"reason"`
-		Code    string `json:"code"`
-	}
+	var body spec.ErrorResponse
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.Equal(t, "Promotion blocked: the agent identity for \"staging\" is still being provisioned", body.Message)
-	assert.Equal(t, "retry once provisioning completes", body.Reason)
+	require.NotNil(t, body.Reason)
+	assert.Equal(t, "retry once provisioning completes", *body.Reason)
 	assert.Equal(t, utils.ErrCodeValidation, body.Code)
 }

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4330,8 +4330,29 @@ func (s *agentManagerService) assertMCPBindingsSurvivePromotion(
 	}
 	sort.Strings(brokenByPromotion)
 
-	return fmt.Errorf("%w: agent %q uses MCP connection(s) %s, which work in environment %q but have no endpoint in %q — promoting would deploy the agent with an empty MCP URL and API key. Bind those MCP proxies to an endpoint in %q, then promote",
-		utils.ErrInvalidInput, agentName, strings.Join(brokenByPromotion, ", "), sourceEnv, targetEnv, targetEnv)
+	brokenList := strings.Join(brokenByPromotion, ", ")
+	s.logger.Warn("Promotion blocked: MCP connection(s) resolve in the source environment but have no endpoint in the "+
+		"target — promoting would deploy the agent with an empty MCP URL and API key, so it would start and then fail "+
+		"on every tool call",
+		"agentName", agentName, "projectName", projectName, "ouID", ouID,
+		"sourceEnvironment", sourceEnv, "targetEnvironment", targetEnv, "connections", brokenList)
+	return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+		fmt.Sprintf("Promotion blocked: MCP connection(s) %s have no endpoint in %q", briefUIDetail(brokenList), targetEnv),
+		fmt.Sprintf("bind them to an endpoint in %q, then promote", targetEnv))
+}
+
+// maxBriefUIDetail caps how much of an unbounded detail (an upstream failure
+// message, a list of connection names) a caller-facing error echoes. These
+// promotion errors are rendered inline in the console, which shows the
+// message and reason together, so the full text goes to the log instead.
+const maxBriefUIDetail = 40
+
+func briefUIDetail(detail string) string {
+	runes := []rune(detail)
+	if len(runes) <= maxBriefUIDetail {
+		return detail
+	}
+	return string(runes[:maxBriefUIDetail]) + "…"
 }
 
 // promotionIdentityPollInterval/promotionIdentityPollBudget bound
@@ -4391,49 +4412,62 @@ func (s *agentManagerService) buildPromotionIdentityBlockedError(ctx context.Con
 		// AgentID provisioning is disabled for this deployment, so nothing can
 		// ever mint the target's own credential — unlike the "just triggered"
 		// case below, this will never resolve on its own by retrying.
-		return fmt.Errorf(
-			"%w: agent %q has no AgentID identity for target environment %q, and AgentID provisioning is disabled "+
-				"for this deployment — promotion is blocked to prevent the promoted pod from inheriting a "+
-				"different environment's real credentials. Enable AgentID provisioning and provision this "+
-				"environment before promoting",
-			utils.ErrInvalidInput, agentName, envName,
-		)
+		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+			"the agent has no AgentID identity in the target environment and AgentID provisioning is disabled for this "+
+				"deployment, so nothing can ever mint the target's own credential — promoting would let the promoted pod "+
+				"inherit a different environment's real credentials")
+		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+			fmt.Sprintf("Promotion blocked: no agent identity for %q and identity provisioning is disabled", envName),
+			fmt.Sprintf("enable AgentID provisioning and provision %q first", envName))
 	}
 
 	state, err := s.agentThunderProvisioning.GetBindingState(ctx, ouID, projectName, agentName, envName)
 	if err != nil {
-		s.logger.Warn("Failed to read agent thunder binding state for promotion error message, falling back to a generic message",
+		s.logger.Warn("Failed to read agent thunder binding state for promotion error message, falling back to the not-provisioned-yet message",
 			"agentName", agentName, "environment", envName, "error", err)
 		state = nil
 	}
 
 	switch {
 	case state == nil:
-		return fmt.Errorf(
-			"%w: agent %q has no AgentID identity for target environment %q yet — provisioning was just triggered; "+
-				"check GET .../identities for this agent and retry shortly",
-			utils.ErrInvalidInput, agentName, envName,
-		)
+		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+			"the agent has no AgentID binding in the target environment yet and provisioning was only just triggered — "+
+				"promoting before it completes would let the promoted pod inherit a different environment's real credentials")
+		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+			fmt.Sprintf("Promotion blocked: the agent identity for %q is still being provisioned", envName),
+			"provisioning was just triggered; retry in a moment")
 	case state.Status == models.AgentThunderStatusFailed:
-		return fmt.Errorf(
-			"%w: agent %q's AgentID provisioning for target environment %q has permanently failed (%s). "+
-				"Retrying promotion will not fix this — check GET .../identities for this agent and re-provision the environment",
-			utils.ErrInvalidInput, agentName, envName, state.LastError,
-		)
+		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+			"AgentID provisioning for the target environment has permanently failed, so retrying the promotion cannot fix "+
+				"it — the environment has to be re-provisioned first",
+			"lastError", state.LastError)
+		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+			fmt.Sprintf("Promotion blocked: agent identity provisioning for %q failed", envName),
+			fmt.Sprintf("re-provision the identity, then retry (%s)", briefUIDetail(state.LastError)))
 	case state.Status == models.AgentThunderStatusCompleted && !state.HasSecret:
-		return fmt.Errorf(
-			"%w: agent %q's AgentID credential for target environment %q has been revoked. "+
-				"Retrying promotion will not fix this — regenerate the credential for %q before promoting",
-			utils.ErrInvalidInput, agentName, envName, envName,
-		)
+		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+			"the agent's AgentID credential for the target environment has been revoked, so retrying the promotion cannot "+
+				"fix it — the credential has to be regenerated first")
+		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+			fmt.Sprintf("Promotion blocked: the agent identity credential for %q was revoked", envName),
+			fmt.Sprintf("regenerate the credential for %q, then promote", envName))
 	default: // Pending / InProgress, or any other in-flight state
-		return fmt.Errorf(
-			"%w: agent %q's AgentID identity for target environment %q is not ready yet (still provisioning). "+
-				"Promotion is blocked to prevent the promoted pod from inheriting a different environment's credentials — "+
-				"check GET .../identities for this agent and retry once it shows status=completed for %q",
-			utils.ErrInvalidInput, agentName, envName, envName,
-		)
+		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+			"the agent's AgentID identity for the target environment is still provisioning — promoting now would let the "+
+				"promoted pod inherit a different environment's real credentials",
+			"status", state.Status)
+		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+			fmt.Sprintf("Promotion blocked: the agent identity for %q is still being provisioned", envName),
+			"retry once provisioning completes")
 	}
+}
+
+// logPromotionBlocked records why a promotion was refused. The caller only
+// ever sees the short message/reason pair the block returns, so this log is
+// the only place the whole diagnosis exists.
+func (s *agentManagerService) logPromotionBlocked(ouID, projectName, agentName, envName, diagnosis string, extra ...any) {
+	fields := []any{"agentName", agentName, "projectName", projectName, "ouID", ouID, "environment", envName}
+	s.logger.Warn("Promotion blocked: "+diagnosis, append(fields, extra...)...)
 }
 
 // UpdateAgentDeploySettings updates per-environment deploy settings (CORS, API key security,

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4406,7 +4406,8 @@ func (s *agentManagerService) pollForTargetIdentityReady(ctx context.Context, ou
 // provisioning, permanently failed, and revoked all look identical from
 // there. Only "still provisioning" is something a retry actually fixes; the
 // other states need a state-specific message so the caller knows what to do
-// instead of being told to simply wait and retry.
+// instead of being told to simply wait and retry. Returns the underlying read
+// failure — not a block — when the state cannot be determined at all.
 func (s *agentManagerService) buildPromotionIdentityBlockedError(ctx context.Context, ouID, projectName, agentName, envName string) error {
 	if s.agentThunderProvisioning == nil {
 		// AgentID provisioning is disabled for this deployment, so nothing can
@@ -4421,11 +4422,15 @@ func (s *agentManagerService) buildPromotionIdentityBlockedError(ctx context.Con
 			fmt.Sprintf("enable AgentID provisioning and provision %q first", envName))
 	}
 
+	// GetBindingState reserves (nil, nil) for "no binding row yet" and wraps
+	// every other failure, so an error here is an operational fault. Blocking
+	// as a retryable validation error would answer 400 for a server-side
+	// failure and tell the caller to retry something a retry cannot fix.
 	state, err := s.agentThunderProvisioning.GetBindingState(ctx, ouID, projectName, agentName, envName)
 	if err != nil {
-		s.logger.Warn("Failed to read agent thunder binding state for promotion error message, falling back to the not-provisioned-yet message",
-			"agentName", agentName, "environment", envName, "error", err)
-		state = nil
+		s.logger.Error("Failed to read agent thunder binding state while blocking a promotion",
+			"agentName", agentName, "projectName", projectName, "ouID", ouID, "environment", envName, "error", err)
+		return fmt.Errorf("read AgentID binding state for environment %q: %w", envName, err)
 	}
 
 	switch {

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
@@ -3955,8 +3956,13 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 		return fmt.Errorf("failed to fetch target env system-managed keys: %w", err)
 	}
 	if len(srcSystemKeys) > 0 && len(tgtSystemKeys) == 0 {
-		return fmt.Errorf("%w: agent %q has LLM/system configuration in source environment %q but none in target environment %q — configure system variables in the target environment before promoting",
-			utils.ErrInvalidInput, agentName, req.SourceEnvironment, req.TargetEnvironment)
+		s.logPromotionBlocked(ouID, projectName, agentName, req.TargetEnvironment,
+			"the agent has LLM/system configuration in the source environment but none in the target — promoting would "+
+				"deploy it without the system variables it needs",
+			"sourceEnvironment", req.SourceEnvironment)
+		return utils.NewInvalidInputError(
+			fmt.Sprintf("Promotion blocked: no LLM/system configuration in %q", req.TargetEnvironment),
+			fmt.Sprintf("configure system variables in %q, then promote", req.TargetEnvironment))
 	}
 
 	// The key-presence check above cannot see a connection that is present but dead: an MCP
@@ -4331,28 +4337,49 @@ func (s *agentManagerService) assertMCPBindingsSurvivePromotion(
 	sort.Strings(brokenByPromotion)
 
 	brokenList := strings.Join(brokenByPromotion, ", ")
-	s.logger.Warn("Promotion blocked: MCP connection(s) resolve in the source environment but have no endpoint in the "+
-		"target — promoting would deploy the agent with an empty MCP URL and API key, so it would start and then fail "+
-		"on every tool call",
-		"agentName", agentName, "projectName", projectName, "ouID", ouID,
-		"sourceEnvironment", sourceEnv, "targetEnvironment", targetEnv, "connections", brokenList)
-	return utils.NewValidationErrorFor(utils.ErrInvalidInput,
-		fmt.Sprintf("Promotion blocked: MCP connection(s) %s have no endpoint in %q", briefUIDetail(brokenList), targetEnv),
+	s.logPromotionBlocked(ouID, projectName, agentName, targetEnv,
+		"MCP connection(s) resolve in the source environment but have no endpoint in the target — promoting would "+
+			"deploy the agent with an empty MCP URL and API key, so it would start and then fail on every tool call",
+		"sourceEnvironment", sourceEnv, "connections", brokenList)
+	return utils.NewInvalidInputError(
+		fmt.Sprintf("Promotion blocked: MCP connection(s) %s have no endpoint in %q",
+			briefConnectionList(brokenByPromotion), targetEnv),
 		fmt.Sprintf("bind them to an endpoint in %q, then promote", targetEnv))
 }
 
-// maxBriefUIDetail caps how much of an unbounded detail (an upstream failure
-// message, a list of connection names) a caller-facing error echoes. These
-// promotion errors are rendered inline in the console, which shows the
-// message and reason together, so the full text goes to the log instead.
+// maxBriefUIDetail caps how much of an unbounded upstream detail (a Thunder
+// failure message) a caller-facing error echoes. These promotion errors are
+// rendered inline in the console, which shows the message and reason together,
+// so the full text goes to the log instead.
 const maxBriefUIDetail = 40
 
+// briefUIDetail bounds an opaque upstream string for display. The value is
+// sanitised first because it originates outside this service, matching how
+// every other untrusted string is clamped (see audit.clean).
 func briefUIDetail(detail string) string {
-	runes := []rune(detail)
-	if len(runes) <= maxBriefUIDetail {
-		return detail
+	return utils.TruncateForLog(utils.SanitizeForLog(detail), maxBriefUIDetail)
+}
+
+// maxBriefConnectionList budgets the connection names a blocked promotion puts
+// on screen. Names are dropped whole and the remainder counted — truncating the
+// joined string mid-name would put a connection that does not exist in front of
+// the user, and the full list goes to the log either way.
+const maxBriefConnectionList = 40
+
+func briefConnectionList(names []string) string {
+	shown := 0
+	width := 0
+	for _, name := range names {
+		width += utf8.RuneCountInString(name) + len(", ")
+		if shown > 0 && width > maxBriefConnectionList {
+			break
+		}
+		shown++
 	}
-	return string(runes[:maxBriefUIDetail]) + "…"
+	if shown == len(names) {
+		return strings.Join(names, ", ")
+	}
+	return fmt.Sprintf("%s (+%d more)", strings.Join(names[:shown], ", "), len(names)-shown)
 }
 
 // promotionIdentityPollInterval/promotionIdentityPollBudget bound
@@ -4409,15 +4436,22 @@ func (s *agentManagerService) pollForTargetIdentityReady(ctx context.Context, ou
 // instead of being told to simply wait and retry. Returns the underlying read
 // failure — not a block — when the state cannot be determined at all.
 func (s *agentManagerService) buildPromotionIdentityBlockedError(ctx context.Context, ouID, projectName, agentName, envName string) error {
+	// blocked pairs the operator-facing diagnosis (logged in full) with the
+	// short message/reason the caller sees, so every arm below states both
+	// halves once instead of repeating the log call and the sentinel.
+	blocked := func(diagnosis, message, reason string, logFields ...any) error {
+		s.logPromotionBlocked(ouID, projectName, agentName, envName, diagnosis, logFields...)
+		return utils.NewInvalidInputError(message, reason)
+	}
+
 	if s.agentThunderProvisioning == nil {
 		// AgentID provisioning is disabled for this deployment, so nothing can
 		// ever mint the target's own credential — unlike the "just triggered"
 		// case below, this will never resolve on its own by retrying.
-		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+		return blocked(
 			"the agent has no AgentID identity in the target environment and AgentID provisioning is disabled for this "+
 				"deployment, so nothing can ever mint the target's own credential — promoting would let the promoted pod "+
-				"inherit a different environment's real credentials")
-		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+				"inherit a different environment's real credentials",
 			fmt.Sprintf("Promotion blocked: no agent identity for %q and identity provisioning is disabled", envName),
 			fmt.Sprintf("enable AgentID provisioning and provision %q first", envName))
 	}
@@ -4435,35 +4469,31 @@ func (s *agentManagerService) buildPromotionIdentityBlockedError(ctx context.Con
 
 	switch {
 	case state == nil:
-		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+		return blocked(
 			"the agent has no AgentID binding in the target environment yet and provisioning was only just triggered — "+
-				"promoting before it completes would let the promoted pod inherit a different environment's real credentials")
-		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+				"promoting before it completes would let the promoted pod inherit a different environment's real credentials",
 			fmt.Sprintf("Promotion blocked: the agent identity for %q is still being provisioned", envName),
 			"provisioning was just triggered; retry in a moment")
 	case state.Status == models.AgentThunderStatusFailed:
-		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+		return blocked(
 			"AgentID provisioning for the target environment has permanently failed, so retrying the promotion cannot fix "+
 				"it — the environment has to be re-provisioned first",
-			"lastError", state.LastError)
-		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
 			fmt.Sprintf("Promotion blocked: agent identity provisioning for %q failed", envName),
-			fmt.Sprintf("re-provision the identity, then retry (%s)", briefUIDetail(state.LastError)))
+			fmt.Sprintf("re-provision the identity, then retry (%s)", briefUIDetail(state.LastError)),
+			"lastError", state.LastError)
 	case state.Status == models.AgentThunderStatusCompleted && !state.HasSecret:
-		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+		return blocked(
 			"the agent's AgentID credential for the target environment has been revoked, so retrying the promotion cannot "+
-				"fix it — the credential has to be regenerated first")
-		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
+				"fix it — the credential has to be regenerated first",
 			fmt.Sprintf("Promotion blocked: the agent identity credential for %q was revoked", envName),
 			fmt.Sprintf("regenerate the credential for %q, then promote", envName))
 	default: // Pending / InProgress, or any other in-flight state
-		s.logPromotionBlocked(ouID, projectName, agentName, envName,
+		return blocked(
 			"the agent's AgentID identity for the target environment is still provisioning — promoting now would let the "+
 				"promoted pod inherit a different environment's real credentials",
-			"status", state.Status)
-		return utils.NewValidationErrorFor(utils.ErrInvalidInput,
 			fmt.Sprintf("Promotion blocked: the agent identity for %q is still being provisioned", envName),
-			"retry once provisioning completes")
+			"retry once provisioning completes",
+			"status", state.Status)
 	}
 }
 

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -17,6 +17,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -731,9 +732,9 @@ func TestPromoteAgent_BlocksWhenMCPConnectionUnresolvableInTarget(t *testing.T) 
 		TargetEnvironment: "staging",
 	})
 
-	require.Error(t, err)
-	assert.ErrorIs(t, err, utils.ErrInvalidInput)
-	assert.Contains(t, err.Error(), "booking")
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "booking", "the message must name the connection that blocks the promotion")
+	assert.Contains(t, ve.Reason, "bind")
 	assert.False(t, *promoteCalled,
 		"promotion must be refused before PromoteComponent — otherwise the agent is already running with an empty MCP URL by the time this error is returned")
 }
@@ -795,8 +796,8 @@ func TestPromoteAgent_ListsBrokenMCPConnectionsInStableOrder(t *testing.T) {
 		TargetEnvironment: "staging",
 	})
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "booking, payments")
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "booking, payments")
 }
 
 func TestPromoteAgent_BlocksWhenTargetIdentityNotReady(t *testing.T) {
@@ -809,9 +810,8 @@ func TestPromoteAgent_BlocksWhenTargetIdentityNotReady(t *testing.T) {
 		TargetEnvironment: "staging",
 	})
 
-	require.Error(t, err)
-	assert.ErrorIs(t, err, utils.ErrInvalidInput)
-	assert.Contains(t, err.Error(), "not ready yet")
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "still being provisioned")
 	assert.False(t, *promoteCalled,
 		"promotion must be blocked BEFORE calling PromoteComponent — otherwise the pod is already promoted with leaked credentials by the time this error is returned")
 }
@@ -942,8 +942,8 @@ func TestPromoteAgent_KickOffThenRetry_SucceedsOnceTargetIdentityCompletes(t *te
 	// First attempt: target environment is brand new — kicks off provisioning
 	// (ProvisionForEnvironmentIfMissing), but the identity isn't ready yet.
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not ready yet")
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "still being provisioned")
 	assert.False(t, promoteCalled, "must not promote while the target identity is still provisioning")
 
 	// Simulate the async provisioning attempt completing in the background.
@@ -1050,10 +1050,10 @@ func TestPromoteAgent_TargetCredentialRevoked_BlocksWithRegenerateMessage(t *tes
 		TargetEnvironment: "staging",
 	})
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "revoked")
-	assert.Contains(t, err.Error(), "regenerate")
-	assert.NotContains(t, err.Error(), "still provisioning", "a revoked credential must not tell the caller to just retry")
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "revoked")
+	assert.Contains(t, ve.Reason, "regenerate")
+	assert.NotContains(t, ve.Message+ve.Reason, "still being provisioned", "a revoked credential must not tell the caller to just retry")
 	assert.False(t, *promoteCalled)
 }
 
@@ -1075,11 +1075,115 @@ func TestPromoteAgent_TargetProvisioningFailed_BlocksWithReprovisionMessage(t *t
 		TargetEnvironment: "staging",
 	})
 
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "failed")
+	assert.Contains(t, ve.Reason, "thunder unreachable")
+	assert.Contains(t, ve.Reason, "re-provision")
+	assert.NotContains(t, ve.Message+ve.Reason, "still being provisioned", "a permanently failed binding must not tell the caller to just retry")
+	assert.False(t, *promoteCalled)
+}
+
+// maxPromotionUIErrorLen bounds what a blocked promotion may put on screen.
+// The console renders a failed request as "<message>: <reason>" (see
+// extractServerErrorMessage in the api-client), so both halves together are
+// the UI string — 160 characters is roughly one line of an inline alert.
+const maxPromotionUIErrorLen = 160
+
+// captureLogs points s at a buffer-backed logger and returns the accumulated
+// output, so a test can assert that detail withheld from the UI still reaches
+// the operator.
+func captureLogs(t *testing.T, s *agentManagerService) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	s.logger = slog.New(slog.NewTextHandler(&buf, nil))
+	return buf.String
+}
+
+// requireBriefPromotionBlock asserts err is the caller-facing form of a
+// blocked promotion: a ValidationError (so the UI gets the short Message
+// instead of the whole technical string) that still classifies as invalid
+// input, and whose rendered form fits an inline alert.
+func requireBriefPromotionBlock(t *testing.T, err error) *utils.ValidationError {
+	t.Helper()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "permanently failed")
-	assert.Contains(t, err.Error(), "thunder unreachable")
-	assert.Contains(t, err.Error(), "re-provision")
-	assert.NotContains(t, err.Error(), "still provisioning", "a permanently failed binding must not tell the caller to just retry")
+	require.ErrorIs(t, err, utils.ErrInvalidInput, "the block must still classify as invalid input, or the controller answers 500 instead of 400")
+	ve := utils.IsValidationError(err)
+	require.NotNil(t, ve, "the block must carry a short UI Message separate from its technical Reason")
+
+	rendered := ve.Message + ": " + ve.Reason
+	assert.LessOrEqual(t, len(rendered), maxPromotionUIErrorLen,
+		"the UI string is too lengthy (%d chars): %s", len(rendered), rendered)
+	assert.NotContains(t, rendered, "GET ", "REST call hints belong in the logs, not the UI")
+	return ve
+}
+
+// The UI must get a short, actionable sentence when the target environment's
+// identity is still provisioning; the rationale for the block (a
+// cross-environment credential leak) is operator detail and belongs in the
+// log instead.
+func TestPromoteAgent_IdentityStillProvisioning_KeepsUIErrorBriefAndLogsDetail(t *testing.T) {
+	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
+	logs := captureLogs(t, s)
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "staging", "the message must name the environment that blocked the promotion")
+	assert.Contains(t, ve.Message, "still being provisioned")
+	assert.NotContains(t, ve.Message, "inherit", "the leak rationale is operator detail, not a UI message")
+	assert.Contains(t, logs(), "inherit", "the full rationale must still reach the log")
+	assert.Contains(t, logs(), "staging")
+	assert.False(t, *promoteCalled)
+}
+
+// The same short-message contract for the state the hard block cannot explain
+// from a binding row: provisioning was only just triggered, so no row exists
+// yet.
+func TestPromoteAgent_IdentityBindingMissing_KeepsUIErrorBriefAndSaysRetry(t *testing.T) {
+	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
+	logs := captureLogs(t, s)
+	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
+	require.True(t, ok)
+	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
+		return nil, nil //nolint:nilnil // "no binding row yet" is what GetBindingState itself returns for a missing row
+	}
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "staging")
+	assert.Contains(t, ve.Reason, "retry")
+	assert.Contains(t, logs(), "staging")
+	assert.False(t, *promoteCalled)
+}
+
+// A Thunder failure message is unbounded — the whole point of the split is
+// that it cannot push the UI string back over the limit. The full text must
+// still be logged verbatim.
+func TestPromoteAgent_ProvisioningFailedWithLongLastError_TruncatesUIReason(t *testing.T) {
+	longLastError := "thunder unreachable: " + strings.Repeat("connection refused; ", 30)
+	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
+	logs := captureLogs(t, s)
+	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
+	require.True(t, ok)
+	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
+		return &AgentThunderBindingState{Status: models.AgentThunderStatusFailed, LastError: longLastError}, nil
+	}
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Reason, "thunder unreachable", "the head of the failure is the most useful part to keep")
+	assert.Contains(t, logs(), longLastError, "the untruncated failure must reach the log")
 	assert.False(t, *promoteCalled)
 }
 
@@ -1215,8 +1319,8 @@ func TestPromoteAgent_ProvisioningDisabledButLowestEnvHasRealCredential_StillBlo
 		TargetEnvironment: "staging",
 	})
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "AgentID provisioning is disabled")
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "provisioning is disabled")
 	assert.False(t, promoteCalled,
 		"promotion must be blocked BEFORE calling PromoteComponent — otherwise the pod is already promoted with the lowest environment's leaked credentials by the time this error is returned")
 }

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -713,19 +714,29 @@ func (s *provisionForEnvIfMissingStub) ProvisionForEnvironmentIfMissing(_ contex
 	return false, nil
 }
 
+// stubUnresolvedMCPs makes the named connections unresolved in blockedEnv only,
+// which is what makes a promotion into that environment break them.
+func stubUnresolvedMCPs(t *testing.T, s *agentManagerService, blockedEnv string, names ...string) {
+	t.Helper()
+	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
+	require.True(t, ok)
+	agentConfigSvc.UnresolvedMCPsFunc = func(_ context.Context, _, _, _, envName string) (map[string]struct{}, error) {
+		unresolved := map[string]struct{}{}
+		if envName == blockedEnv {
+			for _, name := range names {
+				unresolved[name] = struct{}{}
+			}
+		}
+		return unresolved, nil
+	}
+}
+
 // An MCP connection that resolves in the source but not the target would promote with its
 // URL and API key injected as empty strings — the agent starts, then fails on every tool
 // call. The promotion must be refused instead, before the component is promoted.
 func TestPromoteAgent_BlocksWhenMCPConnectionUnresolvableInTarget(t *testing.T) {
 	s, promoteCalled := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
-	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
-	require.True(t, ok)
-	agentConfigSvc.UnresolvedMCPsFunc = func(_ context.Context, _, _, _, envName string) (map[string]struct{}, error) {
-		if envName == "staging" {
-			return map[string]struct{}{"booking": {}}, nil
-		}
-		return map[string]struct{}{}, nil
-	}
+	stubUnresolvedMCPs(t, s, "staging", "booking")
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",
@@ -782,14 +793,7 @@ func TestPromoteAgent_BlocksWhenMCPBindingLookupFails(t *testing.T) {
 // the same message on every run instead of reshuffling with Go's map iteration order.
 func TestPromoteAgent_ListsBrokenMCPConnectionsInStableOrder(t *testing.T) {
 	s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
-	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
-	require.True(t, ok)
-	agentConfigSvc.UnresolvedMCPsFunc = func(_ context.Context, _, _, _, envName string) (map[string]struct{}, error) {
-		if envName == "staging" {
-			return map[string]struct{}{"payments": {}, "booking": {}}, nil
-		}
-		return map[string]struct{}{}, nil
-	}
+	stubUnresolvedMCPs(t, s, "staging", "payments", "booking")
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",
@@ -798,22 +802,6 @@ func TestPromoteAgent_ListsBrokenMCPConnectionsInStableOrder(t *testing.T) {
 
 	ve := requireBriefPromotionBlock(t, err)
 	assert.Contains(t, ve.Message, "booking, payments")
-}
-
-func TestPromoteAgent_BlocksWhenTargetIdentityNotReady(t *testing.T) {
-	// Empty, no-error result — exactly what EnvVarsForEnvironment returns
-	// when the target's AgentID binding hasn't finished provisioning yet.
-	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
-
-	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
-		SourceEnvironment: "dev",
-		TargetEnvironment: "staging",
-	})
-
-	ve := requireBriefPromotionBlock(t, err)
-	assert.Contains(t, ve.Message, "still being provisioned")
-	assert.False(t, *promoteCalled,
-		"promotion must be blocked BEFORE calling PromoteComponent — otherwise the pod is already promoted with leaked credentials by the time this error is returned")
 }
 
 func TestPromoteAgent_TargetIdentityReady_PromotesWithTargetOnlyCredentials(t *testing.T) {
@@ -1039,11 +1027,7 @@ func TestPromoteAgent_PollSucceedsWithinBudget_PromotesOnFirstCall(t *testing.T)
 func TestPromoteAgent_TargetCredentialRevoked_BlocksWithRegenerateMessage(t *testing.T) {
 	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
 
-	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
-	require.True(t, ok)
-	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
-		return &AgentThunderBindingState{Status: models.AgentThunderStatusCompleted, HasSecret: false}, nil
-	}
+	stubBindingState(t, s, &AgentThunderBindingState{Status: models.AgentThunderStatusCompleted, HasSecret: false}, nil)
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",
@@ -1053,7 +1037,7 @@ func TestPromoteAgent_TargetCredentialRevoked_BlocksWithRegenerateMessage(t *tes
 	ve := requireBriefPromotionBlock(t, err)
 	assert.Contains(t, ve.Message, "revoked")
 	assert.Contains(t, ve.Reason, "regenerate")
-	assert.NotContains(t, ve.Message+ve.Reason, "still being provisioned", "a revoked credential must not tell the caller to just retry")
+	assert.NotContains(t, renderedUIError(ve), "still being provisioned", "a revoked credential must not tell the caller to just retry")
 	assert.False(t, *promoteCalled)
 }
 
@@ -1064,11 +1048,7 @@ func TestPromoteAgent_TargetCredentialRevoked_BlocksWithRegenerateMessage(t *tes
 func TestPromoteAgent_TargetProvisioningFailed_BlocksWithReprovisionMessage(t *testing.T) {
 	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
 
-	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
-	require.True(t, ok)
-	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
-		return &AgentThunderBindingState{Status: models.AgentThunderStatusFailed, LastError: "thunder unreachable"}, nil
-	}
+	stubBindingState(t, s, &AgentThunderBindingState{Status: models.AgentThunderStatusFailed, LastError: "thunder unreachable"}, nil)
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",
@@ -1079,30 +1059,54 @@ func TestPromoteAgent_TargetProvisioningFailed_BlocksWithReprovisionMessage(t *t
 	assert.Contains(t, ve.Message, "failed")
 	assert.Contains(t, ve.Reason, "thunder unreachable")
 	assert.Contains(t, ve.Reason, "re-provision")
-	assert.NotContains(t, ve.Message+ve.Reason, "still being provisioned", "a permanently failed binding must not tell the caller to just retry")
+	assert.NotContains(t, renderedUIError(ve), "still being provisioned", "a permanently failed binding must not tell the caller to just retry")
 	assert.False(t, *promoteCalled)
 }
 
-// maxPromotionUIErrorLen bounds what a blocked promotion may put on screen.
-// The console renders a failed request as "<message>: <reason>" (see
-// extractServerErrorMessage in the api-client), so both halves together are
-// the UI string — 160 characters is roughly one line of an inline alert.
-const maxPromotionUIErrorLen = 160
+// maxPromotionUIErrorLen guards against a blocked promotion regrowing into the
+// wall of text it used to be. The console renders a failed request as
+// "<message>: <reason>" (see extractServerErrorMessage in the api-client), so
+// both halves together are the UI string. The alert wraps rather than
+// truncates, so this is a legibility budget rather than a rendering limit —
+// the pre-split messages ran past 300 characters.
+//
+// What the code bounds is the unbounded detail it interpolates: upstream
+// failure text and the list of connection names. The environment name is
+// echoed verbatim on purpose (the caller needs to know which one blocked), so
+// a deliberately long environment name can still push a message past this.
+const maxPromotionUIErrorLen = 200
 
 // captureLogs points s at a buffer-backed logger and returns the accumulated
 // output, so a test can assert that detail withheld from the UI still reaches
 // the operator.
-func captureLogs(t *testing.T, s *agentManagerService) func() string {
-	t.Helper()
+func captureLogs(s *agentManagerService) func() string {
 	var buf bytes.Buffer
 	s.logger = slog.New(slog.NewTextHandler(&buf, nil))
 	return buf.String
 }
 
+// stubBindingState makes GetBindingState return a fixed result, selecting which
+// arm of the hard block's state switch runs.
+func stubBindingState(t *testing.T, s *agentManagerService, state *AgentThunderBindingState, err error) {
+	t.Helper()
+	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
+	require.True(t, ok)
+	// (nil, nil) is what GetBindingState itself returns for a missing row.
+	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
+		return state, err
+	}
+}
+
+// renderedUIError is the string the console actually shows for a failed
+// request, so assertions about "what the user sees" all measure the same thing.
+func renderedUIError(ve *utils.ValidationError) string {
+	return ve.Message + ": " + ve.Reason
+}
+
 // requireBriefPromotionBlock asserts err is the caller-facing form of a
 // blocked promotion: a ValidationError (so the UI gets the short Message
 // instead of the whole technical string) that still classifies as invalid
-// input, and whose rendered form fits an inline alert.
+// input, and whose rendered form stays inside the legibility budget.
 func requireBriefPromotionBlock(t *testing.T, err error) *utils.ValidationError {
 	t.Helper()
 	require.Error(t, err)
@@ -1110,10 +1114,10 @@ func requireBriefPromotionBlock(t *testing.T, err error) *utils.ValidationError 
 	ve := utils.IsValidationError(err)
 	require.NotNil(t, ve, "the block must carry a short UI Message separate from its technical Reason")
 
-	rendered := ve.Message + ": " + ve.Reason
-	assert.LessOrEqual(t, len(rendered), maxPromotionUIErrorLen,
-		"the UI string is too lengthy (%d chars): %s", len(rendered), rendered)
-	assert.NotContains(t, rendered, "GET ", "REST call hints belong in the logs, not the UI")
+	rendered := renderedUIError(ve)
+	assert.LessOrEqual(t, utf8.RuneCountInString(rendered), maxPromotionUIErrorLen,
+		"the UI string is too lengthy (%d runes): %s", utf8.RuneCountInString(rendered), rendered)
+	assert.NotContains(t, rendered, "check GET ", "REST call hints belong in the logs, not the UI")
 	return ve
 }
 
@@ -1123,7 +1127,7 @@ func requireBriefPromotionBlock(t *testing.T, err error) *utils.ValidationError 
 // log instead.
 func TestPromoteAgent_IdentityStillProvisioning_KeepsUIErrorBriefAndLogsDetail(t *testing.T) {
 	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
-	logs := captureLogs(t, s)
+	logs := captureLogs(s)
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",
@@ -1136,7 +1140,8 @@ func TestPromoteAgent_IdentityStillProvisioning_KeepsUIErrorBriefAndLogsDetail(t
 	assert.NotContains(t, ve.Message, "inherit", "the leak rationale is operator detail, not a UI message")
 	assert.Contains(t, logs(), "inherit", "the full rationale must still reach the log")
 	assert.Contains(t, logs(), "staging")
-	assert.False(t, *promoteCalled)
+	assert.False(t, *promoteCalled,
+		"promotion must be blocked BEFORE calling PromoteComponent — otherwise the pod is already promoted with leaked credentials by the time this error is returned")
 }
 
 // The same short-message contract for the state the hard block cannot explain
@@ -1144,12 +1149,8 @@ func TestPromoteAgent_IdentityStillProvisioning_KeepsUIErrorBriefAndLogsDetail(t
 // yet.
 func TestPromoteAgent_IdentityBindingMissing_KeepsUIErrorBriefAndSaysRetry(t *testing.T) {
 	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
-	logs := captureLogs(t, s)
-	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
-	require.True(t, ok)
-	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
-		return nil, nil //nolint:nilnil // "no binding row yet" is what GetBindingState itself returns for a missing row
-	}
+	logs := captureLogs(s)
+	stubBindingState(t, s, nil, nil)
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",
@@ -1158,7 +1159,8 @@ func TestPromoteAgent_IdentityBindingMissing_KeepsUIErrorBriefAndSaysRetry(t *te
 
 	ve := requireBriefPromotionBlock(t, err)
 	assert.Contains(t, ve.Message, "staging")
-	assert.Contains(t, ve.Reason, "retry")
+	assert.Contains(t, ve.Reason, "just triggered",
+		"the missing-row arm must be distinguishable from the still-provisioning arm, which shares its Message")
 	assert.Contains(t, logs(), "staging")
 	assert.False(t, *promoteCalled)
 }
@@ -1171,12 +1173,8 @@ func TestPromoteAgent_IdentityBindingMissing_KeepsUIErrorBriefAndSaysRetry(t *te
 func TestPromoteAgent_BindingStateReadFails_ReportsOperationalFailureNotValidation(t *testing.T) {
 	readFailure := errors.New("read agent thunder binding state: dial tcp: connection refused")
 	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
-	logs := captureLogs(t, s)
-	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
-	require.True(t, ok)
-	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
-		return nil, readFailure
-	}
+	logs := captureLogs(s)
+	stubBindingState(t, s, nil, readFailure)
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",
@@ -1191,18 +1189,40 @@ func TestPromoteAgent_BindingStateReadFails_ReportsOperationalFailureNotValidati
 	assert.False(t, *promoteCalled)
 }
 
+// Realistic worst case for the MCP block: several long connection names.
+// Connection names are user-supplied and unbounded, so
+// without shortening the list the UI string grows into the wall of text the
+// split exists to prevent — and shortening must drop whole names, never cut one
+// mid-name and put a connection that does not exist in front of the user.
+func TestPromoteAgent_ManyLongMCPConnectionNames_KeepsUIErrorBriefAndNamesNoPartialConnection(t *testing.T) {
+	names := []string{"booking-service", "invoicing-api", "notifications-fanout", "payments-gateway", "search-indexer"}
+	s, promoteCalled := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "target-client-id"}}, nil)
+	stubUnresolvedMCPs(t, s, "staging", names...)
+	logs := captureLogs(s)
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, "(+", "a shortened list must say how many connections it left out")
+	assert.NotContains(t, ve.Message, "…",
+		"a list is shortened by dropping whole names, so no name may be cut mid-word")
+	for _, name := range names {
+		assert.Contains(t, logs(), name, "every blocked connection must reach the log")
+	}
+	assert.False(t, *promoteCalled)
+}
+
 // A Thunder failure message is unbounded — the whole point of the split is
 // that it cannot push the UI string back over the limit. The full text must
 // still be logged verbatim.
 func TestPromoteAgent_ProvisioningFailedWithLongLastError_TruncatesUIReason(t *testing.T) {
 	longLastError := "thunder unreachable: " + strings.Repeat("connection refused; ", 30)
 	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
-	logs := captureLogs(t, s)
-	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
-	require.True(t, ok)
-	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
-		return &AgentThunderBindingState{Status: models.AgentThunderStatusFailed, LastError: longLastError}, nil
-	}
+	logs := captureLogs(s)
+	stubBindingState(t, s, &AgentThunderBindingState{Status: models.AgentThunderStatusFailed, LastError: longLastError}, nil)
 
 	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
 		SourceEnvironment: "dev",

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -1163,6 +1163,34 @@ func TestPromoteAgent_IdentityBindingMissing_KeepsUIErrorBriefAndSaysRetry(t *te
 	assert.False(t, *promoteCalled)
 }
 
+// A repository failure reading the binding row is an operational fault, not a
+// caller mistake: GetBindingState reserves (nil, nil) for "no binding row yet"
+// and wraps everything else. Reporting it as a validation error would tell the
+// user to retry a promotion that a retry cannot fix, and would answer 400 for
+// a server-side failure.
+func TestPromoteAgent_BindingStateReadFails_ReportsOperationalFailureNotValidation(t *testing.T) {
+	readFailure := errors.New("read agent thunder binding state: dial tcp: connection refused")
+	s, promoteCalled := promoteAgentTestFixture(t, nil, nil)
+	logs := captureLogs(t, s)
+	stub, ok := s.agentThunderProvisioning.(*provisionForEnvIfMissingStub)
+	require.True(t, ok)
+	stub.GetBindingStateFunc = func(context.Context, string, string, string, string) (*AgentThunderBindingState, error) {
+		return nil, readFailure
+	}
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, readFailure, "the underlying failure must stay wrapped so the cause survives to the logs")
+	assert.NotErrorIs(t, err, utils.ErrInvalidInput, "a repository failure is not invalid input; classifying it as one answers 400 for a server fault")
+	assert.Nil(t, utils.IsValidationError(err), "an operational failure must not be dressed up as a user-facing validation message")
+	assert.Contains(t, logs(), "proj1", "the failure must be logged with the project context")
+	assert.False(t, *promoteCalled)
+}
+
 // A Thunder failure message is unbounded — the whole point of the split is
 // that it cannot push the UI string back over the limit. The full text must
 // still be logged verbatim.

--- a/agent-manager-service/tests/promote_agent_test.go
+++ b/agent-manager-service/tests/promote_agent_test.go
@@ -376,6 +376,9 @@ func TestPromoteAgent(t *testing.T) {
 		app.ServeHTTP(rr, req)
 
 		require.Equal(t, http.StatusBadRequest, rr.Code)
-		require.Contains(t, rr.Body.String(), "is not ready yet")
+		require.Contains(t, rr.Body.String(), "still being provisioned")
+		// The console renders a failed request as "<message>: <reason>", so
+		// neither half may carry the operator-only rationale for the block.
+		require.NotContains(t, rr.Body.String(), "inherit")
 	})
 }

--- a/agent-manager-service/tests/promote_agent_test.go
+++ b/agent-manager-service/tests/promote_agent_test.go
@@ -376,9 +376,15 @@ func TestPromoteAgent(t *testing.T) {
 		app.ServeHTTP(rr, req)
 
 		require.Equal(t, http.StatusBadRequest, rr.Code)
-		require.Contains(t, rr.Body.String(), "still being provisioned")
+
+		var errResp spec.ErrorResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+		require.Contains(t, errResp.Message, "still being provisioned")
 		// The console renders a failed request as "<message>: <reason>", so
 		// neither half may carry the operator-only rationale for the block.
-		require.NotContains(t, rr.Body.String(), "inherit")
+		require.NotContains(t, errResp.Message, "inherit")
+		if errResp.Reason != nil {
+			require.NotContains(t, *errResp.Reason, "inherit")
+		}
 	})
 }

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -34,10 +34,11 @@ type ValidationError struct {
 	// Example: "inputInterface.schema.path is required and must start with /"
 	Reason string
 
-	// Sentinel, when set, is the classification error this failure also matches
+	// sentinel, when set, is the classification error this failure also matches
 	// under errors.Is — so a check like errors.Is(err, ErrInvalidInput) still
 	// recognises a ValidationError raised in place of a wrapped sentinel.
-	Sentinel error
+	// Unexported so a constructor is the only way to set it.
+	sentinel error
 }
 
 // Error implements the error interface, returning the technical reason for logging.
@@ -47,36 +48,30 @@ func (e *ValidationError) Error() string {
 
 // Unwrap exposes the classification sentinel to errors.Is/errors.As.
 func (e *ValidationError) Unwrap() error {
-	return e.Sentinel
+	return e.sentinel
 }
 
 // NewValidationError creates a new ValidationError with user-friendly message and technical reason.
 func NewValidationError(message, reason string) *ValidationError {
-	return &ValidationError{
-		Message: message,
-		Reason:  reason,
-	}
+	return &ValidationError{Message: message, Reason: reason, sentinel: nil}
 }
 
-// NewValidationErrorFor is NewValidationError for a failure that must also keep
-// matching a classification sentinel (e.g. ErrInvalidInput), so callers that
-// route on the sentinel keep working while the UI gets the short Message
-// instead of the whole technical string.
-func NewValidationErrorFor(sentinel error, message, reason string) *ValidationError {
-	return &ValidationError{
-		Message:  message,
-		Reason:   reason,
-		Sentinel: sentinel,
-	}
+// NewInvalidInputError is NewValidationError for a failure that must also keep
+// matching ErrInvalidInput under errors.Is, so callers that route on the
+// sentinel keep working while the UI gets the short Message instead of the
+// whole technical string.
+//
+// The sentinel is fixed rather than a parameter because every ValidationError
+// is rendered as 400 by WriteValidationErrorResponse — pairing one with a
+// not-found or conflict sentinel would still answer 400.
+func NewInvalidInputError(message, reason string) *ValidationError {
+	return &ValidationError{Message: message, Reason: reason, sentinel: ErrInvalidInput}
 }
 
 // NewValidationErrorf creates a new ValidationError with formatted reason string.
 // The message should be user-friendly, while reasonFmt is for technical details.
 func NewValidationErrorf(message, reasonFmt string, args ...interface{}) *ValidationError {
-	return &ValidationError{
-		Message: message,
-		Reason:  fmt.Sprintf(reasonFmt, args...),
-	}
+	return NewValidationError(message, fmt.Sprintf(reasonFmt, args...))
 }
 
 // IsValidationError checks if an error is a ValidationError and returns it.

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -33,6 +33,11 @@ type ValidationError struct {
 	// Can include field names, specific validation rules, etc.
 	// Example: "inputInterface.schema.path is required and must start with /"
 	Reason string
+
+	// Sentinel, when set, is the classification error this failure also matches
+	// under errors.Is — so a check like errors.Is(err, ErrInvalidInput) still
+	// recognises a ValidationError raised in place of a wrapped sentinel.
+	Sentinel error
 }
 
 // Error implements the error interface, returning the technical reason for logging.
@@ -40,11 +45,28 @@ func (e *ValidationError) Error() string {
 	return e.Reason
 }
 
+// Unwrap exposes the classification sentinel to errors.Is/errors.As.
+func (e *ValidationError) Unwrap() error {
+	return e.Sentinel
+}
+
 // NewValidationError creates a new ValidationError with user-friendly message and technical reason.
 func NewValidationError(message, reason string) *ValidationError {
 	return &ValidationError{
 		Message: message,
 		Reason:  reason,
+	}
+}
+
+// NewValidationErrorFor is NewValidationError for a failure that must also keep
+// matching a classification sentinel (e.g. ErrInvalidInput), so callers that
+// route on the sentinel keep working while the UI gets the short Message
+// instead of the whole technical string.
+func NewValidationErrorFor(sentinel error, message, reason string) *ValidationError {
+	return &ValidationError{
+		Message:  message,
+		Reason:   reason,
+		Sentinel: sentinel,
 	}
 }
 

--- a/agent-manager-service/utils/errors_test.go
+++ b/agent-manager-service/utils/errors_test.go
@@ -25,8 +25,8 @@ import (
 // fmt.Errorf("%w: ...", ErrInvalidInput) if callers that classify errors by
 // sentinel still recognise it — otherwise swapping one for the other silently
 // reroutes a 400 into the controller's generic 500 fallback.
-func TestNewValidationErrorFor_MatchesItsSentinelAndKeepsBothHalves(t *testing.T) {
-	err := NewValidationErrorFor(ErrInvalidInput, "Promotion blocked: identity is not ready", "retry once provisioning completes")
+func TestNewInvalidInputError_MatchesItsSentinelAndKeepsBothHalves(t *testing.T) {
+	err := NewInvalidInputError("Promotion blocked: identity is not ready", "retry once provisioning completes")
 
 	if !errors.Is(err, ErrInvalidInput) {
 		t.Errorf("errors.Is(err, ErrInvalidInput) = false, want true")

--- a/agent-manager-service/utils/errors_test.go
+++ b/agent-manager-service/utils/errors_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"errors"
+	"testing"
+)
+
+// A ValidationError carrying a short UI message is only usable in place of a
+// fmt.Errorf("%w: ...", ErrInvalidInput) if callers that classify errors by
+// sentinel still recognise it — otherwise swapping one for the other silently
+// reroutes a 400 into the controller's generic 500 fallback.
+func TestNewValidationErrorFor_MatchesItsSentinelAndKeepsBothHalves(t *testing.T) {
+	err := NewValidationErrorFor(ErrInvalidInput, "Promotion blocked: identity is not ready", "retry once provisioning completes")
+
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Errorf("errors.Is(err, ErrInvalidInput) = false, want true")
+	}
+	ve := IsValidationError(err)
+	if ve == nil {
+		t.Fatalf("IsValidationError(err) = nil, want the ValidationError")
+	}
+	if ve.Message != "Promotion blocked: identity is not ready" {
+		t.Errorf("Message = %q", ve.Message)
+	}
+	if ve.Reason != "retry once provisioning completes" {
+		t.Errorf("Reason = %q", ve.Reason)
+	}
+	if err.Error() != "retry once provisioning completes" {
+		t.Errorf("Error() = %q, want the technical reason", err.Error())
+	}
+}
+
+// A plain NewValidationError has no sentinel to match, and asking whether it
+// matches one must not panic on the nil wrapped error.
+func TestNewValidationError_MatchesNoSentinel(t *testing.T) {
+	err := NewValidationError("Agent type is required", "agentType is required")
+
+	if errors.Is(err, ErrInvalidInput) {
+		t.Errorf("errors.Is(err, ErrInvalidInput) = true, want false for a sentinel-less validation error")
+	}
+}


### PR DESCRIPTION
## Purpose
Resolves #1665

Promoting an agent before its AgentID identity is provisioned in the target environment showed a 330-character, three-line error in the promotion drawer, prefixed twice (`Invalid input provided: invalid input: …`) and ending in a REST hint (`check GET .../identities`) that means nothing to a console user.

Three things combined to produce it:

1. `buildPromotionIdentityBlockedError` and `assertMCPBindingsSurvivePromotion` built long, remediation-heavy strings — the only error messages over 180 characters in the whole `services/` package.
2. Nothing logged them. `PromoteAgent` returned the block without a single `logger` call, so the detail existed only in the UI.
3. The controller maps `ErrInvalidInput` to a bucket label plus `err.Error()` as `reason`, and the console renders `"<message>: <reason>"` — so the whole technical string reached the screen, on top of the sentinel text the message already carried.

The CLI had the opposite problem: `render.textError` prints only `message`, so `amctl promote` showed the useless `Invalid input provided` and no state or remediation at all.

## Goals
Log the full diagnosis for operators, and return a short, actionable message pair that reads well in both the console and the CLI — without changing status codes or the wire contract.

## Approach
- `utils.ValidationError` gained a `Sentinel` field, `Unwrap()`, and a `NewValidationErrorFor(sentinel, message, reason)` constructor. `handleCommonErrors` already checks `IsValidationError` before the sentinel cases and answers 400 with `ErrCodeValidation`, so the response shape is unchanged; the sentinel keeps `errors.Is(err, ErrInvalidInput)` true for anything that routes on it.
- All five promotion blocks (the four AgentID states plus the MCP-binding guard) now `logger.Warn` the full diagnosis with structured fields (`agentName`, `projectName`, `ouID`, `environment`, plus `status`/`lastError`/`connections`), and return a short message/reason pair.
- `briefUIDetail` caps unbounded detail (Thunder's `lastError`, the broken-connection list) at 40 characters so an upstream failure can't push the UI string back out. The untruncated text is always logged.

The issue's case, as the console renders it:

```
before (330 chars, 3 lines):
Invalid input provided: invalid input: agent "kind-agent"'s AgentID identity for target
environment "abcd" is not ready yet (still provisioning). Promotion is blocked to prevent
the promoted pod from inheriting a different environment's credentials — check GET
.../identities for this agent and retry once it shows status=completed for "abcd"

after (110 chars):
Promotion blocked: the agent identity for "abcd" is still being provisioned: retry once
provisioning completes
```

The other four blocks land at 121–141 characters. No console or CLI code changed — the CLI improvement is a side effect of the message now carrying the content.

## User stories
N/A — bug fix to an existing error path, no new user-facing capability.

## Release note
Blocked agent promotions now report a short, actionable reason in the console and CLI, with the full diagnosis written to the service log.

## Documentation
N/A — no documented behaviour changes; the HTTP status, error code, and response fields are unchanged.

## Training
N/A — no training content covers this error path.

## Certification
N/A — no impact on certification exams; this changes error message wording, not product behaviour or configuration.

## Marketing
N/A — internal bug fix.

## Automation tests
 - Unit tests
   > `utils/errors_test.go` (new): sentinel matching, both halves preserved, and no false sentinel match for a plain `NewValidationError`.
   > `controllers/error_mapping_unit_test.go` (new): guards that a `ValidationError` carrying a sentinel reaches the wire as a 400 with its own message rather than the `Invalid input provided` bucket label. Verified it fails if the `IsValidationError` branch is removed from `handleCommonErrors`, so it pins the switch ordering the fix depends on.
   > `services/agent_manager_test.go`: three new tests — brief-UI-plus-full-log for the still-provisioning block, the missing-binding block, and truncation of a long `lastError` — behind a `requireBriefPromotionBlock` helper that holds every block to ≤160 rendered characters and rejects REST hints. Seven existing tests moved off `err.Error()` substring checks onto the `Message`/`Reason` contract.
   > Full unit tier passes; `golangci-lint` with the repo config (including `nilnil`, `nolintlint`, `exhaustruct`) and `gofmt` are clean.
 - Integration tests
   > `tests/promote_agent_test.go` — the existing "returns 400 when target environment AgentID is not ready" case was updated to assert the new short message and to reject the operator-only rationale in the body. **Not executed locally** (no test database available in this worktree); it compiles and `go vet -tags=integration ./tests/` is clean, and the same wire behaviour is covered by the new controller unit test above. Needs a CI run to confirm.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Go codebase; `golangci-lint` with the repo config was run instead
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Worth noting on the security side: the promotion block itself is unchanged. It still hard-blocks promotion whenever the target environment's identity isn't ready, which is what prevents a promoted pod from inheriting another environment's real credentials. Only the wording of the refusal changed. Truncating `lastError` also narrows what an upstream failure can echo back to a caller.

## Samples
N/A — no samples relate to this error path.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no schema or data changes.

## Test environment
Go 1.23 toolchain on Linux (CachyOS, kernel 7.1.8); unit tier run with the dummy config env vars from `scripts/run_unit_tests.sh`. No database required for the tests that were executed.

## Learning
Traced the message end to end before changing anything: service error construction → `handleCommonErrors` → `WriteErrorResponseWithReason` → the console's `extractServerErrorMessage`, which renders `"<message>: <reason>"`. That last hop is why shortening the service string alone would not have been enough, and why the fix uses the repo's existing `ValidationError` message/reason split rather than inventing a new mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment now applies environment variables and file mounts through environment-specific release settings.
  * Promotion errors provide concise, structured messages for common provisioning and validation states.
  * System-managed variables are preserved during deployment.

* **Bug Fixes**
  * Validation errors now retain their custom messages and reasons while returning the correct HTTP 400 response.
  * Improved handling of missing, pending, failed, revoked, and unreadable deployment targets.
  * Long diagnostic details are kept out of user-facing responses while remaining available for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->