### PR TITLE
Inject MCP env vars into kind-sourced agent workloads

### DIFF
--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -5495,18 +5495,26 @@ func (s *agentConfigurationService) ListSystemManagedEnvVarKeys(
 
 // BuildSystemManagedEnvVarsFromConfig constructs system-managed env vars for a given
 // agent and environment from every DB-backed agent config. Used during promotion when
-// the target environment's ReleaseBinding doesn't have these vars yet.
+// the target environment's ReleaseBinding doesn't have these vars yet, and when building
+// a kind-sourced agent's Workload CR at creation. Returns no vars for an agent with no
+// configs, so callers need not pre-check which config types the agent has.
 func (s *agentConfigurationService) BuildSystemManagedEnvVarsFromConfig(
 	ctx context.Context, agentID, ouID, projectName, environmentName string,
 ) ([]client.EnvVar, error) {
-	envUUID, err := s.resolveEnvironmentUUID(ctx, ouID, environmentName)
-	if err != nil {
-		return nil, err
-	}
-
 	configs, err := s.agentConfigRepo.ListByAgent(ctx, ouID, projectName, agentID, agentConfigListAll, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list agent configurations: %w", err)
+	}
+	// Resolve the environment only once we know there is a config to build vars for.
+	// This keeps the no-config case free of a remote environment lookup, so callers can
+	// invoke this unconditionally instead of pre-checking which config types exist.
+	if len(configs) == 0 {
+		return nil, nil
+	}
+
+	envUUID, err := s.resolveEnvironmentUUID(ctx, ouID, environmentName)
+	if err != nil {
+		return nil, err
 	}
 
 	var result []client.EnvVar

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1663,14 +1663,15 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 				kindEnvVars = createAgentReq.Configurations.Env
 				kindFileVars = createAgentReq.Configurations.Files
 			}
-			// Kind-sourced agents bypass the build/workflow system, so the LLM env vars
-			// written into the Component workflow params by createAgentLLMConfigs never reach
-			// the container. The Workload CR is authoritative for these agents, so resolve the
-			// system-managed LLM env vars from the persisted config and inject them here.
-			kindEnvVars, envErr := s.mergeKindWorkloadLLMEnvVars(ctx, req.Name, ouID, projectName, firstEnv, kindEnvVars, len(req.ModelConfig) > 0)
+			// Kind-sourced agents bypass the build/workflow system, so the system-managed env
+			// vars written into the Component workflow params by createAgentLLMConfigs and
+			// createAgentMCPConfigs never reach the container. The Workload CR is authoritative
+			// for these agents, so resolve those env vars from the persisted config and inject
+			// them here.
+			kindEnvVars, envErr := s.mergeKindWorkloadSystemEnvVars(ctx, ouID, projectName, firstEnv, req, kindEnvVars)
 			if envErr != nil {
-				s.logger.Error("Failed to resolve LLM env vars for kind-sourced agent workload", "agentName", req.Name, "environment", firstEnv, "error", envErr)
-				rollbackAgentCreate("LLM env var resolution failure")
+				s.logger.Error("Failed to resolve system-managed env vars for kind-sourced agent workload", "agentName", req.Name, "environment", firstEnv, "error", envErr)
+				rollbackAgentCreate("system env var resolution failure")
 				return envErr
 			}
 			kindEndpoints := inputInterfaceToEndpoints(createAgentReq.InputInterface, req.Name)
@@ -1770,23 +1771,24 @@ func (s *agentManagerService) triggerInitialBuild(ctx context.Context, ouID, pro
 	return nil
 }
 
-// mergeKindWorkloadLLMEnvVars appends the system-managed LLM env vars (proxy URL + API key
-// secret ref) for the first environment onto the user-supplied env vars of a kind-sourced agent.
-// Kind-sourced agents create their Workload CR directly, bypassing the build/workflow system that
-// otherwise carries these vars into the container, so they must be injected into the Workload here.
-// When the agent has no LLM configuration, userEnvVars is returned unchanged.
-func (s *agentManagerService) mergeKindWorkloadLLMEnvVars(
-	ctx context.Context, agentName, ouID, projectName, firstEnv string, userEnvVars []client.EnvVar, hasModelConfig bool,
+// mergeKindWorkloadSystemEnvVars appends the system-managed env vars (proxy URL + API key secret
+// ref, for both LLM and MCP configurations) for the first environment onto the user-supplied env
+// vars of a kind-sourced agent. Kind-sourced agents create their Workload CR directly, bypassing
+// the build/workflow system that otherwise carries these vars into the container, so they must be
+// injected into the Workload here. When the agent has no system-managed configuration at all,
+// userEnvVars is returned unchanged.
+func (s *agentManagerService) mergeKindWorkloadSystemEnvVars(
+	ctx context.Context, ouID, projectName, firstEnv string, req *spec.CreateAgentRequest, userEnvVars []client.EnvVar,
 ) ([]client.EnvVar, error) {
-	if !hasModelConfig {
+	if len(req.ModelConfig) == 0 && len(req.McpConfig) == 0 {
 		return userEnvVars, nil
 	}
-	llmEnvVars, err := s.agentConfigurationService.BuildSystemManagedEnvVarsFromConfig(ctx, agentName, ouID, projectName, firstEnv)
+	systemEnvVars, err := s.agentConfigurationService.BuildSystemManagedEnvVarsFromConfig(ctx, req.Name, ouID, projectName, firstEnv)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build system-managed LLM env vars: agentName %s, ouID %s, projectName %s, env %s, error: %w",
-			agentName, ouID, projectName, firstEnv, err)
+		return nil, fmt.Errorf("failed to build system-managed env vars: agentName %s, ouID %s, projectName %s, env %s, error: %w",
+			req.Name, ouID, projectName, firstEnv, err)
 	}
-	return append(userEnvVars, llmEnvVars...), nil
+	return append(userEnvVars, systemEnvVars...), nil
 }
 
 func (s *agentManagerService) createAgentLLMConfigs(

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1670,7 +1670,8 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 			// them here.
 			kindEnvVars, envErr := s.mergeKindWorkloadSystemEnvVars(ctx, req.Name, ouID, projectName, firstEnv, kindEnvVars)
 			if envErr != nil {
-				s.logger.Error("Failed to resolve system-managed env vars for kind-sourced agent workload", "agentName", req.Name, "environment", firstEnv, "error", envErr)
+				s.logger.Error("Failed to resolve system-managed env vars for kind-sourced agent workload",
+					"agentName", req.Name, "ouID", ouID, "projectName", projectName, "environment", firstEnv, "error", envErr)
 				rollbackAgentCreate("system env var resolution failure")
 				return envErr
 			}

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1668,7 +1668,7 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 			// createAgentMCPConfigs never reach the container. The Workload CR is authoritative
 			// for these agents, so resolve those env vars from the persisted config and inject
 			// them here.
-			kindEnvVars, envErr := s.mergeKindWorkloadSystemEnvVars(ctx, ouID, projectName, firstEnv, req, kindEnvVars)
+			kindEnvVars, envErr := s.mergeKindWorkloadSystemEnvVars(ctx, req.Name, ouID, projectName, firstEnv, kindEnvVars)
 			if envErr != nil {
 				s.logger.Error("Failed to resolve system-managed env vars for kind-sourced agent workload", "agentName", req.Name, "environment", firstEnv, "error", envErr)
 				rollbackAgentCreate("system env var resolution failure")
@@ -1772,21 +1772,22 @@ func (s *agentManagerService) triggerInitialBuild(ctx context.Context, ouID, pro
 }
 
 // mergeKindWorkloadSystemEnvVars appends the system-managed env vars (proxy URL + API key secret
-// ref, for both LLM and MCP configurations) for the first environment onto the user-supplied env
-// vars of a kind-sourced agent. Kind-sourced agents create their Workload CR directly, bypassing
-// the build/workflow system that otherwise carries these vars into the container, so they must be
-// injected into the Workload here. When the agent has no system-managed configuration at all,
-// userEnvVars is returned unchanged.
+// ref, for every DB-backed config type) for the first environment onto the user-supplied env vars
+// of a kind-sourced agent. Kind-sourced agents create their Workload CR directly, bypassing the
+// build/workflow system that otherwise carries these vars into the container, so they must be
+// injected into the Workload here.
+//
+// The resolver is consulted unconditionally and reports what the agent's configs actually are,
+// rather than this deciding up front which config types are worth resolving. Enumerating the
+// types here is what previously dropped the env vars of an MCP-only agent, and would drop them
+// again for the next config type added.
 func (s *agentManagerService) mergeKindWorkloadSystemEnvVars(
-	ctx context.Context, ouID, projectName, firstEnv string, req *spec.CreateAgentRequest, userEnvVars []client.EnvVar,
+	ctx context.Context, agentName, ouID, projectName, firstEnv string, userEnvVars []client.EnvVar,
 ) ([]client.EnvVar, error) {
-	if len(req.ModelConfig) == 0 && len(req.McpConfig) == 0 {
-		return userEnvVars, nil
-	}
-	systemEnvVars, err := s.agentConfigurationService.BuildSystemManagedEnvVarsFromConfig(ctx, req.Name, ouID, projectName, firstEnv)
+	systemEnvVars, err := s.agentConfigurationService.BuildSystemManagedEnvVarsFromConfig(ctx, agentName, ouID, projectName, firstEnv)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build system-managed env vars: agentName %s, ouID %s, projectName %s, env %s, error: %w",
-			req.Name, ouID, projectName, firstEnv, err)
+			agentName, ouID, projectName, firstEnv, err)
 	}
 	return append(userEnvVars, systemEnvVars...), nil
 }

