### PR TITLE
Fix VM installs rejected by the chart values schema

### DIFF
--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -18,10 +18,18 @@ vm_host() {
 # amp_helm_args — hostname-driven core. Reads AMP_HOST_API/THUNDER/CONSOLE/OBSERVER/
 # GATEWAY/CP (CP empty => external gateways off). Emits one helm token per line.
 #
-# The service config lives under different top-level keys across chart versions:
-# `agentManager` (<=main) was renamed to `agentManagerService` (>=0.15.0). Emit
-# both; helm silently ignores whichever key the installed chart doesn't define,
-# so the right one always wins regardless of the --version pulled.
+# Only `agentManagerService` is emitted. The service config used to live under
+# `agentManager` too (renamed in 0.15.0) and both keys were emitted on the theory
+# that helm ignores keys the installed chart doesn't define — true until the chart
+# gained a values.schema.json (1.0.0-rc3), which sets additionalProperties:false
+# at the root and rejects the whole install with "additional properties
+# 'agentManager' not allowed".
+#
+# That schema also types agentsHttpPort/agentsHttpsPort/gatewayVhostPort and
+# console.config.tlsEnabled as strings (the templates `| quote` them), and helm's
+# --set coerces 443 to a number and true to a boolean. Those four need
+# --set-string; agentManagerService.config.tlsEnabled is a real boolean and must
+# stay on --set.
 #
 # config.tlsEnabled (env TLS_ENABLED) selects which advertised endpoint variant
 # amp-api hands the console for deployed agents: when true it emits the https URL
@@ -52,24 +60,21 @@ vm_host() {
 # call (users/roles/groups).
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
-  local k
-  for k in agentManager agentManagerService; do
-    printf '%s\n' \
-      "--set" "${k}.config.serverPublicURL=https://${AMP_HOST_API}" \
-      "--set" "${k}.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
-      "--set" "${k}.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
-      "--set" "${k}.config.keyManager.audience=urn:wso2:amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/mcp" \
-      "--set" "${k}.config.thunder.baseURL=https://${AMP_HOST_THUNDER}" \
-      "--set" "${k}.config.thunder.resolveToHost=amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090" \
-      "--set" "${k}.config.tlsEnabled=true" \
-      "--set" "${k}.config.idpHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
-      "--set" "${k}.config.agentsBaseDomain=${AMP_AGENTS_BASE}" \
-      "--set" "${k}.config.agentsHttpPort=443" \
-      "--set" "${k}.config.agentsHttpsPort=443" \
-      "--set" "${k}.config.gatewayBaseDomain=${AMP_HOST_GATEWAY}" \
-      "--set" "${k}.config.gatewayVhostScheme=https" \
-      "--set" "${k}.config.gatewayVhostPort=443"
-  done
+  printf '%s\n' \
+    "--set" "agentManagerService.config.serverPublicURL=https://${AMP_HOST_API}" \
+    "--set" "agentManagerService.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
+    "--set" "agentManagerService.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
+    "--set" "agentManagerService.config.keyManager.audience=urn:wso2:amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/mcp" \
+    "--set" "agentManagerService.config.thunder.baseURL=https://${AMP_HOST_THUNDER}" \
+    "--set" "agentManagerService.config.thunder.resolveToHost=amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090" \
+    "--set" "agentManagerService.config.tlsEnabled=true" \
+    "--set" "agentManagerService.config.idpHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
+    "--set" "agentManagerService.config.agentsBaseDomain=${AMP_AGENTS_BASE}" \
+    "--set-string" "agentManagerService.config.agentsHttpPort=443" \
+    "--set-string" "agentManagerService.config.agentsHttpsPort=443" \
+    "--set" "agentManagerService.config.gatewayBaseDomain=${AMP_HOST_GATEWAY}" \
+    "--set" "agentManagerService.config.gatewayVhostScheme=https" \
+    "--set-string" "agentManagerService.config.gatewayVhostPort=443"
 
   printf '%s\n' \
     "--set" "console.config.auth.baseUrl=https://${AMP_HOST_THUNDER}" \
@@ -79,11 +84,10 @@ amp_helm_args() {
     "--set" "agentManagerService.config.amObserverPublicURL=https://${AMP_HOST_OBSERVER}" \
     "--set" "console.config.instrumentationUrl=https://${AMP_HOST_GATEWAY}/otel" \
     "--set" "console.config.idpHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
-    "--set" "console.config.tlsEnabled=true"
+    "--set-string" "console.config.tlsEnabled=true"
 
   # Console and API are ClusterIP behind the OC control-plane kgateway; their
   # HTTPRoutes must match the public hosts Caddy forwards (Host is preserved).
-  # Older charts (agentManager key era) predate ocIngress and ignore these.
   printf '%s\n' \
     "--set" "console.ocIngress.hostname=${AMP_HOST_CONSOLE}" \
     "--set" "agentManagerService.ocIngress.hostname=${AMP_HOST_API}"

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -35,6 +35,10 @@ assert_eq() {
 # has <haystack> <needle> -> "yes" if needle present, else "no"
 # (-- so needles starting with '-' aren't parsed as grep options)
 has() { grep -qF -- "$2" <<<"$1" && echo yes || echo no; }
+# flag_for <helm-args> <key=value> -> the flag token emitted just before that
+# KEY=VALUE line. The builders print one token per line, so --set vs --set-string
+# (which decides whether helm coerces 443 to a number) is the preceding line.
+flag_for() { grep -B1 -F -- "$2" <<<"$1" | head -1; }
 
 # --- vm_host ---
 assert_eq "vm_host console" "console.amp.203.0.113.10.sslip.io" "$(vm_host console 203.0.113.10)"
@@ -42,13 +46,14 @@ assert_eq "vm_host thunder" "thunder.amp.203.0.113.10.sslip.io" "$(vm_host thund
 
 # --- build_amp_helm_args (external gateways on by default) ---
 amp="$(build_amp_helm_args 203.0.113.10 true)"
-# Service settings are emitted under BOTH chart keys (agentManager + agentManagerService).
+# Service settings are emitted under `agentManagerService` only. The chart's
+# values.schema.json sets additionalProperties:false at the root, so the legacy
+# pre-0.15.0 `agentManager` key fails the whole install rather than being ignored.
 assert_eq "amp serverPublicURL (service key)" \
   "agentManagerService.config.serverPublicURL=https://api.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.serverPublicURL' <<<"$amp")"
-assert_eq "amp serverPublicURL (legacy key)" \
-  "agentManager.config.serverPublicURL=https://api.amp.203.0.113.10.sslip.io" \
-  "$(grep -F 'agentManager.config.serverPublicURL' <<<"$amp")"
+assert_eq "amp emits no legacy agentManager key" "no" \
+  "$(has "$amp" 'agentManager.config.')"
 assert_eq "amp oauthAuthorizationServers (service key)" \
   "agentManagerService.config.oauthAuthorizationServers=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.oauthAuthorizationServers' <<<"$amp")"
@@ -62,16 +67,16 @@ assert_eq "amp keyManager.audience carries the public API URL (service key)" "ye
   "$(has "$amp" 'agentManagerService.config.keyManager.audience=urn:wso2:amp\,')"
 assert_eq "amp keyManager.audience ends with the public API URL (service key)" "yes" \
   "$(has "$amp" 'am-mcp\,https://api.amp.203.0.113.10.sslip.io/mcp')"
-assert_eq "amp keyManager.audience carries the public API URL (legacy key)" "yes" \
-  "$(has "$amp" 'agentManager.config.keyManager.audience=urn:wso2:amp\,')"
-# tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
-# emitted under both keys (old agentManager + new agentManagerService).
+# tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant.
+# The schema types the service-side flag as a boolean and the console-side one as a
+# string, so they must go out on different helm flags.
 assert_eq "amp tlsEnabled (service key)" \
   "agentManagerService.config.tlsEnabled=true" \
   "$(grep -F 'agentManagerService.config.tlsEnabled' <<<"$amp")"
-assert_eq "amp tlsEnabled (legacy key)" \
-  "agentManager.config.tlsEnabled=true" \
-  "$(grep -F 'agentManager.config.tlsEnabled' <<<"$amp")"
+assert_eq "amp tlsEnabled stays a boolean for the service" "--set" \
+  "$(flag_for "$amp" 'agentManagerService.config.tlsEnabled=true')"
+assert_eq "amp tlsEnabled is a string for the console" "--set-string" \
+  "$(flag_for "$amp" 'console.config.tlsEnabled=true')"
 assert_eq "amp console apiBaseUrl" \
   "console.config.apiBaseUrl=https://api.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'config.apiBaseUrl' <<<"$amp")"
@@ -124,6 +129,12 @@ assert_eq "amp gatewayVhostScheme (service key)" \
 assert_eq "amp gatewayVhostPort (service key)" \
   "agentManagerService.config.gatewayVhostPort=443" \
   "$(grep -F 'agentManagerService.config.gatewayVhostPort' <<<"$amp")"
+# The schema types all three ports as strings; plain --set would hand helm the
+# number 443 and fail validation before anything is installed.
+for port_key in agentsHttpPort agentsHttpsPort gatewayVhostPort; do
+  assert_eq "amp ${port_key} is set as a string" "--set-string" \
+    "$(flag_for "$amp" "agentManagerService.config.${port_key}=443")"
+done
 
 # --- build_amp_helm_args (external gateways disabled) ---
 amp_nocp="$(build_amp_helm_args 203.0.113.10 false)"
@@ -767,6 +778,68 @@ assert_eq "inotify watches floor"             "524288" "$(inotify_bump_target 81
   assert_eq "_public_ip offline exit status"  "0" "$rc"
   assert_eq "_public_ip offline output empty" ""  "$out"
 )
+
+# --- every builder's output passes the target chart's values.schema.json ---
+# The assertions above check the tokens; they cannot see that helm rejects them.
+# 1.0.0-rc3 shipped the first values.schema.json and its simple install failed at
+# the last step on a value type and a stale top-level key, so render each builder's
+# args against the in-repo charts. Rendering (not just linting) is what runs schema
+# validation, and it needs no cluster.
+if command -v helm >/dev/null 2>&1; then
+  CHARTS_DIR="$(cd "${SCRIPT_DIR}/../../helm-charts" && pwd)"
+  assert_schema_accepts() {
+    local label="$1" chart="$2" out; shift 2
+    if out="$(helm template schema-check "${CHARTS_DIR}/${chart}" "$@" 2>&1 >/dev/null)"; then
+      printf 'ok   - %s\n' "$label"
+    else
+      printf 'FAIL - %s\n%s\n' "$label" "$out"
+      echo 1 >>"$FAILLOG"
+    fi
+  }
+  (
+    IP=203.0.113.10
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_amp_helm_args "$IP" true)
+    assert_schema_accepts "amp args pass the chart schema" wso2-agent-manager "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_amp_helm_args "$IP" false)
+    assert_schema_accepts "amp args (no cp) pass the chart schema" wso2-agent-manager "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_thunder_helm_args "$IP")
+    assert_schema_accepts "thunder args pass the chart schema" wso2-amp-thunder-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_observability_helm_args "$IP")
+    assert_schema_accepts "observability args pass the chart schema" wso2-amp-observability-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_gateway_helm_args "$IP")
+    assert_schema_accepts "gateway args pass the chart schema" wso2-amp-api-platform-gateway-extension "${args[@]}"
+    AMP_AGENTS_BASE="agents.${IP}.sslip.io"
+    AMP_HOST_GATEWAY="$(vm_host gateway "$IP")"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_platform_resources_helm_args)
+    assert_schema_accepts "platform-resources args pass the chart schema" \
+      wso2-amp-platform-resources-extension "${args[@]}"
+  )
+  # The advanced installer calls the bare cores with derive_hosts' custom-domain
+  # hostnames instead of the sslip.io wrappers above, so cover that path too — a
+  # value added on only one of the two would otherwise ship unvalidated.
+  (
+    DOMAIN_BASE="amp.example.com"
+    AMP_HOST_CONSOLE="" AMP_HOST_API="" AMP_HOST_THUNDER="" AMP_HOST_OBSERVER=""
+    AMP_HOST_GATEWAY="" AMP_HOST_CP="" AMP_AGENTS_BASE=""
+    derive_hosts
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(amp_helm_args)
+    assert_schema_accepts "advanced amp args pass the chart schema" wso2-agent-manager "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(thunder_helm_args)
+    assert_schema_accepts "advanced thunder args pass the chart schema" \
+      wso2-amp-thunder-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(observability_helm_args)
+    assert_schema_accepts "advanced observability args pass the chart schema" \
+      wso2-amp-observability-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(gateway_helm_args)
+    assert_schema_accepts "advanced gateway args pass the chart schema" \
+      wso2-amp-api-platform-gateway-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_platform_resources_helm_args)
+    assert_schema_accepts "advanced platform-resources args pass the chart schema" \
+      wso2-amp-platform-resources-extension "${args[@]}"
+  )
+else
+  echo "skip - chart schema checks (helm not installed)"
+fi
 
 if [[ -s "$FAILLOG" ]]; then echo "TESTS FAILED"; exit 1; fi
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Purpose

