### PR TITLE
Use public gateway vhost for cloud monitor execution

### DIFF
--- a/agent-manager-service/services/gateway_anchoring_unit_test.go
+++ b/agent-manager-service/services/gateway_anchoring_unit_test.go
@@ -39,7 +39,7 @@ import (
 //     directly. RedeployMCPProxy is a one-line wrapper around it, so the three scope
 //     mutation call sites (create/update/delete) funnel through this exact same resolve
 //     and are not re-tested separately.
-//   - site 3 (resolveInternalProxyURL, monitor_executor.go): the unexported method on a bare
+//   - site 3 (resolveProxyURL, monitor_executor.go): the unexported method on a bare
 //     &monitorExecutor{} literal, per the brief's shape.
 //   - site 5 (resolveMonitorGateway, monitor_manager.go): the unexported method on a bare
 //     &monitorManagerService{} literal. The same helper backs both the monitor-create and
@@ -184,27 +184,11 @@ func TestAnchoring_MonitorRunAgainstDeployedProxy(t *testing.T) {
 				},
 			},
 		}
-		url, err := exec.resolveInternalProxyURL(context.Background(), "org", env.String(), proxy)
+		url, err := exec.resolveProxyURL(context.Background(), "org", env.String(), proxy)
 		require.NoError(t, err)
-		// Runtime URLs are per-gateway in the fixture, so asserting this one rules out the
-		// other gateway. The monitor's evaluation job runs in-cluster and gets the runtime
-		// address verbatim — no scheme defaulting, and never the public vhost.
-		require.Equal(t, both.RuntimeURL, url)
-	})
-
-	t.Run("fails when the anchored gateway has no runtimeUrl", func(t *testing.T) {
-		unregistered := newGateway(t, models.GatewayRoleBoth, true)
-		unregistered.RuntimeURL = ""
-		exec := &monitorExecutor{
-			gatewayRepo: gatewayFixtureRepo(t, env.String(), []*models.Gateway{unregistered}),
-			deploymentRepo: &repomocks.DeploymentRepositoryMock{
-				GetDeployedGatewaysByProviderFunc: func(uuid.UUID, string) ([]string, error) {
-					return []string{unregistered.UUID.String()}, nil
-				},
-			},
-		}
-		_, err := exec.resolveInternalProxyURL(context.Background(), "org", env.String(), proxy)
-		require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
+		// Vhosts are per-gateway in the fixture, so asserting this one rules out the
+		// other gateway. A bare vhost gets the default HTTPS scheme.
+		require.Equal(t, "https://"+both.Vhost, url)
 	})
 
 	t.Run("ambiguity fires only with no deployment", func(t *testing.T) {
@@ -216,7 +200,7 @@ func TestAnchoring_MonitorRunAgainstDeployedProxy(t *testing.T) {
 				},
 			},
 		}
-		_, err := exec.resolveInternalProxyURL(context.Background(), "org", env.String(), proxy)
+		_, err := exec.resolveProxyURL(context.Background(), "org", env.String(), proxy)
 		require.ErrorIs(t, err, errAmbiguousEgressGateway)
 	})
 }

--- a/agent-manager-service/services/monitor_executor.go
+++ b/agent-manager-service/services/monitor_executor.go
@@ -227,7 +227,7 @@ func (e *monitorExecutor) resolveLLMProxyConfig(ctx context.Context, monitor *mo
 		return "", "", "", fmt.Errorf("monitor LLM mapping for monitor %s has no secret KV path — was it provisioned correctly?", monitor.ID)
 	}
 
-	resolvedURL, err := e.resolveInternalProxyURL(ctx, monitor.OUID, monitor.EnvironmentID, mapping.LLMProxy)
+	resolvedURL, err := e.resolveProxyURL(ctx, monitor.OUID, monitor.EnvironmentID, mapping.LLMProxy)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to resolve proxy URL: %w", err)
 	}
@@ -241,13 +241,13 @@ func (e *monitorExecutor) resolveLLMProxyConfig(ctx context.Context, monitor *mo
 	return mapping.SecretKVPath, resolvedURL, templateHandle, nil
 }
 
-// resolveInternalProxyURL derives the proxy base URL from the preloaded LLMProxy and the gateway
+// resolveProxyURL derives the proxy base URL from the preloaded LLMProxy and the gateway
 // the proxy is actually deployed to in this environment. Anchoring matters here more than
 // anywhere else: this runs on every scheduled monitor execution, on resources nobody
 // touched, so re-selecting from the environment would break every pre-existing monitor
