### PR TITLE
Stamp tenant identity on build and eval pods

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
@@ -14,7 +14,17 @@ spec:
   podMetadata:
     labels:
       app.kubernetes.io/name: amp-monitor
+      # Also the key that separates evaluation pods from build pods, which share
+      # the workflows-<org> namespace and are otherwise identical to
+      # kube_pod_labels. Allowlisted in observability-metrics-prometheus.yaml.
       app.kubernetes.io/component: evaluation-job
+      # Tenant identity for usage attribution. kube-state-metrics exports pod
+      # labels on kube_pod_labels only, and only the keys in its allowlist, so
+      # these four are what makes an evaluation run attributable to a tenant.
+      openchoreo.dev/namespace: '{{ "{{" }}workflow.parameters.organization{{ "}}" }}'
+      openchoreo.dev/project: '{{ "{{" }}workflow.parameters.project{{ "}}" }}'
+      openchoreo.dev/component: '{{ "{{" }}workflow.parameters.agent{{ "}}" }}'
+      openchoreo.dev/environment: '{{ "{{" }}workflow.parameters.environment{{ "}}" }}'
   arguments:
     parameters:
       - name: monitor-name

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
@@ -157,6 +157,23 @@ spec:
       name: ${metadata.workflowRunName}
       namespace: ${metadata.namespace}
     spec:
+      # Stamped onto the build pods themselves. metadata.labels above only labels
+      # the Workflow object, and kube-state-metrics reads pod labels — so without
+      # this a build is measurable but not attributable to any tenant.
+      #
+      # No UIDs: the WorkflowRun carries only component and project labels, so
+      # ${metadata.labels['openchoreo.dev/component-uid']} does not resolve here.
+      # Names are unique within a namespace, but a rename splits the series.
+      #
+      # app.kubernetes.io/component separates these from evaluation pods, which
+      # share the workflows-<org> namespace. Both keys must stay in the
+      # kube-state-metrics allowlist in observability-metrics-prometheus.yaml.
+      podMetadata:
+        labels:
+          openchoreo.dev/namespace: ${metadata.namespaceName}
+          openchoreo.dev/project: ${metadata.labels['openchoreo.dev/project']}
+          openchoreo.dev/component: ${metadata.labels['openchoreo.dev/component']}
+          app.kubernetes.io/component: build
       ttlStrategy:
           secondsAfterCompletion: 86400  # Deletes 1 day after it finishes (success or failure)
       activeDeadlineSeconds: 3600

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
@@ -184,6 +184,23 @@ spec:
       name: ${metadata.workflowRunName}
       namespace: ${metadata.namespace}
     spec:
+      # Stamped onto the build pods themselves. metadata.labels above only labels
+      # the Workflow object, and kube-state-metrics reads pod labels — so without
+      # this a build is measurable but not attributable to any tenant.
+      #
+      # No UIDs: the WorkflowRun carries only component and project labels, so
+      # ${metadata.labels['openchoreo.dev/component-uid']} does not resolve here.
+      # Names are unique within a namespace, but a rename splits the series.
+      #
+      # app.kubernetes.io/component separates these from evaluation pods, which
+      # share the workflows-<org> namespace. Both keys must stay in the
+      # kube-state-metrics allowlist in observability-metrics-prometheus.yaml.
+      podMetadata:
+        labels:
+          openchoreo.dev/namespace: ${metadata.namespaceName}
+          openchoreo.dev/project: ${metadata.labels['openchoreo.dev/project']}
+          openchoreo.dev/component: ${metadata.labels['openchoreo.dev/component']}
+          app.kubernetes.io/component: build
       ttlStrategy:
           secondsAfterCompletion: 86400  # Deletes 1 day after it finishes (success or failure)
       activeDeadlineSeconds: 3600

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
@@ -157,6 +157,23 @@ spec:
       name: ${metadata.workflowRunName}
       namespace: ${metadata.namespace}
     spec:
