### PR TITLE
Fall back to the gateway's public vhost when no runtimeUrl is registered

### DIFF
--- a/agent-manager-service/services/agent_configuration_proxy_url_test.go
+++ b/agent-manager-service/services/agent_configuration_proxy_url_test.go
@@ -93,7 +93,7 @@ func TestResourceIdentifierUnchangedByVhostScheme(t *testing.T) {
 	require.Equal(t, buildMCPProxyURL(prefixed, cfg), buildMCPProxyURL(bare, cfg))
 }
 
-func TestBuildInternalProxyURLUsesRuntimeURL(t *testing.T) {
+func TestBuildAgentProxyURLPrefersRuntimeURL(t *testing.T) {
 	// Plaintext http on a non-standard port: the scheme must survive verbatim.
 	gateway := &models.Gateway{
 		Vhost:      "https://dev-acme.gateway.example.com",
@@ -101,24 +101,25 @@ func TestBuildInternalProxyURLUsesRuntimeURL(t *testing.T) {
 	}
 	contextPath := "/llm/proxy"
 
-	withContext, err := buildInternalProxyURL(gateway, &contextPath)
-	require.NoError(t, err)
-	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy", withContext)
-
-	bare, err := buildInternalProxyURL(gateway, nil)
-	require.NoError(t, err)
-	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893", bare)
+	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy",
+		buildAgentProxyURL(gateway, &contextPath))
+	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893",
+		buildAgentProxyURL(gateway, nil))
 }
 
