### PR TITLE
Route platform agents through the gateway's internal URL

### DIFF
--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -27,7 +27,8 @@ import (
 )
 
 func TestBuildPublicProxyURLUsesVhost(t *testing.T) {
-	// RuntimeURL present but must be ignored: every agent gets the public URL.
+	// RuntimeURL present but must be ignored: this is the address handed to callers
+	// outside the cluster — external agents and MCP's resource identifier.
 	gateway := &models.Gateway{
 		Vhost:      "https://dev-acme.gateway.example.com",
 		RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
@@ -38,6 +39,9 @@ func TestBuildPublicProxyURLUsesVhost(t *testing.T) {
 }
 
 func TestBuildMCPProxyURLUsesGatewayVhost(t *testing.T) {
+	// MCP keeps the public vhost even with a RuntimeURL registered: this URL doubles as
+	// the OAuth resource identifier (MCPResourceServerIdentifier), so an in-cluster
+	// address here would put an unroutable audience in every AgentID token.
 	gateway := &models.Gateway{
 		Vhost:      "https://gateway.example.com",
 		RuntimeURL: "http://runtime.acme-dev:22893",

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -323,8 +323,9 @@ func ensureURLScheme(host string) string {
 }
 
 // buildPublicProxyURL constructs the proxy base URL from the gateway's public vhost and
-// an optional context path. Every agent — sandboxed included — gets the public
-// URL so the address always matches the identity resource identifier.
+// an optional context path. This is the address for callers outside the cluster, and for
+// MCP, whose URL doubles as the identity resource identifier. Platform-hosted agents get
+// buildInternalProxyURL instead — they reach the gateway in-cluster.
 func buildPublicProxyURL(gateway *models.Gateway, contextPath *string) string {
 	base := ensureURLScheme(gateway.Vhost)
 	if contextPath != nil {
@@ -1200,7 +1201,7 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		rollbackResources[rbIdx].proxySecretLoc = &proxySecretLoc
 		rollbackResources[rbIdx].secretRefName = secretRefName
 
-		// Build proxy URL with nil-safe context access.
+		// Public proxy URL (nil-safe context) — what an external agent's operator is handed.
 		var proxyContext *string
 		if proxy != nil {
 			proxyContext = proxy.Configuration.Context
@@ -1263,8 +1264,16 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		// The Component CR (global, shared across envs) is updated once after the loop using the
 		// first-environment's vars to avoid last-write-wins clobbering (HIGH-3).
 		if !isExternalAgent {
+			// The agent pod reaches the gateway in-cluster; its NetworkPolicy has no route to the vhost.
+			internalProxyURL, urlErr := buildInternalProxyURL(gateway, proxyContext)
+			if urlErr != nil {
+				s.rollbackProxies(ctx, rollbackResources, ouID)
+				s.compensatingDeleteConfig(ctx, config.UUID, ouID)
+				return nil, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
+			}
+
 			// Build the two env vars (URL plain, API key via secretKeyRef).
-			envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
+			envVarsToInject := buildLLMEnvVars(envConfigTemplates, internalProxyURL, secretRefName)
 
 			// Step 3: Inject per-environment URL and API key ref into the ReleaseBinding.
 			// Each environment gets its own ReleaseBinding with the correct per-env proxy URL,
@@ -1887,7 +1896,10 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	// but a bootstrap default is last-write-wins across environments. The Component CR write is
 	// therefore scoped to the first environment, matching every other injection site in this file.
 	if !isExternalAgent {
-		proxyURL := buildPublicProxyURL(gateway, proxy.Configuration.Context)
+		proxyURL, urlErr := buildInternalProxyURL(gateway, proxy.Configuration.Context)
+		if urlErr != nil {
+			return "", rbRes, pendingAppBinding{}, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
+		}
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); rbErr != nil {
 			s.logger.Error("failed to patch ReleaseBinding in Scenario A", "env", envName, "err", rbErr)
@@ -2165,7 +2177,11 @@ func (s *agentConfigurationService) processNewEnv(
 	// last-write-wins clobbering across multiple environments (HIGH-3).
 	if !isExternalAgent {
 		// Reuse the gateway already resolved for deployment (resolveGatewayForProvider)
-		proxyURL := buildPublicProxyURL(gateway, proxy.Configuration.Context)
+		proxyURL, urlErr := buildInternalProxyURL(gateway, proxy.Configuration.Context)
+		if urlErr != nil {
+			s.rollbackProxies(ctx, []rollbackResource{rbRes}, ouID)
+			return rollbackResource{}, pendingAppBinding{}, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
+		}
 
 		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		// Inject per-env URL into the ReleaseBinding for this specific environment.
@@ -3165,7 +3181,11 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to resolve gateway for re-injection", "environment", envName, "err", gwErr)
 								continue
 							}
-							proxyURL := buildPublicProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
+							proxyURL, urlErr := buildInternalProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
+							if urlErr != nil {
+								s.logger.Warn("Phase 1b: failed to resolve internal proxy URL for re-injection", "environment", envName, "err", urlErr)
+								continue
+							}
 							// Use persisted SecretReference from DB rather than deriving from mutable config name.
 							envVars1b, varErr1b := s.envVariableRepo.ListByConfigAndEnv(ctx, existingConfig.UUID, mapping.EnvironmentUUID)
 							secretRefName := ""
@@ -5604,7 +5624,7 @@ func (s *agentConfigurationService) systemManagedLLMURL(
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for LLM proxy in %s: %w", environmentName, err)
 	}
-	return buildPublicProxyURL(gateway, mapping.LLMProxy.Configuration.Context), nil
+	return buildInternalProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
 }
 
 func (s *agentConfigurationService) systemManagedMCPURL(

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -377,6 +377,21 @@ func buildLLMEnvVars(templates []EnvConfigTemplate, proxyURL, secretRefName stri
 	}
 }
 
+// internalLLMEnvVars builds a platform-hosted agent's LLM env vars against the gateway's
+// in-cluster address, the only one its pod can route to. Every LLM injection site goes
+// through here so the choice of address is made once rather than re-decided per site.
+// Its sibling buildMCPEnvVars still takes a plain URL: an MCP proxy's address is
+// legitimately public, since it doubles as the OAuth resource identifier.
+func internalLLMEnvVars(
+	templates []EnvConfigTemplate, gateway *models.Gateway, contextPath *string, secretRefName string,
+) ([]client.EnvVar, error) {
+	proxyURL, err := buildInternalProxyURL(gateway, contextPath)
+	if err != nil {
+		return nil, err
+	}
+	return buildLLMEnvVars(templates, proxyURL, secretRefName), nil
+}
+
 func buildMCPEnvVars(templates []EnvConfigTemplate, proxyURL, secretRefName string) []client.EnvVar {
 	var envVars []client.EnvVar
 	for _, t := range templates {
@@ -1264,16 +1279,13 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		// The Component CR (global, shared across envs) is updated once after the loop using the
 		// first-environment's vars to avoid last-write-wins clobbering (HIGH-3).
 		if !isExternalAgent {
-			// The agent pod reaches the gateway in-cluster; its NetworkPolicy has no route to the vhost.
-			internalProxyURL, urlErr := buildInternalProxyURL(gateway, proxyContext)
+			// Build the two env vars (URL plain, API key via secretKeyRef).
+			envVarsToInject, urlErr := internalLLMEnvVars(envConfigTemplates, gateway, proxyContext, secretRefName)
 			if urlErr != nil {
 				s.rollbackProxies(ctx, rollbackResources, ouID)
 				s.compensatingDeleteConfig(ctx, config.UUID, ouID)
 				return nil, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
 			}
-
-			// Build the two env vars (URL plain, API key via secretKeyRef).
-			envVarsToInject := buildLLMEnvVars(envConfigTemplates, internalProxyURL, secretRefName)
 
 			// Step 3: Inject per-environment URL and API key ref into the ReleaseBinding.
 			// Each environment gets its own ReleaseBinding with the correct per-env proxy URL,
@@ -1296,7 +1308,8 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		s.logger.Info(
 			"Created proxy and deployment for environment",
 			"environment", envName,
-			"proxyURL", proxyURL,
+			// Public address of the proxy — NOT what a platform agent's pod is handed.
+			"proxyPublicURL", proxyURL,
 			"proxyUUID", proxy.UUID,
 		)
 	}
@@ -1896,11 +1909,10 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	// but a bootstrap default is last-write-wins across environments. The Component CR write is
 	// therefore scoped to the first environment, matching every other injection site in this file.
 	if !isExternalAgent {
-		proxyURL, urlErr := buildInternalProxyURL(gateway, proxy.Configuration.Context)
+		envVarsToInject, urlErr := internalLLMEnvVars(envConfigTemplates, gateway, proxy.Configuration.Context, secretRefName)
 		if urlErr != nil {
 			return "", rbRes, pendingAppBinding{}, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
 		}
-		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); rbErr != nil {
 			s.logger.Error("failed to patch ReleaseBinding in Scenario A", "env", envName, "err", rbErr)
 			return "", rbRes, pendingAppBinding{}, fmt.Errorf("failed to update release binding env vars for environment %s: %w", envName, rbErr)
@@ -2177,13 +2189,11 @@ func (s *agentConfigurationService) processNewEnv(
 	// last-write-wins clobbering across multiple environments (HIGH-3).
 	if !isExternalAgent {
 		// Reuse the gateway already resolved for deployment (resolveGatewayForProvider)
-		proxyURL, urlErr := buildInternalProxyURL(gateway, proxy.Configuration.Context)
+		envVarsToInject, urlErr := internalLLMEnvVars(envConfigTemplates, gateway, proxy.Configuration.Context, secretRefName)
 		if urlErr != nil {
 			s.rollbackProxies(ctx, []rollbackResource{rbRes}, ouID)
 			return rollbackResource{}, pendingAppBinding{}, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
 		}
-
-		envVarsToInject := buildLLMEnvVars(envConfigTemplates, proxyURL, secretRefName)
 		// Inject per-env URL into the ReleaseBinding for this specific environment.
 		if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); rbErr != nil {
 			s.logger.Warn("failed to patch ReleaseBinding in Scenario C", "env", envName, "err", rbErr)
@@ -3181,11 +3191,6 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: failed to resolve gateway for re-injection", "environment", envName, "err", gwErr)
 								continue
 							}
-							proxyURL, urlErr := buildInternalProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
-							if urlErr != nil {
-								s.logger.Warn("Phase 1b: failed to resolve internal proxy URL for re-injection", "environment", envName, "err", urlErr)
-								continue
-							}
 							// Use persisted SecretReference from DB rather than deriving from mutable config name.
 							envVars1b, varErr1b := s.envVariableRepo.ListByConfigAndEnv(ctx, existingConfig.UUID, mapping.EnvironmentUUID)
 							secretRefName := ""
@@ -3206,7 +3211,11 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: no persisted SecretReference found, skipping re-injection", "environment", envName)
 								continue
 							}
-							envVarsToInject := buildLLMEnvVars(newEnvConfigTemplates, proxyURL, secretRefName)
+							envVarsToInject, urlErr := internalLLMEnvVars(newEnvConfigTemplates, gateway, mapping.LLMProxy.Configuration.Context, secretRefName)
+							if urlErr != nil {
+								s.logger.Warn("Phase 1b: failed to resolve internal proxy URL for re-injection", "environment", envName, "err", urlErr)
+								continue
+							}
 							s.logger.Info("Phase 1b: atomically replacing env vars in ReleaseBinding",
 								"environment", envName, "keysToRemove", changedOldKeys, "envVarsToAdd", len(envVarsToInject))
 							if rbErr := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); rbErr != nil {
@@ -5601,6 +5610,9 @@ func (s *agentConfigurationService) BuildSystemManagedEnvVarsFromConfig(
 	return result, nil
 }
 
+// systemManagedLLMURL returns the gateway's IN-CLUSTER address for the config's LLM proxy.
+// Its only consumer builds Workload/ReleaseBinding CRs, i.e. addresses read by an agent pod.
+// Do not reuse it for an API response — see systemManagedMCPURL for the public counterpart.
 func (s *agentConfigurationService) systemManagedLLMURL(
 	ctx context.Context, config *models.AgentConfiguration, ouID, environmentName string, envUUID uuid.UUID,
 ) (string, error) {
@@ -5627,6 +5639,9 @@ func (s *agentConfigurationService) systemManagedLLMURL(
 	return buildInternalProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
 }
 
+// systemManagedMCPURL returns the PUBLIC address for the config's MCP proxy. Unlike its LLM
+// counterpart it must stay public: the same URL is the OAuth resource identifier, so an
+// in-cluster address here would put an unroutable audience in every AgentID token.
 func (s *agentConfigurationService) systemManagedMCPURL(
 	ctx context.Context, config *models.AgentConfiguration, ouID, environmentName string, envUUID uuid.UUID,
 ) (string, error) {

--- a/agent-manager-service/services/agent_configuration_system_managed_test.go
+++ b/agent-manager-service/services/agent_configuration_system_managed_test.go
@@ -77,7 +77,13 @@ func TestSystemManagedMCPURLReturnsProxyURLForMatchingMapping(t *testing.T) {
 			},
 			GetByUUIDFunc: func(gotGatewayID string) (*models.Gateway, error) {
 				require.Equal(t, gatewayUUID.String(), gotGatewayID)
-				return &models.Gateway{UUID: gatewayUUID, Vhost: "https://gateway.example.com"}, nil
+				// RuntimeURL seeded so this asserts MCP stays on the public vhost rather
+				// than merely lacking an internal address to switch to.
+				return &models.Gateway{
+					UUID:       gatewayUUID,
+					Vhost:      "https://gateway.example.com",
+					RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
+				}, nil
 			},
 		},
 	}
@@ -155,4 +161,99 @@ func TestSystemManagedMCPURLMissingEnvMappingReturnsEmptyURL(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Empty(t, url)
+}
+
+// TestSystemManagedLLMURLUsesGatewayRuntimeURL pins the address a platform-hosted agent's
+// pod is handed for its LLM proxy. The pod's NetworkPolicy only permits egress to gateway
+// namespaces on the runtime port, so the public vhost here is a dead address.
+func TestSystemManagedLLMURLUsesGatewayRuntimeURL(t *testing.T) {
+	contextPath := "/llm/proxy"
+	svc, envUUID, configUUID := llmURLFixture(t, &models.Gateway{
+		UUID:       uuid.New(),
+		Vhost:      "https://gateway.example.com",
+		RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
+	}, &contextPath)
+
+	url, err := svc.systemManagedLLMURL(context.Background(), &models.AgentConfiguration{
+		UUID:        configUUID,
+		Name:        "model",
+		ProjectName: "project",
+		AgentID:     "agent",
+	}, "org", "dev", envUUID)
+
+	require.NoError(t, err)
+	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy", url)
+}
+
+// TestSystemManagedLLMURLFailsClosedWithoutRuntimeURL guards the fallback: a gateway with no
+// in-cluster address must abort the injection rather than hand the pod a vhost it cannot reach.
+func TestSystemManagedLLMURLFailsClosedWithoutRuntimeURL(t *testing.T) {
+	contextPath := "/llm/proxy"
+	svc, envUUID, configUUID := llmURLFixture(t, &models.Gateway{
+		UUID:  uuid.New(),
+		Vhost: "https://gateway.example.com",
+	}, &contextPath)
+
+	_, err := svc.systemManagedLLMURL(context.Background(), &models.AgentConfiguration{
+		UUID:        configUUID,
+		Name:        "model",
+		ProjectName: "project",
+		AgentID:     "agent",
+	}, "org", "dev", envUUID)
+
+	require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
+}
+
+// llmURLFixture wires an agentConfigurationService whose single LLM mapping resolves to gateway.
+func llmURLFixture(t *testing.T, gateway *models.Gateway, contextPath *string) (*agentConfigurationService, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	configUUID := uuid.New()
+	envUUID := uuid.New()
+	proxyUUID := uuid.New()
+	svc := &agentConfigurationService{
+		envMappingRepo: &repomocks.EnvAgentModelMappingRepositoryMock{
+			GetByConfigAndEnvFunc: func(_ context.Context, gotConfigUUID, gotEnvUUID uuid.UUID) (*models.EnvAgentModelMapping, error) {
+				require.Equal(t, configUUID, gotConfigUUID)
+				require.Equal(t, envUUID, gotEnvUUID)
+				return &models.EnvAgentModelMapping{
+					ConfigUUID:      configUUID,
+					EnvironmentUUID: envUUID,
+					LLMProxyUUID:    proxyUUID,
+					LLMProxy: &models.LLMProxy{
+						UUID:          proxyUUID,
+						Handle:        "acme-openai-proxy",
+						Configuration: models.LLMProxyConfig{Context: contextPath},
+					},
+				}, nil
+			},
+		},
+		llmProxyDeploymentService: &LLMProxyDeploymentService{
+			proxyRepo: &repomocks.LLMProxyRepositoryMock{
+				GetByIDFunc: func(gotProxyID, gotOuID string) (*models.LLMProxy, error) {
+					require.Equal(t, "acme-openai-proxy", gotProxyID)
+					require.Equal(t, "org", gotOuID)
+					return &models.LLMProxy{UUID: proxyUUID}, nil
+				},
+			},
+			deploymentRepo: &repomocks.DeploymentRepositoryMock{
+				GetDeploymentsWithStateFunc: func(artifactUUID, orgUUID string, _, _ *string, _ int) ([]*models.Deployment, error) {
+					require.Equal(t, proxyUUID.String(), artifactUUID)
+					require.Equal(t, "org", orgUUID)
+					return []*models.Deployment{{GatewayUUID: gateway.UUID}}, nil
+				},
+			},
+		},
+		gatewayRepo: &repomocks.GatewayRepositoryMock{
+			EnvironmentMappingExistsFunc: func(gotGatewayID, gotEnvID string) (bool, error) {
+				require.Equal(t, gateway.UUID.String(), gotGatewayID)
+				require.Equal(t, envUUID.String(), gotEnvID)
+				return true, nil
+			},
+			GetByUUIDFunc: func(gotGatewayID string) (*models.Gateway, error) {
+				require.Equal(t, gateway.UUID.String(), gotGatewayID)
+				return gateway, nil
+			},
+		},
+	}
+	return svc, envUUID, configUUID
 }

--- a/agent-manager-service/services/agent_configuration_system_managed_test.go
+++ b/agent-manager-service/services/agent_configuration_system_managed_test.go
@@ -167,19 +167,11 @@ func TestSystemManagedMCPURLMissingEnvMappingReturnsEmptyURL(t *testing.T) {
 // pod is handed for its LLM proxy. The pod's NetworkPolicy only permits egress to gateway
 // namespaces on the runtime port, so the public vhost here is a dead address.
 func TestSystemManagedLLMURLUsesGatewayRuntimeURL(t *testing.T) {
-	contextPath := "/llm/proxy"
-	svc, envUUID, configUUID := llmURLFixture(t, &models.Gateway{
-		UUID:       uuid.New(),
-		Vhost:      "https://gateway.example.com",
-		RuntimeURL: "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
-	}, &contextPath)
+	gateway := newGateway(t, models.GatewayRoleEgress, true)
+	gateway.Vhost = "https://gateway.example.com"
+	gateway.RuntimeURL = "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893"
 
-	url, err := svc.systemManagedLLMURL(context.Background(), &models.AgentConfiguration{
-		UUID:        configUUID,
-		Name:        "model",
-		ProjectName: "project",
-		AgentID:     "agent",
-	}, "org", "dev", envUUID)
+	url, err := callSystemManagedLLMURL(t, gateway, "/llm/proxy")
 
 	require.NoError(t, err)
 	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy", url)
@@ -188,28 +180,20 @@ func TestSystemManagedLLMURLUsesGatewayRuntimeURL(t *testing.T) {
 // TestSystemManagedLLMURLFailsClosedWithoutRuntimeURL guards the fallback: a gateway with no
 // in-cluster address must abort the injection rather than hand the pod a vhost it cannot reach.
 func TestSystemManagedLLMURLFailsClosedWithoutRuntimeURL(t *testing.T) {
-	contextPath := "/llm/proxy"
-	svc, envUUID, configUUID := llmURLFixture(t, &models.Gateway{
-		UUID:  uuid.New(),
-		Vhost: "https://gateway.example.com",
-	}, &contextPath)
+	gateway := newGateway(t, models.GatewayRoleEgress, true)
+	gateway.Vhost = "https://gateway.example.com"
+	gateway.RuntimeURL = ""
 
-	_, err := svc.systemManagedLLMURL(context.Background(), &models.AgentConfiguration{
-		UUID:        configUUID,
-		Name:        "model",
-		ProjectName: "project",
-		AgentID:     "agent",
-	}, "org", "dev", envUUID)
+	_, err := callSystemManagedLLMURL(t, gateway, "/llm/proxy")
 
 	require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
 }
 
-// llmURLFixture wires an agentConfigurationService whose single LLM mapping resolves to gateway.
-func llmURLFixture(t *testing.T, gateway *models.Gateway, contextPath *string) (*agentConfigurationService, uuid.UUID, uuid.UUID) {
+// callSystemManagedLLMURL resolves the LLM URL for a config whose single mapping is deployed
+// to gateway, reusing gatewayFixtureRepo so gateway lookup behaves as the real SQL does.
+func callSystemManagedLLMURL(t *testing.T, gateway *models.Gateway, contextPath string) (string, error) {
 	t.Helper()
-	configUUID := uuid.New()
-	envUUID := uuid.New()
-	proxyUUID := uuid.New()
+	configUUID, envUUID, proxyUUID := uuid.New(), uuid.New(), uuid.New()
 	svc := &agentConfigurationService{
 		envMappingRepo: &repomocks.EnvAgentModelMappingRepositoryMock{
 			GetByConfigAndEnvFunc: func(_ context.Context, gotConfigUUID, gotEnvUUID uuid.UUID) (*models.EnvAgentModelMapping, error) {
@@ -222,7 +206,7 @@ func llmURLFixture(t *testing.T, gateway *models.Gateway, contextPath *string) (
 					LLMProxy: &models.LLMProxy{
 						UUID:          proxyUUID,
 						Handle:        "acme-openai-proxy",
-						Configuration: models.LLMProxyConfig{Context: contextPath},
+						Configuration: models.LLMProxyConfig{Context: &contextPath},
 					},
 				}, nil
 			},
@@ -243,17 +227,13 @@ func llmURLFixture(t *testing.T, gateway *models.Gateway, contextPath *string) (
 				},
 			},
 		},
-		gatewayRepo: &repomocks.GatewayRepositoryMock{
-			EnvironmentMappingExistsFunc: func(gotGatewayID, gotEnvID string) (bool, error) {
-				require.Equal(t, gateway.UUID.String(), gotGatewayID)
-				require.Equal(t, envUUID.String(), gotEnvID)
-				return true, nil
-			},
-			GetByUUIDFunc: func(gotGatewayID string) (*models.Gateway, error) {
-				require.Equal(t, gateway.UUID.String(), gotGatewayID)
-				return gateway, nil
-			},
-		},
+		gatewayRepo: gatewayFixtureRepo(t, envUUID.String(), []*models.Gateway{gateway}),
 	}
-	return svc, envUUID, configUUID
+
+	return svc.systemManagedLLMURL(context.Background(), &models.AgentConfiguration{
+		UUID:        configUUID,
+		Name:        "model",
+		ProjectName: "project",
+		AgentID:     "agent",
+	}, "org", "dev", envUUID)
 }

--- a/agent-manager-service/services/agent_env_tier_unit_test.go
+++ b/agent-manager-service/services/agent_env_tier_unit_test.go
@@ -127,7 +127,8 @@ func TestRequireEnvTier_ProductionEnvAllowedWithBothScopes(t *testing.T) {
 	svc, _ := tierService(map[string]bool{tierProdEnv: true}, nil)
 
 	env, err := svc.requireEnvTier(
-		tierCtx(t, rbac.AgentEnvNonProduction, rbac.AgentEnvProduction), tierOUID, tierProdEnv)
+		tierCtx(t, rbac.AgentEnvNonProduction, rbac.AgentEnvProduction), tierOUID, tierProdEnv,
+	)
 	require.NoError(t, err)
 	require.True(t, env.IsProduction)
 }
@@ -288,7 +289,8 @@ func TestUpdateAgentConfigurations_ProductionNeedsProductionScope(t *testing.T) 
 
 	err := svc.UpdateAgentConfigurations(
 		tierCtx(t, rbac.AgentEnvNonProduction, rbac.AgentUpdate), tierOUID, "proj1", "my-agent",
-		&spec.UpdateAgentConfigurationsRequest{EnvironmentName: tierProdEnv})
+		&spec.UpdateAgentConfigurationsRequest{EnvironmentName: tierProdEnv},
+	)
 
 	require.ErrorIs(t, err, utils.ErrForbidden)
 	require.Contains(t, err.Error(), rbac.AgentEnvProduction.Scope())
@@ -318,7 +320,8 @@ func TestUpdateAgentDeploySettings_ProductionNeedsProductionScope(t *testing.T) 
 
 	err := svc.UpdateAgentDeploySettings(
 		tierCtx(t, rbac.AgentEnvNonProduction, rbac.AgentUpdate), tierOUID, "proj1", "my-agent",
-		&spec.UpdateAgentDeploySettingsRequest{EnvironmentName: tierProdEnv})
+		&spec.UpdateAgentDeploySettingsRequest{EnvironmentName: tierProdEnv},
+	)
 
 	require.ErrorIs(t, err, utils.ErrForbidden)
 	require.Contains(t, err.Error(), rbac.AgentEnvProduction.Scope())

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -3784,7 +3784,8 @@ func (s *agentManagerService) requireEnvTier(
 		// attempted" survives. Status is left to the envelope for the same
 		// reason. grantedScopes is set because every middleware authz:deny
 		// carries it and anything alerting on the action reads it.
-		audit.RecordAncillary(ctx, audit.ActionAuthzDeny,
+		audit.RecordAncillary(
+			ctx, audit.ActionAuthzDeny,
 			audit.Org(ouID),
 			audit.Environment(envName),
 			audit.OutcomeOpt(audit.OutcomeDeny),


### PR DESCRIPTION
## Purpose
Platform-hosted (internal) agents receive the gateway's **public vhost** as their LLM proxy URL, so an agent pod has to hairpin out through the public ingress and back in to reach an LLM proxy sitting in the same cluster. #1716 fixed exactly this for the monitor evaluation job; this is the same fix for the agent pods themselves.

The in-cluster path is already provisioned and already permitted — nothing was using it:

- `models.Gateway.RuntimeURL` holds the in-cluster address, and #1716 added `buildInternalProxyURL` to build from it.
- The agent sandbox NetworkPolicy already allows egress to gateway namespaces on port **22893** (`deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml`, `networkPolicy.egress`). Its comment already claims to cover "the in-cluster `AMP_OTEL_ENDPOINT` / LLM and MCP proxy URLs injected on agent pods" — until now only the OTEL half of that was true.

The public path works today only through the separate port-19080 rule in the same policy.

## Goals
Inject the gateway's in-cluster runtime URL into platform agents' LLM env vars instead of the public vhost, so managed LLM traffic stays inside the cluster and matches the egress the pod is actually granted.

**External agents and MCP proxies are deliberately unchanged.**

## Approach
Every LLM injection site that is already internal-agent-only now calls `buildInternalProxyURL` instead of `buildPublicProxyURL`. All five are in `services/agent_configuration_service.go`:

| Site | Path | On unresolvable `runtimeUrl` |
|---|---|---|
| `createLLMConfig` | config create | rollback proxies + delete config, return error |
| `processEnvProviderChange` | provider swap (Scenario A) | return error |
| `processNewEnv` | new environment (Scenario C) | rollback, return error |
| `Update` Phase 1b | env-var rename re-injection | `Warn` + `continue`, matching its neighbours |
| `systemManagedLLMURL` | Workload CR build + promotion | return error |

Each was already guarded by `!isExternalAgent` (Phase 1b by an equivalent `Provisioning.Type != ExternalAgent` check), so the internal/external split needed no new branching. In `createLLMConfig` the public URL is still computed alongside — it feeds the `envCredentials` map returned to an external agent's operator.

**Fails closed**, same as #1716: a gateway with no registered `runtimeUrl` returns `errGatewayRuntimeURLUnregistered` rather than falling back to the vhost, which would route the pod out through an ingress its own NetworkPolicy denies.

**Why MCP is excluded.** `buildMCPProxyURL` doubles as the OAuth resource identifier (`MCPProxyService.MCPResourceServerIdentifier`, `services/mcp_rs_identifier.go`). Moving it to an in-cluster address would put an unroutable audience in every AgentID token. LLM proxies have no such tie — they authenticate with an API key (`api-key-auth` policy), which is why the LLM half can move and the MCP half cannot.

**No chart change.** The egress rule this depends on already exists (see Purpose).

The now-stale doc comment on `buildPublicProxyURL` ("Every agent — sandboxed included — gets the public URL") is corrected.

## User stories
As a platform operator, when a platform-hosted agent calls its configured LLM provider, the request reaches the gateway over cluster-internal networking instead of egressing to the public ingress and back.

## Release note
Platform-hosted agents now reach the LLM gateway over its in-cluster runtime address instead of the public vhost. Configuring, promoting, or updating an LLM provider for a platform agent whose gateway has no registered `runtimeUrl` now fails with a clear error instead of injecting an unreachable public URL. Migration 038 backfills `runtimeUrl` only for `api-platform-`-named gateways; any other gateway needs `runtimeUrl` set before it can back a platform agent's LLM config.

## Documentation
N/A — no user-facing API, CLI, or console surface changes. The behavior is internal routing between the agent pod and the gateway.

## Training
N/A — no training content covers agent-to-gateway network routing.

## Certification
N/A — internal routing detail, not covered by certification exams.

## Marketing
N/A — internal reliability fix with no promotable surface.

## Automation tests
 - Unit tests
   > `services` package, full tier green via `make test-unit`.
   > - `TestSystemManagedLLMURLUsesGatewayRuntimeURL` (new) — the URL injected into a platform agent's Workload CR is the gateway's runtime address, not the vhost. Written first and watched fail (`got https://gateway.example.com/llm/proxy`) before the change.
   > - `TestSystemManagedLLMURLFailsClosedWithoutRuntimeURL` (new) — a gateway with no `runtimeUrl` returns `errGatewayRuntimeURLUnregistered` (asserted with `errors.Is`).
   > - `TestBuildMCPProxyURLUsesGatewayVhost` and `TestSystemManagedMCPURLReturnsProxyURLForMatchingMapping` — both **strengthened**: their fixtures previously had no `RuntimeURL`, so they asserted the vhost against a gateway with no internal address to switch to and could not have caught an accidental MCP change. Both now seed a `RuntimeURL`; verified genuinely red by temporarily pointing `mcpProxyServingBase` at `RuntimeURL`.
   > - `TestBuildInternalProxyURLUsesRuntimeURL` / `RejectsMissingRuntimeURL` (from #1716) cover the shared builder and are unchanged.
 - Integration tests
   > None added. **The four env-var injection sites have no direct test coverage** — they sit inside create/update paths that need a provisioned database, and the existing integration tests do not assert the injected URL. They are covered by compile plus the shared `buildInternalProxyURL` unit tests, not by a test that would catch a wrong-site swap. Happy to add integration coverage if reviewers want it.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **no** — FindSecurityBugs is a Java/SpotBugs plugin and does not apply to this Go module. `golangci-lint run ./services/...` reports no new issues (5 pre-existing `unused` findings in `monitor_manager.go`, confirmed present on a clean tree).
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — the change moves a URL only. The LLM API key path is untouched: it still arrives via the existing `SecretReference` secretKeyRef, never inlined.

## Samples
N/A — no sample changes; the behavior is internal to agent LLM invocation.

## Related PRs
- #1716 — the same change for the monitor evaluation job. This PR builds directly on the `buildPublicProxyURL` / `buildInternalProxyURL` pair introduced there.

## Migrations (if applicable)
No new migration. Depends on existing migration 038, which backfills `runtimeUrl` for `api-platform-`-named gateways. Because this change fails closed, a gateway outside that naming pattern must have `runtimeUrl` set (via gateway register/update) before it can back a platform agent's LLM config — see the release note.

## Test environment
Go 1.25 (`go test -race`, unit tier) on macOS (darwin/arm64). Not yet exercised against a live cluster.

## Learning
The non-obvious constraint was why MCP must stay on the public vhost while LLM can move: the MCP proxy URL is also the OAuth resource-server identifier, so its value is baked into AgentID token audiences, whereas LLM proxies authenticate with an API key and have no such coupling. The second was that the enabling NetworkPolicy rule already existed and was already documented as covering LLM — the code just never used it.

---

**Note on the second commit:** `Apply current gofumpt formatting to two service files` is unrelated to this change. `make codegenfmt-check` (CI installs `gofumpt@latest`) currently fails on `agent_env_tier_unit_test.go` and `agent_manager.go` as they stand on `main`; the commit is pure line-wrapping so this branch's CI can go green. Happy to split it out if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Internal agent LLM proxy connections now use the gateway’s internal runtime address for improved reliability.
  - Configuration operations handle missing gateway runtime addresses safely, rolling back or reporting errors as appropriate.
  - Public URLs for external agents and MCP integrations continue using externally accessible addresses.

- **Tests**
  - Added coverage for internal LLM URL resolution and missing runtime address scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->