### PR TITLE
Pass user data to generate-workload as env vars, not shell source

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
@@ -34,6 +34,16 @@ spec:
               secretKeyRef:
                 name: '{{ "{{" }}inputs.parameters.workload-publisher-secret-name{{ "}}" }}'
                 key: workload-publisher-oauth
+          # User text reaches the script as env vars, never as shell source: Argo
+          # escapes a substituted parameter for JSON but not for the shell (#1639).
+          - name: ENDPOINTS
+            value: '{{ "{{" }}workflow.parameters.endpoints{{ "}}" }}'
+          - name: ENV_VARS
+            value: '{{ "{{" }}workflow.parameters.environment-variables{{ "}}" }}'
+          - name: FILE_MOUNTS
+            value: '{{ "{{" }}workflow.parameters.file-mounts{{ "}}" }}'
+          - name: APP_PATH
+            value: '{{ "{{" }}workflow.parameters.app-path{{ "}}" }}'
         image: ghcr.io/openchoreo/podman-runner:v1.0
         command:
           - sh
@@ -51,10 +61,8 @@ spec:
             COMPONENT_NAME={{ "{{" }}workflow.parameters.component-name{{ "}}" }}
             NAMESPACE={{ "{{" }}workflow.parameters.namespace-name{{ "}}" }}
 
-            ENDPOINTS='{{ "{{" }}workflow.parameters.endpoints{{ "}}" }}'
-            ENV_VARS='{{ "{{" }}workflow.parameters.environment-variables{{ "}}" }}'
-            FILE_MOUNTS='{{ "{{" }}workflow.parameters.file-mounts{{ "}}" }}'
-            SOURCE_PATH="/mnt/vol/source/{{ "{{" }}workflow.parameters.app-path{{ "}}" }}"
+            # ENDPOINTS, ENV_VARS, FILE_MOUNTS and APP_PATH come from the env.
+            SOURCE_PATH="/mnt/vol/source/${APP_PATH}"
             OUT="/mnt/vol/workload-cr.yaml"
 
             # Base workload

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
@@ -125,7 +125,7 @@ spec:
             # Endpoints
             if [ -n "$ENDPOINTS" ] && [ "$ENDPOINTS" != "null" ] && [ "$ENDPOINTS" != "[]" ]; then
               echo "  endpoints:" >> "$OUT"
-              while read -r ep; do
+              echo "$ENDPOINTS" | jq -c '.[]' | while read -r ep; do
                 NAME=$(echo "$ep" | jq -r '.name')
                 TYPE=$(echo "$ep" | jq -r '.type // "HTTP"')
                 PORT=$(echo "$ep" | jq -r '.port')
@@ -155,7 +155,7 @@ spec:
                   echo "        content: |" >> "$OUT"
                   sed 's/^/          /' "$SOURCE_PATH$SCHEMA_FILE_PATH" >> "$OUT"
                 fi
