### PR TITLE
Delete only amctl-installed skills on skills remove

### DIFF
--- a/cli/pkg/cmd/skills/remove.go
+++ b/cli/pkg/cmd/skills/remove.go
@@ -19,6 +19,7 @@ package skills
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -75,7 +76,8 @@ func runRemove(ctx context.Context, opts *RemoveOptions) error {
 	w := opts.IO.ErrOut
 
 	if len(result.RemovedSkills) == 0 && len(result.RemovedLinks) == 0 {
-		fmt.Fprintln(w, "No skills installed.")
+		fmt.Fprintln(w, "No skills installed by amctl.")
+		printUnmanaged(opts, result.UnmanagedSkills)
 		return nil
 	}
 
@@ -94,6 +96,19 @@ func runRemove(ctx context.Context, opts *RemoveOptions) error {
 		plural(len(result.RemovedSkills), "skill", "skills"),
 		plural(len(result.RemovedLinks), "link", "links"),
 	)
+	printUnmanaged(opts, result.UnmanagedSkills)
 
 	return nil
+}
+
+// printUnmanaged reports skills left in place because amctl has no record of
+// installing them.
+func printUnmanaged(opts *RemoveOptions, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	w := opts.IO.ErrOut
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Left %s in %s that amctl did not install: %s\n",
+		plural(len(names), "skill", "skills"), opts.DestDir, strings.Join(names, ", "))
 }

--- a/cli/pkg/cmd/skills/remove.go
+++ b/cli/pkg/cmd/skills/remove.go
@@ -77,38 +77,30 @@ func runRemove(ctx context.Context, opts *RemoveOptions) error {
 
 	if len(result.RemovedSkills) == 0 && len(result.RemovedLinks) == 0 {
 		fmt.Fprintln(w, "No skills installed by amctl.")
-		printUnmanaged(opts, result.UnmanagedSkills)
-		return nil
+	} else {
+		fmt.Fprintln(w, "Removing skills...")
+		fmt.Fprintln(w)
+
+		for _, link := range result.RemovedLinks {
+			fmt.Fprintf(w, "  %s Removed link %s\n", cs.SuccessIcon(), link)
+		}
+		for _, name := range result.RemovedSkills {
+			fmt.Fprintf(w, "  %s Removed %s\n", cs.SuccessIcon(), name)
+		}
+
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Removed %s and %s.\n",
+			plural(len(result.RemovedSkills), "skill", "skills"),
+			plural(len(result.RemovedLinks), "link", "links"),
+		)
 	}
 
-	fmt.Fprintln(w, "Removing skills...")
-	fmt.Fprintln(w)
-
-	for _, link := range result.RemovedLinks {
-		fmt.Fprintf(w, "  %s Removed link %s\n", cs.SuccessIcon(), link)
+	if len(result.UnmanagedSkills) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Left %s in %s that amctl did not install: %s\n",
+			plural(len(result.UnmanagedSkills), "skill", "skills"),
+			opts.DestDir, strings.Join(result.UnmanagedSkills, ", "))
 	}
-	for _, name := range result.RemovedSkills {
-		fmt.Fprintf(w, "  %s Removed %s\n", cs.SuccessIcon(), name)
-	}
-
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Removed %s and %s.\n",
-		plural(len(result.RemovedSkills), "skill", "skills"),
-		plural(len(result.RemovedLinks), "link", "links"),
-	)
-	printUnmanaged(opts, result.UnmanagedSkills)
 
 	return nil
-}
-
-// printUnmanaged reports skills left in place because amctl has no record of
-// installing them.
-func printUnmanaged(opts *RemoveOptions, names []string) {
-	if len(names) == 0 {
-		return
-	}
-	w := opts.IO.ErrOut
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Left %s in %s that amctl did not install: %s\n",
-		plural(len(names), "skill", "skills"), opts.DestDir, strings.Join(names, ", "))
 }

