### PR TITLE
Give each MCP endpoint its own Thunder resource server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ thunder-up:
 	@helm dependency update deployments/helm-charts/wso2-amp-thunder-extension
 	@helm upgrade --install amp-thunder-extension deployments/helm-charts/wso2-amp-thunder-extension \
 		--namespace amp-thunder --create-namespace \
-		--set thunder.bootstrap.agentManagerMcpDevBaseUrl=http://localhost:9000 \
+		--set thunder.bootstrap.agentManagerMcpBaseUrl=http://localhost:9000 \
 		--set thunder.setup.admin.password=admin
 	@echo "⏳ Waiting for Platform Thunder deployment..."
 	@kubectl rollout status deployment -n amp-thunder -l app.kubernetes.io/instance=amp-thunder-extension --timeout=120s 2>/dev/null || true

--- a/agent-manager-observer/handlers/well_known.go
+++ b/agent-manager-observer/handlers/well_known.go
@@ -53,7 +53,7 @@ func RegisterWellKnownRoutes(mux *http.ServeMux, cfg config.AuthConfig) {
 		}
 
 		body := protectedResourceMetadata{
-			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/",
+			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/mcp",
 			AuthorizationServers:   cfg.AuthorizationServers,
 			BearerMethodsSupported: []string{"header"},
 			ScopesSupported:        cfg.ScopesSupported,

--- a/agent-manager-observer/handlers/well_known.go
+++ b/agent-manager-observer/handlers/well_known.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/wso2/agent-manager/agent-manager-observer/config"
 	"github.com/wso2/agent-manager/agent-manager-observer/middleware/logger"
@@ -52,7 +53,7 @@ func RegisterWellKnownRoutes(mux *http.ServeMux, cfg config.AuthConfig) {
 		}
 
 		body := protectedResourceMetadata{
-			Resource:               cfg.ServerPublicURL,
+			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/",
 			AuthorizationServers:   cfg.AuthorizationServers,
 			BearerMethodsSupported: []string{"header"},
 			ScopesSupported:        cfg.ScopesSupported,

--- a/agent-manager-observer/handlers/well_known_test.go
+++ b/agent-manager-observer/handlers/well_known_test.go
@@ -58,8 +58,8 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body.Resource != cfg.ServerPublicURL+"/" {
-		t.Errorf("expected resource %q, got %q", cfg.ServerPublicURL+"/", body.Resource)
+	if body.Resource != cfg.ServerPublicURL+"/mcp" {
+		t.Errorf("expected resource %q, got %q", cfg.ServerPublicURL+"/mcp", body.Resource)
 	}
 	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://thunder.example.com" {
 		t.Errorf("expected authorization_servers [https://thunder.example.com], got %v", body.AuthorizationServers)

--- a/agent-manager-observer/handlers/well_known_test.go
+++ b/agent-manager-observer/handlers/well_known_test.go
@@ -58,8 +58,8 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body.Resource != cfg.ServerPublicURL {
-		t.Errorf("expected resource %q, got %q", cfg.ServerPublicURL, body.Resource)
+	if body.Resource != cfg.ServerPublicURL+"/" {
+		t.Errorf("expected resource %q, got %q", cfg.ServerPublicURL+"/", body.Resource)
 	}
 	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://thunder.example.com" {
 		t.Errorf("expected authorization_servers [https://thunder.example.com], got %v", body.AuthorizationServers)

--- a/agent-manager-service/api/route_authz_invariant_test.go
+++ b/agent-manager-service/api/route_authz_invariant_test.go
@@ -711,6 +711,12 @@ func thunderBootstrapRoleScopes(t *testing.T) map[string]map[string]bool {
 			!strings.Contains(block, "      - resourceServerId: amp-resource-server\n") {
 			t.Fatalf("Thunder bootstrap role %q no longer has the reviewed declarative role identity", handle)
 		}
+		// MCP resource servers intentionally repeat a role's applicable scope
+		// strings under different resourceServerId values. This invariant compares
+		// the service policy with the canonical amp-resource-server block only.
+		if mcpBlocks := strings.Index(block, "    {{- range $server := .Values.thunder.bootstrap.mcpResourceServers }}"); mcpBlocks >= 0 {
+			block = block[:mcpBlocks]
+		}
 		roles[handle] = map[string]bool{}
 		for _, scopeMatch := range scopePattern.FindAllStringSubmatch(block, -1) {
 			scope := scopeMatch[1]

--- a/agent-manager-service/api/well_known_routes.go
+++ b/agent-manager-service/api/well_known_routes.go
@@ -49,7 +49,7 @@ func registerWellKnownRoutes(mux *http.ServeMux) {
 		}
 
 		body := protectedResourceMetadata{
-			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/",
+			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/mcp",
 			AuthorizationServers:   cfg.OAuthAuthorizationServers,
 			BearerMethodsSupported: []string{"header"},
 			ScopesSupported:        rbac.MainMCPScopes(),

--- a/agent-manager-service/api/well_known_routes.go
+++ b/agent-manager-service/api/well_known_routes.go
@@ -19,9 +19,11 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/logger"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 )
 
 type protectedResourceMetadata struct {
@@ -47,10 +49,10 @@ func registerWellKnownRoutes(mux *http.ServeMux) {
 		}
 
 		body := protectedResourceMetadata{
-			Resource:               cfg.ServerPublicURL,
+			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/",
 			AuthorizationServers:   cfg.OAuthAuthorizationServers,
 			BearerMethodsSupported: []string{"header"},
-			ScopesSupported:        cfg.OAuthScopesSupported,
+			ScopesSupported:        rbac.MainMCPScopes(),
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/agent-manager-service/api/well_known_routes_test.go
+++ b/agent-manager-service/api/well_known_routes_test.go
@@ -20,9 +20,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/rbac"
 )
 
 func setupWellKnownMux() *http.ServeMux {
@@ -69,8 +71,8 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body.Resource != "https://am.example.com" {
-		t.Errorf("expected resource %q, got %q", "https://am.example.com", body.Resource)
+	if body.Resource != "https://am.example.com/" {
+		t.Errorf("expected resource %q, got %q", "https://am.example.com/", body.Resource)
 	}
 	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://idp.example.com" {
 		t.Errorf("expected authorization_servers [https://idp.example.com], got %v", body.AuthorizationServers)
@@ -78,8 +80,8 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	if len(body.BearerMethodsSupported) != 1 || body.BearerMethodsSupported[0] != "header" {
 		t.Errorf("expected bearer_methods_supported [header], got %v", body.BearerMethodsSupported)
 	}
-	if len(body.ScopesSupported) != 2 || body.ScopesSupported[0] != "org:view" || body.ScopesSupported[1] != "project:read" {
-		t.Errorf("expected scopes_supported [org:view, project:read], got %v", body.ScopesSupported)
+	if expected := rbac.MainMCPScopes(); !reflect.DeepEqual(body.ScopesSupported, expected) {
+		t.Errorf("expected MCP scopes %v, got %v", expected, body.ScopesSupported)
 	}
 }
 

--- a/agent-manager-service/api/well_known_routes_test.go
+++ b/agent-manager-service/api/well_known_routes_test.go
@@ -71,8 +71,8 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body.Resource != "https://am.example.com/" {
-		t.Errorf("expected resource %q, got %q", "https://am.example.com/", body.Resource)
+	if body.Resource != "https://am.example.com/mcp" {
+		t.Errorf("expected resource %q, got %q", "https://am.example.com/mcp", body.Resource)
 	}
 	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://idp.example.com" {
 		t.Errorf("expected authorization_servers [https://idp.example.com], got %v", body.AuthorizationServers)
@@ -109,7 +109,7 @@ func TestWellKnownOAuthProtectedResource_MultipleAuthorizationServers(t *testing
 	}
 }
 
-func TestWellKnownOAuthProtectedResource_TrailingSlashPreserved(t *testing.T) {
+func TestWellKnownOAuthProtectedResource_TrailingSlashNormalized(t *testing.T) {
 	withWellKnownConfig(t, "https://am.example.com/", []string{"https://idp.example.com/"}, nil)
 
 	mux := setupWellKnownMux()
@@ -125,9 +125,12 @@ func TestWellKnownOAuthProtectedResource_TrailingSlashPreserved(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body.Resource != "https://am.example.com/" {
-		t.Errorf("expected resource to preserve trailing slash, got %q", body.Resource)
+	// A trailing slash on ServerPublicURL must not become "//mcp" — it's trimmed
+	// before "/mcp" is appended, matching the MCP spec's no-trailing-slash guidance.
+	if body.Resource != "https://am.example.com/mcp" {
+		t.Errorf("expected resource with trailing slash normalized away, got %q", body.Resource)
 	}
+	// authorization_servers is passed through verbatim — untouched by resource normalization.
 	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://idp.example.com/" {
 		t.Errorf("expected authorization_servers to preserve trailing slash, got %v", body.AuthorizationServers)
 	}

--- a/agent-manager-service/rbac/chart_parity_test.go
+++ b/agent-manager-service/rbac/chart_parity_test.go
@@ -72,9 +72,22 @@ func bootstrapDocument(t *testing.T, raw, key string) string {
 		t.Fatalf("ConfigMap key %q not found in %s", key, bootstrapPath)
 	}
 	var body []string
+	templateDepth := 0
 	for _, line := range lines[start:] {
 		if configMapKeyLine.MatchString(line) {
 			break
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "{{- range ") || strings.HasPrefix(trimmed, "{{- if ") {
+			templateDepth++
+			continue
+		}
+		if strings.HasPrefix(trimmed, "{{- end") && templateDepth > 0 {
+			templateDepth--
+			continue
+		}
+		if templateDepth > 0 {
+			continue
 		}
 		if strings.Contains(line, "{{") {
 			t.Fatalf("document %q now contains Go templating (%q); this test can no longer parse it as YAML", key, strings.TrimSpace(line))

--- a/agent-manager-service/rbac/permissions.go
+++ b/agent-manager-service/rbac/permissions.go
@@ -38,6 +38,27 @@ func (p Permission) Scope() string {
 	return ResourceServer + ":" + string(p)
 }
 
+// MainMCPScopes returns exactly the permission scopes required by the tools
+// registered on the Agent Manager MCP endpoint.
+func MainMCPScopes() []string {
+	permissions := []Permission{
+		ProjectRead,
+		ProjectCreate,
+		AgentRead,
+		AgentCreate,
+		AgentTokenManage,
+		AgentBuild,
+		AgentEnvNonProduction,
+		AgentSuspend,
+		EnvironmentRead,
+	}
+	scopes := make([]string, 0, len(permissions))
+	for _, permission := range permissions {
+		scopes = append(scopes, permission.Scope())
+	}
+	return scopes
+}
+
 // Org permissions
 const (
 	OrgView                 Permission = "org:view"

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -65,9 +65,10 @@ services:
       # Accepts Thunder-issued tokens (client_credentials for publisher)
       - KEY_MANAGER_JWKS_URL=http://thunder.amp.localhost:8080/oauth2/jwks
       - KEY_MANAGER_ISSUER=Agent Management Platform Local,http://thunder.amp.localhost:8080
-      # Last entry is SERVER_PUBLIC_URL above plus a trailing slash — an MCP
-      # token's `aud`. The Helm charts derive this; here it moves by hand.
-      - KEY_MANAGER_AUDIENCE=urn:wso2:amp,localhost,amp-publisher-*,amp-api-client,amp-console-client,amctl,am-mcp,http://localhost:9000/
+      # Last entry is SERVER_PUBLIC_URL above plus "/mcp" (no trailing slash,
+      # per the MCP spec's canonical-URI guidance) — an MCP token's `aud`.
+      # The Helm charts derive this; here it moves by hand.
+      - KEY_MANAGER_AUDIENCE=urn:wso2:amp,localhost,amp-publisher-*,amp-api-client,amp-console-client,amctl,am-mcp,http://localhost:9000/mcp
       - AMP_VERSION=v0.8.0
       - OPEN_CHOREO_BASE_URL=http://api.openchoreo.localhost:8195
       # OpenBao/Vault Secret Management Configuration

--- a/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
@@ -114,14 +114,16 @@ app.kubernetes.io/component: agent-manager-service
 {{- end }}
 
 {{/*
-Accepted token audiences: keyManager.audience plus serverPublicURL with the
-trailing slash Thunder stamps on RFC 8707 resource identifiers. nospace keeps a
-spaced-out list from defeating the uniq. See values.yaml for why it is derived.
+Accepted token audiences: keyManager.audience plus serverPublicURL with /mcp
+appended (no trailing slash — the MCP spec's canonical-URI guidance prefers
+the form without one) — the RFC 8707 resource identifier Thunder stamps into
+MCP tokens. nospace keeps a spaced-out list from defeating the uniq. See
+values.yaml for why it is derived.
 */}}
 {{- define "agent-management-platform.agentManagerService.audience" -}}
 {{- $audiences := .Values.agentManagerService.config.keyManager.audience | nospace | splitList "," | compact -}}
 {{- with .Values.agentManagerService.config.serverPublicURL -}}
-{{- $audiences = append $audiences (printf "%s/" (trimSuffix "/" .)) -}}
+{{- $audiences = append $audiences (printf "%s/mcp" (trimSuffix "/" .)) -}}
 {{- end -}}
 {{- join "," (uniq $audiences) -}}
 {{- end }}

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -55,7 +55,7 @@ CLIENTS="urn:wso2:amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am
 # Defaults must stay byte-identical to the pre-derivation literals, so existing
 # installs and quick-start (which passes no overrides) are unaffected.
 assert_cm "default audience keeps the gateway resource entry" \
-  KEY_MANAGER_AUDIENCE "${CLIENTS},http://api.amp.localhost:8080/"
+  KEY_MANAGER_AUDIENCE "${CLIENTS},http://api.amp.localhost:8080/mcp"
 assert_cm "default authorization servers fall back to the default issuer" \
   OAUTH_AUTHORIZATION_SERVERS "http://thunder.amp.localhost:8080"
 
@@ -71,26 +71,27 @@ assert_cm "explicit authorization servers win over the issuer" \
   --set agentManagerService.config.oauthAuthorizationServers=https://as.example.com
 
 # Issue #1414: serverPublicURL is the RFC 8707 resource identifier MCP tokens are
-# minted with, so it must reach the audience list with exactly one trailing slash.
+# minted with, so it must reach the audience list with "/mcp" appended and no
+# trailing slash (per the MCP spec's canonical-URI guidance).
 assert_cm "serverPublicURL override is appended to the audience" \
-  KEY_MANAGER_AUDIENCE "${CLIENTS},https://api.example.com/" \
+  KEY_MANAGER_AUDIENCE "${CLIENTS},https://api.example.com/mcp" \
   --set agentManagerService.config.serverPublicURL=https://api.example.com
 assert_cm "a serverPublicURL that already ends in a slash is not doubled" \
-  KEY_MANAGER_AUDIENCE "${CLIENTS},https://api.example.com/" \
+  KEY_MANAGER_AUDIENCE "${CLIENTS},https://api.example.com/mcp" \
   --set agentManagerService.config.serverPublicURL=https://api.example.com/
 assert_cm "an audience that already lists the resource gains no duplicate" \
-  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/" \
+  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/mcp" \
   --set agentManagerService.config.serverPublicURL=https://api.example.com \
-  --set 'agentManagerService.config.keyManager.audience=amp\,https://api.example.com/'
+  --set 'agentManagerService.config.keyManager.audience=amp\,https://api.example.com/mcp'
 assert_cm "whitespace in the audience does not defeat the duplicate check" \
-  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/" \
+  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/mcp" \
   --set agentManagerService.config.serverPublicURL=https://api.example.com \
-  --set 'agentManagerService.config.keyManager.audience=amp\, https://api.example.com/'
+  --set 'agentManagerService.config.keyManager.audience=amp\, https://api.example.com/mcp'
 assert_cm "an empty serverPublicURL appends nothing and leaves no trailing comma" \
   KEY_MANAGER_AUDIENCE "$CLIENTS" \
   --set-string agentManagerService.config.serverPublicURL=
 assert_cm "a stray comma in the audience does not produce an empty entry" \
-  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/" \
+  KEY_MANAGER_AUDIENCE "amp,https://api.example.com/mcp" \
   --set agentManagerService.config.serverPublicURL=https://api.example.com \
   --set 'agentManagerService.config.keyManager.audience=amp\,'
 

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -231,8 +231,9 @@ agentManagerService:
     # Token audiences accepted by this service. Console/CLI logins arrive with
     # aud=urn:wso2:amp (the amp resource server's identifier — keep in sync with
     # 60-amp-resource-server.yaml in the Thunder extension chart); MCP logins arrive
-    # with serverPublicURL plus a trailing slash, which the chart appends
-    # automatically — list only client IDs here.
+    # with serverPublicURL plus "/mcp" (no trailing slash, per the MCP spec's
+    # canonical-URI guidance), which the chart appends automatically — list
+    # only client IDs here.
     keyManager:
       issuer: "http://thunder.amp.localhost:8080"
       audience: "urn:wso2:amp,amp-console-client,amp-api-client,amp-publisher-*,amctl,am-mcp"

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
@@ -51,14 +51,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Accepted token audiences: auth.audience plus publicUrl with the trailing slash
-Thunder stamps on RFC 8707 resource identifiers. nospace keeps a spaced-out list
-from defeating the uniq. See values.yaml for why it is derived.
+Accepted token audiences: auth.audience plus publicUrl with /mcp appended (no
+trailing slash — the MCP spec's canonical-URI guidance prefers the form
+without one) — the RFC 8707 resource identifier Thunder stamps into MCP
+tokens. nospace keeps a spaced-out list from defeating the uniq. See
+values.yaml for why it is derived.
 */}}
 {{- define "amp-observability-extension.audience" -}}
 {{- $audiences := .Values.amObserver.auth.audience | nospace | splitList "," | compact -}}
 {{- with .Values.amObserver.publicUrl -}}
-{{- $audiences = append $audiences (printf "%s/" (trimSuffix "/" .)) -}}
+{{- $audiences = append $audiences (printf "%s/mcp" (trimSuffix "/" .)) -}}
 {{- end -}}
 {{- join "," (uniq $audiences) -}}
 {{- end }}

--- a/deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh
@@ -51,7 +51,7 @@ assert_env() {
 # Defaults must stay byte-identical to the pre-derivation literals, so that
 # existing installs and quick-start (which passes no overrides) are unaffected.
 assert_env "default audience keeps the k3d resource entry" \
-  KEY_MANAGER_AUDIENCE "urn:wso2:amp,amp-api-client,am-obs-mcp,http://traces.amp.localhost:11080/"
+  KEY_MANAGER_AUDIENCE "urn:wso2:amp,amp-api-client,am-obs-mcp,http://traces.amp.localhost:11080/mcp"
 assert_env "default authorization servers fall back to the default issuer" \
   OAUTH_AUTHORIZATION_SERVERS "http://thunder.amp.localhost:8080"
 
@@ -67,26 +67,27 @@ assert_env "explicit authorization servers win over the issuer" \
   --set amObserver.oauth.authorizationServers=https://as.example.com
 
 # publicUrl carries the RFC 8707 resource identifier MCP tokens are minted with,
-# so it must reach the audience list with exactly one trailing slash.
+# so it must reach the audience list with "/mcp" appended and no trailing slash
+# (per the MCP spec's canonical-URI guidance).
 assert_env "publicUrl override is appended to the audience" \
-  KEY_MANAGER_AUDIENCE "urn:wso2:amp,amp-api-client,am-obs-mcp,https://traces.example.com/" \
+  KEY_MANAGER_AUDIENCE "urn:wso2:amp,amp-api-client,am-obs-mcp,https://traces.example.com/mcp" \
   --set amObserver.publicUrl=https://traces.example.com
 assert_env "a publicUrl that already ends in a slash is not doubled" \
-  KEY_MANAGER_AUDIENCE "urn:wso2:amp,amp-api-client,am-obs-mcp,https://traces.example.com/" \
+  KEY_MANAGER_AUDIENCE "urn:wso2:amp,amp-api-client,am-obs-mcp,https://traces.example.com/mcp" \
   --set amObserver.publicUrl=https://traces.example.com/
 assert_env "an audience that already lists the resource gains no duplicate" \
-  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/" \
+  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/mcp" \
   --set amObserver.publicUrl=https://traces.example.com \
-  --set 'amObserver.auth.audience=amp\,https://traces.example.com/'
+  --set 'amObserver.auth.audience=amp\,https://traces.example.com/mcp'
 assert_env "whitespace in the audience does not defeat the duplicate check" \
-  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/" \
+  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/mcp" \
   --set amObserver.publicUrl=https://traces.example.com \
-  --set 'amObserver.auth.audience=amp\, https://traces.example.com/'
+  --set 'amObserver.auth.audience=amp\, https://traces.example.com/mcp'
 assert_env "an empty publicUrl appends nothing and leaves no trailing comma" \
   KEY_MANAGER_AUDIENCE "urn:wso2:amp,amp-api-client,am-obs-mcp" \
   --set-string amObserver.publicUrl=
 assert_env "a stray comma in the audience does not produce an empty entry" \
-  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/" \
+  KEY_MANAGER_AUDIENCE "amp,https://traces.example.com/mcp" \
   --set amObserver.publicUrl=https://traces.example.com \
   --set 'amObserver.auth.audience=amp\,'
 

--- a/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
@@ -67,10 +67,11 @@ amObserver:
   # Publisher tokens (aud amp-publisher-*) are matched by a separate regex in
   # the observer's auth middleware and do not need to be listed here.
   # MCP tokens minted for the observer MCP client (am-obs-mcp) carry the
-  # RFC 8707 resource identifier — this service's publicUrl WITH a trailing
-  # slash — as their audience. That URL is NOT listed here: the chart appends
-  # publicUrl (slash included) to this list automatically, so overriding
-  # publicUrl alone keeps MCP tokens valid. "am-obs-mcp" is listed
+  # RFC 8707 resource identifier — this service's publicUrl with "/mcp"
+  # appended (no trailing slash, per the MCP spec's canonical-URI guidance) —
+  # as their audience. That URL is NOT listed here: the chart appends
+  # publicUrl+"/mcp" to this list automatically, so overriding publicUrl
+  # alone keeps MCP tokens valid. "am-obs-mcp" is listed
   # defensively; MCP logins normally carry that resource URL as the
   # audience, not the client ID (unlike amp-api-client's client-credentials
   # fallback, this can't occur for am-obs-mcp, a public client restricted to

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -547,7 +547,7 @@ data:
     id: {{ $server.id | quote }}
     name: {{ $server.name | quote }}
     description: {{ $server.description | quote }}
-    identifier: {{ printf "%s/" ($baseURL | trimSuffix "/") | quote }}
+    identifier: {{ printf "%s/mcp" ($baseURL | trimSuffix "/") | quote }}
     ouHandle: default
     delimiter: ":"
     resources:

--- a/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/templates/amp-thunder-bootstrap.yaml
@@ -532,6 +532,68 @@ data:
         actions:
           - { name: Read, handle: read, description: "Browse repository branches and commits" }
 
+  60-mcp-resource-servers.yaml: |
+  {{- $firstMCPResourceServer := true }}
+  {{- range $server := .Values.thunder.bootstrap.mcpResourceServers }}
+  {{- $baseURL := index $.Values.thunder.bootstrap $server.baseUrlValue }}
+  {{- if and (not $baseURL) (not $server.optional) }}
+  {{- fail (printf "thunder.bootstrap.%s must be set" $server.baseUrlValue) }}
+  {{- end }}
+  {{- if $baseURL }}
+  {{- if not $firstMCPResourceServer }}
+    ---
+  {{- end }}
+    resource_type: resource_server
+    id: {{ $server.id | quote }}
+    name: {{ $server.name | quote }}
+    description: {{ $server.description | quote }}
+    identifier: {{ printf "%s/" ($baseURL | trimSuffix "/") | quote }}
+    ouHandle: default
+    delimiter: ":"
+    resources:
+      - name: Agent Manager
+        handle: amp
+        description: Top-level namespace for Agent Manager MCP permissions
+    {{- if eq $server.permissionSet "observability-only" }}
+      - name: Observability
+        handle: observability
+        parent: amp
+        description: Observability MCP permissions
+        actions:
+          - { name: Trace Read, handle: trace-read, description: "Read agent execution traces" }
+          - { name: Log Read, handle: log-read, description: "Read agent runtime logs" }
+          - { name: Build Log Read, handle: build-log-read, description: "Read agent build logs" }
+          - { name: Metric Read, handle: metric-read, description: "Read agent and system metrics" }
+    {{- else }}
+      - name: Project
+        handle: project
+        parent: amp
+        description: Project operations exposed by Agent Manager MCP
+        actions:
+          - { name: Create, handle: create, description: "Create a project" }
+          - { name: Read, handle: read, description: "View project details" }
+      - name: Environment
+        handle: environment
+        parent: amp
+        description: Environment operations exposed by Agent Manager MCP
+        actions:
+          - { name: Read, handle: read, description: "View environment details" }
+      - name: Agent
+        handle: agent
+        parent: amp
+        description: Agent operations exposed by Agent Manager MCP
+        actions:
+          - { name: Create, handle: create, description: "Create an agent" }
+          - { name: Read, handle: read, description: "View agent details" }
+          - { name: Build, handle: build, description: "Trigger an agent build" }
+          - { name: Act on Non-Production Environments, handle: env-non-production, description: "Deploy or suspend an agent in a non-production environment" }
+          - { name: Suspend, handle: suspend, description: "Suspend an agent deployment" }
+          - { name: Manage Token, handle: token-manage, description: "Generate agent tokens" }
+    {{- end }}
+  {{- $firstMCPResourceServer = false }}
+  {{- end }}
+  {{- end }}
+
   61-amp-role-admin.yaml: |
     resource_type: role
     id: amp-role-admin
@@ -644,6 +706,28 @@ data:
           - "amp:repository:read"
           - "amp:profile:read"
           - "amp:profile:update-attributes"
+    {{- range $server := .Values.thunder.bootstrap.mcpResourceServers }}
+    {{- if index $.Values.thunder.bootstrap $server.baseUrlValue }}
+      - resourceServerId: {{ $server.id }}
+        permissions:
+    {{- if eq $server.permissionSet "observability-only" }}
+          - "amp:observability:trace-read"
+          - "amp:observability:log-read"
+          - "amp:observability:build-log-read"
+          - "amp:observability:metric-read"
+    {{- else }}
+          - "amp:project:create"
+          - "amp:project:read"
+          - "amp:environment:read"
+          - "amp:agent:create"
+          - "amp:agent:read"
+          - "amp:agent:build"
+          - "amp:agent:env-non-production"
+          - "amp:agent:suspend"
+          - "amp:agent:token-manage"
+    {{- end }}
+    {{- end }}
+    {{- end }}
     assignments:
       - id: amp-api-client
         type: app
@@ -715,6 +799,28 @@ data:
           - "amp:repository:read"
           - "amp:profile:read"
           - "amp:profile:update-attributes"
+    {{- range $server := .Values.thunder.bootstrap.mcpResourceServers }}
+    {{- if index $.Values.thunder.bootstrap $server.baseUrlValue }}
+      - resourceServerId: {{ $server.id }}
+        permissions:
+    {{- if eq $server.permissionSet "observability-only" }}
+          - "amp:observability:trace-read"
+          - "amp:observability:log-read"
+          - "amp:observability:build-log-read"
+          - "amp:observability:metric-read"
+    {{- else }}
+          - "amp:project:create"
+          - "amp:project:read"
+          - "amp:environment:read"
+          - "amp:agent:create"
+          - "amp:agent:read"
+          - "amp:agent:build"
+          - "amp:agent:env-non-production"
+          - "amp:agent:suspend"
+          - "amp:agent:token-manage"
+    {{- end }}
+    {{- end }}
+    {{- end }}
 
   63-amp-role-ai-lead.yaml: |
     resource_type: role
@@ -776,6 +882,23 @@ data:
           - "amp:repository:read"
           - "amp:profile:read"
           - "amp:profile:update-attributes"
+    {{- range $server := .Values.thunder.bootstrap.mcpResourceServers }}
+    {{- if index $.Values.thunder.bootstrap $server.baseUrlValue }}
+      - resourceServerId: {{ $server.id }}
+        permissions:
+    {{- if eq $server.permissionSet "observability-only" }}
+          - "amp:observability:trace-read"
+          - "amp:observability:metric-read"
+    {{- else }}
+          - "amp:project:read"
+          - "amp:environment:read"
+          - "amp:agent:read"
+          - "amp:agent:build"
+          - "amp:agent:env-non-production"
+          - "amp:agent:suspend"
+    {{- end }}
+    {{- end }}
+    {{- end }}
 
   64-amp-role-platform-engineer.yaml: |
     resource_type: role
@@ -855,6 +978,26 @@ data:
           - "amp:catalog:read"
           - "amp:profile:read"
           - "amp:profile:update-attributes"
+    {{- range $server := .Values.thunder.bootstrap.mcpResourceServers }}
+    {{- if index $.Values.thunder.bootstrap $server.baseUrlValue }}
+      - resourceServerId: {{ $server.id }}
+        permissions:
+    {{- if eq $server.permissionSet "observability-only" }}
+          - "amp:observability:trace-read"
+          - "amp:observability:log-read"
+          - "amp:observability:build-log-read"
+          - "amp:observability:metric-read"
+    {{- else }}
+          - "amp:project:create"
+          - "amp:project:read"
+          - "amp:environment:read"
+          - "amp:agent:read"
+          - "amp:agent:build"
+          - "amp:agent:env-non-production"
+          - "amp:agent:suspend"
+    {{- end }}
+    {{- end }}
+    {{- end }}
 
   65-amp-group-admins.yaml: |
     resource_type: group

--- a/deployments/helm-charts/wso2-amp-thunder-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/tests/render.sh
@@ -30,8 +30,8 @@ assert all(isinstance(server, dict) for server in servers)
 by_id = {server["id"]: server for server in servers}
 main = by_id["amp-agent-manager-mcp-resource-server"]
 observer = by_id["amp-observer-mcp-resource-server"]
-assert main["identifier"] == "http://api.amp.localhost:8080/"
-assert observer["identifier"] == "http://traces.amp.localhost:11080/"
+assert main["identifier"] == "http://api.amp.localhost:8080/mcp"
+assert observer["identifier"] == "http://traces.amp.localhost:11080/mcp"
 assert "amp-agent-manager-dev-mcp-resource-server" not in by_id
 
 setup_job = next(

--- a/deployments/helm-charts/wso2-amp-thunder-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/tests/render.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rendered="$(mktemp)"
+trap 'rm -f "$rendered"' EXIT
+
+helm template test "$CHART_DIR" "$@" >"$rendered"
+
+python3 - "$rendered" <<'PY'
+import sys
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as stream:
+    documents = list(yaml.safe_load_all(stream))
+
+bootstrap = next(
+    doc for doc in documents
+    if isinstance(doc, dict)
+    and doc.get("kind") == "ConfigMap"
+    and doc.get("metadata", {}).get("name") == "amp-thunder-bootstrap"
+)
+data = bootstrap["data"]
+
+amp = yaml.safe_load(data["60-amp-resource-server.yaml"])
+assert amp["identifier"] == "urn:wso2:amp", amp["identifier"]
+
+servers = list(yaml.safe_load_all(data["60-mcp-resource-servers.yaml"]))
+assert all(isinstance(server, dict) for server in servers)
+by_id = {server["id"]: server for server in servers}
+main = by_id["amp-agent-manager-mcp-resource-server"]
+observer = by_id["amp-observer-mcp-resource-server"]
+assert main["identifier"] == "http://api.amp.localhost:8080/"
+assert observer["identifier"] == "http://traces.amp.localhost:11080/"
+assert "amp-agent-manager-dev-mcp-resource-server" not in by_id
+
+setup_job = next(
+    doc for doc in documents
+    if isinstance(doc, dict)
+    and doc.get("kind") == "Job"
+    and doc.get("metadata", {}).get("name", "").endswith("-thunder-setup")
+)
+mounts = setup_job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+assert any(mount.get("subPath") == "60-mcp-resource-servers.yaml" for mount in mounts)
+
+main_permissions = {
+    action["handle"]
+    for resource in main["resources"]
+    for action in resource.get("actions", [])
+}
+assert main_permissions == {
+    "create", "read", "build", "env-non-production", "suspend", "token-manage"
+}
+observer_permissions = {
+    action["handle"]
+    for resource in observer["resources"]
+    for action in resource.get("actions", [])
+}
+assert observer_permissions == {"trace-read", "log-read", "build-log-read", "metric-read"}
+
+for filename in (
+    "61-amp-role-admin.yaml",
+    "62-amp-role-developer.yaml",
+    "63-amp-role-ai-lead.yaml",
+    "64-amp-role-platform-engineer.yaml",
+):
+    role = yaml.safe_load(data[filename])
+    ids = {entry["resourceServerId"] for entry in role["permissions"]}
+    assert "amp-resource-server" in ids
+    assert "amp-agent-manager-mcp-resource-server" in ids
+    assert "amp-observer-mcp-resource-server" in ids
+
+print("Thunder MCP resource-server render checks passed")
+PY

--- a/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-thunder-extension/values.yaml
@@ -338,6 +338,7 @@ thunder:
         - 58-amctl-client.yaml
         - 59-am-mcp-client.yaml
         - 60-amp-resource-server.yaml
+        - 60-mcp-resource-servers.yaml
         - 61-amp-role-admin.yaml
         - 62-amp-role-developer.yaml
         - 63-amp-role-ai-lead.yaml
@@ -533,32 +534,24 @@ thunder:
         - "groups"
         - "ouId"
         - "ouHandle"
-    # RFC 8707 resource-server definitions for the platform's own MCP endpoints
-    # (agent-manager's MCP endpoint, its docker-compose dev variant, and the
-    # observer's MCP endpoint). NOT currently consumed by any template in this
-    # chart — nothing renders these into Thunder on install/upgrade yet; see
-    # deployments/setup/register-amp-resources.sh for the manual/bash
-    # registration that has to be run by hand instead. baseUrlValue names the
-    # scalar below holding that entry's base URL; permissionSet picks which
-    # slice of the amp permission tree it gets ("amp-minus-observability" or
-    # "observability-only"); `optional: true` entries are skipped when their
-    # base URL is empty.
+    # RFC 8707 resource servers for the public MCP origins. The bootstrap
+    # renders these as separate resource servers; urn:wso2:amp remains the
+    # platform API resource identifier. baseUrlValue selects the deployment-
+    # specific origin — one scalar per MCP endpoint, overridden to whatever
+    # that install actually serves (docker-compose dev, k3d, a VM, or a real
+    # domain); there is no separate "dev" scalar to keep in sync, the same way
+    # observerMcpBaseUrl has never needed one.
     agentManagerMcpBaseUrl: "http://api.amp.localhost:8080"
-    agentManagerMcpDevBaseUrl: ""
     observerMcpBaseUrl: "http://traces.amp.localhost:11080"
     mcpResourceServers:
       - name: "AMP Agent Manager MCP"
+        id: "amp-agent-manager-mcp-resource-server"
         handle: ""
         baseUrlValue: "agentManagerMcpBaseUrl"
         description: "Resource identifier for the agent-manager MCP endpoint"
         permissionSet: "amp-minus-observability"
-      - name: "AMP Agent Manager MCP (dev)"
-        handle: ""
-        baseUrlValue: "agentManagerMcpDevBaseUrl"
-        optional: true
-        description: "Resource identifier for the agent-manager MCP endpoint on the docker-compose dev stack"
-        permissionSet: "amp-minus-observability"
       - name: "AMP Observer MCP"
+        id: "amp-observer-mcp-resource-server"
         handle: ""
         baseUrlValue: "observerMcpBaseUrl"
         description: "Resource identifier for the observer MCP endpoint"

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -462,7 +462,7 @@ log_success "Default OU ID: $DEFAULT_OU_ID"
 # 1. Resource server
 # ===========================================================================
 log_info "Creating 'amp' resource server..."
-RS_ID=$(create_or_get_rs "Agent Manager API" "amp" "amp" "Agent Manager platform permissions" "$DEFAULT_OU_ID")
+RS_ID=$(create_or_get_rs "Agent Manager API" "amp" "urn:wso2:amp" "Agent Manager platform permissions" "$DEFAULT_OU_ID")
 log_info "Resource server ready (id: $RS_ID)"
 
 # ===========================================================================

--- a/deployments/setup/setup-amp-extensions.sh
+++ b/deployments/setup/setup-amp-extensions.sh
@@ -70,15 +70,16 @@ install_thunder_extension() {
     fi
 
     # The dev stack runs amp-api on a published host port rather than behind the
-    # gateway, so register that origin as a second MCP resource identifier too —
-    # Thunder matches the authorize request's `resource` value exactly.
+    # gateway, so override the MCP resource identifier to that origin — Thunder
+    # matches the authorize request's `resource` value exactly, and this dev
+    # stack never serves the chart's own k3d-gateway default at all.
     # thunder.setup.admin.password fixes the console admin login at "admin" for
     # local dev convenience — the chart's own default (unset) would generate a
     # random one instead, which is what production wants but is annoying to
     # look up every time on a machine only you can reach anyway.
     helm upgrade --install amp-thunder-extension "${SCRIPT_DIR}/../helm-charts/wso2-amp-thunder-extension" \
         --namespace amp-thunder --create-namespace \
-        --set thunder.bootstrap.agentManagerMcpDevBaseUrl=http://localhost:9000 \
+        --set thunder.bootstrap.agentManagerMcpBaseUrl=http://localhost:9000 \
         --set thunder.setup.admin.password=admin
     echo "✅ AMP Thunder Extension installed/upgraded successfully"
 }

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -447,10 +447,6 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   assert_eq "core thunder MCP base URL (observer)" \
     "thunder.bootstrap.observerMcpBaseUrl=https://observer.amp.example.com" \
     "$(grep -F 'observerMcpBaseUrl' <<<"$core_th")"
-  # The dev origin is opt-in (empty chart default), so a VM install must not
-  # register it at all.
-  assert_eq "core thunder leaves the dev MCP origin unset" "" \
-    "$(grep -F 'agentManagerMcpDevBaseUrl' <<<"$core_th")"
 
   core_obs="$(observability_helm_args)"
   assert_eq "core observability audience carries the public observer URL" \

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -81,7 +81,7 @@ The docker-compose dev stack publishes `agent-manager-service` straight onto a h
 http://localhost:9000/mcp
 ```
 
-Each install registers only the origins it actually serves: `make setup` registers both (the gateway origin and the dev host port), while a Quick Start or k3d install registers the gateway origin alone. If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value — and see the warning below.
+Each install registers exactly the one origin it actually serves — `make setup` overrides the identifier to the dev host port, while a Quick Start or k3d install leaves it at the chart's gateway-origin default. If you have changed `serverPublicURL` (Helm) or `SERVER_PUBLIC_URL` (docker-compose), substitute that value — and see the warning below.
 
 :::warning Moving the public URL is a two-place change
 
@@ -109,10 +109,10 @@ The matching `aud` entry needs no separate setting: `wso2-agent-manager` appends
 so that list only carries client IDs. (Charts released before that derivation
 list the URL literally — there, moving the public URL is a three-place change.)
 
-Identifiers are matched exactly, so a deployment reachable on more than one
-origin needs one resource server per origin. `thunder.bootstrap.agentManagerMcpDevBaseUrl`
-is the opt-in second origin for the docker-compose dev stack; `make setup-openchoreo`
-sets it, and other installs leave it empty.
+Identifiers are matched exactly, so there is exactly one `agentManagerMcpBaseUrl`
+scalar to override — the same one every install type sets, from `make setup`'s
+docker-compose host port to a real domain in production — not a separate
+value per environment.
 
 :::
 
@@ -126,13 +126,15 @@ AMP ships a pre-registered OAuth application in Thunder for MCP clients:
 
 The client is public (no secret), PKCE is required, and the callback port is pinned to **33418**. Because the redirect URIs are baked into the OAuth client registration, every MCP client must run its local OAuth listener on port `33418` to complete the login.
 
-The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extension` Helm chart (script `59-am-mcp-client.sh`) and is already wired into `KEY_MANAGER_AUDIENCE` on the docker-compose setup, so no manual registration is required for the default installations.
+The `am-mcp` client is provisioned automatically by the `wso2-amp-thunder-extension` Helm chart's bootstrap job (`59-am-mcp-client.yaml`) and is already wired into `KEY_MANAGER_AUDIENCE` on the docker-compose setup, so no manual registration is required for the default installations.
+
+The MCP resource-server identifier registered for this endpoint is a dedicated resource server, `amp-agent-manager-mcp-resource-server`, seeded from `60-mcp-resource-servers.yaml`. It is separate both from the general "Agent Manager API" resource server (`urn:wso2:amp`) that console, amctl, and `client_credentials` callers use, and from the Observer MCP endpoint's own resource server: an MCP client discovers the `resource` value from *this* endpoint's own metadata and requires it to match the origin it actually connected to, so a URN can't be the identifier (RFC 8707 requires an absolute URI) and one identifier can't cover two different origins. See [Observer MCP Server](./observer-mcp-server.mdx) for that endpoint's own identifier.
 
 :::note Upgrading an existing install
 
-Both the MCP resource-server identifiers and the permissions that become MCP token scopes are seeded by `60-amp-resource-server.sh`, which lives in a ConfigMap annotated `helm.sh/hook: pre-install`. Helm does **not** re-apply that ConfigMap on `helm upgrade`, so upgrading the chart leaves the old scripts in place and re-running the setup job would just re-seed the old values.
+Both the MCP resource-server identifiers (`60-mcp-resource-servers.yaml`) and the role permissions that become MCP token scopes (the four role documents, `61`–`64`) are seeded by a ConfigMap annotated `helm.sh/hook: pre-install`. Helm does **not** re-apply that ConfigMap on `helm upgrade`, so upgrading the chart leaves the old bootstrap data in place and re-running the setup job would just re-seed the old values.
 
-To pick up either, **reinstall the `amp-thunder-extension` release** (or replace the `amp-thunder-bootstrap` ConfigMap, then re-run the job). Symptoms if you skip it: an install seeded before the gateway origin was added registered only `http://localhost:9000/`, so a Quick Start or k3d client fails authorize with `invalid_target`; an install seeded without the permissions issues MCP tokens with an empty scope list and every tool call returns 403. Identifiers no longer in use are inert and can be left in place.
+To pick up either, **reinstall the `amp-thunder-extension` release** (or replace the `amp-thunder-bootstrap` ConfigMap, then re-run the job). Symptoms if you skip it: an install seeded before the dedicated MCP resource servers existed has no identifier for the `/mcp` endpoint at all, so every client fails authorize with `invalid_target`; an install seeded without the current role permissions issues MCP tokens with an empty scope list and every tool call returns 403.
 
 :::
 

--- a/documentation/docs/reference/mcp-server.mdx
+++ b/documentation/docs/reference/mcp-server.mdx
@@ -85,10 +85,12 @@ Each install registers exactly the one origin it actually serves — `make setup
 
 :::warning Moving the public URL is a two-place change
 
-MCP clients send the server's public URL — with a trailing slash — as the OAuth
-`resource` parameter (RFC 8707), and Thunder both validates that value against
-its registered resource servers and stamps it into the token's `aud`. Changing
-the public URL therefore means changing two settings together, in two charts:
+MCP clients send the server's public URL with `/mcp` appended — no trailing
+slash, per the MCP spec's canonical-URI guidance (the endpoint's actual path,
+not a bare origin) — as the OAuth `resource` parameter (RFC 8707), and Thunder
+both validates that value against its registered resource servers and stamps
+it into the token's `aud`. Changing the public URL therefore means changing
+two settings together, in two charts:
 
 | Setting                                      | Chart                        | Value               |
 | -------------------------------------------- | ---------------------------- | ------------------- |
@@ -97,17 +99,17 @@ the public URL therefore means changing two settings together, in two charts:
 
 On docker-compose there is no chart to derive anything, so all three move together
 by hand in `deployments/docker-compose.yml`: `SERVER_PUBLIC_URL`, the matching
-`KEY_MANAGER_AUDIENCE` entry (the same URL **plus a trailing slash**), and the
-identifier registered in Thunder.
+`KEY_MANAGER_AUDIENCE` entry (the same URL **plus `/mcp`, no trailing slash**),
+and the identifier registered in Thunder.
 
 Leaving `agentManagerMcpBaseUrl` behind makes the browser redirect fail with
 `invalid_target: The resource parameter does not match any registered resource
 server`.
 
 The matching `aud` entry needs no separate setting: `wso2-agent-manager` appends
-`serverPublicURL` plus a trailing slash to `keyManager.audience` when it renders,
-so that list only carries client IDs. (Charts released before that derivation
-list the URL literally — there, moving the public URL is a three-place change.)
+`serverPublicURL` plus `/mcp` to `keyManager.audience` when it renders, so that
+list only carries client IDs. (Charts released before that derivation list the
+URL literally — there, moving the public URL is a three-place change.)
 
 Identifiers are matched exactly, so there is exactly one `agentManagerMcpBaseUrl`
 scalar to override — the same one every install type sets, from `make setup`'s

--- a/documentation/docs/reference/observer-mcp-server.mdx
+++ b/documentation/docs/reference/observer-mcp-server.mdx
@@ -137,6 +137,8 @@ http://traces.amp.localhost:11080/mcp
 
 If you have changed the observer's public URL from the default, substitute that value.
 
+This endpoint is registered in Thunder as its own dedicated resource server, `amp-observer-mcp-resource-server`, separate from the main MCP server's resource server — see the [main MCP server reference](./mcp-server.mdx#default-oauth-client) for why each `/mcp` endpoint needs its own identifier rather than sharing one.
+
 ## Configuring AI Assistants
 
 The observer MCP server has its own dedicated pre-registered OAuth client — `am-obs-mcp`, with pinned callback port `33419` — distinct from the [main MCP server](./mcp-server.mdx#default-oauth-client)'s `am-mcp`/`33418`. The `am-obs-mcp` client is allowed only the OIDC scopes plus the four `amp:observability:*-read` scopes, so a token obtained for the main MCP server cannot be reused here (and vice versa). Follow the [Configuring AI Assistants](./mcp-server.mdx#configuring-ai-assistants) instructions there, substituting the observer MCP server URL, client ID, and callback port, for example:


### PR DESCRIPTION
## Purpose
> Resolves #1732 — MCP login to Agent Manager and Observer failed with `invalid_target`, and (once that was patched) tokens came back with an empty scope list, so every MCP tool call returned 403.

## Goals
> Make MCP OAuth login work correctly and reliably for both the Agent Manager MCP endpoint and the Observer MCP endpoint, on every installation type (`make setup`, Quick Start/k3d, VM, production), without breaking console/amctl/`client_credentials` login.

## Approach
> An MCP client discovers a `resource` identifier from the server it connects to and requires that value to match the origin it actually dialed — so one resource server can never correctly represent two different origins (Agent Manager's API and the Observer are always on different hosts). The fix registers a **dedicated Thunder resource server per MCP endpoint** instead of trying to share one:
> - `amp-agent-manager-mcp-resource-server` for the Agent Manager `/mcp` endpoint
> - `amp-observer-mcp-resource-server` for the Observer `/mcp` endpoint
> - the existing general `amp-resource-server` (`urn:wso2:amp`) is untouched and keeps serving console/amctl/`client_credentials`
>
> Each is wired automatically by the Thunder bootstrap job from a single `agentManagerMcpBaseUrl` / `observerMcpBaseUrl` value — one scalar per endpoint, overridden to whatever origin that install type actually serves (a real domain in production, the k3d gateway for Quick Start, the docker-compose host port for `make setup`). Previously `make setup` additionally registered a second, unused "dev" resource server on top of the real one; that duplicate is removed, and `make setup` now just overrides the one real value directly, the same way every other install type already did.
>
> Also fixed two stale doc references to a bootstrap script that no longer exists (the bootstrap moved from bash to declarative YAML), and updated the MCP reference docs to name the new resource servers so they're identifiable in the Thunder console.

## User stories
> N/A

## Release note
> N/A

## Documentation
> Updated `documentation/docs/reference/mcp-server.mdx` and `documentation/docs/reference/observer-mcp-server.mdx` to describe the per-endpoint resource servers and correct the stale bootstrap-script references.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
- Unit tests
  > `agent-manager-service`: `make test-unit` — all passing (rbac, api, clients/thundersvc packages cover the changed lookup/scope logic). `agent-manager-observer`: `make test` — all passing.
- Integration tests
  > `agent-manager-service`: `make test-integration` against an isolated Postgres DB — 1147 tests passing, 0 failures, including controller/service-level coverage.
  > Also verified as a real MCP client would: as an AI coding agent, I drove an actual browser through the full ThunderID login page for both `am-mcp` and `am-obs-mcp`, captured the real authorization code from the callback redirect, exchanged it for a real token, and called each MCP endpoint's `initialize`, `tools/list`, and a real `tools/call` — confirming both endpoints work end-to-end, not just that the code compiles or unit tests pass.

- Test Evidance
- https://github.com/user-attachments/assets/709f7646-6ae6-4453-8abc-aa5025b6cd0f

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — this PR contains no Java code (Go, Helm, shell, and docs only); `golangci-lint` was run instead and reports 0 issues.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> macOS (Darwin), local hybrid stack: `agent-manager-service`/console/db via Docker Compose, Thunder/Observer via a k3d cluster. Go 1.x (per `go.mod`), Helm 3.19, `kubeconform` 0.7.0. Real OAuth logins performed against ThunderID v1.0.0 via an actual browser session.

## Learning
> N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable MCP resource servers with dedicated identifiers, base URLs, permissions, and role assignments.
  * Registered the main and observer MCP endpoints as separate resource servers.
* **Bug Fixes**
  * Standardized MCP resource URLs and token audiences to use `/mcp` without trailing slashes.
  * Updated OAuth metadata to report the correct MCP scopes.
* **Documentation**
  * Updated MCP setup, deployment, audience, and resource-server guidance.
* **Validation**
  * Added deployment checks for MCP resources, permissions, mounts, and role assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->