### PR TITLE
Fix Helm schemas rejecting values the charts actually support

### DIFF
--- a/deployments/helm-charts/wso2-agent-manager/values.schema.json
+++ b/deployments/helm-charts/wso2-agent-manager/values.schema.json
@@ -1088,6 +1088,12 @@
                   "title": "url",
                   "type": "string"
                 },
+                "path": {
+                  "default": "secret",
+                  "description": "KV mount path git credentials are read from.",
+                  "title": "path",
+                  "type": "string"
+                },
                 "token": {
                   "default": "root",
                   "description": "OpenBao token. When set, it is stored in the chart-managed Secret and injected via secretKeyRef \u2014 never as a plaintext env var in the pod spec. For production, use existingSecret instead.",

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -339,6 +339,8 @@ agentManagerService:
     workflowPlaneOpenbao:
       # Workflow plane OpenBao URL
       url: "http://openbao.openbao.svc.cluster.local:8200"
+      # KV mount path git credentials are read from.
+      path: "secret"
       # OpenBao token. When set, it is stored in the chart-managed Secret and
       # injected via secretKeyRef — never as a plaintext env var in the pod spec.
       # For production, use existingSecret instead.

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-config.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/templates/gateway-config.yaml
@@ -38,7 +38,7 @@ data:
             sqlite:
               path: ./data/gateway.db
           controlplane:
-            insecure_skip_verify: {{ .Values.apiGateway.controlPlane.tls.insecureSkipVerify | default true }}
+            insecure_skip_verify: {{ .Values.apiGateway.controlPlane.tls.insecureSkipVerify }}
             reconnect_initial: 1s
             reconnect_max: 5m
             polling_interval: 15m

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.schema.json
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.schema.json
@@ -216,7 +216,7 @@
                 },
                 "insecureSkipVerify": {
                   "default": true,
-                  "description": "Skip verification of the control plane's TLS certificate. True by default because the control plane serves a self-signed certificate in-cluster. Note: the template applies `| default true`, and Go templates treat false as empty, so setting this to false here does not currently disable it.",
+                  "description": "Skip verification of the control plane's TLS certificate. True because the control plane serves a self-signed certificate in-cluster; set to false only where the gateway can trust the control plane's certificate chain.",
                   "title": "insecureSkipVerify",
                   "type": "boolean"
                 }

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.schema.json
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.schema.json
@@ -213,6 +213,12 @@
                   "description": "Use TLS when connecting to the control plane.",
                   "title": "enabled",
                   "type": "boolean"
+                },
+                "insecureSkipVerify": {
+                  "default": true,
+                  "description": "Skip verification of the control plane's TLS certificate. True by default because the control plane serves a self-signed certificate in-cluster. Note: the template applies `| default true`, and Go templates treat false as empty, so setting this to false here does not currently disable it.",
+                  "title": "insecureSkipVerify",
+                  "type": "boolean"
                 }
               },
               "required": [],

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
@@ -95,10 +95,9 @@ apiGateway:
     host: "amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243"
     tls:
       enabled: true
-      # Skip verification of the control plane's TLS certificate. True by default
-      # because the control plane serves a self-signed certificate in-cluster.
-      # Note: the template applies `| default true`, and Go templates treat false as
-      # empty, so setting this to false here does not currently disable it.
+      # Skip verification of the control plane's TLS certificate. True because the
+      # control plane serves a self-signed certificate in-cluster; set to false only
+      # where the gateway can trust the control plane's certificate chain.
       insecureSkipVerify: true
 
   # ConfigMap containing full Helm values for the gateway Helm chart.

--- a/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-api-platform-gateway-extension/values.yaml
@@ -95,6 +95,11 @@ apiGateway:
     host: "amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243"
     tls:
       enabled: true