-              done < <(echo "$ENDPOINTS" | jq -c '.[]')
+              done
             fi
 
             echo "Workload CR saved to $OUT"

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Render assertions for wso2-amp-platform-resources-extension.
+# Run: bash deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
+#
+# Covers the shell quoting of the amp-generate-workload build step. Argo escapes
+# a substituted parameter for JSON, never for the shell, so a parameter carrying
+# user text that is interpolated into the step's script becomes shell source: one
+# apostrophe in a file mount closes the string early and the rest of the script
+# is reparsed as code. The build then dies on a bare `(` far from the real cause
+# and Argo reports only a missing output artifact (see issue #1639). The values
+# have to reach the container as env vars, which the shell never parses.
+set -uo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKLOAD_TMPL=templates/cluster-workflow-templates/generate-workload.yaml
+FAILURES=0
+
+if ! RENDERED="$(helm template test-release "$CHART_DIR" --show-only "$WORKLOAD_TMPL" 2>&1)"; then
+  printf 'FAIL - helm template failed\n%s\n' "$RENDERED"
+  exit 1
+fi
+
+# script_body — prints the container args block scalar, dedented. Everything in
+# it is shell source, so a parameter reaching this text is a parameter the shell
+# parses.
+script_body() {
+  awk '
+    function ind(s) { match(s, /^ */); return RLENGTH }
+    !found && $0 ~ /^ *- \|-?$/ { found = 1; bi = ind($0); next }
+    found {
+      if ($0 ~ /^[ ]*$/) { print ""; next }
+      if (ind($0) <= bi) { exit }
+      if (ci == 0) ci = ind($0)
+      print substr($0, ci + 1)
+    }
+  ' <<<"$RENDERED"
+}
+
+SCRIPT="$(script_body)"
+
+if [[ -z "$SCRIPT" ]]; then
+  printf 'FAIL - could not extract the generate-workload script from %s\n' "$WORKLOAD_TMPL"
+  exit 1
+fi
+
+# resolve — reads the script on stdin and substitutes the Argo placeholders the
+# way the controller would, taking each parameter value from V_* in the
+# environment. Placeholders with no V_* entry become an inert token, so a check
+# reports the quoting defect and not an unrelated empty expansion.
+resolve() {
+  awk '
+    function replace(s, from, to,   out, p) {
+      while ((p = index(s, from)) > 0) {
+        out = out substr(s, 1, p - 1) to
+        s = substr(s, p + length(from))
+      }
+      return out s
+    }
+    BEGIN {
+      n = 0
+      keys[++n] = "{{workflow.parameters.file-mounts}}";           vals[n] = ENVIRON["V_FILE_MOUNTS"]
+      keys[++n] = "{{workflow.parameters.environment-variables}}"; vals[n] = ENVIRON["V_ENV_VARS"]
+      keys[++n] = "{{workflow.parameters.endpoints}}";             vals[n] = ENVIRON["V_ENDPOINTS"]
+      keys[++n] = "{{workflow.parameters.app-path}}";              vals[n] = ENVIRON["V_APP_PATH"]
+    }
+    {
+      line = $0
+      for (i = 1; i <= n; i++) line = replace(line, keys[i], vals[i])
+      while ((a = index(line, "{{")) > 0) {
+        rest = substr(line, a + 2)
+        b = index(rest, "}}")
+        if (b == 0) break
+        line = substr(line, 1, a - 1) "placeholder" substr(rest, b + 2)
+      }
+      print line
+    }
+  '
+}
+
+# Benign values for the parameters a case is not exercising. Exactly one hostile
+# value per case: two stray apostrophes re-balance the quoting and the script
+# parses again while silently carrying mangled data, which would report a defect
+# as fixed.
+BENIGN_ENDPOINTS='[]'
+BENIGN_ENV_VARS='[{"name":"GREETING","value":"hello"}]'
+BENIGN_FILE_MOUNTS='[{"key":"policy","mountPath":"/etc/policy.txt","value":"plain"}]'
+BENIGN_APP_PATH='.'
+
+# assert_parses <label> <endpoints> <env-vars> <file-mounts> <app-path>
+# Checked with bash rather than sh: the script uses process substitution, which a
+# POSIX shell rejects on its own and which would mask the quoting defect behind an
+# unrelated parse error. Unbalanced quoting is a syntax error in every shell, so
+# bash -n reproduces the same failure the build hits in its own image.
+assert_parses() {
+  local label="$1" err
+  err="$(V_ENDPOINTS="$2" V_ENV_VARS="$3" V_FILE_MOUNTS="$4" V_APP_PATH="$5" \
+    resolve <<<"$SCRIPT" | bash -n 2>&1)"
+  if [[ -z "$err" ]]; then
+    printf 'ok   - generate-workload parses with %s\n' "$label"
+  else
+    printf 'FAIL - %s breaks generate-workload\n      %s\n' "$label" "$err"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# The literal case that broke a real build was a cancellation policy reading
+# "charged one night's rate". The other two carry the same user text through
+# different parameters, and a build path is exercised with the double quote that
+# would close the one string it is interpolated into.
+assert_parses "an apostrophe in a file mount" \
+  "$BENIGN_ENDPOINTS" "$BENIGN_ENV_VARS" \
+  '[{"key":"policy","mountPath":"/etc/policy.txt","value":"charged one night'\''s rate"}]' \
+  "$BENIGN_APP_PATH"
+assert_parses "an apostrophe in an environment variable" \
+  "$BENIGN_ENDPOINTS" '[{"name":"GREETING","value":"it'\''s here"}]' \
+  "$BENIGN_FILE_MOUNTS" "$BENIGN_APP_PATH"
+assert_parses "an apostrophe in an endpoint schema" \
+  '[{"name":"api","port":8080,"basePath":"/","visibility":["Public"],"schemaContent":"summary: the user'\''s profile"}]' \
+  "$BENIGN_ENV_VARS" "$BENIGN_FILE_MOUNTS" "$BENIGN_APP_PATH"
+assert_parses "a double quote in the build path" \
+  "$BENIGN_ENDPOINTS" "$BENIGN_ENV_VARS" "$BENIGN_FILE_MOUNTS" 'app"dir'
+
+# env_value <name> — the container env value for that variable, empty when the
+# variable is not rendered at all.
+env_value() {
+  awk -v n="$1" '
+    $1 == "-" && $2 == "name:" { in_var = ($3 == n); next }
+    in_var && $1 == "value:" {
+      sub(/^[[:space:]]*value:[[:space:]]*/, "")
+      sub(/[[:space:]]+$/, "")
+      gsub(/^'\''|'\''$/, "")
+      gsub(/^"|"$/, "")
+      print
+      exit
+    }
+  ' <<<"$RENDERED"
+}
+
+# The parameters that carry arbitrary user text — OpenAPI schemas, environment
+# variable values, file mount contents, and a build path — must be delivered
+# through the pod spec rather than pasted into the script. A syntax check alone
+# would pass on an even number of stray quotes, so this is what keeps the values
+# out of the shell's reach in the first place.
+assert_param_via_env() {
+  local var="$1" param="$2"
+  if grep -qF "{{$param}}" <<<"$SCRIPT"; then
+    printf 'FAIL - %s is interpolated into the script instead of reaching it as $%s\n' "$param" "$var"
+    FAILURES=$((FAILURES + 1))
+    return
+  fi
+  local actual
+  actual="$(env_value "$var")"
+  if [[ "$actual" == "{{$param}}" ]]; then
+    printf 'ok   - %s reaches the container as $%s\n' "$param" "$var"
+  else
+    printf 'FAIL - $%s does not carry %s\n      actual: %q\n' "$var" "$param" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+assert_param_via_env ENDPOINTS workflow.parameters.endpoints
+assert_param_via_env ENV_VARS workflow.parameters.environment-variables
+assert_param_via_env FILE_MOUNTS workflow.parameters.file-mounts
+assert_param_via_env APP_PATH workflow.parameters.app-path
+
+# The defect was one quoting style in one step; this is the pattern itself, so a
+# parameter added later in the same shape is caught before it ships.
+QUOTED_ASSIGNMENT="$(grep -nE "^[A-Z_]+='\{\{" <<<"$SCRIPT")"
+if [[ -z "$QUOTED_ASSIGNMENT" ]]; then
+  printf 'ok   - no Argo parameter is assigned inside a single-quoted string\n'
+else
+  printf 'FAIL - an Argo parameter is assigned inside a single-quoted string\n%s\n' "$QUOTED_ASSIGNMENT"
+  FAILURES=$((FAILURES + 1))
+fi
+
+if ((FAILURES > 0)); then
+  printf '\n%d assertion(s) failed\n' "$FAILURES"
+  exit 1
+fi
+printf '\nAll render assertions passed\n'

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
@@ -87,14 +87,12 @@ BENIGN_FILE_MOUNTS='[{"key":"policy","mountPath":"/etc/policy.txt","value":"plai
 BENIGN_APP_PATH='.'
 
 # assert_parses <label> <endpoints> <env-vars> <file-mounts> <app-path>
-# Checked with bash rather than sh: the script uses process substitution, which a
-# POSIX shell rejects on its own and which would mask the quoting defect behind an
-# unrelated parse error. Unbalanced quoting is a syntax error in every shell, so
-# bash -n reproduces the same failure the build hits in its own image.
+# Checked with sh, which is what the step's container runs the script under, so a
+# bashism that a bash-backed image happens to tolerate cannot pass unnoticed.
 assert_parses() {
   local label="$1" err
   err="$(V_ENDPOINTS="$2" V_ENV_VARS="$3" V_FILE_MOUNTS="$4" V_APP_PATH="$5" \
-    resolve <<<"$SCRIPT" | bash -n 2>&1)"
+    resolve <<<"$SCRIPT" | sh -n 2>&1)"
   if [[ -z "$err" ]]; then
     printf 'ok   - generate-workload parses with %s\n' "$label"
   else


### PR DESCRIPTION
## Purpose
Resolves #1639.

The `amp-generate-workload` build step interpolated Argo workflow parameters straight into single-quoted shell assignments:

```sh
ENDPOINTS='{{workflow.parameters.endpoints}}'
ENV_VARS='{{workflow.parameters.environment-variables}}'
FILE_MOUNTS='{{workflow.parameters.file-mounts}}'
SOURCE_PATH="/mnt/vol/source/{{workflow.parameters.app-path}}"
```

Argo escapes a substituted parameter for JSON, never for the shell. Those parameters carry arbitrary user text — OpenAPI schema content, environment variable values, file mount contents — so a single apostrophe closes the string early and the remaining ~215 lines of the script are reparsed as code. The build dies on the first bare `(`, far from the real cause:

```
/bin/sh: syntax error: unexpected "("
Error: open /mainctrfs/mnt/vol/workload-cr.yaml: no such file or directory
```

The second line is downstream noise: the script exits 2 before writing its output artifact, so Argo's output parameter lookup fails. `apk add jq` on line 4 succeeds first because sh parses incrementally, which makes the log misleading. The real case that hit this was a `cancellation-policy.txt` file mount containing `charged one night's rate`.

Because it depends on the data, it looks intermittent.

## Goals
Deliver every parameter carrying user text to the container through the pod spec instead of pasting it into shell source, so no user value is ever parsed by the shell.

## Approach
Moved `endpoints`, `environment-variables`, `file-mounts` and `app-path` into the step container's existing `env:` block, and deleted the four assignments from the script body. Argo substitutes into the pod spec's env value, and the shell reads them as ordinary variables — every consumer downstream already referenced `"$ENDPOINTS"`, `"$ENV_VARS"` and `"$FILE_MOUNTS"` as quoted variables, so nothing else in the script changed. `SOURCE_PATH` now expands `${APP_PATH}`.

`app-path` is included beyond the reported apostrophe case: it was interpolated inside a double-quoted string, so a `"` or `$(...)` in a build path would break the script or execute in the build container.

The validated identifiers — `image`, `project-name`, `component-name`, `namespace-name`, `run-name` — and the chart-supplied OAuth/API settings are left as they are.

Also replaced the one process substitution in the endpoints loop (`done < <(echo "$ENDPOINTS" | jq -c '.[]')`) with the pipeline form the two sibling loops over `ENV_VARS` and `FILE_MOUNTS` already use. The step runs under `sh`, and a real POSIX shell rejected the script outright — `Syntax error: redirection unexpected` — regardless of the data in it. The loop body only appends to `$OUT`, so running it in a subshell changes nothing; verified the emitted CR is byte-identical, including a two-endpoint case with multiple visibility entries. This is what lets the new test assert with `sh -n` instead of `bash -n`, so the check now runs the script the way the container does.

Not changed here: the same quoting pattern exists for `BUILD_ENV_JSON` in `ballerina-buildpack-build.yaml` and `gcp-buildpack-build.yaml`, and for `BUILD_ENV_JSON`/`BUILD_ARGS_JSON` in `dockefile-build.yaml`. Those carry build env and args rather than free-form document content, so they are far less likely to be hit, but they are vulnerable to the same failure and are worth a follow-up.

## User stories
As a developer, I can build an agent whose OpenAPI schema, environment variables, or mounted files contain an apostrophe, and the build succeeds instead of failing with an unrelated shell syntax error.

## Release note
Fixed agent builds failing with `/bin/sh: syntax error: unexpected "("` when a file mount, environment variable, or OpenAPI schema contained an apostrophe.

## Documentation
N/A — internal build workflow template; no user-facing behaviour is documented for it.

## Training
N/A — no training content covers the build workflow templates.

## Certification
N/A — no certification exam covers the internal Argo workflow templates.

## Marketing
N/A — bug fix.

## Automation tests
 - Unit tests
   > Added `deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh`, picked up automatically by the existing "Run chart render assertions" step in `helm-charts-pr-check.yml`. It renders the chart, extracts the generate-workload script, resolves the Argo placeholders the way the controller would, and asserts:
   > - the script parses (`sh -n`) with an apostrophe in a file mount, in an environment variable, and in an endpoint schema, and with a double quote in the build path — one hostile value per case, because two stray apostrophes re-balance the quoting and would hide the defect
   > - each of the four parameters is absent from the script body and present as a container env var
   > - no `VAR='{{...}}'` assignment remains, so a parameter added later in the same shape is caught
   >
   > Against the unfixed template all nine assertions fail, reproducing the reported error at the same line 169. Against the fix all nine pass.
 - Integration tests
   > None added — the step is an Argo `ClusterWorkflowTemplate` with no integration harness in this repo. Verified functionally instead: ran the CR-generation half of the rendered script with apostrophe-bearing values in `FILE_MOUNTS`, `ENV_VARS` and `ENDPOINTS`, and the emitted Workload CR is valid YAML with the apostrophes preserved verbatim (`value: "charged one night's rate"`, `content: |` carrying `summary: the user's profile`).

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable, the change is a Helm template with no Java code
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples relate to this step.

## Related PRs
None. #1663 fixed the same class of shell-quoting defect in the generated Identity Provider commands; this applies the equivalent treatment to the build workflow.

## Migrations (if applicable)
N/A — no schema or data changes. The chart change takes effect on the next chart upgrade; running workflows are unaffected.

## Test environment
macOS 15 (darwin 25.0.0), Helm v4.1.0, bash 3.2 and GNU awk, against chart `wso2-amp-platform-resources-extension`. The render assertions were run twice: under the system `sh` and under a dash-backed `sh` (what CI's Ubuntu runner provides), passing in both. Also ran `helm lint --strict` and the shared `deployments/helm-charts/tests/no-nil-render.sh` — both pass.

## Learning
Argo's parameter substitution runs over the serialized template and escapes values for JSON only, so anything landing in a `script`/`args` body is shell source regardless of how it is quoted there. Passing values through container env vars is the standard remedy and needs no sanitizing on the producer side. Two things worth noting for future checks of this kind: an even number of stray apostrophes re-balances the quoting and the script parses again while silently carrying mangled data, so a syntax check has to inject exactly one hostile value at a time; and a syntax check is only meaningful under the shell that actually runs the script, since a bashism sails through `bash -n` and fails in the container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload generation to safely handle endpoints, environment variables, file mounts, and application paths containing special characters.
  * Prevented user-provided values from being interpreted as shell commands during workload setup.

* **Tests**
  * Added automated validation for parameter handling, quoting, and generated workflow syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
