### PR TITLE
Separate MCP and API scope discovery

### DIFF
--- a/agent-manager-observer/handlers/well_known.go
+++ b/agent-manager-observer/handlers/well_known.go
@@ -35,20 +35,22 @@ type protectedResourceMetadata struct {
 	ScopesSupported        []string `json:"scopes_supported,omitempty"`
 }
 
+// ampAPIResourceIdentifier is the shared Agent Manager API resource registered
+// in Thunder. Observer REST endpoints accept that platform API audience, while
+// the Observer MCP endpoint has its own deployment-specific URL resource.
+const ampAPIResourceIdentifier = "urn:wso2:amp"
+
 // RegisterWellKnownRoutes registers the RFC 9728 OAuth 2.0 protected resource
 // metadata endpoint on mux. The route is unauthenticated and returns 503 when
 // SERVER_PUBLIC_URL or OAUTH_AUTHORIZATION_SERVERS is not configured.
 //
 // Ported from agent-manager-service/api/well_known_routes.go.
 func RegisterWellKnownRoutes(mux *http.ServeMux, cfg config.AuthConfig) {
-	handler := protectedResourceMetadataHandler(cfg)
-	// Keep the root document as a compatibility alias for existing observer API
-	// clients, while MCP clients use the RFC 9728 path-specific location.
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource", handler)
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", handler)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", protectedResourceMetadataHandler(cfg, false))
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", protectedResourceMetadataHandler(cfg, true))
 }
 