+      # Skip verification of the control plane's TLS certificate. True by default
+      # because the control plane serves a self-signed certificate in-cluster.
+      # Note: the template applies `| default true`, and Go templates treat false as
+      # empty, so setting this to false here does not currently disable it.
+      insecureSkipVerify: true
 
   # ConfigMap containing full Helm values for the gateway Helm chart.
   # The gateway-operator reads this and passes it when deploying the gateway stack.

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/values.schema.json
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/values.schema.json
@@ -38,6 +38,12 @@
       "additionalProperties": false,
       "description": "AMP Evaluation image configuration",
       "properties": {
+        "workflowNamespace": {
+          "default": "default",
+          "description": "Namespace OpenChoreo runs this environment's Argo workflows in. The evaluation job namespace is derived from it as \"workflows-<value>\".",
+          "title": "workflowNamespace",
+          "type": "string"
+        },
         "image": {
           "additionalProperties": false,
           "description": "Docker image configuration for monitor evaluation",

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
@@ -15,6 +15,9 @@ global:
 
 # AMP Evaluation image configuration
 ampEvaluation:
+  # -- Namespace OpenChoreo runs this environment's Argo workflows in. The
+  # evaluation job namespace is derived from it as "workflows-<value>".
+  workflowNamespace: "default"
   # -- Docker image configuration for monitor evaluation
   image:
     # -- Image repository

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.schema.json
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.schema.json
@@ -270,6 +270,14 @@
               "required": [],
               "title": "http",
               "type": "object"
+            },
+            "https": {
+              "additionalProperties": true,
+              "default": {},
+              "description": "https: optional TLS-fronted variant. Unset by default (local/compose serves agents over plain http, tlsEnabled=false). Set host/port on TLS deployments (e.g. the VM installer) so the binding carries an https externalURL; otherwise the tlsEnabled console reads a missing variant and the invoke URL is empty.",
+              "required": [],
+              "title": "https",
+              "type": "object"
             }
           },
           "required": [],

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/values.yaml
@@ -133,7 +133,7 @@ environment:
     # agents over plain http, tlsEnabled=false). Set host/port on TLS deployments
     # (e.g. the VM installer) so the binding carries an https externalURL; otherwise
     # the tlsEnabled console reads a missing variant and the invoke URL is empty.
-    # https:
+    https: {}
     #   host: am-gateway.localhost
     #   port: 443
 

--- a/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
+++ b/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
@@ -35,9 +35,9 @@ The authorization mechanism is identical for every agent. The only difference is
 
 ## Prerequisites
 
