### PR TITLE
Fix LLM env vars not reaching agents configured during a build

### DIFF
--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -5023,10 +5023,6 @@ func (s *agentManagerService) getSystemManagedEnvVars(
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(existingConfigs) == 0 {
-		s.logger.Debug("No existing env vars found in component configurations", "agentName", componentName)
-		return nil, nil, nil
-	}
 
 	// Fetch the set of SecretReference names that belong to LLM configurations for this agent
 	// and environment from the DB. These are the source of truth — provider-agnostic.
@@ -5083,6 +5079,23 @@ func (s *agentManagerService) getSystemManagedEnvVars(
 		result = append(result, client.EnvVar{Key: existing.Key, Value: existing.Value})
 		keySet[existing.Key] = true
 		s.logger.Info("Identified system-managed plain env var", "key", existing.Key)
+	}
+
+	// The scans above only see what already reached the cluster; rebuild the rest from the DB so a
+	// full-replace caller does not drop vars that never made it into a Workload or ReleaseBinding.
+	if len(keySet) < len(systemKeys) {
+		dbVars, dbErr := s.agentConfigurationService.BuildSystemManagedEnvVarsFromConfig(ctx, componentName, ouID, projectName, environmentName)
+		if dbErr != nil {
+			return nil, nil, fmt.Errorf("failed to build system-managed env vars from configuration: %w", dbErr)
+		}
+		for _, dbVar := range dbVars {
+			if keySet[dbVar.Key] {
+				continue
+			}
+			result = append(result, dbVar)
+			keySet[dbVar.Key] = true
+			s.logger.Info("Injected system-managed env var missing from cluster state", "key", dbVar.Key)
+		}
 	}
 
 	return result, keySet, nil

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -5562,6 +5562,9 @@ func (s *agentManagerService) GetAgentDeployments(ctx context.Context, ouID stri
 		if agent.Type.Type == string(utils.AgentTypeAPI) {
 			s.reconcileIsolationRuntimeClass(ctx, ouID, agentName, deployments)
 		}
+		if agent.Provisioning.Type == string(utils.InternalAgent) {
+			s.reconcileSystemManagedEnvVars(ctx, ouID, projectName, agentName, deployments)
+		}
 		s.resolveDeployedKindVersions(ctx, ouID, agent.KindName, deployments)
 	}
 
@@ -5637,6 +5640,78 @@ func (s *agentManagerService) reconcileIsolationRuntimeClass(ctx context.Context
 			s.logger.Warn("isolation reconcile: failed to set runtimeClassName",
 				"agentName", agentName, "environment", d.Environment, "runtimeClass", rc, "error", err)
 		}
+	}
+}
+
+// reconcileSystemManagedEnvVars backfills DB-tracked system-managed env vars into each environment's
+// binding, since AutoDeploy creates the first ReleaseBinding without DeployAgent ever running.
+// Only missing vars are written: UpdateReleaseBindingEnvVars stamps restartedAt, so an
+// unconditional write would restart the pod on every deployments poll.
+func (s *agentManagerService) reconcileSystemManagedEnvVars(
+	ctx context.Context, ouID, projectName, agentName string, deployments []*models.DeploymentResponse,
+) {
+	for _, d := range deployments {
+		if d == nil || d.Environment == "" {
+			continue
+		}
+		dbKeys, err := s.agentConfigurationService.ListSystemManagedEnvVarKeys(ctx, agentName, ouID, projectName, d.Environment)
+		if err != nil {
+			s.logger.Warn("system env var reconcile: failed to list DB keys",
+				"agentName", agentName, "environment", d.Environment, "error", err)
+			continue
+		}
+		if len(dbKeys) == 0 {
+			continue
+		}
+
+		live, err := s.ocClient.GetComponentConfigurations(ctx, ouID, projectName, agentName, d.Environment)
+		if err != nil {
+			s.logger.Warn("system env var reconcile: failed to read live configurations",
+				"agentName", agentName, "environment", d.Environment, "error", err)
+			continue
+		}
+		present := make(map[string]bool, len(live))
+		for _, e := range live {
+			present[e.Key] = true
+		}
+		missing := false
+		for k := range dbKeys {
+			if !present[k] {
+				missing = true
+				break
+			}
+		}
+		if !missing {
+			continue
+		}
+
+		dbVars, err := s.agentConfigurationService.BuildSystemManagedEnvVarsFromConfig(ctx, agentName, ouID, projectName, d.Environment)
+		if err != nil {
+			s.logger.Warn("system env var reconcile: failed to build vars from configuration",
+				"agentName", agentName, "environment", d.Environment, "error", err)
+			continue
+		}
+		toInject := make([]client.EnvVar, 0, len(dbVars))
+		for _, v := range dbVars {
+			if !present[v.Key] {
+				toInject = append(toInject, v)
+			}
+		}
+		if len(toInject) == 0 {
+			continue
+		}
+
+		if err := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, projectName, agentName, d.Environment, toInject); err != nil {
+			s.logger.Warn("system env var reconcile: failed to patch release binding",
+				"agentName", agentName, "environment", d.Environment, "error", err)
+			continue
+		}
+		keys := make([]string, 0, len(toInject))
+		for _, v := range toInject {
+			keys = append(keys, v.Key)
+		}
+		s.logger.Info("system env var reconcile: injected vars missing from binding",
+			"agentName", agentName, "environment", d.Environment, "keys", keys)
 	}
 }
 