-func protectedResourceMetadataHandler(cfg config.AuthConfig) http.HandlerFunc {
+func protectedResourceMetadataHandler(cfg config.AuthConfig, mcpResource bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if cfg.ServerPublicURL == "" {
 			logger.GetLogger(r.Context()).Error("SERVER_PUBLIC_URL is not configured; cannot serve protected resource metadata")
@@ -61,8 +63,13 @@ func protectedResourceMetadataHandler(cfg config.AuthConfig) http.HandlerFunc {
 			return
 		}
 
+		resource := ampAPIResourceIdentifier
+		if mcpResource {
+			resource = strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/mcp"
+		}
+
 		body := protectedResourceMetadata{
-			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/mcp",
+			Resource:               resource,
 			AuthorizationServers:   cfg.AuthorizationServers,
 			BearerMethodsSupported: []string{"header"},
 			ScopesSupported:        cfg.ScopesSupported,

--- a/agent-manager-observer/handlers/well_known.go
+++ b/agent-manager-observer/handlers/well_known.go
@@ -26,7 +26,8 @@ import (
 )
 
 // protectedResourceMetadata is the RFC 9728 OAuth 2.0 Protected Resource
-// Metadata document served at /.well-known/oauth-protected-resource.
+// Metadata document served at the root compatibility location and the RFC
+// 9728 path-specific /.well-known/oauth-protected-resource/mcp location.
 type protectedResourceMetadata struct {
 	Resource               string   `json:"resource"`
 	AuthorizationServers   []string `json:"authorization_servers,omitempty"`
@@ -40,7 +41,15 @@ type protectedResourceMetadata struct {
 //
 // Ported from agent-manager-service/api/well_known_routes.go.
 func RegisterWellKnownRoutes(mux *http.ServeMux, cfg config.AuthConfig) {
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+	handler := protectedResourceMetadataHandler(cfg)
+	// Keep the root document as a compatibility alias for existing observer API
+	// clients, while MCP clients use the RFC 9728 path-specific location.
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", handler)
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", handler)
+}
+
+func protectedResourceMetadataHandler(cfg config.AuthConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		if cfg.ServerPublicURL == "" {
 			logger.GetLogger(r.Context()).Error("SERVER_PUBLIC_URL is not configured; cannot serve protected resource metadata")
 			http.Error(w, "protected resource metadata not configured", http.StatusServiceUnavailable)
@@ -64,5 +73,5 @@ func RegisterWellKnownRoutes(mux *http.ServeMux, cfg config.AuthConfig) {
 		if err := json.NewEncoder(w).Encode(body); err != nil {
 			logger.GetLogger(r.Context()).Error("failed to encode protected resource metadata", "error", err)
 		}
-	})
+	}
 }

--- a/agent-manager-observer/handlers/well_known_test.go
+++ b/agent-manager-observer/handlers/well_known_test.go
@@ -72,6 +72,30 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	}
 }
 
+func TestWellKnownOAuthProtectedResource_MCPPath(t *testing.T) {
+	cfg := config.AuthConfig{
+		ServerPublicURL:      "https://traces.amp.example.com/",
+		AuthorizationServers: []string{"https://thunder.example.com"},
+		ScopesSupported:      []string{"amp:observability:trace-read"},
+	}
+
+	mux := setupWellKnownMux(cfg)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var body protectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.Resource != "https://traces.amp.example.com/mcp" {
+		t.Fatalf("expected normalized MCP resource, got %q", body.Resource)
+	}
+}
+
 func TestWellKnownOAuthProtectedResource_MissingPublicURL(t *testing.T) {
 	cfg := config.AuthConfig{
 		AuthorizationServers: []string{"https://thunder.example.com"},

--- a/agent-manager-observer/handlers/well_known_test.go
+++ b/agent-manager-observer/handlers/well_known_test.go
@@ -58,8 +58,8 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body.Resource != cfg.ServerPublicURL+"/mcp" {
-		t.Errorf("expected resource %q, got %q", cfg.ServerPublicURL+"/mcp", body.Resource)
+	if body.Resource != ampAPIResourceIdentifier {
+		t.Errorf("expected REST API resource %q, got %q", ampAPIResourceIdentifier, body.Resource)
 	}
 	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://thunder.example.com" {
 		t.Errorf("expected authorization_servers [https://thunder.example.com], got %v", body.AuthorizationServers)
@@ -93,6 +93,9 @@ func TestWellKnownOAuthProtectedResource_MCPPath(t *testing.T) {
 	}
 	if body.Resource != "https://traces.amp.example.com/mcp" {
 		t.Fatalf("expected normalized MCP resource, got %q", body.Resource)
+	}
+	if body.Resource == ampAPIResourceIdentifier {
+		t.Fatal("expected MCP metadata to remain distinct from REST API metadata")
 	}
 }
 

--- a/agent-manager-observer/main.go
+++ b/agent-manager-observer/main.go
@@ -143,7 +143,7 @@ func main() {
 		Tracing:       controller,
 		Observability: obsController,
 		RBACEnabled:   cfg.Auth.RBACEnabled,
-	}, middleware.JWTAuth(cfg.Auth))
+	}, middleware.JWTAuthForMCP(cfg.Auth))
 	slog.Info("am-obs-mcp registered", "path", "/mcp")
 
 	// Apply middleware: Request Logger -> CORS

--- a/agent-manager-observer/mcp/README.md
+++ b/agent-manager-observer/mcp/README.md
@@ -26,7 +26,7 @@ JWT middleware, which means every tool call goes through the standard OAuth
      `http://localhost:9098/mcp`. During the OAuth flow the MCP client
      validates that the server's advertised resource identifier
      (`SERVER_PUBLIC_URL`, served from
-     `/.well-known/oauth-protected-resource`) matches the URL it was
+     `/.well-known/oauth-protected-resource/mcp`) matches the URL it was
      configured with; a mismatch fails with
      `Protected resource ... does not match expected ...` before login
      even starts.
@@ -75,7 +75,7 @@ OAUTH_SCOPES_SUPPORTED=amp:observability:trace-read,amp:observability:log-read,a
 ```
 
 When either `SERVER_PUBLIC_URL` or `OAUTH_AUTHORIZATION_SERVERS` is unset,
-`GET /.well-known/oauth-protected-resource` returns 503 and MCP clients cannot
+`GET /.well-known/oauth-protected-resource/mcp` returns 503 and MCP clients cannot
 complete OAuth discovery.
 
 In the Helm deployment these come from

--- a/agent-manager-observer/middleware/auth.go
+++ b/agent-manager-observer/middleware/auth.go
@@ -132,9 +132,22 @@ func buildBearerChallenge(resourceMetadataURL, errorCode string) string {
 // JWTAuth returns a middleware that validates Bearer JWTs on every request.
 // Routes wrapped by this middleware require a valid token in the Authorization header.
 func JWTAuth(cfg config.AuthConfig) func(http.Handler) http.Handler {
+	return jwtAuth(cfg, false)
+}
+
+// JWTAuthForMCP points authentication challenges at the path-specific RFC
+// 9728 metadata document for the Observer MCP resource.
+func JWTAuthForMCP(cfg config.AuthConfig) func(http.Handler) http.Handler {
+	return jwtAuth(cfg, true)
+}
+
+func jwtAuth(cfg config.AuthConfig, mcpResource bool) func(http.Handler) http.Handler {
 	resourceMetadataURL := ""
 	if cfg.ServerPublicURL != "" {
-		resourceMetadataURL = cfg.ServerPublicURL + "/.well-known/oauth-protected-resource"
+		resourceMetadataURL = strings.TrimRight(cfg.ServerPublicURL, "/") + "/.well-known/oauth-protected-resource"
+		if mcpResource {
+			resourceMetadataURL += "/mcp"
+		}
 	}
 
 	return func(next http.Handler) http.Handler {

--- a/agent-manager-observer/middleware/auth_test.go
+++ b/agent-manager-observer/middleware/auth_test.go
@@ -146,3 +146,15 @@ func TestJWTAuth_ValidTokenNoChallengeHeader(t *testing.T) {
 		t.Errorf("expected no WWW-Authenticate header on success, got %q", got)
 	}
 }
+
+func TestJWTAuthForMCP_AdvertisesPathSpecificMetadata(t *testing.T) {
+	cfg := config.AuthConfig{IsLocalDevEnv: true, ServerPublicURL: "https://traces.amp.example.com/"}
+	handler := JWTAuthForMCP(cfg)(passThroughHandler(new(bool)))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+
+	want := `Bearer realm="agent-manager-observer", resource_metadata="https://traces.amp.example.com/.well-known/oauth-protected-resource/mcp"`
+	if got := rec.Header().Get("WWW-Authenticate"); got != want {
+		t.Fatalf("expected WWW-Authenticate %q, got %q", want, got)
+	}
+}

--- a/agent-manager-service/api/route_authz_invariant_test.go
+++ b/agent-manager-service/api/route_authz_invariant_test.go
@@ -91,6 +91,8 @@ var unguardedRouteAllowlist = map[routeKey]string{
 		"fails closed on lookup errors, and is rate-limited instead of using user RBAC.",
 	{"registerWellKnownRoutes", "HandleFunc", "GET /.well-known/oauth-protected-resource"}: "GET /.well-known/oauth-protected-resource is RFC 9728 resource metadata and must be " +
 		"unauthenticated so clients can discover how to authenticate.",
+	{"registerWellKnownRoutes", "HandleFunc", "GET /.well-known/oauth-protected-resource/mcp"}: "path-specific RFC 9728 metadata for the MCP resource must be unauthenticated " +
+		"so MCP clients can discover how to authenticate.",
 	{"registerConfigRoutes", "Handle", "/api/v1/config"}:       "public console/CLI discovery endpoint; exposes only the observer public URL.",
 	{"MakeHTTPHandler", "Handle", "/api/v1/"}:                  "mount point for the JWT-authenticated API sub-router, not a leaf endpoint.",
 	{"MakeInternalHTTPHandler", "HandleFunc", "/health"}:       "internal-listener liveness probe.",

--- a/agent-manager-service/api/well_known_routes.go
+++ b/agent-manager-service/api/well_known_routes.go
@@ -34,7 +34,12 @@ type protectedResourceMetadata struct {
 }
 
 func registerWellKnownRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /.well-known/oauth-protected-resource", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource", protectedResourceMetadataHandler(false))
+	mux.HandleFunc("GET /.well-known/oauth-protected-resource/mcp", protectedResourceMetadataHandler(true))
+}
+
+func protectedResourceMetadataHandler(mcpResource bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		cfg := config.GetConfig()
 
 		if cfg.ServerPublicURL == "" {
@@ -48,11 +53,18 @@ func registerWellKnownRoutes(mux *http.ServeMux) {
 			return
 		}
 
+		resource := strings.TrimSuffix(cfg.ServerPublicURL, "/")
+		scopes := cfg.OAuthScopesSupported
+		if mcpResource {
+			resource += "/mcp"
+			scopes = rbac.MainMCPScopes()
+		}
+
 		body := protectedResourceMetadata{
-			Resource:               strings.TrimSuffix(cfg.ServerPublicURL, "/") + "/mcp",
+			Resource:               resource,
 			AuthorizationServers:   cfg.OAuthAuthorizationServers,
 			BearerMethodsSupported: []string{"header"},
-			ScopesSupported:        rbac.MainMCPScopes(),
+			ScopesSupported:        scopes,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -60,5 +72,5 @@ func registerWellKnownRoutes(mux *http.ServeMux) {
 		if err := json.NewEncoder(w).Encode(body); err != nil {
 			logger.GetLogger(r.Context()).Error("failed to encode protected resource metadata", "error", err)
 		}
-	})
+	}
 }

--- a/agent-manager-service/api/well_known_routes_test.go
+++ b/agent-manager-service/api/well_known_routes_test.go
@@ -71,14 +71,38 @@ func TestWellKnownOAuthProtectedResource_HappyPath(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	if body.Resource != "https://am.example.com/mcp" {
-		t.Errorf("expected resource %q, got %q", "https://am.example.com/mcp", body.Resource)
+	if body.Resource != "https://am.example.com" {
+		t.Errorf("expected resource %q, got %q", "https://am.example.com", body.Resource)
 	}
 	if len(body.AuthorizationServers) != 1 || body.AuthorizationServers[0] != "https://idp.example.com" {
 		t.Errorf("expected authorization_servers [https://idp.example.com], got %v", body.AuthorizationServers)
 	}
 	if len(body.BearerMethodsSupported) != 1 || body.BearerMethodsSupported[0] != "header" {
 		t.Errorf("expected bearer_methods_supported [header], got %v", body.BearerMethodsSupported)
+	}
+	if expected := []string{"org:view", "project:read"}; !reflect.DeepEqual(body.ScopesSupported, expected) {
+		t.Errorf("expected API/CLI scopes %v, got %v", expected, body.ScopesSupported)
+	}
+}
+
+func TestWellKnownOAuthProtectedResource_MCPMetadata(t *testing.T) {
+	withWellKnownConfig(t, "https://am.example.com/", []string{"https://idp.example.com"}, []string{"api:scope"})
+
+	mux := setupWellKnownMux()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body protectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.Resource != "https://am.example.com/mcp" {
+		t.Errorf("expected MCP resource %q, got %q", "https://am.example.com/mcp", body.Resource)
 	}
 	if expected := rbac.MainMCPScopes(); !reflect.DeepEqual(body.ScopesSupported, expected) {
 		t.Errorf("expected MCP scopes %v, got %v", expected, body.ScopesSupported)
@@ -125,9 +149,9 @@ func TestWellKnownOAuthProtectedResource_TrailingSlashNormalized(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
-	// A trailing slash on ServerPublicURL must not become "//mcp" — it's trimmed
-	// before "/mcp" is appended, matching the MCP spec's no-trailing-slash guidance.
-	if body.Resource != "https://am.example.com/mcp" {
+	// The API/CLI resource is the normalized public service URL. MCP metadata is
+	// served separately at /.well-known/oauth-protected-resource/mcp.
+	if body.Resource != "https://am.example.com" {
 		t.Errorf("expected resource with trailing slash normalized away, got %q", body.Resource)
 	}
 	// authorization_servers is passed through verbatim — untouched by resource normalization.

--- a/agent-manager-service/mcp/README.md
+++ b/agent-manager-service/mcp/README.md
@@ -91,7 +91,7 @@ The relevant env vars on `agent-manager-service` are already set:
 - SERVER_PUBLIC_URL=http://localhost:9000
 - OAUTH_AUTHORIZATION_SERVERS=http://thunder.amp.localhost:8080
 - KEY_MANAGER_ISSUER=Agent Management Platform Local,http://thunder.amp.localhost:8080
-- KEY_MANAGER_AUDIENCE=localhost,amp-publisher-*,amp-api-client,amp-console-client,am-cli,http://localhost:9000/
+- KEY_MANAGER_AUDIENCE=localhost,amp-publisher-*,amp-api-client,amp-console-client,am-cli,http://localhost:9000/mcp
 ```
 
 ### Helm

--- a/agent-manager-service/middleware/jwtassertion/auth.go
+++ b/agent-manager-service/middleware/jwtassertion/auth.go
@@ -233,12 +233,29 @@ func buildBearerChallenge(resourceMetadataURL, errorCode string) string {
 }
 
 func JWTAuthMiddleware(header, resourceMetadataURL string) func(http.Handler) http.Handler {
+	return JWTAuthMiddlewareWithResourceMetadataResolver(header, func(*http.Request) string {
+		return resourceMetadataURL
+	})
+}
+
+// JWTAuthMiddlewareWithResourceMetadataResolver validates bearer tokens and
+// lets each protected resource advertise its own RFC 9728 metadata document.
+// This is needed when one HTTP server exposes both its REST API and an MCP
+// resource, which intentionally have different resources and scope catalogs.
+func JWTAuthMiddlewareWithResourceMetadataResolver(
+	header string,
+	resourceMetadataURL func(*http.Request) string,
+) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metadataURL := ""
+			if resourceMetadataURL != nil {
+				metadataURL = resourceMetadataURL(r)
+			}
 			tokenString := r.Header.Get(header)
 			if tokenString == "" {
 				notifyAuthFailure(r, "missing-header")
-				w.Header().Set("WWW-Authenticate", buildBearerChallenge(resourceMetadataURL, ""))
+				w.Header().Set("WWW-Authenticate", buildBearerChallenge(metadataURL, ""))
 				utils.WriteErrorResponse(w, http.StatusUnauthorized, fmt.Sprintf("missing header: %s", header))
 				return
 			}
@@ -257,7 +274,7 @@ func JWTAuthMiddleware(header, resourceMetadataURL string) func(http.Handler) ht
 					"path", utils.SanitizeForLog(r.URL.Path),
 					"clientIp", utils.ClientIP(r))
 				notifyAuthFailure(r, classifyAuthFailure(err))
