### PR TITLE
Lower env-Thunder handle minimum to 3 characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,13 +142,14 @@ setup-openchoreo:
 # migrated (store_via_ams needs it) — hence after dev-migrate, not in setup-openchoreo.sh.
 setup-default-env-thunder:
 	@ENV_NAME=default DISPLAY_NAME="Default" ORG_NAME=default \
+	  THUNDER_HANDLE=default-idp \
 	  WAIT_TIMEOUT=300s \
 	  AMP_API_URL="http://localhost:9000/api/v1" \
 	  bash deployments/scripts/add-environment-thunder.sh \
 	  && echo "✅ Default environment Thunder ID instance provisioned" \
 	  || { \
 	    echo "⚠️  Default-env Thunder provisioning failed — continuing with remaining setup steps."; \
-	    echo "    Re-run manually: ENV_NAME=default DISPLAY_NAME=Default ORG_NAME=default \\"; \
+	    echo "    Re-run manually: ENV_NAME=default DISPLAY_NAME=Default ORG_NAME=default THUNDER_HANDLE=default-idp \\"; \
 	    echo "      AMP_API_URL=http://localhost:9000/api/v1 \\"; \
 	    echo "      bash deployments/scripts/add-environment-thunder.sh"; \
 	  }

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -14471,11 +14471,10 @@ components:
             DNS-label-safe handle (lowercase alphanumeric with hyphens, no
             leading/trailing hyphen) that replaces "<org>-<env>" in
             "<handle>.<baseDomain>". Must be globally unique across
-            all orgs/environments, and at least 10 characters (matching what
-            the server itself generates — anything shorter is trivially
-            guessable). Omit to auto-generate a 10-character handle.
+            all orgs/environments, and at least 3 characters. Omit to
+            auto-generate a 10-character handle.
           pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
-          minLength: 10
+          minLength: 3
           maxLength: 63
           example: x7f2q9kzab
 
@@ -14491,7 +14490,7 @@ components:
         handle:
           type: string
           pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
-          minLength: 10
+          minLength: 3
           maxLength: 63
           example: x7f2q9kzab
 

--- a/agent-manager-service/services/environment_service.go
+++ b/agent-manager-service/services/environment_service.go
@@ -609,34 +609,41 @@ var thunderHandlePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 // embeds the handle as-is into "<handle>.<baseDomain>").
 const maxThunderHandleLen = 63
 
-// minThunderHandleLen matches generatedThunderHandleLen — a caller-supplied
-// handle shorter than what AMS itself would generate is too easy to guess and
-// defeats the point of the feature, so it's a hard floor, not just UI advice.
-const minThunderHandleLen = generatedThunderHandleLen
+// minThunderHandleLen is the hard floor on a caller-supplied handle, not just
+// UI advice — enforced server-side regardless of what any client sends.
+const minThunderHandleLen = 3
 
-// reservedThunderHandles blocks labels that identify a real platform component,
-// namespace, or Kubernetes-reserved name — allowing a handle to equal one risks
-// hijacking or confusion once that component sits at the same hostname level
-// (<handle>.<baseDomain>). Mirrored on the console side by
-// environmentSchema.ts's RESTRICTED_THUNDER_HANDLES; keep both in sync.
-//
-// Every entry here must be >= minThunderHandleLen characters, or it can never
-// actually be submitted as a handle and the check is dead code (the platform's
-// own fixed subdomains — console, api, thunder, observer, gateway, cp, agents —
-// are all short enough that this length floor alone already keeps a handle
-// from ever colliding with one of them; they don't need their own entries).
+// reservedThunderHandles blocks labels that identify a real platform component
+// or namespace — allowing a handle to equal one risks hijacking or confusion
+// once that component sits at the same hostname level (<handle>.<baseDomain>).
+// Covers every fixed subdomain across all deployment flavors (VM, k3d/quick-start,
+// docker-compose, the custom-domain guide, and the AI Gateway setup target), since
+// several services go by different names depending on flavor. Mirrored on the
+// console side by environmentSchema.ts's RESTRICTED_THUNDER_HANDLES; keep both in sync.
 var reservedThunderHandles = map[string]bool{
-	"kubernetes":      true,
-	"kube-system":     true,
-	"kube-public":     true,
-	"kube-node-lease": true,
-	"openchoreo":      true,
-	"opensearch":      true,
-	"prometheus":      true,
-	"otel-collector":  true,
-	"fluent-bit":      true,
-	"agent-manager":   true,
-	"observability":   true,
+	"kubernetes":           true,
+	"kube-system":          true,
+	"kube-public":          true,
+	"kube-node-lease":      true,
+	"openchoreo":           true,
+	"opensearch":           true,
+	"prometheus":           true,
+	"otel-collector":       true,
+	"fluent-bit":           true,
+	"agent-manager":        true,
+	"observability":        true,
+	"console":              true,
+	"api":                  true,
+	"api-amp":              true,
+	"thunder":              true,
+	"observer":             true,
+	"traces":               true,
+	"gateway":              true,
+	"api-platform-gateway": true,
+	"ai-gateway":           true,
+	"otel":                 true,
+	"cp":                   true,
+	"agents":               true,
 }
 
 // validateThunderHandle checks handle's format. It does not check uniqueness —