-func TestBuildInternalProxyURLRejectsMissingRuntimeURL(t *testing.T) {
-	// A gateway with no reachable in-cluster address must fail closed, never fall back
-	// to the vhost. Migration 038 only backfills "api-platform-" names, so this is live.
+func TestBuildAgentProxyURLFallsBackToVhostWithoutRuntimeURL(t *testing.T) {
+	// A gateway registered with no in-cluster address — every cloud gateway, since only the
+	// on-prem gateway extension chart POSTs a runtimeUrl. The agent reaches it over the same
+	// public host its MCP proxies already use, so this must not fail.
 	contextPath := "/llm/proxy"
 	empty := &models.Gateway{UUID: uuid.New(), Vhost: "https://gw.example.com"}
-	_, err := buildInternalProxyURL(empty, &contextPath)
-	require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
+	require.Equal(t, "https://gw.example.com/llm/proxy", buildAgentProxyURL(empty, &contextPath))
+	require.Equal(t, "https://gw.example.com", buildAgentProxyURL(empty, nil))
 
 	whitespace := &models.Gateway{UUID: uuid.New(), Vhost: "https://gw.example.com", RuntimeURL: "   "}
-	_, err = buildInternalProxyURL(whitespace, &contextPath)
-	require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
+	require.Equal(t, "https://gw.example.com/llm/proxy", buildAgentProxyURL(whitespace, &contextPath))
+
+	// A bare vhost still picks up the https default, as the public builder does.
+	bare := &models.Gateway{UUID: uuid.New(), Vhost: "gw.example.com"}
+	require.Equal(t, "https://gw.example.com/llm/proxy", buildAgentProxyURL(bare, &contextPath))
 }

--- a/agent-manager-service/services/agent_configuration_service.go
+++ b/agent-manager-service/services/agent_configuration_service.go
@@ -339,8 +339,8 @@ func ensureURLScheme(host string) string {
 
 // buildPublicProxyURL constructs the proxy base URL from the gateway's public vhost and
 // an optional context path. This is the address for callers outside the cluster, and for
-// MCP, whose URL doubles as the identity resource identifier. Platform-hosted agents get
-// buildInternalProxyURL instead — they reach the gateway in-cluster.
+// MCP, whose URL doubles as the identity resource identifier. Platform-hosted agents go
+// through buildAgentProxyURL, which prefers the in-cluster address where one exists.
 func buildPublicProxyURL(gateway *models.Gateway, contextPath *string) string {
 	base := ensureURLScheme(gateway.Vhost)
 	if contextPath != nil {
@@ -349,22 +349,25 @@ func buildPublicProxyURL(gateway *models.Gateway, contextPath *string) string {
 	return base
 }
 
-// errGatewayRuntimeURLUnregistered means the gateway has no in-cluster address recorded, so
-// no internal caller can reach it. Falling back to the public vhost would hairpin the caller
-// out through an ingress its NetworkPolicy denies, so this fails closed.
-var errGatewayRuntimeURLUnregistered = errors.New("gateway has no runtimeUrl registered")
-
-// buildInternalProxyURL constructs the proxy base URL from the gateway's in-cluster runtime
-// address, for callers that run inside the cluster.
-func buildInternalProxyURL(gateway *models.Gateway, contextPath *string) (string, error) {
+// buildAgentProxyURL constructs the proxy base URL to hand a platform-hosted agent: the
+// gateway's in-cluster runtime address when one is registered, otherwise its public vhost.
+//
+// The in-cluster address is preferred because a sandboxed pod's NetworkPolicy permits egress
+// to the gateway namespace and not out through the ingress, so hairpinning would be a dead
+// address. An unregistered runtimeUrl is not a misconfiguration to fail on, though: it is the
+// documented meaning of a NULL gateways.runtime_url — this gateway has no internal address.
+// The on-prem gateway extension chart always registers one, so those agents keep the
+// in-cluster path; cloud registers a vhost only, and its agents reach the gateway over that
+// public host exactly as the MCP proxies alongside them already do.
+func buildAgentProxyURL(gateway *models.Gateway, contextPath *string) string {
 	base := strings.TrimSpace(gateway.RuntimeURL)
 	if base == "" {
-		return "", fmt.Errorf("%w: %s", errGatewayRuntimeURLUnregistered, gateway.UUID)
+		return buildPublicProxyURL(gateway, contextPath)
 	}
 	if contextPath != nil {
-		return fmt.Sprintf("%s%s", base, *contextPath), nil
+		return fmt.Sprintf("%s%s", base, *contextPath)
 	}
-	return base, nil
+	return base
 }
 
 // buildLLMEnvVars constructs the two env vars (URL and API key) from the env config templates.
@@ -392,19 +395,15 @@ func buildLLMEnvVars(templates []EnvConfigTemplate, proxyURL, secretRefName stri
 	}
 }
 
-// internalLLMEnvVars builds a platform-hosted agent's LLM env vars against the gateway's
-// in-cluster address, the only one its pod can route to. Every LLM injection site goes
-// through here so the choice of address is made once rather than re-decided per site.
-// Its sibling buildMCPEnvVars still takes a plain URL: an MCP proxy's address is
-// legitimately public, since it doubles as the OAuth resource identifier.
-func internalLLMEnvVars(
+// agentLLMEnvVars builds a platform-hosted agent's LLM env vars against the address its pod
+// can route to. Every LLM injection site goes through here so the choice of address is made
+// once rather than re-decided per site. Its sibling buildMCPEnvVars still takes a plain URL:
+// an MCP proxy's address is legitimately public, since it doubles as the OAuth resource
+// identifier.
+func agentLLMEnvVars(
 	templates []EnvConfigTemplate, gateway *models.Gateway, contextPath *string, secretRefName string,
-) ([]client.EnvVar, error) {
-	proxyURL, err := buildInternalProxyURL(gateway, contextPath)
-	if err != nil {
-		return nil, err
-	}
-	return buildLLMEnvVars(templates, proxyURL, secretRefName), nil
+) []client.EnvVar {
+	return buildLLMEnvVars(templates, buildAgentProxyURL(gateway, contextPath), secretRefName)
 }
 
 func buildMCPEnvVars(templates []EnvConfigTemplate, proxyURL, secretRefName string) []client.EnvVar {
@@ -1323,12 +1322,7 @@ func (s *agentConfigurationService) createLLMConfig(ctx context.Context, ouID, p
 		// first-environment's vars to avoid last-write-wins clobbering (HIGH-3).
 		if !isExternalAgent {
 			// Build the two env vars (URL plain, API key via secretKeyRef).
-			envVarsToInject, urlErr := internalLLMEnvVars(envConfigTemplates, gateway, proxyContext, secretRefName)
-			if urlErr != nil {
-				s.rollbackProxies(ctx, rollbackResources, ouID)
-				s.compensatingDeleteConfig(ctx, config.UUID, ouID)
-				return nil, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
-			}
+			envVarsToInject := agentLLMEnvVars(envConfigTemplates, gateway, proxyContext, secretRefName)
 
 			// Step 3: Inject per-environment URL and API key ref into the ReleaseBinding.
 			// Each environment gets its own ReleaseBinding with the correct per-env proxy URL,
@@ -1952,10 +1946,7 @@ func (s *agentConfigurationService) processEnvProviderChange(
 	// but a bootstrap default is last-write-wins across environments. The Component CR write is
 	// therefore scoped to the first environment, matching every other injection site in this file.
 	if !isExternalAgent {
-		envVarsToInject, urlErr := internalLLMEnvVars(envConfigTemplates, gateway, proxy.Configuration.Context, secretRefName)
-		if urlErr != nil {
-			return "", rbRes, pendingAppBinding{}, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
-		}
+		envVarsToInject := agentLLMEnvVars(envConfigTemplates, gateway, proxy.Configuration.Context, secretRefName)
 		if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); rbErr != nil {
 			s.logger.Error("failed to patch ReleaseBinding in Scenario A", "env", envName, "err", rbErr)
 			return "", rbRes, pendingAppBinding{}, fmt.Errorf("failed to update release binding env vars for environment %s: %w", envName, rbErr)
@@ -2232,11 +2223,7 @@ func (s *agentConfigurationService) processNewEnv(
 	// last-write-wins clobbering across multiple environments (HIGH-3).
 	if !isExternalAgent {
 		// Reuse the gateway already resolved for deployment (resolveGatewayForProvider)
-		envVarsToInject, urlErr := internalLLMEnvVars(envConfigTemplates, gateway, proxy.Configuration.Context, secretRefName)
-		if urlErr != nil {
-			s.rollbackProxies(ctx, []rollbackResource{rbRes}, ouID)
-			return rollbackResource{}, pendingAppBinding{}, fmt.Errorf("failed to resolve internal proxy URL for environment %s: %w", envName, urlErr)
-		}
+		envVarsToInject := agentLLMEnvVars(envConfigTemplates, gateway, proxy.Configuration.Context, secretRefName)
 		// Inject per-env URL into the ReleaseBinding for this specific environment.
 		if rbErr := s.ocClient.UpdateReleaseBindingEnvVars(ctx, ouID, config.ProjectName, config.AgentID, envName, envVarsToInject); rbErr != nil {
 			s.logger.Warn("failed to patch ReleaseBinding in Scenario C", "env", envName, "err", rbErr)
@@ -3271,11 +3258,7 @@ func (s *agentConfigurationService) Update(ctx context.Context, configUUID uuid.
 								s.logger.Warn("Phase 1b: no persisted SecretReference found, skipping re-injection", "environment", envName)
 								continue
 							}
-							envVarsToInject, urlErr := internalLLMEnvVars(newEnvConfigTemplates, gateway, mapping.LLMProxy.Configuration.Context, secretRefName)
-							if urlErr != nil {
-								s.logger.Warn("Phase 1b: failed to resolve internal proxy URL for re-injection", "environment", envName, "err", urlErr)
-								continue
-							}
+							envVarsToInject := agentLLMEnvVars(newEnvConfigTemplates, gateway, mapping.LLMProxy.Configuration.Context, secretRefName)
 							s.logger.Info("Phase 1b: atomically replacing env vars in ReleaseBinding",
 								"environment", envName, "keysToRemove", changedOldKeys, "envVarsToAdd", len(envVarsToInject))
 							if rbErr := s.ocClient.ReplaceReleaseBindingEnvVars(ctx, ouID, projectName, agentName, envName, changedOldKeys, envVarsToInject); rbErr != nil {
@@ -5741,7 +5724,7 @@ func (s *agentConfigurationService) systemManagedLLMURL(
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve gateway for LLM proxy in %s: %w", environmentName, err)
 	}
-	return buildInternalProxyURL(gateway, mapping.LLMProxy.Configuration.Context)
+	return buildAgentProxyURL(gateway, mapping.LLMProxy.Configuration.Context), nil
 }
 
 // systemManagedMCPURL returns the PUBLIC address for the config's MCP proxy. Unlike its LLM

--- a/agent-manager-service/services/agent_configuration_system_managed_test.go
+++ b/agent-manager-service/services/agent_configuration_system_managed_test.go
@@ -177,16 +177,18 @@ func TestSystemManagedLLMURLUsesGatewayRuntimeURL(t *testing.T) {
 	require.Equal(t, "http://api-platform-acme-dev-gw-gateway-gateway-runtime.acme-dev:22893/llm/proxy", url)
 }
 
-// TestSystemManagedLLMURLFailsClosedWithoutRuntimeURL guards the fallback: a gateway with no
-// in-cluster address must abort the injection rather than hand the pod a vhost it cannot reach.
-func TestSystemManagedLLMURLFailsClosedWithoutRuntimeURL(t *testing.T) {
+// TestSystemManagedLLMURLFallsBackToVhostWithoutRuntimeURL covers the cloud gateway: nothing
+// registers a runtimeUrl there, and the pod reaches the gateway over the public vhost, so the
+// injection must resolve rather than abort.
+func TestSystemManagedLLMURLFallsBackToVhostWithoutRuntimeURL(t *testing.T) {
 	gateway := newGateway(t, models.GatewayRoleEgress, true)
 	gateway.Vhost = "https://gateway.example.com"
 	gateway.RuntimeURL = ""
 
-	_, err := callSystemManagedLLMURL(t, gateway, "/llm/proxy")
+	url, err := callSystemManagedLLMURL(t, gateway, "/llm/proxy")
 
-	require.ErrorIs(t, err, errGatewayRuntimeURLUnregistered)
+	require.NoError(t, err)
+	require.Equal(t, "https://gateway.example.com/llm/proxy", url)
 }
 
 // callSystemManagedLLMURL resolves the LLM URL for a config whose single mapping is deployed


### PR DESCRIPTION
## Purpose
Attaching an LLM config to an agent fails in cloud with:

```
failed to resolve internal proxy URL for environment development:
gateway has no runtimeUrl registered .....
```

`buildInternalProxyURL` fails closed when `gateways.runtime_url` is empty, aborting the whole create and rolling it back. Only the on-prem `wso2-amp-api-platform-gateway-extension` chart ever supplies that value; the cloud registration payload has no `runtimeUrl` field at all, and migration 038's backfill only matches gateway names prefixed `api-platform-`, which cloud names never are. So every cloud gateway has an empty `runtime_url` and every LLM-config attach fails.

Resolves: _<issue link>_

## Goals
Let platform-hosted agents resolve an LLM proxy address on both deployments, without regressing the in-cluster routing on-prem sandboxed agents depend on.

## Approach
`buildInternalProxyURL` / `internalLLMEnvVars` become `buildAgentProxyURL` / `agentLLMEnvVars`, which prefer the gateway's `runtimeUrl` and fall back to its public vhost when there is none — the documented meaning of a NULL `gateways.runtime_url` ("consumers fall back to vhost"). The four LLM injection sites plus `systemManagedLLMURL` drop their now-dead error branches.

On-prem always registers a `runtimeUrl`, so those agents keep the in-cluster address their sandbox NetworkPolicy requires; cloud never does, so its agents use the public vhost — the same host their MCP proxies already use.

## User stories
As a cloud user, I can attach an LLM configuration to an agent and have it deploy successfully.

## Release note
Fixed LLM configuration attachment failing with "gateway has no runtimeUrl registered" on deployments where gateways are registered without an in-cluster runtime address.

## Documentation
N/A 

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- **Unit tests** —  Rewrote `TestBuildAgentProxyURL{PrefersRuntimeURL,FallsBackToVhostWithoutRuntimeURL}` and `TestSystemManagedLLMURLFallsBackToVhostWithoutRuntimeURL`, covering runtimeUrl present, empty, whitespace-only, and bare-vhost-defaults-to-https.
- **Integration tests** — none added

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** (Go; `golangci-lint` with the repo CI config reports nothing on the changed files)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Migrations (if applicable)
None.

## Test environment
Go 1.26.6, macOS