### PR TITLE
Mark agent pods for usage metering

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-types/agent-api.yaml
@@ -146,7 +146,21 @@ spec:
         spec:
           podTemplate:
             metadata:
-              labels: ${metadata.podSelectors}
+              # amp.wso2.com/workload is the usage-metering marker, matching the
+              # build and evaluation pods that already carry workload=build and
+              # workload=evaluation. The runtime recording rules scope on it so
+              # that a data plane shared with other workloads is not measured as
+              # agent runtime; a pod that is missing it is dropped from the meter
+              # rather than counted, which under-reports rather than over-charges.
+              #
+              # Merged into the pod template's labels only. It must never be added
+              # to podSelectors, which feeds spec.selector.matchLabels on the
+              # rendered objects -- Kubernetes makes that immutable once created.
+              #
+              # SandboxWarmPool pods inherit this through sandboxTemplateRef, and
+              # the Service selector uses podSelectors (a subset), so it still
+              # matches.
+              labels: '${oc_merge(metadata.podSelectors, {"amp.wso2.com/workload": "agent"})}'
               annotations:
                 openchoreo.dev/restarted-at: ${environmentConfigs.restartedAt}
             spec:


### PR DESCRIPTION
## Purpose

Usage metering measures the compute an agent reserves by selecting pods in the data-plane namespaces. Those namespaces can hold workloads that are not agents, so a namespace selector on its own cannot separate agent runtime from anything else sharing the data plane, and compute that is not an agent's can be measured as though it were.

Build and evaluation pods already solve this: both carry an `amp.wso2.com/workload` marker, and the meters that read them scope on it. Agent pods carry no equivalent, so the agent runtime meters have nothing to scope on.

## Goals

Give agent pods the same workload marker that build and evaluation pods already have, so a runtime meter can attribute compute by what the workload is rather than by which namespace it happens to sit in.

## Approach

Stamp `amp.wso2.com/workload: agent` on the `agent-api` component type's SandboxTemplate pod template, merged into the pod template's labels.

`agent-api` is the only component type here that renders a pod, so this is the only pod template that needs the marker. `external-agent-api` renders a ConfigMap and nothing else, because the agent itself runs on infrastructure this platform does not own. `SandboxWarmPool` pods inherit the label through `sandboxTemplateRef`, so warm-pool pods are covered without a second edit.

The marker is merged into the pod template's labels only, never into `podSelectors`. That map feeds `spec.selector.matchLabels` on the rendered objects, which Kubernetes makes immutable once an object exists, so adding a key there would break redeployment of every existing agent. The Service selector uses `podSelectors`, a subset of the pod template's labels, so it still matches.

A pod missing the marker is dropped from the meter rather than counted, so a gap in coverage under-reports usage instead of over-charging for it.

## User stories

N/A. Enabling change for usage metering, with no behaviour a user of the platform can observe.

## Release note

Agent pods now carry an `amp.wso2.com/workload: agent` label, letting usage metering attribute agent runtime compute by workload rather than by namespace.

## Documentation

N/A. No product documentation describes the labels on rendered agent pods.

## Training

N/A. No training content covers metering internals.

## Certification

N/A. No impact on certification exams.

## Marketing

N/A. Internal metering correctness, nothing to promote.

## Automation tests

 - Unit tests
   > N/A. This is a declarative change to a chart template with no code path to unit test.
 - Integration tests
   > `helm template` renders the chart and the expected label appears in the SandboxTemplate pod template. The two-key `oc_merge` form matches existing usage elsewhere in the same file. The consuming metering query was verified separately against a live Prometheus, where the same marker selector returns exactly the agent pods and the correct reserved-compute values.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A, no Java or compiled code in this change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A. No samples relate to pod labels or metering.

## Related PRs

N/A in this repository. The meter that reads this label is defined outside it, so there is no public counterpart PR to link.

## Migrations (if applicable)

No data migration. The marker appears on a pod when its SandboxTemplate is next rendered, so existing agents pick it up on their next deployment. Until then those pods are absent from the meter, which under-reports rather than over-charges.

## Test environment

Chart rendering verified with `helm template` on macOS. The metering query behaviour was verified against a running Prometheus rather than by inspection.

## Learning

Worth recording that this chart's `agent-api` pod template had drifted from the deployed equivalent and carried no `amp.wso2.com` labels at all. Drift between a chart template and its deployed counterpart is invisible until something reads a label that only one of them sets, which is exactly the failure mode metering is prone to: the pods run, the query returns nothing, and nothing reports an error.
