### PR TITLE
Fix build/deploy related issues 

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployment_readiness_test.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -258,5 +259,109 @@ func TestNotReadyResourceIsReportedAsFailed(t *testing.T) {
 			externalSecretNode("env-secrets", "False", "SecretSyncedError", syncErr),
 		)
 		assert.False(t, runtimeReplicaStateFromTree(tree).isFailed())
+	})
+}
+
+// bindingBootingSince returns a Ready binding whose last deploy happened `ago` in the past,
+// which is what bootDeadlineExceeded measures against. LastSpecUpdateTime is set because
+// getLastDeployedTime takes the max of it and the Ready condition's transition time.
+func bindingBootingSince(ago time.Duration) *gen.ReleaseBinding {
+	binding := readyBinding()
+	deployedAt := time.Now().Add(-ago)
+	(*binding.Status.Conditions)[0].LastTransitionTime = deployedAt
+	binding.Status.LastSpecUpdateTime = &deployedAt
+	return binding
+}
+
+// An agent whose container never binds its port fails its TCP startup probe forever: the
+// pod is replaced every few minutes, and because pods are absent from the resource tree and
+// the warm pool reports Healthy with zero ready replicas, every payload the control plane
+// sees is identical to a healthy boot. Without a deadline the deployment reports
+// "in-progress" for as long as the agent exists.
+func TestBootingPastTheStartupBudgetIsReportedAsFailed(t *testing.T) {
+	booting := runtimeReplicaState{found: true, desired: 1, ready: 0}
+
+	t.Run("within the budget is still in progress", func(t *testing.T) {
+		binding := bindingBootingSince(agentStartupBudget / 2)
+		assert.Equal(t, DeploymentStatusInProgress, determineDeploymentStatus(binding, booting))
+	})
+
+	t.Run("past the budget is failed", func(t *testing.T) {
+		binding := bindingBootingSince(agentStartupBudget + time.Minute)
+		assert.Equal(t, DeploymentStatusFailed, determineDeploymentStatus(binding, booting),
+			"a startup probe that has already given up is not still starting")
+	})
+
+	t.Run("a serving agent is never failed by age", func(t *testing.T) {
+		// The budget only applies to a boot in progress. A long-running healthy agent has
+		// a last-deployed time far in the past and must stay active.
+		serving := runtimeReplicaState{found: true, desired: 1, ready: 1}
+		binding := bindingBootingSince(30 * 24 * time.Hour)
+		assert.Equal(t, DeploymentStatusActive, determineDeploymentStatus(binding, serving))
+	})
+
+	t.Run("unknown readiness is never failed by age", func(t *testing.T) {
+		// Tree fetch failed or no warm pool node: isBooting() is false, so the binding
+		// alone decides and the deadline is never consulted.
+		binding := bindingBootingSince(agentStartupBudget + time.Minute)
+		assert.Equal(t, DeploymentStatusActive, determineDeploymentStatus(binding, runtimeReplicaState{}))
+	})
+
+	t.Run("a binding with no timestamps stays in progress", func(t *testing.T) {
+		// getLastDeployedTime returns the zero time when the binding carries no condition
+		// transition, no spec update and no creation timestamp. time.Since(zero) is
+		// centuries, so without the IsZero guard every such binding would report failed.
+		binding := readyBinding()
+		assert.True(t, getLastDeployedTime(binding).IsZero(), "guards the premise of this case")
+		assert.Equal(t, DeploymentStatusInProgress, determineDeploymentStatus(binding, booting))
+	})
+
+	t.Run("an old binding with no deploy timestamps stays in progress", func(t *testing.T) {
+		// Creation dates the binding, not an attempt to start the agent. A binding that
+		// has existed for weeks and is redeploying now must not be failed on the strength
+		// of its age, so the budget is measured from deployAttemptTime, which excludes
+		// the creation timestamp getLastDeployedTime falls back to.
+		binding := readyBinding()
+		created := time.Now().Add(-30 * 24 * time.Hour)
+		binding.Metadata.CreationTimestamp = &created
+		(*binding.Status.Conditions)[0].LastTransitionTime = time.Time{}
+		binding.Status.LastSpecUpdateTime = nil
+
+		assert.Equal(t, created, getLastDeployedTime(binding),
+			"display still falls back to creation")
+		assert.True(t, deployAttemptTime(binding).IsZero(),
+			"but no deploy attempt is recorded")
+		assert.Equal(t, DeploymentStatusInProgress, determineDeploymentStatus(binding, booting))
+	})
+
+	t.Run("an overrunning boot does not override suspended", func(t *testing.T) {
+		binding := bindingBootingSince(agentStartupBudget + time.Minute)
+		state := gen.ReleaseBindingSpecStateUndeploy
+		binding.Spec.State = &state
+		assert.Equal(t, DeploymentStatusSuspended, determineDeploymentStatus(binding, booting))
+	})
+}
+
+// The probed port is the one fact in the failure log that distinguishes a misdeclared port
+// from an agent that is merely slow, so it must survive the shapes a binding can take.
+func TestProbedPorts(t *testing.T) {
+	t.Run("reads the service URL port", func(t *testing.T) {
+		port := int32(8000)
+		binding := readyBinding()
+		binding.Status.Endpoints = &[]gen.EndpointURLStatus{{
+			Name:       "it-helpdesk-endpoint",
+			ServiceURL: &gen.EndpointURL{Host: "it-helpdesk.dp-default", Port: &port},
+		}}
+		assert.Equal(t, []int32{8000}, probedPorts(binding))
+	})
+
+	t.Run("an endpoint without a service URL contributes nothing", func(t *testing.T) {
+		binding := readyBinding()
+		binding.Status.Endpoints = &[]gen.EndpointURLStatus{{Name: "no-url"}}
+		assert.Empty(t, probedPorts(binding))
+	})
+
+	t.Run("no endpoints is empty, not a panic", func(t *testing.T) {
+		assert.Empty(t, probedPorts(readyBinding()))
 	})
 }

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -1192,14 +1192,45 @@ const agentStartupBudget = 10 * time.Minute
 // bootDeadlineExceeded reports whether a booting agent has been booting for longer than
 // any pod could plausibly take to start.
 //
