### PR TITLE
Advertise MCP proxy scopes through the mcp-auth policy

### DIFF
--- a/agent-manager-service/services/mcp_proxy_deployment.go
+++ b/agent-manager-service/services/mcp_proxy_deployment.go
@@ -537,10 +537,12 @@ func appendMCPAPIKeyAuthPolicy(policies []models.MCPPolicy, security *models.Sec
 // appendMCPIdentityAuthPolicies emits the Agent Identity gateway policies for a
 // flattened per-environment artifact: mcp-auth (JWT validation against the
 // ThunderKeyManager key manager) and mcp-authz (per-tool requiredScopes
-// enforcement). mcp-auth must NOT carry requiredScopes: it forwards its params
-// verbatim to jwt-auth, which enforces every listed scope (all-of), so a scope
-// union there 401s any token holding only a subset. Tools with no covering scope
-// get no rule — gateway default-permit means authenticated-only.
+// enforcement). mcp-auth's requiredScopes is advertisement only — it becomes
+// scopes_supported in the protected resource metadata and the scope hint in the
+// WWW-Authenticate challenge, so clients learn what to request; mcp-auth strips
+// it before delegating to jwt-auth (wso2/gateway-controllers commit 7045133,
+// mcp-auth v1.1.1). Tools with no covering scope get no mcp-authz rule — gateway
+// default-permit means authenticated-only.
 func appendMCPIdentityAuthPolicies(policies []models.MCPPolicy, security *models.SecurityConfig, proxyHandle string, scopes []models.MCPProxyScope) []models.MCPPolicy {
 	if !mcpIdentityEnabled(security) {
 		return policies
@@ -555,8 +557,10 @@ func appendMCPIdentityAuthPolicies(policies []models.MCPPolicy, security *models
 	// *describes* all-of semantics; the shipped code is any-of. Re-verify on any
 	// gateway policy version bump.
 	toolScopes := map[string][]string{}
+	scopeSet := map[string]struct{}{}
 	for _, sc := range scopes {
 		str := sc.ScopeString(proxyHandle)
+		scopeSet[str] = struct{}{}
 		for _, tool := range sc.Tools {
 			toolScopes[tool] = append(toolScopes[tool], str)
 		}
@@ -575,6 +579,16 @@ func appendMCPIdentityAuthPolicies(policies []models.MCPPolicy, security *models
 
 	authParams := map[string]interface{}{
 		"issuers": []interface{}{mcpIdentityIssuerKeyManager},
+	}
+	// Every scope of the proxy, including ones covering no tool: the union is what
+	// a client should ask for, not what any single call enforces.
+	if len(scopeSet) > 0 {
+		union := make([]string, 0, len(scopeSet))
+		for sc := range scopeSet {
+			union = append(union, sc)
+		}
+		sort.Strings(union)
+		authParams["requiredScopes"] = union
 	}
 
 	out := make([]models.MCPPolicy, 0, len(policies)+2)

--- a/agent-manager-service/services/mcp_proxy_deployment_test.go
+++ b/agent-manager-service/services/mcp_proxy_deployment_test.go
@@ -738,8 +738,8 @@ func TestGenerateMCPProxyDeploymentYAML_UpstreamURLPassthrough(t *testing.T) {
 }
 
 // TestAppendMCPIdentityAuthPolicies_InvertsScopesToPerToolRules covers the Agent Identity
-// policy emission: mcp-auth (pinned issuer, no requiredScopes — jwt-auth would enforce
-// all of them) plus one mcp-authz rule per tool, inverted from the proxy's scope->tools rows.
+// policy emission: mcp-auth (pinned issuer + the advertised scope union) plus one mcp-authz
+// rule per tool, inverted from the proxy's scope->tools rows.
 func TestAppendMCPIdentityAuthPolicies_InvertsScopesToPerToolRules(t *testing.T) {
 	sec := identityEnabledSecurity()
 	scopes := []models.MCPProxyScope{
@@ -752,7 +752,7 @@ func TestAppendMCPIdentityAuthPolicies_InvertsScopesToPerToolRules(t *testing.T)
 	auth := out[0]
 	assert.Equal(t, "mcp-auth", auth.Name)
 	assert.Equal(t, []interface{}{"ThunderKeyManager"}, auth.Params["issuers"])
-	assert.NotContains(t, auth.Params, "requiredScopes")
+	assert.Equal(t, []string{"gh-proxy:admin", "gh-proxy:read"}, auth.Params["requiredScopes"])
 
 	authz := out[1]
 	assert.Equal(t, "mcp-authz", authz.Name)
@@ -770,6 +770,22 @@ func TestAppendMCPIdentityAuthPolicies_NoScopesEmitsAuthOnly(t *testing.T) {
 	assert.Equal(t, "mcp-auth", out[0].Name)
 	_, hasScopes := out[0].Params["requiredScopes"]
 	assert.False(t, hasScopes)
+}
+
+// A scope covering no tool still belongs in mcp-auth's advertised union — it is a scope
+// clients may request — even though it yields no mcp-authz rule to enforce.
+func TestAppendMCPIdentityAuthPolicies_ToollessScopeIsAdvertisedButNotEnforced(t *testing.T) {
+	scopes := []models.MCPProxyScope{
+		{Action: "read", Tools: []string{"get_repo"}},
+		{Action: "audit"},
+	}
+	out := appendMCPIdentityAuthPolicies(nil, identityEnabledSecurity(), "gh-proxy", scopes)
+	assert.Len(t, out, 2)
+
+	assert.Equal(t, []string{"gh-proxy:audit", "gh-proxy:read"}, out[0].Params["requiredScopes"])
+	assert.Equal(t, []map[string]interface{}{
+		{"name": "get_repo", "requiredScopes": []string{"gh-proxy:read"}},
+	}, out[1].Params["tools"])
 }
 
 func TestAppendMCPIdentityAuthPolicies_IdentityOffEmitsNothing(t *testing.T) {
@@ -827,4 +843,5 @@ func TestAppendMCPIdentityAuthPolicies_ScopeWithNoToolsEmitsAuthOnly(t *testing.
 	})
 	assert.Len(t, out, 1)
 	assert.Equal(t, "mcp-auth", out[0].Name)
+	assert.Equal(t, []string{"gh-proxy:read"}, out[0].Params["requiredScopes"])
 }


### PR DESCRIPTION
## Purpose
Identity-secured MCP proxies were not telling clients which OAuth scopes to ask for. The `mcp-auth` gateway policy was emitted with only `issuers`, so its protected resource metadata document (`/.well-known/oauth-protected-resource`) advertised an empty `scopes_supported`, and the `WWW-Authenticate` challenge on a 401 carried no `scope` hint. A client discovering the proxy had no way to learn the scopes the proxy defines.

The scope union used to be emitted, but was removed in 4e5e06c7a as a stopgap: `mcp-auth` forwarded its whole params map to `jwt-auth`, which *enforces* `requiredScopes` all-of, so the union 401'd any token holding only a subset. That gateway bug was fixed in wso2/gateway-controllers commit 7045133 (mcp-auth v1.1.1), which strips `requiredScopes` before delegating. The parameter is now advertisement-only, as its policy definition states, so the emission is safe to restore.

## Goals
Restore the advertised scope union on `mcp-auth` so MCP clients can discover the scopes an identity-secured proxy defines, without changing what any request actually enforces.

## Approach
In `appendMCPIdentityAuthPolicies`, rebuild the deduped, sorted union of every scope on the proxy and set it as `mcp-auth`'s `requiredScopes`.

The union covers *all* scope rows, including scopes that map to no tool — it describes what a client should request, not what any single call enforces. Enforcement is unchanged: `mcp-authz` still carries the per-tool rules inverted from the scope→tools rows, and a tool with no covering scope still gets no rule (gateway default-permit means authenticated-only).

The doc comment that asserted the opposite is replaced with the current contract and a pointer to the gateway commit and policy version, so the removal isn't re-derived by the next reader.

One compatibility note for reviewers: AMS pins `mcpAuthPolicyVersion` to the major (`v1`), while the advertise-only fix lands in mcp-auth >= v1.1.1. A gateway still on v1.0.x or v1.1.0 would resume forwarding `requiredScopes` to `jwt-auth` and enforce it. Emission is unconditional here on the basis that deployed gateways are on >= v1.1.1. If that turns out not to hold, gating is a small follow-up — `extractGatewayPolicyManifestItems` already returns the full version string.

## User stories
As an MCP client author integrating with an identity-secured MCP proxy, I can read the proxy's protected resource metadata and learn which scopes to request in my token, instead of discovering them out of band.

## Release note
Identity-secured MCP proxies now advertise their defined scopes through the `mcp-auth` policy's protected resource metadata and `WWW-Authenticate` challenge. Scope enforcement is unchanged.

## Documentation
N/A — no user-facing configuration or API surface changes; the advertised value is derived from scopes users already define on a proxy.

## Training
N/A — no training content covers MCP proxy scope emission.

## Certification
N/A — no impact on certification exams; this is an internal gateway policy emission detail.

## Marketing
N/A — internal correctness fix with no promotable surface.

## Automation tests
 - Unit tests
   > Covered in `agent-manager-service/services/mcp_proxy_deployment_test.go`. `TestAppendMCPIdentityAuthPolicies_InvertsScopesToPerToolRules` now asserts the sorted, deduped union on `mcp-auth` alongside the existing per-tool `mcp-authz` rules. `TestAppendMCPIdentityAuthPolicies_ScopeWithNoToolsEmitsAuthOnly` additionally asserts the toolless scope is advertised. New `TestAppendMCPIdentityAuthPolicies_ToollessScopeIsAdvertisedButNotEnforced` covers the case where the advertised union and the enforced rule set legitimately diverge. `TestAppendMCPIdentityAuthPolicies_NoScopesEmitsAuthOnly` still asserts no `requiredScopes` key when the proxy defines no scopes. Full `services` package passes.
 - Integration tests
   > None added — the change is a pure function over scope rows with no I/O, fully covered at the unit tier.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Java-only tool; this is a Go change. `make lint` (golangci-lint, includes gosec) reports 0 issues.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes; the behaviour is exercised by any identity-secured MCP proxy that defines scopes.

## Related PRs
wso2/gateway-controllers 7045133 (`fix(mcp-auth): do not enforce requiredScopes, advertise only`) is the prerequisite that makes this emission safe.

## Migrations (if applicable)
N/A — no schema or stored-data changes. Existing identity-secured proxies pick up the advertised scopes on their next gateway artifact deploy.

## Test environment
Go 1.x on macOS (darwin/arm64). `make fmt`, `make lint` and `go test ./services/` run locally against the `agent-manager-service` module; no database required for the affected tier.

## Learning
Traced the actual runtime behaviour of `requiredScopes` through the `mcp-auth` policy source in wso2/gateway-controllers rather than trusting the policy definition YAML: the value reaches only `ProtectedResourceMetadata.ScopesSupported` and `generateWwwAuthenticateHeaderFromFields`, and is deleted from the params map before `jwt-auth` delegation. `TestOnRequestBody_RequiredScopes_NotEnforced` in that repo is the upstream regression test (wso2/api-platform#2589).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP authentication scope reporting to include all configured proxy scopes.
  * Authentication challenges now advertise scopes even when they are not assigned to specific tools.
  * Tool-level authorization continues to enforce access only for applicable scopes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->