+      # Stamped onto the build pods themselves. metadata.labels above only labels
+      # the Workflow object, and kube-state-metrics reads pod labels — so without
+      # this a build is measurable but not attributable to any tenant.
+      #
+      # No UIDs: the WorkflowRun carries only component and project labels, so
+      # ${metadata.labels['openchoreo.dev/component-uid']} does not resolve here.
+      # Names are unique within a namespace, but a rename splits the series.
+      #
+      # app.kubernetes.io/component separates these from evaluation pods, which
+      # share the workflows-<org> namespace. Both keys must stay in the
+      # kube-state-metrics allowlist in observability-metrics-prometheus.yaml.
+      podMetadata:
+        labels:
+          openchoreo.dev/namespace: ${metadata.namespaceName}
+          openchoreo.dev/project: ${metadata.labels['openchoreo.dev/project']}
+          openchoreo.dev/component: ${metadata.labels['openchoreo.dev/component']}
+          app.kubernetes.io/component: build
       ttlStrategy:
           secondsAfterCompletion: 86400  # Deletes 1 day after it finishes (success or failure)
       activeDeadlineSeconds: 3600

--- a/deployments/values/observability-metrics-prometheus.yaml
+++ b/deployments/values/observability-metrics-prometheus.yaml
@@ -59,3 +59,17 @@ kube-prometheus-stack:
           regex: ';.+'
           targetLabel: container
           replacement: sandbox
+
+  # kube-state-metrics label allowlist.
+  #
+  # Only the keys listed here reach kube_pod_labels, which is the only pod metric
+  # carrying pod labels at all — reservations and timestamps carry namespace/pod/uid
+  # and nothing else, so every tenant-attributed query joins against it.
+  #
+  # The first seven keys are the upstream defaults, reproduced because helm replaces
+  # list values rather than merging them. app.kubernetes.io/component is ours: build
+  # and evaluation pods share the workflows-<org> namespace, and without a key that
+  # separates them a namespace-scoped duration sums both into one bucket.
+  kube-state-metrics:
+    metricLabelsAllowlist:
+      - pods=[openchoreo.dev/component-uid,openchoreo.dev/project-uid,openchoreo.dev/environment-uid,openchoreo.dev/namespace,openchoreo.dev/component,openchoreo.dev/project,openchoreo.dev/environment,app.kubernetes.io/component]

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -1236,12 +1236,18 @@ helm upgrade observability-logs-opensearch \
   --set fluent-bit.enabled=true \
   --timeout 10m
 
-# Metrics module
+# Metrics module.
+#
+# The values file widens the kube-state-metrics label allowlist. Only labels on
+# that list reach the metrics store, and usage attribution needs them: without
+# it, build and evaluation pods are indistinguishable once collected and their
+# durations are summed into a single figure.
 helm upgrade --install observability-metrics-prometheus \
   oci://ghcr.io/openchoreo/helm-charts/observability-metrics-prometheus \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.6.1 \
+  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/observability-metrics-prometheus.yaml \
   --timeout 10m
 
 # Tracing module (uses the custom OTel Collector ConfigMap)


### PR DESCRIPTION
## Purpose
Build and evaluation pods carry no tenant labels, so the resource metrics collected for them cannot be attributed to a project or a component. An agent's runtime pods already carry the full `openchoreo.dev/*` set and attribute correctly; the pods that build an agent and the pods that evaluate it do not, so their CPU, memory and duration land in one undifferentiated bucket per namespace.

Only `kube_pod_labels` carries pod labels through to the metrics backend, and it exports just the keys in the kube-state-metrics label allowlist, so closing the gap needs a change on both sides: labels on the pods, and the allowlist admitting the key that separates the two pod kinds.

No linked issue.

## Goals
Make build and evaluation pod metrics attributable to the tenant that caused them, and distinguishable from each other, without changing how either workflow runs.

## Approach
The three component builders set `podMetadata` on their `runTemplate`, carrying `openchoreo.dev/namespace`, `openchoreo.dev/project` and `openchoreo.dev/component` from substitutions already in scope there (`${metadata.namespaceName}` and the two WorkflowRun labels).

The evaluation `ClusterWorkflowTemplate` gains the same three keys plus `openchoreo.dev/environment`, read from its workflow parameters. These go on the template rather than the `runTemplate` because an evaluation run merges through `workflowTemplateRef`: setting `podMetadata` on the run replaces the template's, which would drop the two `app.kubernetes.io` labels that `amp-evaluation-job-egress` selects on and cut the job's egress.

