### PR TITLE
Add network policy for build-workflows

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/_helpers.tpl
@@ -113,3 +113,12 @@ the controller rather than by Helm.
 {{- printf "%s.${metadata.componentNamespace}-${metadata.environmentName}" $svc -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Stamped onto build-stage pods (Argo applies templates[].metadata to the pod), and the only
+thing build-workflow-networkpolicy.yaml's podSelector can match — CR labels never reach the pod.
+*/}}
+{{- define "amp.buildWorkflowPodLabels" -}}
+app.kubernetes.io/name: amp-build
+app.kubernetes.io/component: build-workflow
+{{- end -}}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-namespace.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-namespace.yaml
@@ -1,7 +1,13 @@
 {{- if .Values.networkPolicy.buildWorkflows.enabled }}
-{{- $buildNamespace := .Values.networkPolicy.buildWorkflows.namespace | default (printf "workflows-%s" (.Values.environment.name | default "default")) }}
-{{- if ne $buildNamespace .Release.Namespace }}
-{{- if not (lookup "v1" "Namespace" "" $buildNamespace) }}
+{{- $bw := .Values.networkPolicy.buildWorkflows }}
+{{- $namespaces := without ($bw.namespaces | default list) "" nil }}
+{{- if not $namespaces }}
+{{- $namespaces = list (printf "workflows-%s" (.Values.environment.name | default "default")) }}
+{{- end }}
+{{- range $namespace := $namespaces }}
+{{- if ne $namespace $.Release.Namespace }}
+{{- if not (lookup "v1" "Namespace" "" $namespace) }}
+---
 # OpenChoreo does not create this namespace until a workflow first runs there, so rendering
 # only the NetworkPolicy fails a fresh install with `namespaces "<name>" not found`.
 #
@@ -16,11 +22,12 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ $buildNamespace }}
+  name: {{ $namespace }}
   annotations:
     helm.sh/resource-policy: keep
   labels:
-{{- include "amp-build-extension.labels" . | nindent 4 }}
+{{- include "amp-build-extension.labels" $ | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-namespace.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-namespace.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.networkPolicy.buildWorkflows.enabled }}
+{{- $buildNamespace := .Values.networkPolicy.buildWorkflows.namespace | default (printf "workflows-%s" (.Values.environment.name | default "default")) }}
+{{- if ne $buildNamespace .Release.Namespace }}
+{{- if not (lookup "v1" "Namespace" "" $buildNamespace) }}
+# OpenChoreo does not create this namespace until a workflow first runs there, so rendering
+# only the NetworkPolicy fails a fresh install with `namespaces "<name>" not found`.
+#
+# Only when it is absent: Helm refuses to adopt a resource lacking its ownership metadata,
+# so rendering unconditionally fails with `invalid ownership metadata` wherever OpenChoreo,
+# an installer, or the evaluation chart created it first. The lookup needs a live cluster;
+# a path without one (helm template, GitOps dry-run) emits it, which is correct for a first
+# install and the safe direction to be wrong in.
+#
+# resource-policy: keep — OpenChoreo owns this namespace's lifecycle and it holds running
+# workflows, so uninstalling this chart must never delete it.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $buildNamespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+{{- include "amp-build-extension.labels" . | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-networkpolicy.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-networkpolicy.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.networkPolicy.buildWorkflows.enabled }}
+{{- $buildNamespace := .Values.networkPolicy.buildWorkflows.namespace | default (printf "workflows-%s" (.Values.environment.name | default "default")) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: amp-build-workflow-egress
+  namespace: {{ $buildNamespace }}
+  labels:
+{{- include "amp-build-extension.labels" . | nindent 4 }}
+spec:
+  # generate-workload-cr is unlabelled and so unselected: it calls the OpenChoreo API and
+  # Thunder, and runs no user content.
+  podSelector:
+    matchLabels:
+{{- include "amp.buildWorkflowPodLabels" . | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    # Matched post-DNAT: every rule names the backing pod's address and containerPort, not the Service's.
+
+    # Scoped to the DNS workload, not left open — build pods run untrusted code.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.buildWorkflows.dns.namespace }}
+          podSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.buildWorkflows.dns.podLabel.key }}: {{ .Values.networkPolicy.buildWorkflows.dns.podLabel.value }}
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+
+    # The point of the policy: builds keep the internet, lose the private network. No
+    # `ports`, so a mirror or registry on a non-standard port cannot break.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            {{- $excluded := without (.Values.networkPolicy.buildWorkflows.internet.excludedCidrs | default list) "" nil }}
+            {{- with $excluded }}
+            except:
+              {{- range . }}
+              - {{ . }}
+              {{- end }}
+            {{- end }}
+        {{- $v6 := without (.Values.networkPolicy.buildWorkflows.internet.excludedCidrsV6 | default list) "" nil }}
+        {{- if .Values.networkPolicy.buildWorkflows.internet.ipv6 }}
+        # A policy with only an IPv4 block denies all IPv6 egress, so dual-stack builds fail.
+        - ipBlock:
+            cidr: ::/0
+            {{- with $v6 }}
+            except:
+              {{- range . }}
+              - {{ . }}
+              {{- end }}
+            {{- end }}
+        {{- end }}
+
+    {{- with .Values.networkPolicy.buildWorkflows.apiServer }}
+    {{- $cidrs := without (.cidrs | default list) "" nil }}
+    {{- if and $cidrs .ports }}
+    # wait reports WorkflowTaskResults here; no pod backs the API server, so ipBlock. Pods
+    # are the unit of policy, so this reaches the build container too — workflow-sa can only
+    # create/patch workflowtaskresults.
+    - to:
+        {{- range $cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        {{- range .ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.networkPolicy.buildWorkflows.registry }}
+    {{- $cidrs := without (.cidrs | default list) "" nil }}
+    {{- if and $cidrs .ports }}
+    # publish-image pushes here and build-image pulls cached buildpacks; reached on the node
+    # network, which the internet rule's except withholds. registry.<baseDomain> needs no rule.
+    - to:
+        {{- range $cidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        {{- range .ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.networkPolicy.buildWorkflows.registry }}
+    {{- with .inCluster }}
+    {{- if and .namespace .ports }}
+    # A registry addressed by Service DNS is matched post-DNAT, so this names the registry
+    # pod's namespace and its containerPort — the Service's own port never matches.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .namespace }}
+      ports:
+        {{- range .ports }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+
+    {{- with .Values.networkPolicy.buildWorkflows.extraEgress }}
+    # Private-network destinations a build needs: self-hosted git, internal registry, proxy.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-networkpolicy.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/build-workflow-networkpolicy.yaml
@@ -1,18 +1,24 @@
 {{- if .Values.networkPolicy.buildWorkflows.enabled }}
-{{- $buildNamespace := .Values.networkPolicy.buildWorkflows.namespace | default (printf "workflows-%s" (.Values.environment.name | default "default")) }}
+{{- $bw := .Values.networkPolicy.buildWorkflows }}
+{{- $namespaces := without ($bw.namespaces | default list) "" nil }}
+{{- if not $namespaces }}
+{{- $namespaces = list (printf "workflows-%s" (.Values.environment.name | default "default")) }}
+{{- end }}
+{{- range $namespace := $namespaces }}
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: amp-build-workflow-egress
-  namespace: {{ $buildNamespace }}
+  namespace: {{ $namespace }}
   labels:
-{{- include "amp-build-extension.labels" . | nindent 4 }}
+{{- include "amp-build-extension.labels" $ | nindent 4 }}
 spec:
   # generate-workload-cr is unlabelled and so unselected: it calls the OpenChoreo API and
   # Thunder, and runs no user content.
   podSelector:
     matchLabels:
-{{- include "amp.buildWorkflowPodLabels" . | nindent 6 }}
+{{- include "amp.buildWorkflowPodLabels" $ | nindent 6 }}
   policyTypes: [Egress]
   egress:
     # Matched post-DNAT: every rule names the backing pod's address and containerPort, not the Service's.
@@ -21,10 +27,10 @@ spec:
     - to:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.networkPolicy.buildWorkflows.dns.namespace }}
+              kubernetes.io/metadata.name: {{ $bw.dns.namespace }}
           podSelector:
             matchLabels:
-              {{ .Values.networkPolicy.buildWorkflows.dns.podLabel.key }}: {{ .Values.networkPolicy.buildWorkflows.dns.podLabel.value }}
+              {{ $bw.dns.podLabel.key }}: {{ $bw.dns.podLabel.value }}
       ports:
         - port: 53
           protocol: UDP
@@ -36,19 +42,17 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
-            {{- $excluded := without (.Values.networkPolicy.buildWorkflows.internet.excludedCidrs | default list) "" nil }}
-            {{- with $excluded }}
+            {{- with without ($bw.internet.excludedCidrs | default list) "" nil }}
             except:
               {{- range . }}
               - {{ . }}
               {{- end }}
             {{- end }}
-        {{- $v6 := without (.Values.networkPolicy.buildWorkflows.internet.excludedCidrsV6 | default list) "" nil }}
-        {{- if .Values.networkPolicy.buildWorkflows.internet.ipv6 }}
+        {{- if $bw.internet.ipv6 }}
         # A policy with only an IPv4 block denies all IPv6 egress, so dual-stack builds fail.
         - ipBlock:
             cidr: ::/0
-            {{- with $v6 }}
+            {{- with without ($bw.internet.excludedCidrsV6 | default list) "" nil }}
             except:
               {{- range . }}
               - {{ . }}
@@ -56,7 +60,7 @@ spec:
             {{- end }}
         {{- end }}
 
-    {{- with .Values.networkPolicy.buildWorkflows.apiServer }}
+    {{- with $bw.apiServer }}
     {{- $cidrs := without (.cidrs | default list) "" nil }}
     {{- if and $cidrs .ports }}
     # wait reports WorkflowTaskResults here; no pod backs the API server, so ipBlock. Pods
@@ -75,7 +79,7 @@ spec:
     {{- end }}
     {{- end }}
 
-    {{- with .Values.networkPolicy.buildWorkflows.registry }}
+    {{- with $bw.registry }}
     {{- $cidrs := without (.cidrs | default list) "" nil }}
     {{- if and $cidrs .ports }}
     # publish-image pushes here and build-image pulls cached buildpacks; reached on the node
@@ -91,17 +95,21 @@ spec:
           protocol: TCP
         {{- end }}
     {{- end }}
-    {{- end }}
 
-    {{- with .Values.networkPolicy.buildWorkflows.registry }}
     {{- with .inCluster }}
     {{- if and .namespace .ports }}
     # A registry addressed by Service DNS is matched post-DNAT, so this names the registry
-    # pod's namespace and its containerPort — the Service's own port never matches.
+    # pod's namespace and its containerPort — the Service's own port never matches. Without
+    # podLabels this reaches every pod in that namespace on those ports.
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .namespace }}
+          {{- with .podLabels }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
       ports:
         {{- range .ports }}
         - port: {{ . }}
@@ -111,8 +119,9 @@ spec:
     {{- end }}
     {{- end }}
 
-    {{- with .Values.networkPolicy.buildWorkflows.extraEgress }}
+    {{- with $bw.extraEgress }}
     # Private-network destinations a build needs: self-hosted git, internal registry, proxy.
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/ballerina-buildpack-build.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/ballerina-buildpack-build.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   templates:
     - name: build-image
+      metadata:
+        labels:
+{{- include "amp.buildWorkflowPodLabels" . | nindent 10 }}
       inputs:
         parameters:
           - name: git-revision

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/checkout-source.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/checkout-source.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   templates:
     - name: checkout
+      metadata:
+        labels:
+{{- include "amp.buildWorkflowPodLabels" . | nindent 10 }}
       outputs:
         parameters:
           - name: git-revision

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/dockefile-build.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/dockefile-build.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   templates:
     - name: build-image
+      metadata:
+        labels:
+{{- include "amp.buildWorkflowPodLabels" . | nindent 10 }}
       # User-namespaced builds need idmapped-mount kernel support (~6.3+);
       # buildWorkflows.userNamespaces in values.yaml documents the trade-off.
       podSpecPatch: '{{ if .Values.buildWorkflows.userNamespaces }}{"hostUsers": false}{{ else }}{}{{ end }}'

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/gcp-buildpack-build.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/gcp-buildpack-build.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   templates:
     - name: build-image
+      metadata:
+        labels:
+{{- include "amp.buildWorkflowPodLabels" . | nindent 10 }}
       # User-namespaced builds need idmapped-mount kernel support (~6.3+);
       # buildWorkflows.userNamespaces in values.yaml documents the trade-off.
       podSpecPatch: '{{ if .Values.buildWorkflows.userNamespaces }}{"hostUsers": false}{{ else }}{}{{ end }}'

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/publish-image.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/publish-image.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   templates:
     - name: publish-image
+      metadata:
+        labels:
+{{- include "amp.buildWorkflowPodLabels" . | nindent 10 }}
       inputs:
         parameters:
           - name: git-revision

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/build-egress-render.sh
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/build-egress-render.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Render assertions for the build-workflow egress NetworkPolicy.
+# Run: bash deployments/helm-charts/wso2-amp-platform-resources-extension/tests/build-egress-render.sh
+#
+# The policy is matched post-DNAT, and is inert without the pod labels its podSelector
+# targets — so both are asserted here. Kept separate from render.sh, which covers the
+# shell quoting of the build steps.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=0
+
+render() {
+  local out
+  if ! out="$(helm template test-release "$CHART_DIR" "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$out" >&2
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
+# probe <python-expr-file> [helm --set args...]
+probe() {
+  local script="$1"; shift
+  local rendered
+  rendered="$(render "$@")" || return 1
+  printf '%s' "$rendered" | python3 -c "$script"
+}
+
+assert() {
+  local label="$1" expected="$2" script="$3"
+  shift 3
+  local actual
+  # Without this, a render failure returns empty and reads as a passing "no rule" case.
+  if ! actual="$(probe "$script" "$@")"; then
+    printf 'FAIL - %s\n      render failed\n' "$label"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected: %q\n      actual:   %q\n' "$label" "$expected" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# --- the policy itself ---------------------------------------------------------------
+
+READ_NETPOL='
+import sys, yaml
+policy = None
+for doc in yaml.safe_load_all(sys.stdin):
+    if doc and doc.get("kind") == "NetworkPolicy" and doc["metadata"]["name"] == "amp-build-workflow-egress":
+        policy = doc
+if policy is None:
+    print("ABSENT")
+    raise SystemExit
+'
+
+INTERNET_RULE=$READ_NETPOL'
+for rule in policy["spec"]["egress"]:
+    blocks = [t["ipBlock"] for t in rule.get("to") or [] if "ipBlock" in t]
+    if any(b["cidr"] == "0.0.0.0/0" for b in blocks):
+        # Reported, never skipped: a ports key here would break a non-standard-port mirror.
+        ports = ",".join(str(p["port"]) for p in rule.get("ports") or []) or "ALL"
+        print(ports + "|" + ",".join(blocks[0].get("except") or []))
+'
+
+# cidrs of the ipBlock rule carrying <port>
+IPBLOCK_RULE=$READ_NETPOL'
+import os
+want = os.environ["WANT_PORT"]
+for rule in policy["spec"]["egress"]:
+    ports = [str(p["port"]) for p in rule.get("ports") or []]
+    if want in ports:
+        blocks = [t["ipBlock"]["cidr"] for t in rule.get("to") or [] if "ipBlock" in t]
+        if blocks:
+            print(",".join(blocks) + "|" + ",".join(ports))
+'
+
+NS_RULE=$READ_NETPOL'
+import os
+want = os.environ["WANT_NS_PORT"]
+for rule in policy["spec"]["egress"]:
+    ports = [str(p["port"]) for p in rule.get("ports") or []]
+    if want not in ports:
+        continue
+    for t in rule.get("to") or []:
+        ns = (t.get("namespaceSelector") or {}).get("matchLabels", {})
+        if ns and not t.get("podSelector"):
+            print(ns["kubernetes.io/metadata.name"] + "|" + ",".join(ports))
+'
+
+# Every rule carrying port 5000, so an unset in-cluster namespace can be shown to render none.
+NS_RULE_PORTS=$READ_NETPOL'
+for rule in policy["spec"]["egress"]:
+    if "5000" in [str(p["port"]) for p in rule.get("ports") or []]:
+        print("PRESENT")
+'
+
+DNS_RULE=$READ_NETPOL'
+for rule in policy["spec"]["egress"]:
+    for t in rule.get("to") or []:
+        ns = (t.get("namespaceSelector") or {}).get("matchLabels", {})
+        pod = (t.get("podSelector") or {}).get("matchLabels", {})
+        if ns or pod:
+            print(",".join(f"{k}={v}" for k, v in sorted({**ns, **pod}.items()))
+                  + "|" + ",".join(f'"'"'{p["protocol"]}{p["port"]}'"'"' for p in rule.get("ports") or []))
+'
+
+# Guards a render that quietly attaches ports, or drops an except CIDR (169.254.0.0/16 is
+# what blocks the cloud metadata endpoint).
+assert "internet rule is portless and withholds every private range" \
+  "ALL|10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,100.64.0.0/10" \
+  "$INTERNET_RULE"
+
+# Emptying the list is the documented way to open the policy right up; a bare `except:`
+# key would be rendered instead of dropping it.
+assert "an empty excludedCidrs list drops the except key" \
+  "ALL|" \
+  "$INTERNET_RULE" --set "networkPolicy.buildWorkflows.internet.excludedCidrs={}"
+
+# A policy with only an IPv4 block denies every IPv6 destination, so dual-stack builds fail.
+assert "the internet rule covers IPv6 as well as IPv4" \
+  "0.0.0.0/0,::/0" \
+  "$READ_NETPOL"'
+for rule in policy["spec"]["egress"]:
+    blocks = [t["ipBlock"]["cidr"] for t in rule.get("to") or [] if "ipBlock" in t]
+    if "0.0.0.0/0" in blocks:
+        print(",".join(blocks))
+'
+
+# The chart must be installable before OpenChoreo has created workflows-<env>.
+assert "a Namespace is rendered alongside the policy" \
+  "workflows-default" \
+  '
+import sys, yaml
+for doc in yaml.safe_load_all(sys.stdin):
+    if doc and doc.get("kind") == "Namespace":
+        print(doc["metadata"]["name"])
+'
+
+assert "DNS egress is scoped to the kube-dns workload" \
+  'k8s-app=kube-dns,kubernetes.io/metadata.name=kube-system|UDP53,TCP53' \
+  "$DNS_RULE"
+
+WANT_PORT=6443 assert "default render carries the API-server rule on both control-plane ports" \
+  "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16|443,6443" \
+  "$IPBLOCK_RULE"
+
+WANT_PORT=10082 assert "default render carries the registry rule" \
+  "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16|10082" \
+  "$IPBLOCK_RULE"
+
+# --set cidrs[0]=X must replace the RFC1918 default, not merge into it.
+WANT_PORT=6443 assert "apiServer.cidrs[0] override replaces the default list" \
+  "172.19.0.0/16|443,6443" \
+  "$IPBLOCK_RULE" --set "networkPolicy.buildWorkflows.apiServer.cidrs[0]=172.19.0.0/16"
+
+WANT_PORT=10082 assert "registry.cidrs[0] override replaces the default list" \
+  "172.19.0.0/16|10082" \
+  "$IPBLOCK_RULE" --set "networkPolicy.buildWorkflows.registry.cidrs[0]=172.19.0.0/16"
+
+# `cidr: null` is rejected by the API server, failing the whole install.
+WANT_PORT=6443 assert "an empty apiServer CIDR drops the rule instead of rendering cidr: null" \
+  "" \
+  "$IPBLOCK_RULE" --set "networkPolicy.buildWorkflows.apiServer.cidrs[0]="
+
+assert "extraEgress leaves the internet rule untouched" \
+  "ALL|10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,100.64.0.0/10" \
+  "$INTERNET_RULE" \
+  --set "networkPolicy.buildWorkflows.extraEgress[0].to[0].ipBlock.cidr=10.1.2.0/24"
+
+WANT_PORT=8443 assert "extraEgress rules reach the rendered policy" \
+  "10.1.2.0/24|8443" \
+  "$IPBLOCK_RULE" \
+  --set "networkPolicy.buildWorkflows.extraEgress[0].to[0].ipBlock.cidr=10.1.2.0/24" \
+  --set "networkPolicy.buildWorkflows.extraEgress[0].ports[0].port=8443" \
+  --set "networkPolicy.buildWorkflows.extraEgress[0].ports[0].protocol=TCP"
+
+# The in-cluster registry rule is off by default: an unset namespace must not render a
+# namespaceSelector matching every namespace.
+assert "no in-cluster registry rule without a namespace" \
+  "" \
+  "$NS_RULE_PORTS"
+
+WANT_NS_PORT=5000 assert "in-cluster registry rule names the containerPort, not the Service port" \
+  "openchoreo-workflow-plane|5000" \
+  "$NS_RULE" --set "networkPolicy.buildWorkflows.registry.inCluster.namespace=openchoreo-workflow-plane"
+
+assert "enabled=false renders no policy at all" \
+  "ABSENT" \
+  "$READ_NETPOL"'print("PRESENT")' \
+  --set "networkPolicy.buildWorkflows.enabled=false"
+
+assert "the policy lands in workflows-<environment.name>" \
+  "workflows-staging" \
+  "$READ_NETPOL"'print(policy["metadata"]["namespace"])' \
+  --set "environment.name=staging"
+
+# --- the pod labels the podSelector depends on ---------------------------------------
+
+# The policy is inert if these drift apart, and nothing else would catch it.
+LABELLED_TEMPLATES='
+import sys, yaml
+selector = None
+labelled = []
+for doc in yaml.safe_load_all(sys.stdin):
+    if not doc:
+        continue
+    if doc.get("kind") == "NetworkPolicy" and doc["metadata"]["name"] == "amp-build-workflow-egress":
+        selector = doc["spec"]["podSelector"]["matchLabels"]
+    if doc.get("kind") == "ClusterWorkflowTemplate":
+        for t in doc["spec"].get("templates") or []:
+            if (t.get("metadata") or {}).get("labels"):
+                labelled.append((doc["metadata"]["name"], t["name"], t["metadata"]["labels"]))
+print(",".join(sorted(f"{c}/{t}" for c, t, _ in labelled)))
+assert all(l == selector for _, _, l in labelled), f"pod labels do not match podSelector {selector}"
+'
+
+assert "exactly the untrusted build stages carry the podSelector labels" \
+  "ballerina-buildpack-build/build-image,checkout-source/checkout,containerfile-build/build-image,gcp-buildpacks-build/build-image,publish-image/publish-image" \
+  "$LABELLED_TEMPLATES"
+
+if (( FAILURES )); then
+  printf '\n%d assertion(s) failed\n' "$FAILURES"
+  exit 1
+fi
+printf '\nall assertions passed\n'

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/build-egress-render.sh
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/build-egress-render.sh
@@ -93,6 +93,22 @@ for rule in policy["spec"]["egress"]:
 '
 
 # Every rule carrying port 5000, so an unset in-cluster namespace can be shown to render none.
+NS_RULE_PODS=$READ_NETPOL'
+import os
+want = os.environ["WANT_NS_PORT"]
+for rule in policy["spec"]["egress"]:
+    ports = [str(p["port"]) for p in rule.get("ports") or []]
+    if want not in ports:
+        continue
+    for t in rule.get("to") or []:
+        ns = (t.get("namespaceSelector") or {}).get("matchLabels", {})
+        if not ns:
+            continue
+        pod = (t.get("podSelector") or {}).get("matchLabels", {})
+        print(ns["kubernetes.io/metadata.name"] + "|" + ",".join(ports) + "|"
+              + ",".join(f"{k}={v}" for k, v in sorted(pod.items())))
+'
+
 NS_RULE_PORTS=$READ_NETPOL'
 for rule in policy["spec"]["egress"]:
     if "5000" in [str(p["port"]) for p in rule.get("ports") or []]:
@@ -193,6 +209,31 @@ assert "enabled=false renders no policy at all" \
   "ABSENT" \
   "$READ_NETPOL"'print("PRESENT")' \
   --set "networkPolicy.buildWorkflows.enabled=false"
+
+# One policy per namespace: a multi-environment install must not leave the environments it
+# did not name unprotected.
+assert "one policy and one namespace render per configured namespace" \
+  "NP:workflows-default,workflows-staging NS:workflows-default,workflows-staging" \
+  '
+import sys, yaml
+np, ns = [], []
+for doc in yaml.safe_load_all(sys.stdin):
+    if not doc:
+        continue
+    if doc.get("kind") == "NetworkPolicy" and doc["metadata"]["name"] == "amp-build-workflow-egress":
+        np.append(doc["metadata"]["namespace"])
+    if doc.get("kind") == "Namespace":
+        ns.append(doc["metadata"]["name"])
+print("NP:" + ",".join(sorted(np)) + " NS:" + ",".join(sorted(ns)))
+' \
+  --set "networkPolicy.buildWorkflows.namespaces={workflows-default,workflows-staging}"
+
+# Without a podSelector the rule reaches every pod in the registry's namespace.
+WANT_NS_PORT=5000 assert "in-cluster registry rule carries the registry podSelector" \
+  "openchoreo-workflow-plane|5000|app=docker-registry" \
+  "$NS_RULE_PODS" \
+  --set "networkPolicy.buildWorkflows.registry.inCluster.namespace=openchoreo-workflow-plane" \
+  --set "networkPolicy.buildWorkflows.registry.inCluster.podLabels.app=docker-registry"
 
 assert "the policy lands in workflows-<environment.name>" \
   "workflows-staging" \

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -252,3 +252,58 @@ gatewayTls:
     name: openchoreo-data-plane-selfsigned-issuer
     # Issuer kind: Issuer or ClusterIssuer
     kind: Issuer
+
+# Egress restriction for build-workflow pods (checkout, build-image, publish-image): builds
+# keep the internet, lose the private network. Inert on a CNI that does not enforce policy.
+networkPolicy:
+  buildWorkflows:
+    # -- Enable the build-workflow egress NetworkPolicy
+    enabled: true
+    # -- Namespace OpenChoreo runs this environment's Argo workflows in.
+    # Empty derives "workflows-<environment.name>".
+    namespace: ""
+    dns:
+      namespace: kube-system
+      podLabel:
+        key: k8s-app
+        value: kube-dns
+    internet:
+      # -- Include an ::/0 rule too. A policy carrying only an IPv4 block denies every IPv6
+      # destination, so dual-stack clusters need this; harmless on IPv4-only ones.
+      ipv6: true
+      # -- Withheld from ::/0. fc00::/7 is the IPv6 private range, fe80::/10 link-local.
+      excludedCidrsV6:
+        - fc00::/7
+        - fe80::/10
+      # -- Withheld from the otherwise-unrestricted 0.0.0.0/0 rule; 169.254.0.0/16 is what
+      # blocks the cloud metadata endpoint.
+      excludedCidrs:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - 169.254.0.0/16
+        - 100.64.0.0/10
+    apiServer:
+      # -- Where the kube-apiserver is reachable post-DNAT. Narrow to the node network when
+      # known; the RFC1918 default also spans the pod and Service CIDRs.
+      cidrs:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+      ports: [443, 6443]
+    registry:
+      # -- A registry published on the node network (k3d, and the VM and quick-start
+      # installers, all reach it this way).
+      cidrs:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+      ports: [10082]
+      # -- A registry addressed by in-cluster Service DNS instead. Matched post-DNAT, so
+      # ports is the registry's containerPort (5000 for docker-registry), not the Service
+      # port. Unset by default; registry.<baseDomain> and other public endpoints need no rule.
+      inCluster:
+        namespace: ""
+        ports: [5000]
+    # -- Extra egress rules, appended verbatim (NetworkPolicyEgressRule list).
+    extraEgress: []

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -259,9 +259,10 @@ networkPolicy:
   buildWorkflows:
     # -- Enable the build-workflow egress NetworkPolicy
     enabled: true
-    # -- Namespace OpenChoreo runs this environment's Argo workflows in.
-    # Empty derives "workflows-<environment.name>".
-    namespace: ""
+    # -- Namespaces OpenChoreo runs Argo workflows in, one policy rendered per entry.
+    # Empty derives the single "workflows-<environment.name>"; list every environment's
+    # workflow namespace on an install that has more than one.
+    namespaces: []
     dns:
       namespace: kube-system
       podLabel:
@@ -304,6 +305,9 @@ networkPolicy:
       # port. Unset by default; registry.<baseDomain> and other public endpoints need no rule.
       inCluster:
         namespace: ""
+        # -- Labels of the registry pod. Leave empty and the rule reaches every pod in that
+        # namespace on the ports below; set it to scope the rule to the registry itself.
+        podLabels: {}
         ports: [5000]
     # -- Extra egress rules, appended verbatim (NetworkPolicyEgressRule list).
     extraEgress: []

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -340,13 +340,7 @@ install_evaluation_extension() {
     local chart_version="${VERSION}"
     local release_name="amp-evaluation-extension"
 
-    # The chart's NetworkPolicy targets "workflows-<env>" (workflows-default unless
-    # ampEvaluation.workflowNamespace is overridden) — the namespace OpenChoreo's control
-    # plane runs that environment's Argo workflows in. On a fresh cluster nothing has
-    # triggered a workflow yet, so OpenChoreo hasn't created it and the install fails with
-    # "namespaces \"workflows-default\" not found". Pre-create it (idempotent) so install
-    # order doesn't depend on a workflow having already run.
-    kubectl create namespace workflows-default --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    ensure_workflows_namespace
 
     # The eval pod runs untrusted evaluator code, so scope its API-server egress to the k3d node
     # network rather than taking the chart's RFC1918 default, which also spans pod and service CIDRs.
@@ -395,15 +389,36 @@ install_agent_sandbox_module() {
     return 0
 }
 
+# OpenChoreo creates this only once a workflow has run there, so both charts that place a
+# NetworkPolicy in it would otherwise fail; unowned, neither chart's lookup guard renders it.
+ensure_workflows_namespace() {
+    kubectl create namespace workflows-default --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+}
+
 # Install Platform Resources Extension
 install_platform_resources_extension() {
     local chart_ref="oci://${HELM_CHART_REGISTRY}/${PLATFORM_RESOURCES_CHART_NAME}"
     local chart_version="${VERSION}"
     local release_name="amp-platform-resources"
 
+    ensure_workflows_namespace
+
+    # Narrow the build netpol's API-server and registry egress to the k3d node network,
+    # which carries both; the chart's RFC1918 default also spans pod and service CIDRs.
+    local netpol_args=() node_cidr
+    node_cidr=$(docker network inspect "k3d-${CLUSTER_NAME}" \
+        --format '{{ (index .IPAM.Config 0).Subnet }}' 2>/dev/null || echo "")
+    if [[ -n "$node_cidr" ]]; then
+        netpol_args=(
+            --set "networkPolicy.buildWorkflows.apiServer.cidrs[0]=${node_cidr}"
+            --set "networkPolicy.buildWorkflows.registry.cidrs[0]=${node_cidr}"
+        )
+    fi
+
     # Install Helm chart
     if ! install_amp_helm_chart "${release_name}" "${chart_ref}" "${DEFAULT_NS}" "${TIMEOUT_AMP_INSTALL}" \
         --version "${chart_version}" \
+        ${netpol_args[@]+"${netpol_args[@]}"} \
         "${PLATFORM_RESOURCES_HELM_ARGS[@]}"; then
         return 1
     fi

--- a/deployments/setup/setup-amp-extensions.sh
+++ b/deployments/setup/setup-amp-extensions.sh
@@ -19,6 +19,11 @@ kubectl config use-context $CLUSTER_CONTEXT >/dev/null
 
 echo "=== Installing AMP Extensions ==="
 
+# Two charts put a NetworkPolicy here and install in parallel below; created unowned, so
+# neither chart's lookup guard renders it and neither hits "invalid ownership metadata".
+echo "   Ensuring workflows-default namespace exists..."
+kubectl create namespace workflows-default --dry-run=client -o yaml | kubectl apply -f -
+
 # Pre-update helm dependencies (must run before parallel installs)
 echo "   Updating Helm dependencies..."
 helm dependency update "${SCRIPT_DIR}/../helm-charts/wso2-amp-thunder-extension"
@@ -86,13 +91,6 @@ install_thunder_extension() {
 install_evaluation_workflows() {
     echo "📦 Installing/Upgrading Evaluation Workflows Extension..."
 
-    # The chart's NetworkPolicy targets "workflows-<env>" (workflows-default here) — the
-    # namespace OpenChoreo's control plane runs that environment's Argo workflows in. On a
-    # fresh cluster nothing has triggered a workflow yet, so OpenChoreo hasn't created it and
-    # `helm install` fails with "namespaces \"workflows-default\" not found". Pre-create it
-    # (idempotent) so install order doesn't depend on a workflow having already run.
-    kubectl create namespace workflows-default --dry-run=client -o yaml | kubectl apply -f -
-
     # The k3d node network carries both the API server and the host-published agent-manager-service,
     # so it is the ipBlock for both NetworkPolicy exceptions; disable the policy if we can't compute it.
     local node_cidr network_policy_enabled
@@ -122,8 +120,30 @@ install_evaluation_workflows() {
 install_platform_resources() {
     echo "📦 Installing/Upgrading Default Platform Resources..."
     echo "   Creating default Organization, Project, Environment, and DeploymentPipeline..."
+
+    # Narrow the build netpol's API-server and registry egress to the k3d node network,
+    # which carries both; disable the policy rather than let a failed derivation break builds.
+    # The CIDRs are only passed when derived, so a later --reuse-values upgrade that turns the
+    # policy back on cannot resurrect it with both rules emptied out.
+    local node_cidr
+    local -a netpol_args
+    node_cidr=$(docker network inspect "k3d-${CLUSTER_NAME}" \
+        --format '{{ (index .IPAM.Config 0).Subnet }}' 2>/dev/null || echo "")
+    if [[ -z "$node_cidr" ]]; then
+        echo "⚠️  Could not determine k3d docker network subnet for k3d-${CLUSTER_NAME} — disabling"
+        echo "   the build-workflow egress NetworkPolicy for this install so local builds keep working."
+        netpol_args=(--set networkPolicy.buildWorkflows.enabled=false)
+    else
+        netpol_args=(
+            --set networkPolicy.buildWorkflows.enabled=true
+            --set "networkPolicy.buildWorkflows.apiServer.cidrs[0]=${node_cidr}"
+            --set "networkPolicy.buildWorkflows.registry.cidrs[0]=${node_cidr}"
+        )
+    fi
+
     helm upgrade --install amp-default-platform-resources "${SCRIPT_DIR}/../helm-charts/wso2-amp-platform-resources-extension" \
-        --namespace default
+        --namespace default \
+        "${netpol_args[@]}"
     echo "✅ Default Platform Resources installed/upgraded successfully"
 }
 

--- a/documentation/docs/guides/_partials/_amp-installation.mdx
+++ b/documentation/docs/guides/_partials/_amp-installation.mdx
@@ -426,13 +426,12 @@ This chart also ships `amp-build-workflow-egress`, a `NetworkPolicy` on the `wor
 
 Builds keep **unrestricted egress to the public internet on every port**, IPv4 and IPv6, which is what base images, package registries, and mirrors need. What is withheld is RFC1918, `169.254.0.0/16` (the metadata endpoint), `100.64.0.0/10`, and the IPv6 private and link-local ranges — minus the two re-allowances builds cannot work without: your API server (Argo reports step status there) and your registry. Left at their RFC1918 defaults those two span far more than the intended hosts, so narrow them.
 
-This policy lands in `workflows-<environment>`, which OpenChoreo does not create until a workflow first runs there. The chart creates it if it is absent, so a fresh install works either way; an environment you add later needs its own render with `networkPolicy.buildWorkflows.namespace` set.
+This policy lands in `workflows-<environment>`, which OpenChoreo does not create until a workflow first runs there. The chart creates it if it is absent, so a fresh install works either way. If builds run in more than one workflow namespace on your install, name them all in `networkPolicy.buildWorkflows.namespaces` — one policy is rendered per entry, and a namespace left off the list has no policy.
 
-Two cases need a `--set`:
+Two cases need a `--set`. `kubectl -n default get endpoints kubernetes` prints an address, not a subnet, so turn it into a host CIDR with `/32` (`172.19.0.2` becomes `172.19.0.2/32`) or use the control-plane subnet it sits in if you know it:
 
 ```bash
-  # your control-plane subnet, from `kubectl -n default get endpoints kubernetes`
-  --set "networkPolicy.buildWorkflows.apiServer.cidrs[0]=<control-plane-subnet>" \
+  --set "networkPolicy.buildWorkflows.apiServer.cidrs[0]=<api-server-ip>/32" \
   # the subnet your registry is on, if it is not reached over the public internet
   --set "networkPolicy.buildWorkflows.registry.cidrs[0]=<registry-subnet>"
 ```

--- a/documentation/docs/guides/_partials/_amp-installation.mdx
+++ b/documentation/docs/guides/_partials/_amp-installation.mdx
@@ -421,6 +421,43 @@ Get it wrong and nothing reports an error. The agent starts and serves requests 
 If you install the gateway extension into `<org>-<env>` instead, leave this unset.
 :::
 
+:::caution Build workflows lose access to your private network
+This chart also ships `amp-build-workflow-egress`, a `NetworkPolicy` on the `workflows-<env>` namespace that stops build pods reaching cluster-internal services. Build steps run code from the repository being built — a `RUN` line in a Dockerfile, a `setup.py`, a postinstall hook — so without it a build can call any Service in the cluster and the cloud metadata endpoint.
+
+Builds keep **unrestricted egress to the public internet on every port**, IPv4 and IPv6, which is what base images, package registries, and mirrors need. What is withheld is RFC1918, `169.254.0.0/16` (the metadata endpoint), `100.64.0.0/10`, and the IPv6 private and link-local ranges — minus the two re-allowances builds cannot work without: your API server (Argo reports step status there) and your registry. Left at their RFC1918 defaults those two span far more than the intended hosts, so narrow them.
+
+This policy lands in `workflows-<environment>`, which OpenChoreo does not create until a workflow first runs there. The chart creates it if it is absent, so a fresh install works either way; an environment you add later needs its own render with `networkPolicy.buildWorkflows.namespace` set.
+
+Two cases need a `--set`:
+
+```bash
+  # your control-plane subnet, from `kubectl -n default get endpoints kubernetes`
+  --set "networkPolicy.buildWorkflows.apiServer.cidrs[0]=<control-plane-subnet>" \
+  # the subnet your registry is on, if it is not reached over the public internet
+  --set "networkPolicy.buildWorkflows.registry.cidrs[0]=<registry-subnet>"
+```
+
+Both default to all of RFC1918, which covers most private clusters but also spans your pod and service CIDRs — narrow them if you can. A **public** API server endpoint (public GKE/AKS control planes) needs no setting at all: the internet rule already permits it. An endpoint on `100.64.0.0/10` does need `apiServer.cidrs` set, since that range is withheld — otherwise every build hangs with its `wait` container unable to report step results.
+
+If your registry is reached by in-cluster Service DNS rather than on the node network, name its namespace instead. This is matched after DNAT, so `ports` is the registry's **containerPort**, not the Service port — `docker-registry` serves 5000 behind a Service on 10082:
+
+```bash
+  --set "networkPolicy.buildWorkflows.registry.inCluster.namespace=<registry-namespace>"
+```
+
+A registry at `registry.<baseDomain>`, or any other public endpoint, needs no rule.
+
+Anything else on a private address that a build legitimately needs — a self-hosted Git server, an internal package mirror, an egress proxy — goes in `networkPolicy.buildWorkflows.extraEgress`, which is appended to the policy verbatim:
+
+```bash
+  --set "networkPolicy.buildWorkflows.extraEgress[0].to[0].ipBlock.cidr=10.20.0.0/16"
+```
+
+`networkPolicy.buildWorkflows.enabled=false` turns the policy off entirely.
+
+The `generate-workload` step is deliberately **not** covered: it runs no repository code, and it is the step that calls `global.apiServer.url` and `global.oauth.tokenUrl` above.
+:::
+
 export const RegistryConfig = ({expanded}) => {
   const content = (
     <>

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -47,7 +47,7 @@ The main flow assumes you control a DNS zone. If you are evaluating on a cluster
 | LoadBalancer support | Required |
 | Default StorageClass | Required, and it must actually provision volumes. On EKS check both halves: clusters created at 1.30+ ship **no default class at all**, and the stock `gp2` class (default on upgraded clusters) references the in-tree provisioner removed in Kubernetes 1.27, so without the EBS CSI driver its PVCs are accepted and stay `Pending` forever. Install the EBS CSI driver and mark a CSI-backed class (e.g. `gp3`) as default |
 | Node kernel (build nodes) | Linux **6.3+** for user-namespaced agent builds (idmapped-mount support). On older kernels (Ubuntu 22.04's 5.15, Amazon Linux 2's 5.10) set `buildWorkflows.userNamespaces=false` on the Platform Resources chart — see [Troubleshooting](#build-pods-fail-with-mount_attr_idmap--idmap-mounts-errors) |
-| NetworkPolicy-enforcing CNI | Recommended. The Observability and Evaluation extension charts each ship a `NetworkPolicy` (collector ingress, evaluation-job egress) — inert on a CNI that doesn't implement the NetworkPolicy API. EKS's default VPC CNI, AKS, and legacy GKE don't enforce it out of the box; enable your provider's policy add-on (or install Calico/Cilium) if you want these to actually take effect. k3s (local/CI) enforces it by default. |
+| NetworkPolicy-enforcing CNI | Recommended. The Observability, Evaluation, and Platform Resources extension charts each ship a `NetworkPolicy` (collector ingress, evaluation-job egress, build-workflow egress) — inert on a CNI that doesn't implement the NetworkPolicy API. EKS's default VPC CNI, AKS, and legacy GKE don't enforce it out of the box; enable your provider's policy add-on (or install Calico/Cilium) if you want these to actually take effect. k3s (local/CI) enforces it by default. |
 
 ### Supported Providers
 
@@ -1697,6 +1697,7 @@ Work down this table against an existing install. The **When** column matters: t
 | Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Both are set during installation |
 | Post-upgrade patches re-applied | [After a chart upgrade](#after-a-chart-upgrade) | After every relevant `helm upgrade` |
 | Build workloads bounded by a node pool or ResourceQuota | [Build workflows](#build-workflows) | Any time |
+| Build egress policy active, with API-server and registry CIDRs narrowed, in every environment's `workflows-<env>` | [Build egress](#build-egress) | Any time — affects new builds |
 | Stateless services running multiple replicas | [High availability](#high-availability-and-scaling) | Any time |
 | NetworkPolicies, RBAC, and Pod Security Standards applied | [Cluster security](#certificates-and-cluster-security) | Any time |
 | Stronger isolation tier chosen where agents run untrusted code | [Agent isolation](#agent-isolation) | Any time, per environment |
@@ -1890,6 +1891,32 @@ A memory limit under what a build needs gets the step OOMKilled, and a low CPU l
 `workflows-<environment>` is created by OpenChoreo the first time a workflow runs there, so apply these after the first successful build rather than during the install. Repeat them for each environment you add.
 :::
 
+#### Build egress
+
+Build steps execute code from the repository being built, so a `RUN` line, a `setup.py`, or an npm postinstall hook runs with the build pod's network access. The Platform Resources chart ships `amp-build-workflow-egress` in `workflows-<environment>` to bound that: builds keep unrestricted egress to the public internet on every port, IPv4 and IPv6 — base images, package registries, and mirrors all depend on it — and lose RFC1918, `169.254.0.0/16` (the cloud metadata endpoint), `100.64.0.0/10`, and the IPv6 equivalents.
+
+The chart renders **one** policy, for `environment.name`. An environment added later gets its own `workflows-<env>` namespace with no policy in it, so repeat the chart's `networkPolicy.buildWorkflows.namespace` for each one — the same caveat as the ResourceQuota above.
+
+Two destinations are re-allowed because builds cannot work without them, and both may need narrowing on your cluster:
+
+| Value | Why | Default |
+|---|---|---|
+| `networkPolicy.buildWorkflows.apiServer.cidrs` | Argo's `wait` container reports step results to the API server. Wrong value and every build hangs rather than failing. | all of RFC1918 |
+| `networkPolicy.buildWorkflows.registry.cidrs` | `publish-image` pushes the built image; `build-image` pulls cached buildpacks. Only for a registry on a private address — a public one is covered by the internet rule. | all of RFC1918, port 10082 |
+| `networkPolicy.buildWorkflows.registry.inCluster.namespace` | Use instead of `cidrs` when the registry is reached by Service DNS. `ports` here is the registry's **containerPort** (5000 for `docker-registry`), not the Service port. | unset |
+
+All of these are matched **after** kube-proxy DNAT, so they name the endpoint address and container port — never a Service ClusterIP or Service port. Get the API server's from `kubectl -n default get endpoints kubernetes`. A public API server endpoint needs no setting; one on `100.64.0.0/10` does, since that range is withheld.
+
+Anything else on a private address a build legitimately reaches — a self-hosted Git server, an internal package mirror, an egress proxy — goes in `networkPolicy.buildWorkflows.extraEgress`, appended to the policy verbatim. The escape hatch is `networkPolicy.buildWorkflows.enabled=false`.
+
+:::warning The defaults are wider than "no private network"
+Left at their RFC1918 defaults, the two re-allowances above let build code reach **any** in-cluster address on 443, 6443, and 10082 — the policy cannot tell your API server and registry apart from anything else in those ranges. Only narrowing them to the real subnets makes the restriction what it says on the tin, and nothing fails if you skip it. The bundled k3d, quick-start, and VM installers narrow both automatically; a manual install does not.
+:::
+
+:::note What this does not close
+A build container can still reach the API server, because policy applies to pods and the `wait` container needs that access. The token it can use is `workflow-sa`'s, which is allowed only to create and patch `workflowtaskresults` in its own namespace.
+:::
+
 ### High Availability and Scaling
 
 The production install already runs the Agent Manager API, console, and observer at two replicas. Spread them across availability zones with your cluster's default topology spreading, and adjust to load:
@@ -1908,7 +1935,7 @@ With the Let's Encrypt DNS-01 issuer, certificate renewals are automatic — mon
 
 Apply your organization's standard cluster hardening around the platform: restrict namespace-to-namespace traffic with NetworkPolicies — in particular, only the gateways should reach the OTel collector and OpenSearch — scope RBAC for humans and CI to the namespaces they operate in, and enforce Pod Security Standards on the workload namespaces.
 
-Confirm your CNI actually **enforces** the `NetworkPolicy` objects the platform ships (the Observability and Evaluation extensions each include one — see [Cluster Requirements](#cluster-requirements)). A cluster without a policy engine selected — EKS's default VPC CNI, AKS, or legacy GKE — accepts those objects silently while blocking nothing, so the protection you think you have is not there.
+Confirm your CNI actually **enforces** the `NetworkPolicy` objects the platform ships (the Observability, Evaluation, and Platform Resources extensions each include one — see [Cluster Requirements](#cluster-requirements)). A cluster without a policy engine selected — EKS's default VPC CNI, AKS, or legacy GKE — accepts those objects silently while blocking nothing, so the protection you think you have is not there.
 
 ### Agent Isolation
 
@@ -2159,7 +2186,7 @@ kubectl delete pvc -n amp-thunder --all
 <details>
 <summary>Evaluations mysteriously fail or hang with connection errors</summary>
 
-The evaluation-job NetworkPolicy scopes DNS egress to a specific namespace/pod label (default: `kube-system` / `k8s-app=kube-dns`). If your cluster's DNS runs elsewhere — NodeLocal DNSCache, a relabeled CoreDNS, a managed provider's own DNS add-on — that egress rule won't match it, DNS resolution fails inside the eval-job pod, and *every* other egress rule fails right along with it, since nothing can resolve first. Check this first when evaluations fail with generic connection errors: point `networkPolicy.evaluationJob.dns.namespace`/`podLabel` at your cluster's actual DNS workload.
+The evaluation-job and build-workflow NetworkPolicies each scope DNS egress to a specific namespace/pod label (default: `kube-system` / `k8s-app=kube-dns`). If your cluster's DNS runs elsewhere — NodeLocal DNSCache, a relabeled CoreDNS, a managed provider's own DNS add-on — that egress rule won't match it, DNS resolution fails inside the eval-job pod, and *every* other egress rule fails right along with it, since nothing can resolve first. Check this first when evaluations fail with generic connection errors: point `networkPolicy.evaluationJob.dns.namespace`/`podLabel` at your cluster's actual DNS workload. The build-workflow policy has the same failure mode and the same fix under `networkPolicy.buildWorkflows.dns` — there it surfaces as a build whose checkout step cannot resolve your Git host.
 
 </details>
 

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -1697,7 +1697,7 @@ Work down this table against an existing install. The **When** column matters: t
 | Gateway development mode off with encryption keys configured | [Gateway hardening](#gateway-hardening) | Both are set during installation |
 | Post-upgrade patches re-applied | [After a chart upgrade](#after-a-chart-upgrade) | After every relevant `helm upgrade` |
 | Build workloads bounded by a node pool or ResourceQuota | [Build workflows](#build-workflows) | Any time |
-| Build egress policy active, with API-server and registry CIDRs narrowed, in every environment's `workflows-<env>` | [Build egress](#build-egress) | Any time — affects new builds |
+| Build egress policy active, with API-server and registry CIDRs narrowed, covering every workflow namespace | [Build egress](#build-egress) | Any time — affects new builds |
 | Stateless services running multiple replicas | [High availability](#high-availability-and-scaling) | Any time |
 | NetworkPolicies, RBAC, and Pod Security Standards applied | [Cluster security](#certificates-and-cluster-security) | Any time |
 | Stronger isolation tier chosen where agents run untrusted code | [Agent isolation](#agent-isolation) | Any time, per environment |
@@ -1895,7 +1895,11 @@ A memory limit under what a build needs gets the step OOMKilled, and a low CPU l
 
 Build steps execute code from the repository being built, so a `RUN` line, a `setup.py`, or an npm postinstall hook runs with the build pod's network access. The Platform Resources chart ships `amp-build-workflow-egress` in `workflows-<environment>` to bound that: builds keep unrestricted egress to the public internet on every port, IPv4 and IPv6 — base images, package registries, and mirrors all depend on it — and lose RFC1918, `169.254.0.0/16` (the cloud metadata endpoint), `100.64.0.0/10`, and the IPv6 equivalents.
 
-The chart renders **one** policy, for `environment.name`. An environment added later gets its own `workflows-<env>` namespace with no policy in it, so repeat the chart's `networkPolicy.buildWorkflows.namespace` for each one — the same caveat as the ResourceQuota above.
+The chart renders one policy per entry in `networkPolicy.buildWorkflows.namespaces`, and left empty that derives the single `workflows-<environment.name>`. If your install runs builds in more than one workflow namespace, list them all — anything not listed is left unprotected:
+
+```bash
+  --set "networkPolicy.buildWorkflows.namespaces={workflows-default,workflows-staging}"
+```
 
 Two destinations are re-allowed because builds cannot work without them, and both may need narrowing on your cluster:
 
@@ -1903,7 +1907,7 @@ Two destinations are re-allowed because builds cannot work without them, and bot
 |---|---|---|
 | `networkPolicy.buildWorkflows.apiServer.cidrs` | Argo's `wait` container reports step results to the API server. Wrong value and every build hangs rather than failing. | all of RFC1918 |
 | `networkPolicy.buildWorkflows.registry.cidrs` | `publish-image` pushes the built image; `build-image` pulls cached buildpacks. Only for a registry on a private address — a public one is covered by the internet rule. | all of RFC1918, port 10082 |
-| `networkPolicy.buildWorkflows.registry.inCluster.namespace` | Use instead of `cidrs` when the registry is reached by Service DNS. `ports` here is the registry's **containerPort** (5000 for `docker-registry`), not the Service port. | unset |
+| `networkPolicy.buildWorkflows.registry.inCluster.namespace` | Use instead of `cidrs` when the registry is reached by Service DNS. `ports` here is the registry's **containerPort** (5000 for `docker-registry`), not the Service port. Set `inCluster.podLabels` too, or the rule reaches every pod in that namespace on those ports. | unset |
 
 All of these are matched **after** kube-proxy DNAT, so they name the endpoint address and container port — never a Service ClusterIP or Service port. Get the API server's from `kubectl -n default get endpoints kubernetes`. A public API server endpoint needs no setting; one on `100.64.0.0/10` does, since that range is withheld.
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Build workflows in `workflows-<env>` had no NetworkPolicy covering any stage, so a build container could reach every cluster-internal service and the cloud metadata endpoint. Build steps execute code from the repository being built — a `RUN` line in a Dockerfile, a `setup.py`, an npm postinstall hook — so that reach belongs to whoever opened the pull request being built.

Outbound internet access is a functional requirement for builds: base images, package registries, and mirrors all need it, and an allowlist of registries would break real builds. So this does not restrict the internet. It closes the private network instead, while re-allowing the three destinations builds genuinely need: cluster DNS, the kube-apiserver (Argo's `wait` container reports step results there), and the image registry. Anything else on a private address — a self-hosted Git server, an internal mirror, an egress proxy — goes in `extraEgress`, and `enabled=false` turns the whole thing off.

Build pods had no stable label to select, so the five untrusted stages (checkout, the three build variants, publish-image) now carry one. `generate-workload-cr` is deliberately left out: it runs no repository code and it is the step that legitimately calls the OpenChoreo API and Thunder.

Verified on a live k3d cluster rather than by inspection: a full buildpack build succeeded through all four stages with the policy in force, and a probe pod wearing the build labels confirmed GitHub, PyPI, npm, ghcr.io and the Alpine CDN still reachable while Thunder, the registry ClusterIP, the OpenChoreo API and 169.254.169.254 are refused.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable egress network policies for build workflows, including DNS, internet, API server, registry, and custom access rules.
  - Added automatic build-workflow namespace creation and coverage across configured namespaces.
  - Added consistent labels to build and image-publishing workflow pods for improved identification and management.
  - Improved quick-start setup with automatic cluster network detection and safer workflow provisioning.

- **Documentation**
  - Updated installation and environment guides with build-workflow network policy configuration, troubleshooting, and security guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->