--- a/agent-manager-service/services/agent_manager_llmconfig_test.go
+++ b/agent-manager-service/services/agent_manager_llmconfig_test.go
@@ -67,11 +67,11 @@ func TestCreateAgentLLMConfigs_KeysUnderFirstEnv(t *testing.T) {
 	require.Equal(t, "openai", got.ProviderName)
 }
 
-// TestMergeKindWorkloadLLMEnvVars_InjectsLLMEnvVars verifies that for a kind-sourced agent
+// TestMergeKindWorkloadSystemEnvVars_InjectsLLMEnvVars verifies that for a kind-sourced agent
 // with an LLM configuration, the resolved system-managed LLM env vars are appended to the
 // user-supplied env vars that get baked into the Workload CR. Regression test for the bug where
 // LLM provider keys were written to the (unused) Component workflow params instead of the Workload.
-func TestMergeKindWorkloadLLMEnvVars_InjectsLLMEnvVars(t *testing.T) {
+func TestMergeKindWorkloadSystemEnvVars_InjectsLLMEnvVars(t *testing.T) {
 	llmVars := []client.EnvVar{
 		{Key: "OPENAI_BASE_URL", Value: "https://gw/openai"},
 		{Key: "OPENAI_API_KEY", ValueFrom: &client.EnvVarValueFrom{
@@ -82,30 +82,59 @@ func TestMergeKindWorkloadLLMEnvVars_InjectsLLMEnvVars(t *testing.T) {
 	s := &agentManagerService{agentConfigurationService: spy}
 
 	userVars := []client.EnvVar{{Key: "USER_VAR", Value: "v"}}
-	got, err := s.mergeKindWorkloadLLMEnvVars(context.Background(), "my-agent", "org", "proj", "Development", userVars, true)
+	req := &spec.CreateAgentRequest{Name: "my-agent", ModelConfig: []spec.ModelConfigRequest{{ProviderName: "openai"}}}
+	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, userVars)
 	require.NoError(t, err)
 	require.Equal(t, append(append([]client.EnvVar{}, userVars...), llmVars...), got,
 		"user env vars must be preserved and LLM env vars appended")
 }
 
-// TestMergeKindWorkloadLLMEnvVars_NoModelConfig verifies that without an LLM configuration the
-// resolver is not consulted and the user env vars pass through unchanged.
-func TestMergeKindWorkloadLLMEnvVars_NoModelConfig(t *testing.T) {
+// TestMergeKindWorkloadSystemEnvVars_InjectsMCPEnvVars verifies that a kind-sourced agent
+// configured with ONLY an MCP connection (no LLM provider) still gets its system-managed MCP env
+// vars baked into the Workload CR. Regression test for the bug where the injection was gated on
+// the presence of a model config, so an MCP-only agent deployed with no MCP URL or API key in its
+// container and failed on every tool call.
+func TestMergeKindWorkloadSystemEnvVars_InjectsMCPEnvVars(t *testing.T) {
+	mcpVars := []client.EnvVar{
+		{Key: "MY_AGENT_MCP_1_URL", Value: "https://gw/default/booking/mcp"},
+		{Key: "MY_AGENT_MCP_1_API_KEY", ValueFrom: &client.EnvVarValueFrom{
+			SecretKeyRef: &client.SecretKeyRef{Name: "secret-ref", Key: "api-key"},
+		}},
+	}
+	spy := &spyConfigService{systemEnvVars: mcpVars}
+	s := &agentManagerService{agentConfigurationService: spy}
+
+	userVars := []client.EnvVar{{Key: "USER_VAR", Value: "v"}}
+	req := &spec.CreateAgentRequest{
+		Name:      "my-agent",
+		McpConfig: []spec.MCPConfigRequest{{ProxyName: "booking"}},
+	}
+	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, userVars)
+	require.NoError(t, err)
+	require.Equal(t, append(append([]client.EnvVar{}, userVars...), mcpVars...), got,
+		"user env vars must be preserved and MCP env vars appended")
+}
+
+// TestMergeKindWorkloadSystemEnvVars_NoSystemConfig verifies that with neither an LLM nor an MCP
+// configuration the resolver is not consulted and the user env vars pass through unchanged.
+func TestMergeKindWorkloadSystemEnvVars_NoSystemConfig(t *testing.T) {
 	spy := &spyConfigService{systemEnvVarsE: errors.New("resolver must not be called")}
 	s := &agentManagerService{agentConfigurationService: spy}
 
 	userVars := []client.EnvVar{{Key: "USER_VAR", Value: "v"}}
-	got, err := s.mergeKindWorkloadLLMEnvVars(context.Background(), "my-agent", "org", "proj", "Development", userVars, false)
+	req := &spec.CreateAgentRequest{Name: "my-agent"}
+	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, userVars)
 	require.NoError(t, err)
 	require.Equal(t, userVars, got)
 }
 
-// TestMergeKindWorkloadLLMEnvVars_ResolverError verifies the resolver error is propagated so the
-// caller can roll back the partially-created agent rather than deploying without LLM keys.
-func TestMergeKindWorkloadLLMEnvVars_ResolverError(t *testing.T) {
+// TestMergeKindWorkloadSystemEnvVars_ResolverError verifies the resolver error is propagated so the
+// caller can roll back the partially-created agent rather than deploying without system keys.
+func TestMergeKindWorkloadSystemEnvVars_ResolverError(t *testing.T) {
 	spy := &spyConfigService{systemEnvVarsE: errors.New("boom")}
 	s := &agentManagerService{agentConfigurationService: spy}
 
-	_, err := s.mergeKindWorkloadLLMEnvVars(context.Background(), "my-agent", "org", "proj", "Development", nil, true)
+	req := &spec.CreateAgentRequest{Name: "my-agent", ModelConfig: []spec.ModelConfigRequest{{ProviderName: "openai"}}}
+	_, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, nil)
 	require.Error(t, err)
 }

--- a/agent-manager-service/services/agent_manager_llmconfig_test.go
+++ b/agent-manager-service/services/agent_manager_llmconfig_test.go
@@ -82,8 +82,7 @@ func TestMergeKindWorkloadSystemEnvVars_InjectsLLMEnvVars(t *testing.T) {
 	s := &agentManagerService{agentConfigurationService: spy}
 
 	userVars := []client.EnvVar{{Key: "USER_VAR", Value: "v"}}
-	req := &spec.CreateAgentRequest{Name: "my-agent", ModelConfig: []spec.ModelConfigRequest{{ProviderName: "openai"}}}
-	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, userVars)
+	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "my-agent", "org", "proj", "Development", userVars)
 	require.NoError(t, err)
 	require.Equal(t, append(append([]client.EnvVar{}, userVars...), llmVars...), got,
 		"user env vars must be preserved and LLM env vars appended")
@@ -105,25 +104,21 @@ func TestMergeKindWorkloadSystemEnvVars_InjectsMCPEnvVars(t *testing.T) {
 	s := &agentManagerService{agentConfigurationService: spy}
 
 	userVars := []client.EnvVar{{Key: "USER_VAR", Value: "v"}}
-	req := &spec.CreateAgentRequest{
-		Name:      "my-agent",
-		McpConfig: []spec.MCPConfigRequest{{ProxyName: "booking"}},
-	}
-	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, userVars)
+	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "my-agent", "org", "proj", "Development", userVars)
 	require.NoError(t, err)
 	require.Equal(t, append(append([]client.EnvVar{}, userVars...), mcpVars...), got,
 		"user env vars must be preserved and MCP env vars appended")
 }
 