Build and evaluation pods share the `workflows-<org>` namespace and are otherwise indistinguishable once collected, so both also carry `app.kubernetes.io/component` (`build` / `evaluation-job`). That key is added to the kube-state-metrics label allowlist in `deployments/values/observability-metrics-prometheus.yaml`, which restates the existing seven entries because helm replaces list values rather than merging them.

Two limitations worth recording. Build pods get names but no UIDs, because the WorkflowRun exposes only the component and project labels and the UID substitutions do not resolve there; names are unique within a namespace, but a rename splits the series. And a query joining against `kube_pod_labels` over a range that spans a kube-state-metrics restart sees series from both the old and new instance for the same pod, so it must reduce to `(namespace, pod)` before joining or it double counts.

## Production install
Checked against the production guide, which installs the metrics module straight from its chart with **no values file**. The label allowlist in this repository would therefore never have reached a production cluster: pods would carry the new labels, but the exporter would drop the one key that separates build from evaluation, and the two durations would be summed into a single figure. Nothing would fail — the metrics would exist and look reasonable.

The guide now passes the values file by raw URL at the release tag, matching how it already applies the collector ConfigMap.

## User stories
As a platform engineer, I can attribute build and evaluation resource usage to the project and component that caused it, and tell build load apart from evaluation load.

## Release note
Build and evaluation pods are now labelled with their tenant identity, so their resource metrics can be attributed per project and component.

## Documentation
N/A. No user-facing behaviour changes; the labels are internal to metrics collection.

## Training
N/A. No training content covers pod labelling for metrics collection.

## Certification
N/A. No certification exam covers pod labelling for metrics collection.

## Marketing
N/A. Internal observability plumbing with no promotable surface.

## Automation tests
 - Unit tests
   > N/A. The change is Helm chart and values data with no code paths to exercise; `helm template` renders both charts cleanly.
 - Integration tests
   > Verified manually on a local k3d cluster, see Test environment. No automated integration coverage exists for pod labelling; the natural place for it would be a check that a completed build and monitor run appear in `kube_pod_labels` with tenant keys.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A, no Java code in this change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A. No sample applications relate to pod labelling.

## Related PRs
- wso2/agent-manager#1766 — the span counter, split out of this branch; it touches the observability chart rather than the workflow charts and reviews independently.
None.

## Migrations (if applicable)
None. Labels apply to pods created after the charts are upgraded; existing completed pods keep whatever labels they were created with. The allowlist change applies to all pods on the next kube-state-metrics scrape, so a pod that already carried `app.kubernetes.io/component` starts exporting it immediately.

## Test environment
k3d, Kubernetes v1.32.9, on a local OpenChoreo install. Verified against a real build (`amp-google-cloud-buildpacks`, 4-pod DAG) and a real monitor run, both of which completed `Succeeded` after the change.

Checks performed:
- Build pods carry `openchoreo.dev/{namespace,project,component}` and `app.kubernetes.io/component=build`; evaluation pods carry those plus `openchoreo.dev/environment` and `app.kubernetes.io/component=evaluation-job`.
- Both label sets reach `kube_pod_labels` in Prometheus.
- `amp-evaluation-job-egress` still selects the evaluation pod, and the evaluation workflow succeeded.
- A duration query grouped by the tenant keys splits cleanly: the run made before this change reports 242s with no tenant, the run after reports 201s of build and 24s of evaluation attributed to `default/default/customer-success-agent-1`.

## Learning
The distinction that drove the design here is that `metadata.labels` on an Argo workflow object labels only the object, while `podMetadata` is what reaches the pod, and kube-state-metrics reads pods. The `workflowTemplateRef` merge behaviour is the other trap: `podMetadata` set on a run replaces rather than merges with the referenced template's, which is why the evaluation labels had to go on the template.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant and component labels to build and evaluation pods.
  * Enabled component-specific attribution in Kubernetes metrics.
  * Improved visibility of build versus evaluation workloads in monitoring data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
