### PR TITLE
Issue certificates for the VM's fixed hosts

### DIFF
--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -85,6 +85,7 @@ start_caddy() {
     -v /opt/amp/Caddyfile:/etc/caddy/Caddyfile:ro \
     caddy:2
   verify_caddy_up
+  prewarm_fixed_host_certs "$VM_IP" "$EXTERNAL_GATEWAYS"
 }
 
 run_install() {

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -439,8 +439,22 @@ caddyfile() {
     letsencrypt)
       # Every public site forces the TLS-ALPN-01 ACME challenge (it runs inside the
       # :443 TLS handshake) so certificate issuance never depends on inbound port 80.
-      tls_block=$'\ttls {\n\t\tissuer acme {\n\t\t\tdisable_http_challenge\n\t\t}\n\t}\n'
+      #
+      # The fixed hosts (console/api/thunder/observer/gateway/cp) get on_demand as
+      # well, even though their names are known here and could be issued eagerly.
+      # They have to: the env-Thunder site below is a wildcard sitting directly under
+      # the base domain (*.amp.<ip>.sslip.io), so it COVERS every fixed host, and
+      # Caddy skips eager issuance for any name a managed wildcard covers. That
+      # wildcard is itself on-demand, because TLS-ALPN-01 cannot issue a wildcard —
+      # so with the fixed hosts left eager, nothing ever obtains their certificates:
+      # Caddy logs "enabling automatic TLS certificate management" for all of them,
+      # never attempts a single obtain (no ACME account, empty certificate store),
+      # and every request dies in the handshake with an internal error, on a cluster
+      # that is otherwise entirely healthy. on_demand moves issuance to the first
+      # handshake per host, and prewarm_fixed_host_certs walks them at install time
+      # so no user's request is the one that races it.
       agent_tls=$'\ttls {\n\t\ton_demand\n\t\tissuer acme {\n\t\t\tdisable_http_challenge\n\t\t}\n\t}\n'
+      tls_block="$agent_tls"
       [[ -n "$email" ]] && gopts+=$'\temail '"$email"$'\n'
       gopts+=$'\tauto_https disable_redirects\n'
       gopts+=$'\ton_demand_tls {\n\t\task http://127.0.0.1:9753/internal/thunder-ask\n\t}\n'
@@ -554,8 +568,21 @@ caddyfile() {
     # this header existed.
     local ask_secret_header=""
     [[ -n "$ask_secret" ]] && ask_secret_header=$'\t\theader_up X-Thunder-Ask-Secret '"${ask_secret}"$'\n'
-    printf 'http://127.0.0.1:9753 {\n\t@gateway_or_agents expression `{query.domain}.endsWith(".%s") || {query.domain}.endsWith(".%s")`\n\trespond @gateway_or_agents 200\n\treverse_proxy 127.0.0.1:8080 {\n\t\theader_up Host %s\n%s\t}\n}\n\n' \
-      "$AMP_HOST_GATEWAY" "$AMP_AGENTS_BASE" "$AMP_HOST_API" "$ask_secret_header"
+    # The fixed hosts are on-demand too (see the letsencrypt tls_block above), so
+    # their issuance also has to be approved here. They cannot fall through to AMS:
+    # it answers for registered env-Thunder handles, which is a bare single label
+    # under the base domain, and would 403 "console"/"api"/... — leaving the whole
+    # platform without certificates. Matched exactly, not by suffix, so only these
+    # names are covered and a look-alike still has to satisfy AMS.
+    local fixed_hosts=("$AMP_HOST_CONSOLE" "$AMP_HOST_API" "$AMP_HOST_THUNDER" "$AMP_HOST_OBSERVER" "$AMP_HOST_GATEWAY")
+    [[ -n "$AMP_HOST_CP" ]] && fixed_hosts+=("$AMP_HOST_CP")
+    local fixed_expr="" fixed_host
+    for fixed_host in "${fixed_hosts[@]}"; do
+      [[ -n "$fixed_expr" ]] && fixed_expr+=" || "
+      fixed_expr+="{query.domain} == \"${fixed_host}\""
+    done
+    printf 'http://127.0.0.1:9753 {\n\t@gateway_or_agents expression `{query.domain}.endsWith(".%s") || {query.domain}.endsWith(".%s")`\n\trespond @gateway_or_agents 200\n\t@fixed_hosts expression `%s`\n\trespond @fixed_hosts 200\n\treverse_proxy 127.0.0.1:8080 {\n\t\theader_up Host %s\n%s\t}\n}\n\n' \
+      "$AMP_HOST_GATEWAY" "$AMP_AGENTS_BASE" "$fixed_expr" "$AMP_HOST_API" "$ask_secret_header"
   fi
 
   # Deployed-agent endpoints: <org>-<project>.<AGENTS_BASE> (one host per org/project,
@@ -567,6 +594,36 @@ caddyfile() {
     "$([[ "$scheme" == http ]] && printf 'http://')" "$AMP_AGENTS_BASE" "$addr_suffix" "$agent_tls" "$cors_block"
 
   unset -f _site
+}
+
+# prewarm_fixed_host_certs <ip> <external_gateways:true|false (default true)>
+# Walk every fixed host once so its certificate exists before anyone browses to it.
+#
+# Those hosts are on-demand in letsencrypt mode (see caddyfile()), so the first
+# handshake to each triggers issuance — and that first request is consumed by the
+# ACME challenge, so the client sees the challenge certificate rather than the real
+# one, the same one-time error on-a-vm.mdx documents for the dynamic agent hosts.
+# Doing the walk here means the operator's first console visit is never that request.
+#
+# Best-effort by design: a failure here only restores the previous behaviour
+# (issued on the first real request), so it must never fail the install.
+prewarm_fixed_host_certs() {
+  local ip="$1" external_gateways="${2:-true}" host fqdn
+  local hosts=(console api thunder observer gateway)
+  [[ "$external_gateways" == "true" ]] && hosts+=(cp)
+  log "Pre-warming TLS certificates for the fixed hosts"
+  for host in "${hosts[@]}"; do
+    fqdn="$(vm_host "$host" "$ip")"
+    # --resolve pins the connection to the loopback listener, since a cloud VM
+    # often cannot reach its own public IP; SNI still selects the right site, which
+    # is all Caddy needs to start issuance.
+    if curl -sS -o /dev/null -m 90 --retry 2 --retry-all-errors \
+      --resolve "${fqdn}:443:127.0.0.1" "https://${fqdn}/" >/dev/null 2>&1; then
+      log "  ${fqdn}: certificate ready"
+    else
+      log "  ${fqdn}: not issued yet — it will be obtained on the first request"
+    fi
+  done
 }
 
 # render_caddyfile <ip> <acme_email> <external_gateways:true|false (default true)>

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -276,7 +276,9 @@ assert_eq "caddy console upstream (via kgateway)" "	reverse_proxy 127.0.0.1:8080
 # platform-Thunder host, and the env-Thunder base-domain wildcard (*.<domain>,
 # no fixed "thunder." segment) — kgateway itself discriminates by Host header
 # via each backend's HTTPRoute.
-assert_eq "caddy cp-kgateway upstream count" "4" "$(grep -cF '127.0.0.1:8080' <<<"$cf")"
+# console, api, thunder, the env-Thunder base-domain wildcard, and the on-demand ask
+# endpoint — cp is excluded in this render (external gateways off).
+assert_eq "caddy cp-kgateway upstream count" "5" "$(grep -cF '127.0.0.1:8080' <<<"$cf")"
 assert_eq "caddy env-thunder wildcard site" "*.amp.203.0.113.10.sslip.io {" \
   "$(grep -F '*.amp.203.0.113.10.sslip.io {' <<<"$cf" | head -1)"
 # gateway host routes through the kgateway data plane (19080), not the ClusterIP
@@ -369,6 +371,27 @@ assert_eq "coredns host aliases -> node" "yes" \
   "$(has "$cd_cfg" 'name regex (host\.k3d\.internal|host\.docker\.internal) k3d-amp-local-server-0')"
 assert_eq "coredns no longer targets host.k3d.internal as dest" "no" \
   "$(has "$cd_cfg" 'localhost host.k3d.internal')"
+
+# --- render_caddyfile: fixed hosts get on-demand certs, approved at the ask endpoint ---
+# The env-Thunder wildcard (*.amp.<ip>) covers every fixed host, and Caddy skips eager
+# issuance for a name a managed wildcard covers — so left eager these never get a
+# certificate at all and every request fails the handshake.
+cf_od="$(render_caddyfile 203.0.113.10 "ops@example.com" true)"
+# One tls block per site, each carrying on_demand: 6 fixed hosts + 3 wildcard sites.
+assert_eq "caddy on_demand on every site" "9" "$(grep -cE '^\s+on_demand$' <<<"$cf_od")"
+console_tls="$(awk '/^console\.amp/,/^}/' <<<"$cf_od")"
+assert_eq "caddy console site is on-demand" "yes" "$(has "$console_tls" 'on_demand')"
+assert_eq "caddy console keeps TLS-ALPN-01 issuer" "yes" "$(has "$console_tls" 'disable_http_challenge')"
+ask_block="$(awk '/^http:\/\/127\.0\.0\.1:9753/,/^}/' <<<"$cf_od")"
+assert_eq "ask endpoint approves console" "yes" \
+  "$(has "$ask_block" '{query.domain} == "console.amp.203.0.113.10.sslip.io"')"
+assert_eq "ask endpoint approves cp when enabled" "yes" \
+  "$(has "$ask_block" '{query.domain} == "cp.amp.203.0.113.10.sslip.io"')"
+# Exact match only — a look-alike must still satisfy AMS's registered-handle check.
+assert_eq "ask endpoint does not suffix-match the base domain" "no" \
+  "$(has "$ask_block" '{query.domain}.endsWith(".amp.203.0.113.10.sslip.io")')"
+ask_block_nocp="$(awk '/^http:\/\/127\.0\.0\.1:9753/,/^}/' <<<"$cf")"
+assert_eq "ask endpoint omits cp when disabled" "no" "$(has "$ask_block_nocp" 'cp.amp')"
 
 # --- render_caddyfile: deployed-agent invocation (wildcard site, on-demand TLS,
 #     CORS, ask endpoint) ---
@@ -515,6 +538,10 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   AMP_HOST_CP=cp.amp.example.com
   AMP_AGENTS_BASE=agents.amp.example.com
   cf_byoc="$(caddyfile byoc "" /opt/amp/certs/fullchain.pem /opt/amp/certs/privkey.pem "")"
+  # byoc serves one operator-supplied cert on every site, so nothing is ever issued
+  # on demand — the wildcard-coverage problem that forces on_demand under
+  # letsencrypt does not apply here.
+  assert_eq "core caddy byoc has no on_demand" "no" "$(has "$cf_byoc" 'on_demand')"
   assert_eq "byoc serves provided cert/key" "yes" \
     "$(has "$cf_byoc" 'tls /opt/amp/certs/fullchain.pem /opt/amp/certs/privkey.pem')"
   assert_eq "byoc no acme issuer" "no" "$(has "$cf_byoc" 'issuer acme')"


### PR DESCRIPTION
## Purpose
A fresh **simple** VM install serves no TLS at all. Every public host — `console`, `api`, `thunder`, `observer`, `gateway`, `cp` — fails the TLS handshake with an internal error (`curl` reports `000`, browsers an untrusted-certificate error), while the cluster underneath is entirely healthy: all pods Running, every chart deployed, Caddy up and reporting healthy. The installer prints its access URLs and exits 0, so the install looks successful and nothing works.

Caddy is not failing to obtain the certificates — it never attempts to. It logs `enabling automatic TLS certificate management` for all nine names and then makes no obtain attempt at all: no ACME account, an empty certificate store, and nothing further even with `debug` enabled.

## Goals
Make a fresh simple VM install serve trusted certificates on every fixed host, without giving up the wildcard site that routes per-environment Thunder.

## Approach
The env-Thunder site is a wildcard sitting directly under the base domain (`*.amp.<ip>.sslip.io`), because per-environment Thunder handles lost their `thunder.` segment and now sit there as bare labels. That wildcard therefore **covers** every fixed host, and Caddy skips eager issuance for any name a managed wildcard covers. The wildcard is itself on-demand — TLS-ALPN-01 cannot issue a wildcard — so nothing obtains anything: the fixed hosts are skipped as "covered", and the cover never materialises. Commenting out that single site block issues all six certificates within seconds, which is what identified it.

The wildcard has to stay, so the fix goes the other way:

1. **The fixed hosts become on-demand too**, so issuance happens on their first handshake.
2. **They are approved at the ask endpoint by exact match.** They cannot fall through to agent-manager-service: it answers for registered env-Thunder handles, which are bare single labels under the base domain, and would reject `console`/`api`/… — leaving the platform with no certificates again. Exact match, not a suffix, so nothing else is newly approved.
3. **`start_caddy` pre-warms all six.** An on-demand host's first request is consumed by the ACME challenge, so that client sees the challenge certificate — the same one-time error `on-a-vm.mdx` already documents for the dynamic agent hosts. Walking them at install time means the operator's first console visit is never that request. Best-effort: a failure only restores issue-on-first-request, so it never fails the install.

`byoc` and `upstream` modes are untouched — they serve an operator-supplied certificate (or terminate upstream), so nothing is ever issued on demand there. A regression test pins that.

Worth noting for review: an alternative structural fix is to serve the three dynamic tiers from a hostname-less `:443` catch-all site, which would keep the fixed hosts eagerly issued because a hostname-less site contributes no managed name. That is a larger change to the generator and I did not validate it, so this PR takes the smaller, verified route.

## User stories
As someone installing Agent Manager on a VM, I want the URLs the installer prints to load, rather than a completed install whose every endpoint fails its TLS handshake.

## Release note
Fixed a simple VM install serving no TLS: certificates for the console, API, Thunder, observer, gateway, and control-plane hosts are now issued and pre-warmed at install time.

## Documentation
N/A — no documented behaviour changes. The one-time first-request certificate error `on-a-vm.mdx` describes for dynamic hosts still applies only to those; the fixed hosts are pre-warmed, so the documented flow ("open the console URL and sign in") now works as written.

## Training
N/A — no training content covers Caddy certificate issuance.

## Certification
N/A — installer plumbing, not covered by certification exams.

## Marketing
N/A — bug fix.

## Automation tests
- Unit tests
  > Eight assertions added to `deployments/vm/tests/run.sh`: every site carries `on_demand` under letsencrypt, the console site keeps its TLS-ALPN-01 issuer, the ask endpoint approves the fixed hosts (including `cp` when external gateways are on and omitting it when off), the approval is exact rather than a base-domain suffix match, and `byoc` gains no `on_demand`. Full suite passes, 213 assertions.
  >
  > This also corrects a stale expectation in the same group that had been **failing on `main`**: `caddy cp-kgateway upstream count` expected 4. The env-Thunder wildcard site — the same addition that broke issuance — introduced a fifth kgateway upstream, and the assertion was never updated. It is now 5, with the five enumerated in a comment.
- Integration tests
  > Verified on a GCP VM running `1.0.0-RC1`, installed through the simple path.
  > - The Caddyfile this branch generates is **byte-identical** to the hand-patched one proven working on that VM (`diff` empty), and `caddy validate` accepts it.
  > - Deleting `observer`'s certificate from the Caddy data volume and restarting left the store empty for that host; running the new `prewarm_fixed_host_certs` reissued it, and all six hosts reported `certificate ready`.
  > - All six hosts then served from the public internet with `ssl_verify_result=0` (`console` 200; the others return their own 401/404 for a bare `/`, which is expected), and the reissued `observer` certificate is a genuine Let's Encrypt leaf.
  > - The ask endpoint answered `200` for `observer.amp.<ip>.sslip.io` and `403` for `notahandle.amp.<ip>.sslip.io`, confirming the exact-match rule did not widen approval.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes. The change adds no credentials. It does widen on-demand certificate approval, deliberately by exact hostname for the six names the installer itself derives — verified above that an unregistered label is still refused, so this does not become an open issuance endpoint.

## Samples
N/A — no samples affected.

## Related PRs
None. Found while installing `1.0.0-RC1` on a VM; the evaluation-job egress fix from the same install is raised separately.

## Migrations (if applicable)
N/A. Existing installs are repaired by re-running the installer, or by regenerating `/opt/amp/Caddyfile` and restarting `amp-caddy`; certificates already in the `amp-caddy-data` volume are reused rather than re-requested.

## Test environment
GCP VM (`e2-standard-4`, Ubuntu 24.04.4 LTS), Docker 29.7.2, k3d 5.9.0 / k3s v1.32.9, kubectl 1.33.13, Helm 3.21.4, Caddy 2.11.4, Agent Manager `1.0.0-RC1`. Unit tests run on macOS with bash 3.2.

## Learning
The behaviour that makes this non-obvious is that Caddy treats a managed wildcard as covering its subdomains and stops obtaining their individual certificates — sound when the wildcard can actually be issued, which under TLS-ALPN-01 it never can. The generator's own comment reasoned carefully about *routing* precedence ("Caddy always matches the most specific site first"), which is correct and simply unrelated to certificate management; that is the gap this closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed-host TLS certificates are now prewarmed automatically after the gateway becomes available.
  * Improved certificate approval and on-demand issuance for configured fixed hosts.
  * Added conditional support for the control-plane host when enabled.
  * BYOC deployments no longer configure on-demand certificate issuance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->