### PR TITLE
Add bulk .env paste support to environment variable editors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore
+- Author a backlog-ready spec/issue → invoke /spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Key routing rules:
 - Product ideas/brainstorming → invoke /office-hours
 - Strategy/scope → invoke /plan-ceo-review
 - Architecture → invoke /plan-eng-review
+- REST endpoint/resource/operation changes in agent-manager-service → invoke /add-api-resource
 - Design system/plan review → invoke /design-consultation or /plan-design-review
 - Full review pipeline → invoke /autoplan
 - Bugs/errors → invoke /investigate

--- a/console/apps/web-ui/public/config.js
+++ b/console/apps/web-ui/public/config.js
@@ -18,62 +18,56 @@
 
 window.__RUNTIME_CONFIG__ = {
   authConfig: {
-    baseUrl: "http://thunder.amp.localhost:8080",
-    clientId: "amp-console-client",
-    organizationHandle: "".trim() || "default",
-    signInUrl: "http://thunder.amp.localhost:8080/gate",
-    afterSignInUrl: "http://localhost:3000/login",
-    afterSignOutUrl: "http://localhost:3000/login",
-    scopes: (
-      "openid profile email amp:org:view amp:org:modify-settings amp:org:invite-member amp:org:remove-member amp:org:assign-role amp:org:manage-idp amp:org:manage-service-account amp:project:create amp:project:read amp:project:update amp:project:delete amp:environment:create amp:environment:read amp:environment:update amp:environment:delete amp:gateway:create amp:gateway:read amp:gateway:update amp:gateway:delete amp:gateway:token-manage amp:data-plane:read amp:deployment-pipeline:create amp:deployment-pipeline:read amp:deployment-pipeline:update amp:deployment-pipeline:delete amp:git-secret:create amp:git-secret:read amp:git-secret:delete amp:llm-provider-template:create amp:llm-provider-template:read amp:llm-provider-template:update amp:llm-provider-template:delete amp:llm-provider:create amp:llm-provider:read amp:llm-provider:update amp:llm-provider:delete amp:llm-provider:configure-guardrail amp:llm-provider:connect amp:llm-provider:deploy amp:llm-provider:api-key-manage amp:mcp-server:create amp:mcp-server:read amp:mcp-server:update amp:mcp-server:delete amp:mcp-server:configure-guardrail amp:mcp-server:connect amp:mcp-server:api-key-manage amp:llm-proxy:create amp:llm-proxy:read amp:llm-proxy:update amp:llm-proxy:delete amp:llm-proxy:deploy amp:llm-proxy:api-key-manage amp:evaluator:create amp:evaluator:read amp:evaluator:update amp:evaluator:delete amp:agent:create amp:agent:read amp:agent:update amp:agent:delete amp:agent:build amp:agent:env-non-production amp:agent:env-production amp:agent:rollback amp:agent:suspend amp:agent:token-manage amp:agent:api-key-manage amp:monitor:create amp:monitor:read amp:monitor:update amp:monitor:delete amp:monitor:execute amp:monitor:score-read amp:monitor:score-publish amp:observability:trace-read amp:observability:log-read amp:observability:build-log-read amp:observability:metric-read amp:role:create amp:role:read amp:role:update amp:role:delete amp:group:create amp:group:read amp:group:update amp:group:delete amp:catalog:read amp:repository:read amp:agent-kind:read amp:agent-kind:create amp:agent-kind:update amp:agent-kind:delete amp:profile:read amp:profile:update-attributes amp:scope:create amp:scope:read amp:scope:update amp:scope:delete amp:agent-identity:read amp:agent-identity:create amp:agent-identity:update amp:agent-identity:delete".trim() ||
-      "openid profile email"
-    )
-      .split(/\s+/)
-      .filter(Boolean),
-    platform: "AsgardeoV2",
+    baseUrl: 'http://thunder.amp.localhost:8080',
+    clientId: 'amp-console-client',
+    organizationHandle: (''.trim() || 'default'),
+    signInUrl: 'http://thunder.amp.localhost:8080/gate',
+    afterSignInUrl: 'http://localhost:3000/login',
+    afterSignOutUrl: 'http://localhost:3000/login',
+    scopes: ('openid profile email amp:org:view amp:org:modify-settings amp:org:invite-member amp:org:remove-member amp:org:assign-role amp:org:manage-idp amp:org:manage-service-account amp:project:create amp:project:read amp:project:update amp:project:delete amp:environment:create amp:environment:read amp:environment:update amp:environment:delete amp:gateway:create amp:gateway:read amp:gateway:update amp:gateway:delete amp:gateway:token-manage amp:data-plane:read amp:deployment-pipeline:create amp:deployment-pipeline:read amp:deployment-pipeline:update amp:deployment-pipeline:delete amp:git-secret:create amp:git-secret:read amp:git-secret:delete amp:llm-provider-template:create amp:llm-provider-template:read amp:llm-provider-template:update amp:llm-provider-template:delete amp:llm-provider:create amp:llm-provider:read amp:llm-provider:update amp:llm-provider:delete amp:llm-provider:configure-guardrail amp:llm-provider:connect amp:llm-provider:deploy amp:llm-provider:api-key-manage amp:mcp-server:create amp:mcp-server:read amp:mcp-server:update amp:mcp-server:delete amp:mcp-server:configure-guardrail amp:mcp-server:connect amp:mcp-server:api-key-manage amp:llm-proxy:create amp:llm-proxy:read amp:llm-proxy:update amp:llm-proxy:delete amp:llm-proxy:deploy amp:llm-proxy:api-key-manage amp:evaluator:create amp:evaluator:read amp:evaluator:update amp:evaluator:delete amp:agent:create amp:agent:read amp:agent:update amp:agent:delete amp:agent:build amp:agent:env-non-production amp:agent:env-production amp:agent:rollback amp:agent:suspend amp:agent:token-manage amp:agent:api-key-manage amp:monitor:create amp:monitor:read amp:monitor:update amp:monitor:delete amp:monitor:execute amp:monitor:score-read amp:monitor:score-publish amp:observability:trace-read amp:observability:log-read amp:observability:build-log-read amp:observability:metric-read amp:role:create amp:role:read amp:role:update amp:role:delete amp:group:create amp:group:read amp:group:update amp:group:delete amp:catalog:read amp:repository:read amp:agent-kind:read amp:agent-kind:create amp:agent-kind:update amp:agent-kind:delete amp:profile:read amp:profile:update-attributes amp:scope:create amp:scope:read amp:scope:update amp:scope:delete amp:agent-identity:read amp:agent-identity:create amp:agent-identity:update amp:agent-identity:delete'.trim() || 'openid profile email').split(/\s+/).filter(Boolean),
+    platform: 'AsgardeoV2',
     tokenValidation: {
       idToken: {
-        validate: "" === "true",
-        clockTolerance: Number("") || 300,
+        validate: '' === 'true',
+        clockTolerance: Number('') || 300,
       },
     },
-    storage: "localStorage",
+    storage: 'localStorage',
   },
-  disableAuth: "false" === "true",
-  rbacEnabled: "true" === "true",
-  apiBaseUrl: "http://localhost:9000",
-  gatewayControlPlaneUrl: "http://localhost:9243",
-  gatewayVersion: "v0.11.0",
-  ampVersion: "v0.17.0",
-  instrumentationUrl: "http://localhost:22893/otel",
-  agentManagerInternalBaseUrl: "http://host.docker.internal:9000",
-  agentManagerInternalCpHost: "host.docker.internal:9243",
-  guardrailsCatalogUrl:
-    "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=Guardrails,AI&limit=100",
-  guardrailsDefinitionBaseUrl:
-    "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies",
+  disableAuth: 'false' === 'true',
+  rbacEnabled: 'true' === 'true',
+  apiBaseUrl: 'http://localhost:9000',
+  configDiscoveryBaseUrl: '',
+  gatewayControlPlaneUrl: 'http://localhost:9243',
+  gatewayVersion: 'v0.11.0',
+  ampVersion: 'v0.16.0',
+  instrumentationUrl: 'http://default-default.gateway.localhost:19080/otel',
+  agentManagerInternalBaseUrl: 'http://host.docker.internal:9000',
+  agentManagerInternalCpHost: 'host.docker.internal:9243',
+  thunderHostBaseDomain: 'amp.localhost',
+  tlsEnabled: 'false' === 'true',
+  guardrailsCatalogUrl: 'https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=Guardrails,AI&limit=100',
+  guardrailsDefinitionBaseUrl: 'https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies',
   guardrailCapabilities: {
-    awsBedrock: "" === "true",
-    azureContentSafety: "" === "true",
-    graniteGuardian: "" === "true",
-    nemoGuard: "" === "true",
-    semanticGuardrails: "" === "true",
+    awsBedrock:         '' === 'true',
+    azureContentSafety: '' === 'true',
+    graniteGuardian:    '' === 'true',
+    nemoGuard:          '' === 'true',
+    semanticGuardrails: '' === 'true',
   },
   featureFlags: {
-    enablePrivateRepoSupport: "true" === "true",
-    enableIdentityProviderManagedMode: "" === "true",
-    enableProfileManagement: "true" === "true",
-    enableUserManagement: "true" === "true",
+    enablePrivateRepoSupport: 'true' === 'true',
+    enableIdentityProviderManagedMode: '' === 'true',
+    enableProfileManagement: 'true' === 'true',
+    enableUserManagement: 'true' === 'true',
   },
-  docsUrl: "https://wso2.github.io/agent-manager/docs/latest",
+  docsUrl: 'https://wso2.github.io/agent-manager/docs/latest',
   footerLinks: {
-    privacyPolicyUrl: "https://wso2.com/agent-platform/agent-manager/",
-    termsOfUseUrl: "https://wso2.com/agent-platform/agent-manager/",
+    privacyPolicyUrl: 'https://wso2.com/agent-platform/agent-manager/',
+    termsOfUseUrl: 'https://wso2.com/agent-platform/agent-manager/',
   },
   instrumentationDocLinks: {
-    manualInstrumentation:
-      "/guides/amp-instrumentation/#manual-instrumentation",
-    versionMapping:
-      "/guides/amp-instrumentation/#amp-instrumentation-version-mapping",
+    manualInstrumentation: '/guides/amp-instrumentation/#manual-instrumentation',
+    versionMapping: '/guides/amp-instrumentation/#amp-instrumentation-version-mapping',
   },
 };