-// TestMergeKindWorkloadSystemEnvVars_NoSystemConfig verifies that with neither an LLM nor an MCP
-// configuration the resolver is not consulted and the user env vars pass through unchanged.
+// TestMergeKindWorkloadSystemEnvVars_NoSystemConfig verifies that an agent whose configs yield no
+// system-managed vars gets its user env vars back unchanged. The resolver is still consulted — it
+// is the authority on which configs exist — and reports the empty result itself.
 func TestMergeKindWorkloadSystemEnvVars_NoSystemConfig(t *testing.T) {
-	spy := &spyConfigService{systemEnvVarsE: errors.New("resolver must not be called")}
+	spy := &spyConfigService{systemEnvVars: nil}
 	s := &agentManagerService{agentConfigurationService: spy}
 
 	userVars := []client.EnvVar{{Key: "USER_VAR", Value: "v"}}
-	req := &spec.CreateAgentRequest{Name: "my-agent"}
-	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, userVars)
+	got, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "my-agent", "org", "proj", "Development", userVars)
 	require.NoError(t, err)
 	require.Equal(t, userVars, got)
 }
@@ -134,7 +129,6 @@ func TestMergeKindWorkloadSystemEnvVars_ResolverError(t *testing.T) {
 	spy := &spyConfigService{systemEnvVarsE: errors.New("boom")}
 	s := &agentManagerService{agentConfigurationService: spy}
 
-	req := &spec.CreateAgentRequest{Name: "my-agent", ModelConfig: []spec.ModelConfigRequest{{ProviderName: "openai"}}}
-	_, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "org", "proj", "Development", req, nil)
+	_, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "my-agent", "org", "proj", "Development", nil)
 	require.Error(t, err)
 }

