### PR TITLE
Drop the Colima profile and disk-space prechecks from quick start

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -483,40 +483,12 @@ create_plane_cert_resources() {
 
 log_step "OpenChoreo Development Environment Setup"
 
-# Verify Docker is pointing at the dedicated 'agent-manager' Colima profile.
-# Detection works from inside the dev container because `docker info` queries
-# the daemon: Colima names the VM node after its profile ('colima' for the
-# default profile, 'colima-<profile>' otherwise). Non-Colima Docker setups
-# (Docker Desktop, Rancher, Linux) fall through this check.
-EXPECTED_COLIMA_PROFILE="agent-manager"
-check_colima_profile() {
-    local node_name
-    node_name=$(docker info --format '{{.Name}}' 2>/dev/null || echo "")
-
-    # Non-Colima daemon -> nothing to enforce
-    case "${node_name}" in
-        colima|colima-*) ;;
-        *) return 0 ;;
-    esac
-
-    local expected="colima-${EXPECTED_COLIMA_PROFILE}"
-    if [ "${node_name}" = "${expected}" ]; then
-        log_success "Colima profile '${EXPECTED_COLIMA_PROFILE}' is active"
-        return 0
-    fi
-
-    log_error "Expected Colima profile '${EXPECTED_COLIMA_PROFILE}', got '${node_name}'."
-    log_info  "Start it with: colima start --profile ${EXPECTED_COLIMA_PROFILE} --vm-type=vz --vz-rosetta --network-address --cpu 4 --memory 8"
-    return 1
-}
-
 # Check and fix Docker permissions
 check_docker_permissions() {
     # Try docker ps first — Docker contexts (e.g., Colima profiles) route to
     # the correct socket automatically, so we don't need to check a hardcoded path.
     if docker ps &>/dev/null; then
         log_success "Docker access verified"
-        check_colima_profile || return 1
         return 0
     fi
 
@@ -524,7 +496,7 @@ check_docker_permissions() {
     local docker_sock="/var/run/docker.sock"
     if [ ! -S "${docker_sock}" ]; then
         log_error "Docker is not accessible and socket not found at ${docker_sock}"
-        log_info "Make sure Docker is running. If using Colima, ensure the correct profile is started."
+        log_info "Make sure Docker is running."
         return 1
     fi
 

--- a/deployments/quick-start/start.sh
+++ b/deployments/quick-start/start.sh
@@ -13,7 +13,6 @@ set -euo pipefail
 # for the equivalent 0.0.0-dev -> version substitution pattern applied to this file).
 DEFAULT_VERSION="0.0.0-dev"
 IMAGE="${QUICK_START_IMAGE:-ghcr.io/wso2/amp-quick-start}"
-MIN_FREE_DISK_GB=20
 
 log() { printf '\033[0;34m[start]\033[0m %s\n' "$*"; }
 warn() { printf '\033[0;33m[start] WARNING:\033[0m %s\n' "$*" >&2; }
@@ -63,21 +62,6 @@ case "$ARCH" in
   x86_64|amd64|arm64|aarch64) log "Detected architecture: ${ARCH}" ;;
   *) warn "Unrecognized architecture '${ARCH}' — the quick-start image is published for amd64/arm64 only" ;;
 esac
-
-# Check free space on the filesystem backing Docker's data (falls back to /var if
-# docker info doesn't expose it, e.g. on some rootless/Colima setups).
-DOCKER_ROOT="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo /var)"
-if command -v df >/dev/null 2>&1; then
-  AVAIL_KB="$(df -Pk "$DOCKER_ROOT" 2>/dev/null | awk 'NR==2 {print $4}')"
-  if [[ -n "${AVAIL_KB:-}" ]]; then
-    AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
-    if (( AVAIL_GB < MIN_FREE_DISK_GB )); then
-      warn "Only ~${AVAIL_GB} GB free on ${DOCKER_ROOT} — the full platform install (k3d node images, OpenChoreo, AMP) can need ${MIN_FREE_DISK_GB}+ GB. Installation may fail partway through if space runs out."
-    else
-      log "Free disk space on ${DOCKER_ROOT}: ~${AVAIL_GB} GB"
-    fi
-  fi
-fi
 
 log "Starting quick-start dev container (${IMAGE}:v${VERSION})"
 log "The container will run install.sh automatically once it starts (~15-20 minutes)."


### PR DESCRIPTION
## Purpose
Two host prechecks in the quick start reject working setups and stop the install before it starts.

**1. The Colima profile check (`install.sh`)** requires the daemon's VM node to be named exactly `colima-agent-manager`. Any other Colima profile is refused, even when Docker is fully functional. Because the check runs inside `check_docker_permissions`, a name mismatch is reported as a permissions failure:

```
✓ Docker access verified
✗ Expected Colima profile 'agent-manager', got 'colima-dev'.
ℹ Start it with: colima start --profile agent-manager ...
✗ Docker permission check failed
```

