### PR TITLE
Support configurable Thunder system resource selection

### DIFF
--- a/agent-manager-service/clients/thundersvc/client.go
+++ b/agent-manager-service/clients/thundersvc/client.go
@@ -230,9 +230,10 @@ func (c *thunderClient) fetchSystemToken(ctx context.Context) (string, int, erro
 		"grant_type": {"client_credentials"},
 		"scope":      {"system"},
 	}
-	// Scope the token to Thunder's System resource server so the "system" permission is
-	// actually granted (see systemResource field). Omitting this drops the scope and the
-	// admin APIs reject the call with AUTH-4030.
+	// Scope the token to Thunder's System resource server when the deployment has one.
+	// An empty value deliberately omits the RFC 8707 resource parameter so Thunder can
+	// use its configured default resource server; that default must grant this system
+	// client the "system" permission required by the admin APIs.
 	if c.systemResource != "" {
 		data.Set("resource", c.systemResource)
 	}

--- a/agent-manager-service/clients/thundersvc/client_test.go
+++ b/agent-manager-service/clients/thundersvc/client_test.go
@@ -83,6 +83,56 @@ func TestNewThunderClientWithDialOverride_EmptyOverrideDialsBaseURLDirectly(t *t
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestFetchSystemToken_ResourceSelection(t *testing.T) {
+	tests := []struct {
+		name           string
+		systemResource string
+		wantResource   string
+	}{
+		{
+			name:           "explicit system resource is sent",
+			systemResource: "https://idp.example.com/mcp",
+			wantResource:   "https://idp.example.com/mcp",
+		},
+		{
+			name:           "empty system resource uses Thunder default",
+			systemResource: "",
+			wantResource:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotResource string
+			var resourcePresent bool
+			mux := http.NewServeMux()
+			mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, r.ParseForm())
+				gotResource = r.Form.Get("resource")
+				_, resourcePresent = r.Form["resource"]
+				assert.Equal(t, "client_credentials", r.Form.Get("grant_type"))
+				assert.Equal(t, "system", r.Form.Get("scope"))
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "token",
+					"expires_in":   3600,
+				})
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := NewThunderClientWithDialOverride(server.URL, "cid", "secret", "", tc.systemResource)
+			thunder, ok := client.(*thunderClient)
+			require.True(t, ok)
+
+			_, _, err := thunder.fetchSystemToken(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantResource, gotResource)
+			assert.Equal(t, tc.wantResource != "", resourcePresent)
+		})
+	}
+}
+
 // TestCreateApp_SendsRequiredApplicationType guards against a regression:
 // applications require a "type" field on create, and a POST /applications
 // missing it fails outright. createApp's payload must always include it.

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -154,7 +154,17 @@ func NewIdentityClient(baseURL, clientID, clientSecret string) IdentityClient {
 // resolves via the host machine's own DNS/hosts setup. An empty resolveToHost
 // behaves exactly like NewIdentityClient.
 func NewIdentityClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost string) IdentityClient {
-	c := NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, SystemResourceIdentifier(baseURL))
+	return NewIdentityClientWithSystemResource(
+		baseURL, clientID, clientSecret, resolveToHost, SystemResourceIdentifier(baseURL),
+	)
+}
+
+// NewIdentityClientWithSystemResource creates a Thunder identity client with an
+// explicitly selected System resource server. When systemResource is empty, the
+// OAuth token request omits the RFC 8707 resource parameter and Thunder resolves
+// its configured default resource server.
+func NewIdentityClientWithSystemResource(baseURL, clientID, clientSecret, resolveToHost, systemResource string) IdentityClient {
+	c := NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource)
 	return c.(IdentityClient)
 }
 

--- a/agent-manager-service/config/config.go
+++ b/agent-manager-service/config/config.go
@@ -16,6 +16,8 @@
 
 package config
 
