### PR TITLE
Bump the gateway images to 1.2.1

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -45,8 +45,12 @@ GATEWAY_OPERATOR_VERSION="0.11.0"
 # reaches Programmed=True). Chart *version* and container *image tag* are
 # pinned separately below — setting chartVersion alone still runs an older
 # default image, so GATEWAY_IMAGE_VERSION must also be threaded through.
+# The chart trails the images: 1.2.1 gateway-controller/gateway-runtime images
+# are published, but no 1.2.1 gateway chart is, so the newest chart (1.2.0,
+# whose defaults point at 1.2.0 images) is pinned and the image tag override
+# below carries the runtime forward to 1.2.1.
 GATEWAY_CHART_VERSION="1.2.0"
-GATEWAY_IMAGE_VERSION="1.2.0"
+GATEWAY_IMAGE_VERSION="1.2.1"
 
 # The gateway chart (1.2.0-beta+) requires an encryption key to be mounted from a Kubernetes Secret
 GATEWAY_ENCRYPTION_SECRET_NAME="gateway-encryption-keys"

--- a/deployments/setup/env.sh
+++ b/deployments/setup/env.sh
@@ -5,8 +5,12 @@ CLUSTER_CONTEXT="k3d-${CLUSTER_NAME}"
 
 # WSO2 API Platform / Gateway Operator versions
 GATEWAY_OPERATOR_VERSION="0.11.0"
+# The chart trails the images: 1.2.1 gateway-controller/gateway-runtime images
+# are published, but no 1.2.1 gateway chart is. Pin the newest chart (1.2.0)
+# and let the image tag override in ensure-gateway-operator.sh carry the
+# runtime to 1.2.1 — the chart's own defaults still point at 1.2.0 images.
 GATEWAY_CHART_VERSION="1.2.0"
-GATEWAY_IMAGE_VERSION="1.2.0"
+GATEWAY_IMAGE_VERSION="1.2.1"
 
 
 GATEWAY_ENCRYPTION_SECRET_NAME="gateway-encryption-keys"

--- a/documentation/docs/guides/_partials/_amp-installation.mdx
+++ b/documentation/docs/guides/_partials/_amp-installation.mdx
@@ -65,11 +65,15 @@ Store the key with the rest of your platform secrets. It encrypts credentials th
 ```bash
 helm install gateway-operator \
   oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
-  --version 0.10.1 \
+  --version 0.11.0 \
   --namespace ${DATA_PLANE_NS} \
   --set logging.level=debug \
   --set gatewayApi.installStandardCRDs=false \
-  --set gateway.helm.chartVersion=1.2.0-beta \
+  --set gateway.helm.chartVersion=1.2.0 \
+  --set gateway.values.gateway.controller.image.repository=ghcr.io/wso2/api-platform/gateway-controller \
+  --set gateway.values.gateway.controller.image.tag=1.2.1 \
+  --set gateway.values.gateway.gatewayRuntime.image.repository=ghcr.io/wso2/api-platform/gateway-runtime \
+  --set gateway.values.gateway.gatewayRuntime.image.tag=1.2.1 \
   --set gateway.values.gateway.controller.encryptionKeys.enabled=true \
   --set gateway.values.gateway.controller.encryptionKeys.secretName=gateway-encryption-keys \
   --timeout 600s
@@ -82,11 +86,15 @@ helm install gateway-operator \
 ```bash
 helm install gateway-operator \
   oci://ghcr.io/wso2/api-platform/helm-charts/gateway-operator \
-  --version 0.10.1 \
+  --version 0.11.0 \
   --namespace ${DATA_PLANE_NS} \
   --set logging.level=info \
   --set gatewayApi.installStandardCRDs=false \
-  --set gateway.helm.chartVersion=1.2.0-beta \
+  --set gateway.helm.chartVersion=1.2.0 \
+  --set gateway.values.gateway.controller.image.repository=ghcr.io/wso2/api-platform/gateway-controller \
+  --set gateway.values.gateway.controller.image.tag=1.2.1 \
+  --set gateway.values.gateway.gatewayRuntime.image.repository=ghcr.io/wso2/api-platform/gateway-runtime \
+  --set gateway.values.gateway.gatewayRuntime.image.tag=1.2.1 \
   --set gateway.values.gateway.controller.encryptionKeys.enabled=true \
   --set gateway.values.gateway.controller.encryptionKeys.secretName=gateway-encryption-keys \
   --timeout 600s
@@ -95,7 +103,9 @@ helm install gateway-operator \
 </Prod>
 
 :::note Pin the gateway chart, do not inherit it
-`gateway.helm.chartVersion` decides which gateway chart the operator deploys, and it is the only thing that decides it — the `APIGateway` resource carries no chart version. Operator `0.10.1` defaults to `1.2.0-alpha`, whose templates predate the controller reading its control-plane address from configuration while still shipping `1.2.0-beta` images. The result is a gateway that installs, programs, and serves traffic while never registering with Agent Manager, so it never appears in the gateway list. Pin `1.2.0-beta` as above so the chart and the images match.
+`gateway.helm.chartVersion` decides which gateway chart the operator deploys, and it is the only thing that decides it — the `APIGateway` resource carries no chart version. Inheriting the operator's default has historically produced a chart whose templates do not render the controller's control-plane address, giving a gateway that installs, programs, and serves traffic while never registering with Agent Manager — so it never appears in the gateway list. Pin the chart explicitly, as above.
+
+Pin the container images too. The chart version and the image tags move independently: `1.2.0` is the newest published gateway chart and its defaults point at `1.2.0` images, while `1.2.1` controller and runtime images are published without a matching chart. Setting `chartVersion` alone would therefore leave you on `1.2.0` images, so the four `image.repository`/`image.tag` values above carry the runtime to `1.2.1`. Check the pod images after installing rather than trusting the chart version alone.
 
 `gateway.values` is the operator's passthrough into that chart: anything set under it is merged into the values the gateway is deployed with, which is how the encryption keys above are wired.
 :::