--- a/agent-manager-service/services/agent_manager_llmconfig_test.go
+++ b/agent-manager-service/services/agent_manager_llmconfig_test.go
@@ -126,9 +126,10 @@ func TestMergeKindWorkloadSystemEnvVars_NoSystemConfig(t *testing.T) {
 // TestMergeKindWorkloadSystemEnvVars_ResolverError verifies the resolver error is propagated so the
 // caller can roll back the partially-created agent rather than deploying without system keys.
 func TestMergeKindWorkloadSystemEnvVars_ResolverError(t *testing.T) {
-	spy := &spyConfigService{systemEnvVarsE: errors.New("boom")}
+	resolverErr := errors.New("boom")
+	spy := &spyConfigService{systemEnvVarsE: resolverErr}
 	s := &agentManagerService{agentConfigurationService: spy}
 
 	_, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "my-agent", "org", "proj", "Development", nil)
-	require.Error(t, err)
+	require.ErrorIs(t, err, resolverErr, "resolver error must stay unwrappable so callers can inspect it")
 }


### PR DESCRIPTION
## Purpose
Resolves #1580

An agent created from an Agent Kind with an MCP connection deployed without any MCP environment variables in its container. The MCP configuration was persisted correctly (with a resolved proxy URL and API key), but neither `<AGENT>_MCP_1_URL` nor `<AGENT>_MCP_1_API_KEY` reached the pod, so every tool call failed.