--- a/agent-manager-service/services/agent_manager_llmconfig_test.go
+++ b/agent-manager-service/services/agent_manager_llmconfig_test.go
@@ -28,14 +28,14 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
 )
 
-// spyConfigService records the request passed to Create and stubs the LLM env var resolver.
-// Only Create and BuildSystemManagedEnvVarsFromConfig are exercised; the embedded interface
-// satisfies the rest (and panics if any other method is called).
+// spyConfigService records the request passed to Create and stubs the system-managed env var
+// resolvers; the embedded interface panics on any other method.
 type spyConfigService struct {
 	AgentConfigurationService
 	lastReq        models.CreateAgentModelConfigRequest
 	systemEnvVars  []client.EnvVar
 	systemEnvVarsE error
+	systemEnvKeys  map[string]bool
 }
 
 func (s *spyConfigService) Create(_ context.Context, _, _, _ string,
@@ -47,6 +47,14 @@ func (s *spyConfigService) Create(_ context.Context, _, _, _ string,
 
 func (s *spyConfigService) BuildSystemManagedEnvVarsFromConfig(_ context.Context, _, _, _, _ string) ([]client.EnvVar, error) {
 	return s.systemEnvVars, s.systemEnvVarsE
+}
+
+func (s *spyConfigService) ListSystemManagedEnvVarKeys(_ context.Context, _, _, _, _ string) (map[string]bool, error) {
+	return s.systemEnvKeys, nil
+}
+
+func (s *spyConfigService) ListAgentLLMConfigSecretReferences(_ context.Context, _, _, _ string) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
 }
 
 func TestCreateAgentLLMConfigs_KeysUnderFirstEnv(t *testing.T) {
@@ -132,4 +140,26 @@ func TestMergeKindWorkloadSystemEnvVars_ResolverError(t *testing.T) {
 
 	_, err := s.mergeKindWorkloadSystemEnvVars(context.Background(), "my-agent", "org", "proj", "Development", nil)
 	require.ErrorIs(t, err, resolverErr, "resolver error must stay unwrappable so callers can inspect it")
+}
+
+// #1736: vars configured while the first build ran exist only in the DB, so a deploy that
+// rebuilds from live cluster state alone would full-replace the overrides without them.
+func TestDeployAgent_InjectsSystemEnvVarsAbsentFromClusterState(t *testing.T) {
+	llmVars := []client.EnvVar{
+		{Key: "OPENAI_BASE_URL", Value: "http://gateway.cluster.local/openai"},
+		{Key: "OPENAI_API_KEY", ValueFrom: &client.EnvVarValueFrom{
+			SecretKeyRef: &client.SecretKeyRef{Name: "secret-ref", Key: "api-key"},
+		}},
+	}
+	s, _, capturedOverrides := deployAPIAgentMocks(nil)
+	s.agentConfigurationService = &spyConfigService{
+		systemEnvVars: llmVars,
+		systemEnvKeys: map[string]bool{"OPENAI_BASE_URL": true, "OPENAI_API_KEY": true},
+	}
+
+	_, err := s.DeployAgent(auditableCtx(t), "acme", "proj1", "my-agent",
+		&spec.DeployAgentRequest{ImageId: "registry.example.com/my-agent:v1"})
+
+	require.NoError(t, err)
+	require.Equal(t, llmVars, *capturedOverrides, "workload overrides must carry the DB-tracked LLM vars")
 }

--- a/agent-manager-service/services/agent_manager_llmconfig_test.go
+++ b/agent-manager-service/services/agent_manager_llmconfig_test.go
@@ -21,11 +21,14 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/spec"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
 // spyConfigService records the request passed to Create and stubs the system-managed env var
@@ -162,4 +165,76 @@ func TestDeployAgent_InjectsSystemEnvVarsAbsentFromClusterState(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, llmVars, *capturedOverrides, "workload overrides must carry the DB-tracked LLM vars")
+}
+
+// Drives GetAgentDeployments for an internal API agent in one environment; liveEnv is what the
+// cluster already carries. Captures the env vars any reconcile writes to the binding.
+func deploymentsReconcileMocks(liveEnv []models.EnvVars, spy *spyConfigService) (*agentManagerService, *[]client.EnvVar, *int) {
+	var captured []client.EnvVar
+	writes := 0
+	ocClient := &clientmocks.OpenChoreoClientMock{
+		GetProjectFunc: func(_ context.Context, _, name string) (*models.ProjectResponse, error) {
+			return &models.ProjectResponse{Name: name, DeploymentPipeline: "default"}, nil
+		},
+		GetDeploymentsFunc: func(context.Context, string, string, string, string) ([]*models.DeploymentResponse, error) {
+			return []*models.DeploymentResponse{{AgentName: "it-help-5", Environment: "default"}}, nil
+		},
+		GetComponentFunc: func(_ context.Context, _, _, _ string) (*models.AgentResponse, error) {
+			return &models.AgentResponse{
+				Provisioning: models.Provisioning{Type: string(utils.InternalAgent)},
+				Type:         models.AgentType{Type: string(utils.AgentTypeAPI)},
+			}, nil
+		},
+		ListEnvironmentsFunc: func(context.Context, string) ([]*models.EnvironmentResponse, error) {
+			return []*models.EnvironmentResponse{{Name: "default"}}, nil
+		},
+		GetComponentConfigurationsFunc: func(context.Context, string, string, string, string) ([]models.EnvVars, error) {
+			return liveEnv, nil
+		},
+		UpdateReleaseBindingEnvVarsFunc: func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
+			captured = envVars
+			writes++
+			return nil
+		},
+	}
+	s := &agentManagerService{ocClient: ocClient, agentConfigurationService: spy, logger: discardLogger()}
+	return s, &captured, &writes
+}
+
+// #1736 creation path: the LLM config is created after the build is triggered and AutoDeploy
+// builds the first binding from that build's Workload, so DeployAgent never runs. The
+// deployments poll must converge the binding on the DB.
+func TestGetAgentDeployments_InjectsSystemEnvVarsMissingFromBinding(t *testing.T) {
+	llmVars := []client.EnvVar{
+		{Key: "OPENAI_URL", Value: "http://gateway.cluster.local/openai"},
+		{Key: "OPENAI_API_KEY", ValueFrom: &client.EnvVarValueFrom{
+			SecretKeyRef: &client.SecretKeyRef{Name: "proxy-secrets", Key: "api-key"},
+		}},
+	}
+	spy := &spyConfigService{
+		systemEnvVars: llmVars,
+		systemEnvKeys: map[string]bool{"OPENAI_URL": true, "OPENAI_API_KEY": true},
+	}
+	s, captured, writes := deploymentsReconcileMocks([]models.EnvVars{{Key: "OPENAI_API_TEST", Value: "123"}}, spy)
+
+	_, err := s.GetAgentDeployments(context.Background(), "acme", "default", "it-help-5")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, *writes, "the binding must be patched exactly once")
+	assert.ElementsMatch(t, llmVars, *captured, "both LLM vars must be merged into the binding")
+}
+
+// UpdateReleaseBindingEnvVars stamps restartedAt, so an unconditional write would restart the
+// pod on every poll.
+func TestGetAgentDeployments_SkipsWriteWhenSystemEnvVarsAlreadyPresent(t *testing.T) {
+	spy := &spyConfigService{
+		systemEnvVars: []client.EnvVar{{Key: "OPENAI_URL", Value: "http://gateway.cluster.local/openai"}},
+		systemEnvKeys: map[string]bool{"OPENAI_URL": true},
+	}
+	s, _, writes := deploymentsReconcileMocks([]models.EnvVars{{Key: "OPENAI_URL", Value: "http://gateway.cluster.local/openai"}}, spy)
+
+	_, err := s.GetAgentDeployments(context.Background(), "acme", "default", "it-help-5")
+
+	require.NoError(t, err)
+	assert.Zero(t, *writes, "nothing is missing, so the binding must not be rewritten")
 }

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -537,7 +537,12 @@ func TestDeployAgent_IdentityInjectionError_AbortsDeploy(t *testing.T) {
 			return nil, boom
 		},
 	}
