### PR TITLE
Announce new pull requests in Google Chat

### DIFF
--- a/.github/workflows/pr-open-notify.yaml
+++ b/.github/workflows/pr-open-notify.yaml
@@ -1,0 +1,87 @@
+name: PR Open Notification
+
+# Announces new pull requests in Google Chat so reviewers see them without
+# watching the repository. Fires on `opened` and `reopened` for ready PRs, and
+# on `ready_for_review` so a PR raised as a draft is announced when it actually
+# becomes reviewable rather than being missed.
+#
+# `pull_request_target` (not `pull_request`) is deliberate: PRs from forks --
+# how most contributions arrive -- cannot read repository secrets under
+# `pull_request`, so the webhook URL would always be empty and every fork PR
+# would go unannounced. The usual `pull_request_target` hazard does not apply
+# here because this workflow never checks out or executes PR code; it only
+# reads fields from the event payload, and it passes them through `env` rather
+# than interpolating them into the shell so a crafted branch name or title
+# cannot inject commands.
+#
+# One-time setup:
+#   - in the Chat space that should receive PR notices: Apps & integrations ->
+#     Webhooks -> add a webhook, and copy its URL
+#   - set that URL as the `GCHAT_PR_WEBHOOK_URL` repository secret
+#
+# That is deliberately a separate secret from the `GCHAT_WEBHOOK_URL` used by
+# nightly.yml, instrumentation-matrix-nightly.yaml and
+# traceloop-release-watch.yaml for build and release alerts. A Chat incoming
+# webhook is bound to the space it was created in -- the space id is part of
+# the URL -- so a different space cannot reuse an existing webhook, and PR
+# traffic wants a different audience than nightly failures anyway. Until the
+# secret exists the job logs a warning and passes, so it never blocks a PR.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+# Reads nothing from the API; the webhook URL is the only credential needed.
+permissions: {}
+
+jobs:
+  notify:
+    name: Post new PR to Google Chat
+    runs-on: ubuntu-latest
+    # Draft PRs stay quiet until they are marked ready for review.
+    if: >-
+      github.repository == 'wso2/agent-manager' &&
+      github.event.pull_request.draft == false
+    steps:
+      - name: Notify Google Chat
+        env:
+          GCHAT_PR_WEBHOOK_URL: ${{ secrets.GCHAT_PR_WEBHOOK_URL }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          EVENT_ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GCHAT_PR_WEBHOOK_URL}" ]; then
+            echo "::warning::GCHAT_PR_WEBHOOK_URL secret is not set; skipping Google Chat notification."
+            exit 0
+          fi
+
+          case "${EVENT_ACTION}" in
+            reopened)         HEADING='Pull request reopened' ;;
+            ready_for_review) HEADING='Pull request ready for review' ;;
+            *)                HEADING='New pull request' ;;
+          esac
+
+          # jq escapes the title and author, which are attacker-controlled text.
+          PAYLOAD=$(jq -n \
+            --arg heading "$HEADING" \
+            --arg number "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg author "$PR_AUTHOR" \
+            --arg base "$BASE_REF" \
+            --arg url "$PR_URL" \
+            '{text: ("*\($heading)* — <\($url)|#\($number)> " + $title
+                     + "\nby \($author) → `\($base)`")}')
+
+          HTTP_CODE=$(curl -sS -o /tmp/gchat-resp.txt -w '%{http_code}' \
+            -X POST -H 'Content-Type: application/json; charset=UTF-8' \
+            -d "$PAYLOAD" "$GCHAT_PR_WEBHOOK_URL")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Google Chat webhook returned HTTP ${HTTP_CODE}"
+            cat /tmp/gchat-resp.txt || true
+            exit 1
+          fi
+          echo "Google Chat notified for PR #${PR_NUMBER}."


### PR DESCRIPTION
## Purpose
New pull requests are easy to miss unless you watch the whole repository, so review requests can sit unnoticed for days. There is no notification path for incoming PRs today, even though the repo already pushes other signals to Google Chat.