`1.0.0-rc3` is the first release to ship a `values.schema.json` for the `wso2-agent-manager` chart. `deployments/vm/lib-vm.sh` predates it and was never updated, so every VM install now fails at the last step with four schema violations, before any resource is created:

```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
wso2-agent-manager:
- at '/agentManagerService/config': validation failed
  - at '/agentManagerService/config/gatewayVhostPort': got number, want string
  - at '/agentManagerService/config/agentsHttpsPort': got number, want string
  - at '/agentManagerService/config/agentsHttpPort': got number, want string
- at '/console/config/tlsEnabled': got boolean, want string
- at '': additional properties 'agentManager' not allowed
```

Both installers are affected — the simple and advanced paths share `amp_helm_args` — so this is a total VM install outage on any release carrying the schema, not an environment-specific failure.

No existing issue tracks this; it was found while installing from the published bundle.

## Goals

Make the VM installer's helm arguments conform to the chart's declared value contract, and close the test gap that let a whole-install failure ship: the existing assertions checked the emitted tokens and could not see helm rejecting them.

## Approach

Two changes in `amp_helm_args`, plus test coverage.

**Drop the legacy `agentManager` key.** The service config was emitted under both `agentManager` and `agentManagerService` as a version-skew hedge, on the theory that helm silently ignores keys a chart does not define. That only holds in the absence of a schema. The schema's root is `additionalProperties: false`, so the pre-0.15.0 key now fails the entire release rather than being ignored. Only `agentManagerService` is emitted.

