### PR TITLE
Let VM eval jobs reach the public LLM-proxy URL

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-networkpolicy.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-networkpolicy.yaml
@@ -85,8 +85,9 @@ spec:
 
     {{- with .Values.networkPolicy.evaluationJob.devEgress }}
     {{- if and .cidr .ports }}
-    # Local-dev only: agent-manager-service and the gateway are reached over the node network,
-    # so namespaceSelector can't match them.
+    # Reached off-cluster, so namespaceSelector can't match: agent-manager-service and the
+    # gateway over the node network in local dev; the VM installer's Caddy front door, which
+    # serves the public LLM-proxy URL llm_judge evaluators call.
     - to:
         - ipBlock:
             cidr: {{ .cidr }}

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
@@ -92,9 +92,11 @@ networkPolicy:
       # the label alone.
       namespace: ""
 
-    # -- Local-dev only: ipBlock exception for the node network, covering agent-manager-service
-    # outside the cluster (8080) and the gateway's node port (19080). Empty (no-op) elsewhere;
-    # setup-amp-extensions.sh sets both.
+    # -- ipBlock exception for targets reached off-cluster, where no pod backs the address and
+    # namespaceSelector therefore cannot match: in local dev, agent-manager-service outside the
+    # cluster (8080) and the gateway's node port (19080); on a VM install, the Caddy front door
+    # (443) that serves the public LLM-proxy URL the judge calls. Empty (no-op) elsewhere;
+    # setup-amp-extensions.sh and deployments/vm/install-vm.sh each set both keys.
     devEgress:
       cidr: ""
       ports: [8080, 19080]

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -109,6 +109,10 @@ run_install() {
   mapfile -t PLATFORM_RESOURCES_HELM_ARGS < <(build_platform_resources_helm_args)
   # shellcheck disable=SC2034
   mapfile -t OBSERVABILITY_HELM_ARGS < <(build_observability_helm_args "$VM_IP")
+  # Lets llm_judge evaluators reach the public LLM-proxy URL amp-api mints; without
+  # it the evaluation job's NetworkPolicy refuses every judge completion.
+  # shellcheck disable=SC2034
+  mapfile -t EVALUATION_HELM_ARGS < <(build_evaluation_helm_args "$VM_IP")
   # Advertise deployed-agent endpoints under a public sslip.io host (Caddy fronts
   # the wildcard *.agents.<ip>.sslip.io with on-demand TLS), not the local default.
   DP_EXTERNAL_INGRESS="$(render_dataplane_external_ingress "$VM_IP")"

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -182,6 +182,31 @@ build_observability_helm_args() {
   observability_helm_args
 }
 
+# build_evaluation_helm_args <ip>
+# Prints EVALUATION_HELM_ARGS tokens, opening one egress hole in the evaluation
+# job's NetworkPolicy: the VM's own public address on :443.
+#
+# The chart already lets the eval job reach the API Platform Gateway in-cluster
+# (:22893), which is what a normal cluster install ends up using — there the
+# gateway's public host lands on an in-cluster ingress, so the policy, matched
+# post-DNAT, still sees a gateway pod. On the VM it does not. amp-api mints the
+# LLM-proxy URL from the public vhost (https://gateway.amp.<ip>.sslip.io/<proxy>,
+# see gateway_helm_args), which resolves to this VM's public IP, where Caddy — a
+# host-network container OUTSIDE the cluster — terminates TLS. No pod backs that
+# destination and no namespaceSelector can match it, so every llm_judge
+# completion is refused at the policy and the run reports "LLM judge failed after
+# 3 attempts: Connection error" with no request ever reaching the gateway.
+#
+# devEgress is the chart's ipBlock hatch for exactly this shape (the local-dev
+# setup path uses it for the node network for the same reason). :443 is the only
+# port Caddy serves, and a /32 keeps the hole to this host.
+build_evaluation_helm_args() {
+  local ip="$1"
+  printf '%s\n' \
+    "--set" "networkPolicy.evaluationJob.devEgress.cidr=${ip}/32" \
+    "--set" "networkPolicy.evaluationJob.devEgress.ports={443}"
+}
+
 # build_cp_helm_args <ip>
 # Prints CP_HELM_ARGS tokens for the OpenChoreo control-plane install. Thunder's
 # issuer is moved to the public sslip.io URL, so the OpenChoreo CP OIDC config

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -179,6 +179,15 @@ assert_eq "dp external has http entry"  "yes" "$(printf '%s\n' "$dpe" | grep -qE
 assert_eq "dp external has https entry" "yes" "$(printf '%s\n' "$dpe" | grep -qE '^        https:' && echo yes || echo no)"
 assert_eq "dp external not local default (19080)" "no" "$(has "$dpe" 'port: 1908')"
 
+# --- build_evaluation_helm_args opens the eval job's egress to Caddy on :443 ---
+ev="$(build_evaluation_helm_args 203.0.113.10)"
+assert_eq "eval devEgress is this VM's /32" \
+  "networkPolicy.evaluationJob.devEgress.cidr=203.0.113.10/32" \
+  "$(grep -F 'devEgress.cidr' <<<"$ev")"
+assert_eq "eval devEgress opens 443 only" \
+  "networkPolicy.evaluationJob.devEgress.ports={443}" \
+  "$(grep -F 'devEgress.ports' <<<"$ev")"
+
 # --- build_cp_helm_args points OpenChoreo CP OIDC issuer at the public Thunder URL ---
 cp_args="$(build_cp_helm_args 203.0.113.10)"
 assert_eq "cp oidc issuer" \


### PR DESCRIPTION
## Purpose
On a VM install every LLM-as-judge evaluation skips with `LLM judge failed after 3 attempts: Connection error. [model=openai/gpt-4o-mini]`, so monitor runs produce no judge scores at all. No judge request ever reaches the gateway — the gateway access log shows agent chat and OTel ingest succeeding while the judge calls are simply absent.

The evaluation job's NetworkPolicy (`amp-evaluation-job-egress`) allows the API Platform Gateway only in-cluster, on `:22893`. That is what a normal cluster install ends up using: there the gateway's public host lands on an in-cluster ingress, so the policy — which matches post-DNAT — still sees a gateway pod. On a VM it does not. amp-api mints the LLM-proxy URL from the public vhost (`https://gateway.amp.<ip>.sslip.io/<proxy>`, set by `gateway_helm_args`), which resolves to the VM's own public IP, where Caddy terminates TLS as a host-network container **outside** the cluster. No pod backs that address, so no `namespaceSelector` can match it and every judge completion is refused at the policy.

## Goals
Let `llm_judge` evaluators on a VM install reach the LLM-proxy URL amp-api actually hands them, without widening egress for the untrusted evaluator code that runs in the same pod.

## Approach
The simple VM installer now sets the chart's existing `devEgress` ipBlock hatch to the VM's own `/32` on `:443`, via a new `build_evaluation_helm_args` in `lib-vm.sh` wired into `EVALUATION_HELM_ARGS` — the same mechanism, and the same reason, as the local-dev setup path that already uses it for services reached over the node network. That hatch exists precisely for targets no `namespaceSelector` can match.

The hole is deliberately narrow: one host, one port. Caddy serves nothing but `:443`, and this pod runs untrusted evaluator code, so a broader CIDR or port range would hand that code egress it has no need for.

Two things worth flagging for review:

- **Why not point the judge at the in-cluster gateway (`:22893`), which the policy already allows?** That URL comes from amp-api's minted LLM-proxy endpoint, which is public by design — the same value the console and users consume. Giving the eval job a second, in-cluster notion of that endpoint is a larger change in agent-manager-service and gateway Host-header routing; this change stays in the installer that created the topology mismatch.
- **`devEgress` now under-describes its use** (it is no longer local-dev only), and the comments in `values.yaml` and the template are updated accordingly. Renaming the key would touch every consumer, so it is left alone here and could be renamed separately.

Only the **simple** installer is wired. The advanced installer terminates `:443` at an in-cluster gateway instead, so its judge traffic DNATs to a pod and may already be covered; that path was not reproduced, so it is deliberately untouched.

## User stories
As someone evaluating Agent Manager on a VM, I want monitor evaluations to produce judge scores, so I can see evaluation results instead of a full column of skips.

## Release note
Fixed LLM-as-judge evaluations failing with a connection error on VM installs, caused by the evaluation job's egress policy not permitting the public LLM-proxy URL.

## Documentation
N/A — no documented behaviour changes; this makes the documented evaluation flow work as described on the VM install path.

## Training
N/A — no training content covers the evaluation job's egress policy.

## Certification
N/A — installer/chart plumbing, not covered by certification exams.

## Marketing
N/A — internal bug fix.

## Automation tests
- Unit tests
  > Two assertions added to `deployments/vm/tests/run.sh` covering `build_evaluation_helm_args`: the CIDR is the VM's own `/32`, and only `:443` is opened. Both pass. Note one **pre-existing** failure in that suite on `main` — `caddy cp-kgateway upstream count` (expected 4, actual 5) — which reproduces on a clean `upstream/main` checkout and is unrelated to this change.
- Integration tests
  > Verified end to end on a GCP VM running `1.0.0-RC1`. With the policy as shipped, a probe pod carrying the job's two selector labels is refused (`ECONNREFUSED`) on the public gateway host 6/6 and on an unrelated external address 6/6, while the in-cluster gateway succeeds 6/6; an unlabeled control pod reaches all three 6/6. The failure was reproduced from inside the `amp-evaluation-monitor:v1.0.0-RC1` image as `openai.APIConnectionError` wrapping `[Errno 111] Connection refused`. After adding this egress rule the same call reaches the gateway and is answered (`401` for a deliberately dummy api-key, i.e. transport healthy). `helm template` output was checked to confirm the rendered rule is the single `/32` on `:443`.
  >
  > Two traps worth recording for anyone re-testing: policy enforcement is programmed a second or two **after** pod start, so a single quick `curl` in a fresh pod succeeds and looks like proof the path is fine — probe repeatedly, after a sleep; and a probe pod is only subject to the policy if it carries **both** selector labels.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes. The change adds no credentials; it widens one NetworkPolicy egress rule, deliberately scoped to a single `/32` and a single port because the pod it applies to runs untrusted evaluator code.

## Samples
N/A — no samples affected.

## Migrations (if applicable)
N/A — no state to migrate. Existing VM installs pick the rule up on the next install or `helm upgrade` of the evaluation extension; until then the policy can be patched in place with the same rule.

## Test environment
GCP VM (`e2-standard-4`, Ubuntu 24.04.4 LTS), Docker 29.7.2, k3d 5.9.0 / k3s v1.32.9, kubectl 1.33.13, Helm 3.21.4, Agent Manager `1.0.0-RC1` installed via the simple VM path. Unit tests and `helm template` run on macOS with bash 3.2 and Helm 3.
