### PR TITLE
Fix agent config secret rename breaking the deployment

### DIFF
--- a/console/workspaces/pages/deploy/src/subComponent/EditDeployConfigDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/EditDeployConfigDrawer.tsx
@@ -56,7 +56,7 @@ import type {
   UpdateAgentDeploySettingsRequest,
 } from "@agent-management-platform/types";
 import { compatibleInstrumentationVersions, pickInstrumentationVersion } from "../utils/instrumentation";
-import { excludeSystemVars, sortSystemLast } from "../utils/envVars";
+import { excludeSystemVars, isStoredSecret, sortSystemLast } from "../utils/envVars";
 import { SecurityConfigSections, type SecurityConfigHandle } from "./SecurityConfigSections";
 
 export interface EditDeployConfigDrawerProps {
@@ -479,7 +479,8 @@ export function EditDeployConfigDrawer({
                     keyValue={item.key}
                     valueValue={item.value}
                     isSensitive={item.isSensitive ?? false}
-                    isExistingSecret={!!(item.secretRef && item.isSensitive)}
+                    isExistingSecret={isStoredSecret(item)}
+                    keyDisabled={isStoredSecret(item)}
                     isSystem={item.isSystem}
                     onKeyChange={(v) => handleEnvChange(index, "key", v)}
                     onValueChange={(v) => handleEnvChange(index, "value", v)}

--- a/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
@@ -62,7 +62,7 @@ import {
   normalizePythonMinor,
   pickInstrumentationVersion,
 } from "../utils/instrumentation";
-import { excludeSystemVars, sortSystemLast } from "../utils/envVars";
+import { excludeSystemVars, isStoredSecret, sortSystemLast } from "../utils/envVars";
 
 interface PromoteAgentDrawerProps {
   open: boolean;
@@ -545,9 +545,8 @@ export function PromoteAgentDrawer({
                                   keyValue={item.key}
                                   valueValue={item.value}
                                   isSensitive={item.isSensitive ?? false}
-                                  isExistingSecret={
-                                    !!(item.secretRef && item.isSensitive)
-                                  }
+                                  isExistingSecret={isStoredSecret(item)}
+                                  keyDisabled={isStoredSecret(item)}
                                   isSystem={item.isSystem}
                                   onKeyChange={(v) =>
                                     handleEnvChange(index, "key", v)

--- a/console/workspaces/pages/deploy/src/utils/envVars.ts
+++ b/console/workspaces/pages/deploy/src/utils/envVars.ts
@@ -16,6 +16,14 @@
  * under the License.
  */
 
+import type { EnvironmentVariable } from "@agent-management-platform/types";
+
+// Its value lives in the secret store and never reaches the console, so the key
+// it is stored under cannot be renamed here.
+export function isStoredSecret(item: EnvironmentVariable): boolean {
+  return !!(item.isSensitive && item.secretRef);
+}
+
 /**
  * Sorts system-injected entries (isSystem=true) below user-managed ones,
  * preserving relative order within each group.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Renaming a configuration secret's key left the agent's deployment in an Error state, because the workload ended up referencing a secret key that holds nothing.

Resolves #1565

Secret values are never sent back to the console, so renaming a key is the one edit where the value field is necessarily left empty — there is no value to retype. Both config drawers then re-sent the row as `{key, isSensitive, secretRef}`, which means "keep the value already stored under this key". Nothing was ever stored under the new key, so the backend wrote the variable nowhere while still emitting it as a `secretKeyRef`, leaving the workload pointing at a key that holds nothing. When it was the agent's only secret, the whole secret was deleted as well.

Neither the console nor the backend can move a stored value to a new key, so a rename cannot be completed at all — it can only be prevented. A stored secret's key is now read-only, which makes that payload impossible to construct. Changing a secret's name is delete plus re-add, which the existing flow already handles in a single write.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.