**Use `--set-string` for the string-typed values.** The schema types `agentsHttpPort`, `agentsHttpsPort`, `gatewayVhostPort` and `console.config.tlsEnabled` as strings, which matches `values.yaml` (`"19080"`, `"443"`, `"false"`) and the templates that `| quote` them. Plain `--set` hands helm the number `443` and the boolean `true`. Note that `agentManagerService.config.tlsEnabled` is a genuine boolean in the schema and deliberately stays on `--set` — it is the one flag in this group that must not change.

The rendered ConfigMaps are byte-identical before and after, verified against the published rc3 chart, so this changes validation only and carries no behavioural risk.

**Tests.** `deployments/vm/tests/run.sh` now asserts which flag each value goes out on (a `flag_for` helper reads the token preceding each `KEY=VALUE` line), and a new group renders every builder's args against the in-repo charts. Rendering, not linting, is what runs schema validation, and it needs no cluster. The group covers both host-derivation paths — the sslip.io `build_*` wrappers used by the simple installer and `derive_hosts`' custom-domain hostnames used by the advanced one — so a value added to only one path cannot ship unvalidated.

## User stories

N/A — an installer defect with no user-facing feature change.

## Release note

Fixed the VM installer failing at the Agent Management Platform step because its Helm values did not conform to the `wso2-agent-manager` chart's values schema.

