### PR TITLE
Allow evaluation jobs to reach the local LLM gateway

### DIFF
--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -347,19 +347,26 @@ install_evaluation_extension() {
     # order doesn't depend on a workflow having already run.
     kubectl create namespace workflows-default --dry-run=client -o yaml | kubectl apply -f - >/dev/null
 
-    # The eval pod runs untrusted evaluator code, so scope its API-server egress to the k3d node
-    # network rather than taking the chart's RFC1918 default, which also spans pod and service CIDRs.
-    local api_server_args=() node_cidr
+    # The eval pod runs untrusted evaluator code, so scope node-network egress to
+    # this k3d network rather than taking the chart's RFC1918 API-server default.
+    # The public LLM gateway hostname is rewritten by CoreDNS to host.k3d.internal
+    # and reached through the node-published port 19080, so the namespace/22893
+    # rule alone cannot match it after DNS resolution.
+    local network_policy_args=() node_cidr
     node_cidr=$(docker network inspect "k3d-${CLUSTER_NAME}" \
         --format '{{ (index .IPAM.Config 0).Subnet }}' 2>/dev/null || echo "")
     if [[ -n "$node_cidr" ]]; then
-        api_server_args=(--set "networkPolicy.evaluationJob.apiServer.cidrs[0]=${node_cidr}")
+        network_policy_args=(
+            --set "networkPolicy.evaluationJob.apiServer.cidrs[0]=${node_cidr}"
+            --set "networkPolicy.evaluationJob.devEgress.cidr=${node_cidr}"
+            --set "networkPolicy.evaluationJob.devEgress.ports={19080}"
+        )
     fi
 
     # Install Helm chart
     if ! install_amp_helm_chart "${release_name}" "${chart_ref}" "${EVALUATION_NS}" "${TIMEOUT_AMP_INSTALL}" \
         --version "${chart_version}" \
-        ${api_server_args[@]+"${api_server_args[@]}"} \
+        ${network_policy_args[@]+"${network_policy_args[@]}"} \
         "${EVALUATION_HELM_ARGS[@]}"; then
         return 1
     fi

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -355,19 +355,22 @@ install_evaluation_extension() {
     local network_policy_args=() node_cidr
     node_cidr=$(docker network inspect "k3d-${CLUSTER_NAME}" \
         --format '{{ (index .IPAM.Config 0).Subnet }}' 2>/dev/null || echo "")
-    if [[ -n "$node_cidr" ]]; then
-        network_policy_args=(
-            --set "networkPolicy.evaluationJob.apiServer.cidrs[0]=${node_cidr}"
-            --set "networkPolicy.evaluationJob.devEgress.cidr=${node_cidr}"
-            --set "networkPolicy.evaluationJob.devEgress.ports={19080}"
-        )
+    if [[ -z "$node_cidr" ]]; then
+        echo "Failed to discover the k3d-${CLUSTER_NAME} network CIDR." >&2
+        echo "Evaluation jobs require that CIDR to reach the local LLM gateway on port 19080." >&2
+        return 1
     fi
+    network_policy_args=(
+        --set "networkPolicy.evaluationJob.apiServer.cidrs[0]=${node_cidr}"
+        --set "networkPolicy.evaluationJob.devEgress.cidr=${node_cidr}"
+        --set "networkPolicy.evaluationJob.devEgress.ports={19080}"
+    )
 
     # Install Helm chart
     if ! install_amp_helm_chart "${release_name}" "${chart_ref}" "${EVALUATION_NS}" "${TIMEOUT_AMP_INSTALL}" \
         --version "${chart_version}" \
-        ${network_policy_args[@]+"${network_policy_args[@]}"} \
-        "${EVALUATION_HELM_ARGS[@]}"; then
+        "${EVALUATION_HELM_ARGS[@]}" \
+        "${network_policy_args[@]}"; then
         return 1
     fi
 

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1627,11 +1627,13 @@ echo ""
 # Install evaluation extension
 log_info "Installing Evaluation Extension (Monitor Evaluation Workflows)..."
 if ! install_evaluation_extension; then
-    log_warning "Evaluation Extension installation failed (non-fatal)"
-    echo "The platform is installed but evaluation features may not work."
+    log_error "Evaluation Extension installation failed"
+    echo "The platform is installed, but quick start cannot complete without working evaluations."
     echo ""
     echo "Troubleshooting steps:"
     echo "  1. Check Helm release: helm list -n ${EVALUATION_NS}"
+    echo "  2. Check the k3d network: docker network inspect k3d-${CLUSTER_NAME}"
+    exit 1
 else
     log_success "Evaluation Extension installed successfully"
 fi


### PR DESCRIPTION
## Purpose

LLM-as-judge evaluations were failing in quick-start installations because evaluation jobs could not reach the local LLM gateway.

## Goals

* Fix LLM judge connection failures in quick-start.
* Keep the existing evaluation-job NetworkPolicy enabled.
* Allow only the required gateway access.

## Approach

Updated the quick-start installer to configure the evaluation extension with access to the local gateway on port `19080`.

The rule is restricted to the discovered k3d node network and the required port only.

## Release note

Fixed LLM-as-judge evaluations failing with connection errors in local quick-start installations.

## Documentation

N/A — no user-facing workflow changes.

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Tests

Validated on a live `v1.0.0-RC1` quick-start installation by successfully running an LLM judge evaluation through the local gateway.

## Security checks

- Followed secure coding standards in the [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)? Yes
- Ran FindSecurityBugs plugin and verified report? N/A — no Java code was changed
- Confirmed that this PR does not commit keys, passwords, tokens, usernames, or other secrets? Yes

## Samples

N/A

## Related PRs

N/A

## Migrations

No migration required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation extension networking by automatically detecting the k3d node network.
  * Configured API-server and developer egress access with more precise network restrictions.
  * Limited developer egress traffic to port 19080 for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->