### PR TITLE
Disable blocked tools in the MCP Create Scope picker

### DIFF
--- a/console/workspaces/pages/mcp-proxies/src/subComponents/CreateScopeDrawer.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/CreateScopeDrawer.tsx
@@ -29,7 +29,7 @@ import {
   TextField,
   Typography,
 } from "@wso2/oxygen-ui";
-import { Plus } from "@wso2/oxygen-ui-icons-react";
+import { Plus, ShieldX } from "@wso2/oxygen-ui-icons-react";
 import {
   DrawerContent,
   DrawerHeader,
@@ -95,6 +95,13 @@ interface CreateScopeDrawerProps {
   environments: Environment[];
   /** Tool identifiers discovered on the current endpoint, offered as scope bindings. */
   tools: string[];
+  /**
+   * Subset of `tools` the endpoint's Manage Tools ACL currently blocks. Listed
+   * but not selectable: binding a scope to a tool the gateway already refuses
+   * would enforce nothing, while hiding them outright would leave the picker
+   * looking empty under a deny-all ACL and give no hint where the tool went.
+   */
+  blockedTools: ReadonlySet<string>;
 }
 
 export function CreateScopeDrawer({
@@ -104,6 +111,7 @@ export function CreateScopeDrawer({
   proxyId,
   environments,
   tools,
+  blockedTools,
 }: CreateScopeDrawerProps) {
   const [formData, setFormData] = useState<CreateScopeFormValues>(DEFAULT_FORM);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
@@ -314,6 +322,34 @@ export function CreateScopeDrawer({
                 options={tools}
                 value={selectedTools}
                 onChange={(_e, value) => setSelectedTools(value)}
+                getOptionDisabled={(tool) => blockedTools.has(tool)}
+                renderOption={(optionProps, tool) => {
+                  const { key, ...liProps } = optionProps;
+                  return (
+                    <li key={key} {...liProps}>
+                      <Stack direction="row" alignItems="center" spacing={1}>
+                        {tool}
+                        {blockedTools.has(tool) && (
+                          // Spelled out in the row rather than behind the tool
+                          // table's tooltip: MUI gives a disabled option
+                          // `pointer-events: none`, so no hover affordance on
+                          // one would ever fire.
+                          <Stack
+                            color="warning.main"
+                            direction="row"
+                            alignItems="center"
+                            spacing={0.5}
+                          >
+                            <ShieldX size={14} />
+                            <Typography component="span" variant="caption">
+                              Blocked in Manage Tools
+                            </Typography>
+                          </Stack>
+                        )}
+                      </Stack>
+                    </li>
+                  );
+                }}
                 renderTags={(value, getTagProps) =>
                   value.map((tool, index) => (
                     <Chip {...getTagProps({ index })} key={tool} label={tool} size="small" />

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/CreateScopeDrawer.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/CreateScopeDrawer.tsx
@@ -325,27 +325,34 @@ export function CreateScopeDrawer({
                 getOptionDisabled={(tool) => blockedTools.has(tool)}
                 renderOption={(optionProps, tool) => {
                   const { key, ...liProps } = optionProps;
+                  if (!blockedTools.has(tool)) {
+                    return (
+                      <li key={key} {...liProps}>
+                        {tool}
+                      </li>
+                    );
+                  }
+                  // Spelled out in the row rather than behind the tool table's
+                  // tooltip: MUI gives a disabled option `pointer-events: none`,
+                  // so no hover affordance on one would ever fire. The name gets
+                  // its own <span> because Stack's spacing selector matches only
+                  // element siblings — a bare text node would sit flush against
+                  // the marker.
                   return (
                     <li key={key} {...liProps}>
                       <Stack direction="row" alignItems="center" spacing={1}>
-                        {tool}
-                        {blockedTools.has(tool) && (
-                          // Spelled out in the row rather than behind the tool
-                          // table's tooltip: MUI gives a disabled option
-                          // `pointer-events: none`, so no hover affordance on
-                          // one would ever fire.
-                          <Stack
-                            color="warning.main"
-                            direction="row"
-                            alignItems="center"
-                            spacing={0.5}
-                          >
-                            <ShieldX size={14} />
-                            <Typography component="span" variant="caption">
-                              Blocked in Manage Tools
-                            </Typography>
-                          </Stack>
-                        )}
+                        <span>{tool}</span>
+                        <Stack
+                          color="warning.main"
+                          direction="row"
+                          alignItems="center"
+                          spacing={0.5}
+                        >
+                          <ShieldX size={14} />
+                          <Typography component="span" variant="caption">
+                            Blocked by Manage Tools
+                          </Typography>
+                        </Stack>
                       </Stack>
                     </li>
                   );

--- a/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
+++ b/console/workspaces/pages/mcp-proxies/src/subComponents/MCPProxySecurityTab.tsx
@@ -791,6 +791,7 @@ export function MCPProxySecurityTab({
           proxyId={proxyId}
           environments={environments}
           tools={toolEntries}
+          blockedTools={blockedToolIds}
         />
       )}
     </Stack>


### PR DESCRIPTION
## Purpose
The MCP Server Security → Create Scope drawer offered every discovered tool in its "Tools" picker, including tools switched off in the Manage Tools tab. Binding a new scope to a tool the gateway already refuses enforces nothing, so the picker was inviting dead bindings.

Resolves https://github.com/wso2/agent-manager/issues/1743

## Goals
Make the Create Scope drawer agree with the rest of the console about ACL-blocked tools: blocked tools stay visible, but can't be picked as scope bindings.

## Approach
`MCPProxySecurityTab` already derives `blockedToolIds` (via `isToolBlockedByAcl`) to render the "Blocked by Manage Tools" marker on its tool-scope table, but never passed that set to `CreateScopeDrawer` — the drawer received the raw `toolEntries` list and had no notion of the ACL policy at all.

- `CreateScopeDrawer` takes a new `blockedTools: ReadonlySet<string>` prop. Its Tools `Autocomplete` gets `getOptionDisabled` plus a `renderOption` that appends a `ShieldX` + "Blocked in Manage Tools" marker to blocked entries.
- `MCPProxySecurityTab` passes the existing, already-memoized `blockedToolIds` — no new derivation.

Blocked tools are listed-but-disabled rather than filtered out, so that:
- a deny-all ACL doesn't leave the picker looking empty with a misleading "No tools discovered on this endpoint" empty state, and
- the user sees where a missing tool went instead of it silently vanishing.

The marker is spelled out in the row rather than reusing the tool table's tooltip because MUI applies `pointer-events: none` to disabled options, so a hover affordance there would never fire.

No backend change: `validateScopeTools` legitimately accepts blocked tools (it only rejects tools absent from the proxy's discovered set), and the Security tab's tool-scope table still lets you manage scopes on already-blocked tools.

## User stories
As a platform admin, when I block a tool in Manage Tools, I don't want that tool offered to me as a scope binding when I create a new scope for the same MCP Server.

## Release note
Fixed the MCP Server Create Scope drawer offering tools that are blocked in the Manage Tools tab.

## Documentation
N/A — bug fix to existing UI behaviour; no documented behaviour changes.

## Training
N/A — no training content covers this drawer.

## Certification
N/A — no impact on certification exams.

## Marketing
N/A — internal bug fix.

## Automation tests
 - Unit tests
   > None added. The `mcp-proxies` package has no test harness (no `test` script or vitest dependency, unlike e.g. `llm-providers`), and adding one was out of scope for this fix.
 - Integration tests
   > N/A — no integration test suite covers the console.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — TypeScript/React change; the plugin targets Java.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no samples relate to this drawer.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data changes.

## Test environment
Verified statically against the console toolchain: `tsc -p tsconfig.lib.json --noEmit` over `@agent-management-platform/mcp-proxies` and `eslint` on both changed files, both clean. Node.js 20.20.2, TypeScript 5.9.3, ESLint 9.36.0. Not yet exercised in a running browser session.

## Learning
Reviewed how the rest of the console treats ACL-blocked tools (Overview tab's allowed/denied chips, the Security tab's tool-scope table marker, configure-agent's `ViewMCPServer` Blocked/Allowed chip) to keep this surface consistent with them, and MUI 7's `Autocomplete` disabled-option behaviour for the marker placement.
