### PR TITLE
Revoke LLM proxy credentials reliably when an agent is deleted

### DIFF
--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -130,6 +130,9 @@ func handleCommonErrors(w http.ResponseWriter, err error, fallbackMsg string) {
 	case errors.Is(err, utils.ErrAgentAlreadyExists):
 		utils.WriteErrorResponseWithReason(w, http.StatusConflict,
 			"Agent already exists", err.Error(), utils.ErrCodeAgentAlreadyExists)
+	case errors.Is(err, utils.ErrOrphanedAgentConfigsExist):
+		utils.WriteErrorResponseWithReason(w, http.StatusConflict,
+			"Configurations from a deleted agent with this name still exist", err.Error(), utils.ErrCodeConflict)
 	case errors.Is(err, utils.ErrProjectAlreadyExists):
 		utils.WriteErrorResponseWithReason(w, http.StatusConflict,
 			"Project already exists", err.Error(), utils.ErrCodeProjectAlreadyExists)

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1447,6 +1447,11 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 		return translateOrgError(err)
 	}
 
+	// Preflight: refuse the name while a deleted agent's configurations still hold it.
+	if err := s.checkNoOrphanedConfigs(ctx, ouID, projectName, req.Name); err != nil {
+		return err
+	}
+
 	if req.Provisioning.Repository != nil && req.Provisioning.Repository.SecretRef.Get() != nil {
 		if err := s.validateGitSecretExists(ctx, ouID, req.Provisioning.Repository.GetSecretRef()); err != nil {
 			return err
@@ -2638,6 +2643,10 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 		translatedErr := translateAgentError(err)
 		if errors.Is(translatedErr, utils.ErrAgentNotFound) {
 			s.logger.Warn("Agent not found during deletion, delete is idempotent", "agentName", agentName, "ouID", ouID, "projectName", projectName)
+			// The component is already gone but a previous partially-completed delete may
+			// have left agent_configurations rows behind, each still holding a live LLM
+			// proxy credential, so run the same revocation cleanup here.
+			go s.deleteAgentLLMConfigurations(context.WithoutCancel(ctx), ouID, projectName, agentName, isExternalAgent)
 			if configErr := s.agentConfigRepo.DeleteAllByAgent(ctx, ouID, projectName, agentName); configErr != nil {
 				s.logger.Warn("Failed to delete agent configs from database", "agentName", agentName, "error", configErr)
 			}
@@ -2661,7 +2670,9 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 		go s.agentThunderProvisioning.DeleteAllBindings(context.WithoutCancel(ctx), ouID, projectName, agentName)
 	}
 
-	// Cleanup agent configs from database
+	// Cleanup agent_configs (per-environment instrumentation, CORS and security settings).
+	// Unrelated to the LLM proxy records the goroutine above revokes, so it does not wait
+	// on them: leaving these rows behind would let a same-named agent inherit them.
 	if configErr := s.agentConfigRepo.DeleteAllByAgent(ctx, ouID, projectName, agentName); configErr != nil {
 		s.logger.Warn("Failed to delete agent configs from database", "agentName", agentName, "error", configErr)
 		// Don't fail the deletion - configs will be orphaned but harmless
@@ -2675,6 +2686,53 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 
 	s.logger.Debug("Agent deleted from OpenChoreo successfully", "ouID", ouID, "agentName", agentName)
 	return nil
+}
+
+// Agent-deletion cleanup runs detached from the request (see deleteAgentLLMConfigurations),
+// so it can afford to wait out the transient gateway/secret-store failures that make
+// revocation fail while the cluster is under load — the failure mode this path was
+// reported for. Four attempts at a doubling delay spans ~14s per configuration.
+// Variables rather than constants so tests can shrink the delay; production never reassigns them.
+var (
+	agentConfigCleanupAttempts   = 4
+	agentConfigCleanupRetryDelay = 2 * time.Second
+)
+
+// withAgentConfigCleanupRetry retries a configuration teardown with exponential backoff.
+//
+// Every external step of DeleteForAgentDeletion tolerates an already-gone resource — the
+// proxy/provider revocations swallow their not-found sentinels and DeleteSecret is
+// idempotent by contract — so re-running it after a partial success finishes the
+// remaining steps instead of double-deleting. That is what makes retrying on *any* error
+// safe here: the error it returns is a joined summary of which steps failed, not a typed
+// sentinel that could be classified as transient or permanent.
+//
+// A permanent failure therefore costs the full attempt budget before giving up. That is
+// the accepted trade: an un-revoked credential stays live until someone intervenes, so
+// spending a few seconds to rule out a transient cause is worth more than failing fast.
+func withAgentConfigCleanupRetry(ctx context.Context, logger *slog.Logger, configUUID string, fn func() error) error {
+	var lastErr error
+	for attempt := range agentConfigCleanupAttempts {
+		lastErr = fn()
+		if lastErr == nil {
+			if attempt > 0 {
+				logger.Info("Configuration teardown succeeded on retry", "configUUID", configUUID, "attempt", attempt+1)
+			}
+			return nil
+		}
+		if attempt == agentConfigCleanupAttempts-1 {
+			break
+		}
+		delay := agentConfigCleanupRetryDelay << attempt
+		logger.Warn("Configuration teardown failed, retrying",
+			"configUUID", configUUID, "attempt", attempt+1, "retryIn", delay, "error", lastErr)
+		select {
+		case <-ctx.Done():
+			return lastErr
+		case <-time.After(delay):
+		}
+	}
+	return lastErr
 }
 
 // cleanupAgentMonitors removes all monitors owned by an agent. Best-effort: orphaned
@@ -2709,6 +2767,37 @@ func (s *agentManagerService) deleteAgentAPIArtifact(ctx context.Context, ouID, 
 	}
 }
 
+// checkNoOrphanedConfigs refuses to create an agent whose name still has agent_configurations
+// rows attached to it.
+//
+// Configurations are keyed by (ou_id, project_name, agent_id) where agent_id is the agent's
+// *name*, not a per-instance identity, and DeleteForAgentDeletion deliberately keeps a row
+// whose external teardown failed so the proxy, key and deployment it names can still be found
+// and revoked. Those two facts together mean a new agent created with a deleted agent's name
+// would adopt the surviving rows — and with them a live, un-rotated LLM proxy credential — with
+// nothing in the UI to distinguish it from a fresh binding. Refusing the create is what keeps
+// that from happening silently; deleting the agent again re-runs the revocation and clears the
+// name once it succeeds.
+//
+// A list failure is fatal here rather than best-effort: without the list we cannot tell a clean
+// name from an orphaned one, and guessing wrong leaks a credential.
+func (s *agentManagerService) checkNoOrphanedConfigs(ctx context.Context, ouID, projectName, agentName string) error {
+	listResp, err := s.agentConfigurationService.List(ctx, ouID, projectName, agentName, 1, 0)
+	if err != nil {
+		s.logger.Error("Failed to check for orphaned agent configurations before create",
+			"agentName", agentName, "ouID", ouID, "projectName", projectName, "error", err)
+		return fmt.Errorf("failed to check for leftover configurations for agent %s: %w", agentName, err)
+	}
+	if listResp.Pagination.Count == 0 {
+		return nil
+	}
+
+	s.logger.Error("Refusing to create agent: configurations from a previously deleted agent with this name were not fully revoked",
+		"agentName", agentName, "ouID", ouID, "projectName", projectName, "orphanedConfigs", listResp.Pagination.Count)
+	return fmt.Errorf("%w: %d configuration(s) for agent %q in project %q remain; deletion cleanup may still be running, so retry shortly, then delete the agent again to re-attempt revoking them, or use a different name",
+		utils.ErrOrphanedAgentConfigsExist, listResp.Pagination.Count, agentName, projectName)
+}
+
 // deleteAgentLLMConfigurations removes all LLM and MCP configurations for an agent during agent deletion.
 // isExternalAgent must be resolved by the caller before the component is deleted so this function
 // requires no OC calls. Calls DeleteForAgentDeletion which skips Component/Workload/ReleaseBinding
@@ -2727,8 +2816,16 @@ func (s *agentManagerService) deleteAgentLLMConfigurations(ctx context.Context, 
 			s.logger.Warn("Failed to parse config UUID during agent deletion", "uuid", cfg.UUID, "type", cfg.Type, "error", parseErr)
 			continue
 		}
-		if delErr := s.agentConfigurationService.DeleteForAgentDeletion(ctx, configUUID, ouID, projectName, agentName, isExternalAgent); delErr != nil {
-			s.logger.Warn("Failed to delete configuration during agent deletion", "configUUID", cfg.UUID, "type", cfg.Type, "error", delErr)
+		delErr := withAgentConfigCleanupRetry(ctx, s.logger, cfg.UUID, func() error {
+			return s.agentConfigurationService.DeleteForAgentDeletion(ctx, configUUID, ouID, projectName, agentName, isExternalAgent)
+		})
+		if delErr != nil {
+			// DeleteForAgentDeletion keeps the agent_configurations row when any external
+			// step failed, so the record of what still needs revoking survives. Creating an
+			// agent with this name is refused until it is gone (see checkNoOrphanedConfigs).
+			s.logger.Error("Gave up revoking configuration during agent deletion; its LLM proxy credential may still be live",
+				"configUUID", cfg.UUID, "type", cfg.Type, "agentName", agentName, "ouID", ouID,
+				"attempts", agentConfigCleanupAttempts, "error", delErr)
 		}
 	}
 

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -2646,7 +2646,11 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 			// The component is already gone but a previous partially-completed delete may
 			// have left agent_configurations rows behind, each still holding a live LLM
 			// proxy credential, so run the same revocation cleanup here.
-			go s.deleteAgentLLMConfigurations(context.WithoutCancel(ctx), ouID, projectName, agentName, isExternalAgent)
+			go func() {
+				cleanupCtx, cancel := detachedCleanupContext(ctx)
+				defer cancel()
+				s.deleteAgentLLMConfigurations(cleanupCtx, ouID, projectName, agentName, isExternalAgent)
+			}()
 			if configErr := s.agentConfigRepo.DeleteAllByAgent(ctx, ouID, projectName, agentName); configErr != nil {
 				s.logger.Warn("Failed to delete agent configs from database", "agentName", agentName, "error", configErr)
 			}
@@ -2662,10 +2666,13 @@ func (s *agentManagerService) DeleteAgent(ctx context.Context, ouID string, proj
 	}
 
 	// Component confirmed deleted — clean up LLM proxy resources and DB records in the
-	// background. context.WithoutCancel detaches the request deadline so the goroutine
-	// is not cancelled when the HTTP handler returns, while still inheriting any values
-	// (trace IDs, logger) from the request context.
-	go s.deleteAgentLLMConfigurations(context.WithoutCancel(ctx), ouID, projectName, agentName, isExternalAgent)
+	// background, on a context that outlives the request but is still bounded
+	// (see detachedCleanupContext).
+	go func() {
+		cleanupCtx, cancel := detachedCleanupContext(ctx)
+		defer cancel()
+		s.deleteAgentLLMConfigurations(cleanupCtx, ouID, projectName, agentName, isExternalAgent)
+	}()
 	if s.agentThunderProvisioning != nil {
 		go s.agentThunderProvisioning.DeleteAllBindings(context.WithoutCancel(ctx), ouID, projectName, agentName)
 	}
@@ -2697,6 +2704,20 @@ var (
 	agentConfigCleanupAttempts   = 4
 	agentConfigCleanupRetryDelay = 2 * time.Second
 )
+
+// agentCleanupTimeout bounds the detached cleanup goroutine. The retry budget above lets a
+// single configuration occupy ~14s of backoff on top of its external calls, so a many-config
+// agent could otherwise keep the goroutine alive indefinitely if a gateway stops answering.
+// Generous on purpose: the ceiling exists to stop a wedged call from pinning the goroutine for
+// the process lifetime, not to cut short revocations that are still making progress.
+const agentCleanupTimeout = 10 * time.Minute
+
+// detachedCleanupContext returns a context for post-delete cleanup that outlives the request.
+// WithoutCancel drops the request deadline while keeping its values (trace IDs, logger) so the
+// work is not cancelled when the HTTP handler returns; the timeout then puts a ceiling back on.
+func detachedCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), agentCleanupTimeout)
+}
 
 // withAgentConfigCleanupRetry retries a configuration teardown with exponential backoff.
 //

