### PR TITLE
Sanitize AgentID provisioning error messages shown to end users

### DIFF
--- a/agent-manager-service/controllers/error_mapping_unit_test.go
+++ b/agent-manager-service/controllers/error_mapping_unit_test.go
@@ -39,7 +39,8 @@ func TestHandleCommonErrors_ValidationErrorWithSentinel_KeepsItsOwnMessage(t *te
 
 	handleCommonErrors(rr, utils.NewInvalidInputError(
 		"Promotion blocked: the agent identity for \"staging\" is still being provisioned",
-		"retry once provisioning completes"), "Failed to promote agent")
+		"retry once provisioning completes",
+	), "Failed to promote agent")
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 	var body spec.ErrorResponse

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -18469,7 +18469,7 @@ components:
           example: 9c1b7a44-3e2f-4d8a-b1c5-6a9f0e2d7c81
         lastError:
           type: string
-          description: Most recent provisioning error, if the last attempt failed
+          description: Short, user-safe reason the last provisioning attempt failed (never raw upstream/database error text)
         requestedBy:
           type: string
           description: Who requested this binding, kept for audit purposes only

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4084,7 +4084,8 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			"sourceEnvironment", req.SourceEnvironment)
 		return utils.NewInvalidInputError(
 			fmt.Sprintf("Promotion blocked: no LLM/system configuration in %q", req.TargetEnvironment),
-			fmt.Sprintf("configure system variables in %q, then promote", req.TargetEnvironment))
+			fmt.Sprintf("configure system variables in %q, then promote", req.TargetEnvironment),
+		)
 	}
 
 	// The key-presence check above cannot see a connection that is present but dead: an MCP
@@ -4466,7 +4467,8 @@ func (s *agentManagerService) assertMCPBindingsSurvivePromotion(
 	return utils.NewInvalidInputError(
 		fmt.Sprintf("Promotion blocked: MCP connection(s) %s have no endpoint in %q",
 			briefConnectionList(brokenByPromotion), targetEnv),
-		fmt.Sprintf("bind them to an endpoint in %q, then promote", targetEnv))
+		fmt.Sprintf("bind them to an endpoint in %q, then promote", targetEnv),
+	)
 }
 
 // maxBriefUIDetail caps how much of an unbounded upstream detail (a Thunder
@@ -4575,7 +4577,8 @@ func (s *agentManagerService) buildPromotionIdentityBlockedError(ctx context.Con
 				"deployment, so nothing can ever mint the target's own credential — promoting would let the promoted pod "+
 				"inherit a different environment's real credentials",
 			fmt.Sprintf("Promotion blocked: no agent identity for %q and identity provisioning is disabled", envName),
-			fmt.Sprintf("enable AgentID provisioning and provision %q first", envName))
+			fmt.Sprintf("enable AgentID provisioning and provision %q first", envName),
+		)
 	}
 
 	// GetBindingState reserves (nil, nil) for "no binding row yet" and wraps