-// A binding with no usable timestamp returns false: without a clock this cannot prove the
-// agent is failed, and reporting a healthy-but-slow rollout as failed is the worse error.
+// Measured from deployAttemptTime, never from getLastDeployedTime: the latter falls back
+// to the binding's creation timestamp, which would date a rollout that has just started
+// to whenever the binding first appeared and fail it on the spot.
+//
+// A binding whose status records no deploy returns false: without a clock this cannot
+// prove the agent is failed, and reporting a healthy-but-slow rollout as failed is the
+// worse error.
 func bootDeadlineExceeded(binding *gen.ReleaseBinding) bool {
-	started := getLastDeployedTime(binding)
+	started := deployAttemptTime(binding)
 	if started.IsZero() {
 		return false
 	}
 	return time.Since(started) > agentStartupBudget
+}
+
+// probedPorts lists the ports the platform's TCP startup probe targets, taken from the
+// endpoints the binding publishes. Logged when a boot overruns its budget: the platform
+// cannot see inside the pod, so the port it probes is the one fact that lets an operator
+// tell a wrongly-declared port (or an agent bound to 127.0.0.1) from an agent that is
+// merely too slow. Empty when the binding publishes no service URL.
+func probedPorts(binding *gen.ReleaseBinding) []int32 {
+	if binding.Status == nil || binding.Status.Endpoints == nil {
+		return nil
+	}
+	var ports []int32
+	for _, ep := range *binding.Status.Endpoints {
+		if ep.ServiceURL != nil && ep.ServiceURL.Port != nil {
+			ports = append(ports, *ep.ServiceURL.Port)
+		}
+	}
+	return ports
+}
+
+// bindingEnvironment is a nil-safe read of the binding's environment for logging.
+func bindingEnvironment(binding *gen.ReleaseBinding) string {
+	if binding.Spec == nil {
+		return ""
+	}
+	return binding.Spec.Environment
 }
 
 // determineDeploymentStatus determines deployment status from release binding conditions,
