### PR TITLE
Fix LLM provider context path auto-sync with Name field

### DIFF
--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -197,6 +197,11 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
   const [isSingleGatewayChoice, setIsSingleGatewayChoice] = useState(false);
   const [endpointEditable, setEndpointEditable] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
+  // Tracks whether the user has taken manual control of the context path.
+  // Set on a direct edit to Context; cleared when they empty it back out,
+  // which is the signal to resume auto-deriving from Name.
+  const [isContextManuallyEdited, setIsContextManuallyEdited] =
+    useState(false);
 
   const handleAddGuardrail = useCallback((guardrail: GuardrailSelection) => {
     setGuardrails((prev) => {
@@ -235,24 +240,25 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
     }
   }, [selectedTemplate]);
 
+  // Name auto-derives the context path until the user manually edits Context,
+  // at which point their input wins and Name edits stop overwriting it.
+  // Clearing Context back to empty un-locks it, resuming auto-derivation on
+  // the next Name edit.
   useEffect(() => {
-    const { displayName, context } = formData;
-    if (displayName) {
-      const derived = toContextPath(displayName);
-      if (derived && (context === "" || derived.startsWith(context ?? ""))) {
-        setFormData((prev) => ({ ...prev, context: derived }));
-        setFieldError(
-          "context",
-          validateField("context", derived, {
-            ...formData,
-            context: derived,
-          }),
-        );
-      }
+    if (isContextManuallyEdited) {
+      return;
     }
+    const derived = toContextPath(formData.displayName);
+    setFormData((prev) =>
+      prev.context === derived ? prev : { ...prev, context: derived },
+    );
+    setFieldError(
+      "context",
+      validateField("context", derived, { ...formData, context: derived }),
+    );
     // Only run when displayName changes; formData for validation
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formData.displayName]);
+  }, [formData.displayName, isContextManuallyEdited]);
 
   const handleFieldChange = useCallback(
     (field: keyof AddLLMProviderFormValues, value: string | string[]) => {
@@ -264,6 +270,14 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
       });
     },
     [setFieldError, validateField],
+  );
+
+  const handleContextChange = useCallback(
+    (value: string) => {
+      setIsContextManuallyEdited(value.trim() !== "");
+      handleFieldChange("context", value);
+    },
+    [handleFieldChange],
   );
 
   const handleTemplateSelect = useCallback(
@@ -420,7 +434,7 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
                   id="context"
                   fullWidth
                   value={formData.context ?? ""}
-                  onChange={(e) => handleFieldChange("context", e.target.value)}
+                  onChange={(e) => handleContextChange(e.target.value)}
                   placeholder="/my-provider"
                   error={Boolean(errors.context)}
                   helperText={

--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -242,8 +242,10 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
 
   // Name auto-derives the context path until the user manually edits Context,
   // at which point their input wins and Name edits stop overwriting it.
-  // Clearing Context back to empty un-locks it, resuming auto-derivation on
-  // the next Name edit.
+  // Clearing Context back to empty un-locks it, but deliberately does NOT
+  // repopulate it on its own — isContextManuallyEdited is intentionally left
+  // out of the dependency array so derivation only fires on the next actual
+  // Name edit, not the instant Context is cleared.
   useEffect(() => {
     if (isContextManuallyEdited) {
       return;
@@ -258,7 +260,7 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
     );
     // Only run when displayName changes; formData for validation
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formData.displayName, isContextManuallyEdited]);
+  }, [formData.displayName]);
 
   const handleFieldChange = useCallback(
     (field: keyof AddLLMProviderFormValues, value: string | string[]) => {


### PR DESCRIPTION
## Purpose
The "Context path" field on the Add LLM Provider form could get filled in wrong by Chrome's autofill, which broke the form. On top of that, once the Context field was edited by hand, it stopped working correctly and it either got stuck forever or kept getting overwritten while typing in the Name field.

## Goals
* Fix Context path being broken by browser autofill and manual edits.
* Keep Context auto-filling from the Name field by default.
* Preserve a manual edit to Context instead of losing it.

## Approach
Added a flag that tracks whether Context has been edited by hand. While set, Name edits no longer overwrite Context. Clearing Context back to empty resets the flag, resuming auto-fill from Name.

## User stories
N/A 

## Release note
N/A 

## Documentation
N/A 

## Training
N/A 

## Certification
N/A 

## Marketing
N/A 

## Automation tests
N/A 

## Security checks
 N/A 

## Samples
N/A 

## Related PRs
N/A 

## Migrations (if applicable)
N/A 

## Test environment
N/A 
 
## Learning
N/A 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved context path handling when adding an LLM provider.
  - Context paths now update automatically when the provider name changes, unless the context was manually customized.
  - Clearing a manually entered context re-enables automatic path suggestions.
  - Editing the Context field now reliably preserves the value entered by the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->