### PR TITLE
enable LLM provider rename and clarify create-conflict error

### DIFF
--- a/agent-manager-service/controllers/llm_controller.go
+++ b/agent-manager-service/controllers/llm_controller.go
@@ -301,12 +301,18 @@ func (c *llmController) DeleteLLMProviderTemplate(w http.ResponseWriter, r *http
 
 // writeCreateLLMProviderError maps service errors from Create/CreateAndDeploy to HTTP responses.
 // Returns true if an error was written (caller should return), false if err is nil.
-func writeCreateLLMProviderError(w http.ResponseWriter, r *http.Request, ouID, templateHandle, providerName string, err error) {
+func writeCreateLLMProviderError(w http.ResponseWriter, r *http.Request, ouID, templateHandle, providerName, providerHandle string, err error) {
 	log := logger.GetLogger(r.Context())
 	switch {
 	case errors.Is(err, utils.ErrLLMProviderExists):
-		log.Warn("CreateLLMProvider: provider already exists", "ouID", ouID, "providerName", providerName)
-		utils.WriteErrorResponse(w, http.StatusConflict, "LLM provider already exists")
+		log.Warn("CreateLLMProvider: provider already exists", "ouID", ouID, "providerName", providerName, "providerHandle", providerHandle)
+		// The ID is auto-generated from the name and is what's actually unique (not the
+		// display name, which can be reused) — renaming a provider never changes its ID,
+		// so this collision can surface even when no provider currently shows this name.
+		utils.WriteErrorResponse(w, http.StatusConflict, fmt.Sprintf(
+			"A provider with the ID %q already exists (auto-generated from the name). Try a different name, or rename/delete the existing provider first.",
+			providerHandle,
+		))
 	case errors.Is(err, utils.ErrLLMProviderTemplateNotFound):
 		log.Error("CreateLLMProvider: template not found", "ouID", ouID, "templateHandle", templateHandle, "error", err)
 		utils.WriteErrorResponse(w, http.StatusBadRequest, "Referenced template not found")
@@ -351,7 +357,7 @@ func (c *llmController) CreateLLMProvider(w http.ResponseWriter, r *http.Request
 		log.Info("CreateLLMProvider: creating and deploying provider to gateways", "ouID", ouID, "gatewayCount", len(req.Gateways))
 		resp, err := c.providerService.CreateAndDeploy(ctx, ouID, "system", provider, req.Gateways, c.deploymentService)
 		if err != nil {
-			writeCreateLLMProviderError(w, r, ouID, req.Template, provider.Configuration.Name, err)
+			writeCreateLLMProviderError(w, r, ouID, req.Template, provider.Configuration.Name, provider.Configuration.Handle, err)
 			return
 		}
 		created = resp.Provider
@@ -372,7 +378,7 @@ func (c *llmController) CreateLLMProvider(w http.ResponseWriter, r *http.Request
 		var err error
 		created, err = c.providerService.Create(ctx, ouID, "system", provider)
 		if err != nil {
-			writeCreateLLMProviderError(w, r, ouID, req.Template, provider.Configuration.Name, err)
+			writeCreateLLMProviderError(w, r, ouID, req.Template, provider.Configuration.Name, provider.Configuration.Handle, err)
 			return
 		}
 	}

--- a/agent-manager-service/repositories/llm_provider_repository.go
+++ b/agent-manager-service/repositories/llm_provider_repository.go
@@ -203,7 +203,7 @@ func (r *LLMProviderRepo) Update(p *models.LLMProvider, providerID string, orgUU
 	return r.db.Transaction(func(tx *gorm.DB) error {
 		slog.Info("LLMProviderRepo.Update: resolved UUID", "providerID", providerID)
 
-		_, err := uuid.Parse(providerID)
+		parsedUUID, err := uuid.Parse(providerID)
 		if err != nil {
 			return fmt.Errorf("error parsing provider id: %s, error: %w", providerID, err)
 		}
@@ -227,6 +227,21 @@ func (r *LLMProviderRepo) Update(p *models.LLMProvider, providerID string, orgUU
 		if result.RowsAffected == 0 {
 			slog.Warn("LLMProviderRepo.Update: no rows affected", "handle", providerID)
 			return gorm.ErrRecordNotFound
+		}
+
+		// The displayed name (list + detail responses) is read from the artifacts
+		// table, not from configuration.name — keep them in sync or a rename is a
+		// silent no-op from the user's perspective.
+		if p.Configuration.Name != "" {
+			slog.Info("LLMProviderRepo.Update: updating artifact name", "handle", providerID)
+			if err := r.artifactRepo.Update(tx, &models.Artifact{
+				UUID: parsedUUID,
+				OUID: orgUUID,
+				Name: p.Configuration.Name,
+			}); err != nil {
+				slog.Error("LLMProviderRepo.Update: failed to update artifact name", "handle", providerID, "error", err)
+				return fmt.Errorf("failed to update artifact name: %w", err)
+			}
 		}
 
 		slog.Info("LLMProviderRepo.Update: completed successfully", "handle", providerID, "rowsAffected", result.RowsAffected)

--- a/agent-manager-service/repositories/llm_provider_repository.go
+++ b/agent-manager-service/repositories/llm_provider_repository.go
@@ -41,7 +41,7 @@ type LLMProviderRepository interface {
 	GetByHandle(handle, orgUUID string) (*models.LLMProvider, error)
 	List(orgUUID string, limit, offset int) ([]*models.LLMProvider, error)
 	Count(orgUUID string) (int, error)
-	Update(p *models.LLMProvider, providerID string, orgUUID string) error
+	Update(ctx context.Context, p *models.LLMProvider, providerID string, orgUUID string) error
 	Delete(providerID, orgUUID string) error
 	Exists(providerID, orgUUID string) (bool, error)
 	HasAssociatedProxies(ctx context.Context, providerUUID uuid.UUID) (bool, error)
@@ -197,10 +197,10 @@ func (r *LLMProviderRepo) Count(orgUUID string) (int, error) {
 }
 
 // Update modifies an existing LLM provider
-func (r *LLMProviderRepo) Update(p *models.LLMProvider, providerID string, orgUUID string) error {
+func (r *LLMProviderRepo) Update(ctx context.Context, p *models.LLMProvider, providerID string, orgUUID string) error {
 	slog.Info("LLMProviderRepo.Update: starting", "providerID", providerID, "orgUUID", orgUUID)
 
-	return r.db.Transaction(func(tx *gorm.DB) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		slog.Info("LLMProviderRepo.Update: resolved UUID", "providerID", providerID)
 
 		parsedUUID, err := uuid.Parse(providerID)
@@ -234,7 +234,7 @@ func (r *LLMProviderRepo) Update(p *models.LLMProvider, providerID string, orgUU
 		// silent no-op from the user's perspective.
 		if p.Configuration.Name != "" {
 			slog.Info("LLMProviderRepo.Update: updating artifact name", "handle", providerID)
-			if err := r.artifactRepo.Update(tx, &models.Artifact{
+			if err := r.artifactRepo.Update(tx.WithContext(ctx), &models.Artifact{
 				UUID: parsedUUID,
 				OUID: orgUUID,
 				Name: p.Configuration.Name,

--- a/agent-manager-service/repositories/llm_provider_repository_test.go
+++ b/agent-manager-service/repositories/llm_provider_repository_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package repositories
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/wso2/agent-manager/agent-manager-service/db"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
+)
+
+// TestLLMProviderRepo_Update_SyncsArtifactName guards against a regression
+// where renaming a provider updated configuration.name (an internal JSONB
+// field) but left artifacts.name untouched. Every read path — both the list
+// and detail LLM provider responses — serves the display name from
+// artifacts.name (see utils.ConvertModelToSpecLLMProvider{ListItem}Response),
+// so without this sync a rename silently never shows up anywhere in the API.
+func TestLLMProviderRepo_Update_SyncsArtifactName(t *testing.T) {
+	gdb := db.GetDB()
+	repo := NewLLMProviderRepo(gdb)
+	orgUUID := uuid.New().String()
+
+	provider := &models.LLMProvider{
+		TemplateHandle: "openai",
+		Configuration: models.LLMProviderConfig{
+			Name:     "Original Name",
+			Handle:   "rename-sync-test-provider",
+			Version:  "v1.0",
+			Template: "openai",
+		},
+		Status: "CREATED",
+	}
+	require.NoError(t, repo.Create(gdb, provider, provider.Configuration.Handle,
+		provider.Configuration.Name, provider.Configuration.Version, orgUUID))
+
+	t.Cleanup(func() {
+		gdb.Exec("DELETE FROM llm_providers WHERE uuid = ?", provider.UUID)
+		gdb.Exec("DELETE FROM artifacts WHERE uuid = ?", provider.UUID)
+	})
+
+	updates := &models.LLMProvider{
+		Configuration: models.LLMProviderConfig{
+			Name:     "Renamed Provider",
+			Handle:   provider.Configuration.Handle,
+			Version:  provider.Configuration.Version,
+			Template: provider.Configuration.Template,
+		},
+	}
+	require.NoError(t, repo.Update(updates, provider.UUID.String(), orgUUID))
+
+	var artifact models.Artifact
+	require.NoError(t, gdb.First(&artifact, "uuid = ?", provider.UUID).Error)
+	require.Equal(t, "Renamed Provider", artifact.Name,
+		"Update must sync the new name into artifacts.name — that's what every read path serves as the provider's display name")
+}
+
+// TestLLMProviderRepo_Update_EmptyNameLeavesArtifactNameUnchanged confirms an
+// update that carries no name (Configuration.Name == "") does not blank out
+// the artifact's existing name — ArtifactRepo.Update conditionally applies
+// each field, so this only holds if callers keep passing "" rather than a
+// literal empty-string overwrite.
+func TestLLMProviderRepo_Update_EmptyNameLeavesArtifactNameUnchanged(t *testing.T) {
+	gdb := db.GetDB()
+	repo := NewLLMProviderRepo(gdb)
+	orgUUID := uuid.New().String()
+
+	provider := &models.LLMProvider{
+		TemplateHandle: "openai",
+		Configuration: models.LLMProviderConfig{
+			Name:     "Keep This Name",
+			Handle:   "rename-sync-test-provider-2",
+			Version:  "v1.0",
+			Template: "openai",
+		},
+		Status: "CREATED",
+	}
+	require.NoError(t, repo.Create(gdb, provider, provider.Configuration.Handle,
+		provider.Configuration.Name, provider.Configuration.Version, orgUUID))
+
+	t.Cleanup(func() {
+		gdb.Exec("DELETE FROM llm_providers WHERE uuid = ?", provider.UUID)
+		gdb.Exec("DELETE FROM artifacts WHERE uuid = ?", provider.UUID)
+	})
+
+	updates := &models.LLMProvider{
+		Description: "updated description only",
+		Configuration: models.LLMProviderConfig{
+			Handle:   provider.Configuration.Handle,
+			Version:  provider.Configuration.Version,
+			Template: provider.Configuration.Template,
+		},
+	}
+	require.NoError(t, repo.Update(updates, provider.UUID.String(), orgUUID))
+
+	var artifact models.Artifact
+	require.NoError(t, gdb.First(&artifact, "uuid = ?", provider.UUID).Error)
+	require.Equal(t, "Keep This Name", artifact.Name)
+}

--- a/agent-manager-service/repositories/llm_provider_repository_test.go
+++ b/agent-manager-service/repositories/llm_provider_repository_test.go
@@ -19,6 +19,7 @@
 package repositories
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/uuid"
@@ -65,7 +66,7 @@ func TestLLMProviderRepo_Update_SyncsArtifactName(t *testing.T) {
 			Template: provider.Configuration.Template,
 		},
 	}
-	require.NoError(t, repo.Update(updates, provider.UUID.String(), orgUUID))
+	require.NoError(t, repo.Update(context.Background(), updates, provider.UUID.String(), orgUUID))
 
 	var artifact models.Artifact
 	require.NoError(t, gdb.First(&artifact, "uuid = ?", provider.UUID).Error)
@@ -109,7 +110,7 @@ func TestLLMProviderRepo_Update_EmptyNameLeavesArtifactNameUnchanged(t *testing.
 			Template: provider.Configuration.Template,
 		},
 	}
-	require.NoError(t, repo.Update(updates, provider.UUID.String(), orgUUID))
+	require.NoError(t, repo.Update(context.Background(), updates, provider.UUID.String(), orgUUID))
 
 	var artifact models.Artifact
 	require.NoError(t, gdb.First(&artifact, "uuid = ?", provider.UUID).Error)

--- a/agent-manager-service/repositories/repomocks/llm_provider_repository_mock.go
+++ b/agent-manager-service/repositories/repomocks/llm_provider_repository_mock.go
@@ -51,7 +51,7 @@ import (
 //			MarkDeletingFunc: func(providerUUID uuid.UUID) (bool, error) {
 //				panic("mock out the MarkDeleting method")
 //			},
-//			UpdateFunc: func(p *models.LLMProvider, providerID string, orgUUID string) error {
+//			UpdateFunc: func(ctx context.Context, p *models.LLMProvider, providerID string, orgUUID string) error {
 //				panic("mock out the Update method")
 //			},
 //		}
@@ -95,7 +95,7 @@ type LLMProviderRepositoryMock struct {
 	MarkDeletingFunc func(providerUUID uuid.UUID) (bool, error)
 
 	// UpdateFunc mocks the Update method.
-	UpdateFunc func(p *models.LLMProvider, providerID string, orgUUID string) error
+	UpdateFunc func(ctx context.Context, p *models.LLMProvider, providerID string, orgUUID string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -184,6 +184,8 @@ type LLMProviderRepositoryMock struct {
 		}
 		// Update holds details about calls to the Update method.
 		Update []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// P is the p argument value.
 			P *models.LLMProvider
 			// ProviderID is the providerID argument value.
@@ -615,15 +617,17 @@ func (mock *LLMProviderRepositoryMock) MarkDeletingCalls() []struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *LLMProviderRepositoryMock) Update(p *models.LLMProvider, providerID string, orgUUID string) error {
+func (mock *LLMProviderRepositoryMock) Update(ctx context.Context, p *models.LLMProvider, providerID string, orgUUID string) error {
 	if mock.UpdateFunc == nil {
 		panic("LLMProviderRepositoryMock.UpdateFunc: method is nil but LLMProviderRepository.Update was just called")
 	}
 	callInfo := struct {
+		Ctx        context.Context
 		P          *models.LLMProvider
 		ProviderID string
 		OrgUUID    string
 	}{
+		Ctx:        ctx,
 		P:          p,
 		ProviderID: providerID,
 		OrgUUID:    orgUUID,
@@ -631,7 +635,7 @@ func (mock *LLMProviderRepositoryMock) Update(p *models.LLMProvider, providerID 
 	mock.lockUpdate.Lock()
 	mock.calls.Update = append(mock.calls.Update, callInfo)
 	mock.lockUpdate.Unlock()
-	return mock.UpdateFunc(p, providerID, orgUUID)
+	return mock.UpdateFunc(ctx, p, providerID, orgUUID)
 }
 
 // UpdateCalls gets all the calls that were made to Update.
@@ -639,11 +643,13 @@ func (mock *LLMProviderRepositoryMock) Update(p *models.LLMProvider, providerID 
 //
 //	len(mockedLLMProviderRepository.UpdateCalls())
 func (mock *LLMProviderRepositoryMock) UpdateCalls() []struct {
+	Ctx        context.Context
 	P          *models.LLMProvider
 	ProviderID string
 	OrgUUID    string
 } {
 	var calls []struct {
+		Ctx        context.Context
 		P          *models.LLMProvider
 		ProviderID string
 		OrgUUID    string

--- a/agent-manager-service/services/llm_provider_service.go
+++ b/agent-manager-service/services/llm_provider_service.go
@@ -595,7 +595,7 @@ func (s *LLMProviderService) Update(ctx context.Context, providerID, ouID string
 
 	// Update provider
 	slog.Info("LLMProviderService.Update: updating provider in database", "ouID", ouID, "providerID", providerID)
-	if err := s.providerRepo.Update(updates, providerID, ouID); err != nil {
+	if err := s.providerRepo.Update(ctx, updates, providerID, ouID); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			slog.Warn("LLMProviderService.Update: provider not found", "ouID", ouID, "providerID", providerID)
 			return nil, utils.ErrLLMProviderNotFound

--- a/agent-manager-service/services/llm_provider_service_test.go
+++ b/agent-manager-service/services/llm_provider_service_test.go
@@ -269,7 +269,7 @@ func TestLLMProviderService_UpdateAndSync_RejectsPlacementInvalidGatewayWithoutU
 		GetByUUIDFunc: func(id, _ string) (*models.LLMProvider, error) {
 			return &models.LLMProvider{UUID: uuid.MustParse(id)}, nil
 		},
-		UpdateFunc: func(_ *models.LLMProvider, _, _ string) error {
+		UpdateFunc: func(_ context.Context, _ *models.LLMProvider, _, _ string) error {
 			return nil
 		},
 	}

--- a/console/workspaces/pages/llm-providers/src/form/schema.ts
+++ b/console/workspaces/pages/llm-providers/src/form/schema.ts
@@ -80,3 +80,20 @@ export const addLLMProviderSchema = z.object({
 });
 
 export type AddLLMProviderFormValues = z.infer<typeof addLLMProviderSchema>;
+
+export const editLLMProviderSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Name is required")
+    .min(2, "Name must be at least 2 characters")
+    .max(120, "Name must be at most 120 characters"),
+  description: z
+    .string()
+    .trim()
+    .max(512, "Description cannot exceed 512 characters")
+    .optional()
+    .or(z.literal("")),
+});
+
+export type EditLLMProviderFormValues = z.infer<typeof editLLMProviderSchema>;

--- a/console/workspaces/pages/llm-providers/src/subComponents/EditLLMProviderDrawer.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/EditLLMProviderDrawer.tsx
@@ -29,6 +29,7 @@ import {
   Typography,
 } from "@wso2/oxygen-ui";
 import { Edit } from "@wso2/oxygen-ui-icons-react";
+import { getErrorMessage } from "@agent-management-platform/shared-component";
 import {
   DrawerWrapper,
   DrawerHeader,
@@ -120,9 +121,7 @@ export function EditLLMProviderDrawer({
         });
         onClose();
       } catch (err) {
-        setSaveError(
-          err instanceof Error ? err.message : "Failed to update LLM provider",
-        );
+        setSaveError(getErrorMessage(err) || "Failed to update LLM provider");
       }
     },
     [formData, validateForm, onUpdate, onClose],

--- a/console/workspaces/pages/llm-providers/src/subComponents/EditLLMProviderDrawer.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/EditLLMProviderDrawer.tsx
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Collapse,
+  Form,
+  FormControl,
+  FormLabel,
+  Stack,
+  TextField,
+  Typography,
+} from "@wso2/oxygen-ui";
+import { Edit } from "@wso2/oxygen-ui-icons-react";
+import {
+  DrawerWrapper,
+  DrawerHeader,
+  DrawerContent,
+  useFormValidation,
+} from "@agent-management-platform/views";
+import type {
+  LLMProviderResponse,
+  UpdateLLMProviderRequest,
+} from "@agent-management-platform/types";
+import {
+  editLLMProviderSchema,
+  type EditLLMProviderFormValues,
+} from "../form/schema";
+
+interface EditLLMProviderDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  provider: LLMProviderResponse;
+  onUpdate: (fields: UpdateLLMProviderRequest) => Promise<LLMProviderResponse>;
+  isUpdating: boolean;
+}
+
+export function EditLLMProviderDrawer({
+  open,
+  onClose,
+  provider,
+  onUpdate,
+  isUpdating,
+}: EditLLMProviderDrawerProps) {
+  const [formData, setFormData] = useState<EditLLMProviderFormValues>({
+    name: provider.name ?? "",
+    description: provider.description ?? "",
+  });
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const { errors, validateForm, setFieldError, validateField } =
+    useFormValidation<EditLLMProviderFormValues>(editLLMProviderSchema);
+
+  const [lastSubmittedValidationErrors, setLastSubmittedValidationErrors] =
+    useState<Partial<Record<keyof EditLLMProviderFormValues, string>>>({});
+
+  useEffect(() => {
+    if (open) {
+      setFormData({
+        name: provider.name ?? "",
+        description: provider.description ?? "",
+      });
+      setLastSubmittedValidationErrors({});
+      setSaveError(null);
+    }
+  }, [provider, open]);
+
+  const handleFieldChange = useCallback(
+    (field: keyof EditLLMProviderFormValues, value: string) => {
+      setFormData((prev) => {
+        const next = { ...prev, [field]: value };
+        const fieldError = validateField(field, next[field], next);
+        setFieldError(field, fieldError);
+        return next;
+      });
+    },
+    [setFieldError, validateField],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      const result = editLLMProviderSchema.safeParse(formData);
+      if (!result.success) {
+        const fieldErrors: Partial<Record<keyof EditLLMProviderFormValues, string>> = {};
+        result.error.issues.forEach((issue) => {
+          if (issue.path[0]) {
+            fieldErrors[issue.path[0] as keyof EditLLMProviderFormValues] =
+              issue.message;
+          }
+        });
+        setLastSubmittedValidationErrors(fieldErrors);
+        validateForm(formData); // syncs errors to form fields
+        return;
+      }
+      setLastSubmittedValidationErrors({});
+      setSaveError(null);
+
+      try {
+        await onUpdate({
+          name: formData.name.trim(),
+          description: formData.description?.trim() || undefined,
+        });
+        onClose();
+      } catch (err) {
+        setSaveError(
+          err instanceof Error ? err.message : "Failed to update LLM provider",
+        );
+      }
+    },
+    [formData, validateForm, onUpdate, onClose],
+  );
+
+  const validationErrorsList = Object.values(lastSubmittedValidationErrors).filter(
+    Boolean,
+  );
+  const hasValidationErrors = validationErrorsList.length > 0;
+
+  return (
+    <DrawerWrapper open={open} onClose={onClose}>
+      <DrawerHeader
+        icon={<Edit size={24} />}
+        title="Edit LLM Provider"
+        onClose={onClose}
+      />
+      <DrawerContent>
+        <form onSubmit={handleSubmit}>
+          <Stack spacing={3}>
+            {saveError && (
+              <Alert severity="error">
+                <Typography variant="body2">{saveError}</Typography>
+              </Alert>
+            )}
+
+            <Collapse in={hasValidationErrors} timeout="auto" unmountOnExit>
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {validationErrorsList.map((error, index) => (
+                  <Box key={index}>{error}</Box>
+                ))}
+              </Alert>
+            </Collapse>
+
+            <Form.Section>
+              <Form.Header>Provider Details</Form.Header>
+              <Form.Stack spacing={2}>
+                <FormControl fullWidth error={Boolean(errors.name)}>
+                  <FormLabel required>Name</FormLabel>
+                  <TextField
+                    fullWidth
+                    size="small"
+                    value={formData.name}
+                    onChange={(e) => handleFieldChange("name", e.target.value)}
+                    placeholder="e.g., Production OpenAI"
+                    error={Boolean(errors.name)}
+                    helperText={errors.name}
+                    disabled={isUpdating}
+                  />
+                </FormControl>
+                <FormControl fullWidth error={Boolean(errors.description)}>
+                  <FormLabel>Description</FormLabel>
+                  <TextField
+                    fullWidth
+                    multiline
+                    minRows={2}
+                    size="small"
+                    value={formData.description}
+                    onChange={(e) =>
+                      handleFieldChange("description", e.target.value)
+                    }
+                    placeholder="Optional description"
+                    error={Boolean(errors.description)}
+                    helperText={errors.description}
+                    disabled={isUpdating}
+                  />
+                </FormControl>
+              </Form.Stack>
+            </Form.Section>
+
+            <Box display="flex" justifyContent="flex-end" gap={1} mt={2}>
+              <Button
+                variant="outlined"
+                color="inherit"
+                onClick={onClose}
+                disabled={isUpdating}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                disabled={isUpdating}
+              >
+                {isUpdating ? "Saving..." : "Save"}
+              </Button>
+            </Box>
+          </Stack>
+        </form>
+      </DrawerContent>
+    </DrawerWrapper>
+  );
+}

--- a/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
@@ -160,14 +160,19 @@ export const ViewLLMProvider: React.FC = () => {
       titleTail={
         <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 1 }}>
           <Tooltip title="Edit provider name and description">
-            <IconButton
-              size="small"
-              onClick={() => setIsEditDrawerOpen(true)}
-              aria-label="Edit provider"
-              disabled={!providerData}
-            >
-              <Edit size={16} />
-            </IconButton>
+            {/* MUI/oxygen-ui Tooltip needs a non-disabled child to receive
+                pointer/focus events — a disabled IconButton alone never
+                triggers the tooltip. */}
+            <span>
+              <IconButton
+                size="small"
+                onClick={() => setIsEditDrawerOpen(true)}
+                aria-label="Edit provider"
+                disabled={!providerData}
+              >
+                <Edit size={16} />
+              </IconButton>
+            </span>
           </Tooltip>
           {templateDisplayName && (
             <Chip

--- a/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
@@ -33,11 +33,15 @@ import {
   Card,
   Chip,
   Divider,
+  IconButton,
   Stack,
   Tab,
   Tabs,
+  Tooltip,
 } from "@wso2/oxygen-ui";
+import { Edit } from "@wso2/oxygen-ui-icons-react";
 import { generatePath, useParams } from "react-router-dom";
+import { EditLLMProviderDrawer } from "./EditLLMProviderDrawer";
 import { LLMProviderAccessControlTab } from "./LLMProviderAccessControlTab";
 import { LLMProviderAPIKeysTab } from "./LLMProviderAPIKeysTab";
 import { LLMProviderConnectionTab } from "./LLMProviderConnectionTab";
@@ -81,6 +85,7 @@ function TabPanel({ value, index, children }: TabPanelProps) {
 
 export const ViewLLMProvider: React.FC = () => {
   const [tabIndex, setTabIndex] = useState(0);
+  const [isEditDrawerOpen, setIsEditDrawerOpen] = useState(false);
 
   const { providerId, orgId } = useParams<{
     providerId: string;
@@ -154,6 +159,16 @@ export const ViewLLMProvider: React.FC = () => {
       }
       titleTail={
         <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 1 }}>
+          <Tooltip title="Edit provider name and description">
+            <IconButton
+              size="small"
+              onClick={() => setIsEditDrawerOpen(true)}
+              aria-label="Edit provider"
+              disabled={!providerData}
+            >
+              <Edit size={16} />
+            </IconButton>
+          </Tooltip>
           {templateDisplayName && (
             <Chip
               label={templateDisplayName}
@@ -311,6 +326,15 @@ export const ViewLLMProvider: React.FC = () => {
           </Box>
         </Card>
       </Stack>
+      {providerData && (
+        <EditLLMProviderDrawer
+          open={isEditDrawerOpen}
+          onClose={() => setIsEditDrawerOpen(false)}
+          provider={providerData}
+          onUpdate={updateProvider}
+          isUpdating={isUpdating}
+        />
+      )}
     </PageLayout>
   );
 };

--- a/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
@@ -30,14 +30,13 @@ import {
 import { CreatedMetadata, PageLayout } from "@agent-management-platform/views";
 import {
   Box,
+  Button,
   Card,
   Chip,
   Divider,
-  IconButton,
   Stack,
   Tab,
   Tabs,
-  Tooltip,
 } from "@wso2/oxygen-ui";
 import { Edit } from "@wso2/oxygen-ui-icons-react";
 import { generatePath, useParams } from "react-router-dom";
@@ -157,23 +156,20 @@ export const ViewLLMProvider: React.FC = () => {
           ? { src: templateLogoUrl, alt: templateDisplayName, color: "transparent" }
           : undefined
       }
+      actions={
+        providerData ? (
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<Edit size={16} />}
+            onClick={() => setIsEditDrawerOpen(true)}
+          >
+            Edit LLM Provider
+          </Button>
+        ) : undefined
+      }
       titleTail={
         <Stack direction="row" spacing={1} alignItems="center" sx={{ ml: 1 }}>
-          <Tooltip title="Edit provider name and description">
-            {/* MUI/oxygen-ui Tooltip needs a non-disabled child to receive
-                pointer/focus events — a disabled IconButton alone never
-                triggers the tooltip. */}
-            <span>
-              <IconButton
-                size="small"
-                onClick={() => setIsEditDrawerOpen(true)}
-                aria-label="Edit provider"
-                disabled={!providerData}
-              >
-                <Edit size={16} />
-              </IconButton>
-            </span>
-          </Tooltip>
           {templateDisplayName && (
             <Chip
               label={templateDisplayName}


### PR DESCRIPTION
## Purpose
Resolves #1769. No visible option existed to rename an LLM provider, and the backend silently failed to persist renames even via direct API calls.

## Goals
- Let users rename an LLM provider (name + description) from the console.
- Fix the backend so a rename actually persists and shows up everywhere (list + detail).
- Give a clearer error when provider creation collides on the auto-generated ID.

## Approach
Added an "Edit LLM Provider" button opening a drawer with Name/Description fields, wired to the existing update API. 

Root cause: LLMProviderRepo.Update wrote the new name into configuration.name (JSONB), but every read path serves the display name from artifacts.name, a separate table Update never touched. Fixed by syncing artifacts.name in the same transaction. 

Also improved the 409 message on provider creation to name the colliding auto-generated ID instead of a generic "already exists".

https://github.com/user-attachments/assets/736fc0d6-04ba-444e-ae87-fa1c9f2d337a

## User stories
As a console user, I can rename an LLM provider and see the new name reflected immediately in both the list and detail views.

## Release note
Fixed LLM Service Providers not supporting renames, added an Edit action to update a provider's name and description.

## Documentation
N/A 

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests: Added llm_provider_repository_test.go covering artifact-name sync on update and no-op when name is empty.
- Integration tests: Manually verified end-to-end via running local stack.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no
- Confirmed no secrets committed: yes

## Samples
N/A

## Related PRs
None

## Migrations
N/A

## Test environment
Dev setup

## Learning
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Edit LLM Provider” action for updating a provider’s name and description.
  * Added validation for required names and description length limits.
  * Displays validation and save errors during editing.

* **Bug Fixes**
  * Provider artifact names now stay synchronized when a provider is renamed.
  * Existing artifact names remain unchanged when no new provider name is supplied.
  * More informative conflict messages explain how provider IDs are generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->