### PR TITLE
Refactor ListAgentConsumersByProxyUUIDs to group by project and agent

### DIFF
--- a/agent-manager-service/repositories/env_agent_model_mapping_repository.go
+++ b/agent-manager-service/repositories/env_agent_model_mapping_repository.go
@@ -115,13 +115,17 @@ func (r *envAgentModelMappingRepository) ListAgentConsumersByProxyUUIDs(ctx cont
 		return nil, nil
 	}
 	var results []AgentConsumer
+	// A single agent gets a distinct LLM proxy artifact per environment, so grouping only
+	// by (project_name, agent_id) — rather than including the per-env proxy handle/name in
+	// the projection — collapses those per-env rows into one consumer entry per agent.
 	err := r.db.WithContext(ctx).
 		Table("env_agent_model_mapping eam").
-		Select("DISTINCT a.handle AS proxy_handle, a.name AS proxy_name, ac.project_name, ac.agent_id").
+		Select("MIN(a.handle) AS proxy_handle, MIN(a.name) AS proxy_name, ac.project_name, ac.agent_id").
 		Joins("JOIN llm_proxies lp ON lp.uuid = eam.llm_proxy_uuid").
 		Joins("JOIN artifacts a ON a.uuid = lp.uuid").
 		Joins("JOIN agent_configurations ac ON ac.uuid = eam.config_uuid").
 		Where("eam.llm_proxy_uuid IN ?", proxyUUIDs).
+		Group("ac.project_name, ac.agent_id").
 		Scan(&results).Error
 	return results, err
 }


### PR DESCRIPTION
<img width="1918" height="987" alt="image" src="https://github.com/user-attachments/assets/4235df62-d861-49bc-936b-89ded4f96ec9" />

## Purpose
This pull request updates the logic for listing agent consumers by proxy UUIDs in the `envAgentModelMappingRepository`. The main change is to ensure that each agent gets a single consumer entry per environment, rather than multiple entries per environment-specific proxy artifact.

**Query logic improvements:**

* Modified the SQL query in `env_agent_model_mapping_repository.go` to group results by `project_name` and `agent_id`, ensuring only one consumer entry per agent per environment. The projection now uses `MIN(a.handle)` and `MIN(a.name)` instead of `DISTINCT`, which collapses per-environment rows and avoids duplicate consumer entries.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.