### PR TITLE
Move agent configuration from the Workload to per-environment release-bindings

### DIFF
--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -39,9 +39,6 @@ import (
 //			CreateInternalAgentFromKindWorkloadFunc: func(ctx context.Context, ouID string, projectName string, componentName string, req client.InternalAgentFromKindWorkloadRequest) error {
 //				panic("mock out the CreateInternalAgentFromKindWorkload method")
 //			},
-//			CreateKindAgentReleaseAndBindingFunc: func(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
-//				panic("mock out the CreateKindAgentReleaseAndBinding method")
-//			},
 //			CreateProjectFunc: func(ctx context.Context, ouID string, req client.CreateProjectRequest) error {
 //				panic("mock out the CreateProject method")
 //			},
@@ -86,6 +83,9 @@ import (
 //			},
 //			EnsureProjectReleaseBindingFunc: func(ctx context.Context, ouID string, projectName string, environmentName string) error {
 //				panic("mock out the EnsureProjectReleaseBinding method")
+//			},
+//			EnsureReleaseAndBindingFunc: func(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+//				panic("mock out the EnsureReleaseAndBinding method")
 //			},
 //			EnsureReleaseBindingRuntimeClassFunc: func(ctx context.Context, ouID string, componentName string, environment string, desiredRuntimeClass string) error {
 //				panic("mock out the EnsureReleaseBindingRuntimeClass method")
@@ -274,9 +274,6 @@ type OpenChoreoClientMock struct {
 	// CreateInternalAgentFromKindWorkloadFunc mocks the CreateInternalAgentFromKindWorkload method.
 	CreateInternalAgentFromKindWorkloadFunc func(ctx context.Context, ouID string, projectName string, componentName string, req client.InternalAgentFromKindWorkloadRequest) error
 
-	// CreateKindAgentReleaseAndBindingFunc mocks the CreateKindAgentReleaseAndBinding method.
-	CreateKindAgentReleaseAndBindingFunc func(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error
-
 	// CreateProjectFunc mocks the CreateProject method.
 	CreateProjectFunc func(ctx context.Context, ouID string, req client.CreateProjectRequest) error
 
@@ -321,6 +318,9 @@ type OpenChoreoClientMock struct {
 
 	// EnsureProjectReleaseBindingFunc mocks the EnsureProjectReleaseBinding method.
 	EnsureProjectReleaseBindingFunc func(ctx context.Context, ouID string, projectName string, environmentName string) error
+
+	// EnsureReleaseAndBindingFunc mocks the EnsureReleaseAndBinding method.
+	EnsureReleaseAndBindingFunc func(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error
 
 	// EnsureReleaseBindingRuntimeClassFunc mocks the EnsureReleaseBindingRuntimeClass method.
 	EnsureReleaseBindingRuntimeClassFunc func(ctx context.Context, ouID string, componentName string, environment string, desiredRuntimeClass string) error
@@ -564,23 +564,6 @@ type OpenChoreoClientMock struct {
 			// Req is the req argument value.
 			Req client.InternalAgentFromKindWorkloadRequest
 		}
-		// CreateKindAgentReleaseAndBinding holds details about calls to the CreateKindAgentReleaseAndBinding method.
-		CreateKindAgentReleaseAndBinding []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// OuID is the ouID argument value.
-			OuID string
-			// ProjectName is the projectName argument value.
-			ProjectName string
-			// ComponentName is the componentName argument value.
-			ComponentName string
-			// Environment is the environment argument value.
-			Environment string
-			// EnvOverrides is the envOverrides argument value.
-			EnvOverrides []client.EnvVar
-			// FileOverrides is the fileOverrides argument value.
-			FileOverrides []client.FileVar
-		}
 		// CreateProject holds details about calls to the CreateProject method.
 		CreateProject []struct {
 			// Ctx is the ctx argument value.
@@ -727,6 +710,23 @@ type OpenChoreoClientMock struct {
 			ProjectName string
 			// EnvironmentName is the environmentName argument value.
 			EnvironmentName string
+		}
+		// EnsureReleaseAndBinding holds details about calls to the EnsureReleaseAndBinding method.
+		EnsureReleaseAndBinding []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OuID is the ouID argument value.
+			OuID string
+			// ProjectName is the projectName argument value.
+			ProjectName string
+			// ComponentName is the componentName argument value.
+			ComponentName string
+			// Environment is the environment argument value.
+			Environment string
+			// EnvOverrides is the envOverrides argument value.
+			EnvOverrides []client.EnvVar
+			// FileOverrides is the fileOverrides argument value.
+			FileOverrides []client.FileVar
 		}
 		// EnsureReleaseBindingRuntimeClass holds details about calls to the EnsureReleaseBindingRuntimeClass method.
 		EnsureReleaseBindingRuntimeClass []struct {
@@ -1341,7 +1341,6 @@ type OpenChoreoClientMock struct {
 	lockCreateEnvironment                      sync.RWMutex
 	lockCreateGitSecret                        sync.RWMutex
 	lockCreateInternalAgentFromKindWorkload    sync.RWMutex
-	lockCreateKindAgentReleaseAndBinding       sync.RWMutex
 	lockCreateProject                          sync.RWMutex
 	lockCreateSecret                           sync.RWMutex
 	lockCreateSecretReference                  sync.RWMutex
@@ -1357,6 +1356,7 @@ type OpenChoreoClientMock struct {
 	lockDetachTrait                            sync.RWMutex
 	lockEnsureClusterRoleBinding               sync.RWMutex
 	lockEnsureProjectReleaseBinding            sync.RWMutex
+	lockEnsureReleaseAndBinding                sync.RWMutex
 	lockEnsureReleaseBindingRuntimeClass       sync.RWMutex
 	lockExpireWorkflowRun                      sync.RWMutex
 	lockGetBuild                               sync.RWMutex
@@ -1725,62 +1725,6 @@ func (mock *OpenChoreoClientMock) CreateInternalAgentFromKindWorkloadCalls() []s
 	mock.lockCreateInternalAgentFromKindWorkload.RLock()
 	calls = mock.calls.CreateInternalAgentFromKindWorkload
 	mock.lockCreateInternalAgentFromKindWorkload.RUnlock()
-	return calls
-}
-
-// CreateKindAgentReleaseAndBinding calls CreateKindAgentReleaseAndBindingFunc.
-func (mock *OpenChoreoClientMock) CreateKindAgentReleaseAndBinding(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
-	if mock.CreateKindAgentReleaseAndBindingFunc == nil {
-		panic("OpenChoreoClientMock.CreateKindAgentReleaseAndBindingFunc: method is nil but OpenChoreoClient.CreateKindAgentReleaseAndBinding was just called")
-	}
-	callInfo := struct {
-		Ctx           context.Context
-		OuID          string
-		ProjectName   string
-		ComponentName string
-		Environment   string
-		EnvOverrides  []client.EnvVar
-		FileOverrides []client.FileVar
-	}{
-		Ctx:           ctx,
-		OuID:          ouID,
-		ProjectName:   projectName,
-		ComponentName: componentName,
-		Environment:   environment,
-		EnvOverrides:  envOverrides,
-		FileOverrides: fileOverrides,
-	}
-	mock.lockCreateKindAgentReleaseAndBinding.Lock()
-	mock.calls.CreateKindAgentReleaseAndBinding = append(mock.calls.CreateKindAgentReleaseAndBinding, callInfo)
-	mock.lockCreateKindAgentReleaseAndBinding.Unlock()
-	return mock.CreateKindAgentReleaseAndBindingFunc(ctx, ouID, projectName, componentName, environment, envOverrides, fileOverrides)
-}
-
-// CreateKindAgentReleaseAndBindingCalls gets all the calls that were made to CreateKindAgentReleaseAndBinding.
-// Check the length with:
-//
-//	len(mockedOpenChoreoClient.CreateKindAgentReleaseAndBindingCalls())
-func (mock *OpenChoreoClientMock) CreateKindAgentReleaseAndBindingCalls() []struct {
-	Ctx           context.Context
-	OuID          string
-	ProjectName   string
-	ComponentName string
-	Environment   string
-	EnvOverrides  []client.EnvVar
-	FileOverrides []client.FileVar
-} {
-	var calls []struct {
-		Ctx           context.Context
-		OuID          string
-		ProjectName   string
-		ComponentName string
-		Environment   string
-		EnvOverrides  []client.EnvVar
-		FileOverrides []client.FileVar
-	}
-	mock.lockCreateKindAgentReleaseAndBinding.RLock()
-	calls = mock.calls.CreateKindAgentReleaseAndBinding
-	mock.lockCreateKindAgentReleaseAndBinding.RUnlock()
 	return calls
 }
 
@@ -2405,6 +2349,62 @@ func (mock *OpenChoreoClientMock) EnsureProjectReleaseBindingCalls() []struct {
 	mock.lockEnsureProjectReleaseBinding.RLock()
 	calls = mock.calls.EnsureProjectReleaseBinding
 	mock.lockEnsureProjectReleaseBinding.RUnlock()
+	return calls
+}
+
+// EnsureReleaseAndBinding calls EnsureReleaseAndBindingFunc.
+func (mock *OpenChoreoClientMock) EnsureReleaseAndBinding(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+	if mock.EnsureReleaseAndBindingFunc == nil {
+		panic("OpenChoreoClientMock.EnsureReleaseAndBindingFunc: method is nil but OpenChoreoClient.EnsureReleaseAndBinding was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		OuID          string
+		ProjectName   string
+		ComponentName string
+		Environment   string
+		EnvOverrides  []client.EnvVar
+		FileOverrides []client.FileVar
+	}{
+		Ctx:           ctx,
+		OuID:          ouID,
+		ProjectName:   projectName,
+		ComponentName: componentName,
+		Environment:   environment,
+		EnvOverrides:  envOverrides,
+		FileOverrides: fileOverrides,
+	}
+	mock.lockEnsureReleaseAndBinding.Lock()
+	mock.calls.EnsureReleaseAndBinding = append(mock.calls.EnsureReleaseAndBinding, callInfo)
+	mock.lockEnsureReleaseAndBinding.Unlock()
+	return mock.EnsureReleaseAndBindingFunc(ctx, ouID, projectName, componentName, environment, envOverrides, fileOverrides)
+}
+
+// EnsureReleaseAndBindingCalls gets all the calls that were made to EnsureReleaseAndBinding.
+// Check the length with:
+//
+//	len(mockedOpenChoreoClient.EnsureReleaseAndBindingCalls())
+func (mock *OpenChoreoClientMock) EnsureReleaseAndBindingCalls() []struct {
+	Ctx           context.Context
+	OuID          string
+	ProjectName   string
+	ComponentName string
+	Environment   string
+	EnvOverrides  []client.EnvVar
+	FileOverrides []client.FileVar
+} {
+	var calls []struct {
+		Ctx           context.Context
+		OuID          string
+		ProjectName   string
+		ComponentName string
+		Environment   string
+		EnvOverrides  []client.EnvVar
+		FileOverrides []client.FileVar
+	}
+	mock.lockEnsureReleaseAndBinding.RLock()
+	calls = mock.calls.EnsureReleaseAndBinding
+	mock.lockEnsureReleaseAndBinding.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -39,6 +39,9 @@ import (
 //			CreateInternalAgentFromKindWorkloadFunc: func(ctx context.Context, ouID string, projectName string, componentName string, req client.InternalAgentFromKindWorkloadRequest) error {
 //				panic("mock out the CreateInternalAgentFromKindWorkload method")
 //			},
+//			CreateKindAgentReleaseAndBindingFunc: func(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+//				panic("mock out the CreateKindAgentReleaseAndBinding method")
+//			},
 //			CreateProjectFunc: func(ctx context.Context, ouID string, req client.CreateProjectRequest) error {
 //				panic("mock out the CreateProject method")
 //			},
@@ -270,6 +273,9 @@ type OpenChoreoClientMock struct {
 
 	// CreateInternalAgentFromKindWorkloadFunc mocks the CreateInternalAgentFromKindWorkload method.
 	CreateInternalAgentFromKindWorkloadFunc func(ctx context.Context, ouID string, projectName string, componentName string, req client.InternalAgentFromKindWorkloadRequest) error
+
+	// CreateKindAgentReleaseAndBindingFunc mocks the CreateKindAgentReleaseAndBinding method.
+	CreateKindAgentReleaseAndBindingFunc func(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error
 
 	// CreateProjectFunc mocks the CreateProject method.
 	CreateProjectFunc func(ctx context.Context, ouID string, req client.CreateProjectRequest) error
@@ -557,6 +563,23 @@ type OpenChoreoClientMock struct {
 			ComponentName string
 			// Req is the req argument value.
 			Req client.InternalAgentFromKindWorkloadRequest
+		}
+		// CreateKindAgentReleaseAndBinding holds details about calls to the CreateKindAgentReleaseAndBinding method.
+		CreateKindAgentReleaseAndBinding []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OuID is the ouID argument value.
+			OuID string
+			// ProjectName is the projectName argument value.
+			ProjectName string
+			// ComponentName is the componentName argument value.
+			ComponentName string
+			// Environment is the environment argument value.
+			Environment string
+			// EnvOverrides is the envOverrides argument value.
+			EnvOverrides []client.EnvVar
+			// FileOverrides is the fileOverrides argument value.
+			FileOverrides []client.FileVar
 		}
 		// CreateProject holds details about calls to the CreateProject method.
 		CreateProject []struct {
@@ -1318,6 +1341,7 @@ type OpenChoreoClientMock struct {
 	lockCreateEnvironment                      sync.RWMutex
 	lockCreateGitSecret                        sync.RWMutex
 	lockCreateInternalAgentFromKindWorkload    sync.RWMutex
+	lockCreateKindAgentReleaseAndBinding       sync.RWMutex
 	lockCreateProject                          sync.RWMutex
 	lockCreateSecret                           sync.RWMutex
 	lockCreateSecretReference                  sync.RWMutex
@@ -1701,6 +1725,62 @@ func (mock *OpenChoreoClientMock) CreateInternalAgentFromKindWorkloadCalls() []s
 	mock.lockCreateInternalAgentFromKindWorkload.RLock()
 	calls = mock.calls.CreateInternalAgentFromKindWorkload
 	mock.lockCreateInternalAgentFromKindWorkload.RUnlock()
+	return calls
+}
+
+// CreateKindAgentReleaseAndBinding calls CreateKindAgentReleaseAndBindingFunc.
+func (mock *OpenChoreoClientMock) CreateKindAgentReleaseAndBinding(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+	if mock.CreateKindAgentReleaseAndBindingFunc == nil {
+		panic("OpenChoreoClientMock.CreateKindAgentReleaseAndBindingFunc: method is nil but OpenChoreoClient.CreateKindAgentReleaseAndBinding was just called")
+	}
+	callInfo := struct {
+		Ctx           context.Context
+		OuID          string
+		ProjectName   string
+		ComponentName string
+		Environment   string
+		EnvOverrides  []client.EnvVar
+		FileOverrides []client.FileVar
+	}{
+		Ctx:           ctx,
+		OuID:          ouID,
+		ProjectName:   projectName,
+		ComponentName: componentName,
+		Environment:   environment,
+		EnvOverrides:  envOverrides,
+		FileOverrides: fileOverrides,
+	}
+	mock.lockCreateKindAgentReleaseAndBinding.Lock()
+	mock.calls.CreateKindAgentReleaseAndBinding = append(mock.calls.CreateKindAgentReleaseAndBinding, callInfo)
+	mock.lockCreateKindAgentReleaseAndBinding.Unlock()
+	return mock.CreateKindAgentReleaseAndBindingFunc(ctx, ouID, projectName, componentName, environment, envOverrides, fileOverrides)
+}
+
+// CreateKindAgentReleaseAndBindingCalls gets all the calls that were made to CreateKindAgentReleaseAndBinding.
+// Check the length with:
+//
+//	len(mockedOpenChoreoClient.CreateKindAgentReleaseAndBindingCalls())
+func (mock *OpenChoreoClientMock) CreateKindAgentReleaseAndBindingCalls() []struct {
+	Ctx           context.Context
+	OuID          string
+	ProjectName   string
+	ComponentName string
+	Environment   string
+	EnvOverrides  []client.EnvVar
+	FileOverrides []client.FileVar
+} {
+	var calls []struct {
+		Ctx           context.Context
+		OuID          string
+		ProjectName   string
+		ComponentName string
+		Environment   string
+		EnvOverrides  []client.EnvVar
+		FileOverrides []client.FileVar
+	}
+	mock.lockCreateKindAgentReleaseAndBinding.RLock()
+	calls = mock.calls.CreateKindAgentReleaseAndBinding
+	mock.lockCreateKindAgentReleaseAndBinding.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/clients/openchoreosvc/client/client.go
+++ b/agent-manager-service/clients/openchoreosvc/client/client.go
@@ -101,9 +101,12 @@ type OpenChoreoClient interface {
 	// Deployment Operations
 	Deploy(ctx context.Context, ouID, projectName, componentName string, req DeployRequest) error
 	CreateInternalAgentFromKindWorkload(ctx context.Context, ouID, projectName, componentName string, req InternalAgentFromKindWorkloadRequest) error
-	// CreateKindAgentReleaseAndBinding cuts the ComponentRelease for a kind-sourced agent and
+	// EnsureReleaseAndBinding cuts a ComponentRelease from the component's current state and
 	// binds it to the environment, carrying that environment's configuration as workloadOverrides.
-	CreateKindAgentReleaseAndBinding(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []EnvVar, fileOverrides []FileVar) error
+	// Components are created with autoDeploy off, so this is the only thing that advances what an
+	// environment runs outside the build workflow: every deploy and every kind-sourced agent
+	// creation goes through it.
+	EnsureReleaseAndBinding(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []EnvVar, fileOverrides []FileVar) error
 	GetDeployments(ctx context.Context, ouID, pipelineName, projectName, componentName string) ([]*models.DeploymentResponse, error)
 	UpdateDeploymentState(ctx context.Context, ouID, projectName, componentName, environment string, state gen.ReleaseBindingSpecState) error
 	IsDeploymentInProgress(ctx context.Context, ouID, componentName, environment string) (bool, error)
@@ -118,7 +121,7 @@ type OpenChoreoClient interface {
 	// Release Binding Operations
 	UpdateReleaseBindingTraitConfigs(ctx context.Context, ouID, componentName, environment string, traitConfigs map[string]interface{}, componentTypeConfigs map[string]interface{}) error
 	// EnsureReleaseBindingRuntimeClass idempotently reconciles runtimeClassName on a binding created
-	// out-of-band by OpenChoreo AutoDeploy. Writes only when the value differs (see impl).
+	// out-of-band by the build workflow. Writes only when the value differs (see impl).
 	EnsureReleaseBindingRuntimeClass(ctx context.Context, ouID, componentName, environment, desiredRuntimeClass string) error
 	ReplaceReleaseBindingWorkloadOverrides(ctx context.Context, ouID, componentName, environment string, envOverrides []EnvVar, fileOverrides []FileVar) error
 

--- a/agent-manager-service/clients/openchoreosvc/client/client.go
+++ b/agent-manager-service/clients/openchoreosvc/client/client.go
@@ -101,6 +101,9 @@ type OpenChoreoClient interface {
 	// Deployment Operations
 	Deploy(ctx context.Context, ouID, projectName, componentName string, req DeployRequest) error
 	CreateInternalAgentFromKindWorkload(ctx context.Context, ouID, projectName, componentName string, req InternalAgentFromKindWorkloadRequest) error
+	// CreateKindAgentReleaseAndBinding cuts the ComponentRelease for a kind-sourced agent and
+	// binds it to the environment, carrying that environment's configuration as workloadOverrides.
+	CreateKindAgentReleaseAndBinding(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []EnvVar, fileOverrides []FileVar) error
 	GetDeployments(ctx context.Context, ouID, pipelineName, projectName, componentName string) ([]*models.DeploymentResponse, error)
 	UpdateDeploymentState(ctx context.Context, ouID, projectName, componentName, environment string, state gen.ReleaseBindingSpecState) error
 	IsDeploymentInProgress(ctx context.Context, ouID, componentName, environment string) (bool, error)

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -123,7 +123,14 @@ func buildInternalAgentFromKindComponentRequestBody(namespaceName, projectName s
 		return gen.CreateComponentJSONRequestBody{}, fmt.Errorf("failed to convert parameters to map: %w", err)
 	}
 
-	autoDeploy := true
+	// Kind-sourced agents have no build workflow, so nothing runs amp-generate-workload
+	// to cut the ComponentRelease and bind it to the first environment. The backend does
+	// that itself instead (CreateKindAgentReleaseAndBinding), for the same reason the
+	// workflow does it for source-built agents: configuration must land on the
+	// per-environment ReleaseBinding rather than the shared Workload, and autoDeploy's
+	// controller-created binding carries no overrides. Both agent kinds therefore set
+	// this to false and own the release/binding themselves.
+	autoDeploy := false
 	return gen.CreateComponentJSONRequestBody{
 		Metadata: gen.ObjectMeta{
 			Name:        req.Name,
@@ -249,7 +256,12 @@ func buildInternalAgentFromSourceComponentRequestBody(namespaceName, projectName
 		return gen.CreateComponentJSONRequestBody{}, fmt.Errorf("error building workflow parameters: %w", err)
 	}
 
-	autoDeploy := true
+	// The build workflow's generate-workload step cuts the ComponentRelease and binds
+	// it to the first environment itself, which is what lets each environment's
+	// configuration live on its own ReleaseBinding instead of on the shared Workload.
+	// autoDeploy would have OpenChoreo's Component controller create and own that same
+	// binding, so the two would fight over spec.releaseName.
+	autoDeploy := false
 	return gen.CreateComponentJSONRequestBody{
 		Metadata: gen.ObjectMeta{
 			Name:        req.Name,

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -125,7 +125,7 @@ func buildInternalAgentFromKindComponentRequestBody(namespaceName, projectName s
 
 	// Kind-sourced agents have no build workflow, so nothing runs amp-generate-workload
 	// to cut the ComponentRelease and bind it to the first environment. The backend does
-	// that itself instead (CreateKindAgentReleaseAndBinding), for the same reason the
+	// that itself instead (EnsureReleaseAndBinding), for the same reason the
 	// workflow does it for source-built agents: configuration must land on the
 	// per-environment ReleaseBinding rather than the shared Workload, and autoDeploy's
 	// controller-created binding carries no overrides. Both agent kinds therefore set
@@ -173,6 +173,10 @@ func buildExternalAgentComponentRequestBody(namespaceName, projectName string, r
 		return gen.CreateComponentJSONRequestBody{}, err
 	}
 
+	// An external agent has no Workload and never deploys, so autoDeploy has nothing to act on.
+	// Stated rather than left to the field's default, so all three component builders answer the
+	// question in the same place.
+	autoDeploy := false
 	return gen.CreateComponentJSONRequestBody{
 		Metadata: gen.ObjectMeta{
 			Name:        req.Name,
@@ -193,6 +197,7 @@ func buildExternalAgentComponentRequestBody(namespaceName, projectName string, r
 			}{
 				ProjectName: projectName,
 			},
+			AutoDeploy: &autoDeploy,
 		},
 	}, nil
 }
@@ -257,10 +262,11 @@ func buildInternalAgentFromSourceComponentRequestBody(namespaceName, projectName
 	}
 
 	// The build workflow's generate-workload step cuts the ComponentRelease and binds
-	// it to the first environment itself, which is what lets each environment's
-	// configuration live on its own ReleaseBinding instead of on the shared Workload.
-	// autoDeploy would have OpenChoreo's Component controller create and own that same
-	// binding, so the two would fight over spec.releaseName.
+	// it to the first environment itself, and every deploy afterwards does the same via
+	// EnsureReleaseAndBinding. That is what lets each environment's configuration live on
+	// its own ReleaseBinding instead of on the shared Workload. autoDeploy would have
+	// OpenChoreo's Component controller create and own that same binding, so the two would
+	// fight over spec.releaseName.
 	autoDeploy := false
 	return gen.CreateComponentJSONRequestBody{
 		Metadata: gen.ObjectMeta{

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -106,9 +106,13 @@ func (c *openChoreoClient) CreateInternalAgentFromKindWorkload(ctx context.Conte
 		endpointMap[name] = workloadEp
 	}
 
-	envVars := toGenEnvVars(req.Env)
-	fileVars := toGenFileVars(req.Files)
-
+	// Env vars and file mounts are deliberately NOT set here. A value on the Workload is
+	// inherited by every environment, and a ReleaseBinding's workloadOverrides can replace
+	// such a value per environment but cannot remove it — making the inheritance impossible
+	// to opt out of. Configuration therefore lives only on the per-environment binding,
+	// written by CreateKindAgentReleaseAndBinding; the Workload carries just the image and
+	// the environment-independent endpoint contract. This mirrors amp-generate-workload,
+	// which splits the same two documents for source-built agents.
 	workload := gen.CreateWorkloadJSONRequestBody{
 		Metadata: gen.ObjectMeta{
 			Name:      workloadName,
@@ -117,8 +121,6 @@ func (c *openChoreoClient) CreateInternalAgentFromKindWorkload(ctx context.Conte
 		Spec: &gen.WorkloadSpec{
 			Container: &gen.WorkloadContainer{
 				Image: req.ImageID,
-				Env:   &envVars,
-				Files: &fileVars,
 			},
 			Owner: &struct {
 				ComponentName string `json:"componentName"`
@@ -470,6 +472,126 @@ func (c *openChoreoClient) ReplaceReleaseBindingWorkloadOverrides(ctx context.Co
 
 		bumpRestartedAt(rb)
 	})
+}
+
+// CreateKindAgentReleaseAndBinding cuts a ComponentRelease for a kind-sourced agent and binds
+// it to the given environment, carrying the environment's configuration as the binding's
+// workloadOverrides.
+//
+// Why this exists: kind-sourced agents run no build workflow, so nothing runs
+// amp-generate-workload to do this for them. They used to rely on OpenChoreo's autoDeploy,
+// but a controller-created binding carries no overrides — and configuration must not sit on
+// the shared Workload, because a value there is inherited by every environment and a binding
+// can replace but never remove it. This is the backend's equivalent of that workflow's
+// Steps 6-7, and is why kind components are now created with autoDeploy off.
+//
+// The binding name follows the same convention the workflow and the promotion path use:
+// <component>-<environment>. Passing nil overrides leaves spec.workloadOverrides unset.
+func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
+	ctx context.Context, ouID, projectName, componentName, environment string,
+	envOverrides []EnvVar, fileOverrides []FileVar,
+) error {
+	namespaceName := c.NamespaceFor(ouID)
+
+	// Step 1: cut the release from the component's current state. The name is left to the
+	// API server to generate; the response carries it back for the binding to pin.
+	releaseResp, err := c.ocClient.GenerateReleaseWithResponse(ctx, namespaceName, componentName,
+		gen.GenerateReleaseJSONRequestBody{})
+	if err != nil {
+		return fmt.Errorf("failed to generate component release for kind-sourced agent: %w", err)
+	}
+	if releaseResp.StatusCode() != http.StatusCreated || releaseResp.JSON201 == nil {
+		return handleErrorResponse(releaseResp.StatusCode(), ErrorResponses{
+			JSON400: releaseResp.JSON400,
+			JSON401: releaseResp.JSON401,
+			JSON403: releaseResp.JSON403,
+			JSON500: releaseResp.JSON500,
+		})
+	}
+	releaseName := releaseResp.JSON201.Metadata.Name
+	if releaseName == "" {
+		return fmt.Errorf("component release for %q was created without a name", componentName)
+	}
+
+	var workloadOverrides *gen.WorkloadOverrides
+	if len(envOverrides) > 0 || len(fileOverrides) > 0 {
+		container := &gen.ContainerOverride{}
+		if len(envOverrides) > 0 {
+			envVars := toGenEnvVars(envOverrides)
+			container.Env = &envVars
+		}
+		if len(fileOverrides) > 0 {
+			fileVars := toGenFileVars(fileOverrides)
+			container.Files = &fileVars
+		}
+		workloadOverrides = &gen.WorkloadOverrides{Container: container}
+	}
+
+	// Step 2: bind the release to the environment. A binding can already exist when an
+	// agent is recreated over a previous one, so update rather than fail on that path;
+	// retryReleaseBindingUpdate re-reads per attempt, as the backend races other writers
+	// of this same binding (MCP env vars, runtime class).
+	bindingName := componentName + "-" + environment
+	existing, err := c.findReleaseBindingForEnv(ctx, namespaceName, componentName, environment)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return c.retryReleaseBindingUpdate(ctx, namespaceName, existing.Metadata.Name, func(rb *gen.ReleaseBinding) {
+			rb.Spec.ReleaseName = &releaseName
+			if workloadOverrides != nil {
+				rb.Spec.WorkloadOverrides = workloadOverrides
+			}
+			bumpRestartedAt(rb)
+		})
+	}
+
+	activeState := gen.ReleaseBindingSpecStateActive
+	createBody := gen.CreateReleaseBindingJSONRequestBody{
+		Metadata: gen.ObjectMeta{
+			Name:      bindingName,
+			Namespace: &namespaceName,
+		},
+		Spec: &gen.ReleaseBindingSpec{
+			Environment:       environment,
+			ReleaseName:       &releaseName,
+			State:             &activeState,
+			WorkloadOverrides: workloadOverrides,
+			Owner: struct {
+				ComponentName string `json:"componentName"`
+				ProjectName   string `json:"projectName"`
+			}{
+				ComponentName: componentName,
+				ProjectName:   projectName,
+			},
+		},
+	}
+
+	createResp, err := c.ocClient.CreateReleaseBindingWithResponse(ctx, namespaceName, createBody)
+	if err != nil {
+		return fmt.Errorf("failed to create release binding for kind-sourced agent: %w", err)
+	}
+	// A concurrent writer can win the create; adopt the binding it made rather than failing
+	// the agent creation, mirroring the workflow's 409 handling.
+	if createResp.StatusCode() == http.StatusConflict {
+		return c.retryReleaseBindingUpdate(ctx, namespaceName, bindingName, func(rb *gen.ReleaseBinding) {
+			rb.Spec.ReleaseName = &releaseName
+			if workloadOverrides != nil {
+				rb.Spec.WorkloadOverrides = workloadOverrides
+			}
+			bumpRestartedAt(rb)
+		})
+	}
+	if createResp.StatusCode() != http.StatusCreated {
+		return handleErrorResponse(createResp.StatusCode(), ErrorResponses{
+			JSON400: createResp.JSON400,
+			JSON401: createResp.JSON401,
+			JSON403: createResp.JSON403,
+			JSON500: createResp.JSON500,
+		})
+	}
+
+	return nil
 }
 
 // PromoteComponent promotes a component from sourceEnvironment to targetEnvironment.

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -534,14 +534,17 @@ func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
 	bindingName := componentName + "-" + environment
 	existing, err := c.findReleaseBindingForEnv(ctx, namespaceName, componentName, environment)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to look up release binding for component %q in environment %q: %w",
+			componentName, environment, err)
 	}
 	if existing != nil {
 		return c.retryReleaseBindingUpdate(ctx, namespaceName, existing.Metadata.Name, func(rb *gen.ReleaseBinding) {
 			rb.Spec.ReleaseName = &releaseName
-			if workloadOverrides != nil {
-				rb.Spec.WorkloadOverrides = workloadOverrides
-			}
+			// Assigned unconditionally: the caller's configuration is authoritative for
+			// this environment, so an empty one (nil here) must clear whatever a previous
+			// binding held rather than leaving it in force. Unlike
+			// ReplaceReleaseBindingWorkloadOverrides, this is not a partial edit.
+			rb.Spec.WorkloadOverrides = workloadOverrides
 			bumpRestartedAt(rb)
 		})
 	}
@@ -576,9 +579,11 @@ func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
 	if createResp.StatusCode() == http.StatusConflict {
 		return c.retryReleaseBindingUpdate(ctx, namespaceName, bindingName, func(rb *gen.ReleaseBinding) {
 			rb.Spec.ReleaseName = &releaseName
-			if workloadOverrides != nil {
-				rb.Spec.WorkloadOverrides = workloadOverrides
-			}
+			// Assigned unconditionally: the caller's configuration is authoritative for
+			// this environment, so an empty one (nil here) must clear whatever a previous
+			// binding held rather than leaving it in force. Unlike
+			// ReplaceReleaseBindingWorkloadOverrides, this is not a partial edit.
+			rb.Spec.WorkloadOverrides = workloadOverrides
 			bumpRestartedAt(rb)
 		})
 	}

--- a/agent-manager-service/clients/openchoreosvc/client/deployments.go
+++ b/agent-manager-service/clients/openchoreosvc/client/deployments.go
@@ -110,7 +110,7 @@ func (c *openChoreoClient) CreateInternalAgentFromKindWorkload(ctx context.Conte
 	// inherited by every environment, and a ReleaseBinding's workloadOverrides can replace
 	// such a value per environment but cannot remove it — making the inheritance impossible
 	// to opt out of. Configuration therefore lives only on the per-environment binding,
-	// written by CreateKindAgentReleaseAndBinding; the Workload carries just the image and
+	// written by EnsureReleaseAndBinding; the Workload carries just the image and
 	// the environment-independent endpoint contract. This mirrors amp-generate-workload,
 	// which splits the same two documents for source-built agents.
 	workload := gen.CreateWorkloadJSONRequestBody{
@@ -386,8 +386,9 @@ func (c *openChoreoClient) UpdateReleaseBindingTraitConfigs(ctx context.Context,
 // EnsureReleaseBindingRuntimeClass idempotently reconciles runtimeClassName on a release
 // binding's ComponentTypeEnvironmentConfigs for (component, environment).
 //
-// Why this exists: OpenChoreo's AutoDeploy creates the release binding when a build completes,
-// WITHOUT going through the backend's deploy-time config write — so an agent in an isolation-tier
+// Why this exists: the build workflow creates the release binding when a build completes,
+// WITHOUT going through the backend's deploy-time config write — it writes the release pin and
+// workloadOverrides only, never componentTypeEnvironmentConfigs — so an agent in an isolation-tier
 // environment first comes up on the default (runc) runtime. This is called from the deploy-status
 // read path to correct that out-of-band binding.
 //
@@ -474,20 +475,29 @@ func (c *openChoreoClient) ReplaceReleaseBindingWorkloadOverrides(ctx context.Co
 	})
 }
 
-// CreateKindAgentReleaseAndBinding cuts a ComponentRelease for a kind-sourced agent and binds
+// EnsureReleaseAndBinding cuts a ComponentRelease from the component's current state and binds
 // it to the given environment, carrying the environment's configuration as the binding's
-// workloadOverrides.
+// workloadOverrides. Creates the binding when the environment has none, and otherwise repins
+// the existing one, so both an agent's first deployment and every redeploy use this one path.
 //
-// Why this exists: kind-sourced agents run no build workflow, so nothing runs
-// amp-generate-workload to do this for them. They used to rely on OpenChoreo's autoDeploy,
-// but a controller-created binding carries no overrides — and configuration must not sit on
-// the shared Workload, because a value there is inherited by every environment and a binding
-// can replace but never remove it. This is the backend's equivalent of that workflow's
-// Steps 6-7, and is why kind components are now created with autoDeploy off.
+// Why this exists: components are created with autoDeploy off, so OpenChoreo's Component
+// controller neither cuts releases nor owns the binding. Nothing else notices that the
+// Workload's image changed — the ReleaseBinding renders from the frozen workload copy inside
+// the pinned ComponentRelease, never from the live Workload — so an image write that is not
+// followed by a new release and a repin is invisible to the data plane.
+//
+// autoDeploy is off because a controller-created binding carries no overrides, and
+// configuration must not sit on the shared Workload: a value there is inherited by every
+// environment and a binding can replace but never remove it. This is the backend's equivalent
+// of amp-generate-workload's Steps 6-7, which do the same for a build.
+//
+// Call it AFTER every write this deployment makes to the Component and the Workload: the
+// release freezes the component's traits, parameters and workload as they are at this moment,
+// so anything written afterwards waits for the next release.
 //
 // The binding name follows the same convention the workflow and the promotion path use:
 // <component>-<environment>. Passing nil overrides leaves spec.workloadOverrides unset.
-func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
+func (c *openChoreoClient) EnsureReleaseAndBinding(
 	ctx context.Context, ouID, projectName, componentName, environment string,
 	envOverrides []EnvVar, fileOverrides []FileVar,
 ) error {
@@ -498,7 +508,7 @@ func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
 	releaseResp, err := c.ocClient.GenerateReleaseWithResponse(ctx, namespaceName, componentName,
 		gen.GenerateReleaseJSONRequestBody{})
 	if err != nil {
-		return fmt.Errorf("failed to generate component release for kind-sourced agent: %w", err)
+		return fmt.Errorf("failed to generate component release for component %q: %w", componentName, err)
 	}
 	if releaseResp.StatusCode() != http.StatusCreated || releaseResp.JSON201 == nil {
 		return handleErrorResponse(releaseResp.StatusCode(), ErrorResponses{
@@ -527,10 +537,12 @@ func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
 		workloadOverrides = &gen.WorkloadOverrides{Container: container}
 	}
 
-	// Step 2: bind the release to the environment. A binding can already exist when an
-	// agent is recreated over a previous one, so update rather than fail on that path;
-	// retryReleaseBindingUpdate re-reads per attempt, as the backend races other writers
-	// of this same binding (MCP env vars, runtime class).
+	// Step 2: bind the release to the environment. A binding usually already exists — every
+	// redeploy comes through here, and so does an agent recreated over a previous one — so
+	// update rather than fail on that path; retryReleaseBindingUpdate re-reads per attempt, as
+	// the backend races other writers of this same binding (MCP env vars, runtime class) and
+	// the build workflow, which repins this same field at the end of a build.
+	activeState := gen.ReleaseBindingSpecStateActive
 	bindingName := componentName + "-" + environment
 	existing, err := c.findReleaseBindingForEnv(ctx, namespaceName, componentName, environment)
 	if err != nil {
@@ -545,20 +557,28 @@ func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
 			// binding held rather than leaving it in force. Unlike
 			// ReplaceReleaseBindingWorkloadOverrides, this is not a partial edit.
 			rb.Spec.WorkloadOverrides = workloadOverrides
+			// Force the binding back to Active. An agent undeployed via UpdateDeploymentState
+			// leaves this at Undeploy, and the read feeding this mutator round-trips it, so a binding
+			// adopted here would pin the release and carry the overrides while the data plane
+			// tore the resources down — with nothing in the response signalling it. Both callers
+			// are explicit deploy intents, so deploying an undeployed agent should redeploy it.
+			rb.Spec.State = &activeState
 			bumpRestartedAt(rb)
 		})
 	}
 
-	activeState := gen.ReleaseBindingSpecStateActive
 	createBody := gen.CreateReleaseBindingJSONRequestBody{
 		Metadata: gen.ObjectMeta{
 			Name:      bindingName,
 			Namespace: &namespaceName,
 		},
 		Spec: &gen.ReleaseBindingSpec{
-			Environment:       environment,
-			ReleaseName:       &releaseName,
-			State:             &activeState,
+			Environment: environment,
+			ReleaseName: &releaseName,
+			// spec.state is left unset: the ReleaseBinding CRD defaults it to Active
+			// (+kubebuilder:default=Active), so a create needs no opinion here. The update
+			// paths above do set it, because defaulting cannot help an existing binding
+			// whose state round-trips through the read.
 			WorkloadOverrides: workloadOverrides,
 			Owner: struct {
 				ComponentName string `json:"componentName"`
@@ -572,7 +592,7 @@ func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
 
 	createResp, err := c.ocClient.CreateReleaseBindingWithResponse(ctx, namespaceName, createBody)
 	if err != nil {
-		return fmt.Errorf("failed to create release binding for kind-sourced agent: %w", err)
+		return fmt.Errorf("failed to create release binding for component %q: %w", componentName, err)
 	}
 	// A concurrent writer can win the create; adopt the binding it made rather than failing
 	// the agent creation, mirroring the workflow's 409 handling.
@@ -584,6 +604,12 @@ func (c *openChoreoClient) CreateKindAgentReleaseAndBinding(
 			// binding held rather than leaving it in force. Unlike
 			// ReplaceReleaseBindingWorkloadOverrides, this is not a partial edit.
 			rb.Spec.WorkloadOverrides = workloadOverrides
+			// Force the binding back to Active. An agent undeployed via UpdateDeploymentState
+			// leaves this at Undeploy, and the read feeding this mutator round-trips it, so a binding
+			// adopted here would pin the release and carry the overrides while the data plane
+			// tore the resources down — with nothing in the response signalling it. Both callers
+			// are explicit deploy intents, so deploying an undeployed agent should redeploy it.
+			rb.Spec.State = &activeState
 			bumpRestartedAt(rb)
 		})
 	}

--- a/agent-manager-service/clients/openchoreosvc/client/secret_references.go
+++ b/agent-manager-service/clients/openchoreosvc/client/secret_references.go
@@ -251,10 +251,53 @@ func (c *openChoreoClient) DeleteSecretReference(ctx context.Context, ouID, secr
 	return nil
 }
 
-// GetWorkloadSecretRefNames retrieves the names of all secret references used by a component's workload
+// GetWorkloadSecretRefNames retrieves the names of every SecretReference an agent's
+// configuration points at, so DeleteAgent can clean them up along with their KV entries.
+//
+// Two sources are unioned, because a secret-backed value can be in either:
+//   - each ReleaseBinding's spec.workloadOverrides, where per-environment configuration now
+//     lives. Every binding for the component is scanned, not just the first environment's: a
+//     value set by a deploy reaches only the environment deployed to, so a secret can exist in
+//     one binding and not another.
+//   - the Workload's container spec, where configuration used to be written before it moved to
+//     the bindings (see EnsureReleaseAndBinding for why). Agents created before that move still
+//     carry their refs there, and skipping them would orphan the secret and the CR permanently.
+//
+// Env vars and file mounts both carry valueFrom.secretKeyRef, so both are scanned in each source.
 func (c *openChoreoClient) GetWorkloadSecretRefNames(ctx context.Context, ouID, projectName, componentName string) ([]string, error) {
 	namespaceName := c.NamespaceFor(ouID)
-	// List workloads filtered by component
+
+	// Collect unique secret reference names across both sources.
+	secretRefNames := make(map[string]struct{})
+
+	// Source 1: per-environment configuration on the release bindings.
+	bindingsResp, err := c.ocClient.ListReleaseBindingsWithResponse(ctx, namespaceName, &gen.ListReleaseBindingsParams{
+		Component: &componentName,
+		Limit:     &defaultListLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list release bindings: %w", err)
+	}
+	if bindingsResp.StatusCode() != http.StatusOK {
+		return nil, handleErrorResponse(bindingsResp.StatusCode(), ErrorResponses{
+			JSON401: bindingsResp.JSON401,
+			JSON403: bindingsResp.JSON403,
+			JSON404: bindingsResp.JSON404,
+			JSON500: bindingsResp.JSON500,
+		})
+	}
+	if bindingsResp.JSON200 != nil {
+		for _, binding := range bindingsResp.JSON200.Items {
+			if binding.Spec == nil || binding.Spec.WorkloadOverrides == nil ||
+				binding.Spec.WorkloadOverrides.Container == nil {
+				continue
+			}
+			container := binding.Spec.WorkloadOverrides.Container
+			collectSecretRefNames(container.Env, container.Files, secretRefNames)
+		}
+	}
+
+	// Source 2: the workload itself, for agents predating the move to bindings.
 	resp, err := c.ocClient.ListWorkloadsWithResponse(ctx, namespaceName, &gen.ListWorkloadsParams{
 		Component: &componentName,
 		Limit:     &defaultListLimit,
@@ -272,21 +315,12 @@ func (c *openChoreoClient) GetWorkloadSecretRefNames(ctx context.Context, ouID, 
 		})
 	}
 
-	if resp.JSON200 == nil || len(resp.JSON200.Items) == 0 {
-		return []string{}, nil
-	}
-
-	// Collect unique secret reference names from env vars
-	secretRefNames := make(map[string]struct{})
-	for _, workload := range resp.JSON200.Items {
-		if workload.Spec == nil || workload.Spec.Container == nil || workload.Spec.Container.Env == nil {
-			continue
-		}
-
-		for _, env := range *workload.Spec.Container.Env {
-			if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil && env.ValueFrom.SecretKeyRef.Name != nil {
-				secretRefNames[*env.ValueFrom.SecretKeyRef.Name] = struct{}{}
+	if resp.JSON200 != nil {
+		for _, workload := range resp.JSON200.Items {
+			if workload.Spec == nil || workload.Spec.Container == nil {
+				continue
 			}
+			collectSecretRefNames(workload.Spec.Container.Env, workload.Spec.Container.Files, secretRefNames)
 		}
 	}
 
@@ -297,6 +331,28 @@ func (c *openChoreoClient) GetWorkloadSecretRefNames(ctx context.Context, ouID, 
 	}
 
 	return result, nil
+}
+
+// collectSecretRefNames adds the SecretReference names behind any valueFrom.secretKeyRef in the
+// given env vars and file mounts to out. Both slices are optional; nil entries are skipped.
+func collectSecretRefNames(env *[]gen.EnvVar, files *[]gen.FileVar, out map[string]struct{}) {
+	if env != nil {
+		for _, e := range *env {
+			addSecretRefName(e.ValueFrom, out)
+		}
+	}
+	if files != nil {
+		for _, f := range *files {
+			addSecretRefName(f.ValueFrom, out)
+		}
+	}
+}
+
+func addSecretRefName(valueFrom *gen.EnvVarValueFrom, out map[string]struct{}) {
+	if valueFrom == nil || valueFrom.SecretKeyRef == nil || valueFrom.SecretKeyRef.Name == nil {
+		return
+	}
+	out[*valueFrom.SecretKeyRef.Name] = struct{}{}
 }
 
 // convertSecretReferenceToInfo converts a gen.SecretReference to SecretReferenceInfo

--- a/agent-manager-service/clients/openchoreosvc/client/secret_references_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/secret_references_test.go
@@ -1,0 +1,144 @@
+//
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
+)
+
+// secretEnvVar builds an env var whose value comes from a SecretReference.
+func secretEnvVar(key, secretName string) gen.EnvVar {
+	name := secretName
+	return gen.EnvVar{
+		Key: key,
+		ValueFrom: &gen.EnvVarValueFrom{
+			SecretKeyRef: &struct {
+				Key  *string `json:"key,omitempty"`
+				Name *string `json:"name,omitempty"`
+			}{Name: &name},
+		},
+	}
+}
+
+// secretFileVar builds a file mount whose content comes from a SecretReference.
+func secretFileVar(key, secretName string) gen.FileVar {
+	name := secretName
+	return gen.FileVar{
+		Key:       key,
+		MountPath: "/etc/" + key,
+		ValueFrom: &gen.EnvVarValueFrom{
+			SecretKeyRef: &struct {
+				Key  *string `json:"key,omitempty"`
+				Name *string `json:"name,omitempty"`
+			}{Name: &name},
+		},
+	}
+}
+
+// serveLists answers the two list calls GetWorkloadSecretRefNames makes.
+func serveLists(t *testing.T, bindings gen.ReleaseBindingList, workloads gen.WorkloadList) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/releasebindings"):
+			require.NoError(t, json.NewEncoder(w).Encode(bindings))
+		case strings.HasSuffix(r.URL.Path, "/workloads"):
+			require.NoError(t, json.NewEncoder(w).Encode(workloads))
+		default:
+			t.Errorf("unexpected request path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func bindingWithOverrides(env []gen.EnvVar, files []gen.FileVar) gen.ReleaseBinding {
+	container := &gen.ContainerOverride{}
+	if len(env) > 0 {
+		container.Env = &env
+	}
+	if len(files) > 0 {
+		container.Files = &files
+	}
+	return gen.ReleaseBinding{
+		Spec: &gen.ReleaseBindingSpec{
+			WorkloadOverrides: &gen.WorkloadOverrides{Container: container},
+		},
+	}
+}
+
+// Configuration lives on the per-environment ReleaseBindings, not the Workload, so deletion has
+// to discover secrets there — and in every environment, since a deploy writes only the
+// environment it targets.
+func TestGetWorkloadSecretRefNames_CollectsFromAllBindings(t *testing.T) {
+	bindings := gen.ReleaseBindingList{Items: []gen.ReleaseBinding{
+		bindingWithOverrides([]gen.EnvVar{secretEnvVar("API_KEY", "dev-api-key")}, nil),
+		bindingWithOverrides(
+			[]gen.EnvVar{secretEnvVar("API_KEY", "prod-api-key")},
+			[]gen.FileVar{secretFileVar("creds.json", "prod-creds")},
+		),
+	}}
+	c := newTestClient(t, serveLists(t, bindings, gen.WorkloadList{}))
+
+	names, err := c.GetWorkloadSecretRefNames(context.Background(), "acme", "my-project", "my-agent")
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"dev-api-key", "prod-api-key", "prod-creds"}, names)
+}
+
+// Agents created before configuration moved to the bindings still carry their refs on the
+// Workload; both sources are unioned, and a ref present in both is reported once.
+func TestGetWorkloadSecretRefNames_UnionsWorkloadAndDeduplicates(t *testing.T) {
+	bindings := gen.ReleaseBindingList{Items: []gen.ReleaseBinding{
+		bindingWithOverrides([]gen.EnvVar{secretEnvVar("API_KEY", "shared-secret")}, nil),
+	}}
+	workloadEnv := []gen.EnvVar{secretEnvVar("API_KEY", "shared-secret"), secretEnvVar("LEGACY", "legacy-secret")}
+	workloads := gen.WorkloadList{Items: []gen.Workload{{
+		Spec: &gen.WorkloadSpec{Container: &gen.WorkloadContainer{Image: "img", Env: &workloadEnv}},
+	}}}
+	c := newTestClient(t, serveLists(t, bindings, workloads))
+
+	names, err := c.GetWorkloadSecretRefNames(context.Background(), "acme", "my-project", "my-agent")
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"shared-secret", "legacy-secret"}, names)
+}
+
+// Bindings without overrides, and plain-valued config, contribute nothing.
+func TestGetWorkloadSecretRefNames_NoSecrets(t *testing.T) {
+	plain := "plain"
+	bindings := gen.ReleaseBindingList{Items: []gen.ReleaseBinding{
+		{Spec: &gen.ReleaseBindingSpec{}},
+		bindingWithOverrides([]gen.EnvVar{{Key: "LOG_LEVEL", Value: &plain}}, nil),
+	}}
+	c := newTestClient(t, serveLists(t, bindings, gen.WorkloadList{}))
+
+	names, err := c.GetWorkloadSecretRefNames(context.Background(), "acme", "my-project", "my-agent")
+
+	require.NoError(t, err)
+	assert.Empty(t, names)
+}

--- a/agent-manager-service/services/agent_env_tier_unit_test.go
+++ b/agent-manager-service/services/agent_env_tier_unit_test.go
@@ -264,7 +264,7 @@ func TestUpdateAgentConfigurations_ProductionNeedsProductionScope(t *testing.T) 
 		GetEnvironmentFunc: func(_ context.Context, _, name string) (*models.EnvironmentResponse, error) {
 			return &models.EnvironmentResponse{Name: name, IsProduction: true}, nil
 		},
-		ReplaceReleaseBindingWorkloadOverridesFunc: func(context.Context, string, string, string, []client.EnvVar, []client.FileVar) error {
+		EnsureReleaseAndBindingFunc: func(context.Context, string, string, string, string, []client.EnvVar, []client.FileVar) error {
 			overridesReplaced = true
 			return nil
 		},

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1703,14 +1703,18 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 				ctx, ouID, projectName, req.Name, firstEnv, kindEnvVars, kindFileVars,
 			); err != nil {
 				s.logger.Error("Failed to create release binding for kind-sourced agent",
-					"agentName", req.Name, "environment", firstEnv, "error", err)
+					"agentName", req.Name, "ouID", ouID, "projectName", projectName,
+					"environment", firstEnv, "error", err)
 				if hasSecrets {
 					s.cleanupSecretsOnRollback(ctx, secretLocation)
 				}
 				if errDeletion := s.ocClient.DeleteComponent(ctx, ouID, projectName, req.Name); errDeletion != nil {
-					s.logger.Error("Failed to rollback agent creation after release-binding failure", "agentName", req.Name, "error", errDeletion)
+					s.logger.Error("Failed to rollback agent creation after release-binding failure",
+						"agentName", req.Name, "ouID", ouID, "projectName", projectName,
+						"environment", firstEnv, "error", errDeletion)
 				}
-				return err
+				return fmt.Errorf("failed to create release binding for agent %q in environment %q: %w",
+					req.Name, firstEnv, err)
 			}
 			s.logger.Info("Bound kind-sourced agent release to environment", "agentName", req.Name, "environment", firstEnv)
 		} else {

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1677,11 +1677,12 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 				return envErr
 			}
 			kindEndpoints := inputInterfaceToEndpoints(createAgentReq.InputInterface, req.Name)
+			// Env/Files are carried to the binding below, not the Workload: a value on the
+			// Workload is inherited by every environment and a binding can replace but never
+			// remove it. CreateInternalAgentFromKindWorkload writes only image + endpoints.
 			if err := s.ocClient.CreateInternalAgentFromKindWorkload(ctx, ouID, projectName, req.Name, client.InternalAgentFromKindWorkloadRequest{
 				ImageID:   imageID,
 				Endpoints: kindEndpoints,
-				Env:       kindEnvVars,
-				Files:     kindFileVars,
 			}); err != nil {
 				s.logger.Error("Failed to create internal-agent-from-kind workload", "agentName", req.Name, "error", err)
 				if hasSecrets {
@@ -1693,6 +1694,25 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 				return err
 			}
 			s.logger.Info("Created internal-agent-from-kind workload", "agentName", req.Name)
+
+			// Cut the release and bind it to the first environment, carrying the resolved
+			// configuration as the binding's workloadOverrides. This is what
+			// amp-generate-workload does for source-built agents; kind components are
+			// created with autoDeploy off so nothing else deploys them.
+			if err := s.ocClient.CreateKindAgentReleaseAndBinding(
+				ctx, ouID, projectName, req.Name, firstEnv, kindEnvVars, kindFileVars,
+			); err != nil {
+				s.logger.Error("Failed to create release binding for kind-sourced agent",
+					"agentName", req.Name, "environment", firstEnv, "error", err)
+				if hasSecrets {
+					s.cleanupSecretsOnRollback(ctx, secretLocation)
+				}
+				if errDeletion := s.ocClient.DeleteComponent(ctx, ouID, projectName, req.Name); errDeletion != nil {
+					s.logger.Error("Failed to rollback agent creation after release-binding failure", "agentName", req.Name, "error", errDeletion)
+				}
+				return err
+			}
+			s.logger.Info("Bound kind-sourced agent release to environment", "agentName", req.Name, "environment", firstEnv)
 		} else {
 			if err := s.triggerInitialBuild(ctx, ouID, projectName, req); err != nil {
 				s.logger.Warn("Failed to trigger initial build for agent, build can be triggered manually", "agentName", req.Name, "error", err)

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -1685,12 +1685,7 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 				Endpoints: kindEndpoints,
 			}); err != nil {
 				s.logger.Error("Failed to create internal-agent-from-kind workload", "agentName", req.Name, "error", err)
-				if hasSecrets {
-					s.cleanupSecretsOnRollback(ctx, secretLocation)
-				}
-				if errDeletion := s.ocClient.DeleteComponent(ctx, ouID, projectName, req.Name); errDeletion != nil {
-					s.logger.Error("Failed to rollback agent creation after kind-workload failure", "agentName", req.Name, "error", errDeletion)
-				}
+				rollbackAgentCreate("kind-workload failure")
 				return err
 			}
 			s.logger.Info("Created internal-agent-from-kind workload", "agentName", req.Name)
@@ -1698,21 +1693,15 @@ func (s *agentManagerService) createComponentAgent(ctx context.Context, ouID, pr
 			// Cut the release and bind it to the first environment, carrying the resolved
 			// configuration as the binding's workloadOverrides. This is what
 			// amp-generate-workload does for source-built agents; kind components are
-			// created with autoDeploy off so nothing else deploys them.
-			if err := s.ocClient.CreateKindAgentReleaseAndBinding(
+			// created with autoDeploy off so nothing else deploys them. Deploy goes through
+			// the same call, which is how a later kind-version switch reaches the pod.
+			if err := s.ocClient.EnsureReleaseAndBinding(
 				ctx, ouID, projectName, req.Name, firstEnv, kindEnvVars, kindFileVars,
 			); err != nil {
 				s.logger.Error("Failed to create release binding for kind-sourced agent",
 					"agentName", req.Name, "ouID", ouID, "projectName", projectName,
 					"environment", firstEnv, "error", err)
-				if hasSecrets {
-					s.cleanupSecretsOnRollback(ctx, secretLocation)
-				}
-				if errDeletion := s.ocClient.DeleteComponent(ctx, ouID, projectName, req.Name); errDeletion != nil {
-					s.logger.Error("Failed to rollback agent creation after release-binding failure",
-						"agentName", req.Name, "ouID", ouID, "projectName", projectName,
-						"environment", firstEnv, "error", errDeletion)
-				}
+				rollbackAgentCreate("release-binding failure")
 				return fmt.Errorf("failed to create release binding for agent %q in environment %q: %w",
 					req.Name, firstEnv, err)
 			}
@@ -3313,9 +3302,16 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	}
 	deployAttempt.Complete(ctx, nil)
 
-	// Write this environment's env vars and file mounts to its release binding, so this deploy's
-	// config reaches this environment only. The component-wide base is left as agent creation
-	// seeded it — see applyEnvScopedWorkloadConfig for why it is not cleared here.
+	// Cut the release this deploy actually runs and pin the environment's binding to it, carrying
+	// this environment's env vars and file mounts as the binding's workloadOverrides so the config
+	// reaches this environment only. The component-wide base is left as agent creation seeded it —
+	// see applyEnvScopedWorkloadConfig for why it is not cleared here.
+	//
+	// The release has to be cut here, after the Component trait writes and the Workload image
+	// write above: components are created with autoDeploy off, so nothing else notices either
+	// change. A binding keeps rendering the frozen workload inside the release it is pinned to,
+	// which is why deploying an image that is not the one the last build pinned — an older build,
+	// or another kind version — used to change the Workload and nothing else.
 	if err := s.applyEnvScopedWorkloadConfig(ctx, ouID, projectName, agentName, lowestEnv, overrideEnvVars, overrideFileVars); err != nil {
 		return "", err
 	}
@@ -3372,19 +3368,21 @@ func (s *agentManagerService) DeployAgent(ctx context.Context, ouID string, proj
 	return lowestEnv, nil
 }
 
-// releaseBindingWaitAttempts / releaseBindingWaitInterval bound how long a deploy waits for the
-// environment's ReleaseBinding to exist. On an agent's first deploy the binding is created by
-// OpenChoreo's component controller once the build's Release lands (ensureReleaseBinding), so it
-// can trail the Deploy call by a reconcile cycle.
-const (
-	releaseBindingWaitAttempts = 10
-	releaseBindingWaitInterval = 2 * time.Second
-)
-
-// applyEnvScopedWorkloadConfig writes the environment's full env var and file mount set to its
-// ReleaseBinding workloadOverrides. Deploy no longer writes to the component-wide base (the
+// applyEnvScopedWorkloadConfig cuts the ComponentRelease this deploy runs and pins the
+// environment's ReleaseBinding to it, writing the environment's full env var and file mount set
+// as that binding's workloadOverrides. Deploy does not write to the component-wide base (the
 // Workload container spec and the Component's build workflow parameters), so config applied here
 // reaches only this environment.
+//
+// Release and config go in one call because they must land in one binding write: the release pin
+// is what makes this deploy's image real, the overrides are what make its config real, and
+// splitting them rolls the pods twice and leaves a window where the environment runs the new
+// image with the old configuration.
+//
+// It creates the binding when the environment has none rather than waiting for one to appear.
+// It used to poll, because autoDeploy had OpenChoreo's Component controller create the binding a
+// reconcile cycle behind the Deploy call; with autoDeploy off, either the build workflow has
+// already created it or nothing ever will.
 //
 // The base is deliberately left untouched. It is seeded once at agent creation and every
 // environment renders base merged with its own overrides, which has a known consequence: a var set
@@ -3402,35 +3400,13 @@ func (s *agentManagerService) applyEnvScopedWorkloadConfig(
 	envVars []client.EnvVar,
 	fileVars []client.FileVar,
 ) error {
-	var lastErr error
-	for attempt := 1; attempt <= releaseBindingWaitAttempts; attempt++ {
-		lastErr = s.ocClient.ReplaceReleaseBindingWorkloadOverrides(ctx, ouID, agentName, environment, envVars, fileVars)
-		if lastErr == nil {
-			break
-		}
-		if !errors.Is(lastErr, utils.ErrNotFound) {
-			s.logger.Error("Failed to write workload overrides to release binding",
-				"agentName", agentName, "environment", environment, "error", lastErr)
-			return fmt.Errorf("failed to apply environment configuration: %w", lastErr)
-		}
-		// Binding not created yet (first deploy) — wait for the controller and retry.
-		s.logger.Debug("Release binding not ready yet, retrying workload override write",
-			"agentName", agentName, "environment", environment, "attempt", attempt)
-		select {
-		case <-ctx.Done():
-			// Wrapped so the caller can still match context.Canceled/DeadlineExceeded with
-			// errors.Is while seeing which operation gave up.
-			return fmt.Errorf("failed to apply environment configuration: %w", ctx.Err())
-		case <-time.After(releaseBindingWaitInterval):
-		}
-	}
-	if lastErr != nil {
-		s.logger.Error("Release binding never became available for workload overrides",
-			"agentName", agentName, "environment", environment, "error", lastErr)
-		return fmt.Errorf("failed to apply environment configuration: %w", lastErr)
+	if err := s.ocClient.EnsureReleaseAndBinding(ctx, ouID, projectName, agentName, environment, envVars, fileVars); err != nil {
+		s.logger.Error("Failed to release the deployed image to the environment",
+			"agentName", agentName, "environment", environment, "error", err)
+		return fmt.Errorf("failed to apply environment configuration: %w", err)
 	}
 
-	s.logger.Debug("Applied environment-scoped workload config", "agentName", agentName,
+	s.logger.Debug("Released image and applied environment-scoped workload config", "agentName", agentName,
 		"environment", environment, "envVarCount", len(envVars), "fileMountCount", len(fileVars))
 	return nil
 }
@@ -5675,7 +5651,7 @@ func (s *agentManagerService) GetAgentDeployments(ctx context.Context, ouID stri
 
 	s.logger.Info("Fetched deployments successfully", "agentName", agentName, "ouID", ouID, "projectName", projectName, "deploymentCount", len(deployments))
 
-	// Reconcile isolation-tier runtimeClassName on out-of-band bindings. OpenChoreo's AutoDeploy
+	// Reconcile isolation-tier runtimeClassName on out-of-band bindings. The build workflow
 	// creates a release binding when a build completes, WITHOUT the backend's deploy-time config
 	// write — so an agent in a gVisor/Kata environment first comes up on the default runtime. The
 	// deploy-status poll is the natural point to detect that the binding now exists and correct it.

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -562,7 +562,7 @@ func TestUpdateAgentConfigurations_IdentityInjectionError_AbortsUpdate(t *testin
 		GetComponentConfigurationsFunc: func(context.Context, string, string, string, string) ([]models.EnvVars, error) {
 			return nil, nil
 		},
-		ReplaceReleaseBindingWorkloadOverridesFunc: func(context.Context, string, string, string, []client.EnvVar, []client.FileVar) error {
+		EnsureReleaseAndBindingFunc: func(context.Context, string, string, string, string, []client.EnvVar, []client.FileVar) error {
 			overridesReplaced = true
 			return nil
 		},
@@ -608,7 +608,7 @@ func TestUpdateAgentConfigurations_RejectsUnownedSecretRef(t *testing.T) {
 		GetComponentConfigurationsFunc: func(context.Context, string, string, string, string) ([]models.EnvVars, error) {
 			return nil, nil
 		},
-		ReplaceReleaseBindingWorkloadOverridesFunc: func(context.Context, string, string, string, []client.EnvVar, []client.FileVar) error {
+		EnsureReleaseAndBindingFunc: func(context.Context, string, string, string, string, []client.EnvVar, []client.FileVar) error {
 			overridesReplaced = true
 			return nil
 		},
@@ -1844,11 +1844,11 @@ func deployAPIAgentMocks(existingConfig *models.AgentConfig) (*agentManagerServi
 		IsDeploymentInProgressFunc: func(context.Context, string, string, string) (bool, error) {
 			return false, nil
 		},
-		// Deploy writes env vars and file mounts to the environment's ReleaseBinding and leaves the
-		// component-wide base alone. ReplaceComponentEnvVars and ReplaceComponentFileMounts are
-		// left unstubbed on purpose: a regression that writes the shared base again panics here
-		// instead of silently leaking config into every environment.
-		ReplaceReleaseBindingWorkloadOverridesFunc: func(context.Context, string, string, string, []client.EnvVar, []client.FileVar) error {
+		// Deploy cuts the release and writes env vars and file mounts to the environment's
+		// ReleaseBinding, leaving the component-wide base alone. ReplaceComponentEnvVars and
+		// ReplaceComponentFileMounts are left unstubbed on purpose: a regression that writes the
+		// shared base again panics here instead of silently leaking config into every environment.
+		EnsureReleaseAndBindingFunc: func(context.Context, string, string, string, string, []client.EnvVar, []client.FileVar) error {
 			return nil
 		},
 		UpdateComponentDeploymentConfigFunc: func(_ context.Context, _, _, _ string, req client.ComponentDeploymentConfigRequest) error {

--- a/agent-manager-service/tests/apitestutils/mock_clients.go
+++ b/agent-manager-service/tests/apitestutils/mock_clients.go
@@ -208,6 +208,9 @@ func CreateMockOpenChoreoClient() *clientmocks.OpenChoreoClientMock {
 		ReplaceReleaseBindingWorkloadOverridesFunc: func(ctx context.Context, ouID string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
 			return nil
 		},
+		EnsureReleaseAndBindingFunc: func(ctx context.Context, ouID string, projectName string, componentName string, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+			return nil
+		},
 		GetComponentConfigurationsFunc: func(ctx context.Context, namespaceName string, projectName string, componentName string, environment string) ([]models.EnvVars, error) {
 			return nil, nil
 		},

--- a/agent-manager-service/tests/create_agent_test.go
+++ b/agent-manager-service/tests/create_agent_test.go
@@ -1059,7 +1059,7 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 		// Kind creation now also cuts the ComponentRelease and binds it to the first
 		// environment, which is where its configuration lives; the shared mock has no
 		// default for it either.
-		openChoreoClient.CreateKindAgentReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+		openChoreoClient.EnsureReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
 			return nil
 		}
 		secretMgmtClient := apitestutils.CreateMockSecretManagementClient()
@@ -1120,7 +1120,7 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 		// Kind creation now also cuts the ComponentRelease and binds it to the first
 		// environment, which is where its configuration lives; the shared mock has no
 		// default for it either.
-		openChoreoClient.CreateKindAgentReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+		openChoreoClient.EnsureReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
 			return nil
 		}
 		secretMgmtClient := apitestutils.CreateMockSecretManagementClient()
@@ -1300,7 +1300,7 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 			// Kind creation now also cuts the ComponentRelease and binds it to the first
 			// environment, which is where its configuration lives; the shared mock has no
 			// default for it either.
-			openChoreoClient.CreateKindAgentReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+			openChoreoClient.EnsureReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
 				return nil
 			}
 			env := []map[string]interface{}{

--- a/agent-manager-service/tests/create_agent_test.go
+++ b/agent-manager-service/tests/create_agent_test.go
@@ -1056,6 +1056,12 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 		openChoreoClient.CreateInternalAgentFromKindWorkloadFunc = func(ctx context.Context, ouID, projectName, componentName string, req client.InternalAgentFromKindWorkloadRequest) error {
 			return nil
 		}
+		// Kind creation now also cuts the ComponentRelease and binds it to the first
+		// environment, which is where its configuration lives; the shared mock has no
+		// default for it either.
+		openChoreoClient.CreateKindAgentReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+			return nil
+		}
 		secretMgmtClient := apitestutils.CreateMockSecretManagementClient()
 		testClients := wiring.TestClients{
 			OpenChoreoClient: openChoreoClient,
@@ -1109,6 +1115,12 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 		// TriggerBuild) since the image is already built; the shared mock has no
 		// default for it.
 		openChoreoClient.CreateInternalAgentFromKindWorkloadFunc = func(ctx context.Context, ouID, projectName, componentName string, req client.InternalAgentFromKindWorkloadRequest) error {
+			return nil
+		}
+		// Kind creation now also cuts the ComponentRelease and binds it to the first
+		// environment, which is where its configuration lives; the shared mock has no
+		// default for it either.
+		openChoreoClient.CreateKindAgentReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
 			return nil
 		}
 		secretMgmtClient := apitestutils.CreateMockSecretManagementClient()
@@ -1283,6 +1295,12 @@ func TestCreateAgentFromKind_SecretConfigDefaults(t *testing.T) {
 
 		t.Run("supplied by the caller: creation succeeds with that value", func(t *testing.T) {
 			openChoreoClient.CreateInternalAgentFromKindWorkloadFunc = func(ctx context.Context, ouID, projectName, componentName string, req client.InternalAgentFromKindWorkloadRequest) error {
+				return nil
+			}
+			// Kind creation now also cuts the ComponentRelease and binds it to the first
+			// environment, which is where its configuration lives; the shared mock has no
+			// default for it either.
+			openChoreoClient.CreateKindAgentReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
 				return nil
 			}
 			env := []map[string]interface{}{

--- a/agent-manager-service/tests/deploy_agent_test.go
+++ b/agent-manager-service/tests/deploy_agent_test.go
@@ -103,9 +103,61 @@ func TestDeployAgent(t *testing.T) {
 		require.Equal(t, "registry.example.com/myapp:v1.0.0", deployCall.Req.ImageID)
 
 		// Env vars are no longer part of DeployRequest: they are written to the
-		// environment's ReleaseBinding so they apply to that environment only.
-		require.Len(t, openChoreoClient.ReplaceReleaseBindingWorkloadOverridesCalls(), 1)
-		require.Empty(t, openChoreoClient.ReplaceReleaseBindingWorkloadOverridesCalls()[0].EnvOverrides) // No env vars provided
+		// environment's ReleaseBinding, along with the release this deploy cut, so they
+		// apply to that environment only.
+		require.Len(t, openChoreoClient.EnsureReleaseAndBindingCalls(), 1)
+		require.Empty(t, openChoreoClient.EnsureReleaseAndBindingCalls()[0].EnvOverrides) // No env vars provided
+	})
+
+	// Components are created with autoDeploy off, so the Component controller neither cuts
+	// releases nor repins the binding: the image written to the Workload only reaches the data
+	// plane because the deploy cuts a ComponentRelease afterwards and pins the environment to it.
+	// Order is the whole point — a release cut before the image write freezes the previous image,
+	// which is how deploying an older build or another kind version silently changed nothing.
+	t.Run("Deploying an agent cuts the release after writing the image", func(t *testing.T) {
+		openChoreoClient := apitestutils.CreateMockOpenChoreoClient()
+		openChoreoClient.ComponentExistsFunc = func(ctx context.Context, orgName string, projName string, agentName string) (bool, error) {
+			return true, nil
+		}
+		var callOrder []string
+		openChoreoClient.DeployFunc = func(ctx context.Context, ouID, projectName, componentName string, req client.DeployRequest) error {
+			callOrder = append(callOrder, "deploy:"+req.ImageID)
+			return nil
+		}
+		openChoreoClient.EnsureReleaseAndBindingFunc = func(ctx context.Context, ouID, projectName, componentName, environment string, envOverrides []client.EnvVar, fileOverrides []client.FileVar) error {
+			callOrder = append(callOrder, "release:"+environment)
+			return nil
+		}
+		testClients := wiring.TestClients{
+			OpenChoreoClient: openChoreoClient,
+		}
+
+		app := apitestutils.MakeAppClientWithDeps(t, testClients, authMiddleware)
+
+		reqBody := new(bytes.Buffer)
+		err := json.NewEncoder(reqBody).Encode(map[string]interface{}{
+			"imageId": "registry.example.com/myapp:v0.9.0",
+		})
+		require.NoError(t, err)
+
+		url := fmt.Sprintf("/api/v1/orgs/%s/projects/%s/agents/%s/deployments",
+			deployTestOrgName, deployTestProjName, deployTestAgentName)
+		req := httptest.NewRequest(http.MethodPost, url, reqBody)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		app.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusAccepted, rr.Code)
+
+		require.Equal(t,
+			[]string{"deploy:registry.example.com/myapp:v0.9.0", "release:Development"},
+			callOrder,
+			"the deployed image must be written to the Workload before the release that freezes it is cut")
+
+		releaseCall := openChoreoClient.EnsureReleaseAndBindingCalls()[0]
+		require.Equal(t, deployTestProjName, releaseCall.ProjectName)
+		require.Equal(t, deployTestAgentName, releaseCall.ComponentName)
+		require.Equal(t, "Development", releaseCall.Environment)
 	})
 
 	t.Run("Deploying agent with imageId and environment variables should return 202", func(t *testing.T) {
@@ -178,8 +230,8 @@ func TestDeployAgent(t *testing.T) {
 		// Validate environment variables. They ride on the environment's
 		// ReleaseBinding overrides now, not on the deploy request, so that adding
 		// a var in one environment cannot leak into the others.
-		require.Len(t, openChoreoClient.ReplaceReleaseBindingWorkloadOverridesCalls(), 1)
-		overrideCall := openChoreoClient.ReplaceReleaseBindingWorkloadOverridesCalls()[0]
+		require.Len(t, openChoreoClient.EnsureReleaseAndBindingCalls(), 1)
+		overrideCall := openChoreoClient.EnsureReleaseAndBindingCalls()[0]
 		require.Equal(t, deployTestAgentName, overrideCall.ComponentName)
 		require.Len(t, overrideCall.EnvOverrides, 3)
 		require.Equal(t, "DATABASE_URL", overrideCall.EnvOverrides[0].Key)

--- a/cli/pkg/cmd/agent/status.go
+++ b/cli/pkg/cmd/agent/status.go
@@ -188,7 +188,7 @@ func buildStatusResult(agent string, order []string, deployments amsvc.Deploymen
 			Endpoints: make([]EndpointRef, 0, len(d.Endpoints)),
 		}
 		// lastDeployed is omitted for bindings that have not deployed yet (e.g.
-		// created by AutoDeploy before the first backend deploy); zero time renders as "-".
+		// created by the build workflow before the first backend deploy); zero time renders as "-".
 		if d.LastDeployed != nil {
 			row.LastDeployed = *d.LastDeployed
 		}

--- a/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
@@ -49,7 +49,6 @@ import {
   useGetAgent,
   useGetAgentConfigurations,
   useGetDeploymentPipeline,
-  useListAgentDeployments,
   useListEnvironments,
 } from "@agent-management-platform/api-client";
 import type {
@@ -176,21 +175,6 @@ export function PromoteAgentDrawer({
       { orgName: orgId, projName: projectId, agentName: agentId },
       { environment: formState.targetEnvironment },
     );
-
-  // Deployment status per environment, used only to tell whether the chosen
-  // target has ever been deployed. Drives the wording of the config-source
-  // hint below (base config on a first promotion vs the target's own current
-  // config on a re-promotion).
-  const { data: deployments } = useListAgentDeployments({
-    orgName: orgId,
-    projName: projectId,
-    agentName: agentId,
-  });
-
-  const targetAlreadyDeployed = useMemo(() => {
-    const status = deployments?.[formState.targetEnvironment]?.status;
-    return !!status && status !== "not-deployed";
-  }, [deployments, formState.targetEnvironment]);
 
   // Tracks which target env we've already pre-filled the editor for, so we fill
   // once per target rather than on every background refetch.

--- a/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
+++ b/console/workspaces/pages/deploy/src/subComponent/PromoteAgentDrawer.tsx
@@ -511,18 +511,6 @@ export function PromoteAgentDrawer({
                   unmountOnExit
                 >
                   <Stack spacing={2}>
-                    <Alert severity="info">
-                      <Typography variant="body2">
-                        {targetAlreadyDeployed
-                          ? `These values are the current configuration of ${envDisplayName(
-                              formState.targetEnvironment,
-                            )}. Editing them here will update that environment on promote.`
-                          : `These values are inherited from the agent's base configuration. Review and adjust them for ${envDisplayName(
-                              formState.targetEnvironment,
-                            )} before promoting.`}
-                      </Typography>
-                    </Alert>
-
                     <Card variant="outlined">
                       <CardContent>
                         <Stack spacing={1.5}>

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/authz-workload-deployer.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/authz-workload-deployer.yaml
@@ -1,0 +1,55 @@
+---
+# Supplementary ClusterAuthzRole for the workload publisher client.
+#
+# OpenChoreo's built-in workload-publisher role covers only publishing the
+# Workload and annotating the WorkflowRun. The amp-generate-workload template
+# also cuts the ComponentRelease and binds it to the first environment — work
+# the Component controller used to do under spec.autoDeploy — so it needs the
+# actions that path touches:
+#
+# componentrelease:create → POST .../generate-release
+# project:view            → reading spec.deploymentPipelineRef
+# deploymentpipeline:view → resolving the promotion root, i.e. the first
+#                           environment to deploy to
+# releasebinding:view/create/update → the first-environment ReleaseBinding that
+#                           carries the release pin and the environment's config
+#
+# This is additive: OpenChoreo's own workload-publisher-binding still applies,
+# and the PDP unions every matching allow rule.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRole
+metadata:
+  name: amp-workload-deployer
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  description: "Allows the AMP build workflow to release a workload to the first environment"
+  actions:
+    - componentrelease:create
+    - project:view
+    - deploymentpipeline:view
+    - releasebinding:view
+    - releasebinding:create
+    - releasebinding:update
+---
+# Binds the role above to the workload publisher client, matching OpenChoreo's
+# own workload-publisher-binding on the `client_id` claim.
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterAuthzRoleBinding
+metadata:
+  name: amp-workload-deployer-binding
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  effect: allow
+  entitlement:
+    claim: client_id
+    value: {{ .Values.global.oauth.clientId | quote }}
+  roleMappings:
+    - roleRef:
+        kind: ClusterAuthzRole
+        name: amp-workload-deployer

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
@@ -470,6 +470,17 @@ spec:
                   -H "Content-Type: application/json" \
                   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
                   -d @/mnt/vol/releasebinding.json)
+              elif [ "${BINDING_GET_HTTP_CODE}" -ge 500 ]; then
+                # The read is as racy as the write below, so spend the same retry budget on
+                # it rather than failing the build on a transient API-server error.
+                if [ "${BINDING_ATTEMPT}" -lt "${BINDING_MAX_ATTEMPTS}" ]; then
+                  echo "ReleaseBinding lookup failed (HTTP ${BINDING_GET_HTTP_CODE}), attempt ${BINDING_ATTEMPT} of ${BINDING_MAX_ATTEMPTS}; retrying"
+                  BINDING_ATTEMPT=$((BINDING_ATTEMPT + 1))
+                  sleep 2
+                  continue
+                fi
+                echo "Failed to look up ReleaseBinding after ${BINDING_MAX_ATTEMPTS} attempts (HTTP ${BINDING_GET_HTTP_CODE}): ${BINDING_GET_BODY}"
+                exit 1
               else
                 echo "Failed to look up ReleaseBinding (HTTP ${BINDING_GET_HTTP_CODE}): ${BINDING_GET_BODY}"
                 exit 1

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/cluster-workflow-templates/generate-workload.yaml
@@ -83,6 +83,7 @@ spec:
             OUT_JSON="/mnt/vol/workload-cr.json"
             OUT_FULL_JSON="/mnt/vol/workload-cr-full.json"
             OUT_YAML="/mnt/vol/workload-cr.yaml"
+            OUT_OVERRIDES_JSON="/mnt/vol/workload-overrides.json"
 
             # Argo leaves an unset parameter as the empty string.
             if [ -z "$ENV_VARS" ] || [ "$ENV_VARS" = "null" ]; then ENV_VARS='[]'; fi
@@ -142,27 +143,23 @@ spec:
             # --- Step 2: Build the Workload CR ---
             # Assembled by jq rather than by echoing YAML lines: every value is
             # encoded as JSON by jq, so no field can inject document structure.
+            #
+            # Env vars and file mounts are deliberately NOT written here. The Workload
+            # is snapshotted verbatim into every ComponentRelease, and a release is
+            # pinned unchanged into each environment it is promoted to, so anything
+            # placed on the Workload is inherited by every environment. A
+            # ReleaseBinding's workloadOverrides can replace such a value per
+            # environment but cannot remove it, which makes the inheritance
+            # impossible to opt out of. Configuration therefore lives only on the
+            # per-environment ReleaseBinding (see Step 7); the Workload carries just
+            # the image and the environment-independent endpoint contract.
             jq -n -c \
               --arg name "${COMPONENT_NAME}-workload" \
               --arg namespace "$NAMESPACE" \
               --arg projectName "$PROJECT_NAME" \
               --arg componentName "$COMPONENT_NAME" \
               --arg image "$IMAGE" \
-              --argjson envVars "$ENV_VARS" \
-              --argjson fileMounts "$FILE_MOUNTS" \
               --argjson endpoints "$ENDPOINTS" '
-                def secret_ref:
-                  (.valueFrom.secretKeyRef.name // "") as $n
-                  | (.valueFrom.secretKeyRef.key // "") as $k
-                  | if $n != "" and $k != ""
-                    then { valueFrom: { secretKeyRef: { name: $n, key: $k } } }
-                    else { value: (.value // "") }
-                    end;
-
-                def env_entry: { key: .name } + secret_ref;
-
-                def file_entry: { key: .key, mountPath: .mountPath } + secret_ref;
-
                 def endpoint_entry:
                   { type: (.type // "HTTP"), port: .port }
                   + (if (.basePath // "") != "" then { basePath: .basePath } else {} end)
@@ -176,11 +173,7 @@ spec:
                   spec: (
                     {
                       owner: { projectName: $projectName, componentName: $componentName },
-                      container: (
-                        { image: $image }
-                        + (if ($envVars | length) > 0 then { env: [ $envVars[] | env_entry ] } else {} end)
-                        + (if ($fileMounts | length) > 0 then { files: [ $fileMounts[] | file_entry ] } else {} end)
-                      )
+                      container: { image: $image }
                     }
                     + (if ($endpoints | length) > 0
                        then { endpoints: ($endpoints | map({ (.name): endpoint_entry }) | add) }
@@ -188,6 +181,32 @@ spec:
                   )
                 }
               ' > "$OUT_JSON"
+
+            # The same env vars and file mounts, shaped as ReleaseBinding
+            # workloadOverrides. Emitted as null when the component has neither, so
+            # Step 7 can leave spec.workloadOverrides unset rather than writing an
+            # empty container object.
+            jq -n -c \
+              --argjson envVars "$ENV_VARS" \
+              --argjson fileMounts "$FILE_MOUNTS" '
+                def secret_ref:
+                  (.valueFrom.secretKeyRef.name // "") as $n
+                  | (.valueFrom.secretKeyRef.key // "") as $k
+                  | if $n != "" and $k != ""
+                    then { valueFrom: { secretKeyRef: { name: $n, key: $k } } }
+                    else { value: (.value // "") }
+                    end;
+
+                def env_entry: { key: .name } + secret_ref;
+
+                def file_entry: { key: .key, mountPath: .mountPath } + secret_ref;
+
+                (
+                  (if ($envVars | length) > 0 then { env: [ $envVars[] | env_entry ] } else {} end)
+                  + (if ($fileMounts | length) > 0 then { files: [ $fileMounts[] | file_entry ] } else {} end)
+                ) as $container
+                | if ($container | length) > 0 then { container: $container } else null end
+              ' > "$OUT_OVERRIDES_JSON"
 
             # The API server payload carries no apiVersion/kind; the YAML rendered
             # for the workflow output parameter does.
@@ -297,6 +316,192 @@ spec:
               echo "Failed to update WorkflowRun (HTTP ${UPDATE_HTTP_CODE}): ${UPDATE_BODY}"
               exit 1
             fi
+
+            # Steps 6-7 do what OpenChoreo's Component controller does when
+            # spec.autoDeploy is set: cut a ComponentRelease from the component's
+            # current state and bind it to the first environment. Driving it from
+            # here instead is what allows the configuration to be attached to the
+            # binding rather than baked into the shared Workload. Components built by
+            # this workflow are created with autoDeploy off, so the controller is not
+            # also managing the binding written below.
+
+            # Small helper for the remaining reads. Echoes "<body>\n<http-code>";
+            # callers split it the same way as the blocks above.
+            api_get() {
+              curl -s -w "\n%{http_code}" \
+                -X GET "${API_URL}$1" \
+                -H "Host: ${API_HOST}" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}"
+            }
+
+            # --- Step 6: Generate the ComponentRelease ---
+            # Named after the WorkflowRun, which is unique per build, so the create
+            # below cannot collide with an earlier release.
+            RELEASE_NAME="${RUN_NAME}"
+
+            echo "Generating ComponentRelease ${RELEASE_NAME}..."
+            jq -n -c --arg releaseName "$RELEASE_NAME" '{ releaseName: $releaseName }' \
+              > /mnt/vol/generate-release.json
+
+            RELEASE_RESPONSE=$(curl -s -w "\n%{http_code}" \
+              -X POST "${API_URL}/api/v1/namespaces/${NAMESPACE}/components/${COMPONENT_NAME}/generate-release" \
+              -H "Host: ${API_HOST}" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              -d @/mnt/vol/generate-release.json)
+
+            RELEASE_HTTP_CODE=$(echo "${RELEASE_RESPONSE}" | tail -1)
+            RELEASE_BODY=$(echo "${RELEASE_RESPONSE}" | sed '$d')
+
+            if [ "${RELEASE_HTTP_CODE}" -lt 200 ] || [ "${RELEASE_HTTP_CODE}" -ge 300 ]; then
+              echo "Failed to generate ComponentRelease (HTTP ${RELEASE_HTTP_CODE}): ${RELEASE_BODY}"
+              exit 1
+            fi
+            echo "ComponentRelease ${RELEASE_NAME} generated (HTTP ${RELEASE_HTTP_CODE})"
+
+            # --- Step 7: Bind the release to the first environment ---
+            # The first environment is the project's promotion root, resolved the way
+            # OpenChoreo's Component controller resolves it: the one source
+            # environment that is never itself a promotion target.
+            PROJECT_RESPONSE=$(api_get "/api/v1/namespaces/${NAMESPACE}/projects/${PROJECT_NAME}")
+            PROJECT_HTTP_CODE=$(echo "${PROJECT_RESPONSE}" | tail -1)
+            PROJECT_BODY=$(echo "${PROJECT_RESPONSE}" | sed '$d')
+
+            if [ "${PROJECT_HTTP_CODE}" -lt 200 ] || [ "${PROJECT_HTTP_CODE}" -ge 300 ]; then
+              echo "Failed to get Project (HTTP ${PROJECT_HTTP_CODE}): ${PROJECT_BODY}"
+              exit 1
+            fi
+
+            PIPELINE_NAME=$(printf '%s' "${PROJECT_BODY}" | jq -r '.spec.deploymentPipelineRef.name // ""')
+            if [ -z "${PIPELINE_NAME}" ]; then
+              echo "Error: project ${PROJECT_NAME} has no deploymentPipelineRef"
+              exit 1
+            fi
+
+            PIPELINE_RESPONSE=$(api_get "/api/v1/namespaces/${NAMESPACE}/deploymentpipelines/${PIPELINE_NAME}")
+            PIPELINE_HTTP_CODE=$(echo "${PIPELINE_RESPONSE}" | tail -1)
+            PIPELINE_BODY=$(echo "${PIPELINE_RESPONSE}" | sed '$d')
+
+            if [ "${PIPELINE_HTTP_CODE}" -lt 200 ] || [ "${PIPELINE_HTTP_CODE}" -ge 300 ]; then
+              echo "Failed to get DeploymentPipeline (HTTP ${PIPELINE_HTTP_CODE}): ${PIPELINE_BODY}"
+              exit 1
+            fi
+
+            FIRST_ENV=$(printf '%s' "${PIPELINE_BODY}" | jq -r '
+              (.spec.promotionPaths // []) as $paths
+              | ([ $paths[].targetEnvironmentRefs[]?.name ] | map({ (.): true }) | add // {}) as $targets
+              | [ $paths[].sourceEnvironmentRef.name
+                  | select(. != null and . != "")
+                  | select($targets[.] != true) ][0] // ""
+            ')
+            if [ -z "${FIRST_ENV}" ]; then
+              echo "Error: deployment pipeline ${PIPELINE_NAME} has no root environment"
+              exit 1
+            fi
+
+            # Name fixed by convention: the promotion path and the backend both look
+            # the first-environment binding up as <component>-<environment>.
+            BINDING_NAME="${COMPONENT_NAME}-${FIRST_ENV}"
+
+            # The whole read-then-write is retried, re-reading the binding each time,
+            # mirroring retryReleaseBindingUpdate in the backend's OpenChoreo client.
+            # Both writes below race the backend, which edits this same binding to
+            # inject MCP env vars and runtime class:
+            #   - a create can lose the race and come back 409, in which case the
+            #     re-read finds the binding and the next attempt updates it instead;
+            #   - an update can collide with a concurrent write inside the API server
+            #     and fail. OpenChoreo surfaces that as a generic 500 rather than a
+            #     409, so both codes are treated as retryable.
+            # Re-reading per attempt also narrows (it cannot close) the window where a
+            # backend write lands between our read and our write: the API replaces the
+            # spec wholesale and does not honour a caller's resourceVersion, so the
+            # last writer wins regardless.
+            BINDING_MAX_ATTEMPTS=3
+            BINDING_ATTEMPT=1
+            BINDING_WRITTEN=false
+
+            while [ "${BINDING_ATTEMPT}" -le "${BINDING_MAX_ATTEMPTS}" ]; do
+              BINDING_GET_RESPONSE=$(api_get "/api/v1/namespaces/${NAMESPACE}/releasebindings/${BINDING_NAME}")
+              BINDING_GET_HTTP_CODE=$(echo "${BINDING_GET_RESPONSE}" | tail -1)
+              BINDING_GET_BODY=$(echo "${BINDING_GET_RESPONSE}" | sed '$d')
+
+              if [ "${BINDING_GET_HTTP_CODE}" -eq 404 ]; then
+                echo "Creating ReleaseBinding ${BINDING_NAME} for environment ${FIRST_ENV}..."
+                jq -n -c \
+                  --arg name "$BINDING_NAME" \
+                  --arg namespace "$NAMESPACE" \
+                  --arg projectName "$PROJECT_NAME" \
+                  --arg componentName "$COMPONENT_NAME" \
+                  --arg environment "$FIRST_ENV" \
+                  --arg releaseName "$RELEASE_NAME" \
+                  --slurpfile overrides "$OUT_OVERRIDES_JSON" '
+                    {
+                      metadata: { name: $name, namespace: $namespace },
+                      spec: (
+                        {
+                          owner: { projectName: $projectName, componentName: $componentName },
+                          environment: $environment,
+                          releaseName: $releaseName
+                        }
+                        + (if $overrides[0] != null then { workloadOverrides: $overrides[0] } else {} end)
+                      )
+                    }
+                  ' > /mnt/vol/releasebinding.json
+
+                BINDING_RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X POST "${API_URL}/api/v1/namespaces/${NAMESPACE}/releasebindings" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -d @/mnt/vol/releasebinding.json)
+              elif [ "${BINDING_GET_HTTP_CODE}" -ge 200 ] && [ "${BINDING_GET_HTTP_CODE}" -lt 300 ]; then
+                # Only the release pin is advanced. Once the binding exists it owns the
+                # environment's configuration, which the backend edits directly; a
+                # rebuild must not roll that back to whatever the component-level
+                # parameters happened to hold.
+                echo "Updating ReleaseBinding ${BINDING_NAME} to release ${RELEASE_NAME}..."
+                printf '%s' "${BINDING_GET_BODY}" > /mnt/vol/releasebinding-get.json
+                jq -c --arg releaseName "$RELEASE_NAME" '.spec.releaseName = $releaseName' \
+                  /mnt/vol/releasebinding-get.json > /mnt/vol/releasebinding.json
+
+                BINDING_RESPONSE=$(curl -s -w "\n%{http_code}" \
+                  -X PUT "${API_URL}/api/v1/namespaces/${NAMESPACE}/releasebindings/${BINDING_NAME}" \
+                  -H "Host: ${API_HOST}" \
+                  -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -d @/mnt/vol/releasebinding.json)
+              else
+                echo "Failed to look up ReleaseBinding (HTTP ${BINDING_GET_HTTP_CODE}): ${BINDING_GET_BODY}"
+                exit 1
+              fi
+
+              BINDING_HTTP_CODE=$(echo "${BINDING_RESPONSE}" | tail -1)
+              BINDING_BODY=$(echo "${BINDING_RESPONSE}" | sed '$d')
+
+              if [ "${BINDING_HTTP_CODE}" -ge 200 ] && [ "${BINDING_HTTP_CODE}" -lt 300 ]; then
+                BINDING_WRITTEN=true
+                break
+              fi
+
+              if [ "${BINDING_HTTP_CODE}" -eq 409 ] || [ "${BINDING_HTTP_CODE}" -ge 500 ]; then
+                if [ "${BINDING_ATTEMPT}" -lt "${BINDING_MAX_ATTEMPTS}" ]; then
+                  echo "ReleaseBinding write failed (HTTP ${BINDING_HTTP_CODE}), attempt ${BINDING_ATTEMPT} of ${BINDING_MAX_ATTEMPTS}; re-reading and retrying"
+                  BINDING_ATTEMPT=$((BINDING_ATTEMPT + 1))
+                  sleep 2
+                  continue
+                fi
+              fi
+
+              echo "Failed to write ReleaseBinding (HTTP ${BINDING_HTTP_CODE}): ${BINDING_BODY}"
+              exit 1
+            done
+
+            if [ "${BINDING_WRITTEN}" != "true" ]; then
+              echo "Failed to write ReleaseBinding after ${BINDING_MAX_ATTEMPTS} attempts (HTTP ${BINDING_HTTP_CODE}): ${BINDING_BODY}"
+              exit 1
+            fi
+
+            echo "ReleaseBinding ${BINDING_NAME} bound to release ${RELEASE_NAME} (HTTP ${BINDING_HTTP_CODE})"
         volumeMounts:
           - name: workspace
             mountPath: /mnt/vol


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

The Workload now carries just the image and the endpoint contract. Configuration moves to `spec.workloadOverrides` on the per-environment ReleaseBinding.

**Source-built agents.** `amp-generate-workload` step in the build workflow gains two steps: cut the ComponentRelease, then create or update the first environment's ReleaseBinding with the configuration as `workloadOverrides`. A rebuild advances only `releaseName` — once the binding exists it owns that environment's configuration, and a rebuild must not roll it back to whatever the component-level parameters happened to hold.

**Kind-sourced agents.** These run no build workflow, so the backend does the same work in `CreateKindAgentReleaseAndBinding`.

**Authorization.** Cutting a release and writing a binding needs actions OpenChoreo's built-in `workload-publisher` role does not grant, so a supplementary `ClusterAuthzRole` covers `componentrelease: create`,
`releasebinding` view/create/update, and the `project` / `deploymentpipeline` reads used to resolve the first environment. The binding matches on the `client_id` claim, as every other machine-client binding in the system does.



Resolves https://github.com/wso2/agent-manager/issues/1771
Resolves https://github.com/wso2/agent-manager/issues/1690 



## Goals
An agent's env vars and file mounts were written onto its Workload CR. A value placed there is inherited by every environment, and while a ReleaseBinding's `workloadOverrides` can *replace* such a value per environment, it cannot
*remove* it — so the inheritance is impossible to opt out of. An environment that should not carry a key has no way to say so.

Make configuration environment-scoped: the Workload carries only what is genuinely environment-independent, and each environment's configuration lives on its own ReleaseBinding. Apply this to both agent sources — source-built and
kind-sourced — so the two paths resolve configuration the same way.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Environment-specific variables and file mounts are now applied through release bindings, preserving configuration independently for each deployment environment.
  - Agent deployments automatically create and bind releases to the initial environment.
  - Rebuilding workloads updates deployment bindings while retaining environment-specific configuration.
  - Secret references are recognized from both shared workloads and environment-specific configuration.
  - Added permissions to support automated release and binding management.

- **Bug Fixes**
  - Prevented environment configuration from being stored on shared workloads, avoiding unintended cross-environment changes.

- **UI Improvements**
  - Simplified the agent promotion configuration panel by removing outdated guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->