### PR DESCRIPTION
## Purpose
The installation paths pin the WSO2 API Platform gateway at `1.2.0`. A `1.2.1` gateway release is available and we want to be running it.

The complication is that `1.2.1` is an image-only release. `gateway-controller:1.2.1` and `gateway-runtime:1.2.1` are published on GHCR, but no `1.2.1` gateway Helm chart is — `1.2.0` is still the newest chart, and its own defaults point back at `1.2.0` images. Bumping the chart version alone is therefore not possible, and bumping nothing else would leave us on the older runtime.

Separately, the installation guide had drifted well behind the scripts: it still pinned gateway-operator `0.10.1` and the pre-release `1.2.0-beta` chart, and it never pinned the container images at all.

## Goals
Run the `1.2.1` gateway runtime on every install path, and close the gap between what the scripts pin and what the guide tells users to run.

## Approach
`GATEWAY_CHART_VERSION` and `GATEWAY_IMAGE_VERSION` are already separate variables precisely because chart and image versions move independently, so this bump uses that seam rather than working around it:

- `deployments/setup/env.sh` and `deployments/quick-start/install.sh` — `GATEWAY_IMAGE_VERSION` goes `1.2.0` → `1.2.1`; `GATEWAY_CHART_VERSION` stays at `1.2.0`, with a comment recording why the chart trails the images.
- `documentation/docs/guides/_partials/_amp-installation.mdx` — the shared partial behind both installation guides moves to operator `0.11.0` and chart `1.2.0`, and gains the four `image.repository` / `image.tag` flags it never had. Without those the documented install inherits the chart defaults and silently lands on `1.2.0` images even when the chart pin is correct.
- The note beside those commands explained an alpha/beta skew that no longer exists. It is rewritten around the point that outlasts any single version: chart and image versions move independently, so pin both and verify the running pod images.

`versioned_docs/` is deliberately left alone — those are frozen snapshots of what each past release shipped with.

Note for reviewers: `ensure-gateway-operator.sh` skips its CRD apply when the operator chart version is unchanged, but still runs `helm upgrade --install`, so this image-only bump does land on long-lived clusters.

## User stories
N/A — an infrastructure version bump with no user-facing feature attached.

## Release note
Upgrade the WSO2 API Platform gateway runtime to 1.2.1.

## Documentation
Included in this PR: `documentation/docs/guides/_partials/_amp-installation.mdx`, the shared partial rendered into both the k3d and the on-your-environment installation guides.

## Training
N/A — no training content covers gateway version pins.

## Certification
N/A — no impact on certification exams; this changes a version pin, not product behaviour a question could be written against.

## Automation tests
 - Unit tests
   > N/A — the change is version pins in shell variables and a docs partial, with no code paths to cover.
 - Integration tests
   > No new tests. Verified against the published artifacts and the real Helm rendering instead:
   > - Both `1.2.1` images exist on GHCR at architecture parity with `1.2.0` (`linux/amd64`, `linux/arm64`).
   > - Confirmed no `1.2.1` gateway chart is published, which is what makes the chart pin stay at `1.2.0`.
   > - `helm template` of gateway-operator `0.11.0` with the new flags renders `helm_chart_version: "1.2.0"` alongside `tag: 1.2.1` for both controller and runtime, so the operator's `gateway.values` passthrough reaches the images as intended.
   > - `bash -n` clean on all three touched/affected scripts; sourcing `env.sh` resolves to `operator=0.11.0 chart=1.2.0 image=1.2.1`.
   > - `npm run build` on the documentation site succeeds under `onBrokenLinks: throw`, and the rendered HTML for both installation guides carries `image.tag=1.2.1` with no stale `1.2.0-beta` or `0.10.1` left on current pages.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples relate to gateway version pins.

## Marketing
N/A — a patch-level dependency bump.

## Related PRs
None.

## Migrations (if applicable)
No migration steps. Existing clusters pick up the new images on the next `make setup-amp` / installer run, since the operator's Helm values are reapplied even when its own chart version is unchanged.

## Test environment
macOS 15 (darwin 25.5.0), Helm rendering against the published GHCR charts, Node 20 for the documentation build. Not yet exercised on a live cluster — the verification above is artifact and template level.

## Learning
The non-obvious part was that the WSO2 API Platform publishes gateway images and gateway charts on independent cadences, so "upgrade the gateway to 1.2.1" does not translate to a single version string. Confirmed by listing GHCR tags for the chart and both image repositories and diffing what exists in each, then reading the `1.2.0` chart's default values to see which image tags it would otherwise apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Gateway installation configurations to use the latest Gateway image version.
  * Added clearer guidance for independently pinning chart and image versions.

* **Documentation**
  * Updated development and production installation commands to use operator version 0.11.0 and Gateway image version 1.2.1.
  * Clarified chart and image version compatibility and override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->