--- a/cli/pkg/cmd/skills/remove.go
+++ b/cli/pkg/cmd/skills/remove.go
@@ -62,7 +62,7 @@ func NewRemoveCmd(f *cmdutil.Factory) *cobra.Command {
 func runRemove(ctx context.Context, opts *RemoveOptions) error {
 	scope := render.Scope{}
 
-	result, err := skills.Remove(opts.DestDir, opts.ToolDirs)
+	result, err := skills.Remove(ctx, opts.DestDir, opts.ToolDirs)
 	if err != nil {
 		return render.Error(opts.IO, scope,
 			clierr.Newf(clierr.SkillRemoveFailed, "%v", err))

--- a/cli/pkg/cmd/skills/remove_test.go
+++ b/cli/pkg/cmd/skills/remove_test.go
@@ -112,7 +112,7 @@ func TestRemoveCmd_ReportsUnmanagedSkills(t *testing.T) {
 	if err := os.MkdirAll(foreign, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(foreign, "SKILL.md"), []byte("---\nname: legible-code\n---\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(foreign, "SKILL.md"), []byte("skill body"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cli/pkg/cmd/skills/remove_test.go
+++ b/cli/pkg/cmd/skills/remove_test.go
@@ -104,3 +104,28 @@ func TestRemoveCmd_JSONNoTextOutput(t *testing.T) {
 		t.Errorf("expected no stderr output in JSON mode, got:\n%s", errOut.String())
 	}
 }
+
+func TestRemoveCmd_ReportsUnmanagedSkills(t *testing.T) {
+	dest := t.TempDir()
+
+	foreign := filepath.Join(dest, "legible-code")
+	if err := os.MkdirAll(foreign, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreign, "SKILL.md"), []byte("---\nname: legible-code\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	io, _, errOut := newTextIO()
+	if err := runRemove(context.Background(), &RemoveOptions{IO: io, DestDir: dest}); err != nil {
+		t.Fatalf("runRemove failed: %v", err)
+	}
+
+	output := errOut.String()
+	if !strings.Contains(output, "amctl did not install") {
+		t.Errorf("expected a note about skills amctl did not install, got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(foreign, "SKILL.md")); err != nil {
+		t.Errorf("unmanaged skill should survive: %v", err)
+	}
+}

--- a/cli/pkg/skills/skills.go
+++ b/cli/pkg/skills/skills.go
@@ -88,18 +88,22 @@ type manifest struct {
 	Skills []string `json:"skills"`
 }
 
-// readManifest returns the skill names amctl recorded in destDir. A missing
-// or unreadable manifest yields no names, which makes Remove a no-op rather
-// than a guess about what amctl owns. Names are validated because Remove
-// turns them straight into paths it deletes.
-func readManifest(destDir string) []string {
+// readManifest returns the skill names amctl recorded in destDir. Only an
+// absent manifest means "amctl owns nothing"; a record that exists but cannot
+// be read is an error, because silently treating it as empty would let Remove
+// discard ownership it merely failed to load. Names are validated because
+// Remove turns them straight into paths it deletes.
+func readManifest(destDir string) ([]string, error) {
 	data, err := os.ReadFile(filepath.Join(destDir, manifestName))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("read install record: %w", err)
 	}
 	var m manifest
 	if err := json.Unmarshal(data, &m); err != nil {
-		return nil
+		return nil, fmt.Errorf("parse install record %s: %w", filepath.Join(destDir, manifestName), err)
 	}
 	var names []string
 	for _, name := range m.Skills {
@@ -107,7 +111,7 @@ func readManifest(destDir string) []string {
 			names = append(names, name)
 		}
 	}
-	return names
+	return names, nil
 }
 
 // writeManifest records names as the set of skills amctl owns in destDir,
@@ -212,7 +216,10 @@ func Install(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string)
 
 	// Persist ownership even when a later skill fails, so a partial install
 	// stays removable.
-	owned := readManifest(destDir)
+	owned, err := readManifest(destDir)
+	if err != nil {
+		return result, err
+	}
 	defer func() {
 		if writeErr := writeManifest(destDir, owned); writeErr != nil && err == nil {
 			err = fmt.Errorf("record installed skills: %w", writeErr)
@@ -326,13 +333,16 @@ func List(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string) ([
 }
 
 // Remove deletes the skills amctl installed into destDir, as recorded in the
-// manifest, and scrubs any symlinks in toolDirs that point at them. Skill
+// manifest, stopping if ctx is cancelled between skills; and scrubs any symlinks in toolDirs that point at them. Skill
 // directories amctl has no record of are reported as unmanaged and left
 // alone. Disk-only — no network access.
-func Remove(destDir string, toolDirs []string) (RemoveResult, error) {
+func Remove(ctx context.Context, destDir string, toolDirs []string) (RemoveResult, error) {
 	var result RemoveResult
 
-	owned := readManifest(destDir)
+	owned, err := readManifest(destDir)
+	if err != nil {
+		return result, err
+	}
 
 	unmanaged, err := unmanagedSkills(destDir, owned)
 	if err != nil {
@@ -341,6 +351,9 @@ func Remove(destDir string, toolDirs []string) (RemoveResult, error) {
 	result.UnmanagedSkills = unmanaged
 
 	for _, name := range owned {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
 		skillDir := filepath.Join(destDir, name)
 
 		links, err := scrubLinks(skillDir, name, toolDirs)

--- a/cli/pkg/skills/skills.go
+++ b/cli/pkg/skills/skills.go
@@ -25,7 +25,6 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -91,7 +90,8 @@ type manifest struct {
 
 // readManifest returns the skill names amctl recorded in destDir. A missing
 // or unreadable manifest yields no names, which makes Remove a no-op rather
-// than a guess about what amctl owns.
+// than a guess about what amctl owns. Names are validated because Remove
+// turns them straight into paths it deletes.
 func readManifest(destDir string) []string {
 	data, err := os.ReadFile(filepath.Join(destDir, manifestName))
 	if err != nil {
@@ -120,12 +120,22 @@ func writeManifest(destDir string, names []string) error {
 		}
 		return nil
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	data, err := json.MarshalIndent(manifest{Skills: names}, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o644)
+	// The manifest decides what Remove may delete, so commit it atomically: a
+	// half-written file reads back as "amctl owns nothing".
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // KnownNativeTools lists tools that read installed skills directly from
@@ -322,58 +332,81 @@ func List(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string) ([
 func Remove(destDir string, toolDirs []string) (RemoveResult, error) {
 	var result RemoveResult
 
-	entries, err := os.ReadDir(destDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return result, nil
-		}
-		return result, fmt.Errorf("read dest dir: %w", err)
-	}
-
 	owned := readManifest(destDir)
 
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
+	unmanaged, err := unmanagedSkills(destDir, owned)
+	if err != nil {
+		return result, err
+	}
+	result.UnmanagedSkills = unmanaged
+
+	for _, name := range owned {
 		skillDir := filepath.Join(destDir, name)
-		if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
-			continue
-		}
-		if !slices.Contains(owned, name) {
-			result.UnmanagedSkills = append(result.UnmanagedSkills, name)
-			continue
+
+		links, err := scrubLinks(skillDir, name, toolDirs)
+		result.RemovedLinks = append(result.RemovedLinks, links...)
+		if err != nil {
+			return result, err
 		}
 
-		for _, td := range toolDirs {
-			linkPath := filepath.Join(td, name)
-			target, err := os.Readlink(linkPath)
-			if err != nil {
-				continue
-			}
-			if filepath.Clean(target) != skillDir {
-				continue
-			}
-			if err := os.Remove(linkPath); err != nil {
-				return result, fmt.Errorf("remove symlink %s: %w", linkPath, err)
-			}
-			result.RemovedLinks = append(result.RemovedLinks, linkPath)
+		// A record can outlive its directory when the user deletes one by
+		// hand; dropping the claim is all that is left to do.
+		if _, err := os.Stat(skillDir); err != nil {
+			continue
 		}
-
 		if err := os.RemoveAll(skillDir); err != nil {
 			return result, fmt.Errorf("remove skill dir %s: %w", skillDir, err)
 		}
 		result.RemovedSkills = append(result.RemovedSkills, name)
 	}
 
-	remaining := slices.DeleteFunc(owned, func(name string) bool {
-		return slices.Contains(result.RemovedSkills, name)
-	})
-	if err := writeManifest(destDir, remaining); err != nil {
+	if err := writeManifest(destDir, nil); err != nil {
 		return result, fmt.Errorf("update install record: %w", err)
 	}
 	return result, nil
+}
+
+// unmanagedSkills lists the skill directories in destDir that amctl has no
+// install record for, so Remove can report what it deliberately left alone.
+func unmanagedSkills(destDir string, owned []string) ([]string, error) {
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read dest dir: %w", err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || slices.Contains(owned, name) {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(destDir, name, "SKILL.md")); err != nil {
+			continue
+		}
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// scrubLinks removes the symlinks in toolDirs that point at skillDir,
+// including ones left dangling by a directory the user deleted by hand.
+func scrubLinks(skillDir, name string, toolDirs []string) ([]string, error) {
+	var removed []string
+	for _, td := range toolDirs {
+		linkPath := filepath.Join(td, name)
+		target, err := os.Readlink(linkPath)
+		if err != nil || filepath.Clean(target) != skillDir {
+			continue
+		}
+		if err := os.Remove(linkPath); err != nil {
+			return removed, fmt.Errorf("remove symlink %s: %w", linkPath, err)
+		}
+		removed = append(removed, linkPath)
+	}
+	return removed, nil
 }
 
 // extractSkillFS copies every regular file under skilldata/<name> in fsys

--- a/cli/pkg/skills/skills.go
+++ b/cli/pkg/skills/skills.go
@@ -18,11 +18,14 @@ package skills
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -54,9 +57,12 @@ type InstallResult struct {
 }
 
 // RemoveResult holds the outcome of a Remove operation.
+// UnmanagedSkills names skill directories amctl has no install record for;
+// they are reported but left on disk.
 type RemoveResult struct {
-	RemovedSkills []string `json:"removed_skills"`
-	RemovedLinks  []string `json:"removed_links"`
+	RemovedSkills   []string `json:"removed_skills"`
+	RemovedLinks    []string `json:"removed_links"`
+	UnmanagedSkills []string `json:"unmanaged_skills,omitempty"`
 }
 
 // SkillInfo describes a skill in the catalog and any on-disk presence.
@@ -71,6 +77,56 @@ type SkillInfo struct {
 
 // DefaultDestRel is the relative path (from home) for the canonical skill directory.
 const DefaultDestRel = ".agents/skills"
+
+// manifestName is the file inside destDir recording which skills amctl
+// installed. Remove deletes only what this manifest claims, so skills the
+// user put in destDir themselves are never touched — destDir is frequently a
+// symlink into a directory the user manages by other means.
+const manifestName = ".amctl-skills.json"
+
+// manifest is the on-disk shape of manifestName.
+type manifest struct {
+	Skills []string `json:"skills"`
+}
+
+// readManifest returns the skill names amctl recorded in destDir. A missing
+// or unreadable manifest yields no names, which makes Remove a no-op rather
+// than a guess about what amctl owns.
+func readManifest(destDir string) []string {
+	data, err := os.ReadFile(filepath.Join(destDir, manifestName))
+	if err != nil {
+		return nil
+	}
+	var m manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil
+	}
+	var names []string
+	for _, name := range m.Skills {
+		if validSkillName(name) {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// writeManifest records names as the set of skills amctl owns in destDir,
+// deleting the manifest once nothing is left to own.
+func writeManifest(destDir string, names []string) error {
+	path := filepath.Join(destDir, manifestName)
+	if len(names) == 0 {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	sort.Strings(names)
+	data, err := json.MarshalIndent(manifest{Skills: names}, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
 
 // KnownNativeTools lists tools that read installed skills directly from
 // DefaultDestRel and therefore do not need a per-tool symlink directory.
@@ -135,9 +191,7 @@ func ResolveLocations() (destDir string, toolDirs []string, err error) {
 // Install reads every skill under fsys's "skilldata" root, writes it to
 // destDir, and creates symlinks from each toolDir to the canonical skill
 // directory.
-func Install(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string) (InstallResult, error) {
-	var result InstallResult
-
+func Install(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string) (result InstallResult, err error) {
 	entries, err := fs.ReadDir(fsys, "skilldata")
 	if err != nil {
 		return result, fmt.Errorf("read skilldata: %w", err)
@@ -145,6 +199,15 @@ func Install(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string)
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return result, fmt.Errorf("create dest dir %s: %w", destDir, err)
 	}
+
+	// Persist ownership even when a later skill fails, so a partial install
+	// stays removable.
+	owned := readManifest(destDir)
+	defer func() {
+		if writeErr := writeManifest(destDir, owned); writeErr != nil && err == nil {
+			err = fmt.Errorf("record installed skills: %w", writeErr)
+		}
+	}()
 
 	for _, entry := range entries {
 		if err := ctx.Err(); err != nil {
@@ -176,6 +239,9 @@ func Install(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string)
 		if err := os.Rename(tmpDir, skillDir); err != nil {
 			os.RemoveAll(tmpDir)
 			return result, fmt.Errorf("install %s: %w", skillDir, err)
+		}
+		if !slices.Contains(owned, name) {
+			owned = append(owned, name)
 		}
 		data, _ := fs.ReadFile(fsys, "skilldata/"+name+"/SKILL.md")
 		meta := parseFrontmatter(data)
@@ -249,9 +315,10 @@ func List(ctx context.Context, fsys fs.FS, destDir string, toolDirs []string) ([
 	return infos, nil
 }
 
-// Remove walks destDir for installed skills (subdirectories containing a
-// SKILL.md), scrubs any symlinks in toolDirs that point at them, and
-// deletes the canonical directories. Disk-only — no network access.
+// Remove deletes the skills amctl installed into destDir, as recorded in the
+// manifest, and scrubs any symlinks in toolDirs that point at them. Skill
+// directories amctl has no record of are reported as unmanaged and left
+// alone. Disk-only — no network access.
 func Remove(destDir string, toolDirs []string) (RemoveResult, error) {
 	var result RemoveResult
 
@@ -263,6 +330,8 @@ func Remove(destDir string, toolDirs []string) (RemoveResult, error) {
 		return result, fmt.Errorf("read dest dir: %w", err)
 	}
 
+	owned := readManifest(destDir)
+
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -270,6 +339,10 @@ func Remove(destDir string, toolDirs []string) (RemoveResult, error) {
 		name := entry.Name()
 		skillDir := filepath.Join(destDir, name)
 		if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+			continue
+		}
+		if !slices.Contains(owned, name) {
+			result.UnmanagedSkills = append(result.UnmanagedSkills, name)
 			continue
 		}
 
@@ -292,6 +365,13 @@ func Remove(destDir string, toolDirs []string) (RemoveResult, error) {
 			return result, fmt.Errorf("remove skill dir %s: %w", skillDir, err)
 		}
 		result.RemovedSkills = append(result.RemovedSkills, name)
+	}
+
+	remaining := slices.DeleteFunc(owned, func(name string) bool {
+		return slices.Contains(result.RemovedSkills, name)
+	})
+	if err := writeManifest(destDir, remaining); err != nil {
+		return result, fmt.Errorf("update install record: %w", err)
 	}
 	return result, nil
 }

--- a/cli/pkg/skills/skills_test.go
+++ b/cli/pkg/skills/skills_test.go
@@ -314,3 +314,84 @@ func TestRemove_SkipsNonAmctlSymlinks(t *testing.T) {
 		t.Error("user content should still exist")
 	}
 }
+
+func TestRemove_LeavesSkillsAmctlDidNotInstall(t *testing.T) {
+	dest := t.TempDir()
+
+	foreign := filepath.Join(dest, "legible-code")
+	if err := os.MkdirAll(foreign, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreign, "SKILL.md"), []byte(skillFrontmatter), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Install(context.Background(), fakeFS(t), dest, nil); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	result, err := Remove(dest, nil)
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if len(result.RemovedSkills) != 1 || result.RemovedSkills[0] != "use-amctl" {
+		t.Errorf("removed skills = %v, want [use-amctl]", result.RemovedSkills)
+	}
+	if _, err := os.Stat(filepath.Join(foreign, "SKILL.md")); err != nil {
+		t.Errorf("skill amctl did not install should survive: %v", err)
+	}
+	if len(result.UnmanagedSkills) != 1 || result.UnmanagedSkills[0] != "legible-code" {
+		t.Errorf("unmanaged skills = %v, want [legible-code]", result.UnmanagedSkills)
+	}
+}
+
+func TestRemove_WithoutManifestRemovesNothing(t *testing.T) {
+	dest := t.TempDir()
+
+	skillDir := filepath.Join(dest, "skill-creator")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillFrontmatter), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Remove(dest, nil)
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if len(result.RemovedSkills) != 0 {
+		t.Errorf("removed skills = %v, want none without an install record", result.RemovedSkills)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+		t.Errorf("skill dir should survive: %v", err)
+	}
+}
+
+func TestRemove_ForgetsSkillsItRemoved(t *testing.T) {
+	dest := t.TempDir()
+
+	if _, err := Install(context.Background(), fakeFS(t), dest, nil); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	if _, err := Remove(dest, nil); err != nil {
+		t.Fatalf("first Remove failed: %v", err)
+	}
+
+	// A skill re-created by hand under the old name is no longer amctl's.
+	skillDir := filepath.Join(dest, "use-amctl")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillFrontmatter), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Remove(dest, nil)
+	if err != nil {
+		t.Fatalf("second Remove failed: %v", err)
+	}
+	if len(result.RemovedSkills) != 0 {
+		t.Errorf("removed skills = %v, want none after the manifest was cleared", result.RemovedSkills)
+	}
+}

--- a/cli/pkg/skills/skills_test.go
+++ b/cli/pkg/skills/skills_test.go
@@ -41,6 +41,19 @@ func fakeFS(t *testing.T) fs.FS {
 	}
 }
 
+// writeSkillDir creates a skill directory in dest that amctl did not install.
+func writeSkillDir(t *testing.T, dest, name string) string {
+	t.Helper()
+	dir := filepath.Join(dest, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillFrontmatter), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 func TestDetectToolDirs_FindsExisting(t *testing.T) {
 	home := t.TempDir()
 	claudeDir := filepath.Join(home, ".claude", "skills")
@@ -318,13 +331,7 @@ func TestRemove_SkipsNonAmctlSymlinks(t *testing.T) {
 func TestRemove_LeavesSkillsAmctlDidNotInstall(t *testing.T) {
 	dest := t.TempDir()
 
-	foreign := filepath.Join(dest, "legible-code")
-	if err := os.MkdirAll(foreign, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(foreign, "SKILL.md"), []byte(skillFrontmatter), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	foreign := writeSkillDir(t, dest, "legible-code")
 
 	if _, err := Install(context.Background(), fakeFS(t), dest, nil); err != nil {
 		t.Fatalf("Install failed: %v", err)
@@ -348,13 +355,7 @@ func TestRemove_LeavesSkillsAmctlDidNotInstall(t *testing.T) {
 func TestRemove_WithoutManifestRemovesNothing(t *testing.T) {
 	dest := t.TempDir()
 
-	skillDir := filepath.Join(dest, "skill-creator")
-	if err := os.MkdirAll(skillDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillFrontmatter), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	skillDir := writeSkillDir(t, dest, "skill-creator")
 
 	result, err := Remove(dest, nil)
 	if err != nil {
@@ -379,13 +380,7 @@ func TestRemove_ForgetsSkillsItRemoved(t *testing.T) {
 	}
 
 	// A skill re-created by hand under the old name is no longer amctl's.
-	skillDir := filepath.Join(dest, "use-amctl")
-	if err := os.MkdirAll(skillDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(skillFrontmatter), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSkillDir(t, dest, "use-amctl")
 
 	result, err := Remove(dest, nil)
 	if err != nil {
@@ -393,5 +388,41 @@ func TestRemove_ForgetsSkillsItRemoved(t *testing.T) {
 	}
 	if len(result.RemovedSkills) != 0 {
 		t.Errorf("removed skills = %v, want none after the manifest was cleared", result.RemovedSkills)
+	}
+}
+
+func TestRemove_ReleasesRecordForDirDeletedByHand(t *testing.T) {
+	dest := t.TempDir()
+	toolDir := t.TempDir()
+
+	if _, err := Install(context.Background(), fakeFS(t), dest, []string{toolDir}); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(dest, "use-amctl")); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Remove(dest, []string{toolDir})
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	if len(result.RemovedSkills) != 0 {
+		t.Errorf("removed skills = %v, want none — the directory was already gone", result.RemovedSkills)
+	}
+	if len(result.RemovedLinks) != 1 {
+		t.Errorf("removed links = %v, want the dangling link scrubbed", result.RemovedLinks)
+	}
+	if _, err := os.Lstat(filepath.Join(toolDir, "use-amctl")); !os.IsNotExist(err) {
+		t.Error("dangling symlink should be removed")
+	}
+
+	// The stale claim is released, so a hand-made skill of the same name is safe.
+	writeSkillDir(t, dest, "use-amctl")
+	result, err = Remove(dest, nil)
+	if err != nil {
+		t.Fatalf("second Remove failed: %v", err)
+	}
+	if len(result.RemovedSkills) != 0 {
+		t.Errorf("removed skills = %v, want none after the claim was released", result.RemovedSkills)
 	}
 }

--- a/cli/pkg/skills/skills_test.go
+++ b/cli/pkg/skills/skills_test.go
@@ -18,6 +18,7 @@ package skills
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -202,7 +203,7 @@ func TestRemove_CleansUpSymlinksAndDirs(t *testing.T) {
 		t.Fatalf("Install failed: %v", err)
 	}
 
-	result, err := Remove(dest, []string{toolDir})
+	result, err := Remove(context.Background(), dest, []string{toolDir})
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
 	}
@@ -225,7 +226,7 @@ func TestRemove_NothingInstalled(t *testing.T) {
 	dest := t.TempDir()
 	toolDir := t.TempDir()
 
-	result, err := Remove(dest, []string{toolDir})
+	result, err := Remove(context.Background(), dest, []string{toolDir})
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
 	}
@@ -237,7 +238,7 @@ func TestRemove_NothingInstalled(t *testing.T) {
 func TestRemove_DestDirDoesNotExist(t *testing.T) {
 	// dest path that doesn't exist at all; Remove should no-op cleanly.
 	dest := filepath.Join(t.TempDir(), "does-not-exist")
-	result, err := Remove(dest, nil)
+	result, err := Remove(context.Background(), dest, nil)
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
 	}
@@ -316,7 +317,7 @@ func TestRemove_SkipsNonAmctlSymlinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := Remove(dest, []string{toolDir})
+	result, err := Remove(context.Background(), dest, []string{toolDir})
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
 	}
@@ -337,7 +338,7 @@ func TestRemove_LeavesSkillsAmctlDidNotInstall(t *testing.T) {
 		t.Fatalf("Install failed: %v", err)
 	}
 
-	result, err := Remove(dest, nil)
+	result, err := Remove(context.Background(), dest, nil)
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
 	}
@@ -357,7 +358,7 @@ func TestRemove_WithoutManifestRemovesNothing(t *testing.T) {
 
 	skillDir := writeSkillDir(t, dest, "skill-creator")
 
-	result, err := Remove(dest, nil)
+	result, err := Remove(context.Background(), dest, nil)
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
 	}
@@ -375,14 +376,14 @@ func TestRemove_ForgetsSkillsItRemoved(t *testing.T) {
 	if _, err := Install(context.Background(), fakeFS(t), dest, nil); err != nil {
 		t.Fatalf("Install failed: %v", err)
 	}
-	if _, err := Remove(dest, nil); err != nil {
+	if _, err := Remove(context.Background(), dest, nil); err != nil {
 		t.Fatalf("first Remove failed: %v", err)
 	}
 
 	// A skill re-created by hand under the old name is no longer amctl's.
 	writeSkillDir(t, dest, "use-amctl")
 
-	result, err := Remove(dest, nil)
+	result, err := Remove(context.Background(), dest, nil)
 	if err != nil {
 		t.Fatalf("second Remove failed: %v", err)
 	}
@@ -402,7 +403,7 @@ func TestRemove_ReleasesRecordForDirDeletedByHand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := Remove(dest, []string{toolDir})
+	result, err := Remove(context.Background(), dest, []string{toolDir})
 	if err != nil {
 		t.Fatalf("Remove failed: %v", err)
 	}
@@ -418,11 +419,55 @@ func TestRemove_ReleasesRecordForDirDeletedByHand(t *testing.T) {
 
 	// The stale claim is released, so a hand-made skill of the same name is safe.
 	writeSkillDir(t, dest, "use-amctl")
-	result, err = Remove(dest, nil)
+	result, err = Remove(context.Background(), dest, nil)
 	if err != nil {
 		t.Fatalf("second Remove failed: %v", err)
 	}
 	if len(result.RemovedSkills) != 0 {
 		t.Errorf("removed skills = %v, want none after the claim was released", result.RemovedSkills)
+	}
+}
+
+func TestRemove_UnreadableManifestDeletesNothing(t *testing.T) {
+	dest := t.TempDir()
+
+	if _, err := Install(context.Background(), fakeFS(t), dest, nil); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+	manifestPath := filepath.Join(dest, manifestName)
+	if err := os.WriteFile(manifestPath, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Remove(context.Background(), dest, nil)
+	if err == nil {
+		t.Fatal("expected an error for a manifest that exists but cannot be parsed")
+	}
+	if len(result.RemovedSkills) != 0 {
+		t.Errorf("removed skills = %v, want none", result.RemovedSkills)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "use-amctl", "SKILL.md")); err != nil {
+		t.Errorf("skill should survive an unreadable record: %v", err)
+	}
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Errorf("the record itself should survive: %v", err)
+	}
+}
+
+func TestRemove_StopsOnCancelledContext(t *testing.T) {
+	dest := t.TempDir()
+
+	if _, err := Install(context.Background(), fakeFS(t), dest, nil); err != nil {
+		t.Fatalf("Install failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := Remove(ctx, dest, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Remove error = %v, want context.Canceled", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "use-amctl", "SKILL.md")); err != nil {
+		t.Errorf("skill should survive a cancelled remove: %v", err)
 	}
 }


### PR DESCRIPTION
## Purpose
`amctl skills remove` can delete skills amctl never installed, including a user's own source files.

`skills.Remove` walked the destination directory (`~/.agents/skills`) and `os.RemoveAll`'d **every** subdirectory containing a `SKILL.md`. It had no record of what `skills install` had put there, so anything else living in that directory was collateral.

That is not hypothetical when the destination is a symlink. On a home-manager setup:

```
~/.agents/skills  -> ... -> ~/.dotfiles/skills   (inode 187318)
~/.claude/skills  -> ... -> ~/.dotfiles/skills   (inode 187318)
```

Both amctl's canonical destination and a detected tool directory resolve to the same real, user-managed directory. A bare `amctl skills remove` (the command takes `cobra.NoArgs`, so removing everything is its only mode) deleted seven skill directories there, four of which amctl had never installed.

## Goals
`remove` deletes only what `install` created, and leaves anything else in place with a note saying so.

## Approach
- `install` records the skill names it writes in a `.amctl-skills.json` manifest inside the destination directory. It merges with any existing record and is written even when a later skill fails, so a partial install stays removable.
- `remove` reads that manifest and deletes only the names it lists. Directories it has no record of are reported in `RemoveResult.UnmanagedSkills` and left untouched. A missing or unreadable manifest means nothing is removed — it fails safe rather than guessing at ownership.
- After a removal the manifest is updated (and deleted when empty), so a directory later re-created by hand under the same name is no longer amctl's to delete.
- Text output gains a line naming the skills that were left behind; the JSON envelope gains `unmanaged_skills` (omitted when empty).

Reinstalling repairs ownership for anyone who installed with an older build: install rewrites the manifest for every skill in the catalog.

## User stories
As a developer whose `~/.agents/skills` is symlinked into a dotfiles repo, I can run `amctl skills remove` without losing skills I wrote myself.

## Release note
Fixed `amctl skills remove` deleting skills that amctl did not install.

## Documentation
N/A — no user-facing docs describe this command's deletion semantics; the change makes the command less destructive, not different to invoke.

## Training
N/A — no training content covers the CLI skills commands.

## Certification
N/A — no certification exam covers the CLI skills commands.

## Marketing
N/A — bug fix.

## Automation tests
 - Unit tests
   > Four new cases. `pkg/skills`: `TestRemove_LeavesSkillsAmctlDidNotInstall` (a foreign skill dir survives and is reported unmanaged), `TestRemove_WithoutManifestRemovesNothing` (no install record → no deletion), `TestRemove_ForgetsSkillsItRemoved` (manifest is cleared after removal). `pkg/cmd/skills`: `TestRemoveCmd_ReportsUnmanagedSkills` (the text output names what was left). Existing install/remove/list tests pass unchanged.
 - Integration tests
   > N/A — no integration suite covers the skills commands. Verified manually instead: a fake `$HOME` reproducing the symlink layout above. The pre-fix binary printed "Removed 7 skills" and emptied the directory; the fixed binary removed nothing, printed "No skills installed by amctl", and all seven directories survived.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — Java-only plugin; this is Go. `go vet ./...` is clean.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A — no schema change. The manifest is created on the next `amctl skills install`; until then `remove` is a safe no-op.

## Test environment
Go 1.x toolchain in `cli/`, Linux (kernel 7.1.8, CachyOS). `go build ./...`, `go vet ./...` and `go test ./pkg/...` all pass.

## Learning
The failure needed no guesswork: `stat -c %i` on the two directories showed amctl's destination and a detected tool directory sharing one inode, which made "delete every SKILL.md directory under dest" equivalent to "delete the user's dotfiles". Ownership tracking, rather than symlink detection, is the fix that holds regardless of how the destination is mounted.

https://claude.ai/code/session_019vHEryRkz6ASGWZnng6s6f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skill removal now tracks which skills were installed by the tool.
  * Skills created or installed elsewhere are preserved during removal and clearly reported.
  * Installation records remain accurate even if a later skill installation fails.

* **Bug Fixes**
  * Prevented removal of unmanaged skills, including when no installation record exists.
  * Removed skills are no longer deleted if they are manually recreated afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->