### PR TITLE
Attribute evaluation runs to an organisation

### DIFF
--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
@@ -23,6 +23,11 @@ spec:
       # app.kubernetes.io/component there would also export it for every platform
       # pod that happens to follow the same convention, which is a lot of them.
       amp.wso2.com/workload: evaluation
+      # The organisation's billing identifier, without which an evaluation run
+      # is measurable but chargeable to nobody. Passed in as a parameter because
+      # this is an Argo template: the OpenChoreo Workflow that invokes it has the
+      # value in its substitution context, this does not.
+      cloud.wso2.com/orguuid: '{{ "{{" }}workflow.parameters.org-uuid{{ "}}" }}'
       # Tenant identity for usage attribution. kube-state-metrics exports pod
       # labels on kube_pod_labels only, and only the keys in its allowlist, so
       # these four are what makes an evaluation run attributable to a tenant.
@@ -34,6 +39,7 @@ spec:
     parameters:
       - name: monitor-name
       - name: organization
+      - name: org-uuid
       - name: project
       - name: agent
       - name: environment

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/workflow-monitor-evaluation.yaml
@@ -148,6 +148,15 @@ spec:
             value: ${parameters.monitor.name}
           - name: organization
             value: ${parameters.organization}
+          # The organisation's billing identifier, read off the workflow run.
+          # This is where it is reachable: the run carries it as a label, and the
+          # Argo template this invokes has no substitution context of its own --
+          # which is why it travels as a parameter rather than being read there.
+          #
+          # It is the identifier and not the namespace name above because the
+          # collector requires a UUID, and that name is a hash of one.
+          - name: org-uuid
+            value: ${metadata.labels['cloud.wso2.com/orguuid']}
           - name: project
             value: ${parameters.project}
           - name: agent


### PR DESCRIPTION
## Purpose
Evaluation compute cannot be billed. The pods carry nothing that identifies the organisation, and the collector requires a UUID — the organisation namespace name that is available is a hash of one, so it cannot be converted.

Measured on the dev cloud workflow plane: **0 of 71** `workflows-*` namespaces carry any `cloud.wso2.com` label, and evaluation pods carry four Argo/app labels and no tenant identity.

## Goals
Make an evaluation run attributable to an organisation, a project, a component and an environment, and separable from a build run.

## Approach
The identifier is reachable, but not from where the pod labels are set. The Argo template that defines those labels has only Argo's parameter templating; the OpenChoreo `Workflow` that invokes it has the substitution context, and the workflow run carries the identifier as a label (verified: 109 of 109 runs on the control plane). So it travels as a parameter — read once where it exists, stamped where it is needed.

`amp.wso2.com/workload` separates evaluation pods from build pods, which share the `workflows-<org>` namespace and are otherwise identical on `kube_pod_labels`. A dedicated key rather than `app.kubernetes.io/component`, because the exporter's allowlist is cluster-wide and dozens of platform pods carry that convention label.

### Why not put the labels on the run template
It would read more directly. But pod metadata on the run **replaces** the template's rather than merging with it, and the template's carries the label the egress network policy selects on — so that shape trades an attribution gap for a connectivity one.

## User stories
N/A — telemetry labelling with no user-facing surface.

## Release note
Evaluation runs now carry tenant identity labels, so evaluation compute can be attributed to an organisation.

## Documentation
N/A — internal labels.

## Training
N/A.

## Certification
N/A.

## Marketing
N/A.

## Automation tests
- Unit tests
  > N/A — Argo/Helm templates, no unit-test harness.
- Integration tests
  > Rendered with `kubectl kustomize` / `helm template`, confirming the labels and the new parameter appear and that the network-policy selector label is untouched. Post-deploy the check is a query for `kube_pod_labels{namespace=~"workflows-.*", label_cloud_wso2_com_orguuid!=""}` against the observability plane after an evaluation run — not an inspection of the template.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — templates only.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A.

## Migrations (if applicable)
Additive. Evaluation runs already in flight keep their current label set; they are short-lived, so the gap closes within a run. Until the caller side of the parameter is in place the label renders empty, which the meters treat as unattributable and count rather than publish — the same outcome as today, reported rather than silent.

## Test environment
Rendered locally; label and namespace coverage measured read-only on the dev cloud clusters.

## Related PRs
The caller side of the `org-uuid` parameter is a matching change where the invoking OpenChoreo Workflow is defined. Both are needed before the label carries a value.

## Learning
The pod labels and the identifier live in two different templating systems, and the boundary between them is invisible in either file on its own. Worth checking which substitution context a template actually gets before assuming a value is reachable in it — the same mistake would have looked like a working change right up to the point where the label rendered empty.
