### PR TITLE
Reword the promotion block for unbound MCP configurations

### DIFF
--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4552,14 +4552,35 @@ func (s *agentManagerService) assertMCPBindingsSurvivePromotion(
 
 	brokenList := strings.Join(brokenByPromotion, ", ")
 	s.logPromotionBlocked(ouID, projectName, agentName, targetEnv,
-		"MCP connection(s) resolve in the source environment but have no endpoint in the target — promoting would "+
-			"deploy the agent with an empty MCP URL and API key, so it would start and then fail on every tool call",
+		"MCP configurations are bound to an MCP server in the source environment but to none in the target — "+
+			"promoting would deploy the agent with an empty MCP URL and API key, so it would start and then fail "+
+			"on every tool call",
 		"sourceEnvironment", sourceEnv, "connections", brokenList)
-	return utils.NewInvalidInputError(
-		fmt.Sprintf("Promotion blocked: MCP connection(s) %s have no endpoint in %q",
-			briefConnectionList(brokenByPromotion), targetEnv),
-		fmt.Sprintf("bind them to an endpoint in %q, then promote", targetEnv),
-	)
+	message, reason := mcpPromotionBlockText(brokenByPromotion, targetEnv)
+	return utils.NewInvalidInputError(message, reason)
+}
+
+// mcpPromotionBlockText renders the caller-facing halves of a promotion blocked
+// by unbound MCP configurations, agreeing with how many there are rather than
+// hedging with "configuration(s)".
+//
+// The message reports only what was observed — the configuration resolves to no
+// MCP server in the target — and not why. Whether the server has an endpoint
+// there is never checked: an absent mapping row alone produces this state, so
+// naming a missing endpoint would send the caller after the wrong problem.
+//
+// A lone name is quoted because it reads as a name; a list is left bare, since
+// briefConnectionList may end it with a "(+N more)" count that must not appear
+// to be part of a name. names must not be empty.
+func mcpPromotionBlockText(names []string, targetEnv string) (message, reason string) {
+	problem := fmt.Sprintf("MCP configuration %q has no MCP server", names[0])
+	remedy := "its MCP server"
+	if len(names) > 1 {
+		problem = fmt.Sprintf("MCP configurations %s have no MCP server", briefConnectionList(names))
+		remedy = "their MCP servers"
+	}
+	return fmt.Sprintf("Promotion blocked: %s in %q", problem, targetEnv),
+		fmt.Sprintf("deploy %s to %q, then promote", remedy, targetEnv)
 }
 
 // maxBriefUIDetail caps how much of an unbounded upstream detail (a Thunder

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -752,7 +752,7 @@ func TestPromoteAgent_BlocksWhenMCPConnectionUnresolvableInTarget(t *testing.T) 
 
 	ve := requireBriefPromotionBlock(t, err)
 	assert.Contains(t, ve.Message, "booking", "the message must name the connection that blocks the promotion")
-	assert.Contains(t, ve.Reason, "bind")
+	assert.Contains(t, ve.Reason, "deploy")
 	assert.False(t, *promoteCalled,
 		"promotion must be refused before PromoteComponent — otherwise the agent is already running with an empty MCP URL by the time this error is returned")
 }