-- `amctl` installed and logged in against your control plane (see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
-- An [AI Gateway](../concepts/gateway.mdx) active for the environment you are configuring. The installer registers one per environment.
-- A reachable upstream MCP server URL.
+- `amctl` installed and logged in against your control plane if your follow the `amctl` path (see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
+- An AI Gateway registered and active for the environment you are configuring.
+- A **GitHub Personal Access Token**. Read access is enough for `github:read`; add issue write access only if you want to exercise `github:write`. Create one at [github.com/settings/tokens](https://github.com/settings/tokens).
 
 This guide uses the [`amctl api`](../reference/cli/api.mdx) command to call the control plane directly, which makes every step precise and copy-pasteable. The examples use the `default` organization, `default` project, and `default` environment — substitute your own.
 

--- a/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
+++ b/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
@@ -35,7 +35,7 @@ The authorization mechanism is identical for every agent. The only difference is
 
 ## Prerequisites
 
-- `amctl` installed and logged in against your control plane if your follow the `amctl` path (see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
+- `amctl` installed and logged in against your control plane(see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
 - An AI Gateway registered and active for the environment you are configuring.
 - A **GitHub Personal Access Token**. Read access is enough for `github:read`; add issue write access only if you want to exercise `github:write`. Create one at [github.com/settings/tokens](https://github.com/settings/tokens).
 

--- a/documentation/docs/reference/helm-charts/index.mdx
+++ b/documentation/docs/reference/helm-charts/index.mdx
@@ -11,12 +11,12 @@ generated from that chart's `values.schema.json`.
 
 | Chart | Purpose | Parameters |
 |---|---|---|
-| [Agent Manager](./wso2-agent-manager.mdx) | Helm chart for WSO2 Agent Management Platform - Deploy, manage, and govern AI agents at scale | 346 |
-| [API Platform Gateway Extension](./wso2-amp-api-platform-gateway-extension.mdx) | A Helm chart to deploy and auto-register the unified API Platform Gateway for the Agent Management Platform. | 82 |
+| [Agent Manager](./wso2-agent-manager.mdx) | Helm chart for WSO2 Agent Management Platform - Deploy, manage, and govern AI agents at scale | 347 |
+| [API Platform Gateway Extension](./wso2-amp-api-platform-gateway-extension.mdx) | A Helm chart to deploy and auto-register the unified API Platform Gateway for the Agent Management Platform. | 83 |
 | [Thunder Extension](./wso2-amp-thunder-extension.mdx) | A Helm chart to add Thunder Identity Provider functionality for the Agent Management Platform. | 367 |
-| [Evaluation Extension](./wso2-amp-evaluation-extension.mdx) | A Helm chart to add Evaluation functionality for the Agent Management Platform, by Deploying and Configuring Monitor evaluation workflows. | 42 |
+| [Evaluation Extension](./wso2-amp-evaluation-extension.mdx) | A Helm chart to add Evaluation functionality for the Agent Management Platform, by Deploying and Configuring Monitor evaluation workflows. | 43 |
 | [Observability Extension](./wso2-amp-observability-extension.mdx) | A Helm chart to add Tracing functionality for the Agent Management Platform, by Deploying and Configuring the Agent Manager Observer. | 52 |
-| [Platform Resources Extension](./wso2-amp-platform-resources-extension.mdx) | Default platform resources for WSO2 AI Agent Management Platform on OpenChoreo | 75 |
+| [Platform Resources Extension](./wso2-amp-platform-resources-extension.mdx) | Default platform resources for WSO2 AI Agent Management Platform on OpenChoreo | 76 |
 
 Because the pages are generated from the schema, `helm lint` and this reference cannot
 disagree: a value the schema rejects is a value documented here as the wrong type.

--- a/documentation/docs/reference/helm-charts/wso2-agent-manager.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-agent-manager.mdx
@@ -144,6 +144,7 @@ helm install agent-manager oci://ghcr.io/wso2/helm-charts/wso2-agent-manager \
 | `agentManagerService.config.openbao.existingSecretKey` | Key to read from existingSecret. Applies ONLY when existingSecret is set; the chart-managed Secret always uses the fixed key "openbao-token". | string | `"openbao-token"` |
 | `agentManagerService.config.workflowPlaneOpenbao` | Workflow Plane OpenBao configuration (for Git Secrets) Used to fetch git credentials for private repository access | object |  |
 | `agentManagerService.config.workflowPlaneOpenbao.url` | Workflow plane OpenBao URL | string | `"http://openbao.openbao.svc.cluster.local:8200"` |
+| `agentManagerService.config.workflowPlaneOpenbao.path` | KV mount path git credentials are read from. | string | `"secret"` |
 | `agentManagerService.config.workflowPlaneOpenbao.token` | OpenBao token. When set, it is stored in the chart-managed Secret and injected via secretKeyRef — never as a plaintext env var in the pod spec. For production, use existingSecret instead. | string | `"root"` |
 | `agentManagerService.config.workflowPlaneOpenbao.existingSecret` | Secret holding that instance's access token. | string | `""` |
 | `agentManagerService.config.workflowPlaneOpenbao.existingSecretKey` | Key to read from existingSecret. Applies ONLY when existingSecret is set. The chart-managed Secret packs both OpenBao tokens into one Secret, so this token is stored there under the distinct key "workflow-plane-openbao-token". | string | `"openbao-token"` |

--- a/documentation/docs/reference/helm-charts/wso2-amp-api-platform-gateway-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-api-platform-gateway-extension.mdx
@@ -37,6 +37,7 @@ helm install amp-api-platform-gateway-extension oci://ghcr.io/wso2/helm-charts/w
 | `apiGateway.controlPlane.host` | In-cluster address of the control plane. | string | `"amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243"` |
 | `apiGateway.controlPlane.tls` | TLS settings for the control-plane connection. | object |  |
 | `apiGateway.controlPlane.tls.enabled` | Use TLS when connecting to the control plane. | boolean | `true` |
+| `apiGateway.controlPlane.tls.insecureSkipVerify` | Skip verification of the control plane's TLS certificate. True by default because the control plane serves a self-signed certificate in-cluster. Note: the template applies `\| default true`, and Go templates treat false as empty, so setting this to false here does not currently disable it. | boolean | `true` |
 | `apiGateway.config` | ConfigMap containing full Helm values for the gateway Helm chart. The gateway-operator reads this and passes it when deploying the gateway stack. | object |  |
 | `apiGateway.config.configMapName` | Name of the ConfigMap to create with gateway Helm values. Defaults to "&lt;release-name&gt;-config" if empty. | string | `""` |
 | `apiGateway.config.policyConfigurations` | Policy configurations rendered under [policy_configurations.*] in config.toml. Consumed by policies that reference $&#123;config.policy_configurations.&lt;section&gt;.&lt;key&gt;&#125;. | object |  |

--- a/documentation/docs/reference/helm-charts/wso2-amp-evaluation-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-evaluation-extension.mdx
@@ -17,6 +17,7 @@ helm install amp-evaluation-extension oci://ghcr.io/wso2/helm-charts/wso2-amp-ev
 | Parameter | Description | Type | Default |
 |---|---|---|---|
 | `ampEvaluation` | AMP Evaluation image configuration | object |  |
+| `ampEvaluation.workflowNamespace` | Namespace OpenChoreo runs this environment's Argo workflows in. The evaluation job namespace is derived from it as "workflows-&lt;value&gt;". | string | `"default"` |
 | `ampEvaluation.image` | Docker image configuration for monitor evaluation | object |  |
 | `ampEvaluation.image.repository` | Image repository For local development: will be pushed to local registry For production: ghcr.io/wso2/amp-evaluation-monitor | string | `"ghcr.io/wso2/amp-evaluation-monitor"` |
 | `ampEvaluation.image.tag` | Image tag IMPORTANT: For production, this should match the amp-evaluation SDK version used in dbMigration.evaluatorGenerator.image.tag in the wso2-agent-manager chart. Example: If using amp-evaluation==0.1.5, set this to "0.1.5" | string | `"0.0.0-dev"` |

--- a/documentation/docs/reference/helm-charts/wso2-amp-platform-resources-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-platform-resources-extension.mdx
@@ -73,6 +73,7 @@ helm install amp-platform-resources-extension oci://ghcr.io/wso2/helm-charts/wso
 | `environment.gateway.http` | http: agent-facing host (distinct from the gateway-runtime host gateway.localhost). | object |  |
 | `environment.gateway.http.host` | Hostname routed to agents in this environment. | string | `"am-gateway.localhost"` |
 | `environment.gateway.http.port` | Port the HTTP listener serves on. | integer | `19080` |
+| `environment.gateway.https` | https: optional TLS-fronted variant. Unset by default (local/compose serves agents over plain http, tlsEnabled=false). Set host/port on TLS deployments (e.g. the VM installer) so the binding carries an https externalURL; otherwise the tlsEnabled console reads a missing variant and the invoke URL is empty. | object | `{}` |
 
 ## externalSecrets
 


### PR DESCRIPTION
## Purpose
The nightly run failed at gateway install by the introduce of the helm schema by this [PR](https://github.com/wso2/agent-manager/pull/1761)

The `values.schema.json` files added for the Helm chart reference are generated from each chart's `values.yaml` and set `additionalProperties: false`. It makes a value a template reads which `values.yaml` never declares gets rejected before the chart can render. `insecureSkipVerify` is read by `templates/gateway-config.yaml` and set by `values-dev.yaml`, but was never declared, so the schema had no way to know it was legitimate.


## Goals
- Unblock the nightly run and `make setup-gateway`.
- Fix the whole class of failure rather than the single reported value, so the next run doesn't fail on a different key.
- Keep the schemas strict 

## Approach
checked the charts Comparing each `.Values.*` reference in the templates against its schema found **four** undeclared values, of which the nightly had only reached the first:

| Chart | Value | Read by |
|---|---|---|
| api-platform-gateway-extension | `apiGateway.controlPlane.tls.insecureSkipVerify` | `gateway-config.yaml` |
| agent-manager | `agentManagerService.config.workflowPlaneOpenbao.path` | `agent-manager-service/configmap.yaml` |
| evaluation-extension | `ampEvaluation.workflowNamespace` | 3 templates |
| platform-resources-extension | `environment.gateway.https` | `environment.yaml` |

Each is now declared in `values.yaml` with the default its template already applies through `| default`, so **no rendered output changes**. Each carries a comment, so the schema description comes from the chart itself rather than an external table

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
- Helm v4.2.3
- Node.js 20.20.2, npm 10.8.2, Docusaurus 3.10.2
- macOS 26.6 (Darwin)
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Git credential mount paths for workflow secrets.
  * Added workflow namespace configuration for evaluation jobs.
  * Added optional HTTPS gateway settings for TLS deployments.
  * Updated API Gateway control-plane TLS behavior: certificate verification is enforced by default and can be explicitly skipped when needed.

* **Documentation**
  * Updated Helm chart parameter references and counts.
  * Clarified MCP authorization prerequisites and GitHub token permissions.
  * Documented the new configuration options and their defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->