--- a/console/apps/web-ui/public/config.js
+++ b/console/apps/web-ui/public/config.js
@@ -18,56 +18,62 @@
 
 window.__RUNTIME_CONFIG__ = {
   authConfig: {
-    baseUrl: 'http://thunder.amp.localhost:8080',
-    clientId: 'amp-console-client',
-    organizationHandle: (''.trim() || 'default'),
-    signInUrl: 'http://thunder.amp.localhost:8080/gate',
-    afterSignInUrl: 'http://localhost:3000/login',
-    afterSignOutUrl: 'http://localhost:3000/login',
-    scopes: ('openid profile email amp:org:view amp:org:modify-settings amp:org:invite-member amp:org:remove-member amp:org:assign-role amp:org:manage-idp amp:org:manage-service-account amp:project:create amp:project:read amp:project:update amp:project:delete amp:environment:create amp:environment:read amp:environment:update amp:environment:delete amp:gateway:create amp:gateway:read amp:gateway:update amp:gateway:delete amp:gateway:token-manage amp:data-plane:read amp:deployment-pipeline:create amp:deployment-pipeline:read amp:deployment-pipeline:update amp:deployment-pipeline:delete amp:git-secret:create amp:git-secret:read amp:git-secret:delete amp:llm-provider-template:create amp:llm-provider-template:read amp:llm-provider-template:update amp:llm-provider-template:delete amp:llm-provider:create amp:llm-provider:read amp:llm-provider:update amp:llm-provider:delete amp:llm-provider:configure-guardrail amp:llm-provider:connect amp:llm-provider:deploy amp:llm-provider:api-key-manage amp:mcp-server:create amp:mcp-server:read amp:mcp-server:update amp:mcp-server:delete amp:mcp-server:configure-guardrail amp:mcp-server:connect amp:mcp-server:api-key-manage amp:llm-proxy:create amp:llm-proxy:read amp:llm-proxy:update amp:llm-proxy:delete amp:llm-proxy:deploy amp:llm-proxy:api-key-manage amp:evaluator:create amp:evaluator:read amp:evaluator:update amp:evaluator:delete amp:agent:create amp:agent:read amp:agent:update amp:agent:delete amp:agent:build amp:agent:env-non-production amp:agent:env-production amp:agent:rollback amp:agent:suspend amp:agent:token-manage amp:agent:api-key-manage amp:monitor:create amp:monitor:read amp:monitor:update amp:monitor:delete amp:monitor:execute amp:monitor:score-read amp:monitor:score-publish amp:observability:trace-read amp:observability:log-read amp:observability:build-log-read amp:observability:metric-read amp:role:create amp:role:read amp:role:update amp:role:delete amp:group:create amp:group:read amp:group:update amp:group:delete amp:catalog:read amp:repository:read amp:agent-kind:read amp:agent-kind:create amp:agent-kind:update amp:agent-kind:delete amp:profile:read amp:profile:update-attributes amp:scope:create amp:scope:read amp:scope:update amp:scope:delete amp:agent-identity:read amp:agent-identity:create amp:agent-identity:update amp:agent-identity:delete'.trim() || 'openid profile email').split(/\s+/).filter(Boolean),
-    platform: 'AsgardeoV2',
+    baseUrl: "http://thunder.amp.localhost:8080",
+    clientId: "amp-console-client",
+    organizationHandle: "".trim() || "default",
+    signInUrl: "http://thunder.amp.localhost:8080/gate",
+    afterSignInUrl: "http://localhost:3000/login",
+    afterSignOutUrl: "http://localhost:3000/login",
+    scopes: (
+      "openid profile email amp:org:view amp:org:modify-settings amp:org:invite-member amp:org:remove-member amp:org:assign-role amp:org:manage-idp amp:org:manage-service-account amp:project:create amp:project:read amp:project:update amp:project:delete amp:environment:create amp:environment:read amp:environment:update amp:environment:delete amp:gateway:create amp:gateway:read amp:gateway:update amp:gateway:delete amp:gateway:token-manage amp:data-plane:read amp:deployment-pipeline:create amp:deployment-pipeline:read amp:deployment-pipeline:update amp:deployment-pipeline:delete amp:git-secret:create amp:git-secret:read amp:git-secret:delete amp:llm-provider-template:create amp:llm-provider-template:read amp:llm-provider-template:update amp:llm-provider-template:delete amp:llm-provider:create amp:llm-provider:read amp:llm-provider:update amp:llm-provider:delete amp:llm-provider:configure-guardrail amp:llm-provider:connect amp:llm-provider:deploy amp:llm-provider:api-key-manage amp:mcp-server:create amp:mcp-server:read amp:mcp-server:update amp:mcp-server:delete amp:mcp-server:configure-guardrail amp:mcp-server:connect amp:mcp-server:api-key-manage amp:llm-proxy:create amp:llm-proxy:read amp:llm-proxy:update amp:llm-proxy:delete amp:llm-proxy:deploy amp:llm-proxy:api-key-manage amp:evaluator:create amp:evaluator:read amp:evaluator:update amp:evaluator:delete amp:agent:create amp:agent:read amp:agent:update amp:agent:delete amp:agent:build amp:agent:env-non-production amp:agent:env-production amp:agent:rollback amp:agent:suspend amp:agent:token-manage amp:agent:api-key-manage amp:monitor:create amp:monitor:read amp:monitor:update amp:monitor:delete amp:monitor:execute amp:monitor:score-read amp:monitor:score-publish amp:observability:trace-read amp:observability:log-read amp:observability:build-log-read amp:observability:metric-read amp:role:create amp:role:read amp:role:update amp:role:delete amp:group:create amp:group:read amp:group:update amp:group:delete amp:catalog:read amp:repository:read amp:agent-kind:read amp:agent-kind:create amp:agent-kind:update amp:agent-kind:delete amp:profile:read amp:profile:update-attributes amp:scope:create amp:scope:read amp:scope:update amp:scope:delete amp:agent-identity:read amp:agent-identity:create amp:agent-identity:update amp:agent-identity:delete".trim() ||
+      "openid profile email"
+    )
+      .split(/\s+/)
+      .filter(Boolean),
+    platform: "AsgardeoV2",
     tokenValidation: {
       idToken: {
-        validate: '' === 'true',
-        clockTolerance: Number('') || 300,
+        validate: "" === "true",
+        clockTolerance: Number("") || 300,
       },
     },
-    storage: 'localStorage',
+    storage: "localStorage",
   },
-  disableAuth: 'false' === 'true',
-  rbacEnabled: 'true' === 'true',
-  apiBaseUrl: 'http://localhost:9000',
-  configDiscoveryBaseUrl: '',
-  gatewayControlPlaneUrl: 'http://localhost:9243',
-  gatewayVersion: 'v0.11.0',
-  ampVersion: 'v0.16.0',
-  instrumentationUrl: 'http://default-default.gateway.localhost:19080/otel',
-  agentManagerInternalBaseUrl: 'http://host.docker.internal:9000',
-  agentManagerInternalCpHost: 'host.docker.internal:9243',
-  thunderHostBaseDomain: 'amp.localhost',
-  tlsEnabled: 'false' === 'true',
-  guardrailsCatalogUrl: 'https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=Guardrails,AI&limit=100',
-  guardrailsDefinitionBaseUrl: 'https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies',
+  disableAuth: "false" === "true",
+  rbacEnabled: "true" === "true",
+  apiBaseUrl: "http://localhost:9000",
+  gatewayControlPlaneUrl: "http://localhost:9243",
+  gatewayVersion: "v0.11.0",
+  ampVersion: "v0.17.0",
+  instrumentationUrl: "http://localhost:22893/otel",
+  agentManagerInternalBaseUrl: "http://host.docker.internal:9000",
+  agentManagerInternalCpHost: "host.docker.internal:9243",
+  guardrailsCatalogUrl:
+    "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=Guardrails,AI&limit=100",
+  guardrailsDefinitionBaseUrl:
+    "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies",
   guardrailCapabilities: {
-    awsBedrock:         '' === 'true',
-    azureContentSafety: '' === 'true',
-    graniteGuardian:    '' === 'true',
-    nemoGuard:          '' === 'true',
-    semanticGuardrails: '' === 'true',
+    awsBedrock: "" === "true",
+    azureContentSafety: "" === "true",
+    graniteGuardian: "" === "true",
+    nemoGuard: "" === "true",
+    semanticGuardrails: "" === "true",
   },
   featureFlags: {
-    enablePrivateRepoSupport: 'true' === 'true',
-    enableIdentityProviderManagedMode: '' === 'true',
-    enableProfileManagement: 'true' === 'true',
-    enableUserManagement: 'true' === 'true',
+    enablePrivateRepoSupport: "true" === "true",
+    enableIdentityProviderManagedMode: "" === "true",
+    enableProfileManagement: "true" === "true",
+    enableUserManagement: "true" === "true",
   },
-  docsUrl: 'https://wso2.github.io/agent-manager/docs/latest',
+  docsUrl: "https://wso2.github.io/agent-manager/docs/latest",
   footerLinks: {
-    privacyPolicyUrl: 'https://wso2.com/agent-platform/agent-manager/',
-    termsOfUseUrl: 'https://wso2.com/agent-platform/agent-manager/',
+    privacyPolicyUrl: "https://wso2.com/agent-platform/agent-manager/",
+    termsOfUseUrl: "https://wso2.com/agent-platform/agent-manager/",
   },
   instrumentationDocLinks: {
-    manualInstrumentation: '/guides/amp-instrumentation/#manual-instrumentation',
-    versionMapping: '/guides/amp-instrumentation/#amp-instrumentation-version-mapping',
+    manualInstrumentation:
+      "/guides/amp-instrumentation/#manual-instrumentation",
+    versionMapping:
+      "/guides/amp-instrumentation/#amp-instrumentation-version-mapping",
   },
 };