@@ -1239,6 +1270,21 @@ func determineDeploymentStatus(binding *gen.ReleaseBinding, runtime runtimeRepli
 					// left, so a boot that overruns its budget is reported as failed
 					// rather than sitting at in-progress forever.
 					if bootDeadlineExceeded(binding) {
+						// The response carries only a status, so this log is the sole
+						// record of WHY a deployment went from starting to failed. It
+						// names what was observed — nothing accepted connections on the
+						// probed port in time — and not a cause: a wrong port, a bind to
+						// 127.0.0.1, a crash during startup and a CPU-throttled import
+						// are indistinguishable from outside the pod, so asserting one
+						// would send the operator after the wrong problem.
+						slog.Debug("Agent never became ready within the startup budget, reporting failed",
+							"binding", binding.Metadata.Name,
+							"environment", bindingEnvironment(binding),
+							"elapsed", time.Since(deployAttemptTime(binding)).Round(time.Second),
+							"budget", agentStartupBudget,
+							"probedPorts", probedPorts(binding),
+							"desiredReplicas", runtime.desired,
+							"readyReplicas", runtime.ready)
 						return DeploymentStatusFailed
 					}
 					return DeploymentStatusInProgress
@@ -1326,6 +1372,26 @@ func toDeploymentDetailsResponse(binding *gen.ReleaseBinding, componentRelease *
 // Sandbox agents stay Ready=True across redeploys — only LastSpecUpdateTime changes on each
 // deploy — so we take the max of both to return the true last-deployed time.
 func getLastDeployedTime(binding *gen.ReleaseBinding) time.Time {
+	if t := deployAttemptTime(binding); !t.IsZero() {
+		return t
+	}
+	// Nothing records a deploy: the binding has existed since creation without one
+	// being observed, which is the closest answer available for display.
+	if binding.Metadata.CreationTimestamp != nil {
+		return *binding.Metadata.CreationTimestamp
+	}
+
+	return time.Time{}
+}
+
+// deployAttemptTime returns when the current deploy attempt was last observed, from the
+// binding's status alone. Zero when the status records no deploy.
+//
+// Deliberately excludes Metadata.CreationTimestamp, which getLastDeployedTime falls back
+// to: creation dates a binding, not an attempt to start the agent. A binding created
+// weeks ago and redeployed a moment ago would otherwise measure a rollout that has just
+// begun as weeks old.
+func deployAttemptTime(binding *gen.ReleaseBinding) time.Time {
 	var readyTime, specUpdateTime time.Time
 
 	if binding.Status != nil {
@@ -1341,18 +1407,10 @@ func getLastDeployedTime(binding *gen.ReleaseBinding) time.Time {
 		}
 	}
 
-	t := readyTime
-	if specUpdateTime.After(t) {
-		t = specUpdateTime
+	if specUpdateTime.After(readyTime) {
+		return specUpdateTime
 	}
-	if !t.IsZero() {
-		return t
-	}
-	if binding.Metadata.CreationTimestamp != nil {
-		return *binding.Metadata.CreationTimestamp
-	}
-
-	return time.Time{}
+	return readyTime
 }
 
 // extractEndpointsFromBinding extracts endpoint URLs from the release binding status

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -1172,6 +1172,36 @@ func (c *openChoreoClient) fetchRuntimeReplicaState(ctx context.Context, namespa
 	return state
 }
 
+// agentStartupBudget bounds how long an agent may report "still starting" before the
+// deployment is called failed instead.
+//
+// The number comes from the probes the agent-api component type renders (see
+// component-types/agent-api.yaml): a startup probe of initialDelaySeconds 10 +
+// periodSeconds 5 x failureThreshold 60 = 310s, after which kubelet kills the container
+// and the warm pool replaces the pod. The extra slack covers what happens before the
+// container starts at all — pulling the agent image and running the instrumentation init
+// container — which is charged to the same clock, because the only timestamp available
+// is the binding's (getLastDeployedTime), not the container's.
+//
+// Past this point the startup probe has already given up at least once, so nothing is
+// still starting. Observed case: an agent throttled at its 100m CPU limit never finished
+// importing, never bound its port, and cycled pods every ~5 minutes while the console
+// showed "in progress" indefinitely.
+const agentStartupBudget = 10 * time.Minute
+
+// bootDeadlineExceeded reports whether a booting agent has been booting for longer than
+// any pod could plausibly take to start.
+//
+// A binding with no usable timestamp returns false: without a clock this cannot prove the
+// agent is failed, and reporting a healthy-but-slow rollout as failed is the worse error.
+func bootDeadlineExceeded(binding *gen.ReleaseBinding) bool {
+	started := getLastDeployedTime(binding)
+	if started.IsZero() {
+		return false
+	}
+	return time.Since(started) > agentStartupBudget
+}
+
 // determineDeploymentStatus determines deployment status from release binding conditions,
 // downgrading "active" to "in-progress" while the agent's pods are still starting.
 // Pass an unknown runtimeReplicaState to derive the status from the binding alone.
@@ -1202,6 +1232,15 @@ func determineDeploymentStatus(binding *gen.ReleaseBinding, runtime runtimeRepli
 					return DeploymentStatusFailed
 				}
 				if runtime.isBooting() {
+					// Nothing in the resource tree distinguishes "still starting" from
+					// "will never start": pods are absent from it, the warm pool reports
+					// Healthy at zero ready replicas, and it publishes no Ready condition
+					// for notReadyResource to pick up. Elapsed time is the only signal
+					// left, so a boot that overruns its budget is reported as failed
+					// rather than sitting at in-progress forever.
+					if bootDeadlineExceeded(binding) {
+						return DeploymentStatusFailed
+					}
 					return DeploymentStatusInProgress
 				}
 				return DeploymentStatusActive

--- a/console/workspaces/pages/configure-agent/src/Configure.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/Configure.Component.tsx
@@ -80,7 +80,8 @@ const mcpLabels: AgentConfigTableLabels = {
 
 // A build only yields a runnable image in these two states; the API reports
 // success under both names.
-const isBuildComplete = (build: BuildResponse) => build.status === "Completed";
+const isBuildComplete = (build: BuildResponse) =>
+  build.status === "Completed" || build.status === "Succeeded";
 
 const NO_COMPLETED_BUILD_REASON =
   "Complete a build for this agent before adding configurations.";
@@ -153,9 +154,14 @@ export const ConfigureComponent: React.FC = () => {
   // agent runs somewhere else entirely and a kind-sourced one takes its image
   // from the published kind, so neither has a build of its own to wait for —
   // gating them would strand their configuration behind a build they cannot
-  // start. Both are also held back until the agent itself has loaded, so the
-  // buttons are never disabled on first paint for an agent that turns out to be
-  // exempt or already built.
+  // start.
+  //
+  // The gate fails open, deliberately. It is a hint, not an authorization check:
+  // nothing server-side refuses a configuration for an agent with no build, and
+  // a configuration added early is a deletable row, not damage. So while either
+  // query is in flight — or if the agent lookup fails outright — the buttons
+  // stay enabled rather than telling every visitor to "complete a build" for an
+  // agent that is exempt, already built, or merely slow to load.
   const { data: agent } = useGetAgent({
     orgName: orgId,
     projName: projectId,

--- a/console/workspaces/pages/configure-agent/src/Configure.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/Configure.Component.tsx
@@ -22,10 +22,15 @@ import { PageLayout } from "@agent-management-platform/views";
 import {
   useDeleteAgentMCPConfig,
   useDeleteAgentModelConfig,
+  useGetAgent,
+  useGetAgentBuilds,
   useListAgentMCPConfigs,
   useListAgentModelConfigs,
 } from "@agent-management-platform/api-client";
-import { absoluteRouteMap } from "@agent-management-platform/types";
+import {
+  absoluteRouteMap,
+  type BuildResponse,
+} from "@agent-management-platform/types";
 import {
   AgentConfigTableSection,
   type AgentConfigTableLabels,
@@ -52,7 +57,8 @@ const llmLabels: AgentConfigTableLabels = {
   removeTooltip: "Remove LLM configuration",
   removeConfirmation: () =>
     "This will remove the LLM configuration and its environment variable mappings from the agent. The catalog service itself will not be affected.",
-  removeAriaLabel: (config) => `Remove configuration ${config.name || config.uuid}`,
+  removeAriaLabel: (config) =>
+    `Remove configuration ${config.name || config.uuid}`,
 };
 
 const mcpLabels: AgentConfigTableLabels = {
@@ -72,6 +78,13 @@ const mcpLabels: AgentConfigTableLabels = {
   removeAriaLabel: (config) => `Remove ${config.name}`,
 };
 
+// A build only yields a runnable image in these two states; the API reports
+// success under both names.
+const isBuildComplete = (build: BuildResponse) => build.status === "Completed";
+
+const NO_COMPLETED_BUILD_REASON =
+  "Complete a build for this agent before adding configurations.";
+
 type TabPanelProps = {
   value: number;
   index: number;
@@ -89,7 +102,9 @@ function TabPanel({ value, index, children }: TabPanelProps) {
 export const ConfigureComponent: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const requestedTabIndex = CONFIGURE_TAB_KEYS.indexOf(
-    searchParams.get(CONFIGURE_TAB_PARAM) as (typeof CONFIGURE_TAB_KEYS)[number],
+    searchParams.get(
+      CONFIGURE_TAB_PARAM,
+    ) as (typeof CONFIGURE_TAB_KEYS)[number],
   );
   const tabIndex = requestedTabIndex === -1 ? 0 : requestedTabIndex;
   const handleTabChange = (_: React.SyntheticEvent, index: number) => {
@@ -128,6 +143,36 @@ export const ConfigureComponent: React.FC = () => {
     { orgName: orgId, projName: projectId, agentName: agentId },
     { limit: 1000, offset: 0 },
   );
+  // Adding a configuration is pointless until the agent has an image to run it
+  // against, so the Add buttons stay closed until at least one build has
+  // completed — an agent whose builds have all failed is blocked for the same
+  // reason as one whose only build is still running. Later builds never
+  // re-block: an earlier completed build has already produced an image.
+  //
+  // The gate only applies to agents that build their own image. An external
+  // agent runs somewhere else entirely and a kind-sourced one takes its image
+  // from the published kind, so neither has a build of its own to wait for —
+  // gating them would strand their configuration behind a build they cannot
+  // start. Both are also held back until the agent itself has loaded, so the
+  // buttons are never disabled on first paint for an agent that turns out to be
+  // exempt or already built.
+  const { data: agent } = useGetAgent({
+    orgName: orgId,
+    projName: projectId,
+    agentName: agentId,
+  });
+  const buildsOwnImage =
+    !!agent && agent.provisioning?.type !== "external" && !agent.kindName;
+
+  const { data: buildsData, isLoading: isLoadingBuilds } = useGetAgentBuilds({
+    orgName: orgId,
+    projName: projectId,
+    agentName: agentId,
+  });
+  const builds = useMemo(() => buildsData?.builds ?? [], [buildsData]);
+  const hasNoCompletedBuild =
+    buildsOwnImage && !isLoadingBuilds && !builds.some(isBuildComplete);
+
   const { mutate: deleteLLMConfig, isPending: isRemovingLLM } =
     useDeleteAgentModelConfig();
   const { mutate: deleteMCPConfig, isPending: isRemovingMCP } =
@@ -193,6 +238,8 @@ export const ConfigureComponent: React.FC = () => {
             getViewPath={getLlmViewPath}
             isRemoving={isRemovingLLM}
             showTitle={false}
+            addDisabled={hasNoCompletedBuild}
+            addDisabledReason={NO_COMPLETED_BUILD_REASON}
             onRemove={(configId) =>
               deleteLLMConfig({
                 ...deleteParams,
@@ -212,6 +259,8 @@ export const ConfigureComponent: React.FC = () => {
             getViewPath={getMcpViewPath}
             isRemoving={isRemovingMCP}
             showTitle={false}
+            addDisabled={hasNoCompletedBuild}
+            addDisabledReason={NO_COMPLETED_BUILD_REASON}
             onRemove={(configId) =>
               deleteMCPConfig({
                 ...deleteParams,

--- a/console/workspaces/pages/configure-agent/src/Configure/subComponents/AgentConfigTableSection.tsx
+++ b/console/workspaces/pages/configure-agent/src/Configure/subComponents/AgentConfigTableSection.tsx
@@ -87,6 +87,14 @@ interface AgentConfigTableSectionProps {
    * under a tab whose label already names it. Defaults to true.
    */
   showTitle?: boolean;
+  /**
+   * Blocks the Add button for a reason of the caller's own (e.g. the agent's
+   * first build has not produced an image yet). Independent of the internal
+   * route-param check, which disables the button regardless.
+   */
+  addDisabled?: boolean;
+  /** Tooltip explaining `addDisabled`. Required for the block to be discoverable. */
+  addDisabledReason?: string;
 }
 
 /**
@@ -105,6 +113,8 @@ export function AgentConfigTableSection({
   onRemove,
   isRemoving = false,
   showTitle = true,
+  addDisabled = false,
+  addDisabledReason,
 }: AgentConfigTableSectionProps) {
   const { orgId, projectId, agentId } = useParams<{
     orgId: string;
@@ -118,7 +128,7 @@ export function AgentConfigTableSection({
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
-  const canAdd = Boolean(orgId && projectId && agentId);
+  const canAdd = Boolean(orgId && projectId && agentId) && !addDisabled;
 
   const filteredConfigs = useMemo(() => {
     if (!searchValue.trim()) return configs;
@@ -163,8 +173,8 @@ export function AgentConfigTableSection({
     });
   };
 
-  const addButton = (variant: "contained" | "outlined") =>
-    onAdd ? (
+  const addButton = (variant: "contained" | "outlined") => {
+    const button = onAdd ? (
       <Button
         variant={variant}
         color="primary"
@@ -188,6 +198,15 @@ export function AgentConfigTableSection({
         {labels.addButtonLabel}
       </Button>
     );
+    if (!addDisabled || !addDisabledReason) return button;
+    // A disabled MUI Button drops pointer events, so the tooltip has to listen
+    // on a wrapper — otherwise the one explanation the user needs never shows.
+    return (
+      <Tooltip title={addDisabledReason}>
+        <span>{button}</span>
+      </Tooltip>
+    );
+  };
 
   const toolbar = (
     <ListingTable.Toolbar

--- a/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/DeployCard.tsx
@@ -97,6 +97,22 @@ import { useCallback, useMemo, useState } from "react";
 import { EditResourceConfigsDrawer } from "./EditResourceConfigsDrawer";
 import { PromoteAgentDrawer } from "./PromoteAgentDrawer";
 
+// Statuses where a deployment exists in the environment and can therefore be
+// torn down. Suspend flips the release binding's state to Undeploy, which
+// OpenChoreo reconciles by DELETING the rendered releases — it is level-
+// triggered, so it is well defined mid-rollout and against a crash-looping
+// agent, neither of which the backend restricts. Gating on ACTIVE alone left
+// the only stop button disabled exactly when it is most needed: a wedged
+// rollout (an unpullable image never leaves "in-progress") or a failing agent
+// restarting in a loop. Only not-deployed/suspended are excluded — there is
+// nothing to undeploy.
+const SUSPENDABLE_STATUSES: DeploymentStatus[] = [
+  DeploymentStatus.ACTIVE,
+  DeploymentStatus.DEPLOYING,
+  DeploymentStatus.ERROR,
+  DeploymentStatus.FAILED,
+];
+
 function DeploymentStatusPanel({ status }: { status: DeploymentStatus }) {
   const theme = useTheme();
   const backgroundColor = useMemo(() => {
@@ -662,7 +678,6 @@ export function DeployCard(props: DeployCardProps) {
                       sx={{ padding: 0.5 }}
                       startIcon={<SlidersVertical size={16} />}
                       onClick={handleOpenConfigureDrawer}
-                      disabled={currentDeployment?.status === DeploymentStatus.DEPLOYING}
                     >
                       Configure
                     </Button>
@@ -789,7 +804,9 @@ export function DeployCard(props: DeployCardProps) {
                       onClick={handleStop}
                       disabled={
                         isUpdating ||
-                        currentDeployment?.status !== DeploymentStatus.ACTIVE
+                        !SUSPENDABLE_STATUSES.includes(
+                          currentDeployment?.status as DeploymentStatus,
+                        )
                       }
                     >
                       Suspend


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

1. [UI] Enable suspend and configure while a deployment is in progress
2. [UI] Disable adding configurations until a build has completed
3. Fail a deployment whose agent never finishes starting

A binding reports Ready=True as soon as its resources are applied, so readiness comes from the warm pool's replica counts instead. An agent that never binds its port sits at desired=1/ready=0 forever: its TCP startup probe fails, kubelet kills the container, the pool replaces the pod, and the cycle repeats. Nothing in the resource tree distinguishes that from a healthy boot — pods are absent from the tree, the pool reports Healthy at zero ready replicas and publishes no Ready condition for notReadyResource to pick up — so the deployment reported "in-progress" indefinitely.

Elapsed time is the only signal left. Past the startup budget the probe has already given up at least once, so report failed instead. A binding with no usable timestamp is left alone: without a clock this cannot
prove failure, and calling a slow-but-healthy rollout failed is worse.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a 10-minute startup deadline for booting agents; deployments now fail when startup takes too long.
  * Configuration options remain unavailable until an agent has at least one completed build, with an explanation shown when disabled.

* **Bug Fixes**
  * Agents in additional deployment states can now be suspended.
  * Configuration editing is available while a deployment is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->