### PR TITLE
Fix Cloud Monitor Tokens to Include Organization Name

### DIFF
--- a/agent-manager-service/clients/thundersvc/client.go
+++ b/agent-manager-service/clients/thundersvc/client.go
@@ -580,14 +580,13 @@ func (c *thunderClient) createApp(ctx context.Context, token, appName, ouID stri
 					"clientId":                appName,
 					"grantTypes":              []string{"client_credentials"},
 					"tokenEndpointAuthMethod": "client_secret_basic",
-					// Thunder only embeds ouId/ouHandle as token claims when a client's own
-					// clientConfig.attributes opts in — without this, RequireOrgMatch in
-					// agent-manager-service rejects this app's tokens as "missing ou
-					// identity in token" even though ouId above is set correctly.
+					// Thunder only embeds configured OU attributes as token claims. Agent
+					// Manager requires ouId/ouHandle, while Cloud Obs Proxy also requires
+					// ouName when the evaluation job's token is passed through for trace reads.
 					"token": map[string]any{
 						"accessToken": map[string]any{
 							"clientConfig": map[string]any{
-								"attributes": []string{"ouId", "ouHandle"},
+								"attributes": []string{"ouId", "ouName", "ouHandle"},
 							},
 						},
 					},

--- a/agent-manager-service/clients/thundersvc/client_test.go
+++ b/agent-manager-service/clients/thundersvc/client_test.go
@@ -133,10 +133,9 @@ func TestFetchSystemToken_ResourceSelection(t *testing.T) {
 	}
 }
 
-// TestCreateApp_SendsRequiredApplicationType guards against a regression:
-// applications require a "type" field on create, and a POST /applications
-// missing it fails outright. createApp's payload must always include it.
-func TestCreateApp_SendsRequiredApplicationType(t *testing.T) {
+// TestCreateApp_SendsRequiredApplicationConfiguration guards the application type
+// and OU claims required by Agent Manager and Cloud Obs Proxy.
+func TestCreateApp_SendsRequiredApplicationConfiguration(t *testing.T) {
 	var gotBody map[string]any
 	mux := http.NewServeMux()
 	mux.HandleFunc("/applications", func(w http.ResponseWriter, r *http.Request) {
@@ -165,6 +164,6 @@ func TestCreateApp_SendsRequiredApplicationType(t *testing.T) {
 	require.True(t, ok)
 	clientConfig, ok := config["token"].(map[string]any)["accessToken"].(map[string]any)["clientConfig"].(map[string]any)
 	require.True(t, ok)
-	assert.ElementsMatch(t, []any{"ouId", "ouHandle"}, clientConfig["attributes"],
-		"clientConfig.attributes must opt this client_credentials app into ouId/ouHandle token claims, or RequireOrgMatch rejects its tokens as missing ou identity")
+	assert.ElementsMatch(t, []any{"ouId", "ouName", "ouHandle"}, clientConfig["attributes"],
+		"clientConfig.attributes must include every OU claim required by Agent Manager and Cloud Obs Proxy")
 }


### PR DESCRIPTION
## Purpose

Cloud monitor execution had two consecutive failures:

1. Existing monitor workflows did not pass the required organization UUID. This was fixed on cloud.

2. After that fix, the evaluation workflow started but failed while fetching traces because the `amp-publisher-*` token did not contain the `ouName` claim required by Cloud Obs Proxy.

## Goals

Ensure dynamically created Thunder M2M applications include all organization claims required for cloud monitor execution.

## Approach

Add `ouName` to the Thunder application's access-token attributes:

```go
[]string{"ouId", "ouName", "ouHandle"}
```

The existing unit test was updated to verify all three claims.

## User stories

Cloud users can create and execute evaluation monitors without trace-fetch authentication failures.

## Release note

Fixed cloud monitor execution failures caused by missing `ouName` claims in Thunder M2M tokens.

## Documentation

N/A — internal authentication fix with no user-facing configuration changes.

## Training

N/A

## Certification

N/A — no certification impact.

## Marketing

N/A

## Automation tests

* **Unit tests**

  * Thunder client test package passes.
  * Verified the application payload contains `ouId`, `ouName`, and `ouHandle`.

* **Integration tests**

  * To be verified in the cloud development environment after deployment.

## Security checks

* Followed secure coding standards: **Yes**
* Ran FindSecurityBugs: **N/A — Go codebase**
* Confirmed no secrets or sensitive data were committed: **Yes**

## Samples

N/A

## Migrations

Existing `amp-publisher-*` and `amp-scheduler-*` Thunder applications must be updated or recreated so their tokens include `ouName`. Associated credential records and cached per-organization clients must be handled during recreation.

New organizations will receive the corrected configuration automatically.

## Test environment

* Go unit-test environment on macOS

## Learning

The workflow migration fixed Argo workflow creation. The subsequent evaluation failure was traced to Cloud Obs Proxy rejecting the forwarded publisher token because it lacked the required `ouName` claim.