### PR TITLE
Harden build parameter handling in the build workflows

### DIFF
--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -519,6 +519,11 @@ func (c *agentController) BuildAgent(w http.ResponseWriter, r *http.Request) {
 	if commitId == "" {
 		log.Debug("BuildAgent: commitId not provided, using latest commit")
 	}
+	if err := utils.ValidateGitCommitID(commitId); err != nil {
+		log.Error("BuildAgent: invalid commitId", "error", err)
+		utils.WriteValidationErrorResponse(w, err)
+		return
+	}
 	build, err := c.agentService.BuildAgent(ctx, ouID, projName, agentName, commitId)
 	if err != nil {
 		log.Error("BuildAgent: failed to build agent", "error", err)

--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -520,7 +520,7 @@ func (c *agentController) BuildAgent(w http.ResponseWriter, r *http.Request) {
 		log.Debug("BuildAgent: commitId not provided, using latest commit")
 	}
 	if err := utils.ValidateGitCommitID(commitId); err != nil {
-		log.Error("BuildAgent: invalid commitId", "error", err)
+		log.Debug("BuildAgent: invalid commitId", "error", err)
 		utils.WriteValidationErrorResponse(w, err)
 		return
 	}

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -11493,6 +11493,9 @@ components:
         dockerfilePath:
           type: string
           description: Path to the Dockerfile relative to the app path (e.g. "Dockerfile" or "docker/Dockerfile")
+          pattern: "^/[A-Za-z0-9._\\-/]*$"
+          maxLength: 1024
+          example: "/Dockerfile"
 
     BuildpackBuild:
       type: object
@@ -11985,6 +11988,11 @@ components:
         - limit
         - offset
     # Repository Configuration
+    # The patterns below document the contract; they are not what enforces it.
+    # This service has no OpenAPI request-validation middleware, so every rule
+    # here is also implemented in Go (agent-manager-service/utils/utils.go). These
+    # values become arguments to git and to the container build inside the build
+    # pod, so keep the two in step when changing either.
     RepositoryConfig:
       type: object
       description: Git repository configuration
@@ -11997,13 +12005,20 @@ components:
         url:
           type: string
           description: URL of the git repository
+          pattern: "^https://github\\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+(?:\\.git)?/?$"
+          maxLength: 2048
+          example: "https://github.com/wso2/agent-manager"
         branch:
           type: string
           description: Branch to use
+          pattern: "^[A-Za-z0-9._@+/-]+$"
+          maxLength: 255
+          example: "main"
         appPath:
           type: string
           description: Path within the repository where the source code resides
-          pattern: "^/.*"
+          pattern: "^/[A-Za-z0-9._\\-/]*$"
+          maxLength: 1024
           example: "/my-agent"
         secretRef:
           type: string

--- a/agent-manager-service/utils/build_input_validation_test.go
+++ b/agent-manager-service/utils/build_input_validation_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
+// repoConfigForTest builds the minimal RepositoryConfig the validator reads:
+// secretRef is left unset, which means a public repository.
 func repoConfigForTest(url, branch, appPath string) *spec.RepositoryConfig {
 	return &spec.RepositoryConfig{
 		Url:     url,
@@ -43,6 +45,9 @@ func repoConfigForTest(url, branch, appPath string) *spec.RepositoryConfig {
 	}
 }
 
+// TestValidateRepoDetails covers the repository fields together, since the
+// validator short-circuits: a case has to keep the other two fields valid for its
+// own field to be the one under test.
 func TestValidateRepoDetails(t *testing.T) {
 	const (
 		okURL     = "https://github.com/wso2/agent-manager"
@@ -121,6 +126,8 @@ func TestValidateRepoDetails(t *testing.T) {
 	}
 }
 
+// TestIsValidGitHubBranch pins both halves of the check: the character allowlist,
+// and the git refname rules a character class cannot express.
 func TestIsValidGitHubBranch(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -172,6 +179,8 @@ func TestIsValidGitHubBranch(t *testing.T) {
 	}
 }
 
+// TestValidateGitCommitID pins the accepted abbreviation range at both ends, an
+// empty value meaning "latest on the branch", and rejection of anything non-hex.
 func TestValidateGitCommitID(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -181,11 +190,14 @@ func TestValidateGitCommitID(t *testing.T) {
 		// Empty means "latest commit on the branch".
 		{"empty", "", false},
 		{"abbreviated", "ee4f70e4", false},
-		{"shortest accepted", "ee4f70e", false},
+		{"rev-parse --short length", "ee4f70e", false},
+		// git's own minimum abbreviation, and what existing callers may send.
+		{"shortest accepted", "abc1", false},
+		{"six characters", "abc123", false},
 		{"full sha", "ee4f70e4cba1234567890abcdef1234567890abc", false},
 		{"upper case", "EE4F70E4", false},
 
-		{"too short", "ee4f70", true},
+		{"too short", "abc", true},
 		{"too long", strings.Repeat("a", 41), true},
 		{"non-hexadecimal", "zzzzzzz", true},
 		// The first eight characters of the commit also become part of the image
@@ -211,6 +223,8 @@ func TestValidateGitCommitID(t *testing.T) {
 	}
 }
 
+// TestValidateBuildConfigurationDockerfilePath exercises the shared path rules
+// through the docker build branch, which is the other caller of validateSafePath.
 func TestValidateBuildConfigurationDockerfilePath(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/agent-manager-service/utils/build_input_validation_test.go
+++ b/agent-manager-service/utils/build_input_validation_test.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// UNIT tests for the repository and build inputs that reach the build workflow.
+// No `//go:build integration` tag, so these run in the fast unit tier
+// (`make test-unit`) and must NOT touch the network.
+//
+// These inputs become arguments to git and to the container build running inside
+// the build pod. The pod holds the git credential secret and the registry push
+// secret, so the character sets below are deliberately narrower than what git or
+// GitHub would accept on their own: the build templates deliver every value as an
+// environment variable so the shell never parses it, and these checks are the
+// second half of that, keeping out values that are hostile to git's own option
+// parser or simply cannot be a real repository.
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/spec"
+)
+
+func repoConfigForTest(url, branch, appPath string) *spec.RepositoryConfig {
+	return &spec.RepositoryConfig{
+		Url:     url,
+		Branch:  branch,
+		AppPath: appPath,
+	}
+}
+
+func TestValidateRepoDetails(t *testing.T) {
+	const (
+		okURL     = "https://github.com/wso2/agent-manager"
+		okBranch  = "main"
+		okAppPath = "/samples/customer-support-agent"
+	)
+
+	tests := []struct {
+		name    string
+		url     string
+		branch  string
+		appPath string
+		wantErr bool
+	}{
+		// Accepted: the shapes real repositories take.
+		{"plain repository", okURL, okBranch, okAppPath, false},
+		{"repository root as app path", okURL, okBranch, "/", false},
+		{".git suffix", "https://github.com/wso2/agent-manager.git", okBranch, okAppPath, false},
+		{"trailing slash", "https://github.com/wso2/agent-manager/", okBranch, okAppPath, false},
+		{"dots in the repository name", "https://github.com/wso2/my.repo", okBranch, okAppPath, false},
+		{"underscores and hyphens", "https://github.com/my-org/my_repo", okBranch, okAppPath, false},
+		{"branch with a slash", okURL, "feature/add-thing", okAppPath, false},
+		{"branch with dots", okURL, "release/1.2.3", okAppPath, false},
+
+		// A ";" needs no quote to break out of a shell assignment, so it is the
+		// cheapest way in and the first thing to keep out.
+		{
+			"command separator in the URL",
+			`https://github.com/wso2/agent-manager;echo injected;`,
+			okBranch, okAppPath, true,
+		},
+		{
+			"command separator in the branch",
+			okURL, `main;echo injected;`, okAppPath, true,
+		},
+
+		// The same class through the other metacharacters.
+		{"command substitution in the URL", "https://github.com/wso2/agent-$(id)", okBranch, okAppPath, true},
+		{"backtick in the repository name", "https://github.com/wso2/agent-`id`", okBranch, okAppPath, true},
+		{"double quote in the branch", okURL, `main";id;"`, okAppPath, true},
+		{"single quote in the branch", okURL, "main'id'", okAppPath, true},
+		{"newline in the branch", okURL, "main\nid", okAppPath, true},
+		{"double quote in the app path", okURL, okBranch, `/x";echo pwned;"`, true},
+		{"command substitution in the app path", okURL, okBranch, "/$(id)", true},
+
+		// git's option parser, not the shell.
+		{"branch opening with a dash", okURL, "--upload-pack=id", okAppPath, true},
+
+		// Traversal and shape.
+		{"traversal in the app path", okURL, okBranch, "/../../etc", true},
+		{"relative app path", okURL, okBranch, "samples/agent", true},
+		{"traversal in the branch", okURL, "feature/../main", okAppPath, true},
+		{"empty branch", okURL, "", okAppPath, true},
+		{"empty app path", okURL, okBranch, "", true},
+		{"empty URL", "", okBranch, okAppPath, true},
+		{"non-GitHub host", "https://gitlab.com/wso2/agent-manager", okBranch, okAppPath, true},
+		{"over-long URL", okURL + strings.Repeat("a", MaxRepositoryURLLength), okBranch, okAppPath, true},
+		{"over-long branch", okURL, strings.Repeat("b", MaxGitBranchLength+1), okAppPath, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRepoDetails(repoConfigForTest(tt.url, tt.branch, tt.appPath))
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected rejection of url=%q branch=%q appPath=%q", tt.url, tt.branch, tt.appPath)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected rejection of url=%q branch=%q appPath=%q: %v",
+					tt.url, tt.branch, tt.appPath, err)
+			}
+			// A rejection has to reach the caller as a 400, not a 500.
+			if err != nil && IsValidationError(err) == nil {
+				t.Errorf("error should be a *ValidationError so it maps to 400, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestIsValidGitHubBranch(t *testing.T) {
+	tests := []struct {
+		name   string
+		branch string
+		want   bool
+	}{
+		{"simple", "main", true},
+		{"namespaced", "feature/add-thing", true},
+		{"version-like", "release/1.2.3", true},
+		{"underscores", "my_branch", true},
+		{"at sign is valid in a ref", "user@work", true},
+		{"plus is valid in a ref", "a+b", true},
+
+		{"empty", "", false},
+		{"command separator", "main;id", false},
+		{"pipe", "main|id", false},
+		{"ampersand", "main&id", false},
+		{"dollar", "main$X", false},
+		{"backtick", "main`id`", false},
+		{"parentheses", "main(id)", false},
+		{"space", "my branch", false},
+		{"tab", "my\tbranch", false},
+		{"newline", "main\nid", false},
+		{"null byte", "main\x00", false},
+		{"tilde", "main~1", false},
+		{"caret", "main^", false},
+		{"colon", "origin:main", false},
+		{"question mark", "main?", false},
+		{"asterisk", "main*", false},
+		{"open bracket", "main[1]", false},
+		{"backslash", "main\\x", false},
+		{"leading dash", "-main", false},
+		{"leading slash", "/main", false},
+		{"trailing slash", "main/", false},
+		{"double slash", "a//b", false},
+		{"traversal", "a/../b", false},
+		{"reflog syntax", "main@{1}", false},
+		{"trailing dot", "main.", false},
+		{"lock suffix", "main.lock", false},
+		{"over-long", strings.Repeat("a", MaxGitBranchLength+1), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidGitHubBranch(tt.branch); got != tt.want {
+				t.Errorf("isValidGitHubBranch(%q) = %v, want %v", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateGitCommitID(t *testing.T) {
+	tests := []struct {
+		name    string
+		commit  string
+		wantErr bool
+	}{
+		// Empty means "latest commit on the branch".
+		{"empty", "", false},
+		{"abbreviated", "ee4f70e4", false},
+		{"shortest accepted", "ee4f70e", false},
+		{"full sha", "ee4f70e4cba1234567890abcdef1234567890abc", false},
+		{"upper case", "EE4F70E4", false},
+
+		{"too short", "ee4f70", true},
+		{"too long", strings.Repeat("a", 41), true},
+		{"non-hexadecimal", "zzzzzzz", true},
+		// The first eight characters of the commit also become part of the image
+		// tag, so a separator here would reach a second script as well.
+		{"command separator", "ee4f70e4;id", true},
+		{"command substitution", "$(id)abc", true},
+		{"leading dash", "-ee4f70e4", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGitCommitID(tt.commit)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected rejection of commitId %q", tt.commit)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected rejection of commitId %q: %v", tt.commit, err)
+			}
+			if err != nil && IsValidationError(err) == nil {
+				t.Errorf("error should be a *ValidationError so it maps to 400, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestValidateBuildConfigurationDockerfilePath(t *testing.T) {
+	tests := []struct {
+		name           string
+		dockerfilePath string
+		wantErr        bool
+	}{
+		{"repository root", "/Dockerfile", false},
+		{"nested", "/docker/Dockerfile", false},
+		{"dotted name", "/build/Dockerfile.prod", false},
+
+		{"empty", "", true},
+		{"relative", "Dockerfile", true},
+		{"traversal", "/../Dockerfile", true},
+		{"double quote", `/x";echo pwned;"`, true},
+		{"command substitution", "/$(id)/Dockerfile", true},
+		{"command separator", "/Dockerfile;id", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			build := spec.DockerBuildAsBuild(&spec.DockerBuild{
+				Docker: spec.DockerConfig{DockerfilePath: tt.dockerfilePath},
+			})
+			err := validateBuildConfiguration(&build)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected rejection of dockerfilePath %q", tt.dockerfilePath)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected rejection of dockerfilePath %q: %v", tt.dockerfilePath, err)
+			}
+		})
+	}
+}

--- a/agent-manager-service/utils/constants.go
+++ b/agent-manager-service/utils/constants.go
@@ -50,6 +50,16 @@ const (
 	MaxMountPathLength      = 4095       // Linux PATH_MAX minus one for safety
 )
 
+// Caps for the repository and build inputs that reach the build workflow. Each
+// of these becomes an argument to git or to the container build running inside
+// the build pod, so each is bounded on its own rather than only by the overall
+// request size.
+const (
+	MaxRepositoryURLLength = 2048 // generous URL bound; the host itself is pinned separately
+	MaxGitBranchLength     = 255  // git has no hard limit, but refs are filenames
+	MaxSafePathLength      = 1024 // application / Dockerfile / schema / base path
+)
+
 // Path parameter names used in HTTP routes
 const (
 	PathParamOrgName      = "orgName"

--- a/agent-manager-service/utils/utils.go
+++ b/agent-manager-service/utils/utils.go
@@ -1323,8 +1323,11 @@ func isValidGitHubBranch(branch string) bool {
 	return true
 }
 
-// gitCommitIDRe matches an abbreviated or full SHA-1 object name.
-var gitCommitIDRe = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+// gitCommitIDRe matches an abbreviated or full SHA-1 object name. The lower bound
+// is git's own minimum abbreviation length rather than the 7 that
+// "git rev-parse --short" happens to emit, so a caller passing a shorter
+// abbreviation is not rejected here and left to fail against the real repository.
+var gitCommitIDRe = regexp.MustCompile(`^[0-9a-fA-F]{4,40}$`)
 
 // ValidateGitCommitID validates an optional commit to build. An empty value means
 // "use the latest commit on the branch" and is accepted. The commit reaches git
@@ -1336,8 +1339,8 @@ func ValidateGitCommitID(commitID string) error {
 	}
 	if !gitCommitIDRe.MatchString(commitID) {
 		return NewValidationError(
-			"Invalid commit. Provide a commit SHA of 7 to 40 hexadecimal characters",
-			"commitId must be a hexadecimal git object name of 7 to 40 characters",
+			"Invalid commit. Provide a commit SHA of 4 to 40 hexadecimal characters",
+			"commitId must be a hexadecimal git object name of 4 to 40 characters",
 		)
 	}
 	return nil

--- a/agent-manager-service/utils/utils.go
+++ b/agent-manager-service/utils/utils.go
@@ -440,11 +440,12 @@ func validateBuildConfiguration(build *spec.Build) error {
 	} else if build.DockerBuild != nil {
 		// Validate docker configuration
 		dockerConfig := build.DockerBuild.Docker
-		if dockerConfig.DockerfilePath == "" || !strings.HasPrefix(dockerConfig.DockerfilePath, "/") {
-			return NewValidationError(
-				"Please provide a valid Dockerfile path starting with /",
-				"dockerfilePath is required and must start with /",
-			)
+		if err := validateSafePath(
+			dockerConfig.DockerfilePath,
+			"dockerfilePath",
+			"Please provide a valid Dockerfile path starting with /",
+		); err != nil {
+			return err
 		}
 	} else {
 		return NewValidationError(
@@ -663,6 +664,36 @@ func ValidateCreateGitSecretRequest(req *spec.CreateGitSecretRequest) error {
 	return nil
 }
 
+// safePathRe restricts the caller-supplied paths on an agent to a conservative
+// POSIX subset. Most of them (application path, Dockerfile path, OpenAPI schema
+// path) become directory and file arguments inside the build container; the
+// endpoint base path lands in the Workload CR and in gateway routing. Nothing
+// outside this set has a legitimate use in either place.
+var safePathRe = regexp.MustCompile(`^/[A-Za-z0-9._\-/]*$`)
+
+// validateSafePath checks one absolute path against safePathRe. userMessage is
+// what the API caller sees; field names the payload field in the technical
+// reason. Mirrors the file-mount mountPath rules (see fileMountPathRe).
+func validateSafePath(path, field, userMessage string) error {
+	if path == "" {
+		return NewValidationErrorf(userMessage, "%s is required", field)
+	}
+	if len(path) > MaxSafePathLength {
+		return NewValidationErrorf(userMessage, "%s is longer than %d characters", field, MaxSafePathLength)
+	}
+	if !safePathRe.MatchString(path) {
+		return NewValidationErrorf(
+			userMessage,
+			"%s must be an absolute path containing only letters, digits, '.', '_', '-' and '/'",
+			field,
+		)
+	}
+	if strings.Contains(path, "..") {
+		return NewValidationErrorf(userMessage, "%s must not contain '..' segments", field)
+	}
+	return nil
+}
+
 func validateRepoDetails(repo *spec.RepositoryConfig) error {
 	if repo == nil {
 		return NewValidationError(
@@ -674,6 +705,12 @@ func validateRepoDetails(repo *spec.RepositoryConfig) error {
 		return NewValidationError(
 			"Please provide a repository URL",
 			"repository URL cannot be empty",
+		)
+	}
+	if len(repo.Url) > MaxRepositoryURLLength {
+		return NewValidationErrorf(
+			"The repository URL is too long",
+			"repository URL is longer than %d characters", MaxRepositoryURLLength,
 		)
 	}
 	if !strings.HasPrefix(repo.Url, "https://github.com/") {
@@ -690,17 +727,34 @@ func validateRepoDetails(repo *spec.RepositoryConfig) error {
 			"invalid GitHub repository format (expected: https://github.com/owner/repo)",
 		)
 	}
+	// ParseGitHubURL's owner/repo groups exclude only "/", so the URL still has
+	// to be held to the character set GitHub itself allows. Both halves are
+	// passed to git inside the build container, where anything else is either
+	// unusable or hostile.
+	if !isValidGitHubIdentifier(owner) || !isValidGitHubIdentifier(repoName) {
+		return NewValidationError(
+			"Invalid repository URL. Please use: https://github.com/owner/repo",
+			"repository owner and name may contain only letters, digits, '.', '_' and '-'",
+		)
+	}
 	if repo.Branch == "" {
 		return NewValidationError(
 			"Please specify a branch for the repository",
 			"repository branch cannot be empty",
 		)
 	}
-	if repo.AppPath == "" || !strings.HasPrefix(repo.AppPath, "/") {
+	if !isValidGitHubBranch(repo.Branch) {
 		return NewValidationError(
-			"Please provide a valid application path starting with /",
-			"repository appPath is required and must start with /",
+			"Invalid branch name. Use letters, digits and '.', '_', '-', '@', '+', '/'",
+			"repository branch is not a valid git ref name",
 		)
+	}
+	if err := validateSafePath(
+		repo.AppPath,
+		"repository appPath",
+		"Please provide a valid application path starting with /",
+	); err != nil {
+		return err
 	}
 	// If secretRef field is present (private repo), it must not be empty
 	if repo.SecretRef.Get() != nil && *repo.SecretRef.Get() == "" {
@@ -726,12 +780,32 @@ func validateInputInterface(agentType spec.AgentType, inputInterface *spec.Input
 			"unsupported inputInterface type: %s", inputInterface.Type,
 		)
 	}
+	// The base path is rendered into the Workload CR and into gateway routing, so
+	// it is checked whenever it is set, not only for the sub-type that requires it.
+	if basePath := StrPointerAsStr(inputInterface.BasePath, ""); basePath != "" {
+		if err := validateSafePath(
+			basePath,
+			"inputInterface.basePath",
+			"Please provide a valid base path starting with /",
+		); err != nil {
+			return err
+		}
+	}
 	if StrPointerAsStr(agentType.SubType, "") == string(AgentSubTypeCustomAPI) {
-		if inputInterface.Schema == nil || !strings.HasPrefix(StrPointerAsStr(inputInterface.Schema.Path, ""), "/") {
+		if inputInterface.Schema == nil {
 			return NewValidationError(
 				"Please provide a valid schema path starting with /",
 				"inputInterface.schema.path is required and must start with /",
 			)
+		}
+		// The schema path is resolved against the checked-out source tree in the
+		// build container, so it gets the same treatment as the other build paths.
+		if err := validateSafePath(
+			StrPointerAsStr(inputInterface.Schema.Path, ""),
+			"inputInterface.schema.path",
+			"Please provide a valid schema path starting with /",
+		); err != nil {
+			return err
 		}
 		if IntPointerAsInt(inputInterface.Port, 0) <= 0 || IntPointerAsInt(inputInterface.Port, 0) > 65535 {
 			return NewValidationError(
@@ -1209,27 +1283,64 @@ func isValidGitHubIdentifier(value string) bool {
 	return true
 }
 
-// isValidGitHubBranch validates branch names
+// gitBranchRe is a positive allowlist for git ref names: letters, digits and the
+// punctuation that real branch names use. An allowlist is used rather than a
+// denylist of git's special characters because a branch name is handed to git
+// inside the build container -- a denylist has to enumerate every character that
+// could matter there, and the previous one permitted ";" among others.
+var gitBranchRe = regexp.MustCompile(`^[A-Za-z0-9._@+/-]+$`)
+
+// isValidGitHubBranch validates branch names. Deliberately stricter than git's
+// own refname rules: it covers every branch name seen in practice while leaving
+// no room for shell metacharacters or for a leading "-" that git would read as
+// an option instead of a ref.
 func isValidGitHubBranch(branch string) bool {
-	if branch == "" {
+	if branch == "" || len(branch) > MaxGitBranchLength {
 		return false
 	}
 
-	// Reject path traversal
-	if strings.Contains(branch, "..") {
+	if !gitBranchRe.MatchString(branch) {
 		return false
 	}
 
-	// Reject control characters and null bytes (prevents injection attacks)
-	controlChars := regexp.MustCompile(`[\x00-\x1f\x7f]`)
-	if controlChars.MatchString(branch) {
+	// A leading "-" is read by git as an option rather than a ref.
+	if strings.HasPrefix(branch, "-") {
 		return false
 	}
 
-	// Reject Git special characters and whitespace
-	// Still allows @, +, and other characters that are valid in branch names
-	gitSpecialChars := regexp.MustCompile(`[\s~^:?*\[\\]`)
-	return !gitSpecialChars.MatchString(branch)
+	// Refname rules the character class above cannot express.
+	if strings.HasPrefix(branch, "/") || strings.HasSuffix(branch, "/") ||
+		strings.Contains(branch, "//") {
+		return false
+	}
+	if strings.Contains(branch, "..") || strings.Contains(branch, "@{") {
+		return false
+	}
+	if strings.HasSuffix(branch, ".") || strings.HasSuffix(branch, ".lock") {
+		return false
+	}
+
+	return true
+}
+
+// gitCommitIDRe matches an abbreviated or full SHA-1 object name.
+var gitCommitIDRe = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+
+// ValidateGitCommitID validates an optional commit to build. An empty value means
+// "use the latest commit on the branch" and is accepted. The commit reaches git
+// inside the build container, and its first eight characters also become part of
+// the built image tag, so it is held to an object name and nothing else.
+func ValidateGitCommitID(commitID string) error {
+	if commitID == "" {
+		return nil
+	}
+	if !gitCommitIDRe.MatchString(commitID) {
+		return NewValidationError(
+			"Invalid commit. Provide a commit SHA of 7 to 40 hexadecimal characters",
+			"commitId must be a hexadecimal git object name of 7 to 40 characters",
+		)
+	}
+	return nil
 }
 
 // ValidateListBranchesRequest validates the ListBranchesRequest payload

--- a/console/workspaces/pages/add-new-agent/src/form/schema.ts
+++ b/console/workspaces/pages/add-new-agent/src/form/schema.ts
@@ -57,6 +57,9 @@ const isBuildPath = (value: string): boolean =>
   !value.includes('..') &&
   (value === '/' || !value.endsWith('/'));
 
+// Only the host and the owner/repo segments; the backend pins the same shape.
+const gitHubRepoUrlRe = /^https:\/\/github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+(?:\.git)?\/?$/;
+
 // Base fields shared by both flows
 const baseAgentFields = {
   displayName: z
@@ -102,7 +105,7 @@ export const createAgentSchema = z.object({
     .min(1, 'Repository URL is required')
     .max(2048, 'Repository URL must be at most 2048 characters')
     .url('Must be a valid URL')
-    .refine((value) => /^https:\/\/github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+(?:\.git)?\/?$/.test(value), {
+    .refine((value) => gitHubRepoUrlRe.test(value), {
       message: 'Must be a GitHub repository URL, e.g. https://github.com/owner/repo',
     }),
   // A branch name is an argument to git, so the allowlist covers the characters

--- a/console/workspaces/pages/add-new-agent/src/form/schema.ts
+++ b/console/workspaces/pages/add-new-agent/src/form/schema.ts
@@ -48,6 +48,15 @@ export interface MCPProxyFormEntry {
   authenticationType?: AuthenticationType;
 }
 
+// Repository-relative paths (Dockerfile, OpenAPI schema, base path) become
+// directory and file arguments inside the build container, so they are held to
+// the same conservative POSIX subset the backend enforces. appPath spells the
+// same rule out field by field below, for per-rule messages.
+const isBuildPath = (value: string): boolean =>
+  /^\/[A-Za-z0-9._\-/]*$/.test(value) &&
+  !value.includes('..') &&
+  (value === '/' || !value.endsWith('/'));
+
 // Base fields shared by both flows
 const baseAgentFields = {
   displayName: z
@@ -84,12 +93,42 @@ export const createAgentSchema = z.object({
   // the authoritative gate. nullable for the case where no AMP-provided
   // instrumentation is available for the chosen Python version.
   instrumentationVersion: z.string().trim().nullable().optional(),
+  // The host and the owner/repo character set are pinned because the URL is
+  // handed to git inside the build container; the backend enforces the same rule
+  // (utils.validateRepoDetails), this is only the earlier, friendlier message.
   repositoryUrl: z
     .string()
     .trim()
     .min(1, 'Repository URL is required')
-    .url('Must be a valid URL'),
-  branch: z.string().trim().min(1, 'Branch is required'),
+    .max(2048, 'Repository URL must be at most 2048 characters')
+    .url('Must be a valid URL')
+    .refine((value) => /^https:\/\/github\.com\/[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+(?:\.git)?\/?$/.test(value), {
+      message: 'Must be a GitHub repository URL, e.g. https://github.com/owner/repo',
+    }),
+  // A branch name is an argument to git, so the allowlist covers the characters
+  // real branch names use and nothing else. The second refine carries the ref
+  // rules the character class cannot express, including the leading dash that
+  // git would read as an option instead of a branch.
+  branch: z
+    .string()
+    .trim()
+    .min(1, 'Branch is required')
+    .max(255, 'Branch must be at most 255 characters')
+    .refine((value) => /^[A-Za-z0-9._@+/-]+$/.test(value), {
+      message: 'Branch can only contain letters, numbers, ., _, @, +, - and /',
+    })
+    .refine(
+      (value) =>
+        !value.startsWith('-') &&
+        !value.startsWith('/') &&
+        !value.endsWith('/') &&
+        !value.includes('//') &&
+        !value.includes('..') &&
+        !value.includes('@{') &&
+        !value.endsWith('.') &&
+        !value.endsWith('.lock'),
+      { message: 'Branch is not a valid git branch name' }
+    ),
   appPath: z
     .string()
     .trim()
@@ -111,10 +150,18 @@ export const createAgentSchema = z.object({
       { message: 'App path must be a valid path (use / for root directory)' }
     ),
   gitSecretRef: z.string().trim().optional(),
+  // runCommand is the container's start command by design -- the buildpack makes
+  // it PID 1 under a shell -- so it is deliberately left unconstrained.
   runCommand: z.string().trim().optional(),
   language: z.string().trim().min(1, 'Language is required'),
   languageVersion: z.string().trim().optional(),
-  dockerfilePath: z.string().trim().optional(),
+  dockerfilePath: z
+    .string()
+    .trim()
+    .refine((value) => value === '' || isBuildPath(value), {
+      message: 'Dockerfile path must start with / and contain only letters, numbers, ., _, - and /',
+    })
+    .optional(),
   interfaceType: z.enum(['DEFAULT', 'CUSTOM']),
   port: z
     .union([z.number(), z.string(), z.undefined()])
@@ -123,8 +170,20 @@ export const createAgentSchema = z.object({
       return typeof val === 'string' ? Number(val) : val;
     })
     .optional(),
-  basePath: z.string().trim().optional(),
-  openApiPath: z.string().trim().optional(),
+  basePath: z
+    .string()
+    .trim()
+    .refine((value) => value === '' || isBuildPath(value), {
+      message: 'Base path must start with / and contain only letters, numbers, ., _, - and /',
+    })
+    .optional(),
+  openApiPath: z
+    .string()
+    .trim()
+    .refine((value) => value === '' || isBuildPath(value), {
+      message: 'OpenAPI path must start with / and contain only letters, numbers, ., _, - and /',
+    })
+    .optional(),
   env: z
     .array(
       z.object({

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/ballerina-buildpack-build.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/ballerina-buildpack-build.yaml
@@ -24,15 +24,27 @@ spec:
         command:
           - sh
           - -c
+        # Workflow parameters arrive as environment variables rather than being
+        # interpolated into the script body: Argo substitution is textual, so a
+        # spliced parameter would be parsed as shell by the interpreter below.
+        env:
+          - name: IMAGE_NAME
+            value: '{{ "{{" }}workflow.parameters.image-name{{ "}}" }}'
+          - name: IMAGE_TAG
+            value: '{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}'
+          - name: GIT_REVISION
+            value: '{{ "{{" }}inputs.parameters.git-revision{{ "}}" }}'
+          - name: APP_PATH
+            value: '{{ "{{" }}workflow.parameters.app-path{{ "}}" }}'
+          - name: BUILD_ENV_JSON
+            value: '{{ "{{" }}inputs.parameters.build-env{{ "}}" }}'
         args:
           - |-
             set -e
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-{{ "{{" }}inputs.parameters.git-revision{{ "}}" }}"
-            APP_PATH="{{ "{{" }}workflow.parameters.app-path{{ "}}" }}"
-            BUILD_ENV_JSON='{{ "{{" }}inputs.parameters.build-env{{ "}}" }}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             if [ ! -d "$WORKDIR/$APP_PATH" ]; then
               echo ">> Error: The specified application path '$APP_PATH' does not exist in the repository"

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/checkout-source.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/checkout-source.yaml
@@ -20,14 +20,34 @@ spec:
         command:
           - sh
           - -c
+        # Workflow parameters are passed as environment variables and never
+        # interpolated into the script body below. Argo substitution is purely
+        # textual, so a parameter spliced into the script would be parsed by this
+        # shell -- quoting the interpolation is not enough, because the value can
+        # contain the quote character itself.
+        env:
+          - name: BRANCH
+            value: '{{ "{{" }}workflow.parameters.branch{{ "}}" }}'
+          - name: REPO
+            value: '{{ "{{" }}workflow.parameters.git-repo{{ "}}" }}'
+          - name: COMMIT
+            value: '{{ "{{" }}workflow.parameters.commit{{ "}}" }}'
         args:
           - |-
             set -e
 
-            BRANCH={{ "{{" }}workflow.parameters.branch{{ "}}" }}
-            REPO={{ "{{" }}workflow.parameters.git-repo{{ "}}" }}
-            COMMIT={{ "{{" }}workflow.parameters.commit{{ "}}" }}
             GIT_SECRET_PATH="/etc/secrets/git-secret"
+
+            # A leading dash would be read by git as an option rather than a ref,
+            # so reject it before either value reaches a git argv.
+            for revision in "$BRANCH" "$COMMIT"; do
+                case "$revision" in
+                    -*)
+                        echo "Invalid git revision '$revision': must not start with '-'"
+                        exit 1
+                        ;;
+                esac
+            done
 
             if [ -d "$GIT_SECRET_PATH" ] && [ "$(ls -A $GIT_SECRET_PATH)" ]; then
                 # Basic auth (kubernetes.io/basic-auth)
@@ -71,15 +91,17 @@ spec:
 
             if [ -n "$COMMIT" ]; then
                 echo "Cloning specific commit: $COMMIT"
-                git clone --no-checkout --depth 1 "$REPO" /mnt/vol/source
+                git clone --no-checkout --depth 1 -- "$REPO" /mnt/vol/source
                 cd /mnt/vol/source
                 git config --global advice.detachedHead false
                 git fetch --depth 1 origin "$COMMIT"
-                git checkout "$COMMIT"
+                # FETCH_HEAD is what the fetch above just resolved, so the commit
+                # never has to be passed to checkout as a ref argument.
+                git checkout FETCH_HEAD
                 echo -n "$COMMIT" | cut -c1-8 > /tmp/git-revision.txt
             else
                 echo "Cloning branch: $BRANCH with latest commit"
-                git clone --single-branch --branch $BRANCH --depth 1 "$REPO" /mnt/vol/source
+                git clone --single-branch --branch "$BRANCH" --depth 1 -- "$REPO" /mnt/vol/source
                 cd /mnt/vol/source
                 COMMIT_SHA=$(git rev-parse HEAD)
                 echo -n "$COMMIT_SHA" | cut -c1-8 > /tmp/git-revision.txt

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/dockefile-build.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/dockefile-build.yaml
@@ -22,16 +22,30 @@ spec:
         command:
           - sh
           - -c
+        # Workflow parameters arrive as environment variables rather than being
+        # interpolated into the script body: Argo substitution is textual, so a
+        # spliced parameter would be parsed as shell by the interpreter below.
+        env:
+          - name: IMAGE_NAME
+            value: '{{ "{{" }}workflow.parameters.image-name{{ "}}" }}'
+          - name: IMAGE_TAG
+            value: '{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}'
+          - name: GIT_REVISION
+            value: '{{ "{{" }}inputs.parameters.git-revision{{ "}}" }}'
+          - name: DOCKER_CONTEXT
+            value: '{{ "{{" }}workflow.parameters.docker-context{{ "}}" }}'
+          - name: DOCKERFILE_PATH
+            value: '{{ "{{" }}workflow.parameters.dockerfile-path{{ "}}" }}'
+          - name: BUILD_ENV_JSON
+            value: '{{ "{{" }}inputs.parameters.build-env{{ "}}" }}'
+          - name: BUILD_ARGS_JSON
+            value: '{{ "{{" }}inputs.parameters.build-args{{ "}}" }}'
         args:
           - |-
             set -e
 
             WORKDIR="/mnt/vol/source"
-            IMAGE="{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-{{ "{{" }}inputs.parameters.git-revision{{ "}}" }}"
-            DOCKER_CONTEXT="{{ "{{" }}workflow.parameters.docker-context{{ "}}" }}"
-            DOCKERFILE_PATH="{{ "{{" }}workflow.parameters.dockerfile-path{{ "}}" }}"
-            BUILD_ENV_JSON='{{ "{{" }}inputs.parameters.build-env{{ "}}" }}'
-            BUILD_ARGS_JSON='{{ "{{" }}inputs.parameters.build-args{{ "}}" }}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
 
             echo ">> Image: $IMAGE"

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/gcp-buildpack-build.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/gcp-buildpack-build.yaml
@@ -21,15 +21,27 @@ spec:
         command:
           - sh
           - -c
+        # Workflow parameters arrive as environment variables rather than being
+        # interpolated into the script body: Argo substitution is textual, so a
+        # spliced parameter would be parsed as shell by the interpreter below.
+        env:
+          - name: IMAGE_NAME
+            value: '{{ "{{" }}workflow.parameters.image-name{{ "}}" }}'
+          - name: IMAGE_TAG
+            value: '{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}'
+          - name: GIT_REVISION
+            value: '{{ "{{" }}inputs.parameters.git-revision{{ "}}" }}'
+          - name: APP_PATH
+            value: '{{ "{{" }}workflow.parameters.app-path{{ "}}" }}'
+          - name: BUILD_ENV_JSON
+            value: '{{ "{{" }}inputs.parameters.build-env{{ "}}" }}'
         args:
           - |-
             set -e
 
             WORKDIR=/mnt/vol/source
 
-            IMAGE="{{ "{{" }}workflow.parameters.image-name{{ "}}" }}:{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}-{{ "{{" }}inputs.parameters.git-revision{{ "}}" }}"
-            APP_PATH="{{ "{{" }}workflow.parameters.app-path{{ "}}" }}"
-            BUILD_ENV_JSON='{{ "{{" }}inputs.parameters.build-env{{ "}}" }}'
+            IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             echo ">> Image: $IMAGE"
             echo ">> App path: $APP_PATH"

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
@@ -89,18 +89,53 @@ spec:
             if [ -z "$FILE_MOUNTS" ] || [ "$FILE_MOUNTS" = "null" ]; then FILE_MOUNTS='[]'; fi
             if [ -z "$ENDPOINTS" ] || [ "$ENDPOINTS" = "null" ]; then ENDPOINTS='[]'; fi
 
+            # An endpoint name becomes a key in the Workload CR, so a repeated name
+            # would drop every earlier endpoint that shares it. Fail instead.
+            DUPLICATE_ENDPOINTS=$(printf '%s' "$ENDPOINTS" \
+              | jq -r '[.[].name] | group_by(.) | map(select(length > 1) | .[0]) | join(", ")')
+            if [ -n "$DUPLICATE_ENDPOINTS" ]; then
+              echo "Error: duplicate endpoint names: ${DUPLICATE_ENDPOINTS}"
+              exit 1
+            fi
+
             # --- Step 1: Resolve endpoint schemas that point at a file in the source tree ---
             # The file is read with jq --rawfile so its contents are JSON-encoded by
             # jq and never pass through the shell or through YAML text assembly.
+            #
+            # The path is validated by the API before it gets here, which stops "..",
+            # but not a symlink committed in the repository: this container mounts its
+            # service account token, and whatever is read lands in the Workload CR the
+            # caller can read back. So the target is canonicalised and required to stay
+            # inside the checkout.
+            SOURCE_ROOT=$(realpath "$SOURCE_PATH" 2>/dev/null || true)
             ENDPOINT_COUNT=$(printf '%s' "$ENDPOINTS" | jq 'length')
             i=0
             while [ "$i" -lt "$ENDPOINT_COUNT" ]; do
               schema_content=$(printf '%s' "$ENDPOINTS" | jq -r --argjson i "$i" '.[$i].schemaContent // ""')
               schema_file=$(printf '%s' "$ENDPOINTS" | jq -r --argjson i "$i" '.[$i].schemaFilePath // ""')
-              if [ -z "$schema_content" ] && [ -n "$schema_file" ] && [ -f "${SOURCE_PATH}${schema_file}" ]; then
-                ENDPOINTS=$(printf '%s' "$ENDPOINTS" | jq --argjson i "$i" \
-                  --rawfile content "${SOURCE_PATH}${schema_file}" '.[$i].schemaContent = $content')
+              if [ -n "$schema_content" ] || [ -z "$schema_file" ]; then
+                i=$((i + 1))
+                continue
               fi
+
+              resolved=$(realpath "${SOURCE_PATH}${schema_file}" 2>/dev/null || true)
+              if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
+                # Pre-existing behaviour is to carry on without a schema; say so
+                # rather than leaving the endpoint silently schema-less.
+                echo "Warning: schema file '${schema_file}' not found; endpoint will have no schema"
+                i=$((i + 1))
+                continue
+              fi
+              case "$resolved" in
+                "$SOURCE_ROOT"/*) ;;
+                *)
+                  echo "Error: schema file '${schema_file}' resolves outside the repository checkout"
+                  exit 1
+                  ;;
+              esac
+
+              ENDPOINTS=$(printf '%s' "$ENDPOINTS" | jq --argjson i "$i" \
+                --rawfile content "$resolved" '.[$i].schemaContent = $content')
               i=$((i + 1))
             done
 

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
@@ -28,22 +28,46 @@ spec:
             valueFrom:
               path: /mnt/vol/workload-cr.yaml
       container:
+        # Workflow parameters arrive as environment variables and are never
+        # interpolated into the script body: Argo escapes a substituted parameter
+        # for JSON but not for the shell, so a spliced parameter would be parsed
+        # as shell by the interpreter below (#1639). The JSON-valued ones
+        # (endpoints, env vars, file mounts) carry arbitrary user text, which is
+        # why they are handed to jq rather than to the shell.
         env:
           - name: OAUTH_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
                 name: '{{ "{{" }}inputs.parameters.workload-publisher-secret-name{{ "}}" }}'
                 key: workload-publisher-oauth
-          # User text reaches the script as env vars, never as shell source: Argo
-          # escapes a substituted parameter for JSON but not for the shell (#1639).
+          - name: IMAGE
+            value: '{{ "{{" }}inputs.parameters.image{{ "}}" }}'
+          - name: PROJECT_NAME
+            value: '{{ "{{" }}workflow.parameters.project-name{{ "}}" }}'
+          - name: COMPONENT_NAME
+            value: '{{ "{{" }}workflow.parameters.component-name{{ "}}" }}'
+          - name: NAMESPACE
+            value: '{{ "{{" }}workflow.parameters.namespace-name{{ "}}" }}'
+          - name: APP_PATH
+            value: '{{ "{{" }}workflow.parameters.app-path{{ "}}" }}'
           - name: ENDPOINTS
             value: '{{ "{{" }}workflow.parameters.endpoints{{ "}}" }}'
           - name: ENV_VARS
             value: '{{ "{{" }}workflow.parameters.environment-variables{{ "}}" }}'
           - name: FILE_MOUNTS
             value: '{{ "{{" }}workflow.parameters.file-mounts{{ "}}" }}'
-          - name: APP_PATH
-            value: '{{ "{{" }}workflow.parameters.app-path{{ "}}" }}'
+          - name: RUN_NAME
+            value: '{{ "{{" }}inputs.parameters.run-name{{ "}}" }}'
+          - name: OAUTH_URL
+            value: '{{ "{{" }}inputs.parameters.oauth-token-url{{ "}}" }}'
+          - name: OAUTH_HOST
+            value: '{{ "{{" }}inputs.parameters.oauth-host-header{{ "}}" }}'
+          - name: CLIENT_ID
+            value: '{{ "{{" }}inputs.parameters.oauth-client-id{{ "}}" }}'
+          - name: API_URL
+            value: '{{ "{{" }}inputs.parameters.api-server-url{{ "}}" }}'
+          - name: API_HOST
+            value: '{{ "{{" }}inputs.parameters.api-server-host-header{{ "}}" }}'
         image: ghcr.io/openchoreo/podman-runner:v1.0
         command:
           - sh
@@ -55,128 +79,92 @@ spec:
             # Install jq
             apk add --no-cache jq
 
-            # Variables
-            IMAGE={{ "{{" }}inputs.parameters.image{{ "}}" }}
-            PROJECT_NAME={{ "{{" }}workflow.parameters.project-name{{ "}}" }}
-            COMPONENT_NAME={{ "{{" }}workflow.parameters.component-name{{ "}}" }}
-            NAMESPACE={{ "{{" }}workflow.parameters.namespace-name{{ "}}" }}
-
-            # ENDPOINTS, ENV_VARS, FILE_MOUNTS and APP_PATH come from the env.
             SOURCE_PATH="/mnt/vol/source/${APP_PATH}"
-            OUT="/mnt/vol/workload-cr.yaml"
+            OUT_JSON="/mnt/vol/workload-cr.json"
+            OUT_FULL_JSON="/mnt/vol/workload-cr-full.json"
+            OUT_YAML="/mnt/vol/workload-cr.yaml"
 
-            # Base workload
-            echo "apiVersion: openchoreo.dev/v1alpha1" > "$OUT"
-            echo "kind: Workload" >> "$OUT"
-            echo "metadata:" >> "$OUT"
-            echo "  name: ${COMPONENT_NAME}-workload" >> "$OUT"
-            echo "  namespace: ${NAMESPACE}" >> "$OUT"
-            echo "spec:" >> "$OUT"
-            echo "  owner:" >> "$OUT"
-            echo "    projectName: ${PROJECT_NAME}" >> "$OUT"
-            echo "    componentName: ${COMPONENT_NAME}" >> "$OUT"
-            echo "  container:" >> "$OUT"
-            echo "    image: ${IMAGE}" >> "$OUT"
+            # Argo leaves an unset parameter as the empty string.
+            if [ -z "$ENV_VARS" ] || [ "$ENV_VARS" = "null" ]; then ENV_VARS='[]'; fi
+            if [ -z "$FILE_MOUNTS" ] || [ "$FILE_MOUNTS" = "null" ]; then FILE_MOUNTS='[]'; fi
+            if [ -z "$ENDPOINTS" ] || [ "$ENDPOINTS" = "null" ]; then ENDPOINTS='[]'; fi
 
-            # Environment variables
-            if [ -n "$ENV_VARS" ] && [ "$ENV_VARS" != "null" ] && [ "$ENV_VARS" != "[]" ]; then
-              echo "    env:" >> "$OUT"
-              echo "$ENV_VARS" | jq -c '.[]' | while read -r env_var; do
-                NAME=$(echo "$env_var" | jq -r '.name')
-                VALUE=$(echo "$env_var" | jq -r '.value // empty')
-                SECRET_NAME=$(echo "$env_var" | jq -r '.valueFrom.secretKeyRef.name // empty')
-                SECRET_KEY=$(echo "$env_var" | jq -r '.valueFrom.secretKeyRef.key // empty')
+            # --- Step 1: Resolve endpoint schemas that point at a file in the source tree ---
+            # The file is read with jq --rawfile so its contents are JSON-encoded by
+            # jq and never pass through the shell or through YAML text assembly.
+            ENDPOINT_COUNT=$(printf '%s' "$ENDPOINTS" | jq 'length')
+            i=0
+            while [ "$i" -lt "$ENDPOINT_COUNT" ]; do
+              schema_content=$(printf '%s' "$ENDPOINTS" | jq -r --argjson i "$i" '.[$i].schemaContent // ""')
+              schema_file=$(printf '%s' "$ENDPOINTS" | jq -r --argjson i "$i" '.[$i].schemaFilePath // ""')
+              if [ -z "$schema_content" ] && [ -n "$schema_file" ] && [ -f "${SOURCE_PATH}${schema_file}" ]; then
+                ENDPOINTS=$(printf '%s' "$ENDPOINTS" | jq --argjson i "$i" \
+                  --rawfile content "${SOURCE_PATH}${schema_file}" '.[$i].schemaContent = $content')
+              fi
+              i=$((i + 1))
+            done
 
-                echo "      - key: ${NAME}" >> "$OUT"
-                if [ -n "$SECRET_NAME" ] && [ -n "$SECRET_KEY" ]; then
-                  echo "        valueFrom:" >> "$OUT"
-                  echo "          secretKeyRef:" >> "$OUT"
-                  echo "            name: ${SECRET_NAME}" >> "$OUT"
-                  echo "            key: ${SECRET_KEY}" >> "$OUT"
-                else
-                  echo "        value: $(printf '%s' "$VALUE" | jq -R .)" >> "$OUT"
-                fi
-              done
-            fi
+            # --- Step 2: Build the Workload CR ---
+            # Assembled by jq rather than by echoing YAML lines: every value is
+            # encoded as JSON by jq, so no field can inject document structure.
+            jq -n -c \
+              --arg name "${COMPONENT_NAME}-workload" \
+              --arg namespace "$NAMESPACE" \
+              --arg projectName "$PROJECT_NAME" \
+              --arg componentName "$COMPONENT_NAME" \
+              --arg image "$IMAGE" \
+              --argjson envVars "$ENV_VARS" \
+              --argjson fileMounts "$FILE_MOUNTS" \
+              --argjson endpoints "$ENDPOINTS" '
+                def secret_ref:
+                  (.valueFrom.secretKeyRef.name // "") as $n
+                  | (.valueFrom.secretKeyRef.key // "") as $k
+                  | if $n != "" and $k != ""
+                    then { valueFrom: { secretKeyRef: { name: $n, key: $k } } }
+                    else { value: (.value // "") }
+                    end;
 
-            # File mounts
-            if [ -n "$FILE_MOUNTS" ] && [ "$FILE_MOUNTS" != "null" ] && [ "$FILE_MOUNTS" != "[]" ]; then
-              echo "    files:" >> "$OUT"
-              echo "$FILE_MOUNTS" | jq -c '.[]' | while read -r file_var; do
-                KEY=$(echo "$file_var" | jq -r '.key')
-                MOUNT_PATH=$(echo "$file_var" | jq -r '.mountPath')
-                VALUE=$(echo "$file_var" | jq -r '.value // empty')
-                SECRET_NAME=$(echo "$file_var" | jq -r '.valueFrom.secretKeyRef.name // empty')
-                SECRET_KEY=$(echo "$file_var" | jq -r '.valueFrom.secretKeyRef.key // empty')
+                def env_entry: { key: .name } + secret_ref;
 
-                echo "      - key: ${KEY}" >> "$OUT"
-                echo "        mountPath: ${MOUNT_PATH}" >> "$OUT"
-                if [ -n "$SECRET_NAME" ] && [ -n "$SECRET_KEY" ]; then
-                  echo "        valueFrom:" >> "$OUT"
-                  echo "          secretKeyRef:" >> "$OUT"
-                  echo "            name: ${SECRET_NAME}" >> "$OUT"
-                  echo "            key: ${SECRET_KEY}" >> "$OUT"
-                else
-                  echo "        value: $(printf '%s' "$VALUE" | jq -R .)" >> "$OUT"
-                fi
-              done
-            fi
+                def file_entry: { key: .key, mountPath: .mountPath } + secret_ref;
 
-            # Endpoints
-            if [ -n "$ENDPOINTS" ] && [ "$ENDPOINTS" != "null" ] && [ "$ENDPOINTS" != "[]" ]; then
-              echo "  endpoints:" >> "$OUT"
-              echo "$ENDPOINTS" | jq -c '.[]' | while read -r ep; do
-                NAME=$(echo "$ep" | jq -r '.name')
-                TYPE=$(echo "$ep" | jq -r '.type // "HTTP"')
-                PORT=$(echo "$ep" | jq -r '.port')
-                BASE_PATH=$(echo "$ep" | jq -r '.basePath')
-                VISIBILITY=$(echo "$ep" | jq -c '.visibility')
-                SCHEMA_TYPE=$(echo "$ep" | jq -r '.schemaType // "REST"')
-                SCHEMA_FILE_PATH=$(echo "$ep" | jq -r '.schemaFilePath // empty')
-                SCHEMA_CONTENT=$(echo "$ep" | jq -r '.schemaContent // empty')
+                def endpoint_entry:
+                  { type: (.type // "HTTP"), port: .port }
+                  + (if (.basePath // "") != "" then { basePath: .basePath } else {} end)
+                  + (if (.visibility // null) != null then { visibility: .visibility } else {} end)
+                  + (if (.schemaContent // "") != ""
+                     then { schema: { type: (.schemaType // "REST"), content: .schemaContent } }
+                     else {} end);
 
-                echo "    ${NAME}:" >> "$OUT"
-                echo "      type: ${TYPE}" >> "$OUT"
-                echo "      port: ${PORT}" >> "$OUT"
-                echo "      basePath: ${BASE_PATH}" >> "$OUT"
-                echo "      visibility:" >> "$OUT"
-                echo "$VISIBILITY" | jq -r '.[]' | while read -r vis; do
-                  echo "        - ${vis}" >> "$OUT"
-                done
+                {
+                  metadata: { name: $name, namespace: $namespace },
+                  spec: (
+                    {
+                      owner: { projectName: $projectName, componentName: $componentName },
+                      container: (
+                        { image: $image }
+                        + (if ($envVars | length) > 0 then { env: [ $envVars[] | env_entry ] } else {} end)
+                        + (if ($fileMounts | length) > 0 then { files: [ $fileMounts[] | file_entry ] } else {} end)
+                      )
+                    }
+                    + (if ($endpoints | length) > 0
+                       then { endpoints: ($endpoints | map({ (.name): endpoint_entry }) | add) }
+                       else {} end)
+                  )
+                }
+              ' > "$OUT_JSON"
 
-                if [ -n "$SCHEMA_CONTENT" ]; then
-                  echo "      schema:" >> "$OUT"
-                  echo "        type: ${SCHEMA_TYPE}" >> "$OUT"
-                  echo "        content: |" >> "$OUT"
-                  echo "$SCHEMA_CONTENT" | sed 's/^/          /' >> "$OUT"
-                elif [ -n "$SCHEMA_FILE_PATH" ] && [ -f "$SOURCE_PATH$SCHEMA_FILE_PATH" ]; then
-                  echo "      schema:" >> "$OUT"
-                  echo "        type: ${SCHEMA_TYPE}" >> "$OUT"
-                  echo "        content: |" >> "$OUT"
-                  sed 's/^/          /' "$SOURCE_PATH$SCHEMA_FILE_PATH" >> "$OUT"
-                fi
-              done
-            fi
-
-            echo "Workload CR saved to $OUT"
-
-            # --- Step 2: Convert workload CR YAML to JSON ---
-            RUN_NAME={{ "{{" }}inputs.parameters.run-name{{ "}}" }}
+            # The API server payload carries no apiVersion/kind; the YAML rendered
+            # for the workflow output parameter does.
+            jq -c '{ apiVersion: "openchoreo.dev/v1alpha1", kind: "Workload" } + .' \
+              "$OUT_JSON" > "$OUT_FULL_JSON"
             podman run --rm \
               -v /mnt/vol:/data:rw \
-              mikefarah/yq -o=json 'del(.apiVersion) | del(.kind)' /data/workload-cr.yaml \
-              > /mnt/vol/workload-cr-raw.json
-            podman run --rm \
-              -v /mnt/vol:/data:rw \
-              ghcr.io/jqlang/jq:1.7.1 -c '.' /data/workload-cr-raw.json \
-              > /mnt/vol/workload-cr.json
-            echo "Generated workload JSON payload"
-
+              mikefarah/yq -p=json -o=yaml '.' /data/workload-cr-full.json \
+              > "$OUT_YAML"
+            echo "Workload CR saved to $OUT_YAML"
 
             # --- Step 3: Get OAuth token ---
-            OAUTH_URL={{ "{{" }}inputs.parameters.oauth-token-url{{ "}}" }}
-            OAUTH_HOST={{ "{{" }}inputs.parameters.oauth-host-header{{ "}}" }}
-            CLIENT_ID={{ "{{" }}inputs.parameters.oauth-client-id{{ "}}" }}
             CLIENT_SECRET="${OAUTH_CLIENT_SECRET}"
 
             echo "Requesting OAuth token from ${OAUTH_URL}..."
@@ -199,10 +187,7 @@ spec:
             echo "Successfully obtained access token"
 
             # --- Step 4: Create or update workload via API server ---
-            API_URL={{ "{{" }}inputs.parameters.api-server-url{{ "}}" }}
-            API_HOST={{ "{{" }}inputs.parameters.api-server-host-header{{ "}}" }}
-
-            WORKLOAD_NAME=$(jq -r '.metadata.name' /mnt/vol/workload-cr.json)
+            WORKLOAD_NAME=$(jq -r '.metadata.name' "$OUT_JSON")
 
             echo "Creating workload via ${API_URL}/api/v1/namespaces/${NAMESPACE}/workloads..."
             RESPONSE=$(curl -s -w "\n%{http_code}" \
@@ -210,7 +195,7 @@ spec:
               -H "Host: ${API_HOST}" \
               -H "Content-Type: application/json" \
               -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-              -d @/mnt/vol/workload-cr.json)
+              -d @"$OUT_JSON")
 
             HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
             BODY=$(echo "${RESPONSE}" | sed '$d')
@@ -224,7 +209,7 @@ spec:
                 -H "Host: ${API_HOST}" \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-                -d @/mnt/vol/workload-cr.json)
+                -d @"$OUT_JSON")
 
               HTTP_CODE=$(echo "${RESPONSE}" | tail -1)
               BODY=$(echo "${RESPONSE}" | sed '$d')
@@ -256,7 +241,7 @@ spec:
             fi
 
             echo "${WF_RUN_BODY}" > /mnt/vol/workflowrun-get.json
-            jq --rawfile wl /mnt/vol/workload-cr.json \
+            jq --rawfile wl "$OUT_JSON" \
               '.metadata.annotations["openchoreo.dev/workload"] = ($wl | rtrimstr("\n"))' \
               /mnt/vol/workflowrun-get.json > /mnt/vol/workflowrun-updated.json
 

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/publish-image.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/publish-image.yaml
@@ -23,13 +23,20 @@ spec:
         command:
           - sh
           - -c
+        # Workflow parameters arrive as environment variables rather than being
+        # interpolated into the script body: Argo substitution is textual, so a
+        # spliced parameter would be parsed as shell by the interpreter below.
+        env:
+          - name: GIT_REVISION
+            value: '{{ "{{" }}inputs.parameters.git-revision{{ "}}" }}'
+          - name: IMAGE_NAME
+            value: '{{ "{{" }}workflow.parameters.image-name{{ "}}" }}'
+          - name: IMAGE_TAG
+            value: '{{ "{{" }}workflow.parameters.image-tag{{ "}}" }}'
         args:
           - |-
             set -e
 
-            GIT_REVISION={{ "{{" }}inputs.parameters.git-revision{{ "}}" }}
-            IMAGE_NAME={{ "{{" }}workflow.parameters.image-name{{ "}}" }}
-            IMAGE_TAG={{ "{{" }}workflow.parameters.image-tag{{ "}}" }}
             SRC_IMAGE="${IMAGE_NAME}:${IMAGE_TAG}-${GIT_REVISION}"
 
             REGISTRY_ENDPOINT="{{ include "openchoreo-workflow-plane.registryEndpoint" . }}"
@@ -47,12 +54,12 @@ spec:
 
             podman load -i /mnt/vol/app-image.tar
 
-            podman tag $SRC_IMAGE $REGISTRY_ENDPOINT/$SRC_IMAGE
+            podman tag "$SRC_IMAGE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
 
             if [ -f "$AUTH_FILE" ]; then
-              podman push --tls-verify={{ .Values.global.defaultResources.registry.tlsVerify }} --authfile "$AUTH_FILE" $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify={{ .Values.global.defaultResources.registry.tlsVerify }} --authfile "$AUTH_FILE" "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             else
-              podman push --tls-verify={{ .Values.global.defaultResources.registry.tlsVerify }} $REGISTRY_ENDPOINT/$SRC_IMAGE
+              podman push --tls-verify={{ .Values.global.defaultResources.registry.tlsVerify }} "$REGISTRY_ENDPOINT/$SRC_IMAGE"
             fi
 
             echo -n "$REGISTRY_ENDPOINT/$SRC_IMAGE" > /tmp/image.txt

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
@@ -2,13 +2,19 @@
 # Render assertions for wso2-amp-platform-resources-extension.
 # Run: bash deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh
 #
-# Covers the shell quoting of the amp-generate-workload build step. Argo escapes
-# a substituted parameter for JSON, never for the shell, so a parameter carrying
-# user text that is interpolated into the step's script becomes shell source: one
-# apostrophe in a file mount closes the string early and the rest of the script
-# is reparsed as code. The build then dies on a bare `(` far from the real cause
-# and Argo reports only a missing output artifact (see issue #1639). The values
-# have to reach the container as env vars, which the shell never parses.
+# Covers the shell quoting of the build steps. Argo escapes a substituted
+# parameter for JSON, never for the shell, so a parameter carrying user text that
+# is interpolated into a step's script becomes shell source: one apostrophe in a
+# file mount closes the string early and the rest of the script is reparsed as
+# code. The build then dies on a bare `(` far from the real cause and Argo
+# reports only a missing output artifact (see issue #1639). A separator such as
+# `;` needs no quote at all -- it just runs. The values have to reach the
+# container as env vars, which the shell never parses.
+#
+# Three groups of assertions: the amp-generate-workload step it started with,
+# then checkout-source, where the repository URL, branch and commit arrive the
+# same way, then the whole chart, since every build step runs `sh -c` over a
+# block scalar and the property has to hold for all of them.
 set -uo pipefail
 
 CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -168,6 +174,86 @@ if [[ -z "$QUOTED_ASSIGNMENT" ]]; then
   printf 'ok   - no Argo parameter is assigned inside a single-quoted string\n'
 else
   printf 'FAIL - an Argo parameter is assigned inside a single-quoted string\n%s\n' "$QUOTED_ASSIGNMENT"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# --- checkout-source ---------------------------------------------------------
+# The repository URL, branch and commit are user input on the same path, and this
+# step holds the git credential secret, so a spliced value runs next to it.
+# script_body and env_value both read $RENDERED, so pointing that at the next
+# template reuses every assertion above.
+CHECKOUT_TMPL=templates/cluster-workflow-templates/checkout-source.yaml
+
+if ! RENDERED="$(helm template test-release "$CHART_DIR" --show-only "$CHECKOUT_TMPL" 2>&1)"; then
+  printf 'FAIL - helm template failed for %s\n%s\n' "$CHECKOUT_TMPL" "$RENDERED"
+  exit 1
+fi
+
+SCRIPT="$(script_body)"
+
+if [[ -z "$SCRIPT" ]]; then
+  printf 'FAIL - could not extract the checkout script from %s\n' "$CHECKOUT_TMPL"
+  exit 1
+fi
+
+assert_param_via_env BRANCH workflow.parameters.branch
+assert_param_via_env REPO workflow.parameters.git-repo
+assert_param_via_env COMMIT workflow.parameters.commit
+
+if [[ -z "$(sh -n <<<"$SCRIPT" 2>&1)" ]]; then
+  printf 'ok   - checkout-source parses under sh\n'
+else
+  printf 'FAIL - checkout-source does not parse under sh\n      %s\n' "$(sh -n <<<"$SCRIPT" 2>&1)"
+  FAILURES=$((FAILURES + 1))
+fi
+
+# Reaching git as an env var removes the shell, but not the option parser: an
+# unquoted expansion still word-splits, and a ref opening with a dash is read as
+# a flag rather than a branch.
+if grep -qF -- '--branch "$BRANCH"' <<<"$SCRIPT"; then
+  printf 'ok   - the clone quotes the branch it expands\n'
+else
+  printf 'FAIL - the branch expansion in the clone is unquoted\n'
+  FAILURES=$((FAILURES + 1))
+fi
+
+if grep -qE '^ *-\*\)' <<<"$SCRIPT"; then
+  printf 'ok   - a ref opening with a dash is rejected before it reaches git\n'
+else
+  printf 'FAIL - nothing stops a ref opening with a dash from becoming a git option\n'
+  FAILURES=$((FAILURES + 1))
+fi
+
+# --- Every build step in the chart -------------------------------------------
+# The defect was one quoting style in one step, then the same style in another.
+# This is the property itself, so a step added later cannot reintroduce it: no
+# Argo parameter may appear anywhere inside a script a shell parses. Scoped to
+# block scalars under args:, because an argv list is passed to exec, not to sh.
+if ! CHART_RENDERED="$(helm template test-release "$CHART_DIR" 2>&1)"; then
+  printf 'FAIL - helm template failed for the chart\n%s\n' "$CHART_RENDERED"
+  exit 1
+fi
+
+SPLICED="$(awk '
+  function ind(s) { match(s, /^ */); return RLENGTH }
+  /^# Source: / { src = $3; next }
+  !in_script && $0 ~ /^ *args:$/ { pending = 1; ai = ind($0); next }
+  pending {
+    if ($0 ~ /^[ ]*$/) next
+    pending = 0
+    if ($0 ~ /^ *- \|-?$/) in_script = 1
+    next
+  }
+  in_script {
+    if ($0 !~ /^[ ]*$/ && ind($0) <= ai) { in_script = 0; next }
+    if ($0 ~ /\{\{(workflow|inputs)\.parameters/) printf "      %s: %s\n", src, $0
+  }
+' <<<"$CHART_RENDERED")"
+
+if [[ -z "$SPLICED" ]]; then
+  printf 'ok   - no Argo parameter is spliced into a shell script anywhere in the chart\n'
+else
+  printf 'FAIL - Argo parameters are spliced into shell scripts\n%s\n' "$SPLICED"
   FAILURES=$((FAILURES + 1))
 fi
 


### PR DESCRIPTION
## Purpose
Argo substitutes a workflow parameter as plain text into whatever it appears in. Every build step in `wso2-amp-platform-resources-extension` runs `sh -c` over a block scalar, so a parameter written into that scalar becomes shell source rather than data.

`checkout-source` received the repository URL, branch and commit as bare shell assignments, so a value carrying a command separator was executed by the checkout container. That container mounts the git credential secret, runs before `rm -rf .git`, and shares its workspace volume with the build and publish stages, which are `privileged: true` and hold the registry push secret and the workload publisher OAuth secret. The build still reported success afterwards, so nothing surfaced.

The same shape was present in the buildpack and containerfile builders (application path, Dockerfile path, docker context, build env/args), in `publish-image`, and in the remaining parameters of `amp-generate-workload` that #1704 did not cover.

Separately, `amp-generate-workload` assembled the Workload CR by echoing YAML lines. Only the two `value:` fields were escaped, so a newline in any other field could contribute document structure of its own. That matters because the CRD accepts `spec.container.command` and the component type propagates it to the deployed pod.

On the input side, the values themselves were barely checked: the branch was only tested for non-emptiness, the URL's owner and repository segments came from a regex excluding just `/`, `appPath` and `dockerfilePath` were checked only for a leading slash, and `commitId` — a query parameter on the build trigger — was not checked at all.

Resolves #1639

## Goals
Make it structurally impossible for a build parameter to be parsed as shell or to contribute YAML structure, and reject input that cannot be a real repository before a build starts rather than after.

## Approach
**Parameters reach the container through the pod spec.** Every `{{workflow.parameters.*}}` and `{{inputs.parameters.*}}` moves out of `container.args` and into `container.env`, referenced as `"$VAR"`. Quoting the interpolation is not sufficient, because the value can contain the quote character; delivering it as an environment variable removes the shell from the path entirely. #1704 established this for the four parameters carrying user text in `amp-generate-workload`; this extends it to the rest of that step and to `checkout-source`, `gcp-buildpack-build`, `ballerina-buildpack-build`, `dockefile-build` and `publish-image`.

**Two follow-ons in `checkout-source`.** The branch is quoted where it expands into the clone, and a ref opening with `-` is rejected up front — reaching git as an environment variable still leaves git's own option parser in the path.

**`amp-generate-workload` builds the CR with jq.** A single `jq -n` program constructs the object from `--arg`/`--argjson` inputs, so every value is encoded rather than concatenated, and the YAML for the output parameter is rendered from that JSON. This replaces about a hundred lines of `echo` with roughly half that. The endpoint schema-file fallback is pre-resolved with `jq --rawfile` so the file contents never pass through the shell either.

**Input validation.** `isValidGitHubBranch` already existed but was wired only to list-branches and permitted `;`, so it is rewritten as a positive allowlist plus the ref rules a character class cannot express, and called from `validateRepoDetails`. The URL's owner and repository segments go through the existing `isValidGitHubIdentifier`. `appPath`, `dockerfilePath`, the OpenAPI schema path and the endpoint base path share one `validateSafePath` helper, matching the file-mount `mountPath` rules already in the file. `commitId` is constrained to a hexadecimal object name.

Environment variable values, file mount contents and `runCommand` are deliberately left unconstrained. They legitimately hold arbitrary bytes — `runCommand` is the container's start command, which the buildpack makes PID 1 under a shell by design — and restricting them would break existing agents for no gain now that no value reaches a build-host shell.

The console form rules and the OpenAPI patterns mirror the Go checks so a bad value is reported in the form rather than after a build starts. The spec patterns are documentation only: this service has no OpenAPI request-validation middleware, which is noted where they are declared.

## User stories
N/A — hardening of an existing path, no new user-facing capability.

## Release note
Build parameters are now delivered to the build steps as environment variables instead of being interpolated into their shell scripts, the Workload CR is generated with jq instead of by string concatenation, and the repository URL, branch, commit and build paths are validated when an agent is created, updated or built.

## Documentation
N/A — no user-facing behaviour changes beyond stricter validation messages on the agent create/update form, which are self-describing.

## Training
N/A

## Certification
N/A — internal hardening with no impact on certification content.

## Marketing
N/A

## Automation tests
 - Unit tests
   > `agent-manager-service/utils/build_input_validation_test.go` adds four table-driven tests (80 cases) over `validateRepoDetails`, `isValidGitHubBranch`, `ValidateGitCommitID` and the Dockerfile path check, covering accepted repository/branch/path shapes as well as separators, command substitution, quotes, newlines, traversal, a leading dash and length caps. `make test-unit` is otherwise unchanged.
 - Integration tests
   > `deployments/helm-charts/wso2-amp-platform-resources-extension/tests/render.sh` grows from 9 to 16 assertions: the same per-parameter checks for `checkout-source`, an `sh -n` parse check, the quoted branch expansion and the leading-dash guard, plus a chart-wide scan that fails if any template puts an Argo parameter inside a script a shell parses. Negative-tested by restoring the previous `checkout-source.yaml`, which fails 6 assertions and names the three spliced parameters.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Java-only tool; this change is Go, shell and YAML.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
#1704 — moved the four user-text parameters in `amp-generate-workload` to `env:` and dropped a process substitution. This builds on it directly: its env var names are kept so its assertions pass unchanged, and its test file is extended rather than duplicated.

## Migrations (if applicable)
None. The workflow templates are cluster-scoped and replaced by `helm upgrade`; in-flight builds finish against the template revision they started with. No CR schema or stored-data change. Existing agents whose stored repository details would not pass the new validation keep building, since the validators run on create, update and build-trigger requests rather than over stored records — worth noting for anyone who wants them rejected retroactively.

## Test environment
Verified on a local single-node k3d cluster (`k3d v5.8.3`, `rancher/k3s v1.32.9-k3s1`) on macOS 15 (darwin/arm64), Go 1.24, chart at revision 3, OpenChoreo 1.2.0.

- Replaying the previously stored hostile repository URL and branch through a build: the checkout log no longer shows the injected output, the branch is printed as literal data, git rejects the URL, and the build fails instead of silently succeeding.
- A full build with a clean repository but hostile environment variable values, file mount contents and endpoint base path: succeeded end to end, and the resulting Workload CR carries every value byte-identical with no `spec.container.command` or `spec.container.args`, verified again in the running pod.
- The jq-built Workload CR was diffed against the CR the previous echo-based script produced from the same parameters: identical.
- Agent create over HTTP: 8 hostile payloads rejected with 400 and field-specific messages, clean payload still accepted; 5 hostile `commitId` values rejected with 400.

## Learning
Argo's parameter substitution escapes for JSON so the template stays valid, which is what makes the result look quoted while leaving the shell to reparse it — so quoting the interpolation site reads like a fix without being one. The reliable boundary is the pod spec: an `env` value is data to the container no matter what it contains. The same reasoning applies one level up, which is why the CR generation moved from concatenating YAML to letting jq do the encoding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stronger validation for repository URLs, branches, commit IDs, Dockerfile paths, application paths, and build configuration.
  * Invalid build inputs now receive clear validation errors before processing.
  * Improved protection against unsafe paths, malformed Git references, traversal, and shell-injection characters.

* **Security**
  * Build and deployment workflows now handle user-provided values more safely, reducing risks from shell interpretation and unsafe command arguments.

* **Tests**
  * Expanded coverage for valid, invalid, malformed, and boundary-length build inputs, along with workflow rendering and shell-safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->