### PR TITLE
Provision AgentID for external agents in environments added after creation

### DIFF
--- a/console/workspaces/libs/api-client/src/hooks/agents.ts
+++ b/console/workspaces/libs/api-client/src/hooks/agents.ts
@@ -326,6 +326,13 @@ export function useProvisionAgentIdentity() {
   >({
     action: { verb: 'create', target: 'agent identity' },
     mutationFn: ({ params, query }) => provisionAgentIdentity(params, query, getToken),
+    // A fixed, humanized message rather than the raw backend error: the
+    // realistic failure here is the environment's ThunderID instance being
+    // briefly unreachable, not something the exact backend wording helps a
+    // user act on. The Retry button on a failed attempt uses the backend's
+    // stored lastError instead, which is a persisted, already-user-facing
+    // diagnostic rather than a raw transport error.
+    errorMessage: "Couldn't create the Agent ID for this environment. Check that the environment is reachable, then try again.",
     onSuccess: (_data, { params }) => {
       queryClient.invalidateQueries({ queryKey: ['agent-identity', params] });
     },

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
@@ -17,10 +17,11 @@
 
 import { useMemo, useState } from "react";
 import { Alert, Avatar, Box, Button, CircularProgress, IconButton, Skeleton, Tooltip, Typography } from "@wso2/oxygen-ui";
-import { AlertTriangle, Copy, Fingerprint, RefreshCw } from "@wso2/oxygen-ui-icons-react";
+import { AlertTriangle, Copy, Fingerprint, Info, RefreshCw } from "@wso2/oxygen-ui-icons-react";
 import {
   useAgentIdentityBinding,
   useListAgentIdentityAgents,
+  useProvisionAgentIdentity,
   useRetryAgentIdentityProvisioning,
 } from "@agent-management-platform/api-client";
 import {
@@ -34,6 +35,14 @@ interface EnvAgentRolesGroupsSectionProps {
   projectId: string;
   agentId: string;
   envId: string;
+  /**
+   * Only Externally-Hosted agents can self-serve provisioning for an
+   * environment added after the agent already existed (see the "Create
+   * Agent ID" action below) — Internal agents get theirs automatically when
+   * promoted to a new environment, and the backend rejects this action for
+   * them, so the action is hidden entirely rather than shown and left to fail.
+   */
+  external?: boolean;
 }
 
 /**
@@ -47,18 +56,34 @@ interface EnvAgentRolesGroupsSectionProps {
  * response.
  */
 export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProps> = ({
-  orgId, projectId, agentId, envId,
+  orgId, projectId, agentId, envId, external,
 }) => {
   const { binding, provisioned, isLoading: isLoadingIdentity } = useAgentIdentityBinding({
     orgId, projectId, agentId, envId,
   });
   const isFailed = binding?.status === "failed";
+  // No binding row exists for this environment at all yet — distinct from
+  // "pending"/"in_progress" (already attempted, still running) or "failed"
+  // (attempted, didn't work). This is the state an Externally-Hosted agent is
+  // stuck in forever if its environment was added to the pipeline after the
+  // agent was created: nothing ever attempts provisioning on its own for that
+  // combination, so it needs an explicit action (see canSelfProvision below).
+  const hasNoBinding = !isLoadingIdentity && !binding;
+  const canSelfProvision = Boolean(external) && hasNoBinding;
 
   const { mutate: retryProvisioning, isPending: isRetrying } = useRetryAgentIdentityProvisioning();
   const handleRetry = () => {
     retryProvisioning({
       params: { orgName: orgId, projName: projectId, agentName: agentId },
       body: { environment: envId },
+    });
+  };
+
+  const { mutate: provisionIdentity, isPending: isProvisioning } = useProvisionAgentIdentity();
+  const handleProvision = () => {
+    provisionIdentity({
+      params: { orgName: orgId, projName: projectId, agentName: agentId },
+      query: { environment: envId },
     });
   };
 
@@ -138,6 +163,10 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
             <Typography variant="body2" color="error">
               Unable to load Agent ID. Try again later.
             </Typography>
+          ) : canSelfProvision ? (
+            <Typography variant="body2" color="text.disabled">
+              Not created for this environment yet
+            </Typography>
           ) : provisioned ? (
             <Typography variant="body2" color="text.disabled">
               Provisioning identity…
@@ -147,32 +176,38 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
               Agent ID not available
             </Typography>
           )}
-          <Box mt={0.5}>
-            {isLoading ? (
-              <Skeleton variant="text" width={180} height={16} />
-            ) : isRolesGroupsError ? (
-              <Typography variant="caption" color="error">
-                Unable to load roles/groups. Try again later.
-              </Typography>
-            ) : hasTags ? (
-              <>
-                {roles.length > 0 && (
-                  <Typography variant="caption" color="text.disabled" display="block">
-                    Roles: {roles.map((role) => role.name).join(", ")}
-                  </Typography>
-                )}
-                {groups.length > 0 && (
-                  <Typography variant="caption" color="text.disabled" display="block">
-                    Groups: {groups.map((group) => group.name).join(", ")}
-                  </Typography>
-                )}
-              </>
-            ) : (
-              <Typography variant="caption" color="text.disabled">
-                No roles or groups assigned
-              </Typography>
-            )}
-          </Box>
+          {/* Roles/groups are meaningless before any identity exists, and
+              "No roles or groups assigned" reads as though one does — skip
+              this sub-row entirely for canSelfProvision; the Alert below
+              already carries the explanation and the action for that case. */}
+          {!canSelfProvision && (
+            <Box mt={0.5}>
+              {isLoading ? (
+                <Skeleton variant="text" width={180} height={16} />
+              ) : isRolesGroupsError ? (
+                <Typography variant="caption" color="error">
+                  Unable to load roles/groups. Try again later.
+                </Typography>
+              ) : hasTags ? (
+                <>
+                  {roles.length > 0 && (
+                    <Typography variant="caption" color="text.disabled" display="block">
+                      Roles: {roles.map((role) => role.name).join(", ")}
+                    </Typography>
+                  )}
+                  {groups.length > 0 && (
+                    <Typography variant="caption" color="text.disabled" display="block">
+                      Groups: {groups.map((group) => group.name).join(", ")}
+                    </Typography>
+                  )}
+                </>
+              ) : (
+                <Typography variant="caption" color="text.disabled">
+                  No roles or groups assigned
+                </Typography>
+              )}
+            </Box>
+          )}
         </Box>
         )}
       </Box>
@@ -195,6 +230,27 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
           sx={{ mt: 1.5, flexWrap: "wrap", "& .MuiAlert-action": { flexShrink: 0 } }}
         >
           Provisioning failed{binding?.lastError ? `: ${binding.lastError}` : ""}
+        </Alert>
+      )}
+      {canSelfProvision && (
+        <Alert
+          severity="info"
+          icon={<Info size={18} />}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={handleProvision}
+              disabled={isProvisioning}
+              startIcon={isProvisioning ? <CircularProgress size={14} color="inherit" /> : <Fingerprint size={14} />}
+              sx={{ whiteSpace: "nowrap" }}
+            >
+              {isProvisioning ? "Creating..." : "Create Agent ID"}
+            </Button>
+          }
+          sx={{ mt: 1.5, flexWrap: "wrap", "& .MuiAlert-action": { flexShrink: 0 } }}
+        >
+          This environment was added after the agent was created, so it has no Agent ID yet.
         </Alert>
       )}
     </OverviewSectionCard>

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
@@ -79,7 +79,14 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
     });
   };
 