## Goals
Announce every pull request in a dedicated Google Chat space the moment it becomes reviewable.

This needs **one new repository secret, `GCHAT_PR_WEBHOOK_URL`**, and cannot reuse the existing `GCHAT_WEBHOOK_URL`: a Chat incoming webhook is bound to the space it was created in — the space id is literally part of the URL (`.../v1/spaces/<SPACE_ID>/messages?key=...`) — so a webhook cannot be retargeted at another space. Keeping the secrets separate also keeps the two audiences independent: PR traffic is high-volume and routine, nightly/release failures are not.

Setup for a maintainer, once: in the destination space, **Apps & integrations → Webhooks → add a webhook**, copy its URL, and save it as the `GCHAT_PR_WEBHOOK_URL` repository secret. This PR can merge before that happens — with the secret absent the job logs a `::warning::` and passes, so it never blocks a PR.

## Approach
Adds `.github/workflows/pr-open-notify.yaml`, which posts a one-line Chat message on `opened`, `reopened` and `ready_for_review`:

```
*New pull request* — <link|#1601> Harden build parameter handling
by <author> → `main`
```

Two decisions worth calling out:

**`pull_request_target`, not `pull_request`.** Most contributions arrive from forks, and fork PRs cannot read repository secrets under `pull_request` — the webhook secret would resolve to an empty string and every fork PR would go unannounced. The usual `pull_request_target` hazard does not apply here because the workflow never checks out or executes PR code: it only reads fields from the event payload, and it passes them through `env` rather than interpolating them into the shell, so a crafted branch name or title cannot inject commands. `permissions: {}` — the job needs no API access at all. `dependency-validation.yml` already uses `pull_request_target` in this repo.

**Drafts stay quiet.** The job is gated on `draft == false`, and `ready_for_review` is in the trigger list, so a PR raised as a draft is announced when it actually becomes reviewable rather than twice or not at all.

Behaviour matches the existing Chat steps in this repo: a missing secret logs a `::warning::` and exits 0 (so forks of this repo, and this repo before the space is set up, don't see red runs), a non-200 from the webhook fails the step, and the payload is built with `jq --arg` so titles and author names are escaped.

## User stories
As a reviewer, I want to be told in Google Chat when a PR needs review, so I don't have to poll the PR list.

## Release note
N/A — CI-only change, no product behaviour.

## Documentation
N/A — no product doc impact. The one-time setup (create a webhook in the destination Chat space, set it as the `GCHAT_PR_WEBHOOK_URL` repository secret) is documented in the workflow header comment, matching how `traceloop-release-watch.yaml` documents its own setup.

## Training
N/A — no product behaviour change.

## Certification
N/A — CI workflow, not covered by certification exams.

## Marketing
N/A — internal CI change.

## Automation tests
- Unit tests
  > N/A — a GitHub Actions workflow; there is no unit-testable code unit. `actionlint` passes on the new file.
- Integration tests
  > The notification step's shell script was extracted and exercised end-to-end against a local HTTP listener: secret-unset (warns, exits 0), `opened` and `ready_for_review` against a 200 webhook (correct escaped payload received, exit 0), and an unreachable webhook (step fails loudly). Payload escaping was verified with a hostile title containing quotes and `$(...)`, which passes through as inert text.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — the webhook URL is read from the `GCHAT_PR_WEBHOOK_URL` repository secret and never echoed. Note that a Chat webhook URL is itself a bearer credential (anyone holding it can post to the space), which is why it goes in a secret rather than the workflow.

## Samples
N/A — no samples affected.

## Related PRs
N/A

## Migrations (if applicable)
N/A — no state to migrate.

## Test environment
GitHub-hosted `ubuntu-latest`; the step script was also exercised locally on macOS with `bash`, `curl` and `jq`.

## Learning
Reviewed the fork-PR secret restriction documented in GitHub's "Keeping your GitHub Actions and workflows secure: Preventing pwn requests", which is what drove the `pull_request_target` choice and the no-checkout constraint that makes it safe.