-				w.Header().Set("WWW-Authenticate", buildBearerChallenge(resourceMetadataURL, "invalid_token"))
+				w.Header().Set("WWW-Authenticate", buildBearerChallenge(metadataURL, "invalid_token"))
 				utils.WriteErrorResponse(w, http.StatusUnauthorized, "invalid jwt")
 				return
 			}

--- a/agent-manager-service/wiring/params.go
+++ b/agent-manager-service/wiring/params.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"gorm.io/gorm"
@@ -111,12 +112,18 @@ func ProvideConfigFromPtr(config *config.Config) config.Config {
 }
 
 func ProvideAuthMiddleware(config config.Config) jwtassertion.Middleware {
-	var resourceMetadataURL string
+	var apiResourceMetadataURL, mcpResourceMetadataURL string
 	if config.ServerPublicURL != "" {
-		resourceMetadataURL = strings.TrimRight(config.ServerPublicURL, "/") +
-			"/.well-known/oauth-protected-resource"
+		baseURL := strings.TrimRight(config.ServerPublicURL, "/")
+		apiResourceMetadataURL = baseURL + "/.well-known/oauth-protected-resource"
+		mcpResourceMetadataURL = apiResourceMetadataURL + "/mcp"
 	}
-	return jwtassertion.JWTAuthMiddleware(config.AuthHeader, resourceMetadataURL)
+	return jwtassertion.JWTAuthMiddlewareWithResourceMetadataResolver(config.AuthHeader, func(r *http.Request) string {
+		if r.URL.Path == "/mcp" || strings.HasPrefix(r.URL.Path, "/mcp/") {
+			return mcpResourceMetadataURL
+		}
+		return apiResourceMetadataURL
+	})
 }
 
 func ProvideJWTSigningConfig(config config.Config) config.JWTSigningConfig {

--- a/agent-manager-service/wiring/params_test.go
+++ b/agent-manager-service/wiring/params_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package wiring
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/config"
+)
+
+func TestProvideAuthMiddlewareAdvertisesResourceSpecificMetadata(t *testing.T) {
+	middleware := ProvideAuthMiddleware(config.Config{
+		AuthHeader:      "Authorization",
+		ServerPublicURL: "https://api.example.com/",
+	})
+	handler := middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "REST API", path: "/api/v1/projects", want: "https://api.example.com/.well-known/oauth-protected-resource"},
+		{name: "MCP", path: "/mcp", want: "https://api.example.com/.well-known/oauth-protected-resource/mcp"},
+		{name: "MCP subpath", path: "/mcp/", want: "https://api.example.com/.well-known/oauth-protected-resource/mcp"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", rec.Code)
+			}
+			challenge := rec.Header().Get("WWW-Authenticate")
+			if !strings.Contains(challenge, `resource_metadata="`+tc.want+`"`) {
+				t.Fatalf("expected challenge to advertise %q, got %q", tc.want, challenge)
+			}
+		})
+	}
+}