-	s := &agentManagerService{ocClient: ocClient, agentIdentityInjection: injector, logger: discardLogger()}
+	s := &agentManagerService{
+		ocClient:                  ocClient,
+		agentIdentityInjection:    injector,
+		agentConfigurationService: &spyConfigService{},
+		logger:                    discardLogger(),
+	}
 
 	_, err := s.DeployAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.DeployAgentRequest{ImageId: "registry.example.com/my-agent:v1"})
 
@@ -576,7 +581,12 @@ func TestUpdateAgentConfigurations_IdentityInjectionError_AbortsUpdate(t *testin
 			return nil, boom
 		},
 	}
-	s := &agentManagerService{ocClient: ocClient, agentIdentityInjection: injector, logger: discardLogger()}
+	s := &agentManagerService{
+		ocClient:                  ocClient,
+		agentIdentityInjection:    injector,
+		agentConfigurationService: &spyConfigService{},
+		logger:                    discardLogger(),
+	}
 
 	err := s.UpdateAgentConfigurations(context.Background(), "acme", "proj1", "my-agent",
 		&spec.UpdateAgentConfigurationsRequest{EnvironmentName: "dev"})
@@ -1720,9 +1730,13 @@ func TestResolveResilienceTimeoutSeconds(t *testing.T) {
 	}
 }
 
