### PR TITLE
Change build workflow kind to Workflow from ClusterWorkflow

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -273,12 +273,26 @@ func buildInternalAgentFromSourceComponentRequestBody(namespaceName, projectName
 			AutoDeploy: &autoDeploy,
 			Parameters: &parameters,
 			Workflow: &gen.ComponentWorkflowConfig{
+				Kind:       &componentWorkflowKind,
 				Name:       componentWorkflowName,
 				Parameters: &componentWorkflowParameters,
 			},
 		},
 	}, nil
 }
+
+// componentWorkflowKind is the kind recorded on a Component's workflow reference.
+//
+// The namespaced Workflow is used rather than the cluster-scoped ClusterWorkflow:
+// a ClusterWorkflow pins workflowPlaneRef to the single cluster-wide
+// ClusterWorkflowPlane, so its builds always run on that one plane. A namespaced
+// Workflow resolves the WorkflowPlane inside the organization's own namespace,
+// which is what lets an org build on the data centre it actually belongs to.
+//
+// Recorded on the Component so each agent keeps the kind it was created with:
+// builds.go reads this and only falls back to ClusterWorkflow when it is unset,
+// which is the case for agents created before this change.
+var componentWorkflowKind = gen.ComponentWorkflowConfigKindWorkflow
 
 func getOpenChoreoComponentType(provisioningType string, agentType string) (string, error) {
 	if provisioningType == string(utils.ExternalAgent) {

--- a/agent-manager-service/clients/openchoreosvc/client/components_workflow_kind_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components_workflow_kind_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+	"github.com/wso2/agent-manager/agent-manager-service/utils"
+)
+
+// A Component must record kind=Workflow on its workflow reference. A
+// ClusterWorkflow pins workflowPlaneRef to the single cluster-wide
+// ClusterWorkflowPlane, so its builds always run on that one plane; a namespaced
+// Workflow resolves the WorkflowPlane inside the org's own namespace, which is
+// what lets the org build on the data centre it belongs to.
+//
+// The kind has to be recorded here, at creation, because builds.go reads it from
+// the Component and only falls back to ClusterWorkflow when it is absent.
+func TestBuildComponentRequest_RecordsNamespacedWorkflowKind(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		build        *BuildConfig
+		wantWorkflow string
+	}{
+		{
+			name:         "docker build",
+			build:        &BuildConfig{Type: BuildTypeDocker, Docker: &DockerConfig{DockerfilePath: "Dockerfile"}},
+			wantWorkflow: WorkflowNameDocker,
+		},
+		{
+			name:         "google buildpack",
+			build:        &BuildConfig{Type: BuildTypeBuildpack, Buildpack: &BuildpackConfig{Language: "python"}},
+			wantWorkflow: WorkflowNameGoogleCloudBuildpacks,
+		},
+		{
+			name:         "ballerina buildpack",
+			build:        &BuildConfig{Type: BuildTypeBuildpack, Buildpack: &BuildpackConfig{Language: "ballerina"}},
+			wantWorkflow: WorkflowNameBallerinaBuilpack,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := buildInternalAgentFromSourceComponentRequestBody("default", "proj1", CreateComponentRequest{
+				Name:             "my-agent",
+				DisplayName:      "My Agent",
+				ProvisioningType: ProvisioningInternal,
+				AgentType:        AgentTypeConfig{Type: string(utils.AgentTypeAPI), SubType: "custom-api"},
+				Build:            tc.build,
+				Repository:       &RepositoryConfig{},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, body.Spec)
+			require.NotNil(t, body.Spec.Workflow)
+			require.NotNil(t, body.Spec.Workflow.Kind,
+				"kind must be recorded, otherwise builds.go falls back to ClusterWorkflow")
+			assert.Equal(t, gen.ComponentWorkflowConfigKindWorkflow, *body.Spec.Workflow.Kind,
+				"must be the namespaced Workflow, not the cluster-scoped ClusterWorkflow")
+			assert.Equal(t, tc.wantWorkflow, body.Spec.Workflow.Name,
+				"the workflow name is unchanged by the kind switch — the namespaced "+
+					"workflows are provisioned under the same names")
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
Builds must run on the data centre the org belongs to. A `ClusterWorkflow`'s `workflowPlaneRef` is typed `*ClusterWorkflowPlaneRef` — enum-restricted to `ClusterWorkflowPlane` and immutable ([types.go](https://github.com/openchoreo/openchoreo/blob/v1.2.2/api/v1alpha1/types.go)) — so it can only ever build on the single cluster-wide plane. That breaks with the new USDC data centre.

## Goals
New agents reference the **namespaced** `Workflow` in their own org namespace, which resolves that org's `WorkflowPlane`.

## Approach
One field on the Component's workflow reference:
- `components.go` — set `Kind: Workflow` (a package var, since the generated field is a pointer)

Deliberately **not** changed:
- `builds.go` already reads the Component's kind and only falls back to `ClusterWorkflow` when absent. Leaving that fallback is what keeps existing agents building unchanged.
- The other three `ComponentWorkflowConfig` sites only create the struct when nil and touch `Parameters` — `Kind` survives their round-trip.

**amp-pre-release only** — `main`/on-prem keeps `ClusterWorkflow` and is untouched.

## User stories
As a developer, an agent I create builds on the data centre my org runs in.

## Release note
Agent builds now use the namespaced workflow for the organization, so builds run on the correct data centre.

## Documentation
N/A — internal resource reference, no user-facing or config change.

## Training
N/A

## Certification
N/A — no change to product concepts or workflows.

## Marketing
N/A

## Automation tests
- Unit tests
  - New `components_workflow_kind_test.go` — asserts the request records `kind: Workflow` and that the workflow **name is unchanged**, across all three build types (docker, google buildpack, ballerina buildpack).
  - `clients/openchoreosvc/client` coverage: 12.1% of statements.
  - `make test-unit` passes; `golangci-lint` reports 0 issues in the changed files.
- Integration tests
  - None added — the change is request construction, covered by the unit test.

## Security checks
- Secure coding guidelines: **yes**
- FindSecurityBugs: **N/A**
- No keys/passwords/tokens committed: **yes**

## Samples
N/A

## Migrations (if applicable)
**Blocked on org migration — do not deploy before it completes.**

Namespaced build workflows arrived in bootstrap v1.5 and currently exist in **4 of 130 orgs** (86 have the `WorkflowPlane`, but not the build workflows). All orgs need `POST /ou/migrate` to v1.5 first; otherwise creating a **new agent** in an un-migrated org fails to resolve its build workflow.

Order matters, and migrate-first has **no broken window** — both steps are additive:
1. Migrate all orgs to v1.5 (adds the per-org workflows; changes nothing existing)
2. Deploy this change (new agents pick them up)
3. Later: flip the `builds.go` fallback so existing agents move over too
4. Last: delete the cluster-scoped workflows in wso2cloud-deployment, once nothing references them

Existing agents, existing builds and build history are unaffected throughout — reads never consult the kind.