--- a/agent-manager-service/services/agent_manager_delete_cleanup_unit_test.go
+++ b/agent-manager-service/services/agent_manager_delete_cleanup_unit_test.go
@@ -1,0 +1,291 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// stubAgentConfigurationService embeds the interface so only the two methods the
+// cleanup path uses need stubbing; any other call panics on the nil interface,
+// which is what makes an unexpected code path fail loudly.
+type stubAgentConfigurationService struct {
+	AgentConfigurationService
+
+	ListFunc                   func(ctx context.Context, ouID, projectName, agentName string, limit, offset int) (*models.AgentModelConfigListResponse, error)
+	DeleteForAgentDeletionFunc func(ctx context.Context, configUUID uuid.UUID, ouID, projectName, agentName string, isExternalAgent bool) error
+}
+
+func (s *stubAgentConfigurationService) List(
+	ctx context.Context, ouID, projectName, agentName string, limit, offset int,
+) (*models.AgentModelConfigListResponse, error) {
+	return s.ListFunc(ctx, ouID, projectName, agentName, limit, offset)
+}
+
+func (s *stubAgentConfigurationService) DeleteForAgentDeletion(
+	ctx context.Context, configUUID uuid.UUID, ouID, projectName, agentName string, isExternalAgent bool,
+) error {
+	return s.DeleteForAgentDeletionFunc(ctx, configUUID, ouID, projectName, agentName, isExternalAgent)
+}
+
+// newAIAppServiceForCleanup builds a real AIApplicationService over mocked repos that
+// report no applications, so the cleanup's final step is a no-op.
+func newAIAppServiceForCleanup() *AIApplicationService {
+	appRepo := &repomocks.AIApplicationRepositoryMock{
+		ListByAgentFunc: func(_ context.Context, _, _, _ string) ([]models.AIApplication, error) {
+			return []models.AIApplication{}, nil
+		},
+		DeleteByAgentFunc: func(_ context.Context, _, _, _ string) error { return nil },
+	}
+	return NewAIApplicationService(appRepo, &repomocks.GatewayRepositoryMock{}, nil, discardLogger())
+}
+
+// shrinkCleanupRetryDelay drops the backoff for the duration of a test so a case that
+// exhausts the attempt budget costs microseconds instead of the production ~14s.
+func shrinkCleanupRetryDelay(t *testing.T) {
+	t.Helper()
+	original := agentConfigCleanupRetryDelay
+	agentConfigCleanupRetryDelay = time.Microsecond
+	t.Cleanup(func() { agentConfigCleanupRetryDelay = original })
+}
+
+// TestDeleteAgentLLMConfigurations covers what keeps LLM proxy credentials from surviving an
+// agent deletion: every configuration the agent owns is handed to DeleteForAgentDeletion, a
+// failure on one does not abandon the rest, and the per-agent AI application records are
+// removed once the loop has run.
+func TestDeleteAgentLLMConfigurations(t *testing.T) {
+	const org, proj, agent = "acme", "proj1", "chat-agent"
+
+	newSvc := func(cfgSvc AgentConfigurationService) *agentManagerService {
+		return &agentManagerService{
+			agentConfigurationService: cfgSvc,
+			aiApplicationService:      newAIAppServiceForCleanup(),
+			logger:                    discardLogger(),
+		}
+	}
+
+	listOf := func(uuids ...string) func(context.Context, string, string, string, int, int) (*models.AgentModelConfigListResponse, error) {
+		items := make([]models.AgentModelConfigListItem, len(uuids))
+		for i, u := range uuids {
+			items[i] = models.AgentModelConfigListItem{UUID: u, Type: "llm"}
+		}
+		return func(_ context.Context, _, _, _ string, _, _ int) (*models.AgentModelConfigListResponse, error) {
+			return &models.AgentModelConfigListResponse{
+				Configs:    items,
+				Pagination: models.PaginationInfo{Count: len(items)},
+			}, nil
+		}
+	}
+
+	t.Run("revokes every configuration the agent owns", func(t *testing.T) {
+		first, second := uuid.NewString(), uuid.NewString()
+		var revoked []string
+
+		cfgSvc := &stubAgentConfigurationService{
+			ListFunc: listOf(first, second),
+			DeleteForAgentDeletionFunc: func(_ context.Context, got uuid.UUID, gotOU, gotProj, gotAgent string, external bool) error {
+				assert.Equal(t, org, gotOU)
+				assert.Equal(t, proj, gotProj)
+				assert.Equal(t, agent, gotAgent)
+				assert.False(t, external)
+				revoked = append(revoked, got.String())
+				return nil
+			},
+		}
+
+		newSvc(cfgSvc).deleteAgentLLMConfigurations(context.Background(), org, proj, agent, false)
+
+		assert.ElementsMatch(t, []string{first, second}, revoked)
+	})
+
+	t.Run("keeps revoking the remaining configurations after one exhausts its retries", func(t *testing.T) {
+		shrinkCleanupRetryDelay(t)
+		doomed, healthy := uuid.NewString(), uuid.NewString()
+		attempts := map[string]int{}
+
+		cfgSvc := &stubAgentConfigurationService{
+			ListFunc: listOf(doomed, healthy),
+			DeleteForAgentDeletionFunc: func(_ context.Context, got uuid.UUID, _, _, _ string, _ bool) error {
+				attempts[got.String()]++
+				if got.String() == doomed {
+					return errors.New("external cleanup incomplete, DB record preserved for retry")
+				}
+				return nil
+			},
+		}
+
+		newSvc(cfgSvc).deleteAgentLLMConfigurations(context.Background(), org, proj, agent, false)
+
+		// A proxy whose credential cannot be revoked must not cost the other configs their
+		// cleanup — each one names a separate live credential.
+		assert.Equal(t, agentConfigCleanupAttempts, attempts[doomed])
+		assert.Equal(t, 1, attempts[healthy])
+	})
+
+	t.Run("skips a configuration whose UUID cannot be parsed", func(t *testing.T) {
+		cfgSvc := &stubAgentConfigurationService{
+			ListFunc: listOf("not-a-uuid"),
+			// DeleteForAgentDeletionFunc left nil: calling it would panic, which is the
+			// assertion — an unparseable UUID must not reach the teardown.
+		}
+
+		newSvc(cfgSvc).deleteAgentLLMConfigurations(context.Background(), org, proj, agent, false)
+	})
+
+	t.Run("does nothing when the configuration list cannot be read", func(t *testing.T) {
+		cfgSvc := &stubAgentConfigurationService{
+			ListFunc: func(_ context.Context, _, _, _ string, _, _ int) (*models.AgentModelConfigListResponse, error) {
+				return nil, errors.New("db unavailable")
+			},
+		}
+
+		newSvc(cfgSvc).deleteAgentLLMConfigurations(context.Background(), org, proj, agent, false)
+	})
+}
+
+// TestCheckNoOrphanedConfigs covers the create-time guard for the credential-reuse path:
+// agent_configurations are keyed by agent *name*, and DeleteForAgentDeletion deliberately keeps
+// a row whose revocation failed, so a new agent taking a deleted agent's name would otherwise
+// adopt that row's live LLM proxy credential.
+func TestCheckNoOrphanedConfigs(t *testing.T) {
+	const org, proj, agent = "acme", "proj1", "chat-agent"
+
+	newSvc := func(cfgSvc AgentConfigurationService) *agentManagerService {
+		return &agentManagerService{agentConfigurationService: cfgSvc, logger: discardLogger()}
+	}
+
+	t.Run("allows a name with no leftover configurations", func(t *testing.T) {
+		cfgSvc := &stubAgentConfigurationService{
+			ListFunc: func(_ context.Context, gotOU, gotProj, gotAgent string, _, _ int) (*models.AgentModelConfigListResponse, error) {
+				assert.Equal(t, org, gotOU)
+				assert.Equal(t, proj, gotProj)
+				assert.Equal(t, agent, gotAgent)
+				return &models.AgentModelConfigListResponse{Pagination: models.PaginationInfo{Count: 0}}, nil
+			},
+		}
+
+		require.NoError(t, newSvc(cfgSvc).checkNoOrphanedConfigs(context.Background(), org, proj, agent))
+	})
+
+	t.Run("refuses a name still holding a deleted agent's configurations", func(t *testing.T) {
+		cfgSvc := &stubAgentConfigurationService{
+			ListFunc: func(_ context.Context, _, _, _ string, _, _ int) (*models.AgentModelConfigListResponse, error) {
+				return &models.AgentModelConfigListResponse{
+					Configs:    []models.AgentModelConfigListItem{{UUID: uuid.NewString(), Type: "llm"}},
+					Pagination: models.PaginationInfo{Count: 2},
+				}, nil
+			},
+		}
+
+		err := newSvc(cfgSvc).checkNoOrphanedConfigs(context.Background(), org, proj, agent)
+
+		require.ErrorIs(t, err, utils.ErrOrphanedAgentConfigsExist)
+		assert.Contains(t, err.Error(), agent)
+	})
+
+	t.Run("refuses the create when the check itself cannot run", func(t *testing.T) {
+		cfgSvc := &stubAgentConfigurationService{
+			ListFunc: func(_ context.Context, _, _, _ string, _, _ int) (*models.AgentModelConfigListResponse, error) {
+				return nil, errors.New("db unavailable")
+			},
+		}
+
+		// Failing open here would reintroduce the very reuse this guard exists to stop.
+		err := newSvc(cfgSvc).checkNoOrphanedConfigs(context.Background(), org, proj, agent)
+
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, utils.ErrOrphanedAgentConfigsExist)
+	})
+}
+
+// TestWithAgentConfigCleanupRetry covers the bounded retry that fronts each configuration
+// teardown. Revocation fails under cluster load — a transient condition — and every step of
+// DeleteForAgentDeletion tolerates an already-gone resource, so re-running it converges.
+func TestWithAgentConfigCleanupRetry(t *testing.T) {
+	t.Run("returns immediately on first success without sleeping", func(t *testing.T) {
+		calls := 0
+		start := time.Now()
+
+		err := withAgentConfigCleanupRetry(context.Background(), discardLogger(), "cfg-1", func() error {
+			calls++
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, calls)
+		assert.Less(t, time.Since(start), agentConfigCleanupRetryDelay, "a first-attempt success must not back off")
+	})
+
+	t.Run("retries a transient failure and reports success", func(t *testing.T) {
+		shrinkCleanupRetryDelay(t)
+		calls := 0
+
+		err := withAgentConfigCleanupRetry(context.Background(), discardLogger(), "cfg-1", func() error {
+			calls++
+			if calls < 2 {
+				return errors.New("gateway unavailable")
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, calls, "should have succeeded on the second attempt")
+	})
+
+	t.Run("gives up after the attempt budget and surfaces the last error", func(t *testing.T) {
+		shrinkCleanupRetryDelay(t)
+		calls := 0
+		wantErr := errors.New("proxy API key revocation failed")
+
+		err := withAgentConfigCleanupRetry(context.Background(), discardLogger(), "cfg-1", func() error {
+			calls++
+			return wantErr
+		})
+
+		require.ErrorIs(t, err, wantErr)
+		assert.Equal(t, agentConfigCleanupAttempts, calls, "should spend exactly the attempt budget")
+	})
+
+	t.Run("stops backing off when the context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		start := time.Now()
+
+		err := withAgentConfigCleanupRetry(ctx, discardLogger(), "cfg-1", func() error {
+			calls++
+			cancel()
+			return errors.New("gateway unavailable")
+		})
+
+		// Cancellation must cut the wait short rather than sleeping out the full budget,
+		// so a shutting-down process is not held open by a doomed retry loop.
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
+		assert.Less(t, time.Since(start), agentConfigCleanupRetryDelay)
+	})
+}

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -194,6 +194,11 @@ var (
 	// Agent Configuration errors
 	ErrAgentConfigNotFound      = errors.New("agent configuration not found")
 	ErrAgentConfigAlreadyExists = errors.New("agent configuration already exists for this agent")
+	// ErrOrphanedAgentConfigsExist is returned when an agent is created with the name of a
+	// previously deleted agent whose configuration rows survived, because revoking their LLM
+	// proxy credentials failed. Configurations are keyed by agent name, so letting the create
+	// through would silently hand the new agent the old agent's un-rotated credential. Maps to 409.
+	ErrOrphanedAgentConfigsExist = errors.New("configurations from a previously deleted agent with this name have not been fully revoked")
 	// ErrAgentConfigNotExternal is returned when a user-managed API key action
 	// (create/rotate/revoke) is attempted against a configuration whose agent is
 	// managed/internal. Only external agents own their proxy API keys; managed


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Deleting an agent tears down each LLM configuration in six ordered steps — revoke the proxy API key, revoke the provider key, undeploy the proxy, delete the proxy record, delete the KV secret, delete the config row — and under cluster load one of the gateway calls in the middle can time out. 


The old code logged that failure and deleted the config row anyway, which left the API key live and the deployment running with nothing left in the system pointing at them, hence the deleted agent still showing in the provider's Consumers tab.  The earlier commits made the final row deletion conditional so a failed teardown keeps its record, but that only preserves the evidence — it doesn't revoke anything. 

This PR introduces a retry mechanism: it re-runs the whole sequence up to four times at a doubling delay, and because every step swallows its own not-found error, a re-run skims past the steps that already succeeded and resumes at the one that broke, converging once the gateway recovers. The cleanup already runs detached from the request, so waiting out a transient failure costs the caller nothing. If all four attempts still fail, the row survives and the new create-time preflight refuses that agent name, so deleting the agent again re-runs the revocation against a healthy cluster and frees the name once it succeeds.



Resolves https://github.com/wso2/agent-manager/issues/1541
Resolves https://github.com/wso2/agent-manager/issues/1545

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.