--- a/agent-manager-service/services/environment_service_unit_test.go
+++ b/agent-manager-service/services/environment_service_unit_test.go
@@ -1459,7 +1459,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		assert.ErrorIs(t, err, boom)
 	})
 
-	t.Run("rejects a handle shorter than 10 characters", func(t *testing.T) {
+	t.Run("rejects a handle shorter than 3 characters", func(t *testing.T) {
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
 				t.Fatal("must not upsert a too-short handle")
@@ -1468,11 +1468,22 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		// 9 characters — one short of the boundary, so this fails precisely
-		// because minThunderHandleLen is 10, not because it's trivially short.
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "abcdefghi")
+		// 2 characters — one short of the boundary, so this fails precisely
+		// because minThunderHandleLen is 3, not because it's trivially short.
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "ab")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle)
+	})
+
+	t.Run("accepts a handle exactly at the 3-character floor", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			InsertFunc: func(context.Context, *models.EnvThunderURL) error { return nil },
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "abc")
+		require.NoError(t, err)
+		assert.Equal(t, "abc", resolved)
 	})
 
 	t.Run("rejects uppercase and other invalid characters", func(t *testing.T) {
@@ -1484,7 +1495,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		// Each is padded to >=10 characters so it actually reaches the format
+		// Each is padded to >=3 characters so it actually reaches the format
 		// check instead of failing on length first — the one invalid trait
 		// (uppercase, underscore, leading/trailing hyphen, dot, space) is what's
 		// under test here, not shortness.
@@ -1518,12 +1529,30 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		// "kubernetes" is exactly 10 characters — long enough to clear
-		// minThunderHandleLen, so this actually exercises the reserved-word
-		// check rather than failing on length first ("localhost" is only 9).
+		// "kubernetes" clears minThunderHandleLen (3), so this actually exercises
+		// the reserved-word check rather than failing on length first.
 		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "kubernetes")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle)