+import "strings"
+
 // Config holds all configuration for the application
 type Config struct {
 	PackageVersion      string
@@ -393,10 +395,10 @@ type InternalServerConfig struct {
 // ThunderConfig holds Thunder admin API configuration for provisioning OAuth apps
 type ThunderConfig struct {
 	// BaseURL is the Thunder API base URL (if empty, provisioner uses static defaults).
-	// Must be Thunder's public/issuer URL: it also derives the System resource server
-	// identifier (RFC 8707) admin API tokens are scoped to — see
-	// thundersvc.systemResourceIdentifier. It does NOT need to be directly dialable
-	// from this process; see ResolveToHost below.
+	// Must be Thunder's public/issuer URL. Unless UseDefaultResourceServer is true or
+	// SystemResourceIdentifier overrides it, this also derives the System resource
+	// server identifier (RFC 8707) admin API tokens are scoped to. It does NOT need
+	// to be directly dialable from this process; see ResolveToHost below.
 	BaseURL string
 	// ClientID is the OAuth2 client ID of the system app (with Administrator role)
 	ClientID string
@@ -404,12 +406,37 @@ type ThunderConfig struct {
 	ClientSecret string `json:"-"`
 	// ResolveToHost, if set, is the host:port this process actually dials for every
 	// Thunder request, while requests still carry BaseURL's host as the HTTP Host
-	// header and BaseURL still derives the System resource server identifier. Set
-	// this when BaseURL isn't directly dialable from here — e.g. agent-manager-service
+	// header and BaseURL still identifies the public Thunder instance. Set this when
+	// BaseURL isn't directly dialable from here — e.g. agent-manager-service
 	// running in-cluster while Thunder's public URL only resolves via the host
 	// machine's own DNS/hosts setup (typically the in-cluster Thunder service's own
 	// cluster-DNS address). Leave empty when BaseURL is already directly dialable.
 	ResolveToHost string
+	// UseDefaultResourceServer omits the RFC 8707 resource parameter from system-token
+	// requests, allowing Thunder to resolve the deployment's configured default resource
+	// server. This is intended for deployments such as WSO2 Cloud where the platform
+	// Thunder does not register its own <issuer>/mcp System resource server.
+	UseDefaultResourceServer bool
+	// SystemResourceIdentifier overrides the System resource server identifier used for
+	// administrative token requests. When empty and UseDefaultResourceServer is false,
+	// the identifier defaults to <BaseURL>/mcp for backward compatibility.
+	SystemResourceIdentifier string
+}
+
+// ResolvedSystemResourceIdentifier returns the RFC 8707 resource parameter for
+// platform-Thunder administrative token requests. An empty result deliberately means
+// "omit resource and let Thunder use its configured default resource server".
+func (c ThunderConfig) ResolvedSystemResourceIdentifier() string {
+	if c.UseDefaultResourceServer {
+		return ""
+	}
+	if c.SystemResourceIdentifier != "" {
+		return c.SystemResourceIdentifier
+	}
+	if c.BaseURL == "" {
+		return ""
+	}
+	return strings.TrimRight(c.BaseURL, "/") + "/mcp"
 }
 
 // WebSocketConfig holds WebSocket-specific configuration

--- a/agent-manager-service/config/config_loader.go
+++ b/agent-manager-service/config/config_loader.go
@@ -250,10 +250,12 @@ func loadEnvs() {
 
 	// Thunder admin API configuration for provisioning per-org OAuth apps
 	config.Thunder = ThunderConfig{
-		BaseURL:       r.readOptionalString("THUNDER_BASE_URL", ""),
-		ClientID:      r.readOptionalString("THUNDER_CLIENT_ID", ""),
-		ClientSecret:  r.readOptionalString("THUNDER_CLIENT_SECRET", ""),
-		ResolveToHost: r.readOptionalString("THUNDER_RESOLVE_TO_HOST", ""),
+		BaseURL:                  r.readOptionalString("THUNDER_BASE_URL", ""),
+		ClientID:                 r.readOptionalString("THUNDER_CLIENT_ID", ""),
+		ClientSecret:             r.readOptionalString("THUNDER_CLIENT_SECRET", ""),
+		ResolveToHost:            r.readOptionalString("THUNDER_RESOLVE_TO_HOST", ""),
+		UseDefaultResourceServer: r.readOptionalBool("AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER", false),
+		SystemResourceIdentifier: r.readOptionalString("AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER", ""),
 	}
 	if config.Thunder.BaseURL != "" && (config.Thunder.ClientID == "" || config.Thunder.ClientSecret == "") {
 		r.errors = append(r.errors, fmt.Errorf("THUNDER_BASE_URL is set but THUNDER_CLIENT_ID and/or THUNDER_CLIENT_SECRET are missing"))
@@ -268,6 +270,7 @@ func loadEnvs() {
 			r.errors = append(r.errors, fmt.Errorf("THUNDER_RESOLVE_TO_HOST must contain a non-empty host and port"))
 		}
 	}
+	validateThunderConfig(config, r)
 
 	config.TLSConfig = TLSConfig{
 		EnableTLS: r.readOptionalBool("TLS_ENABLED", false),
@@ -429,6 +432,40 @@ func validateOAuthAuthorizationServers(cfg *Config, r *configReader) {
 		if u.Host == "" {
 			r.errors = append(r.errors, fmt.Errorf("OAUTH_AUTHORIZATION_SERVERS entry %q must have a non-empty host", raw))
 		}
+	}
+}
+
+func validateThunderConfig(cfg *Config, r *configReader) {
+	thunder := cfg.Thunder
+	if thunder.UseDefaultResourceServer && thunder.SystemResourceIdentifier != "" {
+		r.errors = append(r.errors, fmt.Errorf(
+			"AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER cannot be true when AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER is set",
+		))
+	}
+	if (thunder.UseDefaultResourceServer || thunder.SystemResourceIdentifier != "") && thunder.BaseURL == "" {
+		r.errors = append(r.errors, fmt.Errorf(
+			"AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER and AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER require THUNDER_BASE_URL",
+		))
+	}
+	if thunder.SystemResourceIdentifier == "" {
+		return
+	}
+	u, err := url.Parse(thunder.SystemResourceIdentifier)
+	if err != nil || !u.IsAbs() {
+		r.errors = append(r.errors, fmt.Errorf(
+			"AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER %q must be an absolute URI", thunder.SystemResourceIdentifier,
+		))
+		return
+	}
+	if u.Fragment != "" {
+		r.errors = append(r.errors, fmt.Errorf(
+			"AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER %q must not contain a fragment", thunder.SystemResourceIdentifier,
+		))
+	}
+	if (u.Scheme == "http" || u.Scheme == "https") && u.Host == "" {
+		r.errors = append(r.errors, fmt.Errorf(
+			"AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER %q must have a non-empty host", thunder.SystemResourceIdentifier,
+		))
 	}
 }
 

--- a/agent-manager-service/config/config_loader_test.go
+++ b/agent-manager-service/config/config_loader_test.go
@@ -21,6 +21,193 @@ import (
 	"testing"
 )
 
+func TestThunderConfigResolvedSystemResourceIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  ThunderConfig
+		want string
+	}{
+		{
+			name: "derives mcp identifier by default",
+			cfg:  ThunderConfig{BaseURL: "https://idp.example.com"},
+			want: "https://idp.example.com/mcp",
+		},
+		{
+			name: "trims trailing slash before deriving identifier",
+			cfg:  ThunderConfig{BaseURL: "https://idp.example.com/"},
+			want: "https://idp.example.com/mcp",
+		},
+		{
+			name: "uses explicit identifier",
+			cfg: ThunderConfig{
+				BaseURL:                  "https://idp.example.com",
+				SystemResourceIdentifier: "urn:example:thunder-system",
+			},
+			want: "urn:example:thunder-system",
+		},
+		{
+			name: "omits resource for Thunder default",
+			cfg: ThunderConfig{
+				BaseURL:                  "https://idp.example.com",
+				UseDefaultResourceServer: true,
+			},
+			want: "",
+		},
+		{
+			name: "disabled Thunder has no identifier",
+			cfg:  ThunderConfig{},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.ResolvedSystemResourceIdentifier(); got != tc.want {
+				t.Errorf("ResolvedSystemResourceIdentifier() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateThunderConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         ThunderConfig
+		wantErrors  int
+		errContains string
+	}{
+		{
+			name:       "derived system resource is valid",
+			cfg:        ThunderConfig{BaseURL: "https://idp.example.com"},
+			wantErrors: 0,
+		},
+		{
+			name: "configured default resource server is valid",
+			cfg: ThunderConfig{
+				BaseURL:                  "https://idp.example.com",
+				UseDefaultResourceServer: true,
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "absolute URN override is valid",
+			cfg: ThunderConfig{
+				BaseURL:                  "https://idp.example.com",
+				SystemResourceIdentifier: "urn:example:thunder-system",
+			},
+			wantErrors: 0,
+		},
+		{
+			name: "default and explicit identifier conflict",
+			cfg: ThunderConfig{
+				BaseURL:                  "https://idp.example.com",
+				UseDefaultResourceServer: true,
+				SystemResourceIdentifier: "https://idp.example.com/mcp",
+			},
+			wantErrors:  1,
+			errContains: "cannot be true",
+		},
+		{
+			name: "default requires Thunder base URL",
+			cfg: ThunderConfig{
+				UseDefaultResourceServer: true,
+			},
+			wantErrors:  1,
+			errContains: "require THUNDER_BASE_URL",
+		},
+		{
+			name: "relative identifier is rejected",
+			cfg: ThunderConfig{
+				BaseURL:                  "https://idp.example.com",
+				SystemResourceIdentifier: "/mcp",
+			},
+			wantErrors:  1,
+			errContains: "absolute URI",
+		},
+		{
+			name: "identifier fragment is rejected",
+			cfg: ThunderConfig{
+				BaseURL:                  "https://idp.example.com",
+				SystemResourceIdentifier: "https://idp.example.com/mcp#fragment",
+			},
+			wantErrors:  1,
+			errContains: "must not contain a fragment",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Thunder: tc.cfg}
+			r := &configReader{}
+			validateThunderConfig(cfg, r)
+
+			if len(r.errors) != tc.wantErrors {
+				t.Fatalf("expected %d errors, got %d: %v", tc.wantErrors, len(r.errors), r.errors)
+			}
+			if tc.errContains == "" {
+				return
+			}
+			for _, err := range r.errors {
+				if strings.Contains(err.Error(), tc.errContains) {
+					return
+				}
+			}
+			t.Errorf("expected an error containing %q, got %v", tc.errContains, r.errors)
+		})
+	}
+}
+
+func TestLoadEnvs_ThunderResourceServerSelection(t *testing.T) {
+	requiredEnv := map[string]string{
+		"OPEN_CHOREO_BASE_URL":  "http://localhost/api/v1",
+		"DB_HOST":               "localhost",
+		"DB_USER":               "unit",
+		"DB_PASSWORD":           "unit",
+		"DB_NAME":               "unit",
+		"THUNDER_BASE_URL":      "https://idp.example.com",
+		"THUNDER_CLIENT_ID":     "system-client",
+		"THUNDER_CLIENT_SECRET": "system-secret",
+	}
+
+	setBaseEnv := func(t *testing.T) {
+		t.Helper()
+		for key, value := range requiredEnv {
+			t.Setenv(key, value)
+		}
+		t.Setenv("AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER", "")
+		t.Setenv("AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER", "")
+	}
+
+	t.Run("defaults to derived mcp resource", func(t *testing.T) {
+		setBaseEnv(t)
+		loadEnvs()
+
+		if got := config.Thunder.ResolvedSystemResourceIdentifier(); got != "https://idp.example.com/mcp" {
+			t.Errorf("resolved system resource = %q, want derived /mcp resource", got)
+		}
+	})
+
+	t.Run("AMP flag selects Thunder default resource server", func(t *testing.T) {
+		setBaseEnv(t)
+		t.Setenv("AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER", "true")
+		loadEnvs()
+
+		if got := config.Thunder.ResolvedSystemResourceIdentifier(); got != "" {
+			t.Errorf("resolved system resource = %q, want empty", got)
+		}
+	})
+
+	t.Run("AMP resource identifier overrides derived resource", func(t *testing.T) {
+		setBaseEnv(t)
+		t.Setenv("AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER", "urn:example:thunder-system")
+		loadEnvs()
+
+		if got := config.Thunder.ResolvedSystemResourceIdentifier(); got != "urn:example:thunder-system" {
+			t.Errorf("resolved system resource = %q, want custom URN", got)
+		}
+	})
+}
+
 func TestValidateOAuthAuthorizationServers(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/agent-manager-service/services/publisher_credential_provisioner.go
+++ b/agent-manager-service/services/publisher_credential_provisioner.go
@@ -144,26 +144,18 @@ func NewPublisherCredentialProvisioner(
 		}, nil
 	}
 
-	var thunderCl thundersvc.ThunderClient
-	if cfg.Thunder.ResolveToHost != "" {
-		thunderCl = thundersvc.NewThunderClientWithDialOverride(
-			cfg.Thunder.BaseURL,
-			cfg.Thunder.ClientID,
-			cfg.Thunder.ClientSecret,
-			cfg.Thunder.ResolveToHost,
-			thundersvc.SystemResourceIdentifier(cfg.Thunder.BaseURL),
-		)
-	} else {
-		thunderCl = thundersvc.NewThunderClient(
-			cfg.Thunder.BaseURL,
-			cfg.Thunder.ClientID,
-			cfg.Thunder.ClientSecret,
-		)
-	}
+	thunderCl := thundersvc.NewThunderClientWithDialOverride(
+		cfg.Thunder.BaseURL,
+		cfg.Thunder.ClientID,
+		cfg.Thunder.ClientSecret,
+		cfg.Thunder.ResolveToHost,
+		cfg.Thunder.ResolvedSystemResourceIdentifier(),
+	)
 
 	logger.Info(
 		"Publisher credential provisioner initialized with Thunder",
 		"thunderBaseURL", cfg.Thunder.BaseURL,
+		"usesDefaultResourceServer", cfg.Thunder.UseDefaultResourceServer,
 	)
 
 	return &publisherCredentialProvisioner{

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -585,10 +585,13 @@ func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {
 
 // ProvideIdentityClient creates a Thunder identity client using the Thunder system app credentials.
 func ProvideIdentityClient(cfg config.ThunderConfig) thundersvc.IdentityClient {
-	if cfg.ResolveToHost != "" {
-		return thundersvc.NewIdentityClientWithDialOverride(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret, cfg.ResolveToHost)
-	}
-	return thundersvc.NewIdentityClient(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret)
+	return thundersvc.NewIdentityClientWithSystemResource(
+		cfg.BaseURL,
+		cfg.ClientID,
+		cfg.ClientSecret,
+		cfg.ResolveToHost,
+		cfg.ResolvedSystemResourceIdentifier(),
+	)
 }
 
 // ProvideOrgResolver creates the org resolver backed by Thunder, with a per-org OU ID cache.

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -857,10 +857,13 @@ func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {
 
 // ProvideIdentityClient creates a Thunder identity client using the Thunder system app credentials.
 func ProvideIdentityClient(cfg config.ThunderConfig) thundersvc.IdentityClient {
-	if cfg.ResolveToHost != "" {
-		return thundersvc.NewIdentityClientWithDialOverride(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret, cfg.ResolveToHost)
-	}
-	return thundersvc.NewIdentityClient(cfg.BaseURL, cfg.ClientID, cfg.ClientSecret)
+	return thundersvc.NewIdentityClientWithSystemResource(
+		cfg.BaseURL,
+		cfg.ClientID,
+		cfg.ClientSecret,
+		cfg.ResolveToHost,
+		cfg.ResolvedSystemResourceIdentifier(),
+	)
 }
 
 // ProvideOrgResolver creates the org resolver backed by Thunder, with a per-org OU ID cache.

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/configmap.yaml
@@ -76,11 +76,13 @@ data:
   WORKFLOW_PLANE_OPENBAO_URL: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.url | default "" | quote }}
   WORKFLOW_PLANE_OPENBAO_PATH: {{ .Values.agentManagerService.config.workflowPlaneOpenbao.path | default "secret" | quote }}
   # Thunder admin API configuration (for per-org publisher credentials and the
-  # identity APIs). resolveToHost lets baseURL stay Thunder's public URL (required
-  # for the System resource server identifier) even when that hostname isn't
-  # directly dialable from this pod — see values.yaml's thunder.resolveToHost.
+  # identity APIs). resolveToHost lets baseURL stay Thunder's public URL even when
+  # that hostname isn't directly dialable from this pod. The AMP-prefixed settings
+  # select an explicit/derived resource server or Thunder's configured default.
   THUNDER_BASE_URL: {{ .Values.agentManagerService.config.thunder.baseURL | default "" | quote }}
   THUNDER_RESOLVE_TO_HOST: {{ .Values.agentManagerService.config.thunder.resolveToHost | default "" | quote }}
+  AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER: {{ .Values.agentManagerService.config.thunder.useDefaultResourceServer | default false | quote }}
+  AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER: {{ .Values.agentManagerService.config.thunder.systemResourceIdentifier | default "" | quote }}
   THUNDER_CLIENT_ID: {{ .Values.agentManagerService.config.thunder.clientId | default "" | quote }}
   # Agent resource limits (per-agent upper bounds)
   RESOURCE_MAX_REPLICAS: {{ .Values.agentManagerService.config.perAgentResourceLimits.maxReplicas | default 10 | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -58,6 +58,16 @@ assert_cm "default audience keeps the gateway resource entry" \
   KEY_MANAGER_AUDIENCE "${CLIENTS},http://api.amp.localhost:8080/mcp"
 assert_cm "default authorization servers fall back to the default issuer" \
   OAUTH_AUTHORIZATION_SERVERS "http://thunder.amp.localhost:8080"
+assert_cm "platform Thunder targets its derived System resource by default" \
+  AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER "false"
+assert_cm "platform Thunder has no custom System resource identifier by default" \
+  AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER ""
+assert_cm "platform Thunder can use its configured default resource server" \
+  AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER "true" \
+  --set agentManagerService.config.thunder.useDefaultResourceServer=true
+assert_cm "platform Thunder accepts a custom System resource identifier" \
+  AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER "urn:example:thunder-system" \
+  --set agentManagerService.config.thunder.systemResourceIdentifier=urn:example:thunder-system
 
 # Issue #1424: one issuer override has to move the advertised authorization
 # server too, or MCP clients discover an authorization server whose tokens this

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -385,13 +385,10 @@ agentManagerService:
     # static amp-publisher-client credentials are used instead for publisher
     # provisioning, and the identity APIs are unavailable.
     thunder:
-      # Must be the PUBLIC URL, same as keyManager.issuer above. Every admin API
-      # request asks for a token scoped to Thunder's System resource server via an
-      # RFC 8707 "resource" parameter derived from this value (client.go's
-      # SystemResourceIdentifier), and Thunder only recognizes the public URL as
-      # that resource server's registered identifier — any other value fails with
-      # invalid_target. This does NOT need to be directly dialable from the pod;
-      # see resolveToHost below for that.
+      # Must be the PUBLIC URL, same as keyManager.issuer above. By default every
+      # admin API token request targets <baseURL>/mcp as its RFC 8707 resource.
+      # This does NOT need to be directly dialable from the pod; see
+      # resolveToHost below for that.
       baseURL: "http://thunder.amp.localhost:8080"
       # The host:port this service actually connects to for every Thunder request
       # (baseURL's host is still sent as the HTTP Host header, and still drives the
@@ -400,6 +397,13 @@ agentManagerService:
       # it doesn't resolve from inside this pod. Leave empty only if baseURL is
       # itself directly dialable from the pod (e.g. a real in-cluster DNS name).
       resolveToHost: "amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090"
+      # Omit the OAuth resource parameter and let Thunder select its configured
+      # default resource server. Keep false when this Thunder instance registers
+      # its own <baseURL>/mcp System resource server.
+      useDefaultResourceServer: false
+      # Optional absolute URI overriding the derived <baseURL>/mcp identifier.
+      # Cannot be set together with useDefaultResourceServer=true.
+      systemResourceIdentifier: ""
       # OAuth2 client ID of the system app (with Administrator role)
       clientId: "amp-system-client"
       # OAuth2 client secret of the system app


### PR DESCRIPTION
## Purpose

Cloud Thunder defines the Platform API resource server as its default resource server but does not register the `<platform-idp-url>/mcp` System resource server used by the on-prem deployment.

Agent Manager currently always sends `<THUNDER_BASE_URL>/mcp` as the OAuth `resource` parameter when requesting an administrative token. Consequently, cloud monitor credential provisioning fails with `invalid_target`.

This change allows cloud deployments to use Thunder’s configured default resource server while preserving the existing on-prem behavior.

## Goals

- Allow Agent Manager to omit the OAuth `resource` parameter and use Thunder’s configured default resource server.
- Preserve the existing `<THUNDER_BASE_URL>/mcp` behavior by default.
- Support selecting a custom Thunder System resource-server identifier through configuration.
- Apply the configuration only to platform Thunder clients without changing environment-specific Thunder behavior.
- Validate conflicting or invalid resource-server configurations during startup.

## Approach

This change introduces two configuration options:

- `AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER`
  - When `true`, Agent Manager omits the OAuth `resource` parameter and allows Thunder to select its configured default resource server.
  - Defaults to `false` to preserve existing on-prem behavior.

- `AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER`
  - Optionally specifies an explicit RFC 8707 resource-server identifier.
  - When unset and the default-resource option is disabled, Agent Manager derives `<THUNDER_BASE_URL>/mcp`.

The resource selection order is:

1. Use Thunder’s default resource server when `AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER=true`.
2. Otherwise, use `AMP_THUNDER_SYSTEM_RESOURCE_IDENTIFIER` when configured.
3. Otherwise, derive `<THUNDER_BASE_URL>/mcp`.

The configuration is applied to both the platform Thunder identity client and monitor credential provisioner. Environment-specific Thunder clients continue using their own `/mcp` resource servers.

The Helm chart exposes both configuration options and includes render assertions for the default, custom, and Thunder-default modes.

No UI changes are included.

## User stories

- As a cloud operator, I can configure Agent Manager to use Thunder’s default resource server without registering an additional `/mcp` resource server.
- As an on-prem operator, I retain the existing `/mcp` resource-server behavior without additional configuration.
- As a platform operator, I can switch to a dedicated or custom resource-server identifier through configuration without another code change.

## Release note

Added configurable Thunder resource-server selection for administrative tokens, including support for Thunder’s configured default resource server.

## Documentation

N/A — this is an internal deployment configuration change. The new options and their behavior are documented in the Helm values file.

## Training

N/A — no training content impact.

## Certification

N/A — this deployment-level configuration change does not affect certification exams.

## Marketing

N/A — no marketing impact.

## Automation tests

- Unit tests
  - Added tests covering derived, custom, and Thunder-default resource-server selection.
  - Added tests verifying whether the OAuth `resource` parameter is included or omitted.
  - Added configuration validation and environment-loading tests.
  - Full unit test suite passed.
  - Total reported unit-test coverage: 8.9%.

- Integration tests
  - All integration-tagged Go packages compile successfully.
  - Helm render assertions pass for default, custom, and Thunder-default configurations.
  - No live Thunder integration test was performed.

## Security checks

- Followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)? Yes
- Ran FindSecurityBugs plugin and verified report? N/A — this is a Go change; FindSecurityBugs is Java-specific.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes

## Samples

N/A — no sample changes are required.

## Migrations (if applicable)

No database or data migration is required.

The cloud Agent Manager deployment must set following to work with default

```yaml
- key: AMP_USE_THUNDER_DEFAULT_RESOURCE_SERVER
  value: "true"