### PR TITLE
Stamp the org UUID onto the cell namespace

### DIFF
--- a/agent-manager-service/clients/openchoreosvc/client/constants.go
+++ b/agent-manager-service/clients/openchoreosvc/client/constants.go
@@ -231,6 +231,13 @@ const (
 type LabelKeys string
 
 const (
+	// LabelKeyOrgUUID carries the organization's UUID. Unlike the keys below it
+	// is not an openchoreo.dev key: it belongs to the platform that provisions
+	// the organization, and it is a UUID rather than a name because the systems
+	// that consume it key on one. It is stamped onto the cell namespace so usage
+	// measured from pod metrics can be attributed to an organization.
+	LabelKeyOrgUUID LabelKeys = "cloud.wso2.com/orguuid"
+
 	LabelKeyOrganizationName     LabelKeys = "openchoreo.dev/organization"
 	LabelKeyProjectName          LabelKeys = "openchoreo.dev/project"
 	LabelKeyComponentName        LabelKeys = "openchoreo.dev/component"

--- a/agent-manager-service/clients/openchoreosvc/client/project_release_bindings.go
+++ b/agent-manager-service/clients/openchoreosvc/client/project_release_bindings.go
@@ -70,6 +70,19 @@ func (c *openChoreoClient) EnsureProjectReleaseBinding(ctx context.Context, ouID
 				ProjectName string `json:"projectName"`
 			}{ProjectName: projectName},
 			Environment: environmentName,
+			// The project type merges these labels onto the cell namespace it
+			// creates, which is where this project's pods run. The organization's
+			// UUID goes there because nothing on a pod identifies an
+			// organization and nothing downstream can derive it: the namespace
+			// name is a hash of the UUID, and the renderer copies only its own
+			// fixed label set onto workloads. Without this, compute measured in
+			// this namespace is attributable to a project and a component but to
+			// no customer.
+			EnvironmentConfigs: &map[string]interface{}{
+				"namespaceLabels": map[string]string{
+					string(LabelKeyOrgUUID): ouID,
+				},
+			},
 		},
 	}
 

--- a/agent-manager-service/clients/openchoreosvc/client/project_release_bindings_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/project_release_bindings_test.go
@@ -83,6 +83,29 @@ func TestEnsureProjectReleaseBinding_CreatesBinding(t *testing.T) {
 	assert.Nil(t, gotBody.Spec.ProjectRelease)
 }
 