--- a/cli/pkg/clients/discovery_test.go
+++ b/cli/pkg/clients/discovery_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestDiscoverUsesAPIProtectedResourceScopes(t *testing.T) {
+	wantScopes := []string{
+		"amp:agent:create",
+		"amp:agent:token-manage",
+		"amp:deployment-pipeline:read",
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			_ = json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+				Resource:             server.URL,
+				AuthorizationServers: []string{server.URL},
+				ScopesSupported:      wantScopes,
+			})
+		case "/.well-known/oauth-authorization-server":
+			_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+				Issuer:                server.URL,
+				AuthorizationEndpoint: server.URL + "/oauth2/authorize",
+				TokenEndpoint:         server.URL + "/oauth2/token",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	discovery, err := Discover(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+	if !reflect.DeepEqual(discovery.ScopesSupported, wantScopes) {
+		t.Fatalf("CLI scopes = %v, want %v", discovery.ScopesSupported, wantScopes)
+	}
+}

--- a/deployments/scripts/remove-environment.sh
+++ b/deployments/scripts/remove-environment.sh
@@ -123,9 +123,11 @@ if [ "${DEPROVISION_THUNDER:-true}" = "true" ]; then
     THUNDER_SCRIPT_URL="${THUNDER_SCRIPT_URL:-${SCRIPT_BASE_URL}/remove-environment-thunder.sh}"
     script_tmp="$(mktemp)"
     if curl -fsSL "${THUNDER_SCRIPT_URL}" -o "$script_tmp"; then