-// the moment a second egress gateway appears. The consumer is the in-cluster evaluation job,
-// so the address is the gateway's internal one, not its vhost.
-func (e *monitorExecutor) resolveInternalProxyURL(ctx context.Context, ouID, environmentID string, proxy *models.LLMProxy) (string, error) {
+// the moment a second egress gateway appears. Cloud evaluation jobs run in a separate
+// workflow-plane cluster, so they must use the gateway's public vhost.
+func (e *monitorExecutor) resolveProxyURL(ctx context.Context, ouID, environmentID string, proxy *models.LLMProxy) (string, error) {
 	_ = ctx
 	if proxy == nil {
 		return "", fmt.Errorf("LLM proxy not preloaded for mapping")
@@ -269,7 +269,7 @@ func (e *monitorExecutor) resolveInternalProxyURL(ctx context.Context, ouID, env
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for environment %s: %w", environmentID, err)
 	}
-	return buildInternalProxyURL(gateway, proxy.Configuration.Context)
+	return buildPublicProxyURL(gateway, proxy.Configuration.Context), nil
 }
 
 // buildWorkflowRunRequest constructs the workflow run request for a monitor.

--- a/agent-manager-service/tests/monitor_executor_test.go
+++ b/agent-manager-service/tests/monitor_executor_test.go
@@ -366,7 +366,6 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 		Name:                     "test-gateway-" + gwUUID.String()[:8],
 		DisplayName:              "Test Gateway",
 		Vhost:                    "https://gw.example.com",
-		RuntimeURL:               "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
 		IsActive:                 true,
 		Properties:               map[string]interface{}{},
 		GatewayFunctionalityType: "both",
@@ -411,10 +410,10 @@ func TestExecuteMonitorRun_LLMCredentials(t *testing.T) {
 	// Secret path comes from the persisted SecretReference remoteRef (not a computed KV path).
 	assert.Equal(t, expectedSecretPath, evalParams["llmProxySecretPath"], "llmProxySecretPath should be the SecretReference remoteRef key")
 
-	// The evaluation job runs in-cluster, so it gets the gateway's runtime address, not the
-	// public vhost — its NetworkPolicy only allows egress to the gateway namespace on 22893.
-	expectedProxyURL := gw.RuntimeURL + contextPath
-	assert.Equal(t, expectedProxyURL, evalParams["llmApiBase"], "llmApiBase should be the gateway runtime URL + proxy context path")
+	// Cloud evaluation jobs run in a separate workflow-plane cluster, so they use the
+	// gateway's public vhost rather than its cluster-local runtime URL.
+	expectedProxyURL := gw.Vhost + contextPath
+	assert.Equal(t, expectedProxyURL, evalParams["llmApiBase"], "llmApiBase should be the gateway vhost + proxy context path")
 }
 
 // TestExecuteMonitorRun_NilEvaluatorsReturnsError verifies that calling ExecuteMonitorRun


### PR DESCRIPTION
## Purpose

Monitor execution fails in WSO2 Cloud because evaluation jobs run in the workflow-plane cluster, while gateway runtimes run in a separate data-plane cluster.

The change introduced in [2866b5b](https://github.com/wso2/agent-manager/commit/2866b5b1c39015a475fcf9ea22d5c0dcf898587e) routes monitor evaluation requests through the gateway's cluster-local `RuntimeURL`. This address is not reachable from the cloud workflow-plane cluster.

## Goals

- Allow cloud monitor evaluation jobs to reach the configured LLM proxy.
- Use the gateway's public `Vhost` instead of its cluster-local `RuntimeURL`.
- Preserve gateway deployment anchoring so the correct deployed gateway is selected.

## Approach

The monitor executor continues to resolve the gateway to which the LLM proxy is deployed. After resolving the gateway, it constructs the LLM API base URL using `buildPublicProxyURL`, which uses the gateway's public `Vhost`.

The monitor execution tests were updated to verify that:

- The gateway containing the deployed proxy remains selected.
- The generated `llmApiBase` contains the public gateway vhost and proxy context path.
- A gateway `RuntimeURL` is not required for cloud monitor execution.

No UI changes are included.

## User stories

- As a cloud user, I can execute monitors containing LLM-based evaluators when the workflow plane and gateway run in different clusters.
- As a cloud operator, I can route monitor evaluation traffic through the publicly reachable gateway vhost.

## Release note

Fixed cloud monitor execution failures by routing LLM evaluation requests through the gateway's public vhost.

## Documentation

N/A — this is an internal cloud routing correction and does not change any user-facing APIs or configuration.

## Training

N/A — no training content impact.

## Certification

N/A — this change does not affect certification content or user-facing functionality.

## Marketing

N/A — this is an internal bug fix.

## Automation tests

- Unit tests
  - Updated the monitor gateway anchoring test to verify public-vhost URL resolution.
  - Ran the complete Agent Manager unit test suite successfully.

- Integration tests
  - Updated `TestExecuteMonitorRun_LLMCredentials` to verify that `llmApiBase` uses the public gateway vhost and proxy context path.
  - Successfully compiled all packages with integration build tags.

## Security checks

- Followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)? Yes
- Ran FindSecurityBugs plugin and verified report? N/A 
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples

N/A — no sample changes are required.

## Related PRs

N/A

## Migrations (if applicable)

N/A — no database, configuration, or deployment migration is required.

## Test environment

- Go: 1.25 project toolchain
- Operating system: macOS