+// The organization's UUID has to reach the binding, because the project type
+// merges these labels onto the cell namespace and that is the only place usage
+// measured from pod metrics can be attributed to an organization. A missing
+// label breaks nothing at create time -- it yields pods that meter correctly and
+// bill to no customer -- so it is asserted rather than left to inspection.
+func TestEnsureProjectReleaseBinding_StampsOrgUUIDOnCellNamespace(t *testing.T) {
+	var gotBody gen.ProjectReleaseBinding
+	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.WriteHeader(http.StatusCreated)
+		require.NoError(t, json.NewEncoder(w).Encode(gotBody))
+	}))
+
+	const ouID = "019eafc8-0f23-7974-9119-d762c59c83a1"
+	require.NoError(t, srv.EnsureProjectReleaseBinding(context.Background(), ouID, "my-project", "dev"))
+
+	require.NotNil(t, gotBody.Spec)
+	require.NotNil(t, gotBody.Spec.EnvironmentConfigs)
+	nsLabels, ok := (*gotBody.Spec.EnvironmentConfigs)["namespaceLabels"].(map[string]interface{})
+	require.True(t, ok, "namespaceLabels missing: %#v", *gotBody.Spec.EnvironmentConfigs)
+	assert.Equal(t, ouID, nsLabels[string(LabelKeyOrgUUID)])
+}
+
 func TestEnsureProjectReleaseBinding_ExistingBindingIsSuccess(t *testing.T) {
 	srv := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {


### PR DESCRIPTION
## Purpose
A project's pods carry component, project and environment identity but nothing that identifies the organisation, so compute measured from pod metrics is attributable to a project and a component but to no customer. That blocks consumption billing.

Nothing downstream can recover the identifier:
- The organisation namespace name is derived from it through a hash, so the derivation is one-way.
- The renderer copies only its own fixed label set onto rendered workloads, so a label on the Component — or on the binding's own metadata — reaches neither the namespace nor the pods.

## Goals
Make a project's pods attributable to an organisation, without changing the pods and without new API surface.

## Approach
The project type already merges `spec.environmentConfigs.namespaceLabels` into the cell namespace it creates, and that namespace is where the project's pods run. `EnsureProjectReleaseBinding` now sets the organisation's identifier there:

```yaml
spec:
  environmentConfigs:
    namespaceLabels:
      cloud.wso2.com/orguuid: <organisation UUID>
```

Metering can then attribute a pod by joining on the namespace the pod series already carries, and the pods themselves are untouched — no pod-template change, so no rolling restart.

The identifier is a UUID rather than a name because the systems consuming it key on one. That is also why the new label key sits outside the `openchoreo.dev/` prefix: it belongs to the platform that provisions the organisation rather than to the orchestrator, and that prefix is treated as reserved here.

The value is already a parameter of this call, so nothing new had to be plumbed to reach it.

### Why not a pod label
Adding the key to each component type's pod template would also work and would need no join at all, but it changes the pod-template hash and so restarts every agent in every organisation, it is not retroactive while cells re-render, and it has to be repeated in every component type. ⚠️ If anyone revisits that: the key must never be added to the pod *selector* map, which feeds `spec.selector.matchLabels` and is immutable on an existing Deployment.

## User stories
N/A — platform provisioning change with no user-facing surface.

## Release note
Cell namespaces created for a project now carry the organisation's UUID as a label, so workload usage measured from pod metrics can be attributed to an organisation.

## Documentation
N/A — internal provisioning label; no product documentation describes cell-namespace labels.

## Training
N/A — no user-facing behaviour change.

## Certification
N/A — provisioning internals with no certifiable user-facing behaviour.

## Marketing
N/A — internal change.

## Automation tests
- Unit tests
  > One added, asserting the identifier reaches `spec.environmentConfigs.namespaceLabels` on the created binding. It is asserted rather than left to inspection because a missing label breaks nothing at create time — it yields pods that meter correctly and bill to no customer. Package tests pass; `gofumpt` clean. Note the package requires `DB_HOST`/`DB_USER`/`DB_PASSWORD`/`DB_NAME`/`OPEN_CHOREO_BASE_URL` to be set to run at all, which is pre-existing and unrelated.
- Integration tests
  > Not added. The end-to-end assertion is that a provisioned cell namespace carries the label, which needs a cluster. The intended post-deploy check is a query for the label on a cell namespace, and then on the pod series once the metrics exporter admits it.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Go, not Java.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes. The test fixture is an organisation identifier, not a credential.

## Samples
N/A.

## Migrations (if applicable)
Projects created after this lands get the label. Projects that already exist keep their current bindings, so their cell namespaces are unlabelled until those bindings are re-applied — worth knowing before relying on the label for billing coverage.

## Test environment
`go build` and package tests locally. The mechanism was verified end to end on the dev cloud cluster, not just accepted by the schema: patching `spec.environmentConfigs.namespaceLabels` onto a binding put the label on its cell namespace, and removing `environmentConfigs` removed it again — so propagation is bidirectional and a wrong label can be withdrawn rather than only overwritten. The canary ran against a cell with zero pods using a throwaway probe key, and was reverted. A server-side dry run separately confirmed the API accepts the field with this dotted/slashed key.

## Related PRs
The exporter-side change that makes this label readable from the metrics store is separate; until it lands the label is present and unread. That order is deliberate — a label nothing exports is inert, whereas exporting a label nothing sets reads as an organisation with no usage.

## Learning
The instructive part was how many plausible places this does not work. The identifier is stamped on several control-plane objects by generic provisioning hooks, so it looks available anywhere — but every one of those setters writes top-level `metadata.labels`, and the workload render path builds its pod label set from a fixed map. Availability on an object and availability to a metrics query turned out to be different questions.