Root cause: kind-sourced agents bypass the build/workflow system and get their Workload CR created directly, so the env vars that `createAgentLLMConfigs`/`createAgentMCPConfigs` write into the Component's workflow params never reach the container. The Workload injection that compensates for this was gated on `len(req.ModelConfig) > 0`, so an agent with an MCP config but no LLM provider skipped it entirely.

This is specific to the creation path. Adding an MCP config to an *existing* kind agent already works, because by then the ReleaseBinding exists and gets patched. At creation time the ReleaseBinding does not exist yet, which is why the Workload injection is the only delivery path in that window.

## Goals
- MCP-only kind agents get their system-managed env vars into the container at creation.
- Remove the class of bug rather than the instance: the injection no longer enumerates config types by hand, so a future config type cannot silently regress the same way.

## Approach
Two commits.

**1. `Inject MCP env vars into kind-sourced agent workloads`** — widened the gate to cover MCP and moved the decision out of the call site into the function, so the caller cannot forget a config type. Renamed `mergeKindWorkloadLLMEnvVars` to `mergeKindWorkloadSystemEnvVars` since the LLM-specific naming was half of what invited the gap.

**2. `Resolve kind workload env vars from config instead of request shape`** — dropped the gate entirely. `BuildSystemManagedEnvVarsFromConfig` already iterates every persisted config and switches on type, so it is the authority on what an agent has; the caller no longer re-derives that from the request shape. A third config type now works with no change at this call site.

