### PR TITLE
Support env-Thunder full URLs on amp-pre-release via impersonation

### DIFF
--- a/agent-manager-service/clients/clientmocks/thunder_prober_fake.go
+++ b/agent-manager-service/clients/clientmocks/thunder_prober_fake.go
@@ -14,7 +14,7 @@ import (
 //
 //		// make and configure a mocked thundersvc.Prober
 //		mockedProber := &ThunderProberMock{
-//			ProbeFunc: func(ctx context.Context, org string, env string, handle string) bool {
+//			ProbeFunc: func(ctx context.Context, org string, env string, thunderURL string) bool {
 //				panic("mock out the Probe method")
 //			},
 //		}
@@ -25,7 +25,7 @@ import (
 //	}
 type ThunderProberMock struct {
 	// ProbeFunc mocks the Probe method.
-	ProbeFunc func(ctx context.Context, org string, env string, handle string) bool
+	ProbeFunc func(ctx context.Context, org string, env string, thunderURL string) bool
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -37,33 +37,33 @@ type ThunderProberMock struct {
 			Org string
 			// Env is the env argument value.
 			Env string
-			// Handle is the handle argument value.
-			Handle string
+			// ThunderURL is the thunderURL argument value.
+			ThunderURL string
 		}
 	}
 	lockProbe sync.RWMutex
 }
 
 // Probe calls ProbeFunc.
-func (mock *ThunderProberMock) Probe(ctx context.Context, org string, env string, handle string) bool {
+func (mock *ThunderProberMock) Probe(ctx context.Context, org string, env string, thunderURL string) bool {
 	if mock.ProbeFunc == nil {
 		panic("ThunderProberMock.ProbeFunc: method is nil but Prober.Probe was just called")
 	}
 	callInfo := struct {
-		Ctx    context.Context
-		Org    string
-		Env    string
-		Handle string
+		Ctx        context.Context
+		Org        string
+		Env        string
+		ThunderURL string
 	}{
-		Ctx:    ctx,
-		Org:    org,
-		Env:    env,
-		Handle: handle,
+		Ctx:        ctx,
+		Org:        org,
+		Env:        env,
+		ThunderURL: thunderURL,
 	}
 	mock.lockProbe.Lock()
 	mock.calls.Probe = append(mock.calls.Probe, callInfo)
 	mock.lockProbe.Unlock()
-	return mock.ProbeFunc(ctx, org, env, handle)
+	return mock.ProbeFunc(ctx, org, env, thunderURL)
 }
 
 // ProbeCalls gets all the calls that were made to Probe.
@@ -71,16 +71,16 @@ func (mock *ThunderProberMock) Probe(ctx context.Context, org string, env string
 //
 //	len(mockedProber.ProbeCalls())
 func (mock *ThunderProberMock) ProbeCalls() []struct {
-	Ctx    context.Context
-	Org    string
-	Env    string
-	Handle string
+	Ctx        context.Context
+	Org        string
+	Env        string
+	ThunderURL string
 } {
 	var calls []struct {
-		Ctx    context.Context
-		Org    string
-		Env    string
-		Handle string
+		Ctx        context.Context
+		Org        string
+		Env        string
+		ThunderURL string
 	}
 	mock.lockProbe.RLock()
 	calls = mock.calls.Probe

--- a/agent-manager-service/clients/clientmocks/thunder_prober_fake.go
+++ b/agent-manager-service/clients/clientmocks/thunder_prober_fake.go
@@ -14,7 +14,7 @@ import (
 //
 //		// make and configure a mocked thundersvc.Prober
 //		mockedProber := &ThunderProberMock{
-//			ProbeFunc: func(ctx context.Context, org string, env string, thunderURL string) bool {
+//			ProbeFunc: func(ctx context.Context, org string, env string, thunderURL string, callerSupplied bool) bool {
 //				panic("mock out the Probe method")
 //			},
 //		}
@@ -25,7 +25,7 @@ import (
 //	}
 type ThunderProberMock struct {
 	// ProbeFunc mocks the Probe method.
-	ProbeFunc func(ctx context.Context, org string, env string, thunderURL string) bool
+	ProbeFunc func(ctx context.Context, org string, env string, thunderURL string, callerSupplied bool) bool
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -39,31 +39,35 @@ type ThunderProberMock struct {
 			Env string
 			// ThunderURL is the thunderURL argument value.
 			ThunderURL string
+			// CallerSupplied is the callerSupplied argument value.
+			CallerSupplied bool
 		}
 	}
 	lockProbe sync.RWMutex
 }
 
 // Probe calls ProbeFunc.
-func (mock *ThunderProberMock) Probe(ctx context.Context, org string, env string, thunderURL string) bool {
+func (mock *ThunderProberMock) Probe(ctx context.Context, org string, env string, thunderURL string, callerSupplied bool) bool {
 	if mock.ProbeFunc == nil {
 		panic("ThunderProberMock.ProbeFunc: method is nil but Prober.Probe was just called")
 	}
 	callInfo := struct {
-		Ctx        context.Context
-		Org        string
-		Env        string
-		ThunderURL string
+		Ctx            context.Context
+		Org            string
+		Env            string
+		ThunderURL     string
+		CallerSupplied bool
 	}{
-		Ctx:        ctx,
-		Org:        org,
-		Env:        env,
-		ThunderURL: thunderURL,
+		Ctx:            ctx,
+		Org:            org,
+		Env:            env,
+		ThunderURL:     thunderURL,
+		CallerSupplied: callerSupplied,
 	}
 	mock.lockProbe.Lock()
 	mock.calls.Probe = append(mock.calls.Probe, callInfo)
 	mock.lockProbe.Unlock()
-	return mock.ProbeFunc(ctx, org, env, thunderURL)
+	return mock.ProbeFunc(ctx, org, env, thunderURL, callerSupplied)
 }
 
 // ProbeCalls gets all the calls that were made to Probe.
@@ -71,16 +75,18 @@ func (mock *ThunderProberMock) Probe(ctx context.Context, org string, env string
 //
 //	len(mockedProber.ProbeCalls())
 func (mock *ThunderProberMock) ProbeCalls() []struct {
-	Ctx        context.Context
-	Org        string
-	Env        string
-	ThunderURL string
+	Ctx            context.Context
+	Org            string
+	Env            string
+	ThunderURL     string
+	CallerSupplied bool
 } {
 	var calls []struct {
-		Ctx        context.Context
-		Org        string
-		Env        string
-		ThunderURL string
+		Ctx            context.Context
+		Org            string
+		Env            string
+		ThunderURL     string
+		CallerSupplied bool
 	}
 	mock.lockProbe.RLock()
 	calls = mock.calls.Probe

--- a/agent-manager-service/clients/thundersvc/client.go
+++ b/agent-manager-service/clients/thundersvc/client.go
@@ -33,6 +33,8 @@ import (
 	"time"
 
 	"golang.org/x/sync/singleflight"
+
+	"github.com/wso2/agent-manager/agent-manager-service/utils/ssrf"
 )
 
 // ThunderClient encapsulates the Thunder API calls needed to create OAuth2 applications.
@@ -147,6 +149,24 @@ func NewThunderClient(baseURL, clientID, clientSecret string) ThunderClient {
 // instance's issuer. The System RS identifier is always "<issuer>/mcp", so callers
 // derive it from the instance's issuer URL, not the dialable base URL.
 func NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource string) ThunderClient {
+	return newThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource, false)
+}
+
+// NewEnvThunderClient is NewThunderClientWithDialOverride's env-Thunder variant:
+// when resolveToHost is empty, the dial is SSRF-hardened (re-resolved at
+// connect time, every redirect re-validated) rather than plain. Use this
+// wherever baseURL may be a SaaS-registered EnvThunderURL.ThunderURL, since
+// that value is only checked once at registration time (see
+// EnvironmentService.validateThunderURL) yet gets dialed for every later
+// admin/token call. Platform Thunder's clients deliberately keep using
+// NewThunderClientWithDialOverride instead: its base URL is always AMS's own
+// config, and local dev legitimately runs it on a "*.localhost" address the
+// SSRF guard would otherwise reject.
+func NewEnvThunderClient(baseURL, clientID, clientSecret, resolveToHost, systemResource string) ThunderClient {
+	return newThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource, true)
+}
+
+func newThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource string, ssrfHardenDirectDial bool) ThunderClient {
 	httpClient := &http.Client{Timeout: httpClientTimeout}
 	if resolveToHost != "" {
 		httpClient.Transport = &http.Transport{
@@ -165,6 +185,8 @@ func NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveTo
 		// here — baseURL's host is untouched, so the Host header Kgateway's
 		// host-based routing relies on is unaffected.
 		baseURL = "http://" + strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
+	} else if ssrfHardenDirectDial {
+		httpClient = ssrf.NewClient(httpClientTimeout)
 	}
 	return &thunderClient{
 		baseURL:        baseURL,

--- a/agent-manager-service/clients/thundersvc/client_test.go
+++ b/agent-manager-service/clients/thundersvc/client_test.go
@@ -133,6 +133,48 @@ func TestFetchSystemToken_ResourceSelection(t *testing.T) {
 	}
 }
 
+// TestNewEnvThunderClient_HardensOnlyTheNoOverrideDial proves the two
+// constructors genuinely differ: the same loopback server is reachable via
+// the plain constructor's no-override dial, but rejected by NewEnvThunderClient's
+// (ssrf.NewClient refuses a private/loopback target). The dial-override path
+// is unaffected by either — that target is always AMS's own trusted address.
+func TestNewEnvThunderClient_HardensOnlyTheNoOverrideDial(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth2/jwks", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	doGet := func(client ThunderClient) error {
+		tc, ok := client.(*thunderClient)
+		require.True(t, ok)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tc.baseURL+"/oauth2/jwks", nil)
+		require.NoError(t, err)
+		resp, err := tc.httpClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		return err
+	}
+
+	t.Run("plain constructor: no-override dial reaches the loopback server", func(t *testing.T) {
+		err := doGet(NewThunderClientWithDialOverride(server.URL, "cid", "secret", "", server.URL+"/mcp"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("env-Thunder constructor: no-override dial is rejected as an SSRF target", func(t *testing.T) {
+		err := doGet(NewEnvThunderClient(server.URL, "cid", "secret", "", server.URL+"/mcp"))
+		assert.Error(t, err, "the loopback test server must be REJECTED — this is exactly the case a SaaS-supplied thunder_url pointed at an internal address would hit")
+	})
+
+	t.Run("env-Thunder constructor: an explicit dial override is unaffected, same as the plain constructor", func(t *testing.T) {
+		overrideHost := strings.TrimPrefix(server.URL, "http://")
+		err := doGet(NewEnvThunderClient("http://unreachable.invalid:9999", "cid", "secret", overrideHost, "http://unreachable.invalid:9999/mcp"))
+		assert.NoError(t, err, "an explicit resolveToHost is always AMS's own trusted target, so it must not be SSRF-checked")
+	})
+}
+
 // TestCreateApp_SendsRequiredApplicationType guards against a regression:
 // applications require a "type" field on create, and a POST /applications
 // missing it fails outright. createApp's payload must always include it.

--- a/agent-manager-service/clients/thundersvc/env_resolver.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver.go
@@ -187,7 +187,14 @@ func (r *envThunderResolver) Resolve(ctx context.Context, ouID, orgNamespace, en
 		// The System RS identifier is "<issuer>/mcp", derived from the env-Thunder issuer
 		// URL — not the (possibly cluster-internal) dialable base URL selected above.
 		systemResource := SystemResourceIdentifier(ThunderIssuerURL(thunderURL))
-		client := NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource)
+		// baseURL==thunderURL with no override identifies the one candidate that
+		// may be a SaaS-registered, caller-supplied URL — cluster-internal DNS
+		// never equals thunderURL, and local-dev fallbacks always set resolveToHost.
+		newClient := NewThunderClientWithDialOverride
+		if resolveToHost == "" && baseURL == thunderURL {
+			newClient = NewEnvThunderClient
+		}
+		client := newClient(baseURL, clientID, clientSecret, resolveToHost, systemResource)
 
 		r.mu.Lock()
 		r.cache[cacheKey] = cachedThunderClient{client: client, cachedAt: r.now()}

--- a/agent-manager-service/clients/thundersvc/env_resolver.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver.go
@@ -73,26 +73,28 @@ type (
 	// ErrThunderNotProvisioned for a missing row.
 	ReadSystemClientFunc func(ctx context.Context, ouID, envName string) (clientID, clientSecret string, err error)
 
-	// ReadThunderHandleFunc reads an env-Thunder's registered URL handle (see
-	// EnvThunderURL) from AMS's own Postgres, keyed by (ouID, envName). A
-	// missing row means this environment was never provisioned — it returns
-	// ("", nil), never a value computed from (ouID, envName).
-	ReadThunderHandleFunc func(ctx context.Context, ouID, envName string) (handle string, err error)
+	// ReadThunderURLFunc reads an env-Thunder's registered origin (see
+	// EnvThunderURL.ThunderURL) from AMS's own Postgres, keyed by (ouID, envName).
+	// A missing row means this environment was never provisioned — it returns
+	// ("", nil), never a value computed from (ouID, envName). Works identically
+	// for an on-prem (handle-derived) or SaaS (control-plane-supplied) row —
+	// the resolver never needs to know which path produced the stored URL.
+	ReadThunderURLFunc func(ctx context.Context, ouID, envName string) (thunderURL string, err error)
 
 	// resolveBaseURLFunc picks a reachable base URL for an env-Thunder instance —
 	// injectable so tests don't depend on real network probing.
-	resolveBaseURLFunc func(ctx context.Context, org, env, handle string) (baseURL, resolveToHost string, ok bool)
+	resolveBaseURLFunc func(ctx context.Context, org, env, thunderURL string) (baseURL, resolveToHost string, ok bool)
 )
 
 // envThunderResolver reads the system-client credential via the injected
 // ReadSystemClientFunc (AMS's Postgres, not a key vault — cloud vaults are reveal-once),
-// and the env's URL handle (if any) via the injected ReadThunderHandleFunc.
+// and the env's registered URL (if any) via the injected ReadThunderURLFunc.
 type envThunderResolver struct {
-	readSystemClient  ReadSystemClientFunc
-	readThunderHandle ReadThunderHandleFunc
-	resolveBaseURL    resolveBaseURLFunc
-	ttl               time.Duration
-	now               func() time.Time
+	readSystemClient ReadSystemClientFunc
+	readThunderURL   ReadThunderURLFunc
+	resolveBaseURL   resolveBaseURLFunc
+	ttl              time.Duration
+	now              func() time.Time
 
 	mu    sync.RWMutex
 	cache map[string]cachedThunderClient // keyed by "org/env"
@@ -106,21 +108,21 @@ type cachedThunderClient struct {
 
 // NewEnvThunderResolver creates an EnvThunderResolver backed by the given
 // system-client reader (which decrypts the credential from AMS's Postgres) and
-// URL-handle reader (which looks up a user-chosen handle, if any, from the same DB).
-func NewEnvThunderResolver(readSystemClient ReadSystemClientFunc, readThunderHandle ReadThunderHandleFunc) EnvThunderResolver {
-	return newEnvThunderResolverWithReader(readSystemClient, readThunderHandle, ResolveThunderBaseURL)
+// URL reader (which looks up the registered origin, if any, from the same DB).
+func NewEnvThunderResolver(readSystemClient ReadSystemClientFunc, readThunderURL ReadThunderURLFunc) EnvThunderResolver {
+	return newEnvThunderResolverWithReader(readSystemClient, readThunderURL, ResolveThunderBaseURL)
 }
 
 // newEnvThunderResolverWithReader builds a resolver from injected readers and a
 // base-URL resolver — real implementations in production, fakes in tests.
-func newEnvThunderResolverWithReader(readSystemClient ReadSystemClientFunc, readThunderHandle ReadThunderHandleFunc, resolveBaseURL resolveBaseURLFunc) *envThunderResolver {
+func newEnvThunderResolverWithReader(readSystemClient ReadSystemClientFunc, readThunderURL ReadThunderURLFunc, resolveBaseURL resolveBaseURLFunc) *envThunderResolver {
 	return &envThunderResolver{
-		readSystemClient:  readSystemClient,
-		readThunderHandle: readThunderHandle,
-		resolveBaseURL:    resolveBaseURL,
-		ttl:               envThunderClientCacheTTL,
-		now:               time.Now,
-		cache:             make(map[string]cachedThunderClient),
+		readSystemClient: readSystemClient,
+		readThunderURL:   readThunderURL,
+		resolveBaseURL:   resolveBaseURL,
+		ttl:              envThunderClientCacheTTL,
+		now:              time.Now,
+		cache:            make(map[string]cachedThunderClient),
 	}
 }
 
@@ -166,27 +168,25 @@ func (r *envThunderResolver) Resolve(ctx context.Context, ouID, orgNamespace, en
 			return nil, ErrThunderNotProvisioned
 		}
 
-		// Every environment gets a handle at provisioning time (see SetThunderURL) —
-		// there is no fallback to a pattern computed from org/env. A missing handle
-		// (read error OR genuinely no row) means this env-Thunder was never
-		// provisioned through add-environment-thunder.sh, exactly like a missing
-		// system-client secret above — so it gets the same ErrThunderNotProvisioned,
-		// not a degraded/guessed address.
-		handle, err := r.readThunderHandle(ctx, ouID, envName)
+		// Every environment gets a registered URL at provisioning time — no
+		// fallback to a pattern computed from org/env. A missing URL means
+		// this env-Thunder was never provisioned, same as a missing
+		// system-client secret above: ErrThunderNotProvisioned, not a guess.
+		thunderURL, err := r.readThunderURL(ctx, ouID, envName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read env-thunder url handle for %s/%s: %w", ouID, envName, err)
+			return nil, fmt.Errorf("failed to read env-thunder url for %s/%s: %w", ouID, envName, err)
 		}
-		if handle == "" {
+		if thunderURL == "" {
 			return nil, ErrThunderNotProvisioned
 		}
 
-		baseURL, resolveToHost, ok := r.resolveBaseURL(ctx, orgNamespace, envName, handle)
+		baseURL, resolveToHost, ok := r.resolveBaseURL(ctx, orgNamespace, envName, thunderURL)
 		if !ok {
 			return nil, fmt.Errorf("%w: %s/%s", ErrThunderUnreachable, orgNamespace, envName)
 		}
 		// The System RS identifier is "<issuer>/mcp", derived from the env-Thunder issuer
 		// URL — not the (possibly cluster-internal) dialable base URL selected above.
-		systemResource := SystemResourceIdentifier(ThunderIssuerURL(handle))
+		systemResource := SystemResourceIdentifier(ThunderIssuerURL(thunderURL))
 		client := NewThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveToHost, systemResource)
 
 		r.mu.Lock()

--- a/agent-manager-service/clients/thundersvc/env_resolver.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver.go
@@ -76,14 +76,16 @@ type (
 	// ReadThunderURLFunc reads an env-Thunder's registered origin (see
 	// EnvThunderURL.ThunderURL) from AMS's own Postgres, keyed by (ouID, envName).
 	// A missing row means this environment was never provisioned — it returns
-	// ("", nil), never a value computed from (ouID, envName). Works identically
-	// for an on-prem (handle-derived) or SaaS (control-plane-supplied) row —
-	// the resolver never needs to know which path produced the stored URL.
-	ReadThunderURLFunc func(ctx context.Context, ouID, envName string) (thunderURL string, err error)
+	// ("", false, nil), never a value computed from (ouID, envName).
+	// callerSupplied reports whether the row came from the SaaS/control-plane
+	// path (no handle) rather than the on-prem (handle) one — needed so the
+	// candidate cascade below can tell an attacker-influenced value from one
+	// AMS computed itself under its own trusted domain.
+	ReadThunderURLFunc func(ctx context.Context, ouID, envName string) (thunderURL string, callerSupplied bool, err error)
 
 	// resolveBaseURLFunc picks a reachable base URL for an env-Thunder instance —
 	// injectable so tests don't depend on real network probing.
-	resolveBaseURLFunc func(ctx context.Context, org, env, thunderURL string) (baseURL, resolveToHost string, ok bool)
+	resolveBaseURLFunc func(ctx context.Context, org, env, thunderURL string, callerSupplied bool) (baseURL, resolveToHost string, ok bool)
 )
 
 // envThunderResolver reads the system-client credential via the injected
@@ -172,7 +174,7 @@ func (r *envThunderResolver) Resolve(ctx context.Context, ouID, orgNamespace, en
 		// fallback to a pattern computed from org/env. A missing URL means
 		// this env-Thunder was never provisioned, same as a missing
 		// system-client secret above: ErrThunderNotProvisioned, not a guess.
-		thunderURL, err := r.readThunderURL(ctx, ouID, envName)
+		thunderURL, callerSupplied, err := r.readThunderURL(ctx, ouID, envName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read env-thunder url for %s/%s: %w", ouID, envName, err)
 		}
@@ -180,18 +182,20 @@ func (r *envThunderResolver) Resolve(ctx context.Context, ouID, orgNamespace, en
 			return nil, ErrThunderNotProvisioned
 		}
 
-		baseURL, resolveToHost, ok := r.resolveBaseURL(ctx, orgNamespace, envName, thunderURL)
+		baseURL, resolveToHost, ok := r.resolveBaseURL(ctx, orgNamespace, envName, thunderURL, callerSupplied)
 		if !ok {
 			return nil, fmt.Errorf("%w: %s/%s", ErrThunderUnreachable, orgNamespace, envName)
 		}
 		// The System RS identifier is "<issuer>/mcp", derived from the env-Thunder issuer
 		// URL — not the (possibly cluster-internal) dialable base URL selected above.
 		systemResource := SystemResourceIdentifier(ThunderIssuerURL(thunderURL))
-		// baseURL==thunderURL with no override identifies the one candidate that
-		// may be a SaaS-registered, caller-supplied URL — cluster-internal DNS
-		// never equals thunderURL, and local-dev fallbacks always set resolveToHost.
+		// baseURL==thunderURL with no override identifies the plain-external
+		// candidate; callerSupplied says whether ITS VALUE is attacker-influenced
+		// (a SaaS row) rather than AMS's own trusted computation (an on-prem
+		// row, which can legitimately be a private address — see
+		// thunderURLCandidate's doc comment). Both must hold to harden the dial.
 		newClient := NewThunderClientWithDialOverride
-		if resolveToHost == "" && baseURL == thunderURL {
+		if resolveToHost == "" && baseURL == thunderURL && callerSupplied {
 			newClient = NewEnvThunderClient
 		}
 		client := newClient(baseURL, clientID, clientSecret, resolveToHost, systemResource)

--- a/agent-manager-service/clients/thundersvc/env_resolver_test.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver_test.go
@@ -50,20 +50,21 @@ func fakeResolveBaseURL(_ context.Context, _, _, _ string) (string, string, bool
 	return "http://fake-thunder:8090", "", true
 }
 
-// noHandleReader stands in for an environment that was never provisioned
-// through add-environment-thunder.sh (or whose registration never completed):
-// no URL handle exists, so Resolve must report ErrThunderNotProvisioned — there
-// is no fallback to compute an address from org/env.
-func noHandleReader(context.Context, string, string) (string, error) {
+// noURLReader stands in for an environment that was never provisioned
+// through add-environment-thunder.sh or a control plane (or whose
+// registration never completed): no URL exists, so Resolve must report
+// ErrThunderNotProvisioned — there is no fallback to compute an address from
+// org/env.
+func noURLReader(context.Context, string, string) (string, error) {
 	return "", nil
 }
 
-// okHandleReader returns a fixed handle for any (ouID, env) — the common case
-// for tests that don't care about the handle lookup itself, just that Resolve
-// gets past it.
-func okHandleReader(handle string) ReadThunderHandleFunc {
+// okURLReader returns a fixed thunderURL for any (ouID, env) — the common
+// case for tests that don't care about the URL lookup itself, just that
+// Resolve gets past it.
+func okURLReader(thunderURL string) ReadThunderURLFunc {
 	return func(context.Context, string, string) (string, error) {
-		return handle, nil
+		return thunderURL, nil
 	}
 }
 
@@ -73,7 +74,7 @@ func TestEnvThunderResolver_Resolve_Success(t *testing.T) {
 		gotOUID, gotEnv = ouID, env
 		return "amp-system-client", "the-system-client-secret", nil
 	}
-	resolver := newEnvThunderResolverWithReader(read, okHandleReader("x7f2q9kz"), fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(read, okURLReader("x7f2q9kz"), fakeResolveBaseURL)
 
 	client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 	require.NoError(t, err)
@@ -85,7 +86,7 @@ func TestEnvThunderResolver_Resolve_Success(t *testing.T) {
 // TestEnvThunderResolver_Resolve_UsesStoredClientID confirms the resolver uses
 // the client ID returned by the reader (not only the well-known constant).
 func TestEnvThunderResolver_Resolve_UsesStoredClientID(t *testing.T) {
-	resolver := newEnvThunderResolverWithReader(okReader("custom-client-id", "s3cr3t"), okHandleReader("x7f2q9kz"), fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(okReader("custom-client-id", "s3cr3t"), okURLReader("x7f2q9kz"), fakeResolveBaseURL)
 
 	client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 	require.NoError(t, err)
@@ -101,7 +102,7 @@ func TestEnvThunderResolver_Resolve_RejectsPathBreakingSegments(t *testing.T) {
 		t.Fatal("must not read the store when a segment is invalid")
 		return "", "", nil // unreachable — t.Fatal above halts the test
 	}
-	resolver := newEnvThunderResolverWithReader(read, okHandleReader("x7f2q9kz"), fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(read, okURLReader("x7f2q9kz"), fakeResolveBaseURL)
 
 	cases := []struct{ ouID, ns, env string }{
 		{"..", testOrgNamespace, "staging"},
@@ -127,7 +128,7 @@ func TestEnvThunderResolver_Resolve_Caches(t *testing.T) {
 		calls++
 		return "amp-system-client", "s3cr3t", nil
 	}
-	resolver := newEnvThunderResolverWithReader(read, okHandleReader("x7f2q9kz"), fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(read, okURLReader("x7f2q9kz"), fakeResolveBaseURL)
 
 	c1, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 	require.NoError(t, err)
@@ -146,7 +147,7 @@ func TestEnvThunderResolver_Resolve_ExpiresAfterTTL(t *testing.T) {
 		calls++
 		return "amp-system-client", "s3cr3t", nil
 	}
-	resolver := newEnvThunderResolverWithReader(read, okHandleReader("x7f2q9kz"), fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(read, okURLReader("x7f2q9kz"), fakeResolveBaseURL)
 	now := time.Now()
 	resolver.now = func() time.Time { return now }
 	resolver.ttl = time.Minute
@@ -180,7 +181,7 @@ func TestEnvThunderResolver_Resolve_ConcurrentCacheMiss_DedupesViaSingleflight(t
 		atomic.AddInt64(&probeCalls, 1)
 		return "http://fake-thunder:8090", "", true
 	}
-	resolver := newEnvThunderResolverWithReader(read, okHandleReader("x7f2q9kz"), probeFn)
+	resolver := newEnvThunderResolverWithReader(read, okURLReader("x7f2q9kz"), probeFn)
 
 	const goroutines = 20
 	clients := make([]ThunderClient, goroutines)
@@ -208,7 +209,7 @@ func TestEnvThunderResolver_Resolve_ConcurrentCacheMiss_DedupesViaSingleflight(t
 }
 
 func TestEnvThunderResolver_Resolve_DifferentEnvironmentsAreNotCachedTogether(t *testing.T) {
-	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okHandleReader("x7f2q9kz"), fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("x7f2q9kz"), fakeResolveBaseURL)
 
 	staging, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 	require.NoError(t, err)
@@ -228,7 +229,7 @@ func TestEnvThunderResolver_Resolve_DifferentOUIDsAreNotCachedTogether(t *testin
 		gotOUIDs = append(gotOUIDs, ouID)
 		return "amp-system-client", "s3cr3t-" + ouID, nil
 	}
-	resolver := newEnvThunderResolverWithReader(read, okHandleReader("x7f2q9kz"), fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(read, okURLReader("x7f2q9kz"), fakeResolveBaseURL)
 
 	acme, err := resolver.Resolve(context.Background(), "ou-acme", testOrgNamespace, "staging")
 	require.NoError(t, err)
@@ -243,14 +244,14 @@ func TestEnvThunderResolver_Resolve_NotProvisioned_NoRow(t *testing.T) {
 	read := func(context.Context, string, string) (string, string, error) {
 		return "", "", ErrThunderNotProvisioned
 	}
-	resolver := newEnvThunderResolverWithReader(read, noHandleReader, fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(read, noURLReader, fakeResolveBaseURL)
 
 	_, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "no-such-env")
 	assert.True(t, errors.Is(err, ErrThunderNotProvisioned))
 }
 
 func TestEnvThunderResolver_Resolve_NotProvisioned_EmptySecret(t *testing.T) {
-	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", ""), noHandleReader, fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", ""), noURLReader, fakeResolveBaseURL)
 
 	_, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "half-provisioned-env")
 	assert.True(t, errors.Is(err, ErrThunderNotProvisioned))
@@ -267,7 +268,7 @@ func TestEnvThunderResolver_Resolve_NoHandleRegistered(t *testing.T) {
 		resolveBaseURLCalled = true
 		return "", "", false
 	}
-	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), noHandleReader, resolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), noURLReader, resolveBaseURL)
 
 	_, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "never-registered-env")
 	assert.True(t, errors.Is(err, ErrThunderNotProvisioned), "no handle must be treated as not-provisioned")
@@ -292,7 +293,7 @@ func TestEnvThunderResolver_Resolve_ReadErrorPropagates(t *testing.T) {
 	read := func(context.Context, string, string) (string, string, error) {
 		return "", "", boom
 	}
-	resolver := newEnvThunderResolverWithReader(read, noHandleReader, fakeResolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(read, noURLReader, fakeResolveBaseURL)
 
 	_, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 	require.Error(t, err)
@@ -305,7 +306,7 @@ func TestEnvThunderResolver_Resolve_UsesResolvedBaseURLAndDialOverride(t *testin
 		gotNamespace, gotEnv = ns, env
 		return "http://acme-staging.amp.localhost:8080", "host.docker.internal:8080", true
 	}
-	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okHandleReader("x7f2q9kz"), resolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("x7f2q9kz"), resolveBaseURL)
 
 	client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 	require.NoError(t, err)
@@ -323,7 +324,7 @@ func TestEnvThunderResolver_Resolve_ThunderUnreachable(t *testing.T) {
 	resolveBaseURL := func(_ context.Context, _, _, _ string) (string, string, bool) {
 		return "", "", false
 	}
-	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okHandleReader("x7f2q9kz"), resolveBaseURL)
+	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("x7f2q9kz"), resolveBaseURL)
 
 	_, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 	require.Error(t, err)

--- a/agent-manager-service/clients/thundersvc/env_resolver_test.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver_test.go
@@ -19,6 +19,9 @@ package thundersvc
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -318,6 +321,65 @@ func TestEnvThunderResolver_Resolve_UsesResolvedBaseURLAndDialOverride(t *testin
 	require.True(t, ok)
 	assert.Equal(t, "http://acme-staging.amp.localhost:8080", tc.baseURL)
 	require.NotNil(t, tc.httpClient.Transport, "a non-empty dial override must install a custom transport")
+}
+
+// TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalWinner proves the
+// resolver itself, not just the two constructors in isolation, picks the
+// SSRF-hardened client only for the plain-external winner (baseURL==thunderURL,
+// no override). A cluster-internal-DNS-shaped or dial-override winner must get
+// the plain client, since neither is caller-influenced.
+func TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalWinner(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	doGet := func(t *testing.T, client ThunderClient) error {
+		t.Helper()
+		tc, ok := client.(*thunderClient)
+		require.True(t, ok)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tc.baseURL, nil)
+		require.NoError(t, err)
+		resp, err := tc.httpClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		return err
+	}
+
+	t.Run("plain external winner (baseURL==thunderURL, no override): SSRF-hardened, loopback rejected", func(t *testing.T) {
+		resolveBaseURL := func(_ context.Context, _, _, thunderURL string) (string, string, bool) {
+			return thunderURL, "", true
+		}
+		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader(server.URL), resolveBaseURL)
+
+		client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
+		require.NoError(t, err)
+		assert.Error(t, doGet(t, client), "the loopback server must be rejected — this is what a SaaS-supplied thunder_url pointed at an internal address would hit")
+	})
+
+	t.Run("cluster-internal-DNS-shaped winner (baseURL != thunderURL): plain client, loopback reachable", func(t *testing.T) {
+		resolveBaseURL := func(_ context.Context, _, _, _ string) (string, string, bool) {
+			return server.URL, "", true // baseURL deliberately does NOT equal thunderURL below
+		}
+		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("http://different-thunder-url:8080"), resolveBaseURL)
+
+		client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
+		require.NoError(t, err)
+		assert.NoError(t, doGet(t, client), "AMS's own cluster-internal candidate must never be SSRF-checked, or real in-cluster DNS (always a private IP) would always be rejected")
+	})
+
+	t.Run("dial-override winner: plain client, loopback reachable regardless of baseURL", func(t *testing.T) {
+		overrideHost := strings.TrimPrefix(server.URL, "http://")
+		resolveBaseURL := func(_ context.Context, _, _, thunderURL string) (string, string, bool) {
+			return thunderURL, overrideHost, true
+		}
+		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("http://unreachable.invalid:9999"), resolveBaseURL)
+
+		client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
+		require.NoError(t, err)
+		assert.NoError(t, doGet(t, client), "an explicit dial override is always AMS's own trusted target, so it must not be SSRF-checked")
+	})
 }
 
 func TestEnvThunderResolver_Resolve_ThunderUnreachable(t *testing.T) {

--- a/agent-manager-service/clients/thundersvc/env_resolver_test.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver_test.go
@@ -49,7 +49,7 @@ func okReader(clientID, secret string) ReadSystemClientFunc {
 
 // fakeResolveBaseURL stands in for real network probing — always reports a
 // fake, reachable base URL with no dial override.
-func fakeResolveBaseURL(_ context.Context, _, _, _ string) (string, string, bool) {
+func fakeResolveBaseURL(_ context.Context, _, _, _ string, _ bool) (string, string, bool) {
 	return "http://fake-thunder:8090", "", true
 }
 
@@ -58,16 +58,25 @@ func fakeResolveBaseURL(_ context.Context, _, _, _ string) (string, string, bool
 // registration never completed): no URL exists, so Resolve must report
 // ErrThunderNotProvisioned — there is no fallback to compute an address from
 // org/env.
-func noURLReader(context.Context, string, string) (string, error) {
-	return "", nil
+func noURLReader(context.Context, string, string) (string, bool, error) {
+	return "", false, nil
 }
 
-// okURLReader returns a fixed thunderURL for any (ouID, env) — the common
-// case for tests that don't care about the URL lookup itself, just that
-// Resolve gets past it.
+// okURLReader returns a fixed thunderURL for any (ouID, env), reported as an
+// on-prem (handle) row — the common case for tests that don't care about the
+// URL lookup itself, just that Resolve gets past it. Use okSaaSURLReader for
+// tests specifically about the SaaS/caller-supplied distinction.
 func okURLReader(thunderURL string) ReadThunderURLFunc {
-	return func(context.Context, string, string) (string, error) {
-		return thunderURL, nil
+	return func(context.Context, string, string) (string, bool, error) {
+		return thunderURL, false, nil
+	}
+}
+
+// okSaaSURLReader is okURLReader's counterpart for a SaaS/control-plane row
+// (no handle) — callerSupplied is true.
+func okSaaSURLReader(thunderURL string) ReadThunderURLFunc {
+	return func(context.Context, string, string) (string, bool, error) {
+		return thunderURL, true, nil
 	}
 }
 
@@ -180,7 +189,7 @@ func TestEnvThunderResolver_Resolve_ConcurrentCacheMiss_DedupesViaSingleflight(t
 		time.Sleep(20 * time.Millisecond) // widen the race window
 		return "amp-system-client", "s3cr3t", nil
 	}
-	probeFn := func(_ context.Context, _, _, _ string) (string, string, bool) {
+	probeFn := func(_ context.Context, _, _, _ string, _ bool) (string, string, bool) {
 		atomic.AddInt64(&probeCalls, 1)
 		return "http://fake-thunder:8090", "", true
 	}
@@ -267,7 +276,7 @@ func TestEnvThunderResolver_Resolve_NotProvisioned_EmptySecret(t *testing.T) {
 // be called.
 func TestEnvThunderResolver_Resolve_NoHandleRegistered(t *testing.T) {
 	resolveBaseURLCalled := false
-	resolveBaseURL := func(context.Context, string, string, string) (string, string, bool) {
+	resolveBaseURL := func(context.Context, string, string, string, bool) (string, string, bool) {
 		resolveBaseURLCalled = true
 		return "", "", false
 	}
@@ -280,8 +289,8 @@ func TestEnvThunderResolver_Resolve_NoHandleRegistered(t *testing.T) {
 
 func TestEnvThunderResolver_Resolve_HandleReadErrorPropagates(t *testing.T) {
 	dbErr := errors.New("db unavailable")
-	readHandle := func(context.Context, string, string) (string, error) {
-		return "", dbErr
+	readHandle := func(context.Context, string, string) (string, bool, error) {
+		return "", false, dbErr
 	}
 	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), readHandle, fakeResolveBaseURL)
 
@@ -305,7 +314,7 @@ func TestEnvThunderResolver_Resolve_ReadErrorPropagates(t *testing.T) {
 
 func TestEnvThunderResolver_Resolve_UsesResolvedBaseURLAndDialOverride(t *testing.T) {
 	var gotNamespace, gotEnv string
-	resolveBaseURL := func(_ context.Context, ns, env, _ string) (string, string, bool) {
+	resolveBaseURL := func(_ context.Context, ns, env, _ string, _ bool) (string, string, bool) {
 		gotNamespace, gotEnv = ns, env
 		return "http://acme-staging.amp.localhost:8080", "host.docker.internal:8080", true
 	}
@@ -323,12 +332,15 @@ func TestEnvThunderResolver_Resolve_UsesResolvedBaseURLAndDialOverride(t *testin
 	require.NotNil(t, tc.httpClient.Transport, "a non-empty dial override must install a custom transport")
 }
 
-// TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalWinner proves the
-// resolver itself, not just the two constructors in isolation, picks the
-// SSRF-hardened client only for the plain-external winner (baseURL==thunderURL,
-// no override). A cluster-internal-DNS-shaped or dial-override winner must get
-// the plain client, since neither is caller-influenced.
-func TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalWinner(t *testing.T) {
+// TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalSaaSWinner proves
+// the resolver itself, not just the two constructors in isolation, picks the
+// SSRF-hardened client only when BOTH hold: the winning candidate is the
+// plain-external one (baseURL==thunderURL, no override) AND the row is
+// SaaS/caller-supplied (no handle). Candidate position alone is not enough —
+// an on-prem row landing on that exact same position (e.g. a VM install whose
+// sslip.io hostname resolves to a private LAN IP) must NOT be hardened, or a
+// working deployment goes from reachable to permanently ErrThunderUnreachable.
+func TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalSaaSWinner(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 	server := httptest.NewServer(mux)
@@ -347,34 +359,45 @@ func TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalWinner(t *testing
 		return err
 	}
 
-	t.Run("plain external winner (baseURL==thunderURL, no override): SSRF-hardened, loopback rejected", func(t *testing.T) {
-		resolveBaseURL := func(_ context.Context, _, _, thunderURL string) (string, string, bool) {
+	t.Run("plain external winner, SaaS row (no handle): SSRF-hardened, loopback rejected", func(t *testing.T) {
+		resolveBaseURL := func(_ context.Context, _, _, thunderURL string, _ bool) (string, string, bool) {
 			return thunderURL, "", true
 		}
-		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader(server.URL), resolveBaseURL)
+		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okSaaSURLReader(server.URL), resolveBaseURL)
 
 		client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 		require.NoError(t, err)
 		assert.Error(t, doGet(t, client), "the loopback server must be rejected — this is what a SaaS-supplied thunder_url pointed at an internal address would hit")
 	})
 
-	t.Run("cluster-internal-DNS-shaped winner (baseURL != thunderURL): plain client, loopback reachable", func(t *testing.T) {
-		resolveBaseURL := func(_ context.Context, _, _, _ string) (string, string, bool) {
+	t.Run("plain external winner, on-prem row (handle): plain client, loopback reachable", func(t *testing.T) {
+		resolveBaseURL := func(_ context.Context, _, _, thunderURL string, _ bool) (string, string, bool) {
+			return thunderURL, "", true
+		}
+		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader(server.URL), resolveBaseURL)
+
+		client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
+		require.NoError(t, err)
+		assert.NoError(t, doGet(t, client), "an on-prem (handle) row's URL is AMS's own trusted computation and can legitimately be private (e.g. a VM install's sslip.io hostname on a LAN IP) — hardening it would break a working deployment")
+	})
+
+	t.Run("cluster-internal-DNS-shaped winner (baseURL != thunderURL): plain client, loopback reachable regardless of trust", func(t *testing.T) {
+		resolveBaseURL := func(_ context.Context, _, _, _ string, _ bool) (string, string, bool) {
 			return server.URL, "", true // baseURL deliberately does NOT equal thunderURL below
 		}
-		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("http://different-thunder-url:8080"), resolveBaseURL)
+		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okSaaSURLReader("http://different-thunder-url:8080"), resolveBaseURL)
 
 		client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 		require.NoError(t, err)
 		assert.NoError(t, doGet(t, client), "AMS's own cluster-internal candidate must never be SSRF-checked, or real in-cluster DNS (always a private IP) would always be rejected")
 	})
 
-	t.Run("dial-override winner: plain client, loopback reachable regardless of baseURL", func(t *testing.T) {
+	t.Run("dial-override winner: plain client, loopback reachable regardless of baseURL or trust", func(t *testing.T) {
 		overrideHost := strings.TrimPrefix(server.URL, "http://")
-		resolveBaseURL := func(_ context.Context, _, _, thunderURL string) (string, string, bool) {
+		resolveBaseURL := func(_ context.Context, _, _, thunderURL string, _ bool) (string, string, bool) {
 			return thunderURL, overrideHost, true
 		}
-		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("http://unreachable.invalid:9999"), resolveBaseURL)
+		resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okSaaSURLReader("http://unreachable.invalid:9999"), resolveBaseURL)
 
 		client, err := resolver.Resolve(context.Background(), testOUID, testOrgNamespace, "staging")
 		require.NoError(t, err)
@@ -383,7 +406,7 @@ func TestEnvThunderResolver_Resolve_HardensOnlyThePlainExternalWinner(t *testing
 }
 
 func TestEnvThunderResolver_Resolve_ThunderUnreachable(t *testing.T) {
-	resolveBaseURL := func(_ context.Context, _, _, _ string) (string, string, bool) {
+	resolveBaseURL := func(_ context.Context, _, _, _ string, _ bool) (string, string, bool) {
 		return "", "", false
 	}
 	resolver := newEnvThunderResolverWithReader(okReader("amp-system-client", "s3cr3t"), okURLReader("x7f2q9kz"), resolveBaseURL)

--- a/agent-manager-service/clients/thundersvc/naming.go
+++ b/agent-manager-service/clients/thundersvc/naming.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/utils/ssrf"
 )
 
 const (
@@ -107,43 +108,30 @@ func ThunderTokenURL(org, env string) string {
 	return ThunderInternalURL(org, env) + "/oauth2/token"
 }
 
-// ThunderExternalTokenURL returns the public OAuth2 token endpoint for the env-Thunder instance.
-// Reachable from outside the cluster via the HTTPRoute that maps the handle -> the
-// Thunder service (locally through the k3d gateway; on a VM through the Caddy
-// wildcard site — see deployments/vm/lib-vm.sh).
-// Use this in developer-facing API responses (console copy-buttons, Identity page, etc.).
-// See thunderExternalOrigin for handle.
-func ThunderExternalTokenURL(handle string) string {
-	return thunderExternalOrigin(handle) + "/oauth2/token"
+// ThunderExternalTokenURL returns the public OAuth2 token endpoint for the
+// env-Thunder instance, given its stored EnvThunderURL.ThunderURL origin.
+func ThunderExternalTokenURL(thunderURL string) string {
+	return thunderURL + "/oauth2/token"
 }
 
-// ThunderExternalJWKSURL returns the public JWKS endpoint for the env-Thunder instance.
-// Reachable from outside the cluster via the same route as ThunderExternalTokenURL.
-// Use this in developer-facing API responses. See thunderExternalOrigin for handle.
-func ThunderExternalJWKSURL(handle string) string {
-	return thunderExternalOrigin(handle) + "/oauth2/jwks"
+// ThunderExternalJWKSURL returns the public JWKS endpoint for the env-Thunder
+// instance, given its stored origin.
+func ThunderExternalJWKSURL(thunderURL string) string {
+	return thunderURL + "/oauth2/jwks"
 }
 
-// thunderExternalOrigin returns "<scheme>://<handle>.<baseDomain>[:8080]" — the
-// externally reachable origin for an env-Thunder instance, addressed by its
-// EnvThunderURL handle (see that model's doc comment for why org/env are never
-// used here: every environment is assigned a handle — user-chosen or generated —
-// at provisioning time, so there is nothing else this could be built from).
-// baseDomain is deployment-specific (THUNDER_HOST_BASE_DOMAIN, e.g. "amp.localhost"
-// for local dev or a VM's own real domain) — the handle sits directly under it,
-// with no fixed subdomain segment in between, so a VM's domain shape is honored
-// exactly as configured. reservedThunderHandles (environment_service.go) blocks
-// handles that would collide with the platform's own fixed subdomains (console,
-// api, thunder, etc.) under the same baseDomain.
-// Local dev (config.TLSConfig.EnableTLS == false, the default) reaches env-Thunder
-// directly on the k3d gateway's plain-HTTP port 8080. VM/production deployments
-// (TLS_ENABLED=true — the same flag deployments/vm/lib-vm.sh already sets for
-// platform Thunder's own advertised URLs) front env-Thunder with Caddy on the
-// standard HTTPS port instead, so no port is appended:
-// deployments/scripts/thunder-naming.sh's thunder_issuer() must produce the SAME
-// scheme/port shape when TLS_ENABLED=true, or the URL reported here won't match
-// what env-Thunder itself self-configured as its issuer/publicUrl.
-func thunderExternalOrigin(handle string) string {
+// ThunderOriginFromHandle returns "<scheme>://<handle>.<baseDomain>[:8080]" for
+// an on-prem-registered instance. WRITE-TIME ONLY: called from
+// EnvironmentService.SetThunderURL to compute the value stored as
+// EnvThunderURL.ThunderURL, never by a reader — readers always use the stored
+// value directly, since one global base-domain config can't describe every
+// environment once a cloud control plane provisions across different domains.
+//
+// Scheme/port must match what env-Thunder itself self-configured as its
+// issuer (see thunder-naming.sh's thunder_issuer(), which must stay in sync):
+// local dev (TLS disabled) uses plain HTTP on port 8080; TLS_ENABLED=true
+// (VM/production, fronted by Caddy) drops the port and uses HTTPS.
+func ThunderOriginFromHandle(handle string) string {
 	if handle == "" {
 		panic("thunder url handle must not be empty — callers must check for \"not provisioned\" before building a URL")
 	}
@@ -154,10 +142,12 @@ func thunderExternalOrigin(handle string) string {
 	return fmt.Sprintf("http://%s:8080", host)
 }
 
-// ThunderIssuerURL returns the public issuer URL for the env-Thunder instance —
-// what Thunder stamps into the JWT iss claim. See thunderExternalOrigin for handle.
-func ThunderIssuerURL(handle string) string {
-	return thunderExternalOrigin(handle)
+// ThunderIssuerURL returns the public issuer URL for the env-Thunder
+// instance — what Thunder stamps into the JWT iss claim. Currently an
+// identity function over the stored origin, kept as a distinct name so
+// callers stay self-documenting.
+func ThunderIssuerURL(thunderURL string) string {
+	return thunderURL
 }
 
 // isValidJWKS reports whether body is a syntactically valid JWKS document (a JSON
@@ -180,9 +170,19 @@ func isValidJWKS(body []byte) bool {
 // is empty when the base URL's own host is directly dialable; when set, callers must
 // dial resolveToHost while keeping the base URL's host as the HTTP Host header, so
 // Kgateway's host-based routing still selects the right backend.
+// external marks the ONE candidate dialed by its own host with no internal
+// override — the exact stored EnvThunderURL.ThunderURL. For an on-prem
+// (handle) row that value is server-computed under AMS's own trusted base
+// domain, but for a SaaS (url) row it's caller-supplied — so this candidate,
+// and only this one, is dialed with ssrf.NewClient (re-resolves at dial time,
+// re-validates every redirect hop) rather than the plain default client.
+// Cluster-internal DNS and the local-dev host-override candidates are never
+// marked external: they're either AMS-computed or deliberately private-target
+// by design, and would be wrongly rejected by the SSRF guard's private-IP check.
 type thunderURLCandidate struct {
 	baseURL       string
 	resolveToHost string
+	external      bool
 }
 
 // thunderBaseURLCandidates returns, in preference order, every base URL an env-Thunder
@@ -202,16 +202,17 @@ type thunderURLCandidate struct {
 // env-Thunder's admin API for per-agent client provisioning) build their attempts from
 // this same list, so the two can never drift out of sync with each other.
 //
-// handle builds the external candidate (see thunderExternalOrigin — it must be
-// non-empty; callers check for "not provisioned" before ever reaching here). The
-// internal cluster-DNS candidate is unaffected — it's addressed by org/env, not
-// part of the guessable attack surface handle replaces (see EnvThunderURL's doc
-// comment).
-func thunderBaseURLCandidates(org, env, handle string) []thunderURLCandidate {
-	externalBaseURL := thunderExternalOrigin(handle)
+// thunderURL is the stored EnvThunderURL.ThunderURL origin and builds the
+// external candidate directly; it must be non-empty (callers check for "not
+// provisioned" before ever reaching here).
+func thunderBaseURLCandidates(org, env, thunderURL string) []thunderURLCandidate {
+	if thunderURL == "" {
+		panic("thunder url must not be empty — callers must check for \"not provisioned\" before building candidates")
+	}
+	externalBaseURL := thunderURL
 	candidates := []thunderURLCandidate{
 		{baseURL: ThunderInternalURL(org, env)},
-		{baseURL: externalBaseURL},
+		{baseURL: externalBaseURL, external: true},
 	}
 	if config.GetConfig().IsLocalDevEnv {
 		candidates = append(
@@ -228,7 +229,11 @@ func thunderBaseURLCandidates(org, env, handle string) []thunderURLCandidate {
 // Thunder instance, since an unrelated server answering on a probed fallback address
 // would otherwise be misreported as reachable. Optionally dials resolveToHost instead
 // of the URL's own host (see thunderURLCandidate).
-func probeThunderURL(ctx context.Context, url, resolveToHost string) bool {
+//
+// external selects an SSRF-hardened client (re-resolves at dial time, re-validates
+// every redirect hop) instead of the plain default one — see thunderURLCandidate's
+// doc comment for exactly which candidate this applies to and why.
+func probeThunderURL(ctx context.Context, url, resolveToHost string, external bool) bool {
 	const probeTimeout = 2 * time.Second
 	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
@@ -240,7 +245,11 @@ func probeThunderURL(ctx context.Context, url, resolveToHost string) bool {
 		req.Host = req.URL.Host
 		req.URL.Host = resolveToHost
 	}
-	resp, err := http.DefaultClient.Do(req)
+	httpClient := http.DefaultClient
+	if external {
+		httpClient = ssrf.NewClient(probeTimeout)
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return false
 	}
@@ -263,14 +272,14 @@ type thunderURLProber func(ctx context.Context, candidate thunderURLCandidate) b
 
 // defaultThunderURLProber is the real, network-probing implementation used outside tests.
 func defaultThunderURLProber(ctx context.Context, candidate thunderURLCandidate) bool {
-	return probeThunderURL(ctx, candidate.baseURL+"/oauth2/jwks", candidate.resolveToHost)
+	return probeThunderURL(ctx, candidate.baseURL+"/oauth2/jwks", candidate.resolveToHost, candidate.external)
 }
 
 // resolveThunderBaseURL returns the first candidate base URL that prober reports as
 // reachable, trying them in thunderBaseURLCandidates' preference order. ok is false
 // if none respond.
-func resolveThunderBaseURL(ctx context.Context, org, env, handle string, prober thunderURLProber) (candidate thunderURLCandidate, ok bool) {
-	for _, c := range thunderBaseURLCandidates(org, env, handle) {
+func resolveThunderBaseURL(ctx context.Context, org, env, thunderURL string, prober thunderURLProber) (candidate thunderURLCandidate, ok bool) {
+	for _, c := range thunderBaseURLCandidates(org, env, thunderURL) {
 		if prober(ctx, c) {
 			return c, true
 		}
@@ -283,9 +292,9 @@ func resolveThunderBaseURL(ctx context.Context, org, env, handle string, prober 
 // dev only) Docker Desktop/Linux host-networking fallbacks. Callers that build an HTTP
 // client against the result must dial resolveToHost (when non-empty) instead of the
 // base URL's own host, while still sending the base URL's host as the Host header.
-// See ThunderExternalTokenURL for handle.
-func ResolveThunderBaseURL(ctx context.Context, org, env, handle string) (baseURL, resolveToHost string, ok bool) {
-	c, ok := resolveThunderBaseURL(ctx, org, env, handle, defaultThunderURLProber)
+// thunderURL is the stored EnvThunderURL.ThunderURL origin.
+func ResolveThunderBaseURL(ctx context.Context, org, env, thunderURL string) (baseURL, resolveToHost string, ok bool) {
+	c, ok := resolveThunderBaseURL(ctx, org, env, thunderURL, defaultThunderURLProber)
 	return c.baseURL, c.resolveToHost, ok
 }
 
@@ -294,17 +303,17 @@ func ResolveThunderBaseURL(ctx context.Context, org, env, handle string) (baseUR
 // as an actual JWKS document via isValidJWKS — not just an HTTP 200). All candidates
 // are probed CONCURRENTLY, not one after another, so latency is bounded by a single
 // probe's 2-second timeout rather than the sum of however many are tried. Callers treat
-// a negative probe as "not provisioned" and skip the env. See ThunderExternalTokenURL
-// for handle.
-func ThunderProbe(ctx context.Context, org, env, handle string) bool {
-	candidates := thunderBaseURLCandidates(org, env, handle)
+// a negative probe as "not provisioned" and skip the env. thunderURL is the stored
+// EnvThunderURL.ThunderURL origin.
+func ThunderProbe(ctx context.Context, org, env, thunderURL string) bool {
+	candidates := thunderBaseURLCandidates(org, env, thunderURL)
 
 	probeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	results := make(chan bool, len(candidates))
 	for _, c := range candidates {
 		go func(c thunderURLCandidate) {
-			results <- probeThunderURL(probeCtx, c.baseURL+"/oauth2/jwks", c.resolveToHost)
+			results <- probeThunderURL(probeCtx, c.baseURL+"/oauth2/jwks", c.resolveToHost, c.external)
 		}(c)
 	}
 

--- a/agent-manager-service/clients/thundersvc/naming.go
+++ b/agent-manager-service/clients/thundersvc/naming.go
@@ -40,7 +40,19 @@ const (
 	// just guards against an unrelated server on a fallback address streaming an
 	// unbounded body.
 	maxJWKSProbeBodyBytes = 64 * 1024
+
+	// probeTimeout bounds a single candidate probe (see probeThunderURL).
+	probeTimeout = 2 * time.Second
 )
+
+// ssrfProbeClient is the shared SSRF-hardened client for every external probe
+// (see probeThunderURL). ssrf.NewClient clones http.DefaultTransport, giving
+// it its own connection pool — building one per probe call would leak a pool
+// per call, since ThunderProbe runs once per environment on every
+// ListThunderInstances (every console Identity page load). http.Client is
+// safe for concurrent use, so one shared instance is enough; the per-request
+// timeout already comes from probeThunderURL's own reqCtx.
+var ssrfProbeClient = ssrf.NewClient(probeTimeout)
 
 // ThunderReleaseName returns the Helm release name (and namespace) for an env-Thunder instance.
 // Mirrors thunder_release_name() in deployments/scripts/thunder-naming.sh — must stay in sync.
@@ -171,14 +183,17 @@ func isValidJWKS(body []byte) bool {
 // dial resolveToHost while keeping the base URL's host as the HTTP Host header, so
 // Kgateway's host-based routing still selects the right backend.
 // external marks the ONE candidate dialed by its own host with no internal
-// override — the exact stored EnvThunderURL.ThunderURL. For an on-prem
-// (handle) row that value is server-computed under AMS's own trusted base
-// domain, but for a SaaS (url) row it's caller-supplied — so this candidate,
-// and only this one, is dialed with ssrf.NewClient (re-resolves at dial time,
-// re-validates every redirect hop) rather than the plain default client.
-// Cluster-internal DNS and the local-dev host-override candidates are never
-// marked external: they're either AMS-computed or deliberately private-target
-// by design, and would be wrongly rejected by the SSRF guard's private-IP check.
+// override — the exact stored EnvThunderURL.ThunderURL — AND whose value is
+// caller-supplied (a SaaS/control-plane row, no handle). That combination is
+// dialed with ssrf.NewClient (re-resolves at dial time, re-validates every
+// redirect hop) rather than the plain default client. An on-prem (handle) row
+// is never marked external even at this same candidate position: that value
+// is server-computed under AMS's own trusted base domain and can legitimately
+// be a private address (e.g. a VM install's sslip.io hostname over a LAN IP,
+// or an internal corporate DNS name) — SSRF-hardening it would wrongly reject
+// a working deployment. Cluster-internal DNS and the local-dev host-override
+// candidates are never marked external either, for the same private-target-by
+// -design reason.
 type thunderURLCandidate struct {
 	baseURL       string
 	resolveToHost string
@@ -204,15 +219,18 @@ type thunderURLCandidate struct {
 //
 // thunderURL is the stored EnvThunderURL.ThunderURL origin and builds the
 // external candidate directly; it must be non-empty (callers check for "not
-// provisioned" before ever reaching here).
-func thunderBaseURLCandidates(org, env, thunderURL string) []thunderURLCandidate {
+// provisioned" before ever reaching here). callerSupplied reports whether
+// thunderURL came from a SaaS/control-plane row (no handle) rather than an
+// on-prem (handle) row — see thunderURLCandidate's doc comment for why this,
+// not candidate position alone, decides which candidate gets marked external.
+func thunderBaseURLCandidates(org, env, thunderURL string, callerSupplied bool) []thunderURLCandidate {
 	if thunderURL == "" {
 		panic("thunder url must not be empty — callers must check for \"not provisioned\" before building candidates")
 	}
 	externalBaseURL := thunderURL
 	candidates := []thunderURLCandidate{
 		{baseURL: ThunderInternalURL(org, env)},
-		{baseURL: externalBaseURL, external: true},
+		{baseURL: externalBaseURL, external: callerSupplied},
 	}
 	if config.GetConfig().IsLocalDevEnv {
 		candidates = append(
@@ -234,7 +252,6 @@ func thunderBaseURLCandidates(org, env, thunderURL string) []thunderURLCandidate
 // every redirect hop) instead of the plain default one — see thunderURLCandidate's
 // doc comment for exactly which candidate this applies to and why.
 func probeThunderURL(ctx context.Context, url, resolveToHost string, external bool) bool {
-	const probeTimeout = 2 * time.Second
 	reqCtx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
@@ -247,7 +264,7 @@ func probeThunderURL(ctx context.Context, url, resolveToHost string, external bo
 	}
 	httpClient := http.DefaultClient
 	if external {
-		httpClient = ssrf.NewClient(probeTimeout)
+		httpClient = ssrfProbeClient
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -278,8 +295,8 @@ func defaultThunderURLProber(ctx context.Context, candidate thunderURLCandidate)
 // resolveThunderBaseURL returns the first candidate base URL that prober reports as
 // reachable, trying them in thunderBaseURLCandidates' preference order. ok is false
 // if none respond.
-func resolveThunderBaseURL(ctx context.Context, org, env, thunderURL string, prober thunderURLProber) (candidate thunderURLCandidate, ok bool) {
-	for _, c := range thunderBaseURLCandidates(org, env, thunderURL) {
+func resolveThunderBaseURL(ctx context.Context, org, env, thunderURL string, callerSupplied bool, prober thunderURLProber) (candidate thunderURLCandidate, ok bool) {
+	for _, c := range thunderBaseURLCandidates(org, env, thunderURL, callerSupplied) {
 		if prober(ctx, c) {
 			return c, true
 		}
@@ -292,9 +309,10 @@ func resolveThunderBaseURL(ctx context.Context, org, env, thunderURL string, pro
 // dev only) Docker Desktop/Linux host-networking fallbacks. Callers that build an HTTP
 // client against the result must dial resolveToHost (when non-empty) instead of the
 // base URL's own host, while still sending the base URL's host as the Host header.
-// thunderURL is the stored EnvThunderURL.ThunderURL origin.
-func ResolveThunderBaseURL(ctx context.Context, org, env, thunderURL string) (baseURL, resolveToHost string, ok bool) {
-	c, ok := resolveThunderBaseURL(ctx, org, env, thunderURL, defaultThunderURLProber)
+// thunderURL is the stored EnvThunderURL.ThunderURL origin; callerSupplied reports
+// whether it came from a SaaS/control-plane row (no handle) rather than an on-prem one.
+func ResolveThunderBaseURL(ctx context.Context, org, env, thunderURL string, callerSupplied bool) (baseURL, resolveToHost string, ok bool) {
+	c, ok := resolveThunderBaseURL(ctx, org, env, thunderURL, callerSupplied, defaultThunderURLProber)
 	return c.baseURL, c.resolveToHost, ok
 }
 
@@ -304,9 +322,10 @@ func ResolveThunderBaseURL(ctx context.Context, org, env, thunderURL string) (ba
 // are probed CONCURRENTLY, not one after another, so latency is bounded by a single
 // probe's 2-second timeout rather than the sum of however many are tried. Callers treat
 // a negative probe as "not provisioned" and skip the env. thunderURL is the stored
-// EnvThunderURL.ThunderURL origin.
-func ThunderProbe(ctx context.Context, org, env, thunderURL string) bool {
-	candidates := thunderBaseURLCandidates(org, env, thunderURL)
+// EnvThunderURL.ThunderURL origin; callerSupplied reports whether it came from a
+// SaaS/control-plane row (no handle) rather than an on-prem one.
+func ThunderProbe(ctx context.Context, org, env, thunderURL string, callerSupplied bool) bool {
+	candidates := thunderBaseURLCandidates(org, env, thunderURL, callerSupplied)
 
 	probeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/agent-manager-service/clients/thundersvc/naming_test.go
+++ b/agent-manager-service/clients/thundersvc/naming_test.go
@@ -18,6 +18,8 @@ package thundersvc
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -25,29 +27,34 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 )
 
-// TestThunderExternalURLs_RespectBaseDomainConfig locks in that a VM deployment's
-// THUNDER_HOST_BASE_DOMAIN override flows straight through into every URL builder —
-// this is what makes deployments/vm/lib-vm.sh setting the same value (both for
-// add-environment-thunder.sh and this Go config) keep the reported URLs and the
-// actually-deployed Thunder instance's own issuer in sync.
-func TestThunderExternalURLs_RespectBaseDomainConfig(t *testing.T) {
+// TestThunderOriginFromHandle_RespectsBaseDomainConfig locks in that a VM
+// deployment's THUNDER_HOST_BASE_DOMAIN override flows straight through into
+// the on-prem write-time origin computation — this is what makes
+// deployments/vm/lib-vm.sh setting the same value (both for
+// add-environment-thunder.sh and this Go config) keep the URL AMS stores and
+// the actually-deployed Thunder instance's own issuer in sync.
+func TestThunderOriginFromHandle_RespectsBaseDomainConfig(t *testing.T) {
 	orig := config.GetConfig().ThunderHostBaseDomain
 	defer func() { config.GetConfig().ThunderHostBaseDomain = orig }()
 
 	config.GetConfig().ThunderHostBaseDomain = "amp.203.0.113.10.sslip.io"
-	got := ThunderIssuerURL("x7f2q9kz")
+	got := ThunderOriginFromHandle("x7f2q9kz")
 	want := "http://x7f2q9kz.amp.203.0.113.10.sslip.io:8080"
 	if got != want {
-		t.Errorf("ThunderIssuerURL with overridden base domain: want %q, got %q", want, got)
+		t.Errorf("ThunderOriginFromHandle with overridden base domain: want %q, got %q", want, got)
 	}
 }
 
-// TestThunderExternalURLs_RespectTLSConfig locks in that TLS_ENABLED (the same flag
-// deployments/vm/lib-vm.sh already sets for platform Thunder's own advertised URLs)
-// switches env-Thunder's reported scheme AND drops the :8080 suffix — matching Caddy
-// terminating on the standard HTTPS port on a VM, rather than the k3d gateway's
-// plain-HTTP :8080 in local dev.
-func TestThunderExternalURLs_RespectTLSConfig(t *testing.T) {
+// TestThunderOriginFromHandle_RespectsTLSConfig locks in that TLS_ENABLED (the
+// same flag deployments/vm/lib-vm.sh already sets for platform Thunder's own
+// advertised URLs) switches env-Thunder's computed scheme AND drops the :8080
+// suffix — matching Caddy terminating on the standard HTTPS port on a VM,
+// rather than the k3d gateway's plain-HTTP :8080 in local dev. Also confirms
+// ThunderIssuerURL/ThunderExternalTokenURL/ThunderExternalJWKSURL only ever
+// use the already-resolved origin they're given — no independent TLS/domain
+// awareness of their own, since a SaaS-registered row's origin never came
+// from this config at all.
+func TestThunderOriginFromHandle_RespectsTLSConfig(t *testing.T) {
 	origDomain := config.GetConfig().ThunderHostBaseDomain
 	origTLS := config.GetConfig().TLSConfig.EnableTLS
 	defer func() {
@@ -57,34 +64,111 @@ func TestThunderExternalURLs_RespectTLSConfig(t *testing.T) {
 	config.GetConfig().ThunderHostBaseDomain = "amp.203.0.113.10.sslip.io"
 
 	config.GetConfig().TLSConfig.EnableTLS = false
-	if got, want := ThunderIssuerURL("x7f2q9kz"), "http://x7f2q9kz.amp.203.0.113.10.sslip.io:8080"; got != want {
-		t.Errorf("ThunderIssuerURL (TLS off): want %q, got %q", want, got)
+	originNoTLS := ThunderOriginFromHandle("x7f2q9kz")
+	if want := "http://x7f2q9kz.amp.203.0.113.10.sslip.io:8080"; originNoTLS != want {
+		t.Errorf("ThunderOriginFromHandle (TLS off): want %q, got %q", want, originNoTLS)
 	}
-	if got, want := ThunderExternalJWKSURL("x7f2q9kz"), "http://x7f2q9kz.amp.203.0.113.10.sslip.io:8080/oauth2/jwks"; got != want {
+	if got, want := ThunderIssuerURL(originNoTLS), originNoTLS; got != want {
+		t.Errorf("ThunderIssuerURL must return its input unchanged: want %q, got %q", want, got)
+	}
+	if got, want := ThunderExternalJWKSURL(originNoTLS), originNoTLS+"/oauth2/jwks"; got != want {
 		t.Errorf("ThunderExternalJWKSURL (TLS off): want %q, got %q", want, got)
 	}
 
 	config.GetConfig().TLSConfig.EnableTLS = true
-	if got, want := ThunderIssuerURL("x7f2q9kz"), "https://x7f2q9kz.amp.203.0.113.10.sslip.io"; got != want {
-		t.Errorf("ThunderIssuerURL (TLS on): want %q, got %q", want, got)
+	originTLS := ThunderOriginFromHandle("x7f2q9kz")
+	if want := "https://x7f2q9kz.amp.203.0.113.10.sslip.io"; originTLS != want {
+		t.Errorf("ThunderOriginFromHandle (TLS on): want %q, got %q", want, originTLS)
 	}
-	if got, want := ThunderExternalTokenURL("x7f2q9kz"), "https://x7f2q9kz.amp.203.0.113.10.sslip.io/oauth2/token"; got != want {
+	if got, want := ThunderExternalTokenURL(originTLS), originTLS+"/oauth2/token"; got != want {
 		t.Errorf("ThunderExternalTokenURL (TLS on): want %q, got %q", want, got)
 	}
 }
 
-// TestThunderIssuerURL_PanicsOnEmptyHandle guards the fail-loud contract: a
-// caller must check for "not provisioned" (an environment with no registered
-// handle) BEFORE building a URL — thunderExternalOrigin takes only a handle,
-// with no org/env fallback to degrade to, so an empty handle panics instead
-// of producing a guessable address.
-func TestThunderIssuerURL_PanicsOnEmptyHandle(t *testing.T) {
+// TestThunderIssuerURL_NeverPanics locks in that ThunderIssuerURL (an identity
+// function over an already-resolved, stored origin) has no fail-loud contract
+// of its own — that check belongs to whatever resolved the origin in the
+// first place (ThunderOriginFromHandle for the on-prem path; a caller
+// checking "not provisioned" before ever reaching here for either path).
+func TestThunderIssuerURL_NeverPanics(t *testing.T) {
 	defer func() {
-		if recover() == nil {
-			t.Error(`expected ThunderIssuerURL("") to panic`)
+		if r := recover(); r != nil {
+			t.Errorf(`expected ThunderIssuerURL("") not to panic, got %v`, r)
 		}
 	}()
-	ThunderIssuerURL("")
+	if got := ThunderIssuerURL(""); got != "" {
+		t.Errorf(`expected ThunderIssuerURL("") == "", got %q`, got)
+	}
+}
+
+// TestThunderOriginFromHandle_PanicsOnEmptyHandle guards the fail-loud
+// contract: a caller must check for "not provisioned" (an environment with no
+// registered handle) BEFORE building a URL — ThunderOriginFromHandle takes
+// only a handle, with no org/env fallback to degrade to, so an empty handle
+// panics instead of producing a guessable address.
+func TestThunderOriginFromHandle_PanicsOnEmptyHandle(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error(`expected ThunderOriginFromHandle("") to panic`)
+		}
+	}()
+	ThunderOriginFromHandle("")
+}
+
+// TestThunderBaseURLCandidates_PanicsOnEmptyThunderURL mirrors the same
+// fail-loud contract for the candidate cascade: thunderURL is the stored,
+// already-resolved origin (either registration path), and there is no
+// fallback to compute one from org/env if it's missing.
+func TestThunderBaseURLCandidates_PanicsOnEmptyThunderURL(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error(`expected thunderBaseURLCandidates with an empty thunderURL to panic`)
+		}
+	}()
+	thunderBaseURLCandidates("acme", "staging", "")
+}
+
+// TestThunderBaseURLCandidates_OnlyThePlainExternalOneIsMarkedExternal locks
+// in exactly which candidate gets the SSRF-hardened client in probeThunderURL:
+// the plain external one (the stored, possibly caller-supplied URL, dialed by
+// its own host with no override) — never cluster-internal DNS or a local-dev
+// host-override, both of which are legitimately private-target by design and
+// would be wrongly rejected by the SSRF guard.
+func TestThunderBaseURLCandidates_OnlyThePlainExternalOneIsMarkedExternal(t *testing.T) {
+	orig := config.GetConfig().IsLocalDevEnv
+	config.GetConfig().IsLocalDevEnv = true
+	defer func() { config.GetConfig().IsLocalDevEnv = orig }()
+
+	candidates := thunderBaseURLCandidates("acme", "staging", "https://stage-idp.example.com")
+	if len(candidates) != 4 {
+		t.Fatalf("expected 4 candidates (internal, external, 2 local-dev overrides), got %d", len(candidates))
+	}
+	for i, c := range candidates {
+		wantExternal := i == 1
+		if c.external != wantExternal {
+			t.Errorf("candidate %d (%+v): external = %v, want %v", i, c, c.external, wantExternal)
+		}
+	}
+}
+
+// TestProbeThunderURL_ExternalCandidateIsSSRFHardened proves the wiring is
+// real, not just declared: the SAME loopback server is reachable when
+// external=false (internal/local-dev-override candidates) but rejected when
+// external=true (the plain external candidate), because that one dials
+// through ssrf.NewClient, which refuses to resolve to a private/loopback IP.
+func TestProbeThunderURL_ExternalCandidateIsSSRFHardened(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"abc","use":"sig"}]}`))
+	}))
+	defer server.Close()
+	jwksURL := server.URL + "/oauth2/jwks"
+
+	if ok := probeThunderURL(context.Background(), jwksURL, "", false); !ok {
+		t.Error("external=false: expected the loopback test server to be reachable, matching cluster-internal/local-dev-override candidates' trusted-private-target behavior")
+	}
+	if ok := probeThunderURL(context.Background(), jwksURL, "", true); ok {
+		t.Error("external=true: expected the loopback test server to be REJECTED by the SSRF guard, since httptest.Server binds to 127.0.0.1")
+	}
 }
 
 // TestThunderReleaseName_NoHyphenCollapsing locks in that ThunderReleaseName does
@@ -224,7 +308,7 @@ func TestResolveThunderBaseURL_FallsBackToExternalIngress(t *testing.T) {
 		return c.baseURL == externalBaseURL && c.resolveToHost == ""
 	}
 
-	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", prober)
+	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", externalBaseURL, prober)
 	if !ok {
 		t.Fatal("expected ok=true when the external ingress candidate is reachable")
 	}
@@ -233,28 +317,33 @@ func TestResolveThunderBaseURL_FallsBackToExternalIngress(t *testing.T) {
 	}
 }
 
-// TestResolveThunderBaseURL_ExternalIngressCandidate_RespectsTLSConfig guards a
-// regression: the external ingress candidate must match thunderExternalOrigin's
-// TLS-aware scheme/port (what env-Thunder itself advertises as its issuer/JWKS),
-// not a hardcoded http://...:8080 — otherwise a VM/production deployment
-// (TLS_ENABLED=true) falling back to this candidate probes the wrong scheme and
-// port entirely, and reports a live env-Thunder as unreachable.
-func TestResolveThunderBaseURL_ExternalIngressCandidate_RespectsTLSConfig(t *testing.T) {
+// TestResolveThunderBaseURL_ExternalCandidateIsThunderURLVerbatim guards a
+// regression: the external candidate must be exactly the stored thunderURL
+// passed in — no independent recomputation from TLS config or anything else.
+// That TLS-aware computation only ever happens once, at registration time,
+// in ThunderOriginFromHandle (see its own tests); the candidate cascade must
+// never re-derive it, since a SaaS-registered row's origin never came from
+// this process's TLS config at all.
+func TestResolveThunderBaseURL_ExternalCandidateIsThunderURLVerbatim(t *testing.T) {
 	origTLS := config.GetConfig().TLSConfig.EnableTLS
 	defer func() { config.GetConfig().TLSConfig.EnableTLS = origTLS }()
 	config.GetConfig().TLSConfig.EnableTLS = true
 
-	wantBaseURL := "https://x7f2q9kz.amp.localhost"
+	// Deliberately does NOT match what ThunderOriginFromHandle would compute
+	// for TLSConfig.EnableTLS=true (which would be "https://...", no port) —
+	// if the cascade were still doing any of its own TLS-aware derivation,
+	// this candidate would silently get rewritten and the test would fail.
+	storedThunderURL := "http://x7f2q9kz.amp.example.com:9999"
 	prober := func(_ context.Context, c thunderURLCandidate) bool {
-		return c.baseURL == wantBaseURL && c.resolveToHost == ""
+		return c.baseURL == storedThunderURL && c.resolveToHost == ""
 	}
 
-	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", prober)
+	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", storedThunderURL, prober)
 	if !ok {
-		t.Fatal("expected ok=true when the TLS-aware external ingress candidate is reachable")
+		t.Fatal("expected ok=true when the external candidate (verbatim) is reachable")
 	}
-	if got.baseURL != wantBaseURL || got.resolveToHost != "" {
-		t.Errorf("want TLS-aware external ingress candidate %q, got %+v", wantBaseURL, got)
+	if got.baseURL != storedThunderURL || got.resolveToHost != "" {
+		t.Errorf("want the external candidate to equal thunderURL verbatim %q, got %+v", storedThunderURL, got)
 	}
 }
 

--- a/agent-manager-service/clients/thundersvc/naming_test.go
+++ b/agent-manager-service/clients/thundersvc/naming_test.go
@@ -125,28 +125,33 @@ func TestThunderBaseURLCandidates_PanicsOnEmptyThunderURL(t *testing.T) {
 			t.Error(`expected thunderBaseURLCandidates with an empty thunderURL to panic`)
 		}
 	}()
-	thunderBaseURLCandidates("acme", "staging", "")
+	thunderBaseURLCandidates("acme", "staging", "", false)
 }
 
-// TestThunderBaseURLCandidates_OnlyThePlainExternalOneIsMarkedExternal locks
-// in exactly which candidate gets the SSRF-hardened client in probeThunderURL:
-// the plain external one (the stored, possibly caller-supplied URL, dialed by
-// its own host with no override) — never cluster-internal DNS or a local-dev
-// host-override, both of which are legitimately private-target by design and
-// would be wrongly rejected by the SSRF guard.
-func TestThunderBaseURLCandidates_OnlyThePlainExternalOneIsMarkedExternal(t *testing.T) {
+// TestThunderBaseURLCandidates_OnlyThePlainExternalOneCanBeMarkedExternal locks
+// in exactly which candidate CAN get the SSRF-hardened client in
+// probeThunderURL: the plain external one (dialed by its own host with no
+// override) — never cluster-internal DNS or a local-dev host-override, both
+// of which are legitimately private-target by design and would be wrongly
+// rejected by the SSRF guard. Whether that one candidate actually gets marked
+// depends on callerSupplied — a SaaS row's value is attacker-influenced, an
+// on-prem row's is AMS's own trusted computation (and can legitimately be
+// private, e.g. a VM install's sslip.io hostname over a LAN IP).
+func TestThunderBaseURLCandidates_OnlyThePlainExternalOneCanBeMarkedExternal(t *testing.T) {
 	orig := config.GetConfig().IsLocalDevEnv
 	config.GetConfig().IsLocalDevEnv = true
 	defer func() { config.GetConfig().IsLocalDevEnv = orig }()
 
-	candidates := thunderBaseURLCandidates("acme", "staging", "https://stage-idp.example.com")
-	if len(candidates) != 4 {
-		t.Fatalf("expected 4 candidates (internal, external, 2 local-dev overrides), got %d", len(candidates))
-	}
-	for i, c := range candidates {
-		wantExternal := i == 1
-		if c.external != wantExternal {
-			t.Errorf("candidate %d (%+v): external = %v, want %v", i, c, c.external, wantExternal)
+	for _, callerSupplied := range []bool{true, false} {
+		candidates := thunderBaseURLCandidates("acme", "staging", "https://stage-idp.example.com", callerSupplied)
+		if len(candidates) != 4 {
+			t.Fatalf("expected 4 candidates (internal, external, 2 local-dev overrides), got %d", len(candidates))
+		}
+		for i, c := range candidates {
+			wantExternal := i == 1 && callerSupplied
+			if c.external != wantExternal {
+				t.Errorf("callerSupplied=%v, candidate %d (%+v): external = %v, want %v", callerSupplied, i, c, c.external, wantExternal)
+			}
 		}
 	}
 }
@@ -287,7 +292,7 @@ func TestResolveThunderBaseURL_PrefersClusterInternal(t *testing.T) {
 		return c.baseURL == ThunderInternalURL("acme", "staging")
 	}
 
-	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", prober)
+	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", false, prober)
 	if !ok {
 		t.Fatal("expected ok=true when the cluster-internal candidate is reachable")
 	}
@@ -308,7 +313,7 @@ func TestResolveThunderBaseURL_FallsBackToExternalIngress(t *testing.T) {
 		return c.baseURL == externalBaseURL && c.resolveToHost == ""
 	}
 
-	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", externalBaseURL, prober)
+	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", externalBaseURL, false, prober)
 	if !ok {
 		t.Fatal("expected ok=true when the external ingress candidate is reachable")
 	}
@@ -338,7 +343,7 @@ func TestResolveThunderBaseURL_ExternalCandidateIsThunderURLVerbatim(t *testing.
 		return c.baseURL == storedThunderURL && c.resolveToHost == ""
 	}
 
-	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", storedThunderURL, prober)
+	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", storedThunderURL, false, prober)
 	if !ok {
 		t.Fatal("expected ok=true when the external candidate (verbatim) is reachable")
 	}
@@ -362,7 +367,7 @@ func TestResolveThunderBaseURL_FallsBackToDockerDesktop(t *testing.T) {
 		return c.resolveToHost == "host.docker.internal:8080"
 	}
 
-	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", prober)
+	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", false, prober)
 	if !ok {
 		t.Fatal("expected ok=true when only the host.docker.internal candidate is reachable")
 	}
@@ -380,7 +385,7 @@ func TestResolveThunderBaseURL_FallsBackToLoopback(t *testing.T) {
 		return c.resolveToHost == "127.0.0.1:8080"
 	}
 
-	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", prober)
+	got, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", false, prober)
 	if !ok {
 		t.Fatal("expected ok=true when only the 127.0.0.1 candidate is reachable")
 	}
@@ -392,7 +397,7 @@ func TestResolveThunderBaseURL_FallsBackToLoopback(t *testing.T) {
 func TestResolveThunderBaseURL_AllUnreachable(t *testing.T) {
 	prober := func(_ context.Context, _ thunderURLCandidate) bool { return false }
 
-	_, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", prober)
+	_, ok := resolveThunderBaseURL(context.Background(), "acme", "staging", "x7f2q9kz", false, prober)
 	if ok {
 		t.Error("expected ok=false when no candidate is reachable")
 	}
@@ -404,7 +409,7 @@ func TestResolveThunderBaseURL_PublicWrapperUsesRealCascadeShape(t *testing.T) {
 	// definitely-unreachable org/env, rather than e.g. always returning ok=true.
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	_, _, ok := ResolveThunderBaseURL(ctx, "nonexistent-org-xyz", "nonexistent-env-xyz", "nonexistent-handle-xyz")
+	_, _, ok := ResolveThunderBaseURL(ctx, "nonexistent-org-xyz", "nonexistent-env-xyz", "nonexistent-handle-xyz", false)
 	if ok {
 		t.Error("expected ok=false for an org/env with no env-Thunder deployed anywhere reachable")
 	}

--- a/agent-manager-service/clients/thundersvc/prober.go
+++ b/agent-manager-service/clients/thundersvc/prober.go
@@ -25,11 +25,11 @@ import "context"
 // injected and mocked in unit tests.
 type Prober interface {
 	// Probe reports reachability of the env-Thunder instance addressed by
-	// handle (its registered EnvThunderURL — see ThunderExternalTokenURL).
-	// handle is required: callers only ever probe an environment that already
-	// has one registered — there is no address to probe otherwise, and no
-	// fallback pattern computed from org/env.
-	Probe(ctx context.Context, org, env, handle string) bool
+	// thunderURL (its registered EnvThunderURL.ThunderURL — see
+	// ThunderExternalTokenURL). thunderURL is required: callers only ever
+	// probe an environment that already has one registered — there is no
+	// address to probe otherwise, and no fallback pattern computed from org/env.
+	Probe(ctx context.Context, org, env, thunderURL string) bool
 }
 
 // liveProber is the production Prober, backed by ThunderProbe.
@@ -40,6 +40,6 @@ func NewProber() Prober {
 	return liveProber{}
 }
 
-func (liveProber) Probe(ctx context.Context, org, env, handle string) bool {
-	return ThunderProbe(ctx, org, env, handle)
+func (liveProber) Probe(ctx context.Context, org, env, thunderURL string) bool {
+	return ThunderProbe(ctx, org, env, thunderURL)
 }

--- a/agent-manager-service/clients/thundersvc/prober.go
+++ b/agent-manager-service/clients/thundersvc/prober.go
@@ -29,7 +29,10 @@ type Prober interface {
 	// ThunderExternalTokenURL). thunderURL is required: callers only ever
 	// probe an environment that already has one registered — there is no
 	// address to probe otherwise, and no fallback pattern computed from org/env.
-	Probe(ctx context.Context, org, env, thunderURL string) bool
+	// callerSupplied reports whether thunderURL came from a SaaS/control-plane
+	// row (no handle) rather than an on-prem one — see thunderURLCandidate's
+	// doc comment for why this decides which candidate gets SSRF-hardened.
+	Probe(ctx context.Context, org, env, thunderURL string, callerSupplied bool) bool
 }
 
 // liveProber is the production Prober, backed by ThunderProbe.
@@ -40,6 +43,6 @@ func NewProber() Prober {
 	return liveProber{}
 }
 
-func (liveProber) Probe(ctx context.Context, org, env, thunderURL string) bool {
-	return ThunderProbe(ctx, org, env, thunderURL)
+func (liveProber) Probe(ctx context.Context, org, env, thunderURL string, callerSupplied bool) bool {
+	return ThunderProbe(ctx, org, env, thunderURL, callerSupplied)
 }

--- a/agent-manager-service/controllers/environment_controller.go
+++ b/agent-manager-service/controllers/environment_controller.go
@@ -409,6 +409,18 @@ func (c *environmentController) SetThunderSystemClient(w http.ResponseWriter, r 
 	ouID := middleware.OUIDFromRequest(r)
 	envName := r.PathValue("envID")
 
+	// Header wins over the token; the context is rewritten too. Same pattern
+	// as ListGateways: WSO2 Cloud's control-plane token carries no org
+	// identity of its own, so it names the target via X-Impersonate-Org.
+	if impersonated, ok := impersonatedOUID(r); ok && impersonated != ouID {
+		log.Warn("SetThunderSystemClient: org impersonation header overrides token org",
+			"tokenOuID", ouID, "impersonatedOuID", impersonated)
+		ouID = impersonated
+		org, _ := middleware.GetResolvedOrg(ctx)
+		org.OUID = impersonated
+		ctx = middleware.WithResolvedOrg(ctx, org)
+	}
+
 	var req spec.ThunderSystemClientRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		log.Error("SetThunderSystemClient: failed to decode request", "error", err)
@@ -493,6 +505,18 @@ func (c *environmentController) SetThunderURL(w http.ResponseWriter, r *http.Req
 
 	ouID := middleware.OUIDFromRequest(r)
 	envName := r.PathValue("envID")
+
+	// Header wins over the token; the context is rewritten too. Same pattern
+	// as ListGateways: WSO2 Cloud's control-plane token carries no org
+	// identity of its own, so it names the target via X-Impersonate-Org.
+	if impersonated, ok := impersonatedOUID(r); ok && impersonated != ouID {
+		log.Warn("SetThunderURL: org impersonation header overrides token org",
+			"tokenOuID", ouID, "impersonatedOuID", impersonated)
+		ouID = impersonated
+		org, _ := middleware.GetResolvedOrg(ctx)
+		org.OUID = impersonated
+		ctx = middleware.WithResolvedOrg(ctx, org)
+	}
 
 	// The request body itself is optional (an empty PUT means "generate one for
 	// me"), so a missing/empty body is not a decode error — only malformed JSON is.

--- a/agent-manager-service/controllers/environment_controller.go
+++ b/agent-manager-service/controllers/environment_controller.go
@@ -529,16 +529,19 @@ func (c *environmentController) SetThunderURL(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
-	var handle string
+	var handle, rawURL string
 	if req.Handle != nil {
 		handle = *req.Handle
 	}
+	if req.Url != nil {
+		rawURL = *req.Url
+	}
 
-	// The resolved handle (possibly server-generated) is only known once the
-	// service call returns, so it's added to the record at Complete rather
-	// than here.
+	// The resolved record (possibly server-generated handle, or the
+	// caller-supplied url normalized) is only known once the service call
+	// returns, so it's added to the record at Complete rather than here.
 	attempt, ok := beginAuditOrFail(
-		w, r, "SetThunderURL", "Failed to store thunder url handle", audit.ActionThunderURLSet,
+		w, r, "SetThunderURL", "Failed to store thunder url", audit.ActionThunderURLSet,
 		audit.Org(ouID),
 		audit.ResourceNamed(audit.ResourceThunderURL, envName, envName),
 		audit.Environment(envName),
@@ -547,23 +550,36 @@ func (c *environmentController) SetThunderURL(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	resolved, err := c.environmentService.SetThunderURL(ctx, ouID, envName, handle)
+	resolved, err := c.environmentService.SetThunderURL(ctx, ouID, envName, handle, rawURL)
 	if err != nil {
 		attempt.Complete(ctx, err)
-		log.Error("SetThunderURL: failed to store handle", "ouID", ouID, "envName", envName, "error", err)
+		log.Error("SetThunderURL: failed to store thunder url", "ouID", ouID, "envName", envName, "error", err)
 		switch {
-		case errors.Is(err, utils.ErrThunderHandleTaken):
-			utils.WriteErrorResponse(w, http.StatusConflict, "Thunder URL handle is already in use")
-		case errors.Is(err, utils.ErrInvalidThunderHandle), errors.Is(err, utils.ErrInvalidInput):
+		case errors.Is(err, utils.ErrThunderHandleTaken), errors.Is(err, utils.ErrThunderURLTaken):
+			utils.WriteErrorResponse(w, http.StatusConflict, "Thunder URL is already in use")
+		case errors.Is(err, utils.ErrInvalidThunderHandle), errors.Is(err, utils.ErrInvalidThunderURL),
+			errors.Is(err, utils.ErrThunderHandleAndURLBothSet), errors.Is(err, utils.ErrInvalidInput):
 			utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid input")
 		default:
-			utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to store thunder url handle")
+			utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to store thunder url")
 		}
 		return
 	}
-	attempt.Complete(ctx, nil, audit.Detail("handle", resolved))
+	attempt.Complete(ctx, nil, audit.Detail("handle", resolved.Handle), audit.Detail("url", resolved.URL))
 
-	utils.WriteSuccessResponse(w, http.StatusOK, spec.ThunderUrlResponse{Handle: resolved})
+	utils.WriteSuccessResponse(w, http.StatusOK, toThunderUrlResponse(resolved))
+}
+
+// toThunderUrlResponse maps a resolved record to the wire response, omitting
+// Handle entirely (rather than an empty string) for a SaaS/control-plane row
+// that has none — spec.ThunderUrlResponse.Handle is optional for exactly
+// this reason.
+func toThunderUrlResponse(rec models.ThunderURLRecord) spec.ThunderUrlResponse {
+	resp := spec.ThunderUrlResponse{Url: rec.URL}
+	if rec.Handle != "" {
+		resp.Handle = &rec.Handle
+	}
+	return resp
 }
 
 // GetThunderURL returns an environment's registered env-Thunder URL handle.
@@ -576,18 +592,18 @@ func (c *environmentController) GetThunderURL(w http.ResponseWriter, r *http.Req
 	ouID := middleware.OUIDFromRequest(r)
 	envName := r.PathValue("envID")
 
-	handle, err := c.environmentService.GetThunderURL(ctx, ouID, envName)
+	resolved, err := c.environmentService.GetThunderURL(ctx, ouID, envName)
 	if err != nil {
 		if errors.Is(err, utils.ErrThunderHandleNotFound) {
-			utils.WriteErrorResponse(w, http.StatusNotFound, "No thunder url handle registered for this environment")
+			utils.WriteErrorResponse(w, http.StatusNotFound, "No thunder url registered for this environment")
 			return
 		}
-		log.Error("GetThunderURL: failed to read handle", "ouID", ouID, "envName", envName, "error", err)
-		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to read thunder url handle")
+		log.Error("GetThunderURL: failed to read thunder url", "ouID", ouID, "envName", envName, "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to read thunder url")
 		return
 	}
 
-	utils.WriteSuccessResponse(w, http.StatusOK, spec.ThunderUrlResponse{Handle: handle})
+	utils.WriteSuccessResponse(w, http.StatusOK, toThunderUrlResponse(resolved))
 }
 
 // DeleteThunderURL removes an environment's env-Thunder URL handle (idempotent;
@@ -609,29 +625,29 @@ func (c *environmentController) DeleteThunderURL(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// Read the handle being freed so the success record below names it. A
-	// genuinely missing handle is not an error — Delete is idempotent — but any
+	// Read the record being freed so the success record below names it. A
+	// genuinely missing record is not an error — Delete is idempotent — but any
 	// other read failure must abort before the delete: silently ignoring it
 	// would risk deleting a row the record can no longer identify.
 	existing, err := c.environmentService.GetThunderURL(ctx, ouID, envName)
 	if err != nil && !errors.Is(err, utils.ErrThunderHandleNotFound) {
 		attempt.Complete(ctx, err)
-		log.Error("DeleteThunderURL: failed to read handle before delete", "ouID", ouID, "envName", envName, "error", err)
-		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to delete thunder url handle")
+		log.Error("DeleteThunderURL: failed to read thunder url before delete", "ouID", ouID, "envName", envName, "error", err)
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to delete thunder url")
 		return
 	}
 
 	if err := c.environmentService.DeleteThunderURL(ctx, ouID, envName); err != nil {
 		attempt.Complete(ctx, err)
-		log.Error("DeleteThunderURL: failed to delete handle", "ouID", ouID, "envName", envName, "error", err)
+		log.Error("DeleteThunderURL: failed to delete thunder url", "ouID", ouID, "envName", envName, "error", err)
 		if errors.Is(err, utils.ErrInvalidInput) {
 			utils.WriteErrorResponse(w, http.StatusBadRequest, "Invalid input")
 			return
 		}
-		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to delete thunder url handle")
+		utils.WriteErrorResponse(w, http.StatusInternalServerError, "Failed to delete thunder url")
 		return
 	}
-	attempt.Complete(ctx, nil, audit.Detail("handle", existing))
+	attempt.Complete(ctx, nil, audit.Detail("handle", existing.Handle), audit.Detail("url", existing.URL))
 
 	utils.WriteSuccessResponse(w, http.StatusNoContent, "")
 }

--- a/agent-manager-service/db_migrations/043_add_thunder_url_to_env_thunder_urls.go
+++ b/agent-manager-service/db_migrations/043_add_thunder_url_to_env_thunder_urls.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dbmigrations
+
+import (
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
+)
+
+// migration043 adds thunder_url, the fully-resolved env-Thunder origin
+// (scheme://host[:port]), so a row is self-describing instead of every reader
+// reconstructing it from thunder_handle plus one global base-domain config —
+// which only works when every environment shares one domain. thunder_handle
+// becomes nullable: a SaaS/control-plane caller can now supply thunder_url
+// directly with no handle at all (see EnvironmentService.SetThunderURL).
+//
+// Existing handle-based rows are preserved. Their URL is backfilled through
+// the same configuration-aware helper used by the live write path, so an
+// upgrade respects TLS_ENABLED and THUNDER_HOST_BASE_DOMAIN instead of
+// assuming the local-development origin.
+//
+// uq_env_thunder_urls_url is the new primary invariant. uq_env_thunder_urls_handle
+// stays, scoped to non-null handles — Postgres never treats multiple NULLs as
+// conflicting, so handle-less SaaS rows don't participate in it.
+var migration043 = migration{
+	ID: 43,
+	Migrate: func(db *gorm.DB) error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			if err := runSQL(
+				tx,
+				`ALTER TABLE env_thunder_urls ADD COLUMN IF NOT EXISTS thunder_url VARCHAR(2048)`,
+			); err != nil {
+				return err
+			}
+
+			var rows []struct {
+				ID            string
+				ThunderHandle string
+			}
+			if err := tx.Table("env_thunder_urls").
+				Select("id, thunder_handle").
+				Where("thunder_url IS NULL AND thunder_handle IS NOT NULL").
+				Find(&rows).Error; err != nil {
+				return fmt.Errorf("read pre-existing env_thunder_urls rows for backfill: %w", err)
+			}
+
+			for _, row := range rows {
+				thunderURL := thundersvc.ThunderOriginFromHandle(row.ThunderHandle)
+				if err := tx.Exec(
+					`UPDATE env_thunder_urls SET thunder_url = ? WHERE id = ?`,
+					thunderURL,
+					row.ID,
+				).Error; err != nil {
+					return fmt.Errorf("backfill thunder_url for row %s: %w", row.ID, err)
+				}
+			}
+
+			return runSQL(
+				tx,
+				`ALTER TABLE env_thunder_urls ALTER COLUMN thunder_url SET NOT NULL`,
+				`ALTER TABLE env_thunder_urls ALTER COLUMN thunder_handle DROP NOT NULL`,
+				`ALTER TABLE env_thunder_urls ADD CONSTRAINT uq_env_thunder_urls_url UNIQUE (thunder_url)`,
+			)
+		})
+	},
+}

--- a/agent-manager-service/db_migrations/043_add_thunder_url_to_env_thunder_urls.go
+++ b/agent-manager-service/db_migrations/043_add_thunder_url_to_env_thunder_urls.go
@@ -62,6 +62,15 @@ var migration043 = migration{
 			}
 
 			for _, row := range rows {
+				// The pre-migration schema only required thunder_handle NOT NULL,
+				// with no CHECK against an empty string, so one is a storable
+				// (if never application-written) value. ThunderOriginFromHandle
+				// panics on "" — inside this transaction that would roll back
+				// and re-panic, wedging the upgrade on every retry. Fail with a
+				// clear, row-identifying error instead of hitting that panic.
+				if row.ThunderHandle == "" {
+					return fmt.Errorf("env_thunder_urls row %s has an empty thunder_handle — clear or fix it manually before re-running this migration", row.ID)
+				}
 				thunderURL := thundersvc.ThunderOriginFromHandle(row.ThunderHandle)
 				if err := tx.Exec(
 					`UPDATE env_thunder_urls SET thunder_url = ? WHERE id = ?`,

--- a/agent-manager-service/db_migrations/migration_list.go
+++ b/agent-manager-service/db_migrations/migration_list.go
@@ -16,7 +16,7 @@
 
 package dbmigrations
 
-const latestVersion = 42
+const latestVersion = 43
 
 // migration list sorted by version.  Add new migrations to the end of the list.
 // Previous migrations should not be modified.
@@ -63,4 +63,5 @@ var migrations = []migration{
 	migration040,
 	migration041,
 	migration042,
+	migration043,
 }

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -2068,36 +2068,42 @@ paths:
     put:
       tags:
         - Environments
-      summary: Register an environment's env-Thunder URL handle
+      summary: Register an environment's env-Thunder URL
       description: |
-        Bootstrap-only endpoint used by add-environment-thunder.sh before it
-        provisions an environment's dedicated Thunder instance. Registers an
-        unguessable handle that replaces the predictable "<org>-<env>" segment
-        of that environment's externally-reachable env-Thunder hostname
-        (issuer/token/JWKS URLs) — without this, every such URL is 100%
-        derivable from (org, env) alone. org/env is NEVER used as a fallback:
-        every environment gets a handle, one way or another.
+        Bootstrap-only endpoint used by add-environment-thunder.sh (on-prem)
+        or a control plane (SaaS) before/while provisioning an environment's
+        dedicated Thunder instance. Registers the environment's
+        externally-reachable env-Thunder origin (issuer/token/JWKS URLs) via
+        exactly one of two mutually-exclusive request fields — see
+        ThunderUrlRequest. Without this, an on-prem URL would be 100%
+        derivable from (org, env) alone; org/env is NEVER used as a fallback
+        for either path — every environment gets a registered origin, one way
+        or another.
 
-        The request body's handle is OPTIONAL. Omit it (or send an empty
-        string) to have the server generate one automatically — a 10-character
-        random value. The response always reports the handle that ended up
-        stored, since a caller that left it blank needs to learn what was
+        Both request fields are OPTIONAL, and omitting both is the on-prem
+        auto-generate default: the server picks a 10-character random handle
+        and computes the origin from it. The response always reports the url
+        that ended up stored (and the handle, if the on-prem path produced
+        one), since a caller that left the body blank needs to learn what was
         actually assigned.
 
-        The handle is globally unique across ALL orgs/environments (every
-        env-Thunder instance's HTTPRoute attaches to the same shared Gateway,
-        so hostname routing is cluster-wide, not per-org). If a caller-supplied
-        handle collides with a different environment's, this returns 409. A
-        collision on a GENERATED handle is retried internally with a fresh
-        value and never surfaces as a 409.
+        Both handle and the resolved url are globally unique across ALL
+        orgs/environments (every env-Thunder instance's HTTPRoute attaches to
+        the same shared Gateway, so hostname routing is cluster-wide, not
+        per-org — and a SaaS control plane's own domain space is a single
+        namespace the same way). If a caller-supplied handle or url collides
+        with a different environment's, this returns 409. A collision on a
+        GENERATED handle is retried internally with a fresh value and never
+        surfaces as a 409.
 
         Idempotent for the SAME environment, but never changes an
-        already-registered handle: a blank or matching re-registration is a
-        no-op that reports the existing handle; an explicit DIFFERENT handle
-        is rejected with 409 (Thunder's issuer is immutable once minted — call
-        DELETE first to free the handle before registering a new one). Keyed
-        by OU ID, always taken from the caller's own token (never
-        client-supplied), not orgName — same rationale as thunder-system-client.
+        already-registered value: a blank or matching re-registration is a
+        no-op that reports the existing record; an explicit DIFFERENT
+        handle/url is rejected with 409 (Thunder's issuer is immutable once
+        minted — call DELETE first to free the registration before
+        registering a new one). Keyed by OU ID, always taken from the
+        caller's own token (never client-supplied), not orgName — same
+        rationale as thunder-system-client.
       operationId: setEnvironmentThunderUrl
       requestBody:
         required: false
@@ -2107,13 +2113,13 @@ paths:
               $ref: "#/components/schemas/ThunderUrlRequest"
       responses:
         "200":
-          description: Handle stored successfully — response reports the handle that ended up stored
+          description: Registered successfully — response reports the url (and handle, if applicable) that ended up stored
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ThunderUrlResponse"
         "400":
-          description: Bad request - invalid handle format
+          description: Bad request - invalid handle/url format, or both handle and url were set
           content:
             application/json:
               schema:
@@ -2132,9 +2138,9 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "409":
           description: >-
-            Conflict - handle is already registered to a different
-            environment, or this environment already has a different handle
-            registered (call DELETE first to change it)
+            Conflict - handle or url is already registered to a different
+            environment, or this environment already has a different
+            handle/url registered (call DELETE first to change it)
           content:
             application/json:
               schema:
@@ -2149,13 +2155,14 @@ paths:
     delete:
       tags:
         - Environments
-      summary: Remove an environment's env-Thunder URL handle
+      summary: Remove an environment's env-Thunder URL
       description: |
-        Removes the registered handle for an environment, freeing it for
-        reuse. Called by remove-environment-thunder.sh when an environment's
-        Thunder instance is torn down. Deleting a non-existent handle
-        succeeds (idempotent). Looked up by OU ID, always taken from the
-        caller's own token (never client-supplied), not orgName.
+        Removes the registered origin (and handle, if any) for an
+        environment, freeing both for reuse. Called by
+        remove-environment-thunder.sh when an environment's Thunder instance
+        is torn down. Deleting a non-existent registration succeeds
+        (idempotent). Looked up by OU ID, always taken from the caller's own
+        token (never client-supplied), not orgName.
       operationId: deleteEnvironmentThunderUrl
       responses:
         "204":
@@ -14507,9 +14514,18 @@ components:
     ThunderUrlRequest:
       type: object
       description: |
-        An unguessable handle to register for an environment's env-Thunder
-        URL, replacing the predictable "<org>-<env>" pattern. Optional — omit
-        it (or send an empty string) to have the server generate one.
+        Registers an environment's env-Thunder origin via exactly one of two
+        mutually-exclusive fields — setting both is rejected with 400:
+
+        - `handle` (on-prem path): an unguessable label AMS resolves into the
+          full origin itself, replacing the predictable "<org>-<env>" pattern.
+          Optional — omit it (or send an empty string, with url also omitted)
+          to have the server generate one.
+        - `url` (SaaS/control-plane path): the full origin the caller has
+          already provisioned, for deployments where different environments
+          can live under different domains and there is no single pattern AMS
+          could compute. AMS validates and stores it verbatim; the
+          environment's registration then has no handle at all.
       properties:
         handle:
           type: string
@@ -14518,20 +14534,33 @@ components:
             leading/trailing hyphen) that replaces "<org>-<env>" in
             "<handle>.<baseDomain>". Must be globally unique across
             all orgs/environments, and at least 3 characters. Omit to
-            auto-generate a 10-character handle.
+            auto-generate a 10-character handle. Mutually exclusive with url.
           pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
           minLength: 3
           maxLength: 63
           example: x7f2q9kzab
+        url:
+          type: string
+          format: uri
+          description: |
+            The full env-Thunder origin (scheme + host, no path/query/fragment)
+            this environment is already reachable at — the SaaS/control-plane
+            path. Must be http or https, resolve to a public IP address (no
+            private/loopback hosts), and be globally unique across all
+            orgs/environments. Mutually exclusive with handle.
+          maxLength: 2048
+          example: https://stage-idp.tenant42.example.com
 
     ThunderUrlResponse:
       type: object
       description: |
-        The env-Thunder URL handle registered for an environment — either the
-        caller-supplied value or the value the server generated when the
-        caller left it blank.
+        The env-Thunder registration for an environment. url is always
+        present — the caller-supplied value (either path), or the value the
+        server generated/computed when the caller left handle blank. handle is
+        present only for the on-prem path; it is absent for an environment
+        registered via a caller-supplied url.
       required:
-        - handle
+        - url
       properties:
         handle:
           type: string
@@ -14539,6 +14568,11 @@ components:
           minLength: 3
           maxLength: 63
           example: x7f2q9kzab
+        url:
+          type: string
+          format: uri
+          maxLength: 2048
+          example: https://x7f2q9kzab.amp.example.com
 
     ThunderUrlAvailabilityResponse:
       type: object

--- a/agent-manager-service/models/env_thunder_url.go
+++ b/agent-manager-service/models/env_thunder_url.go
@@ -22,19 +22,31 @@ import (
 	"github.com/google/uuid"
 )
 
-// EnvThunderURL is an unguessable handle (user-chosen or server-generated)
-// that forms an environment's externally-reachable env-Thunder hostname
-// ("<handle>.<baseDomain>"), keyed by (OUID, EnvName). ThunderHandle is
-// additionally globally unique across all orgs/envs — see migration042's doc
-// comment for why.
+// EnvThunderURL records an environment's externally-reachable env-Thunder
+// origin, keyed by (OUID, EnvName). ThunderURL is always set and is the
+// authoritative value every reader uses. ThunderHandle is set only for the
+// on-prem path (AMS computes ThunderURL from it); nil for a SaaS row, which
+// supplies ThunderURL directly. ThunderHandle is *string, not string, so an
+// omitted handle writes SQL NULL rather than "" — uq_env_thunder_urls_handle
+// relies on Postgres never treating multiple NULLs as conflicting to let any
+// number of SaaS rows coexist.
 type EnvThunderURL struct {
 	ID            uuid.UUID `gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
 	OUID          string    `gorm:"column:ou_id;not null;uniqueIndex:uq_env_thunder_urls_ou_env"`
 	EnvName       string    `gorm:"column:env_name;not null;uniqueIndex:uq_env_thunder_urls_ou_env"`
-	ThunderHandle string    `gorm:"column:thunder_handle;not null;uniqueIndex:uq_env_thunder_urls_handle"`
+	ThunderHandle *string   `gorm:"column:thunder_handle;uniqueIndex:uq_env_thunder_urls_handle"`
+	ThunderURL    string    `gorm:"column:thunder_url;not null;uniqueIndex:uq_env_thunder_urls_url"`
 	CreatedAt     time.Time `gorm:"column:created_at;not null;default:NOW()"`
 	UpdatedAt     time.Time `gorm:"column:updated_at;not null;default:NOW()"`
 }
 
 // TableName returns the table name for the EnvThunderURL model.
 func (EnvThunderURL) TableName() string { return "env_thunder_urls" }
+
+// ThunderURLRecord is the public-facing result of resolving an environment's
+// env-Thunder registration. URL is always the authoritative origin; Handle is
+// set only for an on-prem row. A zero value means not provisioned.
+type ThunderURLRecord struct {
+	Handle string
+	URL    string
+}

--- a/agent-manager-service/repositories/env_thunder_url_repository.go
+++ b/agent-manager-service/repositories/env_thunder_url_repository.go
@@ -48,6 +48,9 @@ type EnvThunderURLRepository interface {
 	//   - utils.ErrThunderHandleTaken: rec.ThunderHandle is already registered
 	//     to a DIFFERENT (OUID, EnvName) — a genuine cross-environment
 	//     collision, unrelated to concurrency.
+	//   - utils.ErrThunderURLTaken: rec.ThunderURL is already registered to a
+	//     DIFFERENT (OUID, EnvName) — same idea, for the SaaS/control-plane
+	//     path that has no handle to collide on instead.
 	Insert(ctx context.Context, rec *models.EnvThunderURL) error
 	// Delete removes the handle record for (ouID, envName). Deleting a
 	// non-existent row is not an error.
@@ -93,13 +96,16 @@ func (r *envThunderURLRepo) Insert(ctx context.Context, rec *models.EnvThunderUR
 		// Distinguish WHICH unique constraint fired: (ou_id, env_name) means a
 		// concurrent request beat this one to the SAME environment (a race,
 		// not a real conflict — the caller adopts the winner); thunder_handle
-		// means this exact string is already owned by a DIFFERENT environment
-		// (a genuine collision).
+		// or thunder_url means that exact value is already owned by a
+		// DIFFERENT environment (a genuine collision, one per registration
+		// path — see EnvironmentService.SetThunderURL).
 		switch pgErr.ConstraintName {
 		case "uq_env_thunder_urls_ou_env":
 			return utils.ErrEnvThunderURLAlreadyClaimed
 		case "uq_env_thunder_urls_handle":
 			return utils.ErrThunderHandleTaken
+		case "uq_env_thunder_urls_url":
+			return utils.ErrThunderURLTaken
 		default:
 			return err
 		}

--- a/agent-manager-service/repositories/env_thunder_url_repository_test.go
+++ b/agent-manager-service/repositories/env_thunder_url_repository_test.go
@@ -52,10 +52,10 @@ func TestEnvThunderURLRepo_InsertNeverOverwritesAnExistingRow(t *testing.T) {
 	const ouID, env = "ou-test-insert-no-overwrite", "env-thunder-insert-no-overwrite"
 	cleanupEnvThunderURL(t, repo, ouID, env)
 
-	first := &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: "firsthandle"}
+	first := &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: strPtr("firsthandle"), ThunderURL: "http://firsthandle.amp.localhost:8080"}
 	require.NoError(t, repo.Insert(context.Background(), first))
 
-	second := &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: "secondhandle"}
+	second := &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: strPtr("secondhandle"), ThunderURL: "http://secondhandle.amp.localhost:8080"}
 	err := repo.Insert(context.Background(), second)
 	require.Error(t, err, "a second Insert for the same (ouID, env) must be rejected, not silently accepted")
 	assert.ErrorIs(t, err, utils.ErrEnvThunderURLAlreadyClaimed,
@@ -63,7 +63,8 @@ func TestEnvThunderURLRepo_InsertNeverOverwritesAnExistingRow(t *testing.T) {
 
 	got, getErr := repo.Get(context.Background(), ouID, env)
 	require.NoError(t, getErr)
-	assert.Equal(t, "firsthandle", got.ThunderHandle, "the FIRST insert's handle must survive completely untouched")
+	require.NotNil(t, got.ThunderHandle)
+	assert.Equal(t, "firsthandle", *got.ThunderHandle, "the FIRST insert's handle must survive completely untouched")
 
 	var count int64
 	require.NoError(t, db.GetDB().Model(&models.EnvThunderURL{}).
@@ -87,11 +88,11 @@ func TestEnvThunderURLRepo_ConcurrentFirstInsertsOnlyOneWins(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		results[0] = repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: handleA})
+		results[0] = repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: strPtr(handleA), ThunderURL: "http://" + handleA + ".amp.localhost:8080"})
 	}()
 	go func() {
 		defer wg.Done()
-		results[1] = repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: handleB})
+		results[1] = repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: strPtr(handleB), ThunderURL: "http://" + handleB + ".amp.localhost:8080"})
 	}()
 	wg.Wait()
 
@@ -111,7 +112,8 @@ func TestEnvThunderURLRepo_ConcurrentFirstInsertsOnlyOneWins(t *testing.T) {
 
 	got, err := repo.Get(context.Background(), ouID, env)
 	require.NoError(t, err)
-	assert.Contains(t, []string{handleA, handleB}, got.ThunderHandle,
+	require.NotNil(t, got.ThunderHandle)
+	assert.Contains(t, []string{handleA, handleB}, *got.ThunderHandle,
 		"the surviving row must be exactly one of the two attempted values")
 }
 
@@ -128,9 +130,9 @@ func TestEnvThunderURLRepo_DifferentEnvironmentsCannotShareAHandle(t *testing.T)
 	cleanupEnvThunderURL(t, repo, ouB, envB)
 
 	const sharedHandle = "sharedhandle"
-	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouA, EnvName: envA, ThunderHandle: sharedHandle}))
+	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouA, EnvName: envA, ThunderHandle: strPtr(sharedHandle), ThunderURL: "http://" + sharedHandle + ".amp.localhost:8080"}))
 
-	err := repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouB, EnvName: envB, ThunderHandle: sharedHandle})
+	err := repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouB, EnvName: envB, ThunderHandle: strPtr(sharedHandle), ThunderURL: "http://different-origin-but-same-handle.amp.localhost:8080"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, utils.ErrThunderHandleTaken,
 		"a DIFFERENT environment claiming an already-registered handle string is a genuine collision, distinct from a same-environment race")
@@ -157,7 +159,7 @@ func TestEnvThunderURLRepo_DeleteIsIdempotent(t *testing.T) {
 
 	require.NoError(t, repo.Delete(context.Background(), ouID, env), "deleting a non-existent row must not be an error")
 
-	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: "deleteidempo"}))
+	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: strPtr("deleteidempo"), ThunderURL: "http://deleteidempo.amp.localhost:8080"}))
 	require.NoError(t, repo.Delete(context.Background(), ouID, env))
 	_, err := repo.Get(context.Background(), ouID, env)
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
@@ -166,6 +168,61 @@ func TestEnvThunderURLRepo_DeleteIsIdempotent(t *testing.T) {
 	require.NoError(t, repo.Delete(context.Background(), ouID, env))
 
 	// And the handle must be genuinely free again — a re-insert must succeed.
-	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: "deleteidempo"}))
+	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouID, EnvName: env, ThunderHandle: strPtr("deleteidempo"), ThunderURL: "http://deleteidempo.amp.localhost:8080"}))
 	require.NoError(t, repo.Delete(context.Background(), ouID, env))
 }
+
+// TestEnvThunderURLRepo_SaaSRowsHaveNoHandleButMustHaveAUniqueURL covers the
+// SaaS/control-plane registration path: a row with no thunder_handle at all
+// (NULL — Postgres never conflicts two NULLs on uq_env_thunder_urls_handle),
+// but thunder_url is the primary invariant there, enforced by
+// uq_env_thunder_urls_url exactly like the handle-based path enforces
+// uq_env_thunder_urls_handle.
+func TestEnvThunderURLRepo_SaaSRowsHaveNoHandleButMustHaveAUniqueURL(t *testing.T) {
+	repo := NewEnvThunderURLRepo(db.GetDB())
+	const ouA, envA = "ou-test-saas-url-a", "env-thunder-saas-url-a"
+	const ouB, envB = "ou-test-saas-url-b", "env-thunder-saas-url-b"
+	cleanupEnvThunderURL(t, repo, ouA, envA)
+	cleanupEnvThunderURL(t, repo, ouB, envB)
+
+	const sharedURL = "https://stage-idp.saas-url-test.example.com"
+	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouA, EnvName: envA, ThunderURL: sharedURL}))
+
+	got, err := repo.Get(context.Background(), ouA, envA)
+	require.NoError(t, err)
+	assert.Empty(t, got.ThunderHandle, "a SaaS-registered row has no handle")
+	assert.Equal(t, sharedURL, got.ThunderURL)
+
+	err = repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouB, EnvName: envB, ThunderURL: sharedURL})
+	require.Error(t, err, "a different environment claiming an already-registered url is a genuine collision")
+	assert.ErrorIs(t, err, utils.ErrThunderURLTaken)
+
+	_, getErr := repo.Get(context.Background(), ouB, envB)
+	assert.True(t, errors.Is(getErr, gorm.ErrRecordNotFound), "the rejected insert for envB must not have created a row")
+}
+
+// TestEnvThunderURLRepo_MultipleSaaSRowsWithoutHandlesDoNotConflict proves
+// Postgres's NULL semantics hold here: two handle-less (SaaS) rows for
+// different environments and different URLs must both succeed — NULL never
+// equals NULL under a unique constraint, so uq_env_thunder_urls_handle never
+// fires for either of them.
+func TestEnvThunderURLRepo_MultipleSaaSRowsWithoutHandlesDoNotConflict(t *testing.T) {
+	repo := NewEnvThunderURLRepo(db.GetDB())
+	const ouA, envA = "ou-test-saas-no-handle-a", "env-thunder-saas-no-handle-a"
+	const ouB, envB = "ou-test-saas-no-handle-b", "env-thunder-saas-no-handle-b"
+	cleanupEnvThunderURL(t, repo, ouA, envA)
+	cleanupEnvThunderURL(t, repo, ouB, envB)
+
+	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouA, EnvName: envA, ThunderURL: "https://idp-a.saas-url-test.example.com"}))
+	require.NoError(t, repo.Insert(context.Background(), &models.EnvThunderURL{OUID: ouB, EnvName: envB, ThunderURL: "https://idp-b.saas-url-test.example.com"}))
+
+	gotA, err := repo.Get(context.Background(), ouA, envA)
+	require.NoError(t, err)
+	assert.Empty(t, gotA.ThunderHandle)
+
+	gotB, err := repo.Get(context.Background(), ouB, envB)
+	require.NoError(t, err)
+	assert.Empty(t, gotB.ThunderHandle)
+}
+
+func strPtr(s string) *string { return &s }

--- a/agent-manager-service/services/env_thunder_url_reader.go
+++ b/agent-manager-service/services/env_thunder_url_reader.go
@@ -24,37 +24,36 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 )
 
-// ResolveThunderHandle is the SINGLE place every caller resolves an
-// environment's env-Thunder URL handle — EnvironmentService's own
-// readThunderHandle/GetThunderURL/SetThunderURL and the resolver's injected
-// ReadThunderHandleFunc (via NewEnvThunderURLReader below) all delegate here so
-// this logic can never drift apart between call sites.
-//
-// A missing row means this environment has never been provisioned through
-// SetThunderURL — returns ("", nil), never a value computed from (ouID,
-// envName). There is no grandfathering: every live env-Thunder instance has a
-// row here by construction (SetThunderSystemClientSecret always provisions one
-// first), so a missing row means exactly "not provisioned," full stop.
-func ResolveThunderHandle(ctx context.Context, urlRepo repositories.EnvThunderURLRepository, ouID, envName string) (string, error) {
+// ResolveThunderURL is the SINGLE place every caller resolves an
+// environment's env-Thunder registration, so this logic can never drift
+// apart between call sites. A missing row means never provisioned — returns
+// (models.ThunderURLRecord{}, nil), never a value computed from (ouID, envName).
+func ResolveThunderURL(ctx context.Context, urlRepo repositories.EnvThunderURLRepository, ouID, envName string) (models.ThunderURLRecord, error) {
 	row, err := urlRepo.Get(ctx, ouID, envName)
 	if err == nil {
-		return row.ThunderHandle, nil
+		return toThunderURLRecord(row), nil
 	}
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return "", nil
+		return models.ThunderURLRecord{}, nil
 	}
-	return "", fmt.Errorf("read env-thunder url handle for %s/%s: %w", ouID, envName, err)
+	return models.ThunderURLRecord{}, fmt.Errorf("read env-thunder url for %s/%s: %w", ouID, envName, err)
 }
 
-// NewEnvThunderURLReader builds the resolver's DB-backed handle reader —
-// ResolveThunderHandle widened to thundersvc.ReadThunderHandleFunc's shape.
-// Lives in services (not wiring) for the same reason as
-// NewEnvThunderSecretReader: app.Run's provisioning factory shares it without a cycle.
-func NewEnvThunderURLReader(urlRepo repositories.EnvThunderURLRepository) thundersvc.ReadThunderHandleFunc {
+// NewEnvThunderURLReader builds the resolver's DB-backed URL reader —
+// ResolveThunderURL widened to thundersvc.ReadThunderURLFunc's shape (the
+// resolver only needs the origin, so Handle is discarded). Lives in services
+// (not wiring), same as NewEnvThunderSecretReader, so app.Run's provisioning
+// factory can share it without an import cycle.
+func NewEnvThunderURLReader(urlRepo repositories.EnvThunderURLRepository) thundersvc.ReadThunderURLFunc {
 	return func(ctx context.Context, ouID, envName string) (string, error) {
-		return ResolveThunderHandle(ctx, urlRepo, ouID, envName)
+		rec, err := ResolveThunderURL(ctx, urlRepo, ouID, envName)
+		if err != nil {
+			return "", err
+		}
+		return rec.URL, nil
 	}
 }

--- a/agent-manager-service/services/env_thunder_url_reader.go
+++ b/agent-manager-service/services/env_thunder_url_reader.go
@@ -44,16 +44,19 @@ func ResolveThunderURL(ctx context.Context, urlRepo repositories.EnvThunderURLRe
 }
 
 // NewEnvThunderURLReader builds the resolver's DB-backed URL reader —
-// ResolveThunderURL widened to thundersvc.ReadThunderURLFunc's shape (the
-// resolver only needs the origin, so Handle is discarded). Lives in services
-// (not wiring), same as NewEnvThunderSecretReader, so app.Run's provisioning
-// factory can share it without an import cycle.
+// ResolveThunderURL widened to thundersvc.ReadThunderURLFunc's shape.
+// callerSupplied (Handle == "") tells the resolver whether this row's URL is
+// attacker-influenced (a SaaS row) or AMS's own trusted computation (an
+// on-prem row) — see thunderURLCandidate's doc comment for why that decides
+// which candidate gets SSRF-hardened. Lives in services (not wiring), same as
+// NewEnvThunderSecretReader, so app.Run's provisioning factory can share it
+// without an import cycle.
 func NewEnvThunderURLReader(urlRepo repositories.EnvThunderURLRepository) thundersvc.ReadThunderURLFunc {
-	return func(ctx context.Context, ouID, envName string) (string, error) {
+	return func(ctx context.Context, ouID, envName string) (string, bool, error) {
 		rec, err := ResolveThunderURL(ctx, urlRepo, ouID, envName)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
-		return rec.URL, nil
+		return rec.URL, rec.Handle == "", nil
 	}
 }

--- a/agent-manager-service/services/env_thunder_url_reader_test.go
+++ b/agent-manager-service/services/env_thunder_url_reader_test.go
@@ -29,22 +29,36 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
 )
 
-// TestResolveThunderHandle covers the SINGLE centralized function every caller
-// (EnvironmentService's readThunderHandle/GetThunderURL/SetThunderURL, and the
-// resolver's ReadThunderHandleFunc via NewEnvThunderURLReader) delegates to.
-func TestResolveThunderHandle(t *testing.T) {
-	t.Run("returns the registered handle", func(t *testing.T) {
+// TestResolveThunderURL covers the SINGLE centralized function every caller
+// (EnvironmentService's SetThunderURL/GetThunderURL/ListThunderInstances, and
+// the resolver's ReadThunderURLFunc via NewEnvThunderURLReader) delegates to.
+func TestResolveThunderURL(t *testing.T) {
+	t.Run("returns the registered on-prem record (handle + computed url)", func(t *testing.T) {
 		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(_ context.Context, ouID, envName string) (*models.EnvThunderURL, error) {
 				assert.Equal(t, "ou-1", ouID)
 				assert.Equal(t, "prod", envName)
-				return &models.EnvThunderURL{ThunderHandle: "x7f2q9kz"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr("x7f2q9kz"), ThunderURL: "http://x7f2q9kz.amp.localhost:8080"}, nil
 			},
 		}
 
-		handle, err := ResolveThunderHandle(context.Background(), urlRepo, "ou-1", "prod")
+		rec, err := ResolveThunderURL(context.Background(), urlRepo, "ou-1", "prod")
 		require.NoError(t, err)
-		assert.Equal(t, "x7f2q9kz", handle)
+		assert.Equal(t, "x7f2q9kz", rec.Handle)
+		assert.Equal(t, "http://x7f2q9kz.amp.localhost:8080", rec.URL)
+	})
+
+	t.Run("returns the registered SaaS record (url only, no handle)", func(t *testing.T) {
+		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return &models.EnvThunderURL{ThunderURL: "https://stage-idp.tenant42.example.com"}, nil
+			},
+		}
+
+		rec, err := ResolveThunderURL(context.Background(), urlRepo, "ou-1", "prod")
+		require.NoError(t, err)
+		assert.Empty(t, rec.Handle)
+		assert.Equal(t, "https://stage-idp.tenant42.example.com", rec.URL)
 	})
 
 	t.Run("reports not-provisioned when no row exists — never recomputes a value", func(t *testing.T) {
@@ -54,9 +68,10 @@ func TestResolveThunderHandle(t *testing.T) {
 			},
 		}
 
-		handle, err := ResolveThunderHandle(context.Background(), urlRepo, "ou-1", "prod")
+		rec, err := ResolveThunderURL(context.Background(), urlRepo, "ou-1", "prod")
 		require.NoError(t, err)
-		assert.Empty(t, handle)
+		assert.Empty(t, rec.Handle)
+		assert.Empty(t, rec.URL)
 	})
 
 	t.Run("propagates an unexpected repo error", func(t *testing.T) {
@@ -67,7 +82,7 @@ func TestResolveThunderHandle(t *testing.T) {
 			},
 		}
 
-		_, err := ResolveThunderHandle(context.Background(), urlRepo, "ou-1", "prod")
+		_, err := ResolveThunderURL(context.Background(), urlRepo, "ou-1", "prod")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, boom)
 	})

--- a/agent-manager-service/services/environment_service.go
+++ b/agent-manager-service/services/environment_service.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"net/url"
 	"regexp"
 	"sync"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
+	"github.com/wso2/agent-manager/agent-manager-service/utils/ssrf"
 )
 
 // EnvironmentService defines the interface for environment operations
@@ -50,15 +52,24 @@ type EnvironmentService interface {
 	SetThunderSystemClientSecret(ctx context.Context, ouID, envName, clientID, clientSecret string) error
 	// DeleteThunderSystemClientSecret removes that credential (idempotent), looked up by ouID.
 	DeleteThunderSystemClientSecret(ctx context.Context, ouID, envName string) error
-	// SetThunderURL registers an unguessable handle that replaces the predictable
-	// <org>-<env> segment of this environment's externally-reachable env-Thunder
-	// hostname, and returns the handle that ended up stored. When handle is empty,
-	// one is generated automatically. Returns utils.ErrThunderHandleTaken if a
-	// caller-supplied handle is already registered to a different environment.
-	SetThunderURL(ctx context.Context, ouID, envName, handle string) (string, error)
-	// GetThunderURL returns the registered handle for (ouID, envName), or
-	// utils.ErrThunderHandleNotFound if none has been registered.
-	GetThunderURL(ctx context.Context, ouID, envName string) (string, error)
+	// SetThunderURL registers this environment's env-Thunder registration via
+	// exactly one of two mutually-exclusive paths:
+	//   - handle set (or both empty): on-prem path. An unguessable handle
+	//     replaces the predictable <org>-<env> segment of the environment's
+	//     hostname; AMS computes and stores the full origin server-side. An
+	//     empty handle auto-generates one.
+	//   - url set: SaaS/control-plane path. The caller already knows the
+	//     real, already-provisioned origin (a cloud control plane can put
+	//     different environments under different domains, so there is no
+	//     single pattern AMS could compute); AMS validates and stores it
+	//     verbatim, with no handle at all.
+	// Returns utils.ErrThunderHandleAndURLBothSet if both are non-empty,
+	// utils.ErrThunderHandleTaken/utils.ErrThunderURLTaken if the respective
+	// value is already registered to a different environment.
+	SetThunderURL(ctx context.Context, ouID, envName, handle, url string) (models.ThunderURLRecord, error)
+	// GetThunderURL returns the registered record for (ouID, envName), or
+	// utils.ErrThunderHandleNotFound if nothing has been registered.
+	GetThunderURL(ctx context.Context, ouID, envName string) (models.ThunderURLRecord, error)
 	// DeleteThunderURL removes the handle (idempotent), freeing it for reuse.
 	DeleteThunderURL(ctx context.Context, ouID, envName string) error
 	// IsThunderHandleAvailable checks whether handle passes format validation
@@ -527,7 +538,7 @@ func (s *environmentService) ListThunderInstances(ctx context.Context, ouID stri
 	// must never look identical to "this environment has no Thunder instance" on
 	// the console's Identity page.
 	reachable := make([]bool, len(envs))
-	handles := make([]string, len(envs))
+	thunderURLs := make([]string, len(envs))
 	sem := make(chan struct{}, maxThunderProbeConcurrency)
 	var wg sync.WaitGroup
 	var readErrOnce sync.Once
@@ -541,16 +552,16 @@ func (s *environmentService) ListThunderInstances(ctx context.Context, ouID stri
 		go func(idx int, envName string) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			handle, err := s.readThunderHandle(ctx, ouID, envName)
+			rec, err := s.resolveThunderRecord(ctx, ouID, envName)
 			if err != nil {
-				readErrOnce.Do(func() { readErr = fmt.Errorf("read thunder url handle for env %s: %w", envName, err) })
+				readErrOnce.Do(func() { readErr = fmt.Errorf("read thunder url for env %s: %w", envName, err) })
 				return
 			}
-			handles[idx] = handle
-			if handle == "" {
+			thunderURLs[idx] = rec.URL
+			if rec.URL == "" {
 				return // not provisioned — reachable[idx] stays false, no probe needed
 			}
-			reachable[idx] = s.thunderProber.Probe(ctx, orgNamespace, envName, handle)
+			reachable[idx] = s.thunderProber.Probe(ctx, orgNamespace, envName, rec.URL)
 		}(i, env.Name)
 	}
 	wg.Wait()
@@ -580,22 +591,20 @@ func (s *environmentService) ListThunderInstances(ctx context.Context, ouID stri
 			EnvName:      env.Name,
 			DisplayName:  env.DisplayName,
 			IsProduction: env.IsProduction,
-			IssuerURL:    thundersvc.ThunderIssuerURL(handles[i]),
-			TokenURL:     thundersvc.ThunderExternalTokenURL(handles[i]),
-			JWKSURL:      thundersvc.ThunderExternalJWKSURL(handles[i]),
+			IssuerURL:    thundersvc.ThunderIssuerURL(thunderURLs[i]),
+			TokenURL:     thundersvc.ThunderExternalTokenURL(thunderURLs[i]),
+			JWKSURL:      thundersvc.ThunderExternalJWKSURL(thunderURLs[i]),
 			Namespace:    thundersvc.ThunderNamespace(orgNamespace, env.Name),
 		})
 	}
 	return &models.ThunderInstanceListResponse{ThunderInstances: instances}, nil
 }
 
-// readThunderHandle looks up envName's env-Thunder URL handle via
-// ResolveThunderHandle, which already distinguishes "genuinely never
-// provisioned" (returns "", nil) from a real read failure (returns a wrapped
-// error) — this just widens that same distinction to environmentService's
-// caller instead of collapsing it.
-func (s *environmentService) readThunderHandle(ctx context.Context, ouID, envName string) (string, error) {
-	return ResolveThunderHandle(ctx, s.envThunderURLRepo, ouID, envName)
+// resolveThunderRecord looks up envName's env-Thunder registration via
+// ResolveThunderURL, which distinguishes "never provisioned" (zero-value
+// record, nil error) from a real read failure (wrapped error).
+func (s *environmentService) resolveThunderRecord(ctx context.Context, ouID, envName string) (models.ThunderURLRecord, error) {
+	return ResolveThunderURL(ctx, s.envThunderURLRepo, ouID, envName)
 }
 
 // thunderHandlePattern matches a DNS-label-safe handle: lowercase alphanumeric,
@@ -699,39 +708,99 @@ func generateThunderHandle() (string, error) {
 	return string(out), nil
 }
 
-// SetThunderURL registers handle for (ouID, envName) and returns the handle
-// that actually ended up stored. If handle is empty, one is generated.
+// maxThunderURLLen mirrors the thunder_url column's VARCHAR(2048) cap.
+const maxThunderURLLen = 2048
+
+// validateThunderURL checks rawURL's shape for the SaaS/control-plane
+// registration path and returns it normalized to a bare "scheme://host[:port]"
+// origin (stripping any trailing "/", since callers append their own paths).
+// Must be an absolute http(s) origin with no userinfo/path/query/fragment.
+// Also runs ssrf.ValidateURL: unlike a handle (always AMS's own label under
+// its own trusted domain), this exact value gets dialed later by
+// EnvThunderResolver — genuinely attacker-influenced input, which a handle
+// never was.
+func validateThunderURL(ctx context.Context, rawURL string) (string, error) {
+	if rawURL == "" {
+		return "", fmt.Errorf("%w: url is required", utils.ErrInvalidThunderURL)
+	}
+	if len(rawURL) > maxThunderURLLen {
+		return "", fmt.Errorf("%w: url exceeds %d characters", utils.ErrInvalidThunderURL, maxThunderURLLen)
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", utils.ErrInvalidThunderURL, err.Error())
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("%w: scheme must be http or https", utils.ErrInvalidThunderURL)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("%w: host is required", utils.ErrInvalidThunderURL)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("%w: must not contain userinfo", utils.ErrInvalidThunderURL)
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("%w: must be a bare origin with no path", utils.ErrInvalidThunderURL)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("%w: must not contain a query or fragment", utils.ErrInvalidThunderURL)
+	}
+	origin := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+	if err := ssrf.ValidateURL(ctx, origin); err != nil {
+		return "", fmt.Errorf("%w: %s", utils.ErrInvalidThunderURL, err.Error())
+	}
+	return origin, nil
+}
+
+// SetThunderURL registers this environment's env-Thunder record via exactly
+// one of two mutually-exclusive paths (rejecting both handle and url set at
+// once with utils.ErrThunderHandleAndURLBothSet) — see the interface doc
+// comment for the two paths' shapes.
 //
-// Idempotent, and never changes an already-registered handle: Thunder's issuer
-// is immutable once minted, so a blank-handle call reuses the existing one,
-// and an explicit different handle is rejected (utils.ErrThunderHandleTaken,
-// 409) — callers that want to change it must call DeleteThunderURL first.
+// Idempotent, and never changes an already-registered record: Thunder's
+// issuer is immutable once minted, so a blank or matching request reuses it
+// as a no-op, and an explicit different one is rejected (409) — callers that
+// want to change it must call DeleteThunderURL first.
 //
 // Safe under concurrent first-time provisioning: the up-front read is only a
-// fast path, not the race guard. The actual guarantee comes from
-// claimThunderHandle's use of EnvThunderURLRepository.Insert (insert-only, not
-// an upsert) — whichever request's INSERT commits first wins, and the loser
-// discovers that via the DB's own unique-constraint check rather than a
-// separate read-then-write step.
-func (s *environmentService) SetThunderURL(ctx context.Context, ouID, envName, handle string) (string, error) {
+// fast path. The real guarantee is claimThunderHandle/claimThunderURL's use
+// of EnvThunderURLRepository.Insert (insert-only, not upsert) — whichever
+// INSERT commits first wins, and the loser discovers that via the DB's own
+// unique-constraint check.
+func (s *environmentService) SetThunderURL(ctx context.Context, ouID, envName, handle, rawURL string) (models.ThunderURLRecord, error) {
 	if ouID == "" {
-		return "", fmt.Errorf("%w: ouID is required", utils.ErrInvalidInput)
+		return models.ThunderURLRecord{}, fmt.Errorf("%w: ouID is required", utils.ErrInvalidInput)
 	}
 	if envName == "" {
-		return "", fmt.Errorf("%w: envName is required", utils.ErrInvalidInput)
+		return models.ThunderURLRecord{}, fmt.Errorf("%w: envName is required", utils.ErrInvalidInput)
+	}
+	if handle != "" && rawURL != "" {
+		return models.ThunderURLRecord{}, utils.ErrThunderHandleAndURLBothSet
 	}
 
-	existing, err := ResolveThunderHandle(ctx, s.envThunderURLRepo, ouID, envName)
+	existing, err := ResolveThunderURL(ctx, s.envThunderURLRepo, ouID, envName)
 	if err != nil {
-		return "", fmt.Errorf("failed to check for an existing thunder url handle for %s/%s: %w", ouID, envName, err)
+		return models.ThunderURLRecord{}, fmt.Errorf("failed to check for an existing thunder url for %s/%s: %w", ouID, envName, err)
 	}
-	if existing != "" {
+
+	if rawURL != "" {
+		normalized, err := validateThunderURL(ctx, rawURL)
+		if err != nil {
+			return models.ThunderURLRecord{}, err
+		}
+		if existing.URL != "" {
+			return s.reuseOrRejectThunderURL(existing, normalized, ouID, envName)
+		}
+		return s.claimThunderURL(ctx, ouID, envName, normalized)
+	}
+
+	if existing.URL != "" {
 		return s.reuseOrRejectThunderHandle(existing, handle, ouID, envName)
 	}
 
 	if handle != "" {
 		if err := validateThunderHandle(handle); err != nil {
-			return "", err
+			return models.ThunderURLRecord{}, err
 		}
 		return s.claimThunderHandle(ctx, ouID, envName, handle, false)
 	}
@@ -739,44 +808,75 @@ func (s *environmentService) SetThunderURL(ctx context.Context, ouID, envName, h
 	for attempt := 1; attempt <= maxGenerateThunderHandleAttempts; attempt++ {
 		generated, err := generateThunderHandle()
 		if err != nil {
-			return "", err
+			return models.ThunderURLRecord{}, err
 		}
 		resolved, err := s.claimThunderHandle(ctx, ouID, envName, generated, true)
 		if err == nil {
 			return resolved, nil
 		}
-		if errors.Is(err, utils.ErrThunderHandleTaken) {
-			// The generated value collided with a different environment's
-			// handle — try a fresh one.
+		if errors.Is(err, utils.ErrThunderHandleTaken) || errors.Is(err, utils.ErrThunderURLTaken) {
+			// The generated value's handle or computed URL collided with a
+			// different environment's — try a fresh one.
 			s.logger.Debug("generated thunder url handle collided, retrying", "ouID", ouID, "envName", envName, "attempt", attempt)
 			continue
 		}
-		return "", err
+		return models.ThunderURLRecord{}, err
 	}
-	return "", fmt.Errorf("failed to generate a unique thunder url handle for %s/%s after %d attempts", ouID, envName, maxGenerateThunderHandleAttempts)
+	return models.ThunderURLRecord{}, fmt.Errorf("failed to generate a unique thunder url handle for %s/%s after %d attempts", ouID, envName, maxGenerateThunderHandleAttempts)
 }
 
-// reuseOrRejectThunderHandle applies SetThunderURL's idempotency rule once a
-// registered handle is known — whether seen via an up-front read, or
-// discovered by losing an insert race (see claimThunderHandle): a blank or
-// matching request reuses it as a no-op; a different EXPLICIT request is
-// rejected, since Thunder's issuer is never silently changed once minted.
-func (s *environmentService) reuseOrRejectThunderHandle(existing, requested, ouID, envName string) (string, error) {
-	if requested == "" || requested == existing {
+// reuseOrRejectThunderHandle applies SetThunderURL's idempotency rule for the
+// on-prem handle path once an existing registration is known (via an
+// up-front read, or by losing an insert race — see claimThunderHandle): a
+// blank or matching request reuses it as a no-op; a different EXPLICIT
+// request is rejected. Also correctly rejects an explicit handle against an
+// existing SaaS-registered (handle-less) row, since existing.Handle is "" there.
+func (s *environmentService) reuseOrRejectThunderHandle(existing models.ThunderURLRecord, requested, ouID, envName string) (models.ThunderURLRecord, error) {
+	if requested == "" || requested == existing.Handle {
 		s.logger.Info("Reusing already-registered env-thunder url handle", "ouID", ouID, "envName", envName)
 		return existing, nil
 	}
-	return "", fmt.Errorf("%w: %s/%s already has a registered handle %q — call DeleteThunderURL first to change it",
-		utils.ErrThunderHandleTaken, ouID, envName, existing)
+	if existing.Handle == "" {
+		return models.ThunderURLRecord{}, fmt.Errorf("%w: %s/%s already has a registered thunder url %q (registered via the control-plane URL path, no handle) — call DeleteThunderURL first to change it",
+			utils.ErrThunderHandleTaken, ouID, envName, existing.URL)
+	}
+	return models.ThunderURLRecord{}, fmt.Errorf("%w: %s/%s already has a registered handle %q — call DeleteThunderURL first to change it",
+		utils.ErrThunderHandleTaken, ouID, envName, existing.Handle)
 }
 
-// claimThunderHandle attempts to insert-claim handle for (ouID, envName). If a
-// concurrent request already won the same (ouID, envName) race first, it
-// reads back the winning row: a generated handle always adopts the winner's
-// value, while an explicit caller-supplied handle applies the same
-// reuse-or-reject rule a pre-existing row would get.
-func (s *environmentService) claimThunderHandle(ctx context.Context, ouID, envName, handle string, generated bool) (string, error) {
-	rec := &models.EnvThunderURL{OUID: ouID, EnvName: envName, ThunderHandle: handle}
+// reuseOrRejectThunderURL is reuseOrRejectThunderHandle's counterpart for the
+// SaaS/control-plane URL path: a matching re-registration is a no-op; a
+// different one is rejected, regardless of which path originally minted the
+// existing record.
+func (s *environmentService) reuseOrRejectThunderURL(existing models.ThunderURLRecord, requested, ouID, envName string) (models.ThunderURLRecord, error) {
+	if requested == existing.URL {
+		s.logger.Info("Reusing already-registered env-thunder url", "ouID", ouID, "envName", envName)
+		return existing, nil
+	}
+	return models.ThunderURLRecord{}, fmt.Errorf("%w: %s/%s already has a registered thunder url %q — call DeleteThunderURL first to change it",
+		utils.ErrThunderURLTaken, ouID, envName, existing.URL)
+}
+
+// toThunderURLRecord converts a stored row into the public ThunderURLRecord
+// shape, dereferencing ThunderHandle (nil for a SaaS/control-plane row) down
+// to "" — see EnvThunderURL's doc comment for why the column is a *string.
+func toThunderURLRecord(row *models.EnvThunderURL) models.ThunderURLRecord {
+	rec := models.ThunderURLRecord{URL: row.ThunderURL}
+	if row.ThunderHandle != nil {
+		rec.Handle = *row.ThunderHandle
+	}
+	return rec
+}
+
+// claimThunderHandle attempts to insert-claim handle for (ouID, envName),
+// computing its origin server-side (see thundersvc.ThunderOriginFromHandle)
+// and storing both. If a concurrent request already won the same
+// (ouID, envName) race first, it reads back the winning row: a generated
+// handle always adopts the winner's value, while an explicit caller-supplied
+// handle applies the same reuse-or-reject rule a pre-existing row would get.
+func (s *environmentService) claimThunderHandle(ctx context.Context, ouID, envName, handle string, generated bool) (models.ThunderURLRecord, error) {
+	thunderURL := thundersvc.ThunderOriginFromHandle(handle)
+	rec := &models.EnvThunderURL{OUID: ouID, EnvName: envName, ThunderHandle: &handle, ThunderURL: thunderURL}
 	err := s.envThunderURLRepo.Insert(ctx, rec)
 	if err == nil {
 		if generated {
@@ -784,40 +884,67 @@ func (s *environmentService) claimThunderHandle(ctx context.Context, ouID, envNa
 		} else {
 			s.logger.Info("Stored env-thunder url handle", "ouID", ouID, "envName", envName)
 		}
-		return handle, nil
+		return models.ThunderURLRecord{Handle: handle, URL: thunderURL}, nil
 	}
 	if errors.Is(err, utils.ErrEnvThunderURLAlreadyClaimed) {
 		winner, getErr := s.envThunderURLRepo.Get(ctx, ouID, envName)
 		if getErr != nil {
-			return "", fmt.Errorf("failed to read the winning thunder url handle for %s/%s after a claim race: %w", ouID, envName, getErr)
+			return models.ThunderURLRecord{}, fmt.Errorf("failed to read the winning thunder url for %s/%s after a claim race: %w", ouID, envName, getErr)
 		}
+		winnerRec := toThunderURLRecord(winner)
 		if generated {
-			s.logger.Info("Lost a concurrent first-provisioning race; adopting the winning handle", "ouID", ouID, "envName", envName)
-			return winner.ThunderHandle, nil
+			s.logger.Info("Lost a concurrent first-provisioning race; adopting the winning registration", "ouID", ouID, "envName", envName)
+			return winnerRec, nil
 		}
-		return s.reuseOrRejectThunderHandle(winner.ThunderHandle, handle, ouID, envName)
+		return s.reuseOrRejectThunderHandle(winnerRec, handle, ouID, envName)
 	}
-	if errors.Is(err, utils.ErrThunderHandleTaken) {
-		return "", err
+	if errors.Is(err, utils.ErrThunderHandleTaken) || errors.Is(err, utils.ErrThunderURLTaken) {
+		return models.ThunderURLRecord{}, err
 	}
-	return "", fmt.Errorf("failed to store thunder url handle for %s/%s: %w", ouID, envName, err)
+	return models.ThunderURLRecord{}, fmt.Errorf("failed to store thunder url for %s/%s: %w", ouID, envName, err)
 }
 
-// GetThunderURL returns the registered handle for (ouID, envName) — resolved
-// via ResolveThunderHandle — or utils.ErrThunderHandleNotFound if none has ever
-// been registered.
-func (s *environmentService) GetThunderURL(ctx context.Context, ouID, envName string) (string, error) {
+// claimThunderURL attempts to insert-claim rawURL (already validated and
+// normalized) for (ouID, envName), with no handle at all — the SaaS/
+// control-plane registration path. Mirrors claimThunderHandle's concurrency
+// handling, one level simpler since there is no generated-value retry loop
+// for this path: the caller already knows the exact URL it wants, so there is
+// nothing to regenerate on collision.
+func (s *environmentService) claimThunderURL(ctx context.Context, ouID, envName, rawURL string) (models.ThunderURLRecord, error) {
+	rec := &models.EnvThunderURL{OUID: ouID, EnvName: envName, ThunderURL: rawURL}
+	err := s.envThunderURLRepo.Insert(ctx, rec)
+	if err == nil {
+		s.logger.Info("Stored env-thunder url", "ouID", ouID, "envName", envName)
+		return models.ThunderURLRecord{URL: rawURL}, nil
+	}
+	if errors.Is(err, utils.ErrEnvThunderURLAlreadyClaimed) {
+		winner, getErr := s.envThunderURLRepo.Get(ctx, ouID, envName)
+		if getErr != nil {
+			return models.ThunderURLRecord{}, fmt.Errorf("failed to read the winning thunder url for %s/%s after a claim race: %w", ouID, envName, getErr)
+		}
+		return s.reuseOrRejectThunderURL(toThunderURLRecord(winner), rawURL, ouID, envName)
+	}
+	if errors.Is(err, utils.ErrThunderURLTaken) {
+		return models.ThunderURLRecord{}, err
+	}
+	return models.ThunderURLRecord{}, fmt.Errorf("failed to store thunder url for %s/%s: %w", ouID, envName, err)
+}
+
+// GetThunderURL returns the registered record for (ouID, envName) — resolved
+// via ResolveThunderURL — or utils.ErrThunderHandleNotFound if nothing has
+// ever been registered.
+func (s *environmentService) GetThunderURL(ctx context.Context, ouID, envName string) (models.ThunderURLRecord, error) {
 	if ouID == "" {
-		return "", fmt.Errorf("%w: ouID is required", utils.ErrInvalidInput)
+		return models.ThunderURLRecord{}, fmt.Errorf("%w: ouID is required", utils.ErrInvalidInput)
 	}
-	handle, err := ResolveThunderHandle(ctx, s.envThunderURLRepo, ouID, envName)
+	rec, err := ResolveThunderURL(ctx, s.envThunderURLRepo, ouID, envName)
 	if err != nil {
-		return "", fmt.Errorf("failed to read thunder url handle for %s/%s: %w", ouID, envName, err)
+		return models.ThunderURLRecord{}, fmt.Errorf("failed to read thunder url for %s/%s: %w", ouID, envName, err)
 	}
-	if handle == "" {
-		return "", utils.ErrThunderHandleNotFound
+	if rec.URL == "" {
+		return models.ThunderURLRecord{}, utils.ErrThunderHandleNotFound
 	}
-	return handle, nil
+	return rec, nil
 }
 
 // DeleteThunderURL removes the handle for (ouID, envName). Idempotent — deleting a
@@ -882,7 +1009,7 @@ func (s *environmentService) SetThunderSystemClientSecret(ctx context.Context, o
 	if ouID == "" {
 		return fmt.Errorf("%w: ouID is required", utils.ErrInvalidInput)
 	}
-	if _, err := s.SetThunderURL(ctx, ouID, envName, ""); err != nil {
+	if _, err := s.SetThunderURL(ctx, ouID, envName, "", ""); err != nil {
 		return fmt.Errorf("failed to ensure a thunder url handle exists for %s/%s: %w", ouID, envName, err)
 	}
 	encrypted, err := utils.EncryptBytes([]byte(clientSecret), s.encryptionKey)

--- a/agent-manager-service/services/environment_service.go
+++ b/agent-manager-service/services/environment_service.go
@@ -25,12 +25,14 @@ import (
 	"math/big"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
 
 	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -561,7 +563,7 @@ func (s *environmentService) ListThunderInstances(ctx context.Context, ouID stri
 			if rec.URL == "" {
 				return // not provisioned — reachable[idx] stays false, no probe needed
 			}
-			reachable[idx] = s.thunderProber.Probe(ctx, orgNamespace, envName, rec.URL)
+			reachable[idx] = s.thunderProber.Probe(ctx, orgNamespace, envName, rec.URL, rec.Handle == "")
 		}(i, env.Name)
 	}
 	wg.Wait()
@@ -744,6 +746,18 @@ func validateThunderURL(ctx context.Context, rawURL string) (string, error) {
 	}
 	if parsed.RawQuery != "" || parsed.Fragment != "" {
 		return "", fmt.Errorf("%w: must not contain a query or fragment", utils.ErrInvalidThunderURL)
+	}
+	// A url under THIS deployment's own base domain is still checked against
+	// reservedThunderHandles, the same protection the handle path enforces:
+	// without it, a caller could register e.g. "https://console.<baseDomain>"
+	// and AMS would dial the platform's own console with the environment's
+	// system-client credentials, and advertise it as the environment's
+	// issuer/JWKS. A url under a DIFFERENT domain (the normal SaaS case) never
+	// matches this deployment's base domain, so this never fires for it.
+	if label, rest, ok := strings.Cut(parsed.Hostname(), "."); ok &&
+		strings.EqualFold(rest, config.GetConfig().ThunderHostBaseDomain) &&
+		reservedThunderHandles[strings.ToLower(label)] {
+		return "", fmt.Errorf("%w: %q is a reserved subdomain of %s", utils.ErrInvalidThunderURL, label, rest)
 	}
 	origin := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
 	if err := ssrf.ValidateURL(ctx, origin); err != nil {
@@ -991,26 +1005,27 @@ func (s *environmentService) ThunderHandleRegistered(ctx context.Context, handle
 // SetThunderSystemClientSecret encrypts and upserts the env-Thunder system-client
 // credential, keyed by ouID.
 //
-// Provisions a URL handle (auto-generating one if none is registered yet)
-// BEFORE ever storing the credential — never the other way around. This
-// guarantees every environment with a system-client credential also has a
-// handle row, so ResolveThunderHandle's "not provisioned" answer stays
-// trustworthy: a credential can never exist without a handle already existing
-// first. add-environment-thunder.sh happens to call register_thunder_url
-// before store_via_ams today, but that's an external, unenforced ordering;
-// this call makes the invariant hold by construction for every caller,
-// present and future, not just today's one script. SetThunderURL with an
-// empty handle is already an idempotent no-op when one is already registered,
-// so this changes nothing for an environment that already has one.
+// Does NOT provision a thunder-url registration — on-prem or SaaS, that's
+// SetThunderURL's job, called independently (by add-environment-thunder.sh's
+// register_thunder_url, or by the control plane's own PUT .../thunder-url).
+// This method previously auto-generated a handle here if none was registered
+// yet, to guarantee "a credential never exists without a registration." That
+// guarantee doesn't hold for the SaaS path: a control plane that stores the
+// credential before registering its URL would have gotten a bogus
+// handle-based origin permanently stamped, since SetThunderURL never
+// overwrites an existing registration — the real URL registration would then
+// fail forever with ErrThunderURLTaken. Silently fabricating a registration
+// nobody asked for is worse than a transient "not provisioned": Resolve()
+// already checks the credential and the URL as two independent pieces (see
+// EnvThunderResolver.Resolve), so a credential existing without a URL row is
+// a valid, correctly-handled state — it just reports ErrThunderNotProvisioned
+// until the real registration lands.
 func (s *environmentService) SetThunderSystemClientSecret(ctx context.Context, ouID, envName, clientID, clientSecret string) error {
 	if clientSecret == "" {
 		return fmt.Errorf("%w: clientSecret is required", utils.ErrInvalidInput)
 	}
 	if ouID == "" {
 		return fmt.Errorf("%w: ouID is required", utils.ErrInvalidInput)
-	}
-	if _, err := s.SetThunderURL(ctx, ouID, envName, "", ""); err != nil {
-		return fmt.Errorf("failed to ensure a thunder url handle exists for %s/%s: %w", ouID, envName, err)
 	}
 	encrypted, err := utils.EncryptBytes([]byte(clientSecret), s.encryptionKey)
 	if err != nil {

--- a/agent-manager-service/services/environment_service.go
+++ b/agent-manager-service/services/environment_service.go
@@ -754,8 +754,10 @@ func validateThunderURL(ctx context.Context, rawURL string) (string, error) {
 	// system-client credentials, and advertise it as the environment's
 	// issuer/JWKS. A url under a DIFFERENT domain (the normal SaaS case) never
 	// matches this deployment's base domain, so this never fires for it.
-	if label, rest, ok := strings.Cut(parsed.Hostname(), "."); ok &&
-		strings.EqualFold(rest, config.GetConfig().ThunderHostBaseDomain) &&
+	hostname := strings.TrimSuffix(parsed.Hostname(), ".")
+	baseDomain := strings.TrimSuffix(config.GetConfig().ThunderHostBaseDomain, ".")
+	if label, rest, ok := strings.Cut(hostname, "."); ok &&
+		strings.EqualFold(rest, baseDomain) &&
 		reservedThunderHandles[strings.ToLower(label)] {
 		return "", fmt.Errorf("%w: %q is a reserved subdomain of %s", utils.ErrInvalidThunderURL, label, rest)
 	}

--- a/agent-manager-service/services/environment_service_unit_test.go
+++ b/agent-manager-service/services/environment_service_unit_test.go
@@ -812,7 +812,7 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 		}
 		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(_ context.Context, _, envName string) (*models.EnvThunderURL, error) {
-				return &models.EnvThunderURL{ThunderHandle: envName + "-handle"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr(envName + "-handle"), ThunderURL: "http://" + envName + "-handle.amp.localhost:8080"}, nil
 			},
 		}
 		svc := NewEnvironmentService(discardLogger(), &repomocks.GatewayRepositoryMock{}, oc, prober, nil, nil, urlRepo, nil)
@@ -918,21 +918,29 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 				return []*models.OrganizationResponse{{Namespace: org}}, nil
 			},
 		}
-		// Each env has its OWN distinct handle — nothing derived from org/env.
-		handles := map[string]string{"dev": "aaaa1111", "staging": "bbbb2222"}
-		var probedHandles []string
+		// Each env has its OWN distinct registered origin — nothing derived
+		// from org/env. "staging" is deliberately given a SaaS-style
+		// (handle-less) row to prove the response doesn't depend on a handle
+		// being present at all.
+		urls := map[string]string{"dev": "http://aaaa1111.amp.localhost:8080", "staging": "https://staging.tenant42.example.com"}
+		handles := map[string]string{"dev": "aaaa1111"} // staging: no handle (SaaS-style row)
+		var probedURLs []string
 		var mu sync.Mutex
 		prober := &clientmocks.ThunderProberMock{
-			ProbeFunc: func(_ context.Context, _, _, handle string) bool {
+			ProbeFunc: func(_ context.Context, _, _, thunderURL string) bool {
 				mu.Lock()
-				probedHandles = append(probedHandles, handle)
+				probedURLs = append(probedURLs, thunderURL)
 				mu.Unlock()
 				return true
 			},
 		}
 		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(_ context.Context, _, envName string) (*models.EnvThunderURL, error) {
-				return &models.EnvThunderURL{ThunderHandle: handles[envName]}, nil
+				var handle *string
+				if h, ok := handles[envName]; ok {
+					handle = &h
+				}
+				return &models.EnvThunderURL{ThunderHandle: handle, ThunderURL: urls[envName]}, nil
 			},
 		}
 		svc := NewEnvironmentService(discardLogger(), &repomocks.GatewayRepositoryMock{}, oc, prober, nil, nil, urlRepo, nil)
@@ -942,23 +950,23 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.ThunderInstances, 2)
-		assert.ElementsMatch(t, []string{"aaaa1111", "bbbb2222"}, probedHandles,
-			"the probe must target each env's own registered handle, never a value derived from org/env")
+		assert.ElementsMatch(t, []string{urls["dev"], urls["staging"]}, probedURLs,
+			"the probe must target each env's own registered origin, never a value derived from org/env")
 
 		dev := resp.ThunderInstances[0]
 		assert.Equal(t, "dev", dev.EnvName)
 		assert.Equal(t, "Dev", dev.DisplayName)
 		assert.False(t, dev.IsProduction)
-		assert.Equal(t, thundersvc.ThunderIssuerURL("aaaa1111"), dev.IssuerURL)
-		assert.Equal(t, thundersvc.ThunderExternalTokenURL("aaaa1111"), dev.TokenURL)
-		assert.Equal(t, thundersvc.ThunderExternalJWKSURL("aaaa1111"), dev.JWKSURL)
+		assert.Equal(t, urls["dev"], dev.IssuerURL)
+		assert.Equal(t, urls["dev"]+"/oauth2/token", dev.TokenURL)
+		assert.Equal(t, urls["dev"]+"/oauth2/jwks", dev.JWKSURL)
 		assert.Equal(t, thundersvc.ThunderNamespace(org, "dev"), dev.Namespace)
 		assert.NotContains(t, dev.IssuerURL, org+"-dev", "must never leak an org-env-derived pattern")
 
 		staging := resp.ThunderInstances[1]
 		assert.Equal(t, "staging", staging.EnvName)
 		assert.True(t, staging.IsProduction)
-		assert.Equal(t, thundersvc.ThunderIssuerURL("bbbb2222"), staging.IssuerURL)
+		assert.Equal(t, urls["staging"], staging.IssuerURL)
 	})
 
 	t.Run("skips an environment with a system-client credential but no handle row — never recomputed", func(t *testing.T) {
@@ -1090,11 +1098,12 @@ func TestEnvironmentService_SetThunderSystemClientSecret(t *testing.T) {
 		require.NotNil(t, urlInserted, "a handle must be provisioned before a credential is ever stored")
 		assert.Equal(t, "ou-123", urlInserted.OUID)
 		assert.Equal(t, "staging", urlInserted.EnvName)
-		assert.Len(t, urlInserted.ThunderHandle, generatedThunderHandleLen)
+		require.NotNil(t, urlInserted.ThunderHandle)
+		assert.Len(t, *urlInserted.ThunderHandle, generatedThunderHandleLen)
 	})
 
 	t.Run("reuses an already-registered handle instead of claiming a new one", func(t *testing.T) {
-		existing := &models.EnvThunderURL{OUID: "ou-123", EnvName: "staging", ThunderHandle: "already-registered-handle"}
+		existing := &models.EnvThunderURL{OUID: "ou-123", EnvName: "staging", ThunderHandle: strPtr("already-registered-handle"), ThunderURL: "http://already-registered-handle.amp.localhost:8080"}
 		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
 				return existing, nil
@@ -1188,7 +1197,7 @@ func TestEnvironmentService_DeleteThunderSystemClientSecret(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 func TestEnvironmentService_SetThunderURL(t *testing.T) {
-	t.Run("upserts a caller-supplied handle and returns it unchanged", func(t *testing.T) {
+	t.Run("upserts a caller-supplied handle, computes+stores the origin, and returns both", func(t *testing.T) {
 		var stored *models.EnvThunderURL
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			InsertFunc: func(_ context.Context, rec *models.EnvThunderURL) error {
@@ -1198,16 +1207,19 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "x7f2q9kzab")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "x7f2q9kzab", "")
 		require.NoError(t, err)
-		assert.Equal(t, "x7f2q9kzab", resolved)
+		assert.Equal(t, "x7f2q9kzab", resolved.Handle)
+		assert.Equal(t, thundersvc.ThunderOriginFromHandle("x7f2q9kzab"), resolved.URL)
 		require.NotNil(t, stored)
 		assert.Equal(t, "ou-123", stored.OUID)
 		assert.Equal(t, "prod", stored.EnvName)
-		assert.Equal(t, "x7f2q9kzab", stored.ThunderHandle)
+		require.NotNil(t, stored.ThunderHandle)
+		assert.Equal(t, "x7f2q9kzab", *stored.ThunderHandle)
+		assert.Equal(t, thundersvc.ThunderOriginFromHandle("x7f2q9kzab"), stored.ThunderURL)
 	})
 
-	t.Run("generates a 10-character handle when none is given, and returns it", func(t *testing.T) {
+	t.Run("generates a 10-character handle when both are omitted, and returns it with its computed origin", func(t *testing.T) {
 		var stored *models.EnvThunderURL
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			InsertFunc: func(_ context.Context, rec *models.EnvThunderURL) error {
@@ -1217,12 +1229,14 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "")
 		require.NoError(t, err)
-		assert.Len(t, resolved, 10, "the task's own spec: an auto-generated handle is exactly 10 characters")
-		assert.Regexp(t, `^[a-z0-9]{10}$`, resolved, "generated handle must be lowercase alphanumeric — trivially valid against the format check")
+		assert.Len(t, resolved.Handle, 10, "the task's own spec: an auto-generated handle is exactly 10 characters")
+		assert.Regexp(t, `^[a-z0-9]{10}$`, resolved.Handle, "generated handle must be lowercase alphanumeric — trivially valid against the format check")
+		assert.Equal(t, thundersvc.ThunderOriginFromHandle(resolved.Handle), resolved.URL)
 		require.NotNil(t, stored)
-		assert.Equal(t, resolved, stored.ThunderHandle, "the caller must be told the SAME value that got persisted")
+		require.NotNil(t, stored.ThunderHandle)
+		assert.Equal(t, resolved.Handle, *stored.ThunderHandle, "the caller must be told the SAME value that got persisted")
 	})
 
 	t.Run("retries with a fresh generated value when the first collides", func(t *testing.T) {
@@ -1231,7 +1245,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			InsertFunc: func(_ context.Context, rec *models.EnvThunderURL) error {
 				attempt++
-				generatedHandles = append(generatedHandles, rec.ThunderHandle)
+				generatedHandles = append(generatedHandles, *rec.ThunderHandle)
 				if attempt == 1 {
 					return utils.ErrThunderHandleTaken
 				}
@@ -1240,10 +1254,10 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "")
 		require.NoError(t, err, "a collision on a GENERATED handle must be retried, not surfaced as an error")
 		assert.Equal(t, 2, attempt, "must retry exactly once after the first collision")
-		assert.Equal(t, generatedHandles[1], resolved, "must return the handle that actually succeeded, not the first (rejected) attempt")
+		assert.Equal(t, generatedHandles[1], resolved.Handle, "must return the handle that actually succeeded, not the first (rejected) attempt")
 		assert.NotEqual(t, generatedHandles[0], generatedHandles[1], "the retry must use a FRESH random value, not repeat the collided one")
 	})
 
@@ -1257,7 +1271,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "")
 		require.Error(t, err)
 		assert.Equal(t, maxGenerateThunderHandleAttempts, attempts, "must stop after the documented attempt cap, not loop forever")
 	})
@@ -1272,7 +1286,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "wanted-name")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "wanted-name", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrThunderHandleTaken)
 		assert.Equal(t, 1, attempts, "silently substituting a different value than what the caller asked for would be surprising — must fail immediately, not retry with a random one")
@@ -1287,7 +1301,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		upsertCalls := 0
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
-				return &models.EnvThunderURL{ThunderHandle: "existing1"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr("existing1"), ThunderURL: "http://existing1.amp.localhost:8080"}, nil
 			},
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
 				upsertCalls++
@@ -1296,9 +1310,10 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "")
 		require.NoError(t, err)
-		assert.Equal(t, "existing1", resolved)
+		assert.Equal(t, "existing1", resolved.Handle)
+		assert.Equal(t, "http://existing1.amp.localhost:8080", resolved.URL)
 		assert.Equal(t, 0, upsertCalls, "must not write anything when reusing an already-registered handle")
 	})
 
@@ -1306,7 +1321,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		upsertCalls := 0
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
-				return &models.EnvThunderURL{ThunderHandle: "existing1"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr("existing1"), ThunderURL: "http://existing1.amp.localhost:8080"}, nil
 			},
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
 				upsertCalls++
@@ -1315,9 +1330,9 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "existing1")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "existing1", "")
 		require.NoError(t, err)
-		assert.Equal(t, "existing1", resolved)
+		assert.Equal(t, "existing1", resolved.Handle)
 		assert.Equal(t, 0, upsertCalls)
 	})
 
@@ -1325,7 +1340,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		upsertCalls := 0
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
-				return &models.EnvThunderURL{ThunderHandle: "existing1"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr("existing1"), ThunderURL: "http://existing1.amp.localhost:8080"}, nil
 			},
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
 				upsertCalls++
@@ -1334,7 +1349,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "different1")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "different1", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrThunderHandleTaken, "the controller maps this to 409 — changing an already-provisioned handle requires DeleteThunderURL first")
 		assert.Equal(t, 0, upsertCalls, "must never move an already-registered handle")
@@ -1357,11 +1372,193 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 		svc := NewEnvironmentService(logger, &repomocks.GatewayRepositoryMock{}, &clientmocks.OpenChoreoClientMock{}, &clientmocks.ThunderProberMock{}, nil, nil, urlRepo, nil)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "")
 		require.NoError(t, err)
 		require.NotNil(t, urlInserted)
-		assert.Equal(t, resolved, urlInserted.ThunderHandle)
-		assert.Len(t, resolved, generatedThunderHandleLen)
+		require.NotNil(t, urlInserted.ThunderHandle)
+		assert.Equal(t, resolved.Handle, *urlInserted.ThunderHandle)
+		assert.Equal(t, resolved.URL, urlInserted.ThunderURL)
+		assert.Len(t, resolved.Handle, generatedThunderHandleLen)
+	})
+
+	// --- SaaS/control-plane url path ---
+
+	t.Run("stores a caller-supplied url verbatim, with no handle at all", func(t *testing.T) {
+		var stored *models.EnvThunderURL
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return nil, gorm.ErrRecordNotFound
+			},
+			InsertFunc: func(_ context.Context, rec *models.EnvThunderURL) error {
+				stored = rec
+				return nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://8.8.8.8")
+		require.NoError(t, err)
+		assert.Empty(t, resolved.Handle, "the SaaS path never produces a handle")
+		assert.Equal(t, "https://8.8.8.8", resolved.URL)
+		require.NotNil(t, stored)
+		assert.Empty(t, stored.ThunderHandle)
+		assert.Equal(t, "https://8.8.8.8", stored.ThunderURL)
+	})
+
+	t.Run("normalizes a url with a trailing slash to a bare origin", func(t *testing.T) {
+		var stored *models.EnvThunderURL
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return nil, gorm.ErrRecordNotFound
+			},
+			InsertFunc: func(_ context.Context, rec *models.EnvThunderURL) error {
+				stored = rec
+				return nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://8.8.8.8/")
+		require.NoError(t, err)
+		assert.Equal(t, "https://8.8.8.8", resolved.URL, "a trailing slash must be stripped so ThunderExternalTokenURL never double-slashes")
+		require.NotNil(t, stored)
+		assert.Equal(t, "https://8.8.8.8", stored.ThunderURL)
+	})
+
+	t.Run("rejects both handle and url set at once", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
+				t.Fatal("must not upsert when both handle and url are set")
+				return nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "somehandle1", "https://8.8.8.8")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrThunderHandleAndURLBothSet)
+	})
+
+	t.Run("rejects a url with a disallowed scheme", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
+				t.Fatal("must not upsert an invalid url")
+				return nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "ftp://8.8.8.8")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrInvalidThunderURL)
+	})
+
+	t.Run("rejects a url with a path", func(t *testing.T) {
+		svc := newEnvServiceWithThunderURLRepo(&repomocks.EnvThunderURLRepositoryMock{})
+
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://8.8.8.8/oauth2")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrInvalidThunderURL)
+	})
+
+	t.Run("rejects a url with userinfo", func(t *testing.T) {
+		svc := newEnvServiceWithThunderURLRepo(&repomocks.EnvThunderURLRepositoryMock{})
+
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://user:pass@8.8.8.8")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrInvalidThunderURL)
+	})
+
+	t.Run("rejects a url resolving to a private/loopback address (SSRF guard)", func(t *testing.T) {
+		svc := newEnvServiceWithThunderURLRepo(&repomocks.EnvThunderURLRepositoryMock{})
+
+		for _, private := range []string{"http://localhost:8080", "http://127.0.0.1:8080", "http://10.0.0.5"} {
+			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", private)
+			require.Error(t, err, "url %q must be rejected", private)
+			assert.ErrorIs(t, err, utils.ErrInvalidThunderURL, "url %q", private)
+		}
+	})
+
+	t.Run("re-supplying the SAME url as what's already registered is a no-op", func(t *testing.T) {
+		upsertCalls := 0
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return &models.EnvThunderURL{ThunderURL: "https://8.8.8.8"}, nil
+			},
+			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
+				upsertCalls++
+				return nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://8.8.8.8")
+		require.NoError(t, err)
+		assert.Equal(t, "https://8.8.8.8", resolved.URL)
+		assert.Equal(t, 0, upsertCalls)
+	})
+
+	t.Run("an explicit DIFFERENT url on an already-registered environment is rejected, not applied", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return &models.EnvThunderURL{ThunderURL: "https://8.8.8.8"}, nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://1.1.1.1")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrThunderURLTaken)
+	})
+
+	t.Run("an explicit handle request against an existing SaaS-registered (handle-less) row is rejected", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return &models.EnvThunderURL{ThunderURL: "https://8.8.8.8"}, nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "somehandle1", "")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrThunderHandleTaken)
+	})
+
+	t.Run("maps a url-taken conflict from the repo without wrapping it away", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return nil, gorm.ErrRecordNotFound
+			},
+			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
+				return utils.ErrThunderURLTaken
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://8.8.8.8")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrThunderURLTaken, "the controller maps this specific sentinel to 409 — it must survive unwrapped")
+	})
+
+	t.Run("loses a concurrent first-claim race on the url path and adopts the winner", func(t *testing.T) {
+		var getCalls int
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				getCalls++
+				if getCalls == 1 {
+					return nil, gorm.ErrRecordNotFound
+				}
+				return &models.EnvThunderURL{ThunderURL: "https://8.8.8.8"}, nil
+			},
+			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
+				return utils.ErrEnvThunderURLAlreadyClaimed
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://8.8.8.8")
+		require.NoError(t, err)
+		assert.Equal(t, "https://8.8.8.8", resolved.URL)
 	})
 
 	// The following four tests cover claimThunderHandle's reaction to losing a
@@ -1382,7 +1579,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 				if getCalls == 1 {
 					return nil, gorm.ErrRecordNotFound // ResolveThunderHandle's up-front check: no row yet
 				}
-				return &models.EnvThunderURL{ThunderHandle: "winnerhandle"}, nil // read back after losing the race
+				return &models.EnvThunderURL{ThunderHandle: strPtr("winnerhandle")}, nil // read back after losing the race
 			},
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
 				return utils.ErrEnvThunderURLAlreadyClaimed // a concurrent request won first
@@ -1390,9 +1587,9 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "")
 		require.NoError(t, err, "losing a race while auto-generating must never surface as an error — the caller never asked for a SPECIFIC value")
-		assert.Equal(t, "winnerhandle", resolved, "must adopt whatever handle actually won the race, not retry generation")
+		assert.Equal(t, "winnerhandle", resolved.Handle, "must adopt whatever handle actually won the race, not retry generation")
 	})
 
 	t.Run("loses a concurrent first-provisioning race with an explicit handle that matches the winner — reuses it", func(t *testing.T) {
@@ -1403,7 +1600,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 				if getCalls == 1 {
 					return nil, gorm.ErrRecordNotFound
 				}
-				return &models.EnvThunderURL{ThunderHandle: "samehandle1"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr("samehandle1")}, nil
 			},
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
 				return utils.ErrEnvThunderURLAlreadyClaimed
@@ -1411,9 +1608,9 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "samehandle1")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "samehandle1", "")
 		require.NoError(t, err)
-		assert.Equal(t, "samehandle1", resolved)
+		assert.Equal(t, "samehandle1", resolved.Handle)
 	})
 
 	t.Run("loses a concurrent first-provisioning race with an explicit handle that DIFFERS from the winner — rejected", func(t *testing.T) {
@@ -1424,7 +1621,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 				if getCalls == 1 {
 					return nil, gorm.ErrRecordNotFound
 				}
-				return &models.EnvThunderURL{ThunderHandle: "winnerhandle"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr("winnerhandle")}, nil
 			},
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
 				return utils.ErrEnvThunderURLAlreadyClaimed
@@ -1432,7 +1629,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "myhandle12")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "myhandle12", "")
 		require.Error(t, err, "an explicit value that lost the race and doesn't match the winner must be rejected, never silently substituted")
 		assert.ErrorIs(t, err, utils.ErrThunderHandleTaken)
 	})
@@ -1454,7 +1651,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, boom)
 	})
@@ -1470,7 +1667,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 
 		// 2 characters — one short of the boundary, so this fails precisely
 		// because minThunderHandleLen is 3, not because it's trivially short.
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "ab")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "ab", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle)
 	})
@@ -1481,9 +1678,9 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "abc")
+		resolved, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "abc", "")
 		require.NoError(t, err)
-		assert.Equal(t, "abc", resolved)
+		assert.Equal(t, "abc", resolved.Handle)
 	})
 
 	t.Run("rejects uppercase and other invalid characters", func(t *testing.T) {
@@ -1500,7 +1697,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		// (uppercase, underscore, leading/trailing hyphen, dot, space) is what's
 		// under test here, not shortness.
 		for _, bad := range []string{"Acme123456", "acme_prod1", "-acme12345", "acmeprod1-", "acme.prod1", "acme prod1"} {
-			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", bad)
+			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", bad, "")
 			require.Error(t, err, "handle %q must be rejected", bad)
 			assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle, "handle %q", bad)
 		}
@@ -1515,7 +1712,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", strings.Repeat("a", 64))
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", strings.Repeat("a", 64), "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle)
 	})
@@ -1531,7 +1728,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 
 		// "kubernetes" clears minThunderHandleLen (3), so this actually exercises
 		// the reserved-word check rather than failing on length first.
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "kubernetes")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "kubernetes", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle)
 	})
@@ -1549,7 +1746,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 			"console", "api", "api-amp", "thunder", "observer", "traces",
 			"gateway", "api-platform-gateway", "ai-gateway", "otel", "agents",
 		} {
-			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", reserved)
+			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", reserved, "")
 			require.Error(t, err, "handle %q must be rejected", reserved)
 			assert.ErrorIs(t, err, utils.ErrInvalidThunderHandle, "handle %q", reserved)
 		}
@@ -1564,7 +1761,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "", "prod", "x7f2q9kzab")
+		_, err := svc.SetThunderURL(context.Background(), "", "prod", "x7f2q9kzab", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrInvalidInput)
 	})