--- a/console/workspaces/libs/views/src/component/EnvFileUpload/EnvFileUpload.tsx
+++ b/console/workspaces/libs/views/src/component/EnvFileUpload/EnvFileUpload.tsx
@@ -60,7 +60,7 @@ export function parseEnvFileContent(text: string): ParsedEnvEntry[] {
   return result;
 }
 
-const MAX_FILE_SIZE = 1_000_000; // 1 MB — matches backend schema limit
+export const MAX_FILE_SIZE = 1_000_000; // 1 MB — matches backend schema limit
 
 export interface EnvFileUploadButtonProps {
   /**

--- a/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
+++ b/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
@@ -30,6 +30,7 @@ import {
 import { Edit, Eye, EyeOff, Lock, Trash2 as DeleteOutline, X } from '@wso2/oxygen-ui-icons-react';
 import { useState } from 'react';
 import { TextInput } from '../FormElements';
+import { MAX_FILE_SIZE, parseEnvFileContent } from '../EnvFileUpload';
 
 export interface EnvVariableEditorProps {
   /**
@@ -56,6 +57,12 @@ export interface EnvVariableEditorProps {
    * Callback to remove this environment variable
    */
   onRemove: () => void;
+  /**
+   * Called instead of onKeyChange/onValueChange when the pasted clipboard text
+   * contains multiple "KEY=VALUE" lines (e.g. the full contents of a .env
+   * file), so the caller can split it into multiple rows.
+   */
+  onBulkPaste?: (entries: { key: string; value: string }[]) => void;
   /**
    * Label for the key field (default: "Key")
    */
@@ -109,6 +116,7 @@ export function EnvVariableEditor({
   onKeyChange,
   onValueChange,
   onRemove,
+  onBulkPaste,
   keyLabel = 'Key',
   valueLabel = 'Value',
   isValueSecret = false,
@@ -139,6 +147,31 @@ export function EnvVariableEditor({
   const handleKeyPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
     if (keyDisabled || isValueLocked) return;
     const pasted = e.clipboardData.getData('text');
+
+    // A paste this large is almost certainly the wrong clipboard contents (e.g.
+    // an entire log file), not a real .env list — let the browser's default
+    // paste behavior handle it instead of splitting it into countless rows.
+    if (pasted.length > MAX_FILE_SIZE) return;
+
+    // Pasting one or more "KEY=VALUE" lines (including the full contents of a
+    // .env file) parses through the same helper as the upload path, so a
+    // single entry with a leading/trailing comment line isn't corrupted by
+    // falling through to the raw-text fallback below.
+    if (onBulkPaste) {
+      const entries = parseEnvFileContent(pasted);
+      if (entries.length > 1) {
+        e.preventDefault();
+        onBulkPaste(entries);
+        return;
+      }
+      if (entries.length === 1) {
+        e.preventDefault();
+        onKeyChange(entries[0].key.replace(/\s/g, '_'));
+        onValueChange(entries[0].value);
+        return;
+      }
+    }
+
     const equalsIdx = pasted.indexOf('=');
     if (equalsIdx === -1) return;
 

--- a/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
+++ b/console/workspaces/libs/views/src/component/EnvVariableEditor/EnvVariableEditor.tsx
@@ -166,8 +166,7 @@ export function EnvVariableEditor({
       }
       if (entries.length === 1) {
         e.preventDefault();
-        onKeyChange(entries[0].key.replace(/\s/g, '_'));
-        onValueChange(entries[0].value);
+        onBulkPaste([entries[0]]);
         return;
       }
     }
@@ -309,9 +308,9 @@ export function EnvVariableEditor({
                     isEditing
                       ? undefined
                       : {
-                          visibility: isSecretLocked && !isSystem ? 'visible' : 'hidden',
-                          pointerEvents: isSecretLocked && !isSystem ? 'auto' : 'none',
-                        }
+                        visibility: isSecretLocked && !isSystem ? 'visible' : 'hidden',
+                        pointerEvents: isSecretLocked && !isSystem ? 'auto' : 'none',
+                      }
                   }
                 >
                   {isEditing ? <X size={16} /> : <Edit size={16} />}

--- a/console/workspaces/pages/add-new-agent/src/components/EnvironmentVariable.tsx
+++ b/console/workspaces/pages/add-new-agent/src/components/EnvironmentVariable.tsx
@@ -84,8 +84,10 @@ export const EnvironmentVariable = ({
   const handleEnvFileParsed = (entries: { key: string; value: string }[]) => {
     setFormData((prev) => {
       const nextEnv = [...(prev.env || [])].filter((e) => e.key || e.value);
-      for (const { key, value } of entries) {
-        if (lockedKeys.has(key)) continue;
+      for (const rawEntry of entries) {
+        const key = rawEntry.key.replace(/\s/g, '_');
+        const value = rawEntry.value;
+        if (lockedKeys.has(key) || kindSecretKeys.has(key)) continue;
         const existingIndex = nextEnv.findIndex((e) => e.key === key);
         if (existingIndex !== -1) {
           nextEnv[existingIndex] = { ...nextEnv[existingIndex], key, value };
@@ -100,12 +102,9 @@ export const EnvironmentVariable = ({
   return (
     <Card variant="outlined">
       <CardContent>
-        <Box display="flex" flexDirection="row" alignItems="center" justifyContent="space-between" gap={1}>
-          <Typography variant="h5">
-            {hideAdd ? "Environment Variables" : "Environment Variables (Optional)"}
-          </Typography>
-          {!hideAdd && <EnvFileUploadButton onParsed={handleEnvFileParsed} />}
-        </Box>
+        <Typography variant="h5">
+          {hideAdd ? "Environment Variables" : "Environment Variables (Optional)"}
+        </Typography>
         <Box display="flex" flexDirection="column" py={2} gap={2}>
           {envVariables.map((item, index) => {
             const siblingKeys = new Set(
@@ -129,6 +128,7 @@ export const EnvironmentVariable = ({
                 valueLabel={isKindSecret ? "Value (uses kind default unless edited)" : undefined}
                 onKeyChange={(value) => handleChange(index, 'key', value)}
                 onValueChange={(value) => handleChange(index, 'value', value)}
+                onBulkPaste={isLocked ? undefined : handleEnvFileParsed}
                 onSensitiveChange={isKindSecret ? undefined : (value: boolean) => handleChange(index, 'isSensitive', value)}
                 onRemove={isLocked ? () => {} : () => handleRemove(index)}
                 keyDisabled={isLocked}
@@ -138,16 +138,24 @@ export const EnvironmentVariable = ({
           })}
         </Box>
         {!hideAdd && (
-          <Button
-            startIcon={<Add fontSize="small" />}
-            disabled={isOneEmpty}
-            variant="outlined"
-            color="primary"
-            size="small"
-            onClick={handleAdd}
-          >
-            Add
-          </Button>
+          <Box display="flex" flexDirection="row" alignItems="center" gap={1.5} flexWrap="wrap">
+            <Button
+              startIcon={<Add fontSize="small" />}
+              disabled={isOneEmpty}
+              variant="outlined"
+              color="primary"
+              size="small"
+              onClick={handleAdd}
+            >
+              Add
+            </Button>
+            <Box display="flex" flexDirection="column" alignItems="flex-start">
+              <EnvFileUploadButton onParsed={handleEnvFileParsed} />
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              or paste .env text into a Key field above
+            </Typography>
+          </Box>
         )}
       </CardContent>
     </Card>

--- a/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
+++ b/console/workspaces/pages/agent-kind/src/RuntimeConfigEditor.tsx
@@ -30,7 +30,9 @@ import {
 import { Plus, Trash } from "@wso2/oxygen-ui-icons-react";
 import {
     EnvFileUploadButton,
+    MAX_FILE_SIZE,
     TextInput,
+    parseEnvFileContent,
     type ParsedEnvEntry,
 } from "@agent-management-platform/views";
 
@@ -101,6 +103,12 @@ interface ConfigRowProps {
     onUpdate: <K extends keyof RuntimeConfigRow>(field: K, value: RuntimeConfigRow[K]) => void;
     onUpdateMany: (updates: Partial<RuntimeConfigRow>) => void;
     onRemove: () => void;
+    /**
+     * Called instead of onUpdateMany when the pasted clipboard text contains
+     * multiple "KEY=VALUE" lines (e.g. the full contents of a .env file), so
+     * the caller can split it into multiple rows.
+     */
+    onBulkPaste: (entries: ParsedEnvEntry[]) => void;
 }
 
 const ConfigRow: React.FC<ConfigRowProps> = ({
@@ -111,6 +119,7 @@ const ConfigRow: React.FC<ConfigRowProps> = ({
     onUpdate,
     onUpdateMany,
     onRemove,
+    onBulkPaste,
 }) => (
     <Stack key={row.id} spacing={0.5}>
         <Stack direction="row" spacing={1} alignItems="top" justifyContent="flex-start">
@@ -125,6 +134,32 @@ const ConfigRow: React.FC<ConfigRowProps> = ({
                             onChange={(e) => onUpdate("key", e.target.value.replace(/\s/g, "_"))}
                             onPaste={(e) => {
                                 const pasted = e.clipboardData.getData("text");
+
+                                // A paste this large is almost certainly the wrong clipboard
+                                // contents (e.g. an entire log file), not a real .env list —
+                                // let the browser's default paste handle it instead of
+                                // splitting it into countless rows.
+                                if (pasted.length > MAX_FILE_SIZE) return;
+
+                                // Pasting one or more "KEY=VALUE" lines (including the full
+                                // contents of a .env file) parses through the same helper as
+                                // the upload path, so a single entry with a leading/trailing
+                                // comment line isn't corrupted by the raw-text fallback below.
+                                const bulkEntries = parseEnvFileContent(pasted);
+                                if (bulkEntries.length > 1) {
+                                    e.preventDefault();
+                                    onBulkPaste(bulkEntries);
+                                    return;
+                                }
+                                if (bulkEntries.length === 1) {
+                                    e.preventDefault();
+                                    onUpdateMany({
+                                        key: bulkEntries[0].key.replace(/\s/g, "_"),
+                                        defaultValue: bulkEntries[0].value,
+                                    });
+                                    return;
+                                }
+
                                 const equalsIdx = pasted.indexOf("=");
                                 if (equalsIdx === -1) return;
                                 const pastedKey = pasted.slice(0, equalsIdx).trim();
@@ -268,7 +303,9 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
             if (trimmedKey) indexByKey.set(trimmedKey, i);
         });
 
-        for (const { key, value } of entries) {
+        for (const rawEntry of entries) {
+            const key = rawEntry.key.replace(/\s/g, "_");
+            const value = rawEntry.value;
             const existingIndex = indexByKey.get(key);
             if (existingIndex !== undefined) {
                 next[existingIndex] = { ...next[existingIndex], defaultValue: value };
@@ -293,16 +330,20 @@ export const RuntimeConfigEditor: React.FC<RuntimeConfigEditorProps> = ({
                     onUpdate={(field, value) => updateRow(i, field, value)}
                     onUpdateMany={(updates) => updateRowMany(i, updates)}
                     onRemove={() => removeRow(i)}
+                    onBulkPaste={handleEnvFileParsed}
                 />
             ))}
             {!readonlyKey && (
-                <Box display="flex" flexDirection="row" gap={1} alignItems="flex-start">
+                <Box display="flex" flexDirection="row" gap={1.5} alignItems="center" flexWrap="wrap">
                     <Button size="small" variant="outlined" startIcon={<Plus />} onClick={addRow} disabled={isInvalid}>
                         Add Runtime Key
                     </Button>
                     <Box display="flex" flexDirection="column" alignItems="flex-start">
                         <EnvFileUploadButton onParsed={handleEnvFileParsed} label="Upload .env file" />
                     </Box>
+                    <Typography variant="caption" color="text.secondary">
+                        or paste .env text into a Key field above
+                    </Typography>
                 </Box>
             )}
         </Stack>


### PR DESCRIPTION
## Purpose

Adding env vars one-by-one (or via file upload only) is slow when a user already has a `.env` file's contents on their clipboard. No related issue link.

## Goals

Let users paste the full contents of a `.env` file directly into a Key field and have it auto-split into individual key/value rows, on both the "create agent from source" page and the Agent Kind "Create New Version" drawer.

## Approach

Extended the existing single-line KEY=VALUE paste-into-Key-field handlers to detect multi-line paste via the existing parseEnvFileContent parser and route it through the same merge logic already used for .env file uploads. Added a "or paste .env text into a Key field above" caption next to the existing Upload button on both pages, and a size guard so an oversized accidental paste falls back to default browser paste behavior instead of spawning unbounded rows.

https://github.com/user-attachments/assets/44ae8030-41a8-4909-9a69-516314feb6df

## User stories

As a user creating an agent or publishing a new Agent Kind version, I can paste my entire `.env` file into the key/value editor and have it split into rows automatically, instead of adding vars one at a time or uploading a file.

## Release note

Environment variable editors now support pasting the full contents of a `.env` file directly into a key field, it auto-splits into individual rows.

## Documentation

N/A

## Training

N/A

## Certification

N/A 

## Marketing

N/A

## Automation tests

- Unit tests: N/A
- Integration tests: Manually verified.

## Security checks

- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A
- Confirmed no secrets committed: yes

## Samples

N/A

## Related PRs

None

## Migrations

N/A 

## Test environment

Dev setup

## Learning

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paste `.env` content directly into environment variable fields.
  * Bulk pastes with multiple entries are automatically parsed and added.
  * Added guidance near upload controls explaining paste support.
* **Improvements**
  * Environment variable names are normalized by replacing spaces with underscores.
  * Locked and secret fields are protected from being overwritten during imports.
  * Pasted or uploaded content is limited to 1 MB for safer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->