-      # SCRIPT_BASE_URL is forwarded so the chained script fetches
-      # thunder-naming.sh/ams-auth.sh from the same git ref as this one.
-      if ENV_NAME="${ENV_NAME}" ORG_NAME="${ORG_NAME}" SCRIPT_BASE_URL="${SCRIPT_BASE_URL}" bash "$script_tmp"; then
+      # Forward the API URL and token already validated by this script so the
+      # chained cleanup updates the same Agent Manager deployment.
+      if ENV_NAME="${ENV_NAME}" ORG_NAME="${ORG_NAME}" SCRIPT_BASE_URL="${SCRIPT_BASE_URL}" \
+          AMP_API_URL="${AGENT_MANAGER_API_URL}" AGENT_MANAGER_TOKEN="${AGENT_MANAGER_TOKEN}" \
+          bash "$script_tmp"; then
         echo "✅ Thunder ID instance removed"
       else
         echo "⚠️  Thunder ID removal failed — continuing with gateway removal."
@@ -190,4 +192,3 @@ fi
 echo ""
 echo "=== Environment '${ENV_NAME}' removed ==="
 echo ""
-

--- a/deployments/setup/register-amp-resources.sh
+++ b/deployments/setup/register-amp-resources.sh
@@ -475,8 +475,8 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # ===========================================================================
 # 3. MCP resource servers (RFC 8707 resource indicators)
 # ===========================================================================
