### PR TITLE
Mark build pods for usage metering

### DIFF
--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-ballerina-buildpack-builder.yaml
@@ -165,14 +165,18 @@ spec:
       # ${metadata.labels['openchoreo.dev/component-uid']} does not resolve here.
       # Names are unique within a namespace, but a rename splits the series.
       #
-      # app.kubernetes.io/component separates these from evaluation pods, which
-      # share the workflows-<org> namespace. Both keys must stay in the
-      # kube-state-metrics allowlist in observability-metrics-prometheus.yaml.
+      # amp.wso2.com/workload is what separates build pods from evaluation pods
+      # for metering; they share the workflows-<org> namespace and are otherwise
+      # identical on kube_pod_labels. It is the key the exporter's allowlist
+      # admits, and the only one the metering service reads.
       podMetadata:
         labels:
           openchoreo.dev/namespace: ${metadata.namespaceName}
           openchoreo.dev/project: ${metadata.labels['openchoreo.dev/project']}
           openchoreo.dev/component: ${metadata.labels['openchoreo.dev/component']}
+          amp.wso2.com/workload: build
+          # Convention only: not in the exporter allowlist and selected by
+          # nothing, so it is not a metering signal despite the name.
           app.kubernetes.io/component: build
       ttlStrategy:
           secondsAfterCompletion: 86400  # Deletes 1 day after it finishes (success or failure)

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-dockerfile-builder.yaml
@@ -192,14 +192,18 @@ spec:
       # ${metadata.labels['openchoreo.dev/component-uid']} does not resolve here.
       # Names are unique within a namespace, but a rename splits the series.
       #
-      # app.kubernetes.io/component separates these from evaluation pods, which
-      # share the workflows-<org> namespace. Both keys must stay in the
-      # kube-state-metrics allowlist in observability-metrics-prometheus.yaml.
+      # amp.wso2.com/workload is what separates build pods from evaluation pods
+      # for metering; they share the workflows-<org> namespace and are otherwise
+      # identical on kube_pod_labels. It is the key the exporter's allowlist
+      # admits, and the only one the metering service reads.
       podMetadata:
         labels:
           openchoreo.dev/namespace: ${metadata.namespaceName}
           openchoreo.dev/project: ${metadata.labels['openchoreo.dev/project']}
           openchoreo.dev/component: ${metadata.labels['openchoreo.dev/component']}
+          amp.wso2.com/workload: build
+          # Convention only: not in the exporter allowlist and selected by
+          # nothing, so it is not a metering signal despite the name.
           app.kubernetes.io/component: build
       ttlStrategy:
           secondsAfterCompletion: 86400  # Deletes 1 day after it finishes (success or failure)

--- a/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
+++ b/deployments/helm-charts/wso2-amp-platform-resources-extension/templates/component-workflows/amp-gcp-buildpack-builder.yaml
@@ -165,14 +165,18 @@ spec:
       # ${metadata.labels['openchoreo.dev/component-uid']} does not resolve here.
       # Names are unique within a namespace, but a rename splits the series.
       #
-      # app.kubernetes.io/component separates these from evaluation pods, which
-      # share the workflows-<org> namespace. Both keys must stay in the
-      # kube-state-metrics allowlist in observability-metrics-prometheus.yaml.
+      # amp.wso2.com/workload is what separates build pods from evaluation pods
+      # for metering; they share the workflows-<org> namespace and are otherwise
+      # identical on kube_pod_labels. It is the key the exporter's allowlist
+      # admits, and the only one the metering service reads.
       podMetadata:
         labels:
           openchoreo.dev/namespace: ${metadata.namespaceName}
           openchoreo.dev/project: ${metadata.labels['openchoreo.dev/project']}
           openchoreo.dev/component: ${metadata.labels['openchoreo.dev/component']}
+          amp.wso2.com/workload: build
+          # Convention only: not in the exporter allowlist and selected by
+          # nothing, so it is not a metering signal despite the name.
           app.kubernetes.io/component: build
       ttlStrategy:
           secondsAfterCompletion: 86400  # Deletes 1 day after it finishes (success or failure)


### PR DESCRIPTION
## Purpose

The three build workflow templates label their pods `app.kubernetes.io/component: build` and nothing else identifying the workload. That key is not in the metrics exporter's label allowlist, so it never reaches `kube_pod_labels` and no query can see it.

Build pods share the `workflows-<org>` namespace with evaluation pods and are otherwise identical on that metric, so with no visible workload key the two cannot be told apart and build usage cannot be measured at all.

The evaluation template was converted to a dedicated key, and the exporter allowlist was updated to admit it, but these three were left behind.

## Goals

Make build pods identifiable to usage metering, using the key the allowlist already admits and the evaluation template already uses.

## Approach

Add `amp.wso2.com/workload: build` to the `podMetadata.labels` of all three builder templates.

A dedicated key rather than admitting `app.kubernetes.io/component` into the allowlist: that allowlist is cluster-wide, so admitting a convention key would export it for every platform pod that follows the same convention, which is a great many of them.

The convention label stays — it costs nothing and something may read it — but its comment no longer claims to separate build from evaluation. It cannot: nothing selects it and the exporter drops it.

## User stories

N/A. Enabling change for usage metering with no user-visible behaviour.

## Release note

Build pods now carry an `amp.wso2.com/workload: build` label, so build time can be measured and attributed by usage metering.

## Documentation

N/A. No product documentation describes the labels on build pods.

## Training

N/A.

## Certification

N/A. No impact on certification exams.

## Marketing

N/A.

## Automation tests

 - Unit tests
   > N/A. Declarative label additions to chart templates with no code path.
 - Integration tests
   > `helm template` renders all three and the label appears once per builder. Verified the exporter allowlist in `deployments/values/observability-metrics-prometheus.yaml` admits `amp.wso2.com/workload` and does **not** admit `app.kubernetes.io/component`, which is what makes the existing key invisible. Also grepped the chart for anything selecting the convention label on build pods; nothing does.

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A, no Java or compiled code
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A.

## Related PRs

N/A in this repository. The metering component that reads this label is defined outside it, so there is no public counterpart PR to link.

## Migrations (if applicable)

None. The label appears on build pods started after the chart is upgraded; runs already in flight are unaffected and simply remain unmeasured.

## Test environment

Chart rendering verified with `helm template` on macOS.

## Learning

The evaluation template, the exporter allowlist and these three templates form one contract, and it was changed in two places out of three. Nothing failed as a result — the label is simply absent from a metric, queries return no rows, and an absent row is indistinguishable from a workload that did not run. Worth noting for anyone changing a label that something else reads: the only reliable check is to query the metric and confirm the key is actually there.