-// OpenChoreo client and repository mocks needed to drive DeployAgent
-func deployAPIAgentMocks(existingConfig *models.AgentConfig) (*agentManagerService, *client.ComponentDeploymentConfigRequest) {
+// OpenChoreo client and repository mocks needed to drive DeployAgent. Its config service resolves
+// no system-managed vars; tests that need them replace it.
+func deployAPIAgentMocks(existingConfig *models.AgentConfig) (
+	*agentManagerService, *client.ComponentDeploymentConfigRequest, *[]client.EnvVar,
+) {
 	var capturedDeployConfig client.ComponentDeploymentConfigRequest
+	var capturedOverrideEnvVars []client.EnvVar
 	ocClient := &clientmocks.OpenChoreoClientMock{
 		GetOrganizationFunc: func(_ context.Context, name string) (*models.OrganizationResponse, error) {
 			return &models.OrganizationResponse{Name: name}, nil
@@ -1752,7 +1766,8 @@ func deployAPIAgentMocks(existingConfig *models.AgentConfig) (*agentManagerServi
 		// component-wide base alone. ReplaceComponentEnvVars and ReplaceComponentFileMounts are
 		// left unstubbed on purpose: a regression that writes the shared base again panics here
 		// instead of silently leaking config into every environment.
-		ReplaceReleaseBindingWorkloadOverridesFunc: func(context.Context, string, string, string, []client.EnvVar, []client.FileVar) error {
+		ReplaceReleaseBindingWorkloadOverridesFunc: func(_ context.Context, _, _, _ string, envVars []client.EnvVar, _ []client.FileVar) error {
+			capturedOverrideEnvVars = envVars
 			return nil
 		},
 		UpdateComponentDeploymentConfigFunc: func(_ context.Context, _, _, _ string, req client.ComponentDeploymentConfigRequest) error {
@@ -1789,13 +1804,14 @@ func deployAPIAgentMocks(existingConfig *models.AgentConfig) (*agentManagerServi
 		},
 	}
 	s := &agentManagerService{
-		ocClient:               ocClient,
-		agentIdentityInjection: injector,
-		artifactRepo:           artifactRepo,
-		agentConfigRepo:        agentConfigRepo,
-		logger:                 discardLogger(),
+		ocClient:                  ocClient,
+		agentIdentityInjection:    injector,
+		artifactRepo:              artifactRepo,
+		agentConfigRepo:           agentConfigRepo,
+		agentConfigurationService: &spyConfigService{},
+		logger:                    discardLogger(),
 	}
-	return s, &capturedDeployConfig
+	return s, &capturedDeployConfig, &capturedOverrideEnvVars
 }
 
 // covers the deploy-time wiring of ResilienceTimeoutSeconds into the
@@ -1812,7 +1828,7 @@ func TestDeployAgent_APIAgent_ResilienceTimeout(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, capturedDeployConfig := deployAPIAgentMocks(tc.existingConfig)
+			s, capturedDeployConfig, _ := deployAPIAgentMocks(tc.existingConfig)
 
 			env, err := s.DeployAgent(auditableCtx(t), "acme", "proj1", "my-agent", &spec.DeployAgentRequest{ImageId: "registry.example.com/my-agent:v1"})
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Resolves #1736 

When an LLM provider is connected to an agent, the platform must place two values into the running container: the model endpoint URL and a reference to the secret holding the API key. These are always recorded in the database, but the container actually runs on what the build produced plus the environment's deploy settings — the database is never read at runtime. Two separate gaps meant those values could stay in the database and never reach the container, leaving the agent unable to reach its model.

The first gap was in deploy. Deploy rebuilt the list of LLM variables purely from what it could already see in the cluster. When the values had never been delivered, it found nothing, concluded there was nothing worth keeping, and then overwrote the deploy settings with a list that left them out — erasing them by rebuilding an incomplete picture. Promote already read from the database; deploy was the one path that did not. Deploy now falls back to the database for anything missing, so the values are restored instead of dropped.

The second gap is the one in the reported issue, and it affects brand-new agents. The console creates the agent — which immediately starts a build — and only then creates the LLM provider configuration, so the build captures a recipe with no LLM variables in it. The platform also tries to write the values straight into the environment's deploy settings at that moment, but a brand-new agent has none yet, so that write does nothing. Because these agents have auto-deploy enabled, the platform deploys them by itself once the build finishes, meaning the deploy code — and its new database fallback — never runs at all. The fix follows an existing precedent for exactly this auto-deploy blind spot: when the console polls for deployment status, compare the database against what the environment actually has and add anything missing. It only writes when something is genuinely absent, because every write stamps a restart timestamp and writing on each poll would restart the pod in a loop. A new agent now heals itself within seconds of its build landing, with no deploy needed.

Resolves #1736

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved system-managed environment variables during agent configuration updates and deployments.
  * Restored missing system-managed variables from saved configuration when they are absent from live deployment state.
  * Prevented unnecessary deployment binding updates when required variables are already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->