### PR TITLE
Update the documentation guide section 

### DIFF
--- a/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
+++ b/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
@@ -35,7 +35,7 @@ The authorization mechanism is identical for every agent. The only difference is
 
 ## Prerequisites
 
-- `amctl` installed and logged in against your control plane(see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
+- `amctl` installed and logged in against your control plane if your follow the `amctl` path (see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
 - An AI Gateway registered and active for the environment you are configuring.
 - A **GitHub Personal Access Token**. Read access is enough for `github:read`; add issue write access only if you want to exercise `github:write`. Create one at [github.com/settings/tokens](https://github.com/settings/tokens).
 

--- a/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
+++ b/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
@@ -4,7 +4,7 @@ sidebar_position: 11
 
 # Authorize Agent Access to MCP Tools
 
-When you front an MCP server through the platform as an **identity-secured MCP proxy**, you decide which agents may invoke which tools. This guide walks through the full authorization workflow: you register the resource, define permissions over its tools, bundle those permissions into roles, and grant the roles to agents (or groups). The result is that two agents can hit the *same* proxy endpoint and get *different* capabilities.
+When you front an MCP server through the platform as an identity-secured MCP proxy, you decide which agents may invoke which tools. This guide walks through the full authorization workflow: you register the resource, define permissions over its tools, bundle those permissions into roles, and grant the roles to agents (or groups). The result is that two agents can hit the *same* proxy endpoint and get *different* capabilities.
 
 ## The model
 
@@ -13,21 +13,21 @@ Agent authorization is built from four pieces:
 | Piece | What it is |
 | --- | --- |
 | **Resource** | The thing being accessed. Today this is an **MCP proxy**. Its handle becomes the prefix for every scope you define on it. |
-| **Permission (scope)** | An action on the resource, mapped to a set of the resource's tools. A scope is named `<proxy>:<action>` — e.g. `booking:read`. |
+| **Permission (scope)** | An action on the resource, mapped to a set of the resource's tools. A scope is named `<proxy>:<action>` — e.g. `github:read`. |
 | **Role** | A named bundle of scopes, defined in an environment. |
 | **Assignment** | A role granted to an **agent** or a **group**. |
 
 An agent presents an access token, and the platform filters that token's scopes down to exactly the scopes of the agent's assigned roles **at mint time**. When the agent calls a tool through the gateway, per-tool authorization checks the token's scopes against the scope that covers the tool.
 
-The example below secures a booking MCP server with two scopes and two roles:
+The example below secures **GitHub's hosted MCP server** with two scopes and two roles, so you can follow along against a real upstream rather than a placeholder. The story is an IT helpdesk: one agent only reads the team's issue tracker to spot known problems, while a triage agent may also file and update issues.
 
-| | `booking:read` | `booking:write` |
+| | `github:read` | `github:write` |
 | --- | --- | --- |
-| **Tools** | `list_bookings`, `get_booking` | `create_booking`, `edit_booking`, `remove_booking` |
-| **`booking-reader`** role | ✅ | — |
-| **`booking-admin`** role | ✅ | ✅ |
+| **Tools** | `search_issues`, `issue_read` | `issue_write`, `add_issue_comment` |
+| **`github-reader`** role | ✅ | — |
+| **`github-triager`** role | ✅ | ✅ |
 
-An agent assigned `booking-reader` can list bookings but not create them; an agent assigned `booking-admin` can do both — through the same endpoint.
+An agent assigned `github-reader` can search and read issues but not create them; an agent assigned `github-triager` can do both — through the same endpoint.
 
 :::info Platform-deployed vs. external agents
 The authorization mechanism is identical for every agent. The only difference is how an agent obtains its identity: an agent **deployed on the platform** has its identity credentials injected automatically at deploy time, while an **external agent** is handed a client ID and secret that it presents itself. Either way, the token it ends up with carries only the scopes of its assigned roles.
@@ -47,10 +47,22 @@ This guide uses the [`amctl api`](../reference/cli/api.mdx) command to call the 
 
 Register the upstream MCP server as an identity-secured MCP proxy. The proxy's `id` becomes the scope prefix and a resource server in the environment's Thunder identity provider, and — with a `context` — the gateway path.
 
+### In the Console
+
+1. Switch to the organization view and go to **MCP Servers** under **Resources**.
+2. Click **Register MCP Server** and give it the name `GitHub` and the context path `/default/github`.
+3. Add an endpoint with the **MCP Server Endpoint URL** `https://api.githubcopilot.com/mcp/`, then open **Advanced Configuration** and add the header `Authorization` with the value `Bearer <your-github-pat>`. Agent Manager discovers the server's tools as you add the endpoint. Now save the MCP proxy.
+4. Open the proxy's **Security** tab and set **Authentication** to **Oauth**. This is what turns on per-tool authorization — without it there are no scopes to define in Step 2.
+
+Full field reference: [Register an MCP Proxy](./register-mcp-proxy.mdx).
+
+### With amctl
+
 First discover the upstream server's tools:
 
 ```bash
-echo '{"url": "https://upstream.example.com/mcp"}' \
+echo '{"url": "https://api.githubcopilot.com/mcp/",
+       "auth": {"type": "api-key", "header": "Authorization", "value": "Bearer <your-github-pat>"}}' \
   | amctl api /orgs/default/mcp-proxies/fetch-server-info -X POST --input -
 ```
 
@@ -59,16 +71,19 @@ Then create the proxy with identity security enabled, passing the discovered too
 ```bash
 amctl api /orgs/default/mcp-proxies -X POST --input - <<'JSON'
 {
-  "id": "booking",
-  "name": "Booking MCP",
-  "description": "Proxy for the upstream bookings MCP server",
+  "id": "github",
+  "name": "GitHub MCP",
+  "description": "Proxy for GitHub's hosted MCP server",
   "version": "v1.0",
-  "context": "/booking",
+  "context": "/github",
   "mcpSpecVersion": "2025-06-18",
   "endpoints": [{
     "id": "primary",
     "name": "primary",
-    "upstream": {"main": {"url": "https://upstream.example.com/mcp"}},
+    "upstream": {"main": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "auth": {"type": "api-key", "header": "Authorization", "value": "Bearer <your-github-pat>"}
+    }},
     "capabilities": {"tools": [ /* tools from fetch-server-info */ ]},
     "security": {"enabled": true, "identity": {"enabled": true}},
     "environments": [{"environmentUuid": "<environment-uuid>"}]
@@ -76,35 +91,46 @@ amctl api /orgs/default/mcp-proxies -X POST --input - <<'JSON'
 }
 JSON
 ```
-
-You can also register a proxy through the Console — see [Register an MCP Proxy](./register-mcp-proxy.mdx) — but the rest of this guide uses the API for the parts that define authorization.
-
 ---
 
 ## Step 2: Define permissions over the tools
 
-A **scope** on the proxy names an action and lists the tools it covers. Create one scope per capability level you want to grant. The scope string is `<proxy>:<action>`, so the calls below produce `booking:read` and `booking:write`.
+A **scope** on the proxy names an action and lists the tools it covers. Create one scope per capability level you want to grant. The scope string is `<proxy>:<action>`, so the steps below produce `github:read` and `github:write`.
+
+### In the Console
+
+On the proxy's **Security** tab, with **Authentication** set to **OAuth**, an **Authorization** section appears:
+
+1. Click **Create Scope**.
+2. Enter the action name — `read` — which becomes `github:read`.
+3. Select the tools it covers: `search_issues`, `list_issues` and `issue_read`.
+4. Optionally attach the scope to existing roles right here, which saves revisiting Step 3.
+5. Repeat for `write`, covering `issue_write` and `add_issue_comment`.
+
+The **Tools** sub-tab shows a tool-to-scope table for the whole server, and the **Scopes** sub-tab lists what you've defined.
+
+### With amctl
 
 ```bash
-# booking:read — covers the read-only tools
-echo '{"action": "read", "description": "Read-only booking access",
-       "tools": ["list_bookings", "get_booking"]}' \
-  | amctl api /orgs/default/mcp-proxies/booking/scopes -X POST --input -
+# github:read — covers the read-only tools
+echo '{"action": "read", "description": "Search and read GitHub issues",
+       "tools": ["search_issues", "list_issues", "issue_read"]}' \
+  | amctl api /orgs/default/mcp-proxies/github/scopes -X POST --input -
 
-# booking:write — covers the mutating tools
-echo '{"action": "write", "description": "Create, edit and remove bookings",
-       "tools": ["create_booking", "edit_booking", "remove_booking"]}' \
-  | amctl api /orgs/default/mcp-proxies/booking/scopes -X POST --input -
+# github:write — covers the mutating tools
+echo '{"action": "write", "description": "File and update GitHub issues",
+       "tools": ["issue_write", "add_issue_comment"]}' \
+  | amctl api /orgs/default/mcp-proxies/github/scopes -X POST --input -
 ```
 
 :::caution Cover every tool you want to gate
 A tool that is **not** covered by any scope has no authorization rule and is allowed for any *authenticated* caller (default-permit). Denial only happens for a tool whose covering scope the caller was not granted. Make sure every tool you intend to restrict is listed under some scope.
 :::
 
-List the scopes to confirm:
+List the scopes to confirm — the Console shows the same set on the **Scopes** sub-tab:
 
 ```bash
-amctl api /orgs/default/mcp-proxies/booking/scopes
+amctl api /orgs/default/mcp-proxies/github/scopes
 ```
 
 ---
@@ -113,19 +139,28 @@ amctl api /orgs/default/mcp-proxies/booking/scopes
 
 Roles are defined per environment. Create a role with the set of scopes it should grant — the scopes must already exist (Step 2).
 
+### In the Console
+
+1. At the organization level, go to **Agent Identities → Roles**.
+2. Pick the environment you are configuring. Agent identity roles are per environment, so the same role name in development and production are different objects.
+3. Click **Create Role**, name it `github-reader`, and select the `github:read` scope.
+4. Repeat for `github-triager`, selecting both `github:read` and `github:write`.
+
+### With amctl
+
 ```bash
-# booking-reader — read only
-echo '{"name": "booking-reader", "description": "Read-only booking role",
-       "scopes": ["booking:read"]}' \
+# github-reader — read only
+echo '{"name": "github-reader", "description": "Read-only GitHub issues role",
+       "scopes": ["github:read"]}' \
   | amctl api /orgs/default/environments/default/agent-identities/roles -X POST --input -
 
-# booking-admin — read and write
-echo '{"name": "booking-admin", "description": "Full booking access role",
-       "scopes": ["booking:read", "booking:write"]}' \
+# github-triager — read and write
+echo '{"name": "github-triager", "description": "Read plus file/update issues",
+       "scopes": ["github:read", "github:write"]}' \
   | amctl api /orgs/default/environments/default/agent-identities/roles -X POST --input -
 ```
 
-Fetch the roles back to get each role's ID, which you'll need to assign it:
+Fetch the roles back to get each role's ID, which you'll need to assign it (the Console does this lookup for you):
 
 ```bash
 amctl api /orgs/default/environments/default/agent-identities/roles
@@ -135,7 +170,16 @@ amctl api /orgs/default/environments/default/agent-identities/roles
 
 ## Step 4: Assign the role to an agent or group
 
-Assignments grant a role to a principal. Each assignment names the principal's ID and its `type` — `agent` to grant a single agent identity, or `group` to grant every member of a group at once.
+Assignments grant a role to a principal — `agent` for a single agent identity, or `group` to grant every member of a group at once.
+
+### In the Console
+
+1. Go to **Roles** in the **Agent Identities** section and open `github-reader`.
+2. Use the **agent** tabs to pick the agents, or the groups, that should hold the role, then save.
+
+**Agent ID → Agents** lists the agent identities available in the selected environment if you need to confirm a name first, and **Agent ID → Groups** is where you manage group membership.
+
+### With amctl
 
 First resolve the agent's identity ID (`thunderAgentId`):
 
@@ -146,7 +190,7 @@ amctl api /orgs/default/environments/default/agent-identities/agents
 Then add the assignment, using the role ID from Step 3:
 
 ```bash
-# Grant booking-reader to an agent
+# Grant github-reader to an agent
 echo '{"assignments": [{"id": "<thunder-agent-id>", "type": "agent"}]}' \
   | amctl api /orgs/default/environments/default/agent-identities/roles/<role-id>/assignments/add -X POST --input -
 ```
@@ -170,12 +214,12 @@ amctl api /orgs/default/environments/default/agent-identities/roles/<role-id>/as
 
 Once a role is assigned, the platform enforces it automatically:
 
-1. The agent obtains an access token. Its scopes are **filtered to the scopes of its assigned roles at mint time** — a `booking-reader` agent that requests `booking:read booking:write` receives a token carrying only `booking:read`.
-2. The agent calls a tool through the gateway endpoint (`/booking/mcp`).
+1. The agent obtains an access token. Its scopes are **filtered to the scopes of its assigned roles at mint time**. A `github-reader` agent that requests `github:read github:write` receives a token carrying only `github:read`.
+2. The agent calls a tool through the gateway endpoint (`/github/mcp`).
 3. The gateway authenticates the token, then authorizes the specific tool against the token's scopes:
-   - `booking-reader` calling `list_bookings` → **allowed** (`booking:read` covers it).
-   - `booking-reader` calling `create_booking` → **denied** (`booking:write` required, not granted).
-   - `booking-admin` calling either → **allowed**.
+   - `github-reader` calling `search_issues` → **allowed** (`github:read` covers it).
+   - `github-reader` calling `create_issue` → **denied** (`github:write` required, not granted).
+   - `github-triager` calling either → **allowed**.
 
 Changing who can do what is now a matter of editing scopes and role assignments — the agents themselves do not change.
 

--- a/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
+++ b/documentation/docs/guides/authorize-agent-access-to-mcp-tools.mdx
@@ -35,7 +35,7 @@ The authorization mechanism is identical for every agent. The only difference is
 
 ## Prerequisites
 
-- `amctl` installed and logged in against your control plane if your follow the `amctl` path (see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
+- `amctl` installed and logged in against your control plane if you follow the `amctl` path (see [CLI Installation](./cli-installation.mdx) and [`amctl login`](../reference/cli/login.mdx)).
 - An AI Gateway registered and active for the environment you are configuring.
 - A **GitHub Personal Access Token**. Read access is enough for `github:read`; add issue write access only if you want to exercise `github:write`. Create one at [github.com/settings/tokens](https://github.com/settings/tokens).
 
@@ -50,9 +50,9 @@ Register the upstream MCP server as an identity-secured MCP proxy. The proxy's `
 ### In the Console
 
 1. Switch to the organization view and go to **MCP Servers** under **Resources**.
-2. Click **Register MCP Server** and give it the name `GitHub` and the context path `/default/github`.
+2. Click **Register MCP Server** and give it the name `GitHub` and the context path `/github`.
 3. Add an endpoint with the **MCP Server Endpoint URL** `https://api.githubcopilot.com/mcp/`, then open **Advanced Configuration** and add the header `Authorization` with the value `Bearer <your-github-pat>`. Agent Manager discovers the server's tools as you add the endpoint. Now save the MCP proxy.
-4. Open the proxy's **Security** tab and set **Authentication** to **Oauth**. This is what turns on per-tool authorization — without it there are no scopes to define in Step 2.
+4. Open the proxy's **Security** tab and set **Authentication** to **OAuth**. This is what turns on per-tool authorization — without it there are no scopes to define in Step 2.
 
 Full field reference: [Register an MCP Proxy](./register-mcp-proxy.mdx).
 
@@ -66,7 +66,7 @@ echo '{"url": "https://api.githubcopilot.com/mcp/",
   | amctl api /orgs/default/mcp-proxies/fetch-server-info -X POST --input -
 ```
 
-Then create the proxy with identity security enabled, passing the discovered tools as the endpoint's capabilities:
+Then create the proxy with identity security enabled. List only the tools this guide goes on to gate, rather than everything discovery returned — a tool present in `capabilities` but absent from every scope in Step 2 stays callable by any authenticated caller:
 
 ```bash
 amctl api /orgs/default/mcp-proxies -X POST --input - <<'JSON'
@@ -84,7 +84,10 @@ amctl api /orgs/default/mcp-proxies -X POST --input - <<'JSON'
       "url": "https://api.githubcopilot.com/mcp/",
       "auth": {"type": "api-key", "header": "Authorization", "value": "Bearer <your-github-pat>"}
     }},
-    "capabilities": {"tools": [ /* tools from fetch-server-info */ ]},
+    "capabilities": {"tools": [
+      "search_issues", "list_issues", "issue_read",
+      "issue_write", "add_issue_comment"
+    ]},
     "security": {"enabled": true, "identity": {"enabled": true}},
     "environments": [{"environmentUuid": "<environment-uuid>"}]
   }]