@@ -4595,27 +4598,31 @@ func (s *agentManagerService) buildPromotionIdentityBlockedError(ctx context.Con
 			"the agent has no AgentID binding in the target environment yet and provisioning was only just triggered — "+
 				"promoting before it completes would let the promoted pod inherit a different environment's real credentials",
 			fmt.Sprintf("Promotion blocked: the agent identity for %q is still being provisioned", envName),
-			"provisioning was just triggered; retry in a moment")
+			"provisioning was just triggered; retry in a moment",
+		)
 	case state.Status == models.AgentThunderStatusFailed:
 		return blocked(
 			"AgentID provisioning for the target environment has permanently failed, so retrying the promotion cannot fix "+
 				"it — the environment has to be re-provisioned first",
 			fmt.Sprintf("Promotion blocked: agent identity provisioning for %q failed", envName),
 			fmt.Sprintf("re-provision the identity, then retry (%s)", briefUIDetail(state.LastError)),
-			"lastError", state.LastError)
+			"lastError", state.LastError,
+		)
 	case state.Status == models.AgentThunderStatusCompleted && !state.HasSecret:
 		return blocked(
 			"the agent's AgentID credential for the target environment has been revoked, so retrying the promotion cannot "+
 				"fix it — the credential has to be regenerated first",
 			fmt.Sprintf("Promotion blocked: the agent identity credential for %q was revoked", envName),
-			fmt.Sprintf("regenerate the credential for %q, then promote", envName))
+			fmt.Sprintf("regenerate the credential for %q, then promote", envName),
+		)
 	default: // Pending / InProgress, or any other in-flight state
 		return blocked(
 			"the agent's AgentID identity for the target environment is still provisioning — promoting now would let the "+
 				"promoted pod inherit a different environment's real credentials",
 			fmt.Sprintf("Promotion blocked: the agent identity for %q is still being provisioned", envName),
 			"retry once provisioning completes",
-			"status", state.Status)
+			"status", state.Status,
+		)
 	}
 }
 

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -851,8 +851,15 @@ func (s *agentThunderProvisioningService) recordFailure(ctx context.Context, bin
 	attemptsSoFar := binding.AttemptCount + 1
 	exhausted := attemptsSoFar >= maxProvisionAttempts
 
+	// Full cause goes to the log; LastError below is sanitized for the UI.
+	s.logger.Error("Agent thunder provisioning attempt failed",
+		"bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName,
+		"attempt", attemptsSoFar, "exhausted", exhausted, "error", cause)
+
 	update := repositories.AgentThunderAttemptUpdate{
-		LastError: cause.Error(),
+		// The Overview UI renders LastError verbatim, so it must never carry
+		// cause's raw text (e.g. a SQLSTATE) — see userFacingProvisioningError.
+		LastError: userFacingProvisioningError(cause),
 	}
 	if resolvedAgentID != "" {
 		update.ThunderAgentID = &resolvedAgentID
@@ -885,6 +892,22 @@ func (s *agentThunderProvisioningService) recordFailure(ctx context.Context, bin
 
 	if err := s.repo.UpdateAfterAttempt(ctx, binding.ID, update); err != nil {
 		s.logger.Error("Failed to record agent thunder provisioning failure", "bindingID", binding.ID, "error", err)
+	}
+}
+
+// userFacingProvisioningError maps a provisioning failure to a short, fixed,
+// end-user-safe message — cause may wrap arbitrary internal detail (Thunder,
+// OpenChoreo, the secret manager, even a raw DB error) that must never reach
+// the UI. The two Thunder sentinels get distinct messages since they call for
+// different remediation; everything else collapses to one generic message.
+func userFacingProvisioningError(cause error) string {
+	switch {
+	case errors.Is(cause, thundersvc.ErrThunderNotProvisioned):
+		return "Identity provider is not set up for this environment yet."
+	case errors.Is(cause, thundersvc.ErrThunderUnreachable):
+		return "Identity provider is temporarily unreachable. Please retry."
+	default:
+		return "Identity provisioning failed. Please retry."
 	}
 }
 

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -853,7 +853,8 @@ func (s *agentThunderProvisioningService) recordFailure(ctx context.Context, bin
 
 	// Full cause goes to the log; LastError below is sanitized for the UI.
 	s.logger.Error("Agent thunder provisioning attempt failed",
-		"bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName,
+		"ouID", binding.OUID, "projectName", binding.ProjectName, "bindingID", binding.ID,
+		"agentName", binding.AgentName, "envName", binding.EnvironmentName,
 		"attempt", attemptsSoFar, "exhausted", exhausted, "error", cause)
 
 	update := repositories.AgentThunderAttemptUpdate{

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -370,7 +370,8 @@ func TestAttemptProvision_TransientFailure_SchedulesRetryWithBackoff(t *testing.
 
 			assert.Equal(t, models.AgentThunderStatusPending, recorded.Status,
 				"a transient failure must stay PENDING for the reconciler to retry, not FAILED")
-			assert.Contains(t, recorded.LastError, "connection refused")
+			assert.Equal(t, userFacingProvisioningError(boom), recorded.LastError,
+				"LastError must be the sanitized user-facing message, never the raw cause text")
 			require.NotNil(t, recorded.NextRetryAt)
 			assert.WithinDuration(t, before.Add(tt.expectedDelay), *recorded.NextRetryAt, 2*time.Second)
 		})
@@ -407,7 +408,8 @@ func TestAttemptProvision_FifthFailure_MarksFailedNoMoreRetries(t *testing.T) {
 
 	assert.Equal(t, models.AgentThunderStatusFailed, recorded.Status)
 	assert.Nil(t, recorded.NextRetryAt)
-	assert.Contains(t, recorded.LastError, "thunder unreachable")
+	assert.Equal(t, userFacingProvisioningError(boom), recorded.LastError,
+		"LastError must be the sanitized user-facing message, never the raw cause text")
 }
 
 // TestProvisionBackoffSchedule_TotalRetryWindowWithinSLA guards the actual
@@ -460,6 +462,75 @@ func TestAttemptProvision_ThunderNotProvisioned_RetriesLikeAnyOtherFailure(t *te
 
 	assert.Equal(t, models.AgentThunderStatusFailed, recorded.Status)
 	assert.Nil(t, recorded.NextRetryAt)
+	assert.Equal(t, userFacingProvisioningError(thundersvc.ErrThunderNotProvisioned), recorded.LastError,
+		"once exhausted, the Overview UI reads LastError directly — it must be the sanitized message, not the sentinel's raw text")
+}
+
+// TestUserFacingProvisioningError_ClassifiesKnownCauses guards against
+// leaking raw cause text (e.g. a SQLSTATE) into the UI-facing message.
+func TestUserFacingProvisioningError_ClassifiesKnownCauses(t *testing.T) {
+	tests := []struct {
+		name  string
+		cause error
+	}{
+		{"not provisioned", thundersvc.ErrThunderNotProvisioned},
+		{"not provisioned, wrapped", fmt.Errorf("failed to read env-thunder url handle for acme/default: %w", thundersvc.ErrThunderNotProvisioned)},
+		{"unreachable", thundersvc.ErrThunderUnreachable},
+		{"unreachable, wrapped", fmt.Errorf("%w: default/staging", thundersvc.ErrThunderUnreachable)},
+		{"opaque database error", fmt.Errorf(`failed to read env-thunder url handle for acme/default: ERROR: relation "env_thunder_urls" does not exist (SQLSTATE 42P01)`)},
+		{"opaque thunder API error", errors.New("create agent identity: 500 Internal Server Error")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := userFacingProvisioningError(tt.cause)
+			assert.NotEmpty(t, msg)
+			assert.NotContains(t, msg, "SQLSTATE", "must never leak raw database detail")
+			assert.NotContains(t, msg, "env_thunder_urls", "must never leak internal table/field names")
+		})
+	}
+
+	assert.Equal(t,
+		userFacingProvisioningError(thundersvc.ErrThunderNotProvisioned),
+		userFacingProvisioningError(fmt.Errorf("wrapped: %w", thundersvc.ErrThunderNotProvisioned)),
+		"wrapping must not change the classification")
+	assert.NotEqual(t,
+		userFacingProvisioningError(thundersvc.ErrThunderNotProvisioned),
+		userFacingProvisioningError(thundersvc.ErrThunderUnreachable),
+		"not-provisioned and unreachable point at different remediation and must read differently")
+	assert.NotEqual(t,
+		userFacingProvisioningError(thundersvc.ErrThunderUnreachable),
+		userFacingProvisioningError(errors.New("some other opaque failure")),
+		"an actual sentinel must not collapse to the same message as the generic fallback")
+}
+
+// TestAttemptProvision_Failure_LogsRawCauseButSanitizesLastError guards that
+// sanitizing LastError doesn't also drop the raw cause from the logs.
+func TestAttemptProvision_Failure_LogsRawCauseButSanitizesLastError(t *testing.T) {
+	boom := errors.New(`ERROR: relation "env_thunder_urls" does not exist (SQLSTATE 42P01)`)
+	resolver := &clientmocks.EnvThunderResolverMock{
+		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return nil, boom },
+	}
+	store := &clientmocks.SecretManagementClientMock{}
+	var recorded repositories.AgentThunderAttemptUpdate
+	repo := &repomocks.AgentThunderClientRepositoryMock{
+		ClaimForAttemptFunc: func(_ context.Context, _ uuid.UUID) (bool, error) { return true, nil },
+		UpdateAfterAttemptFunc: func(_ context.Context, _ uuid.UUID, fields repositories.AgentThunderAttemptUpdate) error {
+			recorded = fields
+			return nil
+		},
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	svc := NewAgentThunderProvisioningService(repo, resolver, store, testOCClientResolvingSecretRefs(), nil, logger)
+
+	svc.AttemptProvision(context.Background(), models.AgentThunderClient{
+		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "default",
+	})
+
+	assert.Equal(t, userFacingProvisioningError(boom), recorded.LastError)
+	assert.Contains(t, buf.String(), "SQLSTATE", "the raw cause must still reach the log for operators to diagnose")
+	assert.Contains(t, buf.String(), "env_thunder_urls")
 }
 
 // TestAttemptProvision_ClaimFails_SkipsWithoutTouchingThunder guards the fix
@@ -530,7 +601,9 @@ func TestAttemptProvision_PanicIsRecovered_MarksBindingRetryable(t *testing.T) {
 
 	assert.Equal(t, models.AgentThunderStatusPending, recorded.Status, "must be scheduled for retry, not left stuck in-progress")
 	assert.NotNil(t, recorded.NextRetryAt)
-	assert.Contains(t, recorded.LastError, "panic during provisioning attempt")
+	// Opaque, non-sentinel cause — always the generic branch, any text works.
+	assert.Equal(t, userFacingProvisioningError(errors.New("anything")), recorded.LastError,
+		"LastError must be the sanitized user-facing message, never the raw panic text")
 }
 
 func TestProvisionForAgent_WritesAheadPendingForEveryEnvironment(t *testing.T) {

--- a/agent-manager-service/spec/model_agent_identity_environment_view.go
+++ b/agent-manager-service/spec/model_agent_identity_environment_view.go
@@ -28,7 +28,7 @@ type AgentIdentityEnvironmentView struct {
 	AgentId *string `json:"agentId,omitempty"`
 	// OAuth2 client ID for this AgentID
 	ClientId *string `json:"clientId,omitempty"`
-	// Most recent provisioning error, if the last attempt failed
+	// Short, user-safe reason the last provisioning attempt failed (never raw upstream/database error text)
 	LastError *string `json:"lastError,omitempty"`
 	// Who requested this binding, kept for audit purposes only
 	RequestedBy *string `json:"requestedBy,omitempty"`

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -1329,7 +1329,7 @@ type AgentIdentityEnvironmentView struct {
 	// EnvironmentName Environment this binding belongs to
 	EnvironmentName string `json:"environmentName"`
 
-	// LastError Most recent provisioning error, if the last attempt failed
+	// LastError Short, user-safe reason the last provisioning attempt failed (never raw upstream/database error text)
 	LastError *string `json:"lastError,omitempty"`
 
 	// ProvisioningType Whether the agent runs on the platform (`internal`) or outside it (`external`)


### PR DESCRIPTION
## Purpose
- AgentID provisioning failures were surfacing raw internal error text (e.g. a Postgres `SQLSTATE` and table name) directly on the agent Overview page's "Provisioning Status: Failed" panel.
- The message came straight from `AgentThunderClient.LastError`, which stored `cause.Error()` verbatim from whatever failed inside `AttemptProvision` (Thunder API, OpenChoreo, secret manager, or a DB read).
- Resolved : https://github.com/wso2/agent-manager/issues/1695

## Goals
- Never let an end user see raw upstream/database error text for a failed AgentID provisioning attempt.
- Keep the full technical detail available to operators, just not on the DB-backed field the UI reads.
- Distinguish the two known Thunder failure modes with their own message, since they call for different remediation.

## Approach
- Added `userFacingProvisioningError(cause error) string` in `agent_thunder_provisioning_service.go`, called from `recordFailure` instead of `cause.Error()`.
- `errors.Is(cause, thundersvc.ErrThunderNotProvisioned)` returns "Identity provider is not set up for this environment yet."
- `errors.Is(cause, thundersvc.ErrThunderUnreachable)` returns "Identity provider is temporarily unreachable. Please retry."
- Every other cause (Thunder API errors, secret manager errors, raw DB errors) collapses to "Identity provisioning failed. Please retry."
- `recordFailure` now logs the full raw `cause` via `s.logger.Error` (with `bindingID`, `agentName`, `envName`, `attempt`, `exhausted`) before sanitizing, so the diagnostic detail isn't lost, only kept out of the DB column the console renders.
- Updated the `lastError` field description in `docs/api_v1_openapi.yaml` to document that it's a short, user-safe string, never raw error text.
- No frontend change was needed: `EnvAgentRolesGroupsSection.tsx` already just renders `binding.lastError` verbatim, so sanitizing at the source fixes it everywhere that field is read.

## User stories
- As an agent owner, when AgentID provisioning fails, I see a short, actionable message instead of a raw backend error.
- As an operator, I can still find the exact underlying cause in the service logs.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   Updated `TestAttemptProvision_TransientFailure_SchedulesRetryWithBackoff`
 - Integration tests
   None added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
> List any other related PRs

## Migrations (if applicable)
N/A

## Test environment
macOS (Darwin), Go 1.25 (per `agent-manager-service/go.mod`), unit tier run with dummy env vars (no live Postgres/Thunder required).

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Provisioning failures now display concise, user-safe messages instead of exposing raw upstream or database error details.
  - Known setup and connectivity failures provide distinct guidance, while unexpected failures show a generic retry message.
  - Detailed technical causes remain available in internal logs for troubleshooting.

- **Documentation**
  - Updated API and field descriptions to clarify the safe, summarized nature of provisioning error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->