That change alone would have added a remote OpenChoreo environment lookup for every config-less agent, plus a new failure mode where creation fails on a lookup whose result is not needed — `resolveEnvironmentUUID` ran before the config list. So `BuildSystemManagedEnvVarsFromConfig` now lists configs first and returns early when there are none. The skip-when-nothing-to-do behaviour is preserved without the enumeration, and the no-config path is strictly cheaper than before.

No change was needed to the env-var resolution itself — it was already MCP-aware.

## User stories
As a platform user, when I create an agent from an Agent Kind and attach an MCP server, the agent can call that MCP server's tools without further manual configuration.

## Release note
Fixed MCP environment variables not being injected into agents created from an Agent Kind when no LLM provider was attached.

## Documentation
N/A — bug fix with no user-facing API, schema, or configuration change. The documented behaviour was already what this now does.

## Training
N/A — no training content covers Agent Kind MCP env var injection.

## Certification
N/A — internal env var injection path; no impact on certification exam content.

## Marketing
N/A — bug fix.

## Automation tests
- Unit tests
  > `agent-manager-service/services/agent_manager_llmconfig_test.go`. Added `TestMergeKindWorkloadSystemEnvVars_InjectsMCPEnvVars` covering the MCP-only case, which is the regression. Widened `_NoModelConfig` to `_NoSystemConfig` — it previously asserted the buggy gate (resolver not consulted without a model config) and now asserts the resolver is consulted and reports the empty result itself. `_InjectsLLMEnvVars` and `_ResolverError` retained. The changed function is covered by 4 tests; the full unit tier passes and `golangci-lint` reports 0 issues.
- Integration tests
  > No new integration tests. The behaviour needs a live OpenChoreo control plane plus a deployed MCP proxy, which the integration tier does not currently provision. Verified manually end-to-end instead (see Test environment).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — FindSecurityBugs is a Java/SpotBugs plugin and this change is Go. Ran the repo's `golangci-lint` config instead (0 issues).
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes. The fix is exercised by the existing Agent Kind creation flow.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data migration. The fix changes only how env vars are assembled at agent creation.

## Test environment
- Go 1.26.6, Linux x86_64
- Local k3d cluster with the OpenChoreo control plane and data plane, agent-manager-service via docker-compose
- Verified against issue #1580's reproduction: created an MCP-only agent from an Agent Kind and confirmed both `_MCP_1_URL` and `_MCP_1_API_KEY` are present in the Workload CR and in the running pod's environment, with a correctly resolved gateway URL and an injected key. Re-verified the config-less path after the second commit: creation succeeds, the workload carries only the user's own vars, and no resolver error is logged.

## Learning
The two delivery paths for system-managed env vars are what made this bug non-obvious: post-creation config changes land via the ReleaseBinding's `workloadOverrides`, while creation-time config can only land via the Workload CR, because the ReleaseBinding does not exist yet. Checking only the Workload CR makes the working path look broken, and checking only the ReleaseBinding makes the broken path look fine. The promote path was a useful reference for the fix — it already gates the same resolver on DB state rather than request fields, which is the pattern the second commit adopts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kind-sourced agents now receive all applicable system-managed environment variables, including MCP configuration.
  * Agents without system configuration are handled cleanly without unnecessary environment lookups.
  * Configuration resolution failures continue to trigger safe creation rollback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->