@@ -218,7 +221,7 @@ Once a role is assigned, the platform enforces it automatically:
 2. The agent calls a tool through the gateway endpoint (`/github/mcp`).
 3. The gateway authenticates the token, then authorizes the specific tool against the token's scopes:
    - `github-reader` calling `search_issues` → **allowed** (`github:read` covers it).
-   - `github-reader` calling `create_issue` → **denied** (`github:write` required, not granted).
+   - `github-reader` calling `issue_write` → **denied** (`github:write` required, not granted).
    - `github-triager` calling either → **allowed**.
 
 Changing who can do what is now a matter of editing scopes and role assignments — the agents themselves do not change.

--- a/documentation/docs/guides/configure-agent-mcp-proxies.mdx
+++ b/documentation/docs/guides/configure-agent-mcp-proxies.mdx
@@ -8,6 +8,16 @@ Agents can be configured to use one or more [MCP Proxies](./register-mcp-proxy.m
 
 The agent does not embed the proxy. It references it, and the platform resolves the proxy's endpoint for the agent's target environment at deploy time. Because the org-level proxy owns its per-environment gateway artifacts, changing the proxy does not redeploy the agent automatically — the agent picks up any change on its next deployment.
 
+:::tip
+The API key described in this guide **authenticates** the agent: it proves the caller
+is allowed to reach the proxy at all. It says nothing about *which* tools that agent
+may invoke — any agent holding a valid key can call every tool the endpoint exposes.
+
+When you need that granularity(controling which agent access which tool). See
+[Authorize Agent Access to MCP Tools](./authorize-agent-access-to-mcp-tools.mdx),
+which covers per-tool **authorization** on top of authentication.
+:::
+
 ## Prerequisites
 
 - At least one MCP Proxy registered at the org level (see [Register an MCP Proxy](./register-mcp-proxy.mdx))
@@ -246,3 +256,4 @@ Use the **Search by name or description...** box to filter. Multiple configurati
 - For external agents, the Endpoint URL routes traffic through the AI Gateway, applying any security, access control, and rewrite rules configured on the endpoint serving that environment.
 - The external agent API Key is displayed only right after it is generated or rotated. If lost, rotate the key from the tool configuration's API key section (per environment) to obtain a new value.
 - A single proxy attached from the Configure page maps to every environment in the agent's pipeline; the proxy supplies each environment's endpoint. To use different proxies per environment, attach them during agent creation.
+- An API key controls **whether** an agent may call the proxy, not **which tools** it may call. For per-tool control, use an identity-secured proxy with scopes and roles — see [Authorize Agent Access to MCP Tools](./authorize-agent-access-to-mcp-tools.mdx).

--- a/documentation/docs/guides/on-k3d.mdx
+++ b/documentation/docs/guides/on-k3d.mdx
@@ -313,7 +313,7 @@ The Control Plane is configured with Backstage disabled (Agent Manager provides 
 ```bash
 helm install openchoreo-control-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-control-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-control-plane \
   --create-namespace \
   --timeout 600s \
@@ -324,7 +324,7 @@ kubectl wait --for=condition=Available \
 ```
 
 :::note Webhook race condition
-If the install fails with `no endpoints available for service "controller-manager-webhook-service"`, this is a known transient race in OpenChoreo v1.1.1. Wait for the control plane deployments to become ready, then rerun the `helm install` command.
+If the install fails with `no endpoints available for service "controller-manager-webhook-service"`, this is a known transient race in the OpenChoreo control-plane install. Wait for the control plane deployments to become ready, then rerun the `helm install` command.
 ```bash
 kubectl wait --for=condition=Available deployment --all \
   -n openchoreo-control-plane --timeout=300s
@@ -343,7 +343,7 @@ kubectl wait --for=condition=Available deployment --all \
 
 #### Patch the service-account entitlement claim (required with Thunder ≥ 0.45)
 
-Thunder 0.45+ puts the client name in the `client_id` claim (its `sub` is an opaque UUID), but OpenChoreo 1.1.1 extracts service-account entitlements from `sub`, and the chart does not expose the setting. Without this patch, every service-to-service call is **silently unauthorized** — the API returns `200` with empty lists and `403`s while all pods look healthy, and the gateway bootstrap later fails with `Environment 'default' not found`.
+Thunder 0.45+ puts the client name in the `client_id` claim (its `sub` is an opaque UUID), but OpenChoreo 1.2.0 extracts service-account entitlements from `sub`, and the chart does not expose the setting. Without this patch, every service-to-service call is **silently unauthorized** — the API returns `200` with empty lists and `403`s while all pods look healthy, and the gateway bootstrap later fails with `Environment 'default' not found`.
 
 ```bash
 patched_yaml=$(kubectl get configmap openchoreo-api-config -n openchoreo-control-plane -o yaml \
@@ -383,7 +383,7 @@ kubectl create configmap cluster-gateway-ca \
 ```bash
 helm install openchoreo-data-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-data-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-data-plane \
   --create-namespace \
   --timeout 600s \
@@ -450,12 +450,12 @@ helm upgrade --install registry docker-registry \
   --repo https://twuni.github.io/docker-registry.helm \
   --namespace openchoreo-workflow-plane \
   --create-namespace \
-  --values https://raw.githubusercontent.com/openchoreo/openchoreo/v1.1.1/install/k3d/single-cluster/values-registry.yaml \
+  --values https://raw.githubusercontent.com/openchoreo/openchoreo/v1.2.0/install/k3d/single-cluster/values-registry.yaml \
   --timeout 120s
 
 helm install openchoreo-workflow-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-workflow-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-workflow-plane \
   --create-namespace \
   --timeout 600s
@@ -575,7 +575,7 @@ Install the Observability Plane:
 ```bash
 helm install openchoreo-observability-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-observability-plane \
   --create-namespace \
   --timeout 25m \
@@ -603,7 +603,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.5.3 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --timeout 10m
@@ -612,7 +612,7 @@ helm upgrade --install observability-logs-opensearch \
 helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.5.3 \
   --reuse-values \
   --set fluent-bit.enabled=true \
   --timeout 10m
@@ -630,12 +630,20 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.6.0 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set opentelemetry-collector.configMap.existingName="amp-opentelemetry-collector-config" \
   --timeout 10m
 ```
+
+:::warning Pin the tracing module to 0.6.0 or later
+The OpenChoreo 1.2.0 observer returns a span's status as an object
+(`{code, message}`), but the tracing adapter at 0.5.0 and 0.5.1 still expects a
+string. With those versions the span-details endpoint returns `500` and traces are
+silently dropped. Upstream's own install script still pins 0.5.0; do not follow it
+here.
+:::
 
 Register the Observability Plane and link it to other planes:
 

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -787,7 +787,7 @@ Install the Control Plane with hostnames, TLS, and Thunder OIDC. The OpenChoreo 
 ```bash
 helm upgrade --install openchoreo-control-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-control-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-control-plane \
   --create-namespace \
   --values - <<EOF
@@ -828,7 +828,7 @@ kubectl wait --for=condition=Available \
 ```
 
 :::note Webhook race condition
-If the install fails with `no endpoints available for service "controller-manager-webhook-service"`, this is a known transient race in OpenChoreo v1.1.1. Wait for the control plane deployments to become ready, then rerun the `helm upgrade --install` command.
+If the install fails with `no endpoints available for service "controller-manager-webhook-service"`, this is a known transient race in the OpenChoreo control-plane install. Wait for the control plane deployments to become ready, then rerun the `helm upgrade --install` command.
 ```bash
 kubectl wait --for=condition=Available deployment --all \
   -n openchoreo-control-plane --timeout=300s
@@ -841,7 +841,7 @@ EKS LoadBalancers return a hostname instead of an IP — resolve it with `dig` w
 
 #### Patch the service-account entitlement claim (required with Thunder ≥ 0.45)
 
-Thunder 0.45+ puts the client name in the `client_id` claim (its `sub` is an opaque UUID), but OpenChoreo 1.1.1 extracts service-account entitlements from `sub`, and the chart does not expose the setting. Without this patch, every service-to-service call is **silently unauthorized** — the API returns `200` with empty lists and `403`s while all pods look healthy, and the gateway bootstrap later fails with `Environment 'default' not found`.
+Thunder 0.45+ puts the client name in the `client_id` claim (its `sub` is an opaque UUID), but OpenChoreo 1.2.0 extracts service-account entitlements from `sub`, and the chart does not expose the setting. Without this patch, every service-to-service call is **silently unauthorized** — the API returns `200` with empty lists and `403`s while all pods look healthy, and the gateway bootstrap later fails with `Environment 'default' not found`.
 
 ```bash
 patched_yaml=$(kubectl get configmap openchoreo-api-config -n openchoreo-control-plane -o yaml   | sed -E "s/claim:[[:space:]]*['\"]?sub['\"]?/claim: client_id/g")
@@ -924,7 +924,7 @@ kubectl wait --for=condition=Ready certificate/dp-gateway-tls \
 
 helm install openchoreo-data-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-data-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-data-plane \
   --create-namespace \
   --set clusterAgent.tls.generateCerts=true \
@@ -1021,7 +1021,7 @@ Install the Workflow Plane:
 ```bash
 helm install openchoreo-workflow-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-workflow-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-workflow-plane \
   --create-namespace \
   --set clusterAgent.tls.generateCerts=true \
@@ -1177,7 +1177,7 @@ kubectl wait --for=condition=Ready certificate/obs-gateway-tls \
 
 helm install openchoreo-observability-plane \
   oci://ghcr.io/openchoreo/helm-charts/openchoreo-observability-plane \
-  --version 1.1.1 \
+  --version 1.2.0 \
   --namespace openchoreo-observability-plane \
   --create-namespace \
   --set gateway.tls.enabled=true \
@@ -1218,7 +1218,7 @@ helm upgrade --install observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.5.3 \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials" \
   --set openSearch.persistence.size=100Gi \
@@ -1231,7 +1231,7 @@ helm upgrade --install observability-logs-opensearch \
 helm upgrade observability-logs-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-logs-opensearch \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.5.3 \
   --reuse-values \
   --set fluent-bit.enabled=true \
   --timeout 10m
@@ -1249,12 +1249,22 @@ helm upgrade --install observability-traces-opensearch \
   oci://ghcr.io/openchoreo/helm-charts/observability-tracing-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
-  --version 0.4.1 \
+  --version 0.6.0 \
   --set openSearch.enabled=false \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set opentelemetry-collector.configMap.existingName="amp-opentelemetry-collector-config" \
   --timeout 10m
 ```
+
+:::warning Pin the tracing module to 0.6.0 or later
+The OpenChoreo 1.2.0 observer returns a span's status as an object
+(`{code, message}`), but the tracing adapter at 0.5.0 and 0.5.1 still expects a
+string. With those versions the span-details endpoint returns `500` and traces are
+silently dropped — the traces list loads, individual traces do not open. 0.6.0
+handles the object form.
+
+Upstream's own install script still pins 0.5.0; do not follow it here.
+:::
 
 :::warning GKE: free port 2020 before enabling Fluent Bit
 Fluent Bit runs with `hostNetwork: true` (its Kubernetes filter reads from the node-local kubelet) and binds its monitoring server to **port 2020** on every node. GKE's built-in `fluentbit-gke` logging agent already occupies that port, so all Fluent Bit pods stay in `CrashLoopBackOff` with `Cannot listen on 0.0.0.0:2020` — and the only visible symptom is that logs never reach OpenSearch.

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -1256,16 +1256,6 @@ helm upgrade --install observability-traces-opensearch \
   --timeout 10m
 ```
 
-:::warning Pin the tracing module to 0.6.0 or later
-The OpenChoreo 1.2.0 observer returns a span's status as an object
-(`{code, message}`), but the tracing adapter at 0.5.0 and 0.5.1 still expects a
-string. With those versions the span-details endpoint returns `500` and traces are
-silently dropped — the traces list loads, individual traces do not open. 0.6.0
-handles the object form.
-
-Upstream's own install script still pins 0.5.0; do not follow it here.
-:::
-
 :::warning GKE: free port 2020 before enabling Fluent Bit
 Fluent Bit runs with `hostNetwork: true` (its Kubernetes filter reads from the node-local kubelet) and binds its monitoring server to **port 2020** on every node. GKE's built-in `fluentbit-gke` logging agent already occupies that port, so all Fluent Bit pods stay in `CrashLoopBackOff` with `Cannot listen on 0.0.0.0:2020` — and the only visible symptom is that logs never reach OpenSearch.
 


### PR DESCRIPTION
## Purpose
Refreshes the installation and MCP guides: the MCP authorization guide now walks a real public server
the install guides move to OpenChoreo 1.2.0, and the

## Goals
- Let readers try the MCP tool-authorization flow against a server that already
  exists, rather than one they have to build.
- Bring the install guides in line with `deployments/setup/env.sh` and
  `deployments/quick-start/install.sh`.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the generic MCP authorization example with a GitHub-hosted MCP walkthrough, including OAuth setup, scopes, roles, tools, and verification steps.
  * Clarified that API keys control proxy access, while tool permissions are managed separately.
  * Updated local installation guides to OpenChoreo 1.2.0 and refreshed observability and tracing module versions.
  * Added compatibility guidance warning that older tracing adapters can cause failed span details and dropped traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->