+	})
+
+	t.Run("rejects every platform fixed subdomain across all deployment flavors", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
+				t.Fatal("must not upsert a reserved handle")
+				return nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		for _, reserved := range []string{
+			"console", "api", "api-amp", "thunder", "observer", "traces",
+			"gateway", "api-platform-gateway", "ai-gateway", "otel", "agents",
+		} {
+			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", reserved)
+			require.Error(t, err, "handle %q must be rejected", reserved)
+			assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle, "handle %q", reserved)
+		}
 	})
 
 	t.Run("rejects an empty ouID", func(t *testing.T) {
@@ -1723,7 +1752,7 @@ func TestEnvironmentService_IsThunderHandleAvailable(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		available, err := svc.IsThunderHandleAvailable(context.Background(), "short")
+		available, err := svc.IsThunderHandleAvailable(context.Background(), "ab")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle)
 		assert.False(t, available)

--- a/agent-manager-service/spec/model_thunder_url_request.go
+++ b/agent-manager-service/spec/model_thunder_url_request.go
@@ -19,7 +19,7 @@ var _ MappedNullable = &ThunderUrlRequest{}
 
 // ThunderUrlRequest An unguessable handle to register for an environment's env-Thunder URL, replacing the predictable \"<org>-<env>\" pattern. Optional — omit it (or send an empty string) to have the server generate one.
 type ThunderUrlRequest struct {
-	// DNS-label-safe handle (lowercase alphanumeric with hyphens, no leading/trailing hyphen) that replaces \"<org>-<env>\" in \"<handle>.<baseDomain>\". Must be globally unique across all orgs/environments, and at least 10 characters (matching what the server itself generates — anything shorter is trivially guessable). Omit to auto-generate a 10-character handle.
+	// DNS-label-safe handle (lowercase alphanumeric with hyphens, no leading/trailing hyphen) that replaces \"<org>-<env>\" in \"<handle>.<baseDomain>\". Must be globally unique across all orgs/environments, and at least 3 characters. Omit to auto-generate a 10-character handle.
 	Handle *string `json:"handle,omitempty"`
 }
 

--- a/cli/pkg/clients/amsvc/gen/types.gen.go
+++ b/cli/pkg/clients/amsvc/gen/types.gen.go
@@ -4866,9 +4866,8 @@ type ThunderUrlRequest struct {
 	// Handle DNS-label-safe handle (lowercase alphanumeric with hyphens, no
 	// leading/trailing hyphen) that replaces "<org>-<env>" in
 	// "<handle>.<baseDomain>". Must be globally unique across
-	// all orgs/environments, and at least 10 characters (matching what
-	// the server itself generates — anything shorter is trivially
-	// guessable). Omit to auto-generate a 10-character handle.
+	// all orgs/environments, and at least 3 characters. Omit to
+	// auto-generate a 10-character handle.
 	Handle *string `json:"handle,omitempty"`
 }
 

--- a/console/workspaces/pages/deployment-pipelines/src/form/environmentSchema.ts
+++ b/console/workspaces/pages/deployment-pipelines/src/form/environmentSchema.ts
@@ -54,6 +54,18 @@ const RESTRICTED_THUNDER_HANDLES = new Set([
   "fluent-bit",
   "agent-manager",
   "observability",
+  "console",
+  "api",
+  "api-amp",
+  "thunder",
+  "observer",
+  "traces",
+  "gateway",
+  "api-platform-gateway",
+  "ai-gateway",
+  "otel",
+  "cp",
+  "agents",
 ]);
 
 export const createEnvironmentSchema = z.object({
@@ -70,10 +82,9 @@ export const createEnvironmentSchema = z.object({
   isolationTier: z.enum(isolationTiers).optional(),
   thunderHandle: z
     .string()
-    // Matches agent-manager-service's own minThunderHandleLen — a handle shorter
-    // than what AMS would generate itself is trivially brute-forceable and defeats
-    // the point of the feature, so this is a hard floor, not just advice.
-    .min(10, "Handle must be at least 10 characters")
+    // Matches agent-manager-service's own minThunderHandleLen — a hard floor,
+    // not just client-side advice; the backend enforces it independently.
+    .min(3, "Handle must be at least 3 characters")
     .max(63, "Handle must be 63 characters or less")
     .regex(thunderHandlePattern, "Handle must be lowercase alphanumeric with hyphens only, no leading/trailing hyphen")
     .refine((value) => !RESTRICTED_THUNDER_HANDLES.has(value), {

--- a/console/workspaces/pages/deployment-pipelines/src/subComponents/CreateEnvironmentDrawer.tsx
+++ b/console/workspaces/pages/deployment-pipelines/src/subComponents/CreateEnvironmentDrawer.tsx
@@ -123,6 +123,17 @@ function deriveNameFromDisplayName(displayName: string): string {
     .replace(/^-|-$/g, "");
 }
 
+// Suggests "<name>-idp" as a starting point for the Thunder handle — truncated
+// so the result never exceeds the backend's 63-char limit. Purely a default;
+// the field stays fully editable and diverges from this suggestion the moment
+// the user types into it directly (see the "in sync" checks below).
+const THUNDER_HANDLE_SUFFIX = "-idp";
+function deriveThunderHandleFromName(name: string): string {
+  if (!name) return "";
+  const maxNameLen = 63 - THUNDER_HANDLE_SUFFIX.length;
+  return `${name.slice(0, maxNameLen)}${THUNDER_HANDLE_SUFFIX}`;
+}
+
 function buildScript(
   name: string,
   displayName: string,
@@ -270,14 +281,25 @@ export function CreateEnvironmentDrawer({
           prev.name === "" ||
           prev.name === deriveNameFromDisplayName(prev.displayName);
         const newName = nameInSync ? derivedName : prev.name;
+        const handleInSync =
+          prev.thunderHandle === "" ||
+          prev.thunderHandle === deriveThunderHandleFromName(prev.name);
+        const newThunderHandle = handleInSync
+          ? deriveThunderHandleFromName(newName)
+          : prev.thunderHandle;
         const next = {
           ...prev,
           displayName: value,
           name: newName,
           dnsPrefix: newName,
+          thunderHandle: newThunderHandle,
         };
         setFieldError("displayName", validateField("displayName", value, next));
         setFieldError("name", validateField("name", newName, next));
+        setFieldError(
+          "thunderHandle",
+          validateField("thunderHandle", newThunderHandle, next),
+        );
         return next;
       });
     },
@@ -287,18 +309,32 @@ export function CreateEnvironmentDrawer({
   const handleNameChange = useCallback(
     (value: string) => {
       setFormData((prev) => {
-        const next = { ...prev, name: value, dnsPrefix: value };
+        const handleInSync =
+          prev.thunderHandle === "" ||
+          prev.thunderHandle === deriveThunderHandleFromName(prev.name);
+        const newThunderHandle = handleInSync
+          ? deriveThunderHandleFromName(value)
+          : prev.thunderHandle;
+        const next = {
+          ...prev,
+          name: value,
+          dnsPrefix: value,
+          thunderHandle: newThunderHandle,
+        };
         setFieldError("name", validateField("name", value, next));
+        setFieldError(
+          "thunderHandle",
+          validateField("thunderHandle", newThunderHandle, next),
+        );
         return next;
       });
     },
     [validateField, setFieldError],
   );
 
-  // Deliberately NOT auto-derived from displayName/name (unlike handleNameChange
-  // above) — the whole point of thunderHandle is to be an unguessable value the
-  // user chooses themselves, not something predictable from the environment's
-  // own name. Lowercased as typed, matching the format the backend requires.
+  // Editable: once the user types into this field directly, it diverges from
+  // the name-derived suggestion above and is never overwritten again.
+  // Lowercased as typed, matching the format the backend requires.
   const handleThunderHandleChange = useCallback(
     (value: string) => {
       const lowered = value.toLowerCase();

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -288,6 +288,7 @@ install_default_env_thunder() {
     ENV_NAME=default \
         DISPLAY_NAME="Default" \
         ORG_NAME=default \
+        THUNDER_HANDLE=default-idp \
         AMP_API_URL="${AMP_API_URL:-http://api.amp.localhost:8080/api/v1}" \
         IDP_TOKEN_URL="${IDP_TOKEN_URL:-http://thunder.amp.localhost:8080/oauth2/token}" \
         SCRIPT_BASE_URL="${script_base_url}" \
@@ -299,12 +300,12 @@ install_default_env_thunder() {
     fi
 
     # Learn the handle add-environment-thunder.sh's register_thunder_url actually
-    # stored (always server-generated here, since THUNDER_HANDLE is never set
-    # above) via GET — this process has no other way to know it, and there's no
-    # pattern to compute from org/env instead. Every later consumer of the
-    # default environment's Thunder address (the gateway wiring below, and
-    # install.sh's completion banner) reads this SAME global instead of
-    # re-deriving anything, so they can't drift out of sync with each other.
+    # stored via GET — this process has no other way to know it (a re-run
+    # reuses whatever was registered on the first run, not necessarily
+    # THUNDER_HANDLE above). Every later consumer of the default environment's
+    # Thunder address (the gateway wiring below, and install.sh's completion
+    # banner) reads this SAME global instead of re-deriving anything, so they
+    # can't drift out of sync with each other.
     if ! DEFAULT_ENV_THUNDER_HANDLE="$(AMP_API_URL="${AMP_API_URL:-http://api.amp.localhost:8080/api/v1}" \
         IDP_TOKEN_URL="${IDP_TOKEN_URL:-http://thunder.amp.localhost:8080/oauth2/token}" \
         get_thunder_url_handle default default)"; then

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1588,7 +1588,7 @@ ENV_THUNDER_PROVISIONED=false
 if ! install_default_env_thunder; then
     log_error "Default environment Thunder provisioning failed"
     echo "Re-run manually once the platform is ready:"
-    echo "  ENV_NAME=default DISPLAY_NAME=Default ORG_NAME=default \\"
+    echo "  ENV_NAME=default DISPLAY_NAME=Default ORG_NAME=default THUNDER_HANDLE=default-idp \\"
     echo "  AMP_API_URL=${AMP_API_URL:-http://api.amp.localhost:8080/api/v1} \\"
     echo "  IDP_TOKEN_URL=${IDP_TOKEN_URL:-http://thunder.amp.localhost:8080/oauth2/token} \\"
     # install_default_env_thunder() prefers the bundled script and falls back to

--- a/deployments/scripts/add-environment-thunder.sh
+++ b/deployments/scripts/add-environment-thunder.sh
@@ -395,7 +395,7 @@ register_thunder_url() {
       ;;
     400)
       echo "❌ Thunder url handle '${handle}' was rejected as invalid by agent-manager-service." >&2
-      echo "   Must be lowercase alphanumeric with hyphens (no leading/trailing hyphen), 10-63 chars." >&2
+      echo "   Must be lowercase alphanumeric with hyphens (no leading/trailing hyphen), 3-63 chars." >&2
       ;;
     *)
       echo "⚠️  Could not register the thunder url handle in agent-manager-service (HTTP ${http_code})." >&2
@@ -723,9 +723,9 @@ main() {
     # Length bounds mirror agent-manager-service's minThunderHandleLen/
     # maxThunderHandleLen — checked here too so a bad length fails fast
     # locally instead of a round trip that only fails at the 400 above.
-    if ! validate_name "$requested_handle" || [ "${#requested_handle}" -lt 10 ] || [ "${#requested_handle}" -gt 63 ]; then
+    if ! validate_name "$requested_handle" || [ "${#requested_handle}" -lt 3 ] || [ "${#requested_handle}" -gt 63 ]; then
       echo "❌ Invalid THUNDER_HANDLE '${requested_handle}'"
-      echo "   Must be lowercase alphanumeric with hyphens (no leading/trailing hyphen), 10-63 chars."
+      echo "   Must be lowercase alphanumeric with hyphens (no leading/trailing hyphen), 3-63 chars."
       exit 1
     fi
   fi

--- a/documentation/docs/guides/environment-management.mdx
+++ b/documentation/docs/guides/environment-management.mdx
@@ -40,7 +40,7 @@ Environments are provisioned by a script that creates the environment in Agent M
    | Field | Description | Example |
    |---|---|---|
    | **Display Name** | Human-readable name shown throughout the Console. | `Production` |
-   | **Identity Service Handle** | Optional unique DNS label for this environment's ThunderID URL. Use 10–63 lowercase letters, digits, or hyphens; leave it blank to let Agent Manager generate an unguessable handle. | `x7f2q9kzab` |
+   | **Identity Service Handle** | Optional unique DNS label for this environment's ThunderID URL. Use 3–63 lowercase letters, digits, or hyphens; leave it blank to let Agent Manager generate an unguessable handle. | `x7f2q9kzab` |
    | **Isolation Tier** | Container runtime isolation for agents deployed to this environment. The dropdown lists three sandboxing tiers of increasing strength — `Sandboxing T1 (runc)` (default), `Sandboxing T2 (gVisor)`, and `Sandboxing T3 (Kata Containers)`. Stronger tiers need a dedicated node set up first; see [Isolation tiers](#isolation-tiers) below. | `Sandboxing T1 (runc)` |
    | **Production environment** | Mark this environment as production. Production environments are typically the last stage of a pipeline. | — |
 

--- a/documentation/docs/guides/on-k3d.mdx
+++ b/documentation/docs/guides/on-k3d.mdx
@@ -707,6 +707,7 @@ curl -fsSL "https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/
 ENV_NAME=default \
 DISPLAY_NAME="Default" \
 ORG_NAME=default \
+THUNDER_HANDLE=default-idp \
 AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
 IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
 THUNDER_HOST_BASE_DOMAIN="amp.localhost" \
@@ -714,12 +715,11 @@ bash add-environment-thunder.sh
 ```
 
 The script registers an unguessable handle with Agent Manager before it creates
-the environment's ThunderID instance. To choose a handle yourself, add
-`THUNDER_HANDLE=<3-63-character-handle>` to the command; otherwise Agent
-Manager generates one. The script prints the resulting issuer as
-`http://<handle>.amp.localhost:8080`. Do not derive it from the organization
-and environment names. The existing `*.amp.localhost` routing covers each
-generated handle.
+the environment's ThunderID instance. `THUNDER_HANDLE` is optional (3-63
+characters); omit it to have Agent Manager generate one instead. The script
+prints the resulting issuer as `http://<handle>.amp.localhost:8080`. Do not
+derive it from the organization and environment names. The existing
+`*.amp.localhost` routing covers each handle, generated or chosen.
 
 :::tip Verify
 ```bash

--- a/documentation/docs/guides/on-k3d.mdx
+++ b/documentation/docs/guides/on-k3d.mdx
@@ -715,7 +715,7 @@ bash add-environment-thunder.sh
 
 The script registers an unguessable handle with Agent Manager before it creates
 the environment's ThunderID instance. To choose a handle yourself, add
-`THUNDER_HANDLE=<10-63-character-handle>` to the command; otherwise Agent
+`THUNDER_HANDLE=<3-63-character-handle>` to the command; otherwise Agent
 Manager generates one. The script prints the resulting issuer as
 `http://<handle>.amp.localhost:8080`. Do not derive it from the organization
 and environment names. The existing `*.amp.localhost` routing covers each

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -1539,6 +1539,12 @@ bash add-environment-thunder.sh
   </TabItem>
 </Tabs>
 
+To choose a meaningful handle for this Environment's ThunderID instance (e.g.
+`env-idp-prod` instead of a random string), add
+`THUNDER_HANDLE=<3-63-character-handle>` to either command above; otherwise
+Agent Manager generates one. The script prints the resulting issuer as
+`https://<handle>.${BASE_DOMAIN}`.
+
 :::info
 Only the Let's Encrypt path can use `SKIP_CA_BUNDLE_TRUST=true` — it's specifically for a certificate that's already backed by a CA every trust store already knows. For a Corporate CA, that flag doesn't help you: setting it to `true` skips the fetch outright, and simply omitting it falls back to the script's own auto-detect, which looks for a secret named `amp-local-root-ca-secret` — a name the Corporate CA tab in Step 3 never creates. `PLATFORM_THUNDER_CA_PEM` sidesteps that entirely by pulling whatever certificate is actually being served, live, regardless of what you named things, but it only solves trust *inside the cluster*. The `CURL_CA_BUNDLE` step above is a separate fix for trust on **your own machine**, where this script's own `curl` calls run. (Running with the self-signed evaluation chain? See the [nip.io appendix](#appendix-installing-without-a-domain-nipio).)
 :::

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -1476,6 +1476,7 @@ Platform Thunder's certificate comes from a real, publicly-trusted CA, so env-Th
 ENV_NAME=default \
 DISPLAY_NAME="Default" \
 ORG_NAME=default \
+THUNDER_HANDLE=default-idp \
 WAIT_TIMEOUT=300s \
 AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
 IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
@@ -1523,6 +1524,7 @@ Keeping your system bundle in there too (rather than only the one CA) matters be
 ENV_NAME=default \
 DISPLAY_NAME="Default" \
 ORG_NAME=default \
+THUNDER_HANDLE=default-idp \
 WAIT_TIMEOUT=300s \
 AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
 IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
@@ -1539,10 +1541,9 @@ bash add-environment-thunder.sh
   </TabItem>
 </Tabs>
 
-To choose a meaningful handle for this Environment's ThunderID instance (e.g.
-`env-idp-prod` instead of a random string), add
-`THUNDER_HANDLE=<3-63-character-handle>` to either command above; otherwise
-Agent Manager generates one. The script prints the resulting issuer as
+Both commands above register `default-idp` as this Environment's handle.
+`THUNDER_HANDLE` is optional (3-63 characters); change it or omit it to have
+Agent Manager generate one instead. The script prints the resulting issuer as
 `https://<handle>.${BASE_DOMAIN}`.
 
 :::info


### PR DESCRIPTION
## Purpose
- Env-Thunder handle required 10+ chars, too strict for a caller-supplied value.

## Goals
- Lower minimum to 3 characters.
- Block platform subdomains a 3-char handle could now collide with.

## Approach
- `minThunderHandleLen` decoupled from `generatedThunderHandleLen`, set to 3.
- Audited every deployment flavor for fixed same-level subdomains.
- Added 5 reserved words found: `traces`, `api-amp`, `api-platform-gateway`, `otel`, `ai-gateway`.
- Mirrored floor + reserved list in `environmentSchema.ts`.
- Updated `add-environment-thunder.sh`'s length check.
- Updated OpenAPI spec, regenerated clients.
- Updated handle-length mentions in 3 doc guides.

## User stories
- Operators can use a short, meaningful env-Thunder handle without hitting a reserved-word collision.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   New floor + all 12 reserved words covered. `run_unit_tests.sh`: pass.
 - Integration tests
   None added, validation-only change.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
macOS, Go 1.25, golangci-lint, tsc, bash -n.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ThunderID handles can now use 3–63 characters.
  - Environment provisioning supports optional custom handles and automatically generates one when omitted.
  - Environment names now provide suggested ThunderID handles, which can be customized.
  - Additional reserved platform and service names are blocked.
  - Default environment setup now uses the consistent `default-idp` handle.

- **Documentation**
  - Updated API guidance, validation messages, setup instructions, and environment-management documentation to reflect the new handle requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->