### PR TITLE
Filter non-agent components out of Agent Manager's project agent list

### DIFF
--- a/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
+++ b/agent-manager-service/clients/clientmocks/openchoreo_client_fake.go
@@ -24,6 +24,9 @@ import (
 //			ComponentExistsFunc: func(ctx context.Context, ouID string, projectName string, componentName string) (bool, error) {
 //				panic("mock out the ComponentExists method")
 //			},
+//			CountProjectComponentsFunc: func(ctx context.Context, ouID string, projectName string) (int, error) {
+//				panic("mock out the CountProjectComponents method")
+//			},
 //			CreateComponentFunc: func(ctx context.Context, ouID string, projectName string, req client.CreateComponentRequest) error {
 //				panic("mock out the CreateComponent method")
 //			},
@@ -258,6 +261,9 @@ type OpenChoreoClientMock struct {
 
 	// ComponentExistsFunc mocks the ComponentExists method.
 	ComponentExistsFunc func(ctx context.Context, ouID string, projectName string, componentName string) (bool, error)
+
+	// CountProjectComponentsFunc mocks the CountProjectComponents method.
+	CountProjectComponentsFunc func(ctx context.Context, ouID string, projectName string) (int, error)
 
 	// CreateComponentFunc mocks the CreateComponent method.
 	CreateComponentFunc func(ctx context.Context, ouID string, projectName string, req client.CreateComponentRequest) error
@@ -506,6 +512,15 @@ type OpenChoreoClientMock struct {
 			ProjectName string
 			// ComponentName is the componentName argument value.
 			ComponentName string
+		}
+		// CountProjectComponents holds details about calls to the CountProjectComponents method.
+		CountProjectComponents []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// OuID is the ouID argument value.
+			OuID string
+			// ProjectName is the projectName argument value.
+			ProjectName string
 		}
 		// CreateComponent holds details about calls to the CreateComponent method.
 		CreateComponent []struct {
@@ -1330,6 +1345,7 @@ type OpenChoreoClientMock struct {
 	}
 	lockAttachTraits                           sync.RWMutex
 	lockComponentExists                        sync.RWMutex
+	lockCountProjectComponents                 sync.RWMutex
 	lockCreateComponent                        sync.RWMutex
 	lockCreateDeploymentPipeline               sync.RWMutex
 	lockCreateEnvironment                      sync.RWMutex
@@ -1495,6 +1511,46 @@ func (mock *OpenChoreoClientMock) ComponentExistsCalls() []struct {
 	mock.lockComponentExists.RLock()
 	calls = mock.calls.ComponentExists
 	mock.lockComponentExists.RUnlock()
+	return calls
+}
+
+// CountProjectComponents calls CountProjectComponentsFunc.
+func (mock *OpenChoreoClientMock) CountProjectComponents(ctx context.Context, ouID string, projectName string) (int, error) {
+	if mock.CountProjectComponentsFunc == nil {
+		panic("OpenChoreoClientMock.CountProjectComponentsFunc: method is nil but OpenChoreoClient.CountProjectComponents was just called")
+	}
+	callInfo := struct {
+		Ctx         context.Context
+		OuID        string
+		ProjectName string
+	}{
+		Ctx:         ctx,
+		OuID:        ouID,
+		ProjectName: projectName,
+	}
+	mock.lockCountProjectComponents.Lock()
+	mock.calls.CountProjectComponents = append(mock.calls.CountProjectComponents, callInfo)
+	mock.lockCountProjectComponents.Unlock()
+	return mock.CountProjectComponentsFunc(ctx, ouID, projectName)
+}
+
+// CountProjectComponentsCalls gets all the calls that were made to CountProjectComponents.
+// Check the length with:
+//
+//	len(mockedOpenChoreoClient.CountProjectComponentsCalls())
+func (mock *OpenChoreoClientMock) CountProjectComponentsCalls() []struct {
+	Ctx         context.Context
+	OuID        string
+	ProjectName string
+} {
+	var calls []struct {
+		Ctx         context.Context
+		OuID        string
+		ProjectName string
+	}
+	mock.lockCountProjectComponents.RLock()
+	calls = mock.calls.CountProjectComponents
+	mock.lockCountProjectComponents.RUnlock()
 	return calls
 }
 

--- a/agent-manager-service/clients/openchoreosvc/client/client.go
+++ b/agent-manager-service/clients/openchoreosvc/client/client.go
@@ -76,7 +76,14 @@ type OpenChoreoClient interface {
 	GetEnvResourceConfigs(ctx context.Context, ouID, projectName, componentName, environment string) (*ComponentResourceConfigsResponse, error)
 	UpdateEnvResourceConfigs(ctx context.Context, ouID, projectName, componentName, environment string, req UpdateComponentResourceConfigsRequest) error
 	DeleteComponent(ctx context.Context, ouID, projectName, componentName string) error
+	// ListComponents returns only the agent components in the project. Projects are shared
+	// across WSO2 Cloud products, so a project can also hold components another product
+	// created; those are deliberately left out (see isAgentComponentType).
 	ListComponents(ctx context.Context, ouID, projectName string) ([]*models.AgentResponse, error)
+	// CountProjectComponents counts every component in the project, including those other
+	// products created. Emptiness checks must use this rather than ListComponents, which
+	// would report a project still holding another product's components as empty.
+	CountProjectComponents(ctx context.Context, ouID, projectName string) (int, error)
 	ListComponentsByKind(ctx context.Context, ouID, projectName, kindName string) ([]*models.AgentResponse, error)
 	ComponentExists(ctx context.Context, ouID, projectName, componentName string) (bool, error)
 	AttachTraits(ctx context.Context, ouID, projectName, componentName string, traitRequests []TraitRequest) error

--- a/agent-manager-service/clients/openchoreosvc/client/component_type_filter_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/component_type_filter_test.go
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The component types below are the ones observed on real shared projects. Only the two
+// agent types are agent-manager's own; every other product's components must stay out of
+// the agent list, including the ones whose names read like agents.
+func TestIsAgentComponentType(t *testing.T) {
+	agentTypes := []string{
+		"proxy/agent-api",
+		"proxy/external-agent-api",
+	}
+	for _, componentType := range agentTypes {
+		assert.True(t, isAgentComponentType(componentType), "expected %q to be an agent component type", componentType)
+	}
+
+	foreignTypes := []string{
+		"deployment/service",
+		"deployment/web-application",
+		"deployment/code-server",
+		"deployment/event-integration",
+		"deployment/file-integration",
+		"deployment/integration-as-api",
+		"cronjob/scheduled-task",
+		// Named like agents, but created by other products, not by agent-manager.
+		"deployment/ai-agent",
+		"deployment/pa-service",
+		"job/coding-agent",
+		// Shares the "proxy/" prefix, so a prefix match would wrongly accept it.
+		"proxy/proxy-api",
+		// The unqualified form is not what OpenChoreo stores on a Component.
+		"agent-api",
+		"",
+	}
+	for _, componentType := range foreignTypes {
+		assert.False(t, isAgentComponentType(componentType), "expected %q not to be an agent component type", componentType)
+	}
+}

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -1300,14 +1300,34 @@ func (c *openChoreoClient) ListComponents(ctx context.Context, ouID, projectName
 
 	components := make([]*models.AgentResponse, 0, len(resp.JSON200.Items))
 	for i := range resp.JSON200.Items {
-		comp, err := convertComponentFromTyped(&resp.JSON200.Items[i])
+		item := &resp.JSON200.Items[i]
+		if item.Spec == nil || !isAgentComponentType(item.Spec.ComponentType.Name) {
+			// Projects are shared across WSO2 Cloud products, so a project can contain
+			// components other products created (e.g. a plain "deployment/service").
+			// Agent Manager should only ever list components it itself provisions.
+			continue
+		}
+		comp, err := convertComponentFromTyped(item)
 		if err != nil {
-			slog.Error("failed to convert component", "component", resp.JSON200.Items[i].Metadata.Name, "error", err)
+			slog.Error("failed to convert component", "component", item.Metadata.Name, "error", err)
 			continue
 		}
 		components = append(components, comp)
 	}
 	return components, nil
+}
+
+// isAgentComponentType reports whether componentTypeName is one of the component
+// types agent-manager itself creates (see getOpenChoreoComponentType and
+// buildInternalAgentFromKindComponentRequestBody). Used to filter out components
+// created by other products sharing the same project.
+func isAgentComponentType(componentTypeName string) bool {
+	switch ComponentType(componentTypeName) {
+	case ComponentTypeInternalAgentAPI, ComponentTypeExternalAgentAPI:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *openChoreoClient) ListComponentsByKind(ctx context.Context, ouID, projectName, kindName string) ([]*models.AgentResponse, error) {

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -1317,6 +1317,35 @@ func (c *openChoreoClient) ListComponents(ctx context.Context, ouID, projectName
 	return components, nil
 }
 
+// CountProjectComponents counts every component in the project, whichever product created it.
+//
+// ListComponents answers "which agents does this project have"; this answers "is this project
+// empty". The two differ because projects are shared: a project holding only another product's
+// components has no agents but is not empty, and deleting it would take that product's
+// components with it (the Project carries an openchoreo.dev/project-cleanup finalizer).
+func (c *openChoreoClient) CountProjectComponents(ctx context.Context, ouID, projectName string) (int, error) {
+	namespaceName := c.NamespaceFor(ouID)
+	resp, err := c.ocClient.ListComponentsWithResponse(ctx, namespaceName, &gen.ListComponentsParams{
+		Project: &projectName,
+		Limit:   &defaultListLimit,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list components: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return 0, handleErrorResponse(resp.StatusCode(), ErrorResponses{
+			JSON401: resp.JSON401,
+			JSON403: resp.JSON403,
+			JSON404: resp.JSON404,
+			JSON500: resp.JSON500,
+		})
+	}
+	if resp.JSON200 == nil {
+		return 0, nil
+	}
+	return len(resp.JSON200.Items), nil
+}
+
 // isAgentComponentType reports whether componentTypeName is one of the component
 // types agent-manager itself creates (see getOpenChoreoComponentType and
 // buildInternalAgentFromKindComponentRequestBody). Used to filter out components

--- a/agent-manager-service/services/infra_resource_manager.go
+++ b/agent-manager-service/services/infra_resource_manager.go
@@ -275,22 +275,24 @@ func (s *infraResourceManager) DeleteProject(ctx context.Context, ouID string, p
 		s.logger.Error("Failed to get organization", "ouID", ouID, "error", err)
 		return err
 	}
-	// Check agents exist for the project
-	s.logger.Debug("Checking for associated agents", "projectName", projectName)
-	agents, err := s.ocClient.ListComponents(ctx, ouID, projectName)
+	// Refuse to delete a project that still holds components. This counts every component,
+	// not just agents: projects are shared with other WSO2 Cloud products, and deleting the
+	// project would take their components with it via the project-cleanup finalizer.
+	s.logger.Debug("Checking for components in the project", "projectName", projectName)
+	componentCount, err := s.ocClient.CountProjectComponents(ctx, ouID, projectName)
 	if err != nil {
 		if errors.Is(err, utils.ErrProjectNotFound) {
 			s.logger.Warn("Project not found while listing components; delete is idempotent", "ouID", ouID, "projectName", projectName)
 			return nil
 		}
-		s.logger.Error("Failed to list agents for project", "projectName", projectName, "error", err)
+		s.logger.Error("Failed to count components for project", "projectName", projectName, "error", err)
 		return err
 	}
-	if len(agents) > 0 {
-		s.logger.Warn("Cannot delete project with associated agents", "ouID", ouID, "projectName", projectName, "agentCount", len(agents))
+	if componentCount > 0 {
+		s.logger.Warn("Cannot delete project that still has components", "ouID", ouID, "projectName", projectName, "componentCount", componentCount)
 		return utils.ErrProjectHasAssociatedAgents
 	}
-	s.logger.Debug("No associated agents found, proceeding with deletion", "projectName", projectName)
+	s.logger.Debug("No components found, proceeding with deletion", "projectName", projectName)
 
 	// Delete project from OpenChoreo
 	deleteAttempt, auditErr := audit.Begin(

--- a/agent-manager-service/services/infra_resource_manager_unit_test.go
+++ b/agent-manager-service/services/infra_resource_manager_unit_test.go
@@ -306,11 +306,29 @@ func TestInfraResourceManager_ListProjects(t *testing.T) {
 func TestInfraResourceManager_DeleteProject(t *testing.T) {
 	const org, proj = "acme", "proj-a"
 
-	t.Run("idempotent when ListComponents reports project not found", func(t *testing.T) {
+	t.Run("refuses deletion when only another product's components remain", func(t *testing.T) {
+		// A shared project can hold components no agent list would show. Counting agents
+		// instead of components here would delete the project — and with it, via the
+		// project-cleanup finalizer, another product's components.
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetOrganizationFunc: okOrg(),
+			CountProjectComponentsFunc: func(_ context.Context, _, _ string) (int, error) {
+				return 1, nil
+			},
 			ListComponentsFunc: func(_ context.Context, _, _ string) ([]*models.AgentResponse, error) {
-				return nil, utils.ErrProjectNotFound
+				return []*models.AgentResponse{}, nil // no agents, yet not empty
+			},
+			// DeleteProjectFunc nil => must not be reached.
+		}
+		err := newInfraManager(oc).DeleteProject(auditableCtx(t), org, proj)
+		assert.ErrorIs(t, err, utils.ErrProjectHasAssociatedAgents)
+	})
+
+	t.Run("idempotent when the component count reports project not found", func(t *testing.T) {
+		oc := &clientmocks.OpenChoreoClientMock{
+			GetOrganizationFunc: okOrg(),
+			CountProjectComponentsFunc: func(_ context.Context, _, _ string) (int, error) {
+				return 0, utils.ErrProjectNotFound
 			},
 			// DeleteProjectFunc nil => must not be reached.
 		}
@@ -321,8 +339,8 @@ func TestInfraResourceManager_DeleteProject(t *testing.T) {
 	t.Run("refuses deletion when agents are associated", func(t *testing.T) {
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetOrganizationFunc: okOrg(),
-			ListComponentsFunc: func(_ context.Context, _, _ string) ([]*models.AgentResponse, error) {
-				return []*models.AgentResponse{{Name: "agent-1"}}, nil
+			CountProjectComponentsFunc: func(_ context.Context, _, _ string) (int, error) {
+				return 1, nil
 			},
 		}
 		err := newInfraManager(oc).DeleteProject(auditableCtx(t), org, proj)
@@ -333,8 +351,8 @@ func TestInfraResourceManager_DeleteProject(t *testing.T) {
 		deleted := false
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetOrganizationFunc: okOrg(),
-			ListComponentsFunc: func(_ context.Context, _, _ string) ([]*models.AgentResponse, error) {
-				return []*models.AgentResponse{}, nil
+			CountProjectComponentsFunc: func(_ context.Context, _, _ string) (int, error) {
+				return 0, nil
 			},
 			DeleteProjectFunc: func(_ context.Context, _, _ string) error {
 				deleted = true
@@ -349,8 +367,8 @@ func TestInfraResourceManager_DeleteProject(t *testing.T) {
 	t.Run("idempotent when DeleteProject reports project not found", func(t *testing.T) {
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetOrganizationFunc: okOrg(),
-			ListComponentsFunc: func(_ context.Context, _, _ string) ([]*models.AgentResponse, error) {
-				return []*models.AgentResponse{}, nil
+			CountProjectComponentsFunc: func(_ context.Context, _, _ string) (int, error) {
+				return 0, nil
 			},
 			DeleteProjectFunc: func(_ context.Context, _, _ string) error {
 				return utils.ErrProjectNotFound
@@ -364,8 +382,8 @@ func TestInfraResourceManager_DeleteProject(t *testing.T) {
 		boom := errors.New("list boom")
 		oc := &clientmocks.OpenChoreoClientMock{
 			GetOrganizationFunc: okOrg(),
-			ListComponentsFunc: func(_ context.Context, _, _ string) ([]*models.AgentResponse, error) {
-				return nil, boom
+			CountProjectComponentsFunc: func(_ context.Context, _, _ string) (int, error) {
+				return 0, boom
 			},
 		}
 		err := newInfraManager(oc).DeleteProject(auditableCtx(t), org, proj)

--- a/agent-manager-service/tests/apitestutils/mock_clients.go
+++ b/agent-manager-service/tests/apitestutils/mock_clients.go
@@ -147,6 +147,9 @@ func CreateMockOpenChoreoClient() *clientmocks.OpenChoreoClientMock {
 		ListComponentsFunc: func(ctx context.Context, namespaceName string, projectName string) ([]*models.AgentResponse, error) {
 			return []*models.AgentResponse{}, nil
 		},
+		CountProjectComponentsFunc: func(ctx context.Context, namespaceName string, projectName string) (int, error) {
+			return 0, nil
+		},
 		DeleteProjectFunc: func(ctx context.Context, namespaceName string, projectName string) error {
 			return nil
 		},

--- a/agent-manager-service/tests/delete_project_test.go
+++ b/agent-manager-service/tests/delete_project_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
-	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/tests/apitestutils"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/wiring"
@@ -74,17 +73,11 @@ func TestDeleteProject(t *testing.T) {
 
 	t.Run("Deleting a project with agents should return 409", func(t *testing.T) {
 		openChoreoClient := apitestutils.CreateMockOpenChoreoClient()
-		openChoreoClient.ListComponentsFunc = func(ctx context.Context, orgName string, projectName string) ([]*models.AgentResponse, error) {
+		openChoreoClient.CountProjectComponentsFunc = func(ctx context.Context, orgName string, projectName string) (int, error) {
 			if projectName == testProjectWithAgents {
-				return []*models.AgentResponse{
-					{
-						Name:        "test-agent",
-						ProjectName: projectName,
-						DisplayName: "Test Agent",
-					},
-				}, nil
+				return 1, nil
 			}
-			return []*models.AgentResponse{}, nil
+			return 0, nil
 		}
 		testClients := wiring.TestClients{
 			OpenChoreoClient: openChoreoClient,


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

In WSO2 Cloud, projects are shared across products, so a project can contain components created by other products (e.g. Sample Console). Agent Manager was listing every component in the project as an agent, so a component belonging to another product (e.g. type `deployment/service`) appeared in the Agent Manager console as an agent with type "Unknown".

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Agent Manager should surface only the components it creates and manages, and it must not act on another product's components in a shared project.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

Two related changes in `clients/openchoreosvc/client`:

1. **Agent listing is filtered by component type.** `ListComponents` now skips any component whose `Spec.ComponentType.Name` isn't `proxy/agent-api` or `proxy/external-agent-api` — the only two types Agent Manager creates (`getOpenChoreoComponentType`, `buildInternalAgentFromKindComponentRequestBody`) — before it is converted to an agent. This is a read-time filter; no stored data changes. It covers every agent read path: `ListAgents`, `ListOrgAgents`, the MCP agent tools, and the console's External/Platform/Total panel (computed client-side from the same endpoint).

2. **Project deletion now counts *all* components, not just agents.** `DeleteProject`'s emptiness guard shared the same `ListComponents` call, so with (1) alone a project holding only another product's components would look empty and be deleted — and the `Project` carries an `openchoreo.dev/project-cleanup` finalizer, so that product's components would go with it. A dedicated `CountProjectComponents` (unfiltered) now backs that guard, keeping the existing refusal behavior intact for shared projects.

Note: `ListComponentsByKind` needs no filter — it label-selects on `openchoreo.dev/agent-kind-name`, a label only Agent Manager sets.

## User stories
> Summary of user stories addressed by this change

As a user, I only see agents Agent Manager created in my project's agent list, not unrelated components from other WSO2 Cloud products sharing the project; and deleting a project never silently removes another product's components.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Fixed an issue where components created by other WSO2 Cloud products in a shared project could appear in Agent Manager's agent list.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there's no doc impact

N/A — bug fix with no new user-facing concepts or configuration.

## Training
N/A

## Certification
N/A — no impact on certification exams.

## Marketing
N/A

## Automation tests
 - Unit tests
   > Code coverage information

New `TestIsAgentComponentType` covering both agent types plus every foreign component type observed on real shared projects — including agent-sounding ones (`deployment/ai-agent`, `job/coding-agent`), `proxy/proxy-api` (which a prefix match would wrongly accept), and the unqualified `agent-api` form. New `DeleteProject` case "refuses deletion when only another product's components remain" locks in the guard from regressing. Existing `DeleteProject` unit/API tests updated to the count-based guard. Full unit suite passes (`make test-unit`).
 - Integration tests
   > Details about the test cases and coverage

No new integration tests. `tests/delete_project_test.go` updated and type-checked under the `integration` tag.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — Go codebase; `golangci-lint` with the repo's CI config was run instead.
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

N/A — no data migration. The filter is applied at read time, so existing organizations and projects are corrected as soon as the new build is deployed.

## Test environment
Local Go build

## Learning
N/A