### PR TITLE
Route eval judge calls to the in-cluster gateway

### DIFF
--- a/agent-manager-service/services/gateway_anchoring_unit_test.go
+++ b/agent-manager-service/services/gateway_anchoring_unit_test.go
@@ -183,13 +183,42 @@ func TestAnchoring_MonitorRunAgainstDeployedProxy(t *testing.T) {
 					return []string{both.UUID.String()}, nil
 				},
 			},
+			logger: discardLogger(),
 		}
 		url, err := exec.resolveProxyURL(context.Background(), "org", env.String(), proxy)
 		require.NoError(t, err)
-		// Vhosts are per-gateway in the fixture, so asserting this one rules out the
-		// other gateway; every proxy URL is the public address now, and the bare
-		// fixture vhost gets the default https scheme.
-		require.Equal(t, "https://"+both.Vhost, url)
+		// Runtime URLs are per-gateway in the fixture, so asserting this one rules out
+		// the other gateway. The judge gets the in-cluster address, not the vhost: it
+		// runs under an egress policy that only permits the gateway in-cluster.
+		require.Equal(t, both.RuntimeURL, url)
+	})
+
+	t.Run("judge URL is the in-cluster address, not the public vhost", func(t *testing.T) {
+		exec := &monitorExecutor{logger: discardLogger()}
+		contextPath := "/llm/proxy"
+
+		require.Equal(t, both.RuntimeURL+contextPath, exec.buildJudgeProxyURL(both, &contextPath))
+		require.Equal(t, both.RuntimeURL, exec.buildJudgeProxyURL(both, nil))
+		// The public URL is what the eval job's NetworkPolicy refuses, so it must not
+		// leak into the judge's base URL while an in-cluster address exists.
+		require.NotContains(t, exec.buildJudgeProxyURL(both, &contextPath), both.Vhost)
+	})
+
+	t.Run("falls back to the vhost when the gateway has no in-cluster address", func(t *testing.T) {
+		exec := &monitorExecutor{logger: discardLogger()}
+		contextPath := "/llm/proxy"
+
+		// An externally-hosted gateway has no in-cluster address to offer; its public
+		// vhost is the only one that can work, so the judge has to be sent there.
+		external := newGateway(t, models.GatewayRoleEgress, true)
+		external.RuntimeURL = ""
+		require.Equal(t, "https://"+external.Vhost+contextPath, exec.buildJudgeProxyURL(external, &contextPath))
+
+		// Same for a value too malformed to concatenate (a legacy row predating
+		// validateGatewayRuntimeURL) — fall back rather than build a broken URL.
+		legacy := newGateway(t, models.GatewayRoleEgress, true)
+		legacy.RuntimeURL = "gateway-runtime.acme-dev:22893"
+		require.Equal(t, "https://"+legacy.Vhost+contextPath, exec.buildJudgeProxyURL(legacy, &contextPath))
 	})
 
 	t.Run("ambiguity fires only with no deployment", func(t *testing.T) {

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -268,7 +268,44 @@ func (e *monitorExecutor) resolveProxyURL(ctx context.Context, ouID, environment
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for environment %s: %w", environmentID, err)
 	}
-	return buildProxyURL(gateway, proxy.Configuration.Context), nil
+	return e.buildJudgeProxyURL(gateway, proxy.Configuration.Context), nil
+}
+
+// buildJudgeProxyURL returns the base URL the evaluation job should reach the LLM
+// proxy on: the gateway's in-cluster runtime address rather than its public vhost.
+//
+// This deliberately differs from buildProxyURL, which every other caller wants.
+// Agents and the console are given the public URL so the address matches the
+// identity resource identifier; the evaluation job is the one consumer that runs
+// inside the cluster, under the egress NetworkPolicy the evaluation extension
+// ships (amp-evaluation-job-egress). That policy permits the API Platform Gateway
+// at its in-cluster address and nothing else, while the public vhost resolves to
+// whatever fronts the platform — a VM's host-network Caddy container, a cloud
+// LoadBalancer — which is not a pod and so cannot be matched by any selector the
+// policy can express. Sending judges to the vhost therefore has them refused at
+// the policy, and every llm_judge evaluation skips with a bare "Connection error"
+// while no request ever reaches the gateway. The runtime address is also simply
+// the shorter path: no DNS out of the cluster, no hairpin back in, and untrusted
+// evaluator code needs no public egress at all.
+//
+// runtimeUrl is validated on write (validateGatewayRuntimeURL) as a cluster-local
+// base URL carrying a scheme, an explicit port and no path, so it concatenates
+// with the proxy context exactly as the vhost does. It is empty for a gateway with
+// no in-cluster address to offer — one hosted outside the cluster, or a record
+// written before the bootstrap job began syncing it — and those can only be
+// reached at their public address, so fall back to it and say so.
+func (e *monitorExecutor) buildJudgeProxyURL(gateway *models.Gateway, contextPath *string) string {
+	runtimeURL := strings.TrimSpace(gateway.RuntimeURL)
+	if !strings.Contains(runtimeURL, "://") {
+		e.logger.Warn("Gateway has no in-cluster runtimeUrl; routing evaluation judge calls to the "+
+			"public vhost, which the evaluation job's egress policy may refuse",
+			"gateway", gateway.Name, "vhost", gateway.Vhost)
+		return buildProxyURL(gateway, contextPath)
+	}
+	if contextPath != nil {
+		return runtimeURL + *contextPath
+	}
+	return runtimeURL
 }
 
 // buildWorkflowRunRequest constructs the workflow run request for a monitor.


### PR DESCRIPTION
## Purpose
Every LLM-as-judge evaluation skips with `LLM judge failed after 3 attempts: Connection error. [model=openai/gpt-4o-mini]`, so monitor runs produce no judge scores at all, and the gateway access log shows no judge request ever arriving — while agent chat and OTel ingest through the same gateway succeed.

The monitor hands the evaluation job the egress gateway's **public vhost**. That job runs in-cluster under the egress `NetworkPolicy` the evaluation extension ships (`amp-evaluation-job-egress`), which permits the API Platform Gateway only at its **in-cluster** address. The public vhost resolves to whatever fronts the platform — a VM's host-network Caddy container, a cloud LoadBalancer — which is not a pod, so no selector the policy can express will ever match it, and the judge is refused before it leaves the pod. The policy's own in-cluster rule shows where this traffic was meant to go; the URL and the policy disagreed.

## Goals
Have judge completions reach the gateway on every install topology, using the allowance the shipped policy already grants, and without giving untrusted evaluator code any public egress.

## Approach
Gateways already carry the address this needs: `runtimeUrl`, synced by the gateway bootstrap job and validated on write (`validateGatewayRuntimeURL`) as a cluster-local base URL with a scheme, an explicit port and no path — so it concatenates with the proxy context exactly as the vhost does. `resolveProxyURL` now builds the judge's base URL from it.

`buildProxyURL` is deliberately untouched. Agents and the console must keep the public URL, because it has to match the identity resource identifier; the evaluation job is the one consumer that runs inside the cluster, and it is the only caller changed here.

It falls back to the vhost when a gateway has no in-cluster address to offer — one hosted outside the cluster (an AI gateway registered as `EGRESS` near a private model endpoint), or a record written before the bootstrap job began syncing it — and logs when it does, since that is the case the egress policy may still refuse. A `runtimeUrl` too malformed to concatenate falls back the same way rather than building a broken URL.

**Why here and not in the installers.** The same bug has a different shape per topology, because each reaches the gateway differently: quick-start over the node network on `19080`, a VM install over its own public IP on `443`, a production install over an ingress LoadBalancer, and an external gateway over an address the cluster cannot enumerate at all. That is three ipBlock holes to punch and one that cannot be — and the two nobody punched shipped broken (`setup-amp-extensions.sh` sets `devEgress`; the quick-start and VM installers do not). Sending the traffic in-cluster needs none of them: no DNS out of the cluster, no hairpin back in, no public egress for a pod running user-supplied evaluator code.

This supersedes #1714, which patched the VM installer's `devEgress` for the VM case only. That PR is closed in favour of this one.

## User stories
As someone running evaluations, I want LLM-as-judge evaluators to produce scores instead of a full column of skipped judges, on whichever way I installed the platform.

## Release note
Fixed LLM-as-judge evaluations failing with a connection error: judge completions are now routed to the gateway's in-cluster runtime address instead of its public hostname.

## Documentation
N/A — no documented behaviour changes; this makes the documented evaluation flow work as described.

## Training
N/A — no training content covers judge routing.

## Certification
N/A — internal routing fix, not covered by certification exams.

## Marketing
N/A — bug fix.

## Automation tests
- Unit tests
  > `TestAnchoring_MonitorRunAgainstDeployedProxy` gains two subtests: the judge URL is the gateway's in-cluster address with the proxy context appended and never contains the vhost, and the vhost fallback fires both for a gateway with no `runtimeUrl` and for a malformed one. The existing anchoring assertion is updated to the in-cluster address, which still discriminates between the two fixture gateways (their runtime URLs are per-gateway). `make test-unit` passes; `gofumpt` and `go vet` clean.
- Integration tests
  > Verified end to end on a GCP VM running `1.0.0-RC1`, with the egress policy **exactly as shipped** (a `/32` workaround added during diagnosis was removed first, so the public path was blocked again).
  > - Before: every evaluator skipped on every trace with `Connection error`, reproduced from inside the `amp-evaluation-monitor:v1.0.0-RC1` image as `openai.APIConnectionError` wrapping `[Errno 111] Connection refused`.
  > - After, with `amp-api` rebuilt from this branch, the next scheduled monitor run was handed `http://api-platform-default-default-gw-gateway-gateway-runtime.default-default:22893/<proxy>` and completed `status=SUCCESS`: Accuracy 3/3 (mean 1.000), Reasoning Quality 3/3 (0.833), Groundedness 3/3 (0.333) — no skips, no connection errors.
  > - The in-cluster route was also confirmed to match on path alone, with no public Host header: the real proxy path returns `401` (key demanded), a bogus path `404`. From a pod carrying the job's two labels, `:22893` is reachable 6/6 while the public host is refused 6/6.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes. No credentials are added or logged — the fallback logs only the gateway name and its (public) vhost. This narrows the platform's exposure rather than widening it: the evaluation pod runs user-supplied evaluator code and no longer needs egress off the cluster, and the alternative fix would have granted it a public-network hole.

## Samples
N/A — no samples affected.

## Related PRs
Supersedes #1714 (VM-installer-only `devEgress` workaround). Separately, #1715 fixes the certificate issuance failure found on the same install.

## Migrations (if applicable)
N/A — no state to migrate. Gateways registered by the bootstrap job already carry `runtimeUrl`; any that do not keep the previous behaviour through the fallback.

## Test environment
GCP VM (`e2-standard-4`, Ubuntu 24.04.4 LTS), Docker 29.7.2, k3d 5.9.0 / k3s v1.32.9, kubectl 1.33.13, Helm 3.21.4, Agent Manager `1.0.0-RC1`, Go 1.25. Unit tests on macOS (arm64) and the service image cross-built for linux/amd64.

## Learning
Two things made this expensive to find, and both are worth knowing. `NetworkPolicy` egress is matched **post-DNAT**, which is why the same URL is permitted on a cluster where it lands on an in-cluster ingress and refused on a VM where it lands on a host-network container. And enforcement is programmed a second or two *after* pod start, so a single quick `curl` in a fresh pod succeeds and looks like proof the path is healthy — the failure only reproduces when you probe repeatedly, from a pod carrying both of the policy's selector labels.