@@ -809,6 +809,60 @@ func TestPromoteAgent_ListsBrokenMCPConnectionsInStableOrder(t *testing.T) {
 
 	ve := requireBriefPromotionBlock(t, err)
 	assert.Contains(t, ve.Message, "booking, payments")
+}
+
+// The block reports what was actually checked — that the configuration has no
+// MCP server bound in the target — rather than asserting the server has no
+// endpoint there. Only the absent mapping row is observed; the server may well
+// be deployed to the target, with just the binding missing, and sending the
+// user to look for a missing endpoint would send them after the wrong problem.
+func TestPromoteAgent_BlockedMCPPromotion_ReportsTheMissingBindingNotAnUncheckedCause(t *testing.T) {
+	s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubUnresolvedMCPs(t, s, "staging", "booking")
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, `MCP configuration "booking" has no MCP server in "staging"`)
+	assert.NotContains(t, ve.Message, "endpoint",
+		"whether the MCP server has an endpoint in the target is never checked, so the block must not claim it")
+}
+
+// "Bind them to an endpoint" named no control the console or the CLI offers.
+// Deploying the MCP server to the target is what actually clears the block:
+// this configuration is already mapped in the source, so ReconcileMCPBindingsForProxy
+// backfills the target mapping as soon as the server lands there.
+func TestPromoteAgent_BlockedMCPPromotion_TellsUserToDeployTheMCPServer(t *testing.T) {
+	s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubUnresolvedMCPs(t, s, "staging", "booking")
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Equal(t, `deploy its MCP server to "staging", then promote`, ve.Reason)
+}
+
+// One broken configuration is the common case, so the block reads as a sentence
+// about it instead of hedging with "configuration(s)" and "their".
+func TestPromoteAgent_BlockedMCPPromotion_ReadsAsPluralOnlyWhenSeveralAreBroken(t *testing.T) {
+	s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubUnresolvedMCPs(t, s, "staging", "payments", "booking")
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Contains(t, ve.Message, `MCP configurations booking, payments have no MCP server in "staging"`)
+	assert.Equal(t, `deploy their MCP servers to "staging", then promote`, ve.Reason)
+	assert.NotContains(t, renderedUIError(ve), "(s)", "the wording agrees with the count instead of hedging")
 }
 
 func TestPromoteAgent_TargetIdentityReady_PromotesWithTargetOnlyCredentials(t *testing.T) {


### PR DESCRIPTION
## Purpose
Promoting an agent whose MCP configuration resolves in the source environment but has no mapping in the target is correctly blocked, but the error text misdirected the user in two ways:

- **It asserted a cause that is never checked.** The message said the configurations "have no endpoint in `<env>`". The check (`assertMCPBindingsSurvivePromotion`) only observes that the configuration resolves to no MCP server in the target — an absent `EnvAgentMCPMapping` row is enough to produce that state on its own. The MCP server may well be deployed to the target with only the binding missing, in which case the message sent the user hunting for a missing endpoint that was not the problem.
- **Its remedy named no control that exists.** "Bind them to an endpoint in `<env>`" does not correspond to anything the console or the CLI offers, so there was no action to take from it.

No linked issue.

## Goals
Have the block state only what was actually verified, and point at the step that genuinely clears it.

Before:
```
Promotion blocked: MCP connection(s) booking have no endpoint in "staging"
  : bind them to an endpoint in "staging", then promote
```

After (one configuration):
```
Promotion blocked: MCP configuration "booking" has no MCP server in "staging"
  : deploy its MCP server to "staging", then promote
```

After (several):
```
Promotion blocked: MCP configurations booking, payments have no MCP server in "staging"
  : deploy their MCP servers to "staging", then promote
```

## Approach
Message construction moved into a new `mcpPromotionBlockText` helper in `agent-manager-service/services/agent_manager.go`. Three changes:

1. **Reports the observation, not an unverified cause** — "has no MCP server in `<env>`" is exactly the state the check establishes.
2. **Names the real remedy** — deploying the MCP server to the target is what clears the block. In this code path the configuration is already mapped in the source environment, so `ReconcileMCPBindingsForProxy` backfills the target mapping automatically once the server lands there.
3. **Grammar agrees with the count** instead of hedging with `configuration(s)`. A lone name is quoted because it reads as a name; a list is left bare, since `briefConnectionList` may end it with a `(+N more)` count that must not appear to sit inside quotes.

The operator log line alongside it carried the same unverified "no endpoint" claim and was corrected to match. It keeps the full diagnosis and the complete connection list, unchanged in scope.

No signatures, control flow, or lookups changed — the same promotions are blocked under the same conditions, still as `utils.NewInvalidInputError` so the controller answers 400. This is a text change only.

Terminology note for reviewers: the repo currently has three names for this object — the console labels it "Tool Configurations", the CLI says "MCP proxy configurations", and the service says "MCP connections". I used "MCP configuration" as the closest bridge, but I have no strong attachment to it and would happily switch to whichever term the team considers canonical.

## User stories
As a platform user promoting an agent between environments, when the promotion is refused because an MCP configuration is not bound in the target, I want the error to tell me what was actually detected and which action will unblock me, so I can fix it without guessing or filing a support question.

## Release note
Improved the error shown when an agent promotion is blocked by an MCP configuration that is not bound to an MCP server in the target environment. The message now reports the missing binding rather than asserting a missing endpoint, and points to deploying the MCP server to the target environment.

## Documentation
N/A — this is a runtime error message with no counterpart in product documentation. Verified by grepping the repo (including `documentation/` and all Markdown) for the previous strings; the only occurrences were in the Go source changed here.

## Training
N/A — no training content covers this error path.

## Certification
N/A — a change to error-message wording, with no impact on certification exam content.

## Marketing
N/A — internal error-message quality fix, not a promotable feature.

## Automation tests
 - Unit tests
   > Three tests added and one updated in `agent-manager-service/services/agent_manager_test.go`, all developed test-first and confirmed failing against the old wording before the change:
   > - `TestPromoteAgent_BlockedMCPPromotion_ReportsTheMissingBindingNotAnUncheckedCause` — asserts the message states the missing binding and does not claim a missing endpoint.
   > - `TestPromoteAgent_BlockedMCPPromotion_TellsUserToDeployTheMCPServer` — pins the remedy string.
   > - `TestPromoteAgent_BlockedMCPPromotion_ReadsAsPluralOnlyWhenSeveralAreBroken` — covers plural agreement and the absence of `(s)`.
   > - `TestPromoteAgent_BlocksWhenMCPConnectionUnresolvableInTarget` — updated a stale assertion that required the reason to contain "bind".
   >
   > The pre-existing 200-rune UI legibility budget and `(+N more)` truncation tests pass untouched; the new strings land at roughly 125–140 runes. Unit coverage for the `services` package is 33.9% of statements (most of that package's tests are `//go:build integration`-gated, so its real coverage lives in the integration tier).
 - Integration tests
   > None added. The change alters no behaviour that integration tests observe — the same promotions are refused under the same conditions and the same error type; only the human-readable text differs. Existing integration coverage of the block is unaffected.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs is a Java/SpotBugs plugin and this is a Go change. `golangci-lint` with the repo config (`.github/linters/.golangci.yaml`) was run instead and reports 0 issues.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — the diff is two Go files containing only error-message text and tests. The environment names echoed into the message were already echoed by the previous version, and the connection-name list remains bounded by the existing `briefConnectionList` truncation.

## Samples
N/A — no sample depends on this error path.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema, model, or stored-data change.

## Test environment
- Go 1.26.6, linux/amd64
- Linux kernel 7.1.8 (CachyOS)
- No database required: the affected tests are in the unit tier (`agent-manager-service/scripts/run_unit_tests.sh`), which runs without PostgreSQL.
- Verified: 22 packages pass, `golangci-lint` reports 0 issues, `gofmt` clean.

## Learning
Traced the promote path from `PromoteAgent` through `assertMCPBindingsSurvivePromotion` into `ListUnresolvedMCPBindings` and `systemManagedMCPURL` to establish what the check actually observes — an empty resolved URL caused by a missing `EnvAgentMCPMapping` row — which is what showed that the old "no endpoint" wording was asserting more than the code knew. Reading `ReconcileMCPBindingsForProxy` then confirmed that deploying the MCP server to the target environment is what genuinely clears the block in this path, since a source mapping already exists for the reconcile to work from. That is the basis for the new remedy text.