-# MCP clients (Claude Code etc.) send the service's public base URL, with a
-# trailing slash, as the OAuth `resource` parameter. Thunder rejects the
+# MCP clients (Claude Code etc.) send the MCP endpoint URL as the OAuth
+# `resource` parameter. Thunder rejects the
 # authorize request with invalid_target unless that value exactly matches a
 # registered resource-server identifier, so each MCP endpoint's public URL is
 # registered here as its own resource server.
@@ -492,9 +492,9 @@ log_success "Agent Manager resource server registration complete (all amp permis
 # own entry; set one to "" to skip it. The dev origin is the docker-compose
 # stack's published host port.
 # Unset-only defaults, so an explicit "" survives to the skip above.
-AM_MCP_RESOURCE="${AM_MCP_RESOURCE-http://api.amp.localhost:8080/}"
-AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE-http://localhost:9000/}"
-OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE-http://traces.amp.localhost:11080/}"
+AM_MCP_RESOURCE="${AM_MCP_RESOURCE-http://api.amp.localhost:8080/mcp}"
+AM_MCP_DEV_RESOURCE="${AM_MCP_DEV_RESOURCE-http://localhost:9000/mcp}"
+OBSERVER_MCP_RESOURCE="${OBSERVER_MCP_RESOURCE-http://traces.amp.localhost:11080/mcp}"
 
 log_info "Registering MCP resource servers..."
 register_mcp_resource_server "AMP Agent Manager MCP" "$AM_MCP_RESOURCE" "Resource identifier for the agent-manager MCP endpoint" "amp-minus-observability"

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -58,7 +58,7 @@ amp_helm_args() {
       "--set" "${k}.config.serverPublicURL=https://${AMP_HOST_API}" \
       "--set" "${k}.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
       "--set" "${k}.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
-      "--set" "${k}.config.keyManager.audience=urn:wso2:amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/" \
+      "--set" "${k}.config.keyManager.audience=urn:wso2:amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/mcp" \
       "--set" "${k}.config.thunder.baseURL=https://${AMP_HOST_THUNDER}" \
       "--set" "${k}.config.thunder.resolveToHost=amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090" \
       "--set" "${k}.config.tlsEnabled=true" \
@@ -161,8 +161,8 @@ build_gateway_helm_args() {
 #
 # authorizationServers/audience are restated for the version-skew reason noted
 # above amp_helm_args (including the "urn:wso2:amp" identifier value). The last
-# audience entry is the observer MCP token's `aud` (publicUrl plus a trailing
-# slash); the first three cover console/amctl tokens.
+# audience entry is the observer MCP token's `aud` (its public `/mcp`
+# resource); the first three cover console/amctl tokens.
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 observability_helm_args() {
   printf '%s\n' \
@@ -170,7 +170,7 @@ observability_helm_args() {
     "--set" "amObserver.ocIngress.hostname=${AMP_HOST_OBSERVER}" \
     "--set" "amObserver.publicUrl=https://${AMP_HOST_OBSERVER}" \
     "--set" "amObserver.oauth.authorizationServers=https://${AMP_HOST_THUNDER}" \
-    "--set" "amObserver.auth.audience=urn:wso2:amp\,amp-api-client\,am-obs-mcp\,https://${AMP_HOST_OBSERVER}/"
+    "--set" "amObserver.auth.audience=urn:wso2:amp\,amp-api-client\,am-obs-mcp\,https://${AMP_HOST_OBSERVER}/mcp"
 }
 
 # build_observability_helm_args <ip> — sslip.io-from-IP wrapper.

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -55,13 +55,13 @@ assert_eq "amp oauthAuthorizationServers (service key)" \
 assert_eq "amp keyManager.issuer (service key)" \
   "agentManagerService.config.keyManager.issuer=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.keyManager.issuer' <<<"$amp")"
-# An MCP token's aud is serverPublicURL plus a trailing slash, so the audience
-# has to follow it off the chart's localhost default. Assert only that entry —
+# An MCP token's aud is the public MCP endpoint, so the audience has to follow
+# it off the chart's localhost default. Assert only that entry —
 # pinning the whole list would break on any unrelated audience change.
 assert_eq "amp keyManager.audience carries the public API URL (service key)" "yes" \
   "$(has "$amp" 'agentManagerService.config.keyManager.audience=urn:wso2:amp\,')"
 assert_eq "amp keyManager.audience ends with the public API URL (service key)" "yes" \
-  "$(has "$amp" 'am-mcp\,https://api.amp.203.0.113.10.sslip.io/')"
+  "$(has "$amp" 'am-mcp\,https://api.amp.203.0.113.10.sslip.io/mcp')"
 assert_eq "amp keyManager.audience carries the public API URL (legacy key)" "yes" \
   "$(has "$amp" 'agentManager.config.keyManager.audience=urn:wso2:amp\,')"
 # tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
@@ -162,11 +162,11 @@ assert_eq "observability publicUrl -> public observer host" \
 assert_eq "observability oauth authorizationServers -> public thunder" \
   "amObserver.oauth.authorizationServers=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'amObserver.oauth.authorizationServers' <<<"$obs")"
-# The observer mints MCP tokens whose aud is its own public URL plus a trailing
-# slash, so the audience list has to follow publicUrl off the chart's localhost
+# The observer mints MCP tokens whose aud is its public `/mcp` resource, so the
+# audience list has to follow publicUrl off the chart's localhost
 # default. Commas stay escaped or helm splits the value into a list.
 assert_eq "observability audience carries the public observer URL" \
-  'amObserver.auth.audience=urn:wso2:amp\,amp-api-client\,am-obs-mcp\,https://observer.amp.203.0.113.10.sslip.io/' \
+  'amObserver.auth.audience=urn:wso2:amp\,amp-api-client\,am-obs-mcp\,https://observer.amp.203.0.113.10.sslip.io/mcp' \
   "$(grep -F 'amObserver.auth.audience' <<<"$obs")"
 
 # --- render_dataplane_external_ingress: public host on :443, both http+https entries
@@ -433,7 +433,7 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
   # The audience must land on the same host as serverPublicURL above and as
   # thunder.bootstrap.agentManagerMcpBaseUrl below.
   assert_eq "core amp keyManager.audience carries the public API URL" "yes" \
-    "$(has "$core_amp" 'am-mcp\,https://api.amp.example.com/')"
+    "$(has "$core_amp" 'am-mcp\,https://api.amp.example.com/mcp')"
 
   core_th="$(thunder_helm_args)"
   assert_eq "core thunder jwt.issuer" \
@@ -450,7 +450,7 @@ assert_eq "agent site on_demand + disable_http_challenge" "yes" \
 
   core_obs="$(observability_helm_args)"
   assert_eq "core observability audience carries the public observer URL" \
-    'amObserver.auth.audience=urn:wso2:amp\,amp-api-client\,am-obs-mcp\,https://observer.amp.example.com/' \
+    'amObserver.auth.audience=urn:wso2:amp\,amp-api-client\,am-obs-mcp\,https://observer.amp.example.com/mcp' \
     "$(grep -F 'amObserver.auth.audience' <<<"$core_obs")"
 
   core_gw="$(gateway_helm_args)"


### PR DESCRIPTION
## Purpose
- Resolves #1762: `amctl` got a token missing required scopes and 403'd on agent creation, because a prior MCP fix narrowed the shared scope-discovery endpoint to MCP-only scopes.
- Also fixes: removing an environment on Quick Setup left a stale Thunder system-client and URL handle in the database, breaking reinstall of the same org/environment.

## Goals
- Give `amctl` the full scope catalog again without breaking MCP's own scope discovery.
- Make environment removal actually clean up Thunder's system-client and URL handle.

## Approach
- Split the one `/.well-known/oauth-protected-resource` endpoint into two: the root path now serves the full scope catalog (for `amctl`/REST), a new `/mcp` path serves the narrow MCP-only scopes.
- The 401 challenge now points to whichever of the two matches the request path. Mirrored the same split in `agent-manager-observer`.
- Kept `register-amp-resources.sh` and the VM helm-args script in sync with the identifier convention Thunder already uses.
- Seperate Fix : `remove-environment.sh` now forwards its validated Agent Manager API URL to the chained Thunder cleanup script, preventing it from falling back to the unreachable `localhost:9000` address and leaving environment records behind.

## User stories
- `amctl` works normally right after login, no more 403s from missing scopes.
- Removing an environment fully cleans up, so reinstalling the same org/environment doesn't conflict.

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   New/updated tests cover: the 401 challenge picking the right metadata URL by path, the root path serving full scopes, the observer's mirrored split, and the CLI reading scopes from the root path. `make test-unit`: all pass.
 - Integration tests
   `make test-integration`: all pass. The removal-script fix has no Go test coverage (it's a bash change), verified by reading the cleanup script's own lookup logic.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- https://github.com/wso2/agent-manager/pull/1753

## Migrations (if applicable)
N/A

## Test environment
macOS, Go 1.26.7, k3d v5.9.0, Docker. Verified via `make test-unit` and `make test-integration`.

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated OAuth protected-resource metadata for MCP integrations.
  * OAuth challenges now advertise metadata matching the requested API or MCP endpoint.
  * MCP resource URLs and authorization audiences consistently include `/mcp`.

* **Bug Fixes**
  * Normalized public URLs to prevent incorrect trailing-slash resource values.
  * Corrected OAuth scopes and resource identifiers for API and MCP access.

* **Documentation**
  * Updated MCP setup guidance and local configuration examples for the new metadata and resource URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->