### PR TITLE
Route the evaluation job through the gateway's internal URL

### DIFF
--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -19,20 +19,22 @@ package services
 import (
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 )
 
-func TestBuildProxyURLUsesVhost(t *testing.T) {
+func TestBuildPublicProxyURLUsesVhost(t *testing.T) {
 	// RuntimeURL present but must be ignored: every agent gets the public URL.
 	gateway := &models.Gateway{
 		Vhost:      "https://dev-acme.gateway.example.com",
 		RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
 	}
 	contextPath := "/llm/proxy"
-	require.Equal(t, "https://dev-acme.gateway.example.com/llm/proxy", buildProxyURL(gateway, &contextPath))
-	require.Equal(t, "https://dev-acme.gateway.example.com", buildProxyURL(gateway, nil))
+	require.Equal(t, "https://dev-acme.gateway.example.com/llm/proxy", buildPublicProxyURL(gateway, &contextPath))
+	require.Equal(t, "https://dev-acme.gateway.example.com", buildPublicProxyURL(gateway, nil))
 }
 
 func TestBuildMCPProxyURLUsesGatewayVhost(t *testing.T) {
@@ -61,12 +63,12 @@ func TestBuildMCPProxyURLPrefersProxyVhostOverride(t *testing.T) {
 		buildMCPProxyURL(gateway, models.MCPProxyConfig{Vhost: &empty}))
 }
 
-func TestBuildProxyURLDefaultsBareVhostToHTTPS(t *testing.T) {
+func TestBuildPublicProxyURLDefaultsBareVhostToHTTPS(t *testing.T) {
 	// Gateways registered with a scheme-less vhost must still yield absolute URLs.
 	gateway := &models.Gateway{Vhost: "gw.example.com"}
 	contextPath := "/llm/proxy"
-	require.Equal(t, "https://gw.example.com/llm/proxy", buildProxyURL(gateway, &contextPath))
-	require.Equal(t, "https://gw.example.com", buildProxyURL(gateway, nil))
+	require.Equal(t, "https://gw.example.com/llm/proxy", buildPublicProxyURL(gateway, &contextPath))
+	require.Equal(t, "https://gw.example.com", buildPublicProxyURL(gateway, nil))
 }
 
 func TestBuildMCPProxyURLDefaultsBareGatewayVhostToHTTPS(t *testing.T) {
@@ -85,4 +87,34 @@ func TestResourceIdentifierUnchangedByVhostScheme(t *testing.T) {
 	cfg := models.MCPProxyConfig{Context: &ctxPath}
 	require.Equal(t, "https://gw.example.com/github/mcp", buildMCPProxyURL(bare, cfg))
 	require.Equal(t, buildMCPProxyURL(prefixed, cfg), buildMCPProxyURL(bare, cfg))
+}
+
+func TestBuildInternalProxyURLUsesRuntimeURL(t *testing.T) {
+	// Plaintext http on a non-standard port: the scheme must survive verbatim.
+	gateway := &models.Gateway{
+		Vhost:      "https://dev-acme.gateway.example.com",
+		RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
+	}
+	contextPath := "/llm/proxy"
+
+	withContext, err := buildInternalProxyURL(gateway, &contextPath)
+	require.NoError(t, err)
+	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy", withContext)
+
+	bare, err := buildInternalProxyURL(gateway, nil)
+	require.NoError(t, err)
+	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893", bare)
+}
+
+func TestBuildInternalProxyURLRejectsMissingRuntimeURL(t *testing.T) {
+	// A gateway with no reachable in-cluster address must fail closed, never fall back
+	// to the vhost. Migration 038 only backfills "api-platform-" names, so this is live.
+	contextPath := "/llm/proxy"
+	empty := &models.Gateway{UUID: uuid.New(), Vhost: "https://gw.example.com"}
+	_, err := buildInternalProxyURL(empty, &contextPath)
+	require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
+
+	whitespace := &models.Gateway{UUID: uuid.New(), Vhost: "https://gw.example.com", RuntimeURL: "   "}
+	_, err = buildInternalProxyURL(whitespace, &contextPath)
+	require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
 }

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -322,15 +322,33 @@ func ensureURLScheme(host string) string {
 	return "https://" + host
 }
 
-// buildProxyURL constructs the proxy base URL from the gateway's public vhost and
+// buildPublicProxyURL constructs the proxy base URL from the gateway's public vhost and
 // an optional context path. Every agent — sandboxed included — gets the public
 // URL so the address always matches the identity resource identifier.
-func buildProxyURL(gateway *models.Gateway, contextPath *string) string {
+func buildPublicProxyURL(gateway *models.Gateway, contextPath *string) string {
 	base := ensureURLScheme(gateway.Vhost)
 	if contextPath != nil {
 		return fmt.Sprintf("%s%s", base, *contextPath)
 	}
 	return base
+}
+
+// errGatewayRuntimeURLUnregistered means the gateway has no in-cluster address recorded, so
+// no internal caller can reach it. Falling back to the public vhost would hairpin the caller
+// out through an ingress its NetworkPolicy denies, so this fails closed.
+var errGatewayRuntimeURLUnregistered = errors.New("gateway has no runtimeUrl registered")
+
+// buildInternalProxyURL constructs the proxy base URL from the gateway's in-cluster runtime
+// address, for callers that run inside the cluster.
+func buildInternalProxyURL(gateway *models.Gateway, contextPath *string) (string, error) {
+	base := strings.TrimSpace(gateway.RuntimeURL)
+	if base == "" {
+		return "", fmt.Errorf("%w: %s", errGatewayRuntimeURLUnregistered, gateway.UUID)
+	}
+	if contextPath != nil {
+		return fmt.Sprintf("%s%s", base, *contextPath), nil
+	}
+	return base, nil
 }
 
 // buildLLMEnvVars constructs the two env vars (URL and API key) from the env config templates.
@@ -1187,7 +1205,7 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		if proxy != nil {
 			proxyContext = proxy.Configuration.Context
 		}
-		proxyURL := buildProxyURL(gateway, proxyContext)
+		proxyURL := buildPublicProxyURL(gateway, proxyContext)
 
 		// Capture credentials for external agents.
 		if isExternalAgent {
@@ -1869,7 +1887,7 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	// but a bootstrap default is last-write-wins across environments. The Component CR write is
 	// therefore scoped to the first environment, matching every other injection site in this file.
 	if !isExternalAgent {
-		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context)
+		proxyURL := buildPublicProxyURL(gateway, proxy.Configuration.Context)
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); rbErr != nil {
 			s.logger.Error("failed to patch ReleaseBinding in Scenario A", "env", envName, "err", rbErr)
@@ -2147,7 +2165,7 @@ func (s *agentConfigurationService) processNewEnv(
 	// last-write-wins clobbering across multiple environments (HIGH-3).
 	if !isExternalAgent {
 		// Reuse the gateway already resolved for deployment (resolveGatewayForProvider)
-		proxyURL := buildProxyURL(gateway, proxy.Configuration.Context)
+		proxyURL := buildPublicProxyURL(gateway, proxy.Configuration.Context)
 
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		// Inject per-env URL into the ReleaseBinding for this specific environment.
@@ -3147,7 +3165,7 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to resolve gateway for re-injection", "environment", envName, "err", gwErr)
 								continue
 							}
-							proxyURL := buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
+							proxyURL := buildPublicProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
 							// Use persisted SecretReference from DB rather than deriving from mutable config name.
 							envVars1b, varErr1b := s.envVariableRepo.ListByConfigAndEnv(ctx, existingConfig.UUID, mapping.EnvironmentUUID)
 							secretRefName := ""
@@ -5586,7 +5604,7 @@ func (s *agentConfigurationService) systemManagedLLMURL(
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for LLM proxy in %s: %w", environmentName, err)
 	}
-	return buildProxyURL(gateway, mapping.LLMProxy.Configuration.Context), nil
+	return buildPublicProxyURL(gateway, mapping.LLMProxy.Configuration.Context), nil
 }
 
 func (s *agentConfigurationService) systemManagedMCPURL(

--- a/agent-manager-service/services/gateway_anchoring_unit_test.go
+++ b/agent-manager-service/services/gateway_anchoring_unit_test.go
@@ -39,7 +39,7 @@ import (
 //     directly. RedeployMCPProxy is a one-line wrapper around it, so the three scope
 //     mutation call sites (create/update/delete) funnel through this exact same resolve
 //     and are not re-tested separately.
-//   - site 3 (resolveProxyURL, monitor_executor.go): the unexported method on a bare
+//   - site 3 (resolveInternalProxyURL, monitor_executor.go): the unexported method on a bare
 //     &monitorExecutor{} literal, per the brief's shape.
 //   - site 5 (resolveMonitorGateway, monitor_manager.go): the unexported method on a bare
 //     &monitorManagerService{} literal. The same helper backs both the monitor-create and
@@ -184,12 +184,27 @@ func TestAnchoring_MonitorRunAgainstDeployedProxy(t *testing.T) {
 				},
 			},
 		}
-		url, err := exec.resolveProxyURL(context.Background(), "org", env.String(), proxy)
+		url, err := exec.resolveInternalProxyURL(context.Background(), "org", env.String(), proxy)
 		require.NoError(t, err)
-		// Vhosts are per-gateway in the fixture, so asserting this one rules out the
-		// other gateway; every proxy URL is the public address now, and the bare
-		// fixture vhost gets the default https scheme.
-		require.Equal(t, "https://"+both.Vhost, url)
+		// Runtime URLs are per-gateway in the fixture, so asserting this one rules out the
+		// other gateway. The monitor's evaluation job runs in-cluster and gets the runtime
+		// address verbatim — no scheme defaulting, and never the public vhost.
+		require.Equal(t, both.RuntimeURL, url)
+	})
+
+	t.Run("fails when the anchored gateway has no runtimeUrl", func(t *testing.T) {
+		unregistered := newGateway(t, models.GatewayRoleBoth, true)
+		unregistered.RuntimeURL = ""
+		exec := &monitorExecutor{
+			gatewayRepo: gatewayFixtureRepo(t, env.String(), []*models.Gateway{unregistered}),
+			deploymentRepo: &repomocks.DeploymentRepositoryMock{
+				GetDeployedGatewaysByProviderFunc: func(uuid.UUID, string) ([]string, error) {
+					return []string{unregistered.UUID.String()}, nil
+				},
+			},
+		}
+		_, err := exec.resolveInternalProxyURL(context.Background(), "org", env.String(), proxy)
+		require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
 	})
 
 	t.Run("ambiguity fires only with no deployment", func(t *testing.T) {
@@ -201,7 +216,7 @@ func TestAnchoring_MonitorRunAgainstDeployedProxy(t *testing.T) {
 				},
 			},
 		}
-		_, err := exec.resolveProxyURL(context.Background(), "org", env.String(), proxy)
+		_, err := exec.resolveInternalProxyURL(context.Background(), "org", env.String(), proxy)
 		require.ErrorIs(t, err, errAmbiguousEgressGateway)
 	})
 }