-  const { mutate: provisionIdentity, isPending: isProvisioning } = useProvisionAgentIdentity();
+  // isError persists the last attempt's outcome (not just a transient
+  // snackbar) so a failed click leaves a visible reason behind instead of
+  // silently reverting to the same neutral "not created yet" state — the
+  // same reasoning the existing Retry alert below already follows for a
+  // failed identity. It clears itself the moment a later attempt succeeds,
+  // since TanStack Query's isError reflects only the most recent call.
+  const { mutate: provisionIdentity, isPending: isProvisioning, isError: isProvisionError } =
+    useProvisionAgentIdentity();
   const handleProvision = () => {
     provisionIdentity({
       params: { orgName: orgId, projName: projectId, agentName: agentId },
@@ -234,8 +241,8 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
       )}
       {canSelfProvision && (
         <Alert
-          severity="info"
-          icon={<Info size={18} />}
+          severity={isProvisionError ? "error" : "info"}
+          icon={isProvisionError ? <AlertTriangle size={18} /> : <Info size={18} />}
           action={
             <Button
               color="inherit"
@@ -250,7 +257,9 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
           }
           sx={{ mt: 1.5, flexWrap: "wrap", "& .MuiAlert-action": { flexShrink: 0 } }}
         >
-          This environment was added after the agent was created, so it has no Agent ID yet.
+          {isProvisionError
+            ? "Couldn't create the Agent ID for this environment. Check that the environment is reachable, then try again."
+            : "This environment was added after the agent was created, so it has no Agent ID yet."}
         </Alert>
       )}
     </OverviewSectionCard>

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvironmentSectionsContent.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvironmentSectionsContent.tsx
@@ -66,6 +66,7 @@ export function EnvironmentSectionsContent({
                         projectId={projectId}
                         agentId={agentId}
                         envId={envId}
+                        external={external}
                     />
                 </Grid>
                 <Grid size={{ xs: 12, md: 6 }}>


### PR DESCRIPTION
## Purpose
- Resolved : #1744
- An Externally-Hosted agent's AgentID never gets created for an environment added to the deployment pipeline after the agent already existed.
- The backend endpoint (`PUT .../identities?environment=`) and the frontend hook (`useProvisionAgentIdentity`) already existed, but nothing in the console ever called the hook.

## Goals
- Let the user trigger provisioning for that specific environment from the console.
- Only surface this for External agents; Internal agents get their AgentID automatically on promote, and the backend rejects this action for them.
- Show clear, non-technical error/info states instead of raw backend text.

## Approach
- Added a "Create Agent ID" action to the existing per-environment `EnvAgentRolesGroupsSection` "Agent ID" card, shown only when the agent is External and no identity binding exists yet for that environment, distinct from the existing "still provisioning" and "failed" states.
- Reused the exact `Alert` + `Button` pattern the card's existing "Retry" action already uses, matching this design system's established shape instead of introducing new UI.
- Threaded the `external` flag one level down from `EnvironmentSectionsContent`, matching how it already flows to sibling sections.
- Gave `useProvisionAgentIdentity` a fixed, humanized error message instead of raw backend text, and made the card's alert switch to a persistent error state (not just a transient snackbar) when the last attempt failed, mirroring how the existing failed-identity alert already persists.

- UI Chnages
<img width="1728" height="996" alt="image" src="https://github.com/user-attachments/assets/f6cc49c4-4158-44b6-8452-7e9e12b05d08" />

## User stories
- As an operator of an Externally-Hosted agent, adding a new environment to the deployment pipeline after creating the agent now lets me create its AgentID from the console instead of it never happening.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
> List any other related PRs

## Migrations (if applicable)
N/A

## Test environment
macOS, Node 20.20.2, Rush/pnpm monorepo (console).

## Learning
N/A