### PR TITLE
Use a namespaced ProjectType instead of the cluster-scoped one

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/constants.go
+++ b/agent-manager-service/clients/openchoreosvc/client/constants.go
@@ -44,6 +44,15 @@ const (
 // -----------------------------------------------------------------------------
 type ComponentType string
 
+// DefaultProjectTypeName is the (Cluster)ProjectType every project created by
+// agent-manager references. OpenChoreo 1.2.0+ requires spec.type.
+//
+// The reference is deliberately to the NAMESPACED ProjectType rather than the
+// cluster-scoped ClusterProjectType: a cluster-wide type is shared by every
+// tenant in the cluster, which is not acceptable in a multi-tenant deployment.
+// Each organization's namespace carries its own ProjectType of this name.
+const DefaultProjectTypeName = "default"
+
 const (
 	ComponentTypeInternalAgentAPI ComponentType = "proxy/agent-api"
 	ComponentTypeExternalAgentAPI ComponentType = "proxy/external-agent-api"

--- a/agent-manager-service/clients/openchoreosvc/client/projects.go
+++ b/agent-manager-service/clients/openchoreosvc/client/projects.go
@@ -27,6 +27,10 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
+// projectTypeKind is the kind agent-manager references in Project.spec.type.
+// Declared as a package var because the generated field is a pointer.
+var projectTypeKind = ocapi.ProjectTypeRefKindProjectType
+
 func (c *openChoreoClient) CreateProject(ctx context.Context, ouID string, req CreateProjectRequest) error {
 	namespaceName := c.NamespaceFor(ouID)
 	annotations := map[string]string{
@@ -40,6 +44,13 @@ func (c *openChoreoClient) CreateProject(ctx context.Context, ouID string, req C
 			Annotations: &annotations,
 		},
 		Spec: &ocapi.ProjectSpec{
+			// Required from OpenChoreo 1.2.0, and immutable once set, so it has
+			// to be correct on create. See DefaultProjectTypeName for why this
+			// is the namespaced kind.
+			Type: &ocapi.ProjectTypeRef{
+				Kind: &projectTypeKind,
+				Name: DefaultProjectTypeName,
+			},
 			DeploymentPipelineRef: &struct {
 				Kind *ocapi.ProjectSpecDeploymentPipelineRefKind `json:"kind,omitempty"`
 				Name string                                      `json:"name"`

--- a/agent-manager-service/clients/openchoreosvc/client/projects_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/projects_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+)
+
+// OpenChoreo 1.2.0+ requires Project.spec.type, and rejects a change to it after
+// creation, so the create request is the only chance to get it right. The kind
+// must be the namespaced ProjectType: a ClusterProjectType is shared by every
+// tenant in the cluster, which a multi-tenant deployment cannot use.
+func TestCreateProject_SetsNamespacedProjectType(t *testing.T) {
+	var gotBody gen.Project
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(gotBody))
+	}))
+
+	err := c.CreateProject(context.Background(), "acme", CreateProjectRequest{
+		Name:               "my-project",
+		DisplayName:        "My Project",
+		Description:        "desc",
+		DeploymentPipeline: "default",
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, gotBody.Spec)
+	require.NotNil(t, gotBody.Spec.Type, "spec.type is required from OpenChoreo 1.2.0 — omitting it fails CRD validation")
+	require.NotNil(t, gotBody.Spec.Type.Kind)
+	assert.Equal(t, gen.ProjectTypeRefKindProjectType, *gotBody.Spec.Type.Kind,
+		"must reference the namespaced ProjectType, not the cluster-wide ClusterProjectType")
+	assert.Equal(t, DefaultProjectTypeName, gotBody.Spec.Type.Name)
+
+	// The pipeline reference must survive alongside the new field.
+	require.NotNil(t, gotBody.Spec.DeploymentPipelineRef)
+	assert.Equal(t, "default", gotBody.Spec.DeploymentPipelineRef.Name)
+}
+
+// The type name is also hardcoded in the Helm chart's templates/project-type.yaml
+// and templates/project.yaml. If they drift, the chart provisions a ProjectType
+// under one name while the service references another, and every project created
+// through the API fails to reconcile with ProjectTypeNotFound.
+func TestDefaultProjectTypeName(t *testing.T) {
+	assert.Equal(t, "default", DefaultProjectTypeName)
+}

--- a/agent-manager-service/clients/openchoreosvc/client/projects_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/projects_test.go
@@ -60,10 +60,11 @@ func TestCreateProject_SetsNamespacedProjectType(t *testing.T) {
 	assert.Equal(t, "default", gotBody.Spec.DeploymentPipelineRef.Name)
 }
 
-// The type name is also hardcoded in the Helm chart's templates/project-type.yaml
-// and templates/project.yaml. If they drift, the chart provisions a ProjectType
-// under one name while the service references another, and every project created
-// through the API fails to reconcile with ProjectTypeNotFound.
+// This name is a contract with the Helm chart, which hardcodes the same literal
+// in templates/project-type.yaml and templates/project.yaml — deliberately not a
+// configurable value, because if the two diverged the chart would provision a
+// ProjectType under one name while the service referenced another, and every
+// project created through the API would fail with ProjectTypeNotFound.
 func TestDefaultProjectTypeName(t *testing.T) {
 	assert.Equal(t, "default", DefaultProjectTypeName)
 }

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-release-binding.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-release-binding.yaml
@@ -9,7 +9,7 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: ProjectReleaseBinding
 metadata:
   name: {{ .Values.project.name }}-{{ .Values.environment.name }}
-  namespace: default
+  namespace: {{ .Values.openchoreoNamespace }}
   labels:
     openchoreo.dev/project: {{ .Values.project.name }}
     openchoreo.dev/environment: {{ .Values.environment.name }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-release-binding.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-release-binding.yaml
@@ -1,6 +1,6 @@
 # OpenChoreo 1.2.0+ project-release model: a ProjectReleaseBinding deploys the
 # Project's (Cluster)ProjectType to a specific environment. It owns the cell
-# namespace for (Project, Environment) and applies the ClusterProjectType's
+# namespace for (Project, Environment) and applies the ProjectType's
 # resources (the cell namespace) there. Without it the cell namespace is never
 # created and component ReleaseBindings fail with "namespace ... not found".
 # spec.projectRelease is left unset; the Project controller seeds it once with

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-type.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-type.yaml
@@ -1,13 +1,13 @@
 apiVersion: openchoreo.dev/v1alpha1
 kind: ProjectType
 metadata:
-  name: {{ .Values.projectType.name }}
-  namespace: default
+  name: default
+  namespace: {{ .Values.openchoreoNamespace }}
   annotations:
     openchoreo.dev/display-name: {{ .Values.projectType.displayName | quote }}
     openchoreo.dev/description: {{ .Values.projectType.description | quote }}
   labels:
-    openchoreo.dev/name: {{ .Values.projectType.name }}
+    openchoreo.dev/name: default
 spec:
   # Per-environment overrides supplied via ProjectReleaseBinding.spec.environmentConfigs.
   environmentConfigs:

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-type.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project-type.yaml
@@ -1,7 +1,8 @@
 apiVersion: openchoreo.dev/v1alpha1
-kind: ClusterProjectType
+kind: ProjectType
 metadata:
   name: {{ .Values.projectType.name }}
+  namespace: default
   annotations:
     openchoreo.dev/display-name: {{ .Values.projectType.displayName | quote }}
     openchoreo.dev/description: {{ .Values.projectType.description | quote }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project.yaml
@@ -2,7 +2,7 @@ apiVersion: openchoreo.dev/v1alpha1
 kind: Project
 metadata:
   name: {{ .Values.project.name }}
-  namespace: default
+  namespace: {{ .Values.openchoreoNamespace }}
   annotations:
     openchoreo.dev/display-name: {{ .Values.project.displayName }}
     openchoreo.dev/description: {{ .Values.project.description }}
@@ -12,6 +12,6 @@ spec:
   # OpenChoreo 1.2.0+ requires spec.type — a reference to a (Cluster)ProjectType.
   type:
     kind: ProjectType
-    name: {{ .Values.projectType.name }}
+    name: default
   deploymentPipelineRef:
     name: {{ .Values.deploymentPipeline.name }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/project.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   # OpenChoreo 1.2.0+ requires spec.type — a reference to a (Cluster)ProjectType.
   type:
-    kind: ClusterProjectType
+    kind: ProjectType
     name: {{ .Values.projectType.name }}
   deploymentPipelineRef:
     name: {{ .Values.deploymentPipeline.name }}

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -188,11 +188,12 @@ project:
   # Description for the project
   description: "Default project for WSO2 Agent Manager"
 
-# ClusterProjectType referenced by the default Project.
+# ProjectType referenced by the default Project.
 # OpenChoreo 1.2.0+ makes Project.spec.type a required reference to a
 # (Cluster)ProjectType that 
 projectType:
-  # Name of the ClusterProjectType (must be a DNS-1123 label)
+  # Name of the ProjectType (must be a DNS-1123 label). Namespaced rather than
+  # cluster-scoped so the type is not shared across tenants.
   name: default
   # Display name for the project type
   displayName: "Default Project Type"

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -188,13 +188,23 @@ project:
   # Description for the project
   description: "Default project for WSO2 Agent Manager"
 
+# Namespace the platform resources below are created in. It must match the
+# service's OPEN_CHOREO_DEFAULT_NAMESPACE, since that is the namespace the
+# service creates projects in — and a namespaced ProjectType is only resolvable
+# from within its own namespace.
+openchoreoNamespace: default
+
 # ProjectType referenced by the default Project.
 # OpenChoreo 1.2.0+ makes Project.spec.type a required reference to a
-# (Cluster)ProjectType that 
+# (Cluster)ProjectType, which provides the per-environment resource template
+# (here, the cell namespace). A namespaced ProjectType is used rather than a
+# cluster-scoped ClusterProjectType so the type is not shared across tenants.
+#
+# The name is deliberately not configurable: it is a contract with the service,
+# which references client.DefaultProjectTypeName. If the two diverged, every
+# project created through the API would fail to reconcile with
+# ProjectTypeNotFound.
 projectType:
-  # Name of the ProjectType (must be a DNS-1123 label). Namespaced rather than
-  # cluster-scoped so the type is not shared across tenants.
-  name: default
   # Display name for the project type
   displayName: "Default Project Type"
   # Description for the project type


### PR DESCRIPTION
## Purpose

- OpenChoreo 1.2.0+ requires `Project.spec.type`, a reference to a `ProjectType` (namespaced) or `ClusterProjectType` (cluster-scoped).
- `CreateProject` never set it, so OpenChoreo defaulted it server-side to `ClusterProjectType`.
- A cluster-wide type is shared by every tenant in the cluster, so it is not usable in a multi-tenant deployment. Confirmed with the cloud team.
- Where no `ClusterProjectType` exists, projects fail to reconcile with `ProjectTypeNotFound`, no cell namespace is created, and agents deployed into them fail with `namespaces "dp-..." not found` — with no pod and therefore no logs.

## Goals

- Reference the namespaced `ProjectType` explicitly instead of relying on OpenChoreo's default.
- Make the on-prem chart provision a namespaced `ProjectType` to match.

## Approach

Service:
- `CreateProject` sets `spec.type` to `{kind: ProjectType, name: default}`.
- New `DefaultProjectTypeName` constant documents why the kind is namespaced.

Helm chart (`wso2-amp-platform-resources-extension`):
- `cluster-project-type.yaml` → `project-type.yaml`, `ClusterProjectType` → `ProjectType` in namespace `default` (git rename).
- `project.yaml` references `kind: ProjectType`.
- Comments in `values.yaml` and `project-release-binding.yaml` updated.

Notes:
- `spec.type` is immutable, so this affects **newly created projects only**. Existing projects created with `ClusterProjectType` are not repaired.
- Requires a namespaced `ProjectType` of this name in the target namespace. On-prem the chart provides it; in cloud it is provisioned per org namespace.
- No UI change.

## User stories

- As a developer, a project I create reconciles and I can deploy an agent into it.
- As a platform operator, project types are not shared across tenants.

## Release note

Projects now reference a namespaced ProjectType instead of a cluster-scoped one. Fixes agent deployment failing in newly created projects on OpenChoreo 1.2.

## Documentation

N/A

## Training

N/A

## Certification

N/A 

## Automation tests

- Unit tests
  - New `clients/openchoreosvc/client/projects_test.go`:
    - `TestCreateProject_SetsNamespacedProjectType` — asserts the wire body carries `spec.type` with `kind: ProjectType` and name `default`, and that `deploymentPipelineRef` still survives. Added at client level because the existing `tests/create_project_test.go` mocks at the interface boundary and cannot see the JSON sent — the blind spot that let this ship.
    - `TestDefaultProjectTypeName` — pins the name, which is duplicated in the chart templates. Drift there reproduces `ProjectTypeNotFound`.
  - `make test-unit` and `make test-integration` pass (migrations through `0042`). 
  - `helm lint`, `helm template` and `deployments/helm-charts/tests/no-nil-render.sh` pass for the changed chart.

- Integration tests
  - Verified manually on a fresh `make setup` (k3d, OpenChoreo 1.2.0), which installs the local chart and local code:
    1. Default project — agent deployed; runtime, logs and traces all working.
    2. **New project created through the API, new agent deployed into it — working.** This is the path that was failing in cloud; it exercises project → ProjectRelease → cell namespace → ReleaseBinding.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — Java bytecode tool
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

N/A

## Related PRs

- #1410 — added the `ClusterProjectType` and `spec.type` for OpenChoreo 1.2.0+; this changes that choice to the namespaced kind.
- #1560 — `ProjectReleaseBinding` support, the next step in the same chain.

## Migrations (if applicable)
- No migration steps.

## Test environment

- Go 1.26.4, darwin/arm64
- macOS 15 (Darwin 25.5.0), Apple Silicon
- k3d via `make setup`, OpenChoreo 1.2.0
- PostgreSQL 16 (integration tests)
- Helm v3.21.3

## Learning

- OpenChoreo 1.2.0 has two project type kinds: [`projecttype_types.go`](https://github.com/openchoreo/openchoreo/blob/v1.2.0/api/v1alpha1/projecttype_types.go) and [`clusterprojecttype_types.go`](https://github.com/openchoreo/openchoreo/blob/v1.2.0/api/v1alpha1/clusterprojecttype_types.go). The CRD allows `enum: [ProjectType, ClusterProjectType]` with `default: ProjectType`, and [`project_types.go`](https://github.com/openchoreo/openchoreo/blob/v1.2.0/api/v1alpha1/project_types.go) marks `Type` required.
- Omitting the field is not safe: OpenChoreo defaults it server-side, and to the cluster-scoped kind, which is the opposite of what a multi-tenant deployment wants.
- Reference: [OpenChoreo v1.1 → v1.2 upgrade guide](https://openchoreo.dev/docs/platform-engineer-guide/upgrades/v1.1-to-v1.2/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Projects now use a namespaced project type in the default namespace.
  * Project creation consistently references the configured project type and deployment pipeline.
  * Deployment templates and configuration guidance now reflect the namespaced project type resource.

* **Bug Fixes**
  * Corrected project and release binding references to use the appropriate project type resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->