## Documentation

N/A — no documented behaviour, flag, or installation step changes. The VM install guide stays accurate as written.

## Training

N/A — no training content covers the VM installer internals.

## Certification

N/A — internal installer wiring, not exam material.

## Marketing

N/A — bug fix.

## Automation tests

- Unit tests
  > `bash deployments/vm/tests/run.sh` — all pass. Added: `--set-string` assertions for the three ports and the console TLS flag, a `--set` assertion pinning the service-side boolean, an assertion that no legacy `agentManager.config.` key is emitted, and 13 schema-render checks spanning `wso2-agent-manager`, `wso2-amp-thunder-extension`, `wso2-amp-observability-extension`, `wso2-amp-platform-resources-extension` and `wso2-amp-api-platform-gateway-extension` for both the simple and advanced host paths. Confirmed fail-first: the in-repo chart reproduces the exact rejection for the old-style args.
  > Note that no CI workflow currently runs this suite, which is why the defect reached a release. Wiring it in is left to a follow-up so this fix stays reviewable on its own.
- Integration tests
  > No automated integration coverage exists for the VM installer. Verified manually on a real cloud VM instead (see Test environment).

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — shell only, no Java in this change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no samples relate to installer helm arguments.

## Related PRs

None.

## Migrations (if applicable)

