### PR TITLE
Use a dedicated label to separate build and eval pods

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
@@ -14,10 +14,15 @@ spec:
   podMetadata:
     labels:
       app.kubernetes.io/name: amp-monitor
-      # Also the key that separates evaluation pods from build pods, which share
-      # the workflows-<org> namespace and are otherwise identical to
-      # kube_pod_labels. Allowlisted in observability-metrics-prometheus.yaml.
+      # Selected on by the egress NetworkPolicy, so it stays on the pod.
       app.kubernetes.io/component: evaluation-job
+      # What separates evaluation pods from build pods for metering: they share
+      # the workflows-<org> namespace and are otherwise identical on
+      # kube_pod_labels. A dedicated key rather than reusing the convention
+      # label above, because the exporter's allowlist is cluster-wide -- admitting
+      # app.kubernetes.io/component there would also export it for every platform
+      # pod that happens to follow the same convention, which is a lot of them.
+      amp.wso2.com/workload: evaluation
       # Tenant identity for usage attribution. kube-state-metrics exports pod
       # labels on kube_pod_labels only, and only the keys in its allowlist, so
       # these four are what makes an evaluation run attributable to a tenant.

--- a/deployments/values/observability-metrics-prometheus.yaml
+++ b/deployments/values/observability-metrics-prometheus.yaml
@@ -67,9 +67,15 @@ kube-prometheus-stack:
   # and nothing else, so every tenant-attributed query joins against it.
   #
   # The first seven keys are the upstream defaults, reproduced because helm replaces
-  # list values rather than merging them. app.kubernetes.io/component is ours: build
-  # and evaluation pods share the workflows-<org> namespace, and without a key that
+  # list values rather than merging them. amp.wso2.com/workload is ours: build and
+  # evaluation pods share the workflows-<org> namespace, and without a key that
   # separates them a namespace-scoped duration sums both into one bucket.
+  #
+  # Deliberately not app.kubernetes.io/component, which would have served the same
+  # purpose here. This allowlist applies to every pod the exporter sees, and that
+  # convention label is carried by a great many platform components -- admitting it
+  # would export label series for all of them, into a monitoring stack that does
+  # not want them.
   kube-state-metrics:
     metricLabelsAllowlist:
-      - pods=[openchoreo.dev/component-uid,openchoreo.dev/project-uid,openchoreo.dev/environment-uid,openchoreo.dev/namespace,openchoreo.dev/component,openchoreo.dev/project,openchoreo.dev/environment,app.kubernetes.io/component]
+      - pods=[openchoreo.dev/component-uid,openchoreo.dev/project-uid,openchoreo.dev/environment-uid,openchoreo.dev/namespace,openchoreo.dev/component,openchoreo.dev/project,openchoreo.dev/environment,amp.wso2.com/workload]


### PR DESCRIPTION
## Purpose
Build and evaluation pods share the `workflows-<org>` namespace and carry no key that separates them for metering, so a namespace-scoped duration sums both into one bucket. Evaluation pods already carried `app.kubernetes.io/component`; the exporter's allowlist did not admit it.

Raised in review on the workflow-plane metrics PR: admitting that key is not free. This adds the equivalent key on the evaluation side so the allowlist can name something narrower.

## Goals
Give metering a discriminator between build and evaluation pods that is carried by nothing else, and stop the exporter from having to admit a convention label to get it.

## Approach
Evaluation pods now also carry `amp.wso2.com/workload: evaluation`, and the kube-state-metrics label allowlist admits that in place of `app.kubernetes.io/component`.

**Why not just reuse the convention label.** The allowlist is not scoped to these pods — it applies to every pod the exporter sees. `app.kubernetes.io/component` is widely used: on the workflow plane, thirty platform pods carry it across cert-manager, flux and harbor. Admitting the key in order to read two of our own workloads would have exported label series for all of them, and those pods sit outside the tenant namespaces the platform's own remote-write filters out — so the series would have reached a monitoring stack whose owners have no use for them.

**`app.kubernetes.io/component: evaluation-job` stays on the pod, untouched.** The evaluation egress NetworkPolicy selects on it (`evaluation-job-networkpolicy.yaml`). This changes what is *exported*, not what is *labelled*.

## User stories
N/A — telemetry labelling with no user-facing surface.

## Release note
Evaluation pods carry an additional label used to attribute evaluation compute separately from build compute.

## Documentation
N/A — internal label; no product documentation describes workflow pod labels.

## Training
N/A — no user-facing behaviour change.

## Certification
N/A — infrastructure labelling.

## Marketing
N/A — internal change.

## Automation tests
- Unit tests
  > N/A — Helm templates and a values file; no unit-test harness.
- Integration tests
  > `helm template` on the evaluation extension renders both labels on the pod and leaves the NetworkPolicy selector matching. Post-deploy the check is a query for `kube_pod_labels{label_amp_wso2_com_workload="evaluation"}` against the observability plane, not an inspection of the pod.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — Helm templates.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Migrations (if applicable)
N/A — additive on the pod. Evaluation runs started before this lands keep the old label set; they are short-lived, so the gap closes on its own within one run.

## Test environment
Rendered locally. The thirty-platform-pod figure was measured on the dev cloud workflow plane.

## Related PRs
The build-pod half of this — the same key on the build workflows, and the cloud-side allowlist — is a matching change in the deployment repo.

## Learning
The general lesson is that an exporter allowlist is a cluster-wide decision even when the thing you want from it is narrow. Reaching for the conventional label was the obvious move and would have quietly widened someone else's metric surface; a key nothing else carries costs nothing and cannot.