@@ -1577,7 +1774,7 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "x7f2q9kzab")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "x7f2q9kzab", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, utils.ErrThunderHandleTaken, "the controller maps this specific sentinel to 409 — it must survive unwrapped")
 	})
@@ -1589,26 +1786,41 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "x7f2q9kzab")
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "x7f2q9kzab", "")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, boom)
 	})
 }
 
 func TestEnvironmentService_GetThunderURL(t *testing.T) {
-	t.Run("returns the registered handle", func(t *testing.T) {
+	t.Run("returns the registered on-prem record (handle + url)", func(t *testing.T) {
 		repo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(_ context.Context, ouID, envName string) (*models.EnvThunderURL, error) {
 				assert.Equal(t, "ou-123", ouID)
 				assert.Equal(t, "prod", envName)
-				return &models.EnvThunderURL{ThunderHandle: "x7f2q9kzab"}, nil
+				return &models.EnvThunderURL{ThunderHandle: strPtr("x7f2q9kzab"), ThunderURL: "http://x7f2q9kzab.amp.localhost:8080"}, nil
 			},
 		}
 		svc := newEnvServiceWithThunderURLRepo(repo)
 
-		handle, err := svc.GetThunderURL(context.Background(), "ou-123", "prod")
+		resolved, err := svc.GetThunderURL(context.Background(), "ou-123", "prod")
 		require.NoError(t, err)
-		assert.Equal(t, "x7f2q9kzab", handle)
+		assert.Equal(t, "x7f2q9kzab", resolved.Handle)
+		assert.Equal(t, "http://x7f2q9kzab.amp.localhost:8080", resolved.URL)
+	})
+
+	t.Run("returns the registered SaaS record (url only, no handle)", func(t *testing.T) {
+		repo := &repomocks.EnvThunderURLRepositoryMock{
+			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
+				return &models.EnvThunderURL{ThunderURL: "https://8.8.8.8"}, nil
+			},
+		}
+		svc := newEnvServiceWithThunderURLRepo(repo)
+
+		resolved, err := svc.GetThunderURL(context.Background(), "ou-123", "prod")
+		require.NoError(t, err)
+		assert.Empty(t, resolved.Handle)
+		assert.Equal(t, "https://8.8.8.8", resolved.URL)
 	})
 
 	t.Run("maps a missing row to ErrThunderHandleNotFound when genuinely never provisioned", func(t *testing.T) {

--- a/agent-manager-service/services/environment_service_unit_test.go
+++ b/agent-manager-service/services/environment_service_unit_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -808,7 +809,7 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 			},
 		}
 		prober := &clientmocks.ThunderProberMock{
-			ProbeFunc: func(_ context.Context, _, _, _ string) bool { return false },
+			ProbeFunc: func(_ context.Context, _, _, _ string, _ bool) bool { return false },
 		}
 		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(_ context.Context, _, envName string) (*models.EnvThunderURL, error) {
@@ -925,11 +926,13 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 		urls := map[string]string{"dev": "http://aaaa1111.amp.localhost:8080", "staging": "https://staging.tenant42.example.com"}
 		handles := map[string]string{"dev": "aaaa1111"} // staging: no handle (SaaS-style row)
 		var probedURLs []string
+		callerSuppliedByURL := map[string]bool{}
 		var mu sync.Mutex
 		prober := &clientmocks.ThunderProberMock{
-			ProbeFunc: func(_ context.Context, _, _, thunderURL string) bool {
+			ProbeFunc: func(_ context.Context, _, _, thunderURL string, callerSupplied bool) bool {
 				mu.Lock()
 				probedURLs = append(probedURLs, thunderURL)
+				callerSuppliedByURL[thunderURL] = callerSupplied
 				mu.Unlock()
 				return true
 			},
@@ -952,6 +955,8 @@ func TestEnvironmentService_ListThunderInstances(t *testing.T) {
 		require.Len(t, resp.ThunderInstances, 2)
 		assert.ElementsMatch(t, []string{urls["dev"], urls["staging"]}, probedURLs,
 			"the probe must target each env's own registered origin, never a value derived from org/env")
+		assert.False(t, callerSuppliedByURL[urls["dev"]], "dev is on-prem (handle-registered) — its URL is AMS's own computation, not caller-supplied")
+		assert.True(t, callerSuppliedByURL[urls["staging"]], "staging is SaaS-registered (no handle) — its URL is caller-supplied, so the probe must know to SSRF-harden it")
 
 		dev := resp.ThunderInstances[0]
 		assert.Equal(t, "dev", dev.EnvName)
@@ -1069,47 +1074,21 @@ func TestEnvironmentService_SetThunderSystemClientSecret(t *testing.T) {
 		assert.ErrorIs(t, err, boom)
 	})
 
-	// A credential must never be storable without a handle already existing —
-	// see SetThunderSystemClientSecret's own doc comment for why: this keeps a
-	// missing env_thunder_urls row a trustworthy "not provisioned" signal.
-	t.Run("provisions a thunder url handle before storing a credential, when none is registered yet", func(t *testing.T) {
-		var urlInserted *models.EnvThunderURL
+	// SetThunderSystemClientSecret must NEVER touch env_thunder_urls — on-prem
+	// or SaaS, registering a URL is SetThunderURL's job alone, called
+	// independently. Auto-provisioning a handle here would silently stamp a
+	// bogus origin for a SaaS environment that hasn't been registered yet,
+	// permanently blocking its real registration (SetThunderURL never
+	// overwrites an existing one).
+	t.Run("stores the credential even when no thunder url is registered yet, without touching the registration", func(t *testing.T) {
 		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
 			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
-				return nil, gorm.ErrRecordNotFound
-			},
-			InsertFunc: func(_ context.Context, rec *models.EnvThunderURL) error {
-				urlInserted = rec
-				return nil
-			},
-		}
-		systemClientRepo := &repomocks.EnvThunderSystemClientRepositoryMock{
-			GetFunc: func(context.Context, string, string) (*models.EnvThunderSystemClient, error) {
-				return nil, gorm.ErrRecordNotFound
-			},
-			UpsertFunc: func(context.Context, *models.EnvThunderSystemClient) error { return nil },
-		}
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-		svc := NewEnvironmentService(logger, &repomocks.GatewayRepositoryMock{}, &clientmocks.OpenChoreoClientMock{}, &clientmocks.ThunderProberMock{}, nil, systemClientRepo, urlRepo, envTestKey)
-
-		err := svc.SetThunderSystemClientSecret(context.Background(), "ou-123", "staging", "amp-system-client", "s3cr3t")
-
-		require.NoError(t, err)
-		require.NotNil(t, urlInserted, "a handle must be provisioned before a credential is ever stored")
-		assert.Equal(t, "ou-123", urlInserted.OUID)
-		assert.Equal(t, "staging", urlInserted.EnvName)
-		require.NotNil(t, urlInserted.ThunderHandle)
-		assert.Len(t, *urlInserted.ThunderHandle, generatedThunderHandleLen)
-	})
-
-	t.Run("reuses an already-registered handle instead of claiming a new one", func(t *testing.T) {
-		existing := &models.EnvThunderURL{OUID: "ou-123", EnvName: "staging", ThunderHandle: strPtr("already-registered-handle"), ThunderURL: "http://already-registered-handle.amp.localhost:8080"}
-		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
-			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
-				return existing, nil
+				t.Fatal("must never read or write env_thunder_urls")
+				//nolint:nilnil // unreachable: t.Fatal stops execution
+				return nil, nil
 			},
 			InsertFunc: func(context.Context, *models.EnvThunderURL) error {
-				t.Fatal("must not claim a new handle when one is already registered")
+				t.Fatal("must never provision a thunder url as a side effect of storing a credential")
 				return nil
 			},
 		}
@@ -1122,27 +1101,6 @@ func TestEnvironmentService_SetThunderSystemClientSecret(t *testing.T) {
 		err := svc.SetThunderSystemClientSecret(context.Background(), "ou-123", "staging", "amp-system-client", "s3cr3t")
 
 		require.NoError(t, err)
-	})
-
-	t.Run("does not store the credential when handle provisioning fails", func(t *testing.T) {
-		boom := errors.New("db down")
-		urlRepo := &repomocks.EnvThunderURLRepositoryMock{
-			GetFunc: func(context.Context, string, string) (*models.EnvThunderURL, error) {
-				return nil, boom
-			},
-		}
-		systemClientRepo := &repomocks.EnvThunderSystemClientRepositoryMock{
-			UpsertFunc: func(context.Context, *models.EnvThunderSystemClient) error {
-				t.Fatal("must not store the credential when handle provisioning fails")
-				return nil
-			},
-		}
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-		svc := NewEnvironmentService(logger, &repomocks.GatewayRepositoryMock{}, &clientmocks.OpenChoreoClientMock{}, &clientmocks.ThunderProberMock{}, nil, systemClientRepo, urlRepo, envTestKey)
-
-		err := svc.SetThunderSystemClientSecret(context.Background(), "ou-123", "staging", "amp-system-client", "s3cr3t")
-
-		require.Error(t, err)
 	})
 }
 
@@ -1477,6 +1435,41 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 			require.Error(t, err, "url %q must be rejected", private)
 			assert.ErrorIs(t, err, utils.ErrInvalidThunderURL, "url %q", private)
 		}
+	})
+
+	t.Run("rejects a url whose first label is reserved under this deployment's own base domain", func(t *testing.T) {
+		svc := newEnvServiceWithThunderURLRepo(&repomocks.EnvThunderURLRepositoryMock{})
+
+		// config.GetConfig().ThunderHostBaseDomain defaults to "amp.localhost"
+		// in this unit-test environment (no IDP_HOST_BASE_DOMAIN override).
+		for _, reserved := range []string{"https://console.amp.localhost", "https://api.amp.localhost", "https://thunder.amp.localhost", "https://gateway.amp.localhost"} {
+			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", reserved)
+			require.Error(t, err, "url %q must be rejected", reserved)
+			assert.ErrorIs(t, err, utils.ErrInvalidThunderURL, "url %q", reserved)
+		}
+	})
+
+	t.Run("does not reject a reserved-looking label under a DIFFERENT domain (the normal SaaS case)", func(t *testing.T) {
+		// Both cases below fail (the host doesn't actually resolve — no live
+		// network dependency needed), but for DIFFERENT reasons: the error
+		// message distinguishes "rejected as a reserved subdomain" (fires only
+		// when the host sits under THIS deployment's configured base domain)
+		// from a generic SSRF/DNS failure (any other domain, the normal SaaS
+		// case, where a reserved-looking label is just a coincidence).
+		orig := config.GetConfig().ThunderHostBaseDomain
+		defer func() { config.GetConfig().ThunderHostBaseDomain = orig }()
+
+		svc := newEnvServiceWithThunderURLRepo(&repomocks.EnvThunderURLRepositoryMock{})
+
+		config.GetConfig().ThunderHostBaseDomain = "internal.test"
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://console.internal.test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reserved subdomain", "must reject: this host sits under the configured base domain")
+
+		config.GetConfig().ThunderHostBaseDomain = "some-other-domain.test"
+		_, err = svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://console.internal.test")
+		require.Error(t, err, "still fails, but only because the host doesn't resolve")
+		assert.NotContains(t, err.Error(), "reserved subdomain", "must NOT be rejected as reserved: this host is no longer under the configured base domain")
 	})
 
 	t.Run("re-supplying the SAME url as what's already registered is a no-op", func(t *testing.T) {

--- a/agent-manager-service/services/environment_service_unit_test.go
+++ b/agent-manager-service/services/environment_service_unit_test.go
@@ -1442,11 +1442,24 @@ func TestEnvironmentService_SetThunderURL(t *testing.T) {
 
 		// config.GetConfig().ThunderHostBaseDomain defaults to "amp.localhost"
 		// in this unit-test environment (no IDP_HOST_BASE_DOMAIN override).
-		for _, reserved := range []string{"https://console.amp.localhost", "https://api.amp.localhost", "https://thunder.amp.localhost", "https://gateway.amp.localhost"} {
+		for _, reserved := range []string{"https://console.amp.localhost", "https://api.amp.localhost", "https://thunder.amp.localhost", "https://gateway.amp.localhost", "https://console.amp.localhost."} {
 			_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", reserved)
 			require.Error(t, err, "url %q must be rejected", reserved)
 			assert.ErrorIs(t, err, utils.ErrInvalidThunderURL, "url %q", reserved)
+			assert.Contains(t, err.Error(), "reserved subdomain", "url %q must be rejected by the reserved-subdomain guard", reserved)
 		}
+	})
+
+	t.Run("rejects a terminal-dot reserved url when the configured base domain also has a terminal dot", func(t *testing.T) {
+		orig := config.GetConfig().ThunderHostBaseDomain
+		defer func() { config.GetConfig().ThunderHostBaseDomain = orig }()
+		config.GetConfig().ThunderHostBaseDomain = "amp.localhost."
+
+		svc := newEnvServiceWithThunderURLRepo(&repomocks.EnvThunderURLRepositoryMock{})
+		_, err := svc.SetThunderURL(context.Background(), "ou-123", "prod", "", "https://console.amp.localhost.")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, utils.ErrInvalidThunderURL)
+		assert.Contains(t, err.Error(), "reserved subdomain")
 	})
 
 	t.Run("does not reject a reserved-looking label under a DIFFERENT domain (the normal SaaS case)", func(t *testing.T) {

--- a/agent-manager-service/spec/api_environments.go
+++ b/agent-manager-service/spec/api_environments.go
@@ -660,13 +660,14 @@ func (r ApiDeleteEnvironmentThunderUrlRequest) Execute() (*http.Response, error)
 }
 
 /*
-DeleteEnvironmentThunderUrl Remove an environment's env-Thunder URL handle
+DeleteEnvironmentThunderUrl Remove an environment's env-Thunder URL
 
-Removes the registered handle for an environment, freeing it for
-reuse. Called by remove-environment-thunder.sh when an environment's
-Thunder instance is torn down. Deleting a non-existent handle
-succeeds (idempotent). Looked up by OU ID, always taken from the
-caller's own token (never client-supplied), not orgName.
+Removes the registered origin (and handle, if any) for an
+environment, freeing both for reuse. Called by
+remove-environment-thunder.sh when an environment's Thunder instance
+is torn down. Deleting a non-existent registration succeeds
+(idempotent). Looked up by OU ID, always taken from the caller's own
+token (never client-supplied), not orgName.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle
@@ -1614,36 +1615,42 @@ func (r ApiSetEnvironmentThunderUrlRequest) Execute() (*ThunderUrlResponse, *htt
 }
 
 /*
-SetEnvironmentThunderUrl Register an environment's env-Thunder URL handle
+SetEnvironmentThunderUrl Register an environment's env-Thunder URL
 
-Bootstrap-only endpoint used by add-environment-thunder.sh before it
-provisions an environment's dedicated Thunder instance. Registers an
-unguessable handle that replaces the predictable "<org>-<env>" segment
-of that environment's externally-reachable env-Thunder hostname
-(issuer/token/JWKS URLs) — without this, every such URL is 100%
-derivable from (org, env) alone. org/env is NEVER used as a fallback:
-every environment gets a handle, one way or another.
+Bootstrap-only endpoint used by add-environment-thunder.sh (on-prem)
+or a control plane (SaaS) before/while provisioning an environment's
+dedicated Thunder instance. Registers the environment's
+externally-reachable env-Thunder origin (issuer/token/JWKS URLs) via
+exactly one of two mutually-exclusive request fields — see
+ThunderUrlRequest. Without this, an on-prem URL would be 100%
+derivable from (org, env) alone; org/env is NEVER used as a fallback
+for either path — every environment gets a registered origin, one way
+or another.
 
-The request body's handle is OPTIONAL. Omit it (or send an empty
-string) to have the server generate one automatically — a 10-character
-random value. The response always reports the handle that ended up
-stored, since a caller that left it blank needs to learn what was
+Both request fields are OPTIONAL, and omitting both is the on-prem
+auto-generate default: the server picks a 10-character random handle
+and computes the origin from it. The response always reports the url
+that ended up stored (and the handle, if the on-prem path produced
+one), since a caller that left the body blank needs to learn what was
 actually assigned.
 
-The handle is globally unique across ALL orgs/environments (every
-env-Thunder instance's HTTPRoute attaches to the same shared Gateway,
-so hostname routing is cluster-wide, not per-org). If a caller-supplied
-handle collides with a different environment's, this returns 409. A
-collision on a GENERATED handle is retried internally with a fresh
-value and never surfaces as a 409.
+Both handle and the resolved url are globally unique across ALL
+orgs/environments (every env-Thunder instance's HTTPRoute attaches to
+the same shared Gateway, so hostname routing is cluster-wide, not
+per-org — and a SaaS control plane's own domain space is a single
+namespace the same way). If a caller-supplied handle or url collides
+with a different environment's, this returns 409. A collision on a
+GENERATED handle is retried internally with a fresh value and never
+surfaces as a 409.
 
 Idempotent for the SAME environment, but never changes an
-already-registered handle: a blank or matching re-registration is a
-no-op that reports the existing handle; an explicit DIFFERENT handle
-is rejected with 409 (Thunder's issuer is immutable once minted — call
-DELETE first to free the handle before registering a new one). Keyed
-by OU ID, always taken from the caller's own token (never
-client-supplied), not orgName — same rationale as thunder-system-client.
+already-registered value: a blank or matching re-registration is a
+no-op that reports the existing record; an explicit DIFFERENT
+handle/url is rejected with 409 (Thunder's issuer is immutable once
+minted — call DELETE first to free the registration before
+registering a new one). Keyed by OU ID, always taken from the
+caller's own token (never client-supplied), not orgName — same
+rationale as thunder-system-client.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@param orgName Organization name/handle

--- a/agent-manager-service/spec/model_thunder_url_request.go
+++ b/agent-manager-service/spec/model_thunder_url_request.go
@@ -17,10 +17,12 @@ import (
 // checks if the ThunderUrlRequest type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &ThunderUrlRequest{}
 
-// ThunderUrlRequest An unguessable handle to register for an environment's env-Thunder URL, replacing the predictable \"<org>-<env>\" pattern. Optional — omit it (or send an empty string) to have the server generate one.
+// ThunderUrlRequest Registers an environment's env-Thunder origin via exactly one of two mutually-exclusive fields — setting both is rejected with 400:  - `handle` (on-prem path): an unguessable label AMS resolves into the   full origin itself, replacing the predictable \"<org>-<env>\" pattern.   Optional — omit it (or send an empty string, with url also omitted)   to have the server generate one. - `url` (SaaS/control-plane path): the full origin the caller has   already provisioned, for deployments where different environments   can live under different domains and there is no single pattern AMS   could compute. AMS validates and stores it verbatim; the   environment's registration then has no handle at all.
 type ThunderUrlRequest struct {
-	// DNS-label-safe handle (lowercase alphanumeric with hyphens, no leading/trailing hyphen) that replaces \"<org>-<env>\" in \"<handle>.<baseDomain>\". Must be globally unique across all orgs/environments, and at least 3 characters. Omit to auto-generate a 10-character handle.
+	// DNS-label-safe handle (lowercase alphanumeric with hyphens, no leading/trailing hyphen) that replaces \"<org>-<env>\" in \"<handle>.<baseDomain>\". Must be globally unique across all orgs/environments, and at least 3 characters. Omit to auto-generate a 10-character handle. Mutually exclusive with url.
 	Handle *string `json:"handle,omitempty"`
+	// The full env-Thunder origin (scheme + host, no path/query/fragment) this environment is already reachable at — the SaaS/control-plane path. Must be http or https, resolve to a public IP address (no private/loopback hosts), and be globally unique across all orgs/environments. Mutually exclusive with handle.
+	Url *string `json:"url,omitempty"`
 }
 
 // NewThunderUrlRequest instantiates a new ThunderUrlRequest object
@@ -72,6 +74,38 @@ func (o *ThunderUrlRequest) SetHandle(v string) {
 	o.Handle = &v
 }
 
+// GetUrl returns the Url field value if set, zero value otherwise.
+func (o *ThunderUrlRequest) GetUrl() string {
+	if o == nil || IsNil(o.Url) {
+		var ret string
+		return ret
+	}
+	return *o.Url
+}
+
+// GetUrlOk returns a tuple with the Url field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ThunderUrlRequest) GetUrlOk() (*string, bool) {
+	if o == nil || IsNil(o.Url) {
+		return nil, false
+	}
+	return o.Url, true
+}
+
+// HasUrl returns a boolean if a field has been set.
+func (o *ThunderUrlRequest) HasUrl() bool {
+	if o != nil && !IsNil(o.Url) {
+		return true
+	}
+
+	return false
+}
+
+// SetUrl gets a reference to the given string and assigns it to the Url field.
+func (o *ThunderUrlRequest) SetUrl(v string) {
+	o.Url = &v
+}
+
 func (o ThunderUrlRequest) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -84,6 +118,9 @@ func (o ThunderUrlRequest) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
 	if !IsNil(o.Handle) {
 		toSerialize["handle"] = o.Handle
+	}
+	if !IsNil(o.Url) {
+		toSerialize["url"] = o.Url
 	}
 	return toSerialize, nil
 }

--- a/agent-manager-service/spec/model_thunder_url_response.go
+++ b/agent-manager-service/spec/model_thunder_url_response.go
@@ -17,18 +17,19 @@ import (
 // checks if the ThunderUrlResponse type satisfies the MappedNullable interface at compile time
 var _ MappedNullable = &ThunderUrlResponse{}
 
-// ThunderUrlResponse The env-Thunder URL handle registered for an environment — either the caller-supplied value or the value the server generated when the caller left it blank.
+// ThunderUrlResponse The env-Thunder registration for an environment. url is always present — the caller-supplied value (either path), or the value the server generated/computed when the caller left handle blank. handle is present only for the on-prem path; it is absent for an environment registered via a caller-supplied url.
 type ThunderUrlResponse struct {
-	Handle string `json:"handle"`
+	Handle *string `json:"handle,omitempty"`
+	Url    string  `json:"url"`
 }
 
 // NewThunderUrlResponse instantiates a new ThunderUrlResponse object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewThunderUrlResponse(handle string) *ThunderUrlResponse {
+func NewThunderUrlResponse(url string) *ThunderUrlResponse {
 	this := ThunderUrlResponse{}
-	this.Handle = handle
+	this.Url = url
 	return &this
 }
 
@@ -40,28 +41,60 @@ func NewThunderUrlResponseWithDefaults() *ThunderUrlResponse {
 	return &this
 }
 
-// GetHandle returns the Handle field value
+// GetHandle returns the Handle field value if set, zero value otherwise.
 func (o *ThunderUrlResponse) GetHandle() string {
+	if o == nil || IsNil(o.Handle) {
+		var ret string
+		return ret
+	}
+	return *o.Handle
+}
+
+// GetHandleOk returns a tuple with the Handle field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ThunderUrlResponse) GetHandleOk() (*string, bool) {
+	if o == nil || IsNil(o.Handle) {
+		return nil, false
+	}
+	return o.Handle, true
+}
+
+// HasHandle returns a boolean if a field has been set.
+func (o *ThunderUrlResponse) HasHandle() bool {
+	if o != nil && !IsNil(o.Handle) {
+		return true
+	}
+
+	return false
+}
+
+// SetHandle gets a reference to the given string and assigns it to the Handle field.
+func (o *ThunderUrlResponse) SetHandle(v string) {
+	o.Handle = &v
+}
+
+// GetUrl returns the Url field value
+func (o *ThunderUrlResponse) GetUrl() string {
 	if o == nil {
 		var ret string
 		return ret
 	}
 
-	return o.Handle
+	return o.Url
 }
 
-// GetHandleOk returns a tuple with the Handle field value
+// GetUrlOk returns a tuple with the Url field value
 // and a boolean to check if the value has been set.
-func (o *ThunderUrlResponse) GetHandleOk() (*string, bool) {
+func (o *ThunderUrlResponse) GetUrlOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Handle, true
+	return &o.Url, true
 }
 
-// SetHandle sets field value
-func (o *ThunderUrlResponse) SetHandle(v string) {
-	o.Handle = v
+// SetUrl sets field value
+func (o *ThunderUrlResponse) SetUrl(v string) {
+	o.Url = v
 }
 
 func (o ThunderUrlResponse) MarshalJSON() ([]byte, error) {
@@ -74,7 +107,10 @@ func (o ThunderUrlResponse) MarshalJSON() ([]byte, error) {
 
 func (o ThunderUrlResponse) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	toSerialize["handle"] = o.Handle
+	if !IsNil(o.Handle) {
+		toSerialize["handle"] = o.Handle
+	}
+	toSerialize["url"] = o.Url
 	return toSerialize, nil
 }
 

--- a/agent-manager-service/utils/errors.go
+++ b/agent-manager-service/utils/errors.go
@@ -158,6 +158,17 @@ var (
 	// ErrThunderHandleNotFound is returned when no env-Thunder URL handle has been
 	// registered for an environment. Maps to 404.
 	ErrThunderHandleNotFound = errors.New("thunder url handle not found")
+	// ErrInvalidThunderURL is returned when a caller-supplied full env-Thunder
+	// URL (the SaaS/control-plane registration path) fails shape or SSRF
+	// validation. Maps to 400.
+	ErrInvalidThunderURL = errors.New("invalid thunder url")
+	// ErrThunderURLTaken is returned when a caller-supplied full env-Thunder URL
+	// is already registered to a different (org, env) pair. Maps to 409.
+	ErrThunderURLTaken = errors.New("thunder url is already in use")
+	// ErrThunderHandleAndURLBothSet is returned when a SetThunderURL request
+	// supplies both handle and url — the two registration paths are mutually
+	// exclusive. Maps to 400.
+	ErrThunderHandleAndURLBothSet = errors.New("thunder url request must not set both handle and url")
 	// ErrEnvThunderURLAlreadyClaimed is returned by EnvThunderURLRepository.Insert
 	// when a DIFFERENT concurrent request already claimed the SAME (ouID, envName)
 	// first — i.e. the (ou_id, env_name) unique constraint was violated, not the

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -550,18 +550,18 @@ func ProvideEnvThunderSecretReader(repo repositories.EnvThunderSystemClientRepos
 	return services.NewEnvThunderSecretReader(repo, encryptionKey)
 }
 
-// ProvideEnvThunderURLReader looks up an env-Thunder's registered URL handle
-// from AMS's own Postgres. A missing row means not provisioned — there is no
+// ProvideEnvThunderURLReader looks up an env-Thunder's registered origin from
+// AMS's own Postgres. A missing row means not provisioned — there is no
 // fallback to a value computed from (org, env).
-func ProvideEnvThunderURLReader(repo repositories.EnvThunderURLRepository) thundersvc.ReadThunderHandleFunc {
+func ProvideEnvThunderURLReader(repo repositories.EnvThunderURLRepository) thundersvc.ReadThunderURLFunc {
 	return services.NewEnvThunderURLReader(repo)
 }
 
 // ProvideEnvThunderResolver maps (org, environment) to an authenticated
-// ThunderClient, reading the system-client credential and URL handle via the
-// injected readers.
-func ProvideEnvThunderResolver(readSystemClient thundersvc.ReadSystemClientFunc, readThunderHandle thundersvc.ReadThunderHandleFunc) thundersvc.EnvThunderResolver {
-	return thundersvc.NewEnvThunderResolver(readSystemClient, readThunderHandle)
+// ThunderClient, reading the system-client credential and registered URL via
+// the injected readers.
+func ProvideEnvThunderResolver(readSystemClient thundersvc.ReadSystemClientFunc, readThunderURL thundersvc.ReadThunderURLFunc) thundersvc.EnvThunderResolver {
+	return thundersvc.NewEnvThunderResolver(readSystemClient, readThunderURL)
 }
 
 // ProvideAgentIdentityInjectionService creates the Gateway Binding service that

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -89,8 +89,8 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	envThunderSystemClientRepository := ProvideEnvThunderSystemClientRepository(db)
 	readSystemClientFunc := ProvideEnvThunderSecretReader(envThunderSystemClientRepository, v)
 	envThunderURLRepository := ProvideEnvThunderURLRepository(db)
-	readThunderHandleFunc := ProvideEnvThunderURLReader(envThunderURLRepository)
-	envThunderResolver := ProvideEnvThunderResolver(readSystemClientFunc, readThunderHandleFunc)
+	readThunderURLFunc := ProvideEnvThunderURLReader(envThunderURLRepository)
+	envThunderResolver := ProvideEnvThunderResolver(readSystemClientFunc, readThunderURLFunc)
 	mcpProxyService := services.NewMCPProxyService(db, mcpProxyRepository, mcpProxyEndpointRepository, deploymentRepository, gatewayRepository, envAgentMCPMappingRepository, agentConfigurationRepository, gatewayEventsService, apiKeyRepository, infraResourceManager, agentIdentityInjectionService, logger, v, mcpProxyScopeRepository, envThunderResolver)
 	llmProxyDeploymentService := services.NewLLMProxyDeploymentService(deploymentRepository, llmProxyRepository, llmProviderRepository, gatewayRepository, gatewayEventsService)
 	llmProxyAPIKeyService := services.NewLLMProxyAPIKeyService(llmProxyRepository, gatewayRepository, gatewayEventsService, apiKeyRepository, openChoreoClient)
@@ -272,8 +272,8 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	envThunderSystemClientRepository := ProvideEnvThunderSystemClientRepository(db)
 	readSystemClientFunc := ProvideEnvThunderSecretReader(envThunderSystemClientRepository, v)
 	envThunderURLRepository := ProvideEnvThunderURLRepository(db)
-	readThunderHandleFunc := ProvideEnvThunderURLReader(envThunderURLRepository)
-	envThunderResolver := ProvideEnvThunderResolver(readSystemClientFunc, readThunderHandleFunc)
+	readThunderURLFunc := ProvideEnvThunderURLReader(envThunderURLRepository)
+	envThunderResolver := ProvideEnvThunderResolver(readSystemClientFunc, readThunderURLFunc)
 	mcpProxyService := services.NewMCPProxyService(db, mcpProxyRepository, mcpProxyEndpointRepository, deploymentRepository, gatewayRepository, envAgentMCPMappingRepository, agentConfigurationRepository, gatewayEventsService, apiKeyRepository, infraResourceManager, agentIdentityInjectionService, logger, v, mcpProxyScopeRepository, envThunderResolver)
 	llmProxyDeploymentService := services.NewLLMProxyDeploymentService(deploymentRepository, llmProxyRepository, llmProviderRepository, gatewayRepository, gatewayEventsService)
 	llmProxyAPIKeyService := services.NewLLMProxyAPIKeyService(llmProxyRepository, gatewayRepository, gatewayEventsService, apiKeyRepository, openChoreoClient)
@@ -822,18 +822,18 @@ func ProvideEnvThunderSecretReader(repo repositories.EnvThunderSystemClientRepos
 	return services.NewEnvThunderSecretReader(repo, encryptionKey)
 }
 
-// ProvideEnvThunderURLReader looks up an env-Thunder's registered URL handle
-// from AMS's own Postgres. A missing row means not provisioned — there is no
+// ProvideEnvThunderURLReader looks up an env-Thunder's registered origin from
+// AMS's own Postgres. A missing row means not provisioned — there is no
 // fallback to a value computed from (org, env).
-func ProvideEnvThunderURLReader(repo repositories.EnvThunderURLRepository) thundersvc.ReadThunderHandleFunc {
+func ProvideEnvThunderURLReader(repo repositories.EnvThunderURLRepository) thundersvc.ReadThunderURLFunc {
 	return services.NewEnvThunderURLReader(repo)
 }
 
 // ProvideEnvThunderResolver maps (org, environment) to an authenticated
-// ThunderClient, reading the system-client credential and URL handle via the
-// injected readers.
-func ProvideEnvThunderResolver(readSystemClient thundersvc.ReadSystemClientFunc, readThunderHandle thundersvc.ReadThunderHandleFunc) thundersvc.EnvThunderResolver {
-	return thundersvc.NewEnvThunderResolver(readSystemClient, readThunderHandle)
+// ThunderClient, reading the system-client credential and registered URL via
+// the injected readers.
+func ProvideEnvThunderResolver(readSystemClient thundersvc.ReadSystemClientFunc, readThunderURL thundersvc.ReadThunderURLFunc) thundersvc.EnvThunderResolver {
+	return thundersvc.NewEnvThunderResolver(readSystemClient, readThunderURL)
 }
 
 // ProvideAgentIdentityInjectionService creates the Gateway Binding service that

--- a/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
@@ -88,6 +88,14 @@ spec:
                   {{- end }}
             - name: IS_LOCAL_DEV_ENV
               value: "true"
+            # Migration 043 backfills existing handle-only env-Thunder rows by
+            # using the same deployment-specific origin settings as amp-api.
+            # Keep these in the migration hook as well as the API ConfigMap or
+            # VM/custom-domain upgrades silently persist localhost URLs.
+            - name: THUNDER_HOST_BASE_DOMAIN
+              value: {{ .Values.agentManagerService.config.thunderHostBaseDomain | default "amp.localhost" | quote }}
+            - name: TLS_ENABLED
+              value: {{ .Values.agentManagerService.config.tlsEnabled | default false | quote }}
             - name: LOG_LEVEL
               value: "INFO"
             - name: OPEN_CHOREO_BASE_URL

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -169,6 +169,16 @@ assert_env "sslRootCert reaches the migration job" "$MIG_TMPL" DB_SSL_ROOT_CERT 
   "${EXTERNAL[@]}" --set postgresql.external.sslMode=verify-full \
   --set postgresql.external.sslRootCert=system
 
+# Migration 043 derives a full URL for existing handle-only rows. The hook must
+# receive the same deployment origin settings as the API or a TLS/custom-domain
+# upgrade would backfill localhost URLs even though live writes are correct.
+assert_env "Thunder base domain reaches the migration job" \
+  "$MIG_TMPL" THUNDER_HOST_BASE_DOMAIN "amp.example.com" \
+  --set agentManagerService.config.thunderHostBaseDomain=amp.example.com
+assert_env "TLS setting reaches the migration job" \
+  "$MIG_TMPL" TLS_ENABLED "true" \
+  --set agentManagerService.config.tlsEnabled=true
+
 # The bundled PostgreSQL serves plaintext, so an sslMode left over from an
 # external configuration must not be applied to it — that would fail the API pod
 # and the migration hook on an otherwise working default install.


### PR DESCRIPTION
## Purpose
Two things, bundled because the second depends on the first: (1) bring env-Thunder full-URL support to `amp-pre-release` — currently only on `main`, via a still-open sync PR — so an environment can be registered with a direct URL instead of only an on-prem handle; (2) let WSO2 Cloud's control-plane client actually call that endpoint. That client authenticates as the root OU, not any tenant, so it has no org identity of its own to push credentials or URLs with.

## Goals
- Full-URL registration (DB migration, model, service, and API support) available on `amp-pre-release`.
- The two endpoints WSO2 Cloud calls directly — system-client save and URL save — accept `X-Impersonate-Org` for a root-OU-authenticated caller, the same way `ListGateways` already does.

## Approach
- Cherry-picked 11 of the 15 commits from #1778 (which added full-URL support on `main`) — migration, model, repository, resolver, the `SetThunderURL`/`SetThunderSystemClient` URL-acceptance logic, both SSRF-hardening commits, the migration-safety fix, URL validation, and Helm migration-job config. Dropped 4 as not relevant to this branch: a CLI (`amctl`) regen, an env-var rename whose only consumer (on-prem handle derivation) this branch's target path never touches, a docs fix that existed only for that rename, and a pure comment/wording pass.
- Reused the existing `impersonatedOUID` helper (`controllers/gateway_controller.go`, same package — no import needed) and added the identical override block to `SetThunderSystemClient` and `SetThunderURL`. No new middleware, no new RBAC permission, no new route registrar.

## User stories
N/A 

## Release note
Agent Manager now supports registering an environment's env-Thunder instance by full URL, not just an on-prem handle — and WSO2 Cloud can push both that URL and the system-client credential on behalf of a specific org, the same way it already does for gateway registration.

## Documentation
N/A 

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
`go build`, `go vet`, and full unit suite all pass. `golangci-lint`: one pre-existing failure, confirmed to already exist on `amp-pre-release`'s own tip independent of this change (stale `nolint` directive, unrelated file).

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs: no
- No secrets committed: yes

## Samples
N/A

## Related PRs
#1778 (source of the full-URL commits, partially cherry-picked here)

## Migrations (if applicable)
Adds `thunder_url` column to `env_thunder_urls` (migration 043) — additive, nullable, no data migration needed for existing on-prem rows.

## Test environment
N/A

## Learning
N/A