### PR TITLE
Name the missing MCP configurations in the promotion block

### DIFF
--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -5532,23 +5532,14 @@ func (s *agentConfigurationService) ListAgentLLMConfigSecretReferences(ctx conte
 func (s *agentConfigurationService) ListSystemManagedEnvVarKeys(
 	ctx context.Context, agentID, ouID, projectName, environmentName string,
 ) (map[string]bool, error) {
-	envUUID, err := s.resolveEnvironmentUUID(ctx, ouID, environmentName)
+	configured, err := s.listConfigsWithEnvVars(ctx, agentID, ouID, projectName, environmentName)
 	if err != nil {
 		return nil, err
 	}
 
-	configs, err := s.agentConfigRepo.ListByAgent(ctx, ouID, projectName, agentID, agentConfigListAll, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list agent configurations: %w", err)
-	}
-
 	keys := make(map[string]bool)
-	for _, config := range configs {
-		vars, err := s.envVariableRepo.ListByConfigAndEnv(ctx, config.UUID, envUUID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to list env config variables for config %s: %w", config.UUID, err)
-		}
-		for _, v := range vars {
+	for _, entry := range configured {
+		for _, v := range entry.vars {
 			keys[v.VariableName] = true
 		}
 	}
@@ -5558,6 +5549,34 @@ func (s *agentConfigurationService) ListSystemManagedEnvVarKeys(
 func (s *agentConfigurationService) ListSystemManagedConfigs(
 	ctx context.Context, agentID, ouID, projectName, environmentName string,
 ) ([]SystemManagedConfigRef, error) {
+	configured, err := s.listConfigsWithEnvVars(ctx, agentID, ouID, projectName, environmentName)
+	if err != nil {
+		return nil, err
+	}
+
+	refs := make([]SystemManagedConfigRef, 0, len(configured))
+	for _, entry := range configured {
+		refs = append(refs, SystemManagedConfigRef{Name: entry.config.Name, TypeID: entry.config.TypeID})
+	}
+	return refs, nil
+}
+
+// configWithEnvVars is one agent configuration together with the variable rows it
+// injects into a single environment.
+type configWithEnvVars struct {
+	config *models.AgentConfiguration
+	vars   []models.AgentEnvConfigVariable
+}
+
+// listConfigsWithEnvVars returns the agent's configurations that are set up for
+// environmentName, each with its variable rows there. A configuration with no rows in
+// the environment was never set up for it and is left out, which is the single
+// definition of "system-managed here" that both ListSystemManagedEnvVarKeys and
+// ListSystemManagedConfigs project from — the promotion block decides on the keys and
+// words its refusal from the configurations, so the two must not be able to disagree.
+func (s *agentConfigurationService) listConfigsWithEnvVars(
+	ctx context.Context, agentID, ouID, projectName, environmentName string,
+) ([]configWithEnvVars, error) {
 	envUUID, err := s.resolveEnvironmentUUID(ctx, ouID, environmentName)
 	if err != nil {
 		return nil, err
@@ -5568,9 +5587,7 @@ func (s *agentConfigurationService) ListSystemManagedConfigs(
 		return nil, fmt.Errorf("failed to list agent configurations: %w", err)
 	}
 
-	// A configuration with no variable rows in this environment was never set up for it —
-	// the same condition ListSystemManagedEnvVarKeys expresses by contributing no keys.
-	var refs []SystemManagedConfigRef
+	configured := make([]configWithEnvVars, 0, len(configs))
 	for i := range configs {
 		config := &configs[i]
 		vars, err := s.envVariableRepo.ListByConfigAndEnv(ctx, config.UUID, envUUID)
@@ -5580,9 +5597,9 @@ func (s *agentConfigurationService) ListSystemManagedConfigs(
 		if len(vars) == 0 {
 			continue
 		}
-		refs = append(refs, SystemManagedConfigRef{Name: config.Name, TypeID: config.TypeID})
+		configured = append(configured, configWithEnvVars{config: config, vars: vars})
 	}
-	return refs, nil
+	return configured, nil
 }
 
 // BuildSystemManagedEnvVarsFromConfig constructs system-managed env vars for a given

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -39,6 +39,16 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
+// SystemManagedConfigRef identifies one agent configuration that injects
+// system-managed env vars into an environment. ListSystemManagedEnvVarKeys
+// flattens every configuration into a single set of variable names, which is
+// all its callers need but leaves an error message unable to say what kind of
+// configuration those names came from; this keeps the identity instead.
+type SystemManagedConfigRef struct {
+	Name   string
+	TypeID uint
+}
+
 // AgentConfigurationService interface defines agent configuration business logic
 type AgentConfigurationService interface {
 	Create(ctx context.Context, ouID, projectName, agentID string,
@@ -70,6 +80,11 @@ type AgentConfigurationService interface {
 	// (i.e. injected by agent LLM/MCP configurations) for the given agent and environment.
 	// Used during promote to strip these keys from inherited workload overrides.
 	ListSystemManagedEnvVarKeys(ctx context.Context, agentID, ouID, projectName, environmentName string) (map[string]bool, error)
+	// ListSystemManagedConfigs returns the agent's configurations that have system-managed
+	// env vars in the given environment, by name and type. Promote calls it only once it has
+	// already decided to refuse, to say which configurations the target environment is
+	// missing rather than describing them all as LLM configuration.
+	ListSystemManagedConfigs(ctx context.Context, agentID, ouID, projectName, environmentName string) ([]SystemManagedConfigRef, error)
 	// BuildSystemManagedEnvVarsFromConfig constructs system-managed env vars for a given
 	// agent and environment from all DB configs. Used during promotion when the target
 	// environment's ReleaseBinding doesn't have these vars yet.
@@ -5538,6 +5553,36 @@ func (s *agentConfigurationService) ListSystemManagedEnvVarKeys(
 		}
 	}
 	return keys, nil
+}
+
+func (s *agentConfigurationService) ListSystemManagedConfigs(
+	ctx context.Context, agentID, ouID, projectName, environmentName string,
+) ([]SystemManagedConfigRef, error) {
+	envUUID, err := s.resolveEnvironmentUUID(ctx, ouID, environmentName)
+	if err != nil {
+		return nil, err
+	}
+
+	configs, err := s.agentConfigRepo.ListByAgent(ctx, ouID, projectName, agentID, agentConfigListAll, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list agent configurations: %w", err)
+	}
+
+	// A configuration with no variable rows in this environment was never set up for it —
+	// the same condition ListSystemManagedEnvVarKeys expresses by contributing no keys.
+	var refs []SystemManagedConfigRef
+	for i := range configs {
+		config := &configs[i]
+		vars, err := s.envVariableRepo.ListByConfigAndEnv(ctx, config.UUID, envUUID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list env config variables for config %s: %w", config.UUID, err)
+		}
+		if len(vars) == 0 {
+			continue
+		}
+		refs = append(refs, SystemManagedConfigRef{Name: config.Name, TypeID: config.TypeID})
+	}
+	return refs, nil
 }
 
 // BuildSystemManagedEnvVarsFromConfig constructs system-managed env vars for a given

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4583,32 +4583,31 @@ func (s *agentManagerService) missingTargetConfigText(
 	}
 
 	var mcpNames []string
-	hasNonMCPConfig := false
 	for _, config := range srcConfigs {
 		if config.TypeID == models.AgentConfigTypeIDMCP {
 			mcpNames = append(mcpNames, config.Name)
-			continue
 		}
-		hasNonMCPConfig = true
 	}
 	if len(mcpNames) == 0 {
 		return genericMessage, genericReason
 	}
 	sort.Strings(mcpNames)
+	hasNonMCPConfig := len(mcpNames) != len(srcConfigs)
+	shownMCPNames := clampedConfigNames(mcpNames)
 
 	// An agent missing an LLM configuration too is described by the generic message
 	// accurately, and keeping it byte-identical leaves anything already handling this
 	// block working. The MCP connections still have to be named somewhere, or fixing
 	// only what the message asks for earns the same refusal again.
 	if hasNonMCPConfig {
-		return genericMessage, fmt.Sprintf("configure system variables and connect %s, then promote", mcpConfigList(mcpNames))
+		return genericMessage, fmt.Sprintf("configure system variables and connect %s, then promote", mcpConfigList(shownMCPNames))
 	}
 
 	areNotConnected, remedy := "is not connected", "connect it"
 	if len(mcpNames) > 1 {
 		areNotConnected, remedy = "are not connected", "connect them"
 	}
-	return fmt.Sprintf("Promotion blocked: %s %s in %q", mcpConfigList(mcpNames), areNotConnected, targetEnv),
+	return fmt.Sprintf("Promotion blocked: %s %s in %q", mcpConfigList(shownMCPNames), areNotConnected, targetEnv),
 		fmt.Sprintf("%s in %q, then promote", remedy, targetEnv)
 }
 
@@ -4617,21 +4616,28 @@ func (s *agentManagerService) missingTargetConfigText(
 //
 // A lone name is quoted because it reads as a name; a list is left bare, since
 // briefConnectionList may end it with a "(+N more)" count that must not appear to be
-// part of a name — the same convention mcpPromotionBlockText follows. names must not
-// be empty.
+// part of a name. names must not be empty.
 //
-// Each name is clamped first. Configuration names are accepted up to 255 characters,
-// and briefConnectionList bounds how many names are shown but never shortens one, so
-// a single long name would otherwise bury the sentence around it.
+// How long an individual name may be is the caller's decision, not this one's: a
+// caller that would rather cut a name than lose the sentence around it passes names
+// through clampedConfigNames first, and one that must never show a shortened name
+// passes them whole.
 func mcpConfigList(names []string) string {
+	if len(names) == 1 {
+		return fmt.Sprintf("MCP configuration %q", names[0])
+	}
+	return fmt.Sprintf("MCP configurations %s", briefConnectionList(names))
+}
+
+// clampedConfigNames bounds each name on its own. Configuration names are accepted up
+// to 255 characters, and briefConnectionList bounds how many names are shown but never
+// shortens one, so a single long name would otherwise bury the sentence around it.
+func clampedConfigNames(names []string) []string {
 	shortened := make([]string, 0, len(names))
 	for _, name := range names {
 		shortened = append(shortened, briefUIDetail(name))
 	}
-	if len(shortened) == 1 {
-		return fmt.Sprintf("MCP configuration %q", shortened[0])
-	}
-	return fmt.Sprintf("MCP configurations %s", briefConnectionList(shortened))
+	return shortened
 }
 
 // mcpPromotionBlockText renders the caller-facing halves of a promotion blocked
@@ -4643,17 +4649,13 @@ func mcpConfigList(names []string) string {
 // there is never checked: an absent mapping row alone produces this state, so
 // naming a missing endpoint would send the caller after the wrong problem.
 //
-// A lone name is quoted because it reads as a name; a list is left bare, since
-// briefConnectionList may end it with a "(+N more)" count that must not appear
-// to be part of a name. names must not be empty.
+// names must not be empty.
 func mcpPromotionBlockText(names []string, targetEnv string) (message, reason string) {
-	problem := fmt.Sprintf("MCP configuration %q has no MCP server", names[0])
-	remedy := "its MCP server"
+	haveNo, remedy := "has no MCP server", "its MCP server"
 	if len(names) > 1 {
-		problem = fmt.Sprintf("MCP configurations %s have no MCP server", briefConnectionList(names))
-		remedy = "their MCP servers"
+		haveNo, remedy = "have no MCP server", "their MCP servers"
 	}
-	return fmt.Sprintf("Promotion blocked: %s in %q", problem, targetEnv),
+	return fmt.Sprintf("Promotion blocked: %s %s in %q", mcpConfigList(names), haveNo, targetEnv),
 		fmt.Sprintf("deploy %s to %q, then promote", remedy, targetEnv)
 }
 

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4179,10 +4179,8 @@ func (s *agentManagerService) PromoteAgent(ctx context.Context, ouID string, pro
 			"the agent has LLM/system configuration in the source environment but none in the target — promoting would "+
 				"deploy it without the system variables it needs",
 			"sourceEnvironment", req.SourceEnvironment)
-		return utils.NewInvalidInputError(
-			fmt.Sprintf("Promotion blocked: no LLM/system configuration in %q", req.TargetEnvironment),
-			fmt.Sprintf("configure system variables in %q, then promote", req.TargetEnvironment),
-		)
+		message, reason := s.missingTargetConfigText(ctx, agentName, ouID, projectName, req.SourceEnvironment, req.TargetEnvironment)
+		return utils.NewInvalidInputError(message, reason)
 	}
 
 	// The key-presence check above cannot see a connection that is present but dead: an MCP
@@ -4558,6 +4556,82 @@ func (s *agentManagerService) assertMCPBindingsSurvivePromotion(
 		"sourceEnvironment", sourceEnv, "connections", brokenList)
 	message, reason := mcpPromotionBlockText(brokenByPromotion, targetEnv)
 	return utils.NewInvalidInputError(message, reason)
+}
+
+// missingTargetConfigText renders the caller-facing halves of a promotion blocked
+// because the target environment has none of the system-managed configuration the
+// source has. The generic wording describes it all as LLM configuration, which is
+// what the agent's LLM provider needs but says nothing true about an agent whose
+// only system-managed configuration is an MCP connection.
+//
+// The source's configurations are looked up here rather than alongside the key sets
+// the check itself reads, so the extra query is paid only by a promotion already
+// being refused. A lookup that fails leaves the generic wording in place: a block
+// described imprecisely is still the right answer, and turning it into a 500 would
+// hide it.
+func (s *agentManagerService) missingTargetConfigText(
+	ctx context.Context, agentName, ouID, projectName, sourceEnv, targetEnv string,
+) (message, reason string) {
+	genericMessage := fmt.Sprintf("Promotion blocked: no LLM/system configuration in %q", targetEnv)
+	genericReason := fmt.Sprintf("configure system variables in %q, then promote", targetEnv)
+
+	srcConfigs, err := s.agentConfigurationService.ListSystemManagedConfigs(ctx, agentName, ouID, projectName, sourceEnv)
+	if err != nil {
+		s.logger.Warn("Failed to list source env system-managed configurations for a blocked promotion",
+			"agentName", agentName, "environment", sourceEnv, "error", err)
+		return genericMessage, genericReason
+	}
+
+	var mcpNames []string
+	hasNonMCPConfig := false
+	for _, config := range srcConfigs {
+		if config.TypeID == models.AgentConfigTypeIDMCP {
+			mcpNames = append(mcpNames, config.Name)
+			continue
+		}
+		hasNonMCPConfig = true
+	}
+	if len(mcpNames) == 0 {
+		return genericMessage, genericReason
+	}
+	sort.Strings(mcpNames)
+
+	// An agent missing an LLM configuration too is described by the generic message
+	// accurately, and keeping it byte-identical leaves anything already handling this
+	// block working. The MCP connections still have to be named somewhere, or fixing
+	// only what the message asks for earns the same refusal again.
+	if hasNonMCPConfig {
+		return genericMessage, fmt.Sprintf("configure system variables and connect %s, then promote", mcpConfigList(mcpNames))
+	}
+
+	areNotConnected, remedy := "is not connected", "connect it"
+	if len(mcpNames) > 1 {
+		areNotConnected, remedy = "are not connected", "connect them"
+	}
+	return fmt.Sprintf("Promotion blocked: %s %s in %q", mcpConfigList(mcpNames), areNotConnected, targetEnv),
+		fmt.Sprintf("%s in %q, then promote", remedy, targetEnv)
+}
+
+// mcpConfigList names MCP configurations for a caller-facing sentence, agreeing with
+// how many there are rather than hedging with "configuration(s)".
+//
+// A lone name is quoted because it reads as a name; a list is left bare, since
+// briefConnectionList may end it with a "(+N more)" count that must not appear to be
+// part of a name — the same convention mcpPromotionBlockText follows. names must not
+// be empty.
+//
+// Each name is clamped first. Configuration names are accepted up to 255 characters,
+// and briefConnectionList bounds how many names are shown but never shortens one, so
+// a single long name would otherwise bury the sentence around it.
+func mcpConfigList(names []string) string {
+	shortened := make([]string, 0, len(names))
+	for _, name := range names {
+		shortened = append(shortened, briefUIDetail(name))
+	}
+	if len(shortened) == 1 {
+		return fmt.Sprintf("MCP configuration %q", shortened[0])
+	}
+	return fmt.Sprintf("MCP configurations %s", briefConnectionList(shortened))
 }
 
 // mcpPromotionBlockText renders the caller-facing halves of a promotion blocked

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4578,7 +4578,7 @@ func (s *agentManagerService) missingTargetConfigText(
 	srcConfigs, err := s.agentConfigurationService.ListSystemManagedConfigs(ctx, agentName, ouID, projectName, sourceEnv)
 	if err != nil {
 		s.logger.Warn("Failed to list source env system-managed configurations for a blocked promotion",
-			"agentName", agentName, "environment", sourceEnv, "error", err)
+			"agentName", agentName, "projectName", projectName, "ouID", ouID, "environment", sourceEnv, "error", err)
 		return genericMessage, genericReason
 	}
 
@@ -4593,21 +4593,20 @@ func (s *agentManagerService) missingTargetConfigText(
 	}
 	sort.Strings(mcpNames)
 	hasNonMCPConfig := len(mcpNames) != len(srcConfigs)
-	shownMCPNames := clampedConfigNames(mcpNames)
 
 	// An agent missing an LLM configuration too is described by the generic message
 	// accurately, and keeping it byte-identical leaves anything already handling this
 	// block working. The MCP connections still have to be named somewhere, or fixing
 	// only what the message asks for earns the same refusal again.
 	if hasNonMCPConfig {
-		return genericMessage, fmt.Sprintf("configure system variables and connect %s, then promote", mcpConfigList(shownMCPNames))
+		return genericMessage, fmt.Sprintf("configure system variables and connect %s, then promote", mcpConfigList(mcpNames))
 	}
 
 	areNotConnected, remedy := "is not connected", "connect it"
 	if len(mcpNames) > 1 {
 		areNotConnected, remedy = "are not connected", "connect them"
 	}
-	return fmt.Sprintf("Promotion blocked: %s %s in %q", mcpConfigList(shownMCPNames), areNotConnected, targetEnv),
+	return fmt.Sprintf("Promotion blocked: %s %s in %q", mcpConfigList(mcpNames), areNotConnected, targetEnv),
 		fmt.Sprintf("%s in %q, then promote", remedy, targetEnv)
 }
 
@@ -4618,20 +4617,18 @@ func (s *agentManagerService) missingTargetConfigText(
 // briefConnectionList may end it with a "(+N more)" count that must not appear to be
 // part of a name. names must not be empty.
 //
-// How long an individual name may be is the caller's decision, not this one's: a
-// caller that would rather cut a name than lose the sentence around it passes names
-// through clampedConfigNames first, and one that must never show a shortened name
-// passes them whole.
+// Every name is clamped here rather than at the call sites. Names are caller-supplied
+// and accepted up to 255 characters, so one of them can bury the sentence it sits in;
+// clamping where the names are rendered means a caller cannot forget to.
 func mcpConfigList(names []string) string {
 	if len(names) == 1 {
-		return fmt.Sprintf("MCP configuration %q", names[0])
+		return fmt.Sprintf("MCP configuration %q", briefUIDetail(names[0]))
 	}
-	return fmt.Sprintf("MCP configurations %s", briefConnectionList(names))
+	return fmt.Sprintf("MCP configurations %s", briefConnectionList(clampedConfigNames(names)))
 }
 
-// clampedConfigNames bounds each name on its own. Configuration names are accepted up
-// to 255 characters, and briefConnectionList bounds how many names are shown but never
-// shortens one, so a single long name would otherwise bury the sentence around it.
+// clampedConfigNames bounds each name on its own, because briefConnectionList bounds
+// how many names are shown but never shortens one.
 func clampedConfigNames(names []string) []string {
 	shortened := make([]string, 0, len(names))
 	for _, name := range names {

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -601,7 +601,7 @@ type stubAgentConfigurationServiceForPromote struct {
 // per-configuration wording keep the message they were written against.
 func (s *stubAgentConfigurationServiceForPromote) ListSystemManagedConfigs(ctx context.Context, agentID, ouID, projectName, environmentName string) ([]SystemManagedConfigRef, error) {
 	if s.SystemConfigsFunc == nil {
-		return nil, nil
+		return []SystemManagedConfigRef{}, nil
 	}
 	return s.SystemConfigsFunc(ctx, agentID, ouID, projectName, environmentName)
 }
@@ -880,6 +880,39 @@ func TestPromoteAgent_BlockedMCPPromotion_ReadsAsPluralOnlyWhenSeveralAreBroken(
 	assert.Contains(t, ve.Message, `MCP configurations booking, payments have no MCP server in "staging"`)
 	assert.Equal(t, `deploy their MCP servers to "staging", then promote`, ve.Reason)
 	assert.NotContains(t, renderedUIError(ve), "(s)", "the wording agrees with the count instead of hedging")
+}
+
+// The sibling block below shortens a long configuration name, and this one renders
+// its names through the same helper, so it must shorten too. A 255-character name is
+// legal, and pasting one in whole buries the sentence that says what to do about it.
+func TestPromoteAgent_BlockedMCPPromotion_VeryLongConfigName_IsShortenedNotPastedWhole(t *testing.T) {
+	longName := "hotel-booking" + strings.Repeat("x", 242)
+	require.Len(t, longName, 255, "the fixture must use the longest name the API accepts")
+
+	for _, tc := range []struct {
+		name  string
+		names []string
+	}{
+		{"single configuration", []string{longName}},
+		{"several configurations", []string{longName, "payments"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+			stubUnresolvedMCPs(t, s, "staging", tc.names...)
+			logs := captureLogs(s)
+
+			err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+				SourceEnvironment: "dev",
+				TargetEnvironment: "staging",
+			})
+
+			ve := requireBriefPromotionBlock(t, err)
+			rendered := renderedUIError(ve)
+			assert.NotContains(t, rendered, longName, "the whole name must not reach the UI")
+			assert.Contains(t, rendered, "hotel-booking", "enough of the name must survive to identify the configuration")
+			assert.Contains(t, logs(), longName, "the untruncated name must still reach the log")
+		})
+	}
 }
 
 func TestPromoteAgent_TargetIdentityReady_PromotesWithTargetOnlyCredentials(t *testing.T) {
@@ -2240,7 +2273,7 @@ func stubSystemManagedConfigs(t *testing.T, s *agentManagerService, configuredEn
 	}
 	agentConfigSvc.SystemConfigsFunc = func(_ context.Context, _, _, _, envName string) ([]SystemManagedConfigRef, error) {
 		if envName != configuredEnv {
-			return nil, nil
+			return []SystemManagedConfigRef{}, nil
 		}
 		return configs, nil
 	}

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -731,13 +731,20 @@ func (s *provisionForEnvIfMissingStub) ProvisionForEnvironmentIfMissing(_ contex
 	return false, nil
 }
 
+// promoteConfigStub reaches the agent configuration stub a promote fixture was built
+// with, so each stubbing helper is the closure it installs and nothing else.
+func promoteConfigStub(t *testing.T, s *agentManagerService) *stubAgentConfigurationServiceForPromote {
+	t.Helper()
+	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
+	require.True(t, ok)
+	return agentConfigSvc
+}
+
 // stubUnresolvedMCPs makes the named connections unresolved in blockedEnv only,
 // which is what makes a promotion into that environment break them.
 func stubUnresolvedMCPs(t *testing.T, s *agentManagerService, blockedEnv string, names ...string) {
 	t.Helper()
-	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
-	require.True(t, ok)
-	agentConfigSvc.UnresolvedMCPsFunc = func(_ context.Context, _, _, _, envName string) (map[string]struct{}, error) {
+	promoteConfigStub(t, s).UnresolvedMCPsFunc = func(_ context.Context, _, _, _, envName string) (map[string]struct{}, error) {
 		unresolved := map[string]struct{}{}
 		if envName == blockedEnv {
 			for _, name := range names {
@@ -2220,8 +2227,7 @@ func TestListOrgAgents_ProjectListFailurePropagates(t *testing.T) {
 // missing-configuration block on a promotion out of configuredEnv.
 func stubSystemManagedConfigs(t *testing.T, s *agentManagerService, configuredEnv string, configs ...SystemManagedConfigRef) {
 	t.Helper()
-	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
-	require.True(t, ok)
+	agentConfigSvc := promoteConfigStub(t, s)
 	agentConfigSvc.SystemKeysFunc = func(_ context.Context, _, _, _, envName string) (map[string]bool, error) {
 		if envName != configuredEnv {
 			return map[string]bool{}, nil
@@ -2329,9 +2335,7 @@ func TestPromoteAgent_TargetMissingLLMAndMCPConfigs_KeepsMessageAndNamesMCPInRea
 func TestPromoteAgent_ConfigLookupFailsWhileDescribingBlock_StillRefusesWithGenericWording(t *testing.T) {
 	s, promoteCalled := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
 	stubSystemManagedConfigs(t, s, "dev", mcpConfigRef("booking"))
-	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
-	require.True(t, ok)
-	agentConfigSvc.SystemConfigsFunc = func(_ context.Context, _, _, _, _ string) ([]SystemManagedConfigRef, error) {
+	promoteConfigStub(t, s).SystemConfigsFunc = func(_ context.Context, _, _, _, _ string) ([]SystemManagedConfigRef, error) {
 		return nil, errors.New("database unavailable")
 	}
 
@@ -2357,14 +2361,8 @@ func TestPromoteAgent_ManyMCPConfigsAndLongEnvName_StaysWithinUIBudget(t *testin
 		mcpConfigRef("inventory-connection"),
 		mcpConfigRef("notifications-connection"),
 	}
-	s := &agentManagerService{
-		agentConfigurationService: &stubAgentConfigurationServiceForPromote{
-			SystemConfigsFunc: func(_ context.Context, _, _, _, _ string) ([]SystemManagedConfigRef, error) {
-				return configs, nil
-			},
-		},
-		logger: discardLogger(),
-	}
+	s, _ := promoteAgentTestFixture(t, nil, nil)
+	stubSystemManagedConfigs(t, s, "dev", configs...)
 
 	message, reason := s.missingTargetConfigText(context.Background(), "my-agent", "acme", "proj1", "dev", longEnv)
 
@@ -2378,20 +2376,17 @@ func TestPromoteAgent_VeryLongConfigName_IsShortenedNotPastedWhole(t *testing.T)
 	longName := "hotel-booking" + strings.Repeat("x", 242)
 	require.Len(t, longName, 255, "the fixture must use the longest name the API accepts")
 
-	for name, configs := range map[string][]SystemManagedConfigRef{
-		"single MCP configuration":   {mcpConfigRef(longName)},
-		"several MCP configurations": {mcpConfigRef(longName), mcpConfigRef("payments")},
-		"LLM and MCP configurations": {llmConfigRef("openai"), mcpConfigRef(longName)},
+	for _, tc := range []struct {
+		name    string
+		configs []SystemManagedConfigRef
+	}{
+		{"single MCP configuration", []SystemManagedConfigRef{mcpConfigRef(longName)}},
+		{"several MCP configurations", []SystemManagedConfigRef{mcpConfigRef(longName), mcpConfigRef("payments")}},
+		{"LLM and MCP configurations", []SystemManagedConfigRef{llmConfigRef("openai"), mcpConfigRef(longName)}},
 	} {
-		t.Run(name, func(t *testing.T) {
-			s := &agentManagerService{
-				agentConfigurationService: &stubAgentConfigurationServiceForPromote{
-					SystemConfigsFunc: func(_ context.Context, _, _, _, _ string) ([]SystemManagedConfigRef, error) {
-						return configs, nil
-					},
-				},
-				logger: discardLogger(),
-			}
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := promoteAgentTestFixture(t, nil, nil)
+			stubSystemManagedConfigs(t, s, "dev", tc.configs...)
 
 			message, reason := s.missingTargetConfigText(context.Background(), "my-agent", "acme", "proj1", "dev", "staging")
 

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -593,7 +593,17 @@ type stubAgentConfigurationServiceForPromote struct {
 	AgentConfigurationService
 	SystemKeysFunc     func(ctx context.Context, agentID, ouID, projectName, environmentName string) (map[string]bool, error)
 	SystemVarsFunc     func(ctx context.Context, agentID, ouID, projectName, environmentName string) ([]client.EnvVar, error)
+	SystemConfigsFunc  func(ctx context.Context, agentID, ouID, projectName, environmentName string) ([]SystemManagedConfigRef, error)
 	UnresolvedMCPsFunc func(ctx context.Context, agentID, ouID, projectName, environmentName string) (map[string]struct{}, error)
+}
+
+// Defaults to "no configuration to describe", so tests that predate the block's
+// per-configuration wording keep the message they were written against.
+func (s *stubAgentConfigurationServiceForPromote) ListSystemManagedConfigs(ctx context.Context, agentID, ouID, projectName, environmentName string) ([]SystemManagedConfigRef, error) {
+	if s.SystemConfigsFunc == nil {
+		return nil, nil
+	}
+	return s.SystemConfigsFunc(ctx, agentID, ouID, projectName, environmentName)
 }
 
 func (s *stubAgentConfigurationServiceForPromote) ListSystemManagedEnvVarKeys(ctx context.Context, agentID, ouID, projectName, environmentName string) (map[string]bool, error) {
@@ -2203,4 +2213,193 @@ func TestListOrgAgents_ProjectListFailurePropagates(t *testing.T) {
 
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, utils.ErrOrganizationNotFound, "an unrelated openchoreo failure must not be masked as not-found")
+}
+
+// stubSystemManagedConfigs gives the agent system-managed configuration in
+// configuredEnv and none anywhere else, which is the shape that trips the
+// missing-configuration block on a promotion out of configuredEnv.
+func stubSystemManagedConfigs(t *testing.T, s *agentManagerService, configuredEnv string, configs ...SystemManagedConfigRef) {
+	t.Helper()
+	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
+	require.True(t, ok)
+	agentConfigSvc.SystemKeysFunc = func(_ context.Context, _, _, _, envName string) (map[string]bool, error) {
+		if envName != configuredEnv {
+			return map[string]bool{}, nil
+		}
+		keys := map[string]bool{}
+		for _, config := range configs {
+			keys[config.Name+"_URL"] = true
+		}
+		return keys, nil
+	}
+	agentConfigSvc.SystemConfigsFunc = func(_ context.Context, _, _, _, envName string) ([]SystemManagedConfigRef, error) {
+		if envName != configuredEnv {
+			return nil, nil
+		}
+		return configs, nil
+	}
+}
+
+func mcpConfigRef(name string) SystemManagedConfigRef {
+	return SystemManagedConfigRef{Name: name, TypeID: models.AgentConfigTypeIDMCP}
+}
+
+func llmConfigRef(name string) SystemManagedConfigRef {
+	return SystemManagedConfigRef{Name: name, TypeID: models.AgentConfigTypeIDLLM}
+}
+
+// An agent whose only system-managed configuration is an MCP connection used to be
+// refused with "no LLM/system configuration", sending the user to look for an LLM
+// provider that was never involved. The block must name the configuration that is
+// actually missing from the target.
+func TestPromoteAgent_TargetMissingMCPOnlyConfig_NamesTheConfigurationNotLLM(t *testing.T) {
+	s, promoteCalled := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubSystemManagedConfigs(t, s, "dev", mcpConfigRef("booking"))
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Equal(t, `Promotion blocked: MCP configuration "booking" is not connected in "staging"`, ve.Message)
+	assert.Equal(t, `connect it in "staging", then promote`, ve.Reason)
+	assert.NotContains(t, renderedUIError(ve), "LLM",
+		"no LLM provider is involved, so naming one sends the user after a configuration that does not exist")
+	assert.False(t, *promoteCalled)
+}
+
+// One missing configuration is the common case, so the block reads as a sentence
+// about it rather than hedging with "configuration(s)" and "it/them".
+func TestPromoteAgent_TargetMissingSeveralMCPConfigs_ReadsAsPlural(t *testing.T) {
+	s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubSystemManagedConfigs(t, s, "dev", mcpConfigRef("payments"), mcpConfigRef("booking"))
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Equal(t, `Promotion blocked: MCP configurations booking, payments are not connected in "staging"`, ve.Message,
+		"the names are listed in a stable order, so the same refusal reads the same on every run")
+	assert.Equal(t, `connect them in "staging", then promote`, ve.Reason)
+	assert.NotContains(t, renderedUIError(ve), "(s)", "the wording agrees with the count instead of hedging")
+}
+
+// The same block fires when it really is the LLM provider that the target lacks.
+// That wording is correct there and is what callers already handle, so an agent
+// with no MCP connection must keep the message and reason it has always produced.
+func TestPromoteAgent_TargetMissingLLMConfig_KeepsTheGenericWording(t *testing.T) {
+	s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubSystemManagedConfigs(t, s, "dev", llmConfigRef("openai"))
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Equal(t, `Promotion blocked: no LLM/system configuration in "staging"`, ve.Message)
+	assert.Equal(t, `configure system variables in "staging", then promote`, ve.Reason)
+}
+
+// An agent missing both kinds is genuinely missing its LLM configuration, so the
+// message keeps its wording. The MCP connections are missing too, though, and a
+// user who configures only the system variables would be refused all over again —
+// so the reason names them.
+func TestPromoteAgent_TargetMissingLLMAndMCPConfigs_KeepsMessageAndNamesMCPInReason(t *testing.T) {
+	s, _ := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubSystemManagedConfigs(t, s, "dev", llmConfigRef("openai"), mcpConfigRef("booking"))
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Equal(t, `Promotion blocked: no LLM/system configuration in "staging"`, ve.Message,
+		"the message stays byte-identical so anything already handling this block keeps working")
+	assert.Equal(t, `configure system variables and connect MCP configuration "booking", then promote`, ve.Reason)
+}
+
+// The lookup that names the configurations runs only to describe a refusal that has
+// already been decided. Failing to describe it must not escalate a 400 the caller can
+// act on into a 500 that hides why the promotion stopped.
+func TestPromoteAgent_ConfigLookupFailsWhileDescribingBlock_StillRefusesWithGenericWording(t *testing.T) {
+	s, promoteCalled := promoteAgentTestFixture(t, []client.EnvVar{{Key: "AMP_AGENTID_CLIENT_ID", Value: "staging-client-id"}}, nil)
+	stubSystemManagedConfigs(t, s, "dev", mcpConfigRef("booking"))
+	agentConfigSvc, ok := s.agentConfigurationService.(*stubAgentConfigurationServiceForPromote)
+	require.True(t, ok)
+	agentConfigSvc.SystemConfigsFunc = func(_ context.Context, _, _, _, _ string) ([]SystemManagedConfigRef, error) {
+		return nil, errors.New("database unavailable")
+	}
+
+	err := s.PromoteAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.PromoteAgentRequest{
+		SourceEnvironment: "dev",
+		TargetEnvironment: "staging",
+	})
+
+	ve := requireBriefPromotionBlock(t, err)
+	assert.Equal(t, `Promotion blocked: no LLM/system configuration in "staging"`, ve.Message)
+	assert.False(t, *promoteCalled)
+}
+
+// The reason naming the MCP configurations is the longest string this block can
+// produce, and it is rendered next to an environment name the user chose. Long names
+// and a truncated list together must still fit the console's legibility budget.
+func TestPromoteAgent_ManyMCPConfigsAndLongEnvName_StaysWithinUIBudget(t *testing.T) {
+	longEnv := "production-eu-west-central-1"
+	configs := []SystemManagedConfigRef{
+		llmConfigRef("openai"),
+		mcpConfigRef("hotel-booking-connection"),
+		mcpConfigRef("payments-connection"),
+		mcpConfigRef("inventory-connection"),
+		mcpConfigRef("notifications-connection"),
+	}
+	s := &agentManagerService{
+		agentConfigurationService: &stubAgentConfigurationServiceForPromote{
+			SystemConfigsFunc: func(_ context.Context, _, _, _, _ string) ([]SystemManagedConfigRef, error) {
+				return configs, nil
+			},
+		},
+		logger: discardLogger(),
+	}
+
+	message, reason := s.missingTargetConfigText(context.Background(), "my-agent", "acme", "proj1", "dev", longEnv)
+
+	_ = requireBriefPromotionBlock(t, utils.NewInvalidInputError(message, reason))
+}
+
+// Configuration names are accepted up to 255 characters, and this block is the first
+// thing that puts one on screen. A name long enough to bury the sentence it sits in
+// must be cut down to a recognisable prefix rather than pasted in whole.
+func TestPromoteAgent_VeryLongConfigName_IsShortenedNotPastedWhole(t *testing.T) {
+	longName := "hotel-booking" + strings.Repeat("x", 242)
+	require.Len(t, longName, 255, "the fixture must use the longest name the API accepts")
+
+	for name, configs := range map[string][]SystemManagedConfigRef{
+		"single MCP configuration":   {mcpConfigRef(longName)},
+		"several MCP configurations": {mcpConfigRef(longName), mcpConfigRef("payments")},
+		"LLM and MCP configurations": {llmConfigRef("openai"), mcpConfigRef(longName)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := &agentManagerService{
+				agentConfigurationService: &stubAgentConfigurationServiceForPromote{
+					SystemConfigsFunc: func(_ context.Context, _, _, _, _ string) ([]SystemManagedConfigRef, error) {
+						return configs, nil
+					},
+				},
+				logger: discardLogger(),
+			}
+
+			message, reason := s.missingTargetConfigText(context.Background(), "my-agent", "acme", "proj1", "dev", "staging")
+
+			rendered := renderedUIError(utils.NewInvalidInputError(message, reason))
+			assert.NotContains(t, rendered, longName, "the whole name must not reach the UI")
+			assert.Contains(t, rendered, "hotel-booking", "enough of the name must survive to identify the configuration")
+			assert.LessOrEqual(t, utf8.RuneCountInString(rendered), maxPromotionUIErrorLen,
+				"a single name must not be able to blow the message past the budget: %s", rendered)
+		})
+	}
 }


### PR DESCRIPTION
## Purpose
Promoting an agent whose only system-managed configuration is an MCP connection was refused with:

```
Promotion blocked: no LLM/system configuration in "prod": configure system variables in "prod", then promote
```

No LLM provider is involved in that agent, so the message sends the user looking for configuration that does not exist. The block itself is correct — only its wording is wrong.

This is the sibling of the guard reworded in #1738. That PR fixed `assertMCPBindingsSurvivePromotion`, which fires when the target environment *has* MCP variable rows that resolve to no server. The guard here fires earlier and for a different state: the target has no system-managed rows for the configuration at all, so it never reaches the MCP-aware check.

That state is reached when an environment is created *after* the MCP connection was configured. `CreateEnvironment` does no configuration backfill, and `mcpEnvsNeedingActivation` builds its candidate list from existing variable rows — so an environment with none is never a reconcile candidate, and no proxy update will ever fill it in. Re-saving the connection is what creates the rows, which is why the new wording says "connect", not "deploy".

Resolves the confusing error reported against `hotel-booking-anjanas` promoting `default` → `prod`.

## Goals
Make the block name what is actually missing, without changing which promotions are blocked, and without changing the wording in the case where it is genuinely the LLM configuration that the target lacks.

## Approach
The trigger is untouched — still `len(srcSystemKeys) > 0 && len(tgtSystemKeys) == 0`. No promotion changes outcome.

`ListSystemManagedEnvVarKeys` flattens every configuration into one set of variable names, which is all its three callers need but leaves the message unable to say what kind of configuration those names came from. A sibling `ListSystemManagedConfigs` returns `{Name, TypeID}` per configuration instead. It is called only *inside* the blocked branch, so the happy path pays nothing and the existing callers are untouched. A failed lookup falls back to the current wording rather than turning a 400 the caller can act on into a 500 that hides it.

Resulting text:

| Source configurations | Rendered |
|---|---|
| LLM only | `Promotion blocked: no LLM/system configuration in "prod": configure system variables in "prod", then promote` (**unchanged, byte-identical**) |
| MCP only, one | `Promotion blocked: MCP configuration "hotel-mcp" is not connected in "prod": connect it in "prod", then promote` |
| MCP only, several | `Promotion blocked: MCP configurations booking, payments are not connected in "prod": connect them in "prod", then promote` |
| LLM + MCP | message **unchanged**; reason becomes `configure system variables and connect MCP configuration "hotel-mcp", then promote` |

`is not connected` deliberately differs from #1738's `has no MCP server in`. Different state, different remedy — and per the reasoning in that PR, the message reports only what was actually checked.

In the mixed case the message stays byte-identical so anything already handling this block keeps working, while the reason names the MCP configurations — otherwise a user who configures only the system variables the message asks for earns the same refusal again.

## User stories
As someone promoting an agent, when the promotion is refused I want the error to name the configuration that is actually missing, so I can fix it without hunting for an LLM provider my agent never had.

## Release note
Promotion blocked by missing target-environment configuration now names the MCP configurations involved instead of always reporting missing LLM configuration.

## Documentation
N/A — error message wording only; no documented behaviour, API shape, or field changes.

## Training
N/A — no training content covers this error string.

## Certification
N/A — error message wording; no certifiable behaviour change.

## Marketing
N/A — internal error message clarity fix.

## Automation tests
 - Unit tests
   > Seven new tests in `services/agent_manager_test.go`, all through the existing `promoteAgentTestFixture` and `requireBriefPromotionBlock` helpers: MCP-only names the configuration and never says "LLM"; several MCP configurations read as plural with no `(s)` hedging and in stable order; LLM-only keeps message and reason byte-identical; LLM+MCP keeps the message byte-identical while the reason names the MCP configuration; a failed configuration lookup still refuses with a brief 400 rather than a 500; a very long configuration name is shortened rather than pasted whole; a realistic long environment name with several configurations stays inside the UI budget. An eighth test added in review covers the same clamp on the `assertMCPBindingsSurvivePromotion` block, which without the fix renders at 375 runes (single name) and 388 (list) against the 200-rune budget, and asserts the untruncated name still reaches the log. Full `services` package passes under `-race`; `golangci-lint run --config .github/linters/.golangci.yaml ./services/...` reports 0 issues.
 - Integration tests
   > None added. The change is confined to caller-facing text derived inside an already-covered refusal path; the DB-backed promotion behaviour it guards is unchanged and already covered by `tests/promote_agent_test.go`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not part of this repo's Go toolchain; `golangci-lint` with `.github/linters/.golangci.yaml` reports 0 issues, including `goheader`.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

Configuration names originate from the caller and now reach a caller-facing message, so each is passed through `briefUIDetail` — the same sanitise-and-truncate clamp used elsewhere for untrusted display strings.

## Samples
N/A — no sample changes; the affected agents are existing user agents with MCP connections.

## Related PRs
#1738 — reworded the adjacent `assertMCPBindingsSurvivePromotion` guard. This PR covers the earlier guard that PR did not touch.

## Migrations (if applicable)
N/A — no schema or data changes; the new repository read uses existing tables.

## Test environment
Go toolchain per `agent-manager-service/go.mod`, Linux (CachyOS, kernel 7.1.8). Unit tier only — no database required.

## Learning
Two things surfaced while building this that are worth flagging for review:

1. **`mcpPromotionBlockText` (from #1738) had the same unbounded-name hole, now folded in.** It interpolated names without shortening, and `briefConnectionList` bounds how many names are shown but never shortens one. Raised in review, so it is fixed here rather than deferred — but one level up from the call site: clamping only `mcpPromotionBlockText` fixes the instance while leaving the next caller of `mcpConfigList` free to forget, which is how this one was missed. `mcpConfigList` now clamps every name itself, and `missingTargetConfigText` no longer pre-clamps.

2. **The 200-rune UI budget is not a guarantee across all inputs, and never was.** Environment names are accepted up to 64 characters (`models/environment.go`), and the *untouched* generic wording renders at 228 runes at that length. The budget usefully constrains authored text length, but it cannot promise a bound on user-supplied data without changing the frozen message. A test asserting the longest legal inputs fit was written, observed to fail for this reason, and scaled back to the property the code does control: names are clamped.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Promotion checks now identify missing MCP configurations by name.
  - System-managed configurations retain their names and type information for clearer validation results.

- **Bug Fixes**
  - Promotion messages now distinguish MCP-only issues from missing LLM or system configurations.
  - Improved singular and plural wording for missing configurations.
  - Combined configuration issues are reported more clearly.
  - Long configuration names and environment details are safely shortened to fit the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