N/A — no data or resource migration. Existing installations are unaffected; this only changes how a fresh install passes values to helm.

## Test environment

Validated end to end on a fresh Google Cloud VM: Ubuntu 26.04.1 LTS, 4 vCPU, 7 GB RAM, 58 GB disk, Docker 29.7.2, k3d v5.9.0, kubectl v1.37.0, Helm v3.21.4.

Installed the published `1.0.0-rc3` bundle with only `lib-vm.sh` replaced by this version, confirming first that the shipped bundle carries the defect. All 13 steps completed, the Agent Management Platform step succeeded, and the install log contains no schema errors. The stored release values are correct: ports as `"443"` strings, `console.config.tlsEnabled: "true"` as a string, `agentManagerService.config.tlsEnabled: true` still boolean, and no `agentManager` key. The `amp-api` ConfigMap carries `AGENTS_HTTP_PORT`/`AGENTS_HTTPS_PORT`/`GATEWAY_VHOST_PORT` = `"443"` and `TLS_ENABLED` = `"true"`. All `wso2-amp` pods reached Running, certificates issued for all six fixed hosts, and the console served HTTP 200 over HTTPS with a valid certificate.

Schema conformance was additionally checked against the published rc3 charts for every chart the VM installer touches, in both simple and advanced modes, with external gateways both enabled and disabled.

## Learning

The failure mode is worth remembering: adding a `values.schema.json` to a chart retroactively tightens the contract for every existing caller, and helm's `--set` type inference (`443` becomes a number, `true` a boolean) makes a string-typed field an immediate schema violation. `--set-string` is the only way to pass a string that looks like a number or a boolean.

The related trap is that a chart with `additionalProperties: false` turns the common "emit both the old and new key so any chart version works" pattern from harmless into fatal. Any caller relying on helm ignoring unknown keys needs revisiting whenever a schema lands.

`helm template` against a chart directory runs full schema validation with no cluster, which makes this class of bug cheap to catch in a unit test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated VM deployment configuration to consistently target the current agent manager service.
  * Preserved correct value types for service ports and TLS settings during Helm configuration.
  * Improved deployment validation across standard and custom-domain configurations.
  * Added graceful handling when Helm is unavailable during optional validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->