Docker access had just been verified on the line above. The final message names the wrong subsystem, so the user is sent to debug socket permissions for what is really a naming preference. Anyone with an existing Colima profile — a common setup — has to create a second VM to run the quick start.

**2. The free-disk-space check (`start.sh`)** exits with a bare status 1 and no message at all, before the container is ever launched. `docker info` reports `DockerRootDir` as `/var/lib/docker`, which on macOS (Colima or Docker Desktop) is a path *inside the VM* that does not exist on the host, so `df` fails. Under the script's `set -euo pipefail`, `pipefail` propagates that through the pipe into the command substitution, the assignment itself exits non-zero, and `set -e` aborts the script. The `2>/dev/null` suppresses the only clue and the `if [[ -n "${AVAIL_KB:-}" ]]` guard on the next line never runs.

```
[start] Checking prerequisites...
[start] Docker is installed and reachable
[start] Detected architecture: arm64
$ echo $?
1
```

That one affects every macOS user on Colima or Docker Desktop, and any Linux host where the daemon is remote or rootless — the exact "some rootless/Colima setups" case the comment above the block claims to handle.

## Goals
Let the quick start run on any working Docker daemon, whatever the VM is named and wherever the daemon keeps its data.

## Approach
Remove both checks rather than teach them about every Docker setup.

Neither one gates anything the install actually requires. The profile name has no bearing on whether the daemon works — `docker ps` on the line above already established that. The disk check never blocked anything either: it only ever called `warn`, so its sole real effect was the `set -e` abort. Deleting the block fixes that at the source instead of guarding around it.

- `install.sh`: drop `check_colima_profile`, its `EXPECTED_COLIMA_PROFILE` constant, and its call site. `check_docker_permissions` keeps its genuine Docker logic untouched — the socket-missing branch and the `chmod 666` permission repair. The socket-missing hint loses its "ensure the correct profile is started" clause, which now points at a rule that no longer exists.
- `start.sh`: drop the disk-space block and the now-unused `MIN_FREE_DISK_GB`.

Deliberately kept: `uninstall.sh --delete-colima` is real cleanup, not a validation. The Colima hint in `start.sh`'s *daemon-unreachable* error also stays — it only fires when Docker genuinely isn't reachable, where the suggestion helps and never blocks a working setup.

Net effect is 45 lines removed, 1 changed.

## User stories
As a developer with an existing Colima profile, running the quick start works without creating a second VM named to match.

As a user on macOS, `./start.sh` launches the dev container instead of exiting silently with no output.

## Release note
Fix the quick start refusing to run on Colima profiles not named `agent-manager`, and fix `start.sh` exiting silently before launching the dev container on macOS and other setups where Docker's root directory is not visible on the host.

## Documentation
N/A — no documented flag or command changes. This restores the documented behaviour of the existing quick-start commands; the removed checks were never part of the documented contract.

## Training
N/A — no training content covers the quick-start bootstrap scripts.

## Certification
N/A — no certification exam covers the quick-start bootstrap scripts.

## Marketing
N/A — bug fix in bootstrap scripts, no promotable surface.

## Automation tests
 - Unit tests
   > None. The repo has no test harness for `deployments/**` shell scripts, and the change is a pure deletion of two prechecks whose failure modes depend on the local Docker daemon's reported VM name and root directory.
 - Integration tests
   > `start.sh` verified manually (see Test environment). `bash -n` passes on both files. `shellcheck` is clean on `start.sh`; on `install.sh` it reports the same 20 pre-existing findings before and after this change, so nothing new is introduced. The `install.sh` change is verified by inspection and lint rather than execution — that script only runs inside the dev container and takes 15-20 minutes end to end.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — FindSecurityBugs is a Java static-analysis tool and does not apply to shell scripts. Ran `shellcheck` instead; no new findings.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples relate to the bootstrap scripts.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or state changes.

## Test environment
macOS 15 (Darwin 25.0.0), arm64 (Apple silicon), Colima with the Docker socket at `/var/run/docker.sock`. Confirmed `start.sh` fails before the change and reaches `docker run` after it. Not re-tested on Linux; the removed code paths were host-inspection only, and nothing the install depends on was touched.

## Learning
The `start.sh` bug is the interaction of `set -e` with `pipefail` inside a command substitution used in an assignment: `a="$(cmd | filter)"` takes the pipeline's exit status as the assignment's status, so a `pipefail`-promoted failure aborts the script even though the code that follows was written to handle an empty result. Redirecting the failing command's stderr to `/dev/null` makes this class of bug completely silent.

The `install.sh` bug is a structural one rather than a coding error: a policy check (is the VM named what we expect?) was nested inside a capability check (does Docker work?), so it inherited the caller's error message and reported the wrong cause. Worth keeping the two kinds of check separate when a precheck is genuinely needed.