--- a/agent-manager-service/services/gateway_roles_unit_test.go
+++ b/agent-manager-service/services/gateway_roles_unit_test.go
@@ -46,8 +46,7 @@ func newGateway(t *testing.T, role string, active bool) *models.Gateway {
 		Properties:  map[string]interface{}{},
 		Manifest:    map[string]interface{}{},
 		Vhost:       "vhost-" + id.String() + ".example.com",
-		// Seeded so internal-URL consumers resolve the real address instead of logging the
-		// missing-runtimeUrl ERROR and falling back to the vhost.
+		// Seeded so internal-URL consumers resolve a real address instead of failing closed.
 		RuntimeURL:               "http://gateway-" + id.String() + ".acme-dev:22893",
 		IsCritical:               false,
 		GatewayFunctionalityType: role,

--- a/agent-manager-service/services/llm_proxy_provisioner.go
+++ b/agent-manager-service/services/llm_proxy_provisioner.go
@@ -286,7 +286,7 @@ func (p *LLMProxyProvisioner) ProvisionProxy(ctx context.Context, params Provisi
 		rb.ProxySecretLoc = &proxySecretLoc
 	}
 
-	proxyURL := buildProxyURL(params.Gateway, proxy.Configuration.Context)
+	proxyURL := buildPublicProxyURL(params.Gateway, proxy.Configuration.Context)
 
 	p.logger.Info(
 		"Provisioned LLM proxy",

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -227,7 +227,7 @@ func (e *monitorExecutor) resolveLLMProxyConfig(ctx context.Context, monitor *mo
 		return "", "", "", fmt.Errorf("monitor LLM mapping for monitor %s has no secret KV path — was it provisioned correctly?", monitor.ID)
 	}
 
-	resolvedURL, err := e.resolveProxyURL(ctx, monitor.OUID, monitor.EnvironmentID, mapping.LLMProxy)
+	resolvedURL, err := e.resolveInternalProxyURL(ctx, monitor.OUID, monitor.EnvironmentID, mapping.LLMProxy)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to resolve proxy URL: %w", err)
 	}
@@ -241,12 +241,13 @@ func (e *monitorExecutor) resolveLLMProxyConfig(ctx context.Context, monitor *mo
 	return mapping.SecretKVPath, resolvedURL, templateHandle, nil
 }
 
-// resolveProxyURL derives the proxy base URL from the preloaded LLMProxy and the gateway
+// resolveInternalProxyURL derives the proxy base URL from the preloaded LLMProxy and the gateway
 // the proxy is actually deployed to in this environment. Anchoring matters here more than
 // anywhere else: this runs on every scheduled monitor execution, on resources nobody
 // touched, so re-selecting from the environment would break every pre-existing monitor
-// the moment a second egress gateway appears.
-func (e *monitorExecutor) resolveProxyURL(ctx context.Context, ouID, environmentID string, proxy *models.LLMProxy) (string, error) {
+// the moment a second egress gateway appears. The consumer is the in-cluster evaluation job,
+// so the address is the gateway's internal one, not its vhost.
+func (e *monitorExecutor) resolveInternalProxyURL(ctx context.Context, ouID, environmentID string, proxy *models.LLMProxy) (string, error) {
 	_ = ctx
 	if proxy == nil {
 		return "", fmt.Errorf("LLM proxy not preloaded for mapping")
@@ -268,7 +269,7 @@ func (e *monitorExecutor) resolveProxyURL(ctx context.Context, ouID, environment
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for environment %s: %w", environmentID, err)
 	}
-	return buildProxyURL(gateway, proxy.Configuration.Context), nil
+	return buildInternalProxyURL(gateway, proxy.Configuration.Context)
 }
 
 // buildWorkflowRunRequest constructs the workflow run request for a monitor.

--- a/agent-manager-service/tests/monitor_executor_test.go
+++ b/agent-manager-service/tests/monitor_executor_test.go
@@ -323,7 +323,7 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 	gdb := db.DB(context.Background())
 
 	// Seed an LLMProxy row — Handle is a join-derived field so it is left empty here;
-	// buildProxyURL only needs Configuration.Context from this row.
+	// buildPublicProxyURL only needs Configuration.Context from this row.
 	// session_replication_role disables FK triggers so we don't need to seed artifacts/llm_providers.
 	contextPath := "/test-proxy-ctx"
 	proxyUUID := uuid.New()
@@ -366,6 +366,7 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 		Name:                     "test-gateway-" + gwUUID.String()[:8],
 		DisplayName:              "Test Gateway",
 		Vhost:                    "https://gw.example.com",
+		RuntimeURL:               "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
 		IsActive:                 true,
 		Properties:               map[string]interface{}{},
 		GatewayFunctionalityType: "both",
@@ -410,12 +411,10 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 	// Secret path comes from the persisted SecretReference remoteRef (not a computed KV path).
 	assert.Equal(t, expectedSecretPath, evalParams["llmProxySecretPath"], "llmProxySecretPath should be the SecretReference remoteRef key")
 
-	// Proxy URL is the gateway vhost + context path. buildProxyURL returns the gateway's
-	// vhost; in-cluster callers reach it via the CoreDNS *.gateway.localhost rewrite to the
-	// k3d host, and the gateway routes by vhost Host header into the per-env api-platform
-	// gateway (see services/agent_configuration_service.go:buildProxyURL).
-	expectedProxyURL := gw.Vhost + contextPath
-	assert.Equal(t, expectedProxyURL, evalParams["llmApiBase"], "llmApiBase should be the gateway vhost + proxy context path")
+	// The evaluation job runs in-cluster, so it gets the gateway's runtime address, not the
+	// public vhost — its NetworkPolicy only allows egress to the gateway namespace on 22893.
+	expectedProxyURL := gw.RuntimeURL + contextPath
+	assert.Equal(t, expectedProxyURL, evalParams["llmApiBase"], "llmApiBase should be the gateway runtime URL + proxy context path")
 }
 
 // TestExecuteMonitorRun_NilEvaluatorsReturnsError verifies that calling ExecuteMonitorRun


### PR DESCRIPTION
## Purpose
The monitor evaluation job received the gateway's **public vhost** as `LLM_API_BASE`, so an in-cluster workflow pod had to hairpin out through the public ingress and back in to reach an LLM proxy sitting in the same cluster.

The infrastructure for the direct path already existed but nothing used it:

- `models.Gateway.RuntimeURL` holds the in-cluster address (e.g. `http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893`), computed by the gateway extension chart and registered at bootstrap. It was validated on register/update and returned by the API, but **no code built a URL from it**.
- The evaluation job's NetworkPolicy already allows egress to the gateway namespace on port **22893** — the runtime Service port (`deployments/helm-charts/wso2-amp-evaluation-extension/templates/evaluation-job-networkpolicy.yaml`). The public-vhost path only worked via the local-dev `devEgress` ipBlock on the node network (19080).

## Goals
Give the evaluation job the gateway's in-cluster runtime URL instead of the public vhost, so LLM-judge traffic stays inside the cluster and matches the egress the job is actually granted.

Agent env-var injection, config responses, and MCP proxies are unchanged — they keep the public URL, which must stay identical to the identity resource-server identifier.

## Approach
`buildProxyURL` was the single URL builder for LLM proxies and had no counterpart, which made it easy to reach for the wrong address. It is now an explicit pair:

- **`buildProxyURL` → `buildPublicProxyURL`** — unchanged behavior, 6 call sites (agent env injection, config responses, proxy provisioning).
- **`buildInternalProxyURL`** (new) — builds from `gateway.RuntimeURL`. No scheme defaulting: `validateGatewayRuntimeURL` already requires an explicit `http`/`https`, and forcing `https` would break a plaintext in-cluster address.

`monitorExecutor.resolveProxyURL` → `resolveInternalProxyURL`, now returning `buildInternalProxyURL(...)`.

**Fails closed.** A gateway with no registered `runtimeUrl` returns `errGatewayRuntimeURLUnregistered` (a sentinel, matching the existing gateway-resolution errors in `services/gateway_roles.go`) rather than silently falling back to the vhost — a fallback would route the job out through an ingress its own NetworkPolicy denies, turning a provisioning fault into a confusing network error.

**Why no Host header is needed:** the gateway only applies a host constraint when the deployed artifact carries a `vhost`. For LLM proxies that value comes from `LLMProxyConfig.Vhost`, which has no writer anywhere in AMS — so every LLM proxy deploys with an empty vhost and the gateway routes it on the context path alone. (MCP deliberately differs: `mcpProxyServingBase` honors a per-proxy vhost override, which is why no MCP counterpart is added here.)

## User stories
As a platform operator, when a monitor runs LLM-judge evaluators, the evaluation job reaches the LLM proxy over cluster-internal networking instead of egressing to the public ingress and back.

## Release note
Monitor evaluation jobs now reach the LLM gateway over its in-cluster runtime address instead of the public vhost. A monitor whose gateway has no registered `runtimeUrl` now fails its run instead of attempting the public URL.

## Documentation
N/A — no user-facing API, CLI, or console surface changes. The behavior is internal routing between the evaluation job and the gateway.

## Training
N/A — no training content covers evaluation-job network routing.

## Certification
N/A — internal routing detail, not covered by certification exams.

## Marketing
N/A — internal reliability fix with no promotable surface.

## Automation tests
 - Unit tests
   > `services` package, all passing via `make test-unit` (full tier green).
   > - `TestBuildInternalProxyURLUsesRuntimeURL` — runtime URL with and without a context path; asserts the `http` scheme survives verbatim and is not upgraded to `https`.
   > - `TestBuildInternalProxyURLRejectsMissingRuntimeURL` — empty and whitespace-only `RuntimeURL` both return `errGatewayRuntimeURLUnregistered` (asserted with `errors.Is`, not string matching).
   > - `TestAnchoring_MonitorRunAgainstDeployedProxy` — existing gateway-anchoring test updated to expect the runtime URL; new subtest `fails when the anchored gateway has no runtimeUrl` covers the fail-closed path end-to-end through `resolveInternalProxyURL`.
   > - `TestBuildPublicProxyURLUsesVhost` and the MCP builder tests are unchanged and still green, pinning the no-regression guarantee for agent env injection.
 - Integration tests
   > `tests/monitor_executor_test.go::TestExecuteMonitorRun_LLMCredentials` updated: the seeded gateway now carries a `runtime_url`, and the assertion on the workflow's `llmApiBase` parameter expects the runtime URL + proxy context path. Compiles clean under `-tags=integration`; **not executed** — requires a provisioned test database, so it needs a CI run.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **no** — FindSecurityBugs is a Java/SpotBugs plugin and does not apply to this Go module. `make lint` (golangci-lint, the repo's Go gate) reports 0 issues.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — the change moves a URL only. The LLM API key path is untouched: it still arrives via the existing `SecretReference` remoteRef, never inlined.

## Samples
N/A — no sample changes; the behavior is internal to monitor execution.

## Related PRs
None. Builds on the existing `runtimeUrl` registration work (commits `3466bdcbc`, `31b1cd4b5`, migration `038_gateway_runtime_url.go`), which added and populated the field but had no consumer.

## Migrations (if applicable)
No new migration. **This PR does change the blast radius of an existing one, and reviewers should weigh it:**

Migration 038 backfills `runtime_url` only for gateways whose name starts with `api-platform-`. A custom-named gateway registered before that migration keeps a NULL `runtime_url`, and its monitors will now **fail** rather than fall back to the public vhost. The repair path already exists — the gateway extension chart's bootstrap job PUTs `runtimeUrl` on every upgrade (`sync_runtime_url` in `gateway-bootstrap-job.yaml`) — so a chart upgrade fixes affected gateways. Operators running a custom-named gateway without a chart upgrade should confirm `GET /gateways` reports a non-empty `runtimeUrl` before deploying this.

Failing closed here is deliberate: the fallback would produce an opaque network error from inside the job rather than a clear provisioning error at resolution time.

## Test environment
- Go 1.25.11 (darwin/arm64), macOS 15 (Darwin 25.0.0)
- `make lint` (golangci-lint v2.1.6) — 0 issues
- `make test-unit` — full unit tier passing
- `go vet -tags=integration ./tests/...` — clean
- No live cluster verification: the local k3d cluster was unreachable (TLS verify failure) during this work. The claim that the gateway routes LLM proxies on the runtime address without a Host header is derived from configuration (empty artifact vhost + the NetworkPolicy's existing 22893 allowance), **not** from an observed request. Worth confirming on a live environment before merge.

## Learning
The non-obvious part was establishing that no `Host` header workaround is needed. The public path routes through kgateway, whose HTTPRoute matches on `hostnames: [<vhost>]` — which suggested that bypassing it to hit the runtime Service directly would 404. Tracing the deploy payload showed the artifact-level vhost is the only host constraint the gateway itself applies, and `LLMProxyConfig.Vhost` has no writer in AMS, so LLM proxies are always deployed host-unconstrained. The evaluation job's NetworkPolicy already allowing port 22893 confirmed the direct path was the originally intended design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved proxy URL handling by distinguishing public gateway addresses from internal runtime addresses.
  - Internal services now use the configured gateway runtime URL, including custom schemes, ports, and context paths.
  - Missing runtime URLs fail safely instead of falling back to public addresses.

- **Bug Fixes**
  - Monitor and LLM proxy integrations now resolve to the appropriate internal or public gateway URL, improving connectivity in deployed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->