### PR TITLE
Fix trace and dataset loading on non-UTF-8 platforms

### DIFF
--- a/libs/amp-evaluation/src/amp_evaluation/dataset/loader.py
+++ b/libs/amp-evaluation/src/amp_evaluation/dataset/loader.py
@@ -83,7 +83,7 @@ def load_dataset_from_json(json_path: str) -> Dataset:
         >>> dataset = load_dataset_from_json("benchmarks/my_dataset.json")
     """
     path = Path(json_path)
-    with open(path, "r") as f:
+    with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
     return parse_dataset_dict(data)
@@ -350,7 +350,7 @@ def load_dataset_from_csv(csv_path: str, name: Optional[str] = None) -> Dataset:
 def save_dataset_to_json(dataset: Dataset, path: str, indent: int = 2):
     """Save Dataset object to JSON file."""
     data = dataset_to_dict(dataset)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=indent)
 
 

--- a/libs/amp-evaluation/src/amp_evaluation/trace/fetcher.py
+++ b/libs/amp-evaluation/src/amp_evaluation/trace/fetcher.py
@@ -711,7 +711,7 @@ class TraceLoader:
             return []
 
         try:
-            with open(self.file_path, "r") as f:
+            with open(self.file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
 
                 # Handle different JSON structures

--- a/libs/amp-evaluation/tests/test_file_encoding.py
+++ b/libs/amp-evaluation/tests/test_file_encoding.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Regression tests for JSON file encoding.
+
+JSON is UTF-8 by specification (RFC 8259), but ``open()`` without an explicit
+``encoding`` decodes using the platform default instead. On Windows that default
+is the legacy ANSI code page (cp1252), so loading a trace or dataset file
+containing non-ASCII text raised ``UnicodeDecodeError`` and made every
+file-based flow unusable there.
+
+Two kinds of assertions are used, deliberately:
+
+* Round-trip tests read back non-ASCII content. These fail on cp1252 platforms
+  but pass everywhere on a UTF-8 default locale, so on Linux CI they alone are
+  not enough to catch a regression.
+* Spy tests assert the loaders pass ``encoding="utf-8"`` explicitly. These are
+  platform-independent and fail on any OS if the argument is dropped again.
+"""
+
+import builtins
+import json
+
+import pytest
+
+from amp_evaluation.dataset import load_dataset_from_json, save_dataset_to_json
+from amp_evaluation.trace.fetcher import TraceLoader
+
+# UTF-8 encodes these as e3 81 93 ... — byte 0x81 is undefined in cp1252, so a
+# non-UTF-8 read raises rather than silently mojibaking the text.
+NON_ASCII = "こんにちは"
+
+
+@pytest.fixture
+def open_spy(monkeypatch):
+    """Record the keyword arguments of every ``builtins.open`` call."""
+    real_open = builtins.open
+    calls = []
+
+    def spy(file, *args, **kwargs):
+        calls.append((str(file), kwargs))
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", spy)
+    return calls
+
+
+def encodings_used_for(calls, path):
+    """Encodings that ``open`` was called with for ``path``."""
+    return [kwargs.get("encoding") for opened, kwargs in calls if opened == str(path)]
+
+
+def write_utf8_json(path, payload):
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def dataset_payload():
+    return {
+        "schema_version": "1.0",
+        "metadata": {"name": NON_ASCII, "description": f"dataset about {NON_ASCII}"},
+        "tasks": [{"task_id": "task_001", "input": NON_ASCII, "expected_output": NON_ASCII}],
+    }
+
+
+class TestDatasetJsonEncoding:
+    """load_dataset_from_json / save_dataset_to_json must use UTF-8."""
+
+    def test_load_reads_non_ascii_content(self, tmp_path):
+        path = write_utf8_json(tmp_path / "dataset.json", dataset_payload())
+
+        dataset = load_dataset_from_json(str(path))
+
+        assert dataset.name == NON_ASCII
+        assert dataset.tasks[0].input == NON_ASCII
+
+    def test_load_requests_utf8_explicitly(self, tmp_path, open_spy):
+        path = write_utf8_json(tmp_path / "dataset.json", dataset_payload())
+
+        load_dataset_from_json(str(path))
+
+        assert encodings_used_for(open_spy, path) == ["utf-8"]
+
+    def test_save_round_trips_non_ascii(self, tmp_path):
+        source = write_utf8_json(tmp_path / "dataset.json", dataset_payload())
+        dataset = load_dataset_from_json(str(source))
+        target = tmp_path / "saved.json"
+
+        save_dataset_to_json(dataset, str(target))
+
+        assert load_dataset_from_json(str(target)).tasks[0].input == NON_ASCII
+
+    def test_save_requests_utf8_explicitly(self, tmp_path, open_spy):
+        source = write_utf8_json(tmp_path / "dataset.json", dataset_payload())
+        dataset = load_dataset_from_json(str(source))
+        target = tmp_path / "saved.json"
+
+        save_dataset_to_json(dataset, str(target))
+
+        assert encodings_used_for(open_spy, target) == ["utf-8"]
+
+
+def trace_payload():
+    """A minimal trace in the shape TraceLoader parses, with non-ASCII text."""
+    span = {
+        "traceId": "abc123",
+        "spanId": "span001",
+        "name": "chat",
+        "service": "support-agent",
+        "startTime": "2026-01-01T00:00:00Z",
+        "endTime": "2026-01-01T00:00:01Z",
+        "durationInNanos": 1_000_000_000,
+        "ampAttributes": {"kind": "agent", "input": NON_ASCII, "output": NON_ASCII},
+    }
+    return [
+        {
+            "traceId": "abc123",
+            "rootSpanId": "span001",
+            "rootSpanName": NON_ASCII,
+            "startTime": "2026-01-01T00:00:00Z",
+            "endTime": "2026-01-01T00:00:01Z",
+            "spans": [span],
+        }
+    ]
+
+
+class TestTraceLoaderEncoding:
+    """TraceLoader reads trace files exported by the platform, which are UTF-8."""
+
+    def test_load_traces_reads_non_ascii_content(self, tmp_path):
+        path = write_utf8_json(tmp_path / "traces.json", trace_payload())
+
+        loaded = TraceLoader(file_path=str(path)).load_traces()
+
+        assert loaded[0].rootSpanName == NON_ASCII
+        assert loaded[0].spans[0].ampAttributes.input == NON_ASCII
+
+    def test_load_traces_requests_utf8_explicitly(self, tmp_path, open_spy):
+        path = write_utf8_json(tmp_path / "traces.json", trace_payload())
+
+        TraceLoader(file_path=str(path)).load_traces()
+
+        assert encodings_used_for(open_spy, path) == ["utf-8"]


### PR DESCRIPTION
## Purpose
JSON is UTF-8 by specification (RFC 8259), but `open()` without an explicit `encoding` decodes using the platform default. On Windows that default is the legacy ANSI code page (cp1252), so every file-based flow in the evaluation SDK fails as soon as a trace or dataset contains non-ASCII text.

Running the in-repo sample against the in-repo fixtures reproduces it directly:

```
$ python samples/10-experiment-with-dataset/run_with_traces.py
  File "src/amp_evaluation/trace/fetcher.py", line 715, in _load_traces_from_file
    data = json.load(f)
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 959944: character maps to <undefined>
```

There is no existing issue for this — I hit it while prototyping the evaluation SDK CLI (#273), for which it is a blocker, since a CLI is the most likely part of the SDK to be run on a Windows laptop. Happy to file a tracking issue first if that is preferred.

## Goals
Make trace and dataset files load and save as UTF-8 on every platform, so offline evaluation works regardless of the host's default code page.

## Approach
Three JSON file sites were opened without an explicit encoding and now pass `encoding="utf-8"`:

- `TraceLoader._load_traces_from_file` (`trace/fetcher.py`)
- `load_dataset_from_json` (`dataset/loader.py`)
- `save_dataset_to_json` (`dataset/loader.py`)

This is an oversight rather than a deliberate choice: `load_dataset_from_csv` in the same module already opens with `encoding="utf-8"`, so the convention was established and these three sites missed it.

Reads are what break today. The write is included so that a later switch to `ensure_ascii=False` cannot reintroduce the same failure on the way out.

Behaviour on a UTF-8 default locale, which is what CI runs, is unchanged.

## User stories
As a developer evaluating agent traces locally on Windows, I want to load trace and dataset files containing non-ASCII text, so that I can run offline evaluations without the SDK crashing.

## Release note
Fixed trace and dataset file loading failing with `UnicodeDecodeError` on platforms whose default encoding is not UTF-8, such as Windows.

## Documentation
N/A — no user-facing behaviour changes on UTF-8 platforms, and no documented API or option is added or altered.

## Training
N/A

## Certification
N/A — a platform-portability bug fix with no conceptual or feature surface.

## Marketing
N/A

## Automation tests
- Unit tests
  > 6 new tests in `libs/amp-evaluation/tests/test_file_encoding.py`. Full suite goes from 722 to **728 passed, 25 skipped**.
  >
  > The tests assert this two ways on purpose. **Round-trip tests** read back Japanese text, whose UTF-8 encoding contains byte `0x81` — undefined in cp1252, so it raises rather than silently mojibaking; these reproduce the reported failure but pass on any UTF-8 platform. **Spy tests** additionally assert the loaders pass `encoding="utf-8"` explicitly, which fails on every OS if the argument is dropped again. Without the second kind this regression would stay invisible to Linux CI.
  >
  > Verified by reverting the fix: all 6 fail on Windows, and the 3 spy tests fail even under a UTF-8 default locale.
- Integration tests
  > N/A — the change is confined to file I/O in the Python SDK, covered at unit level.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs is a Java/SpotBugs plugin; this is Python. `ruff` and `mypy` were run instead, both clean.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
`samples/10-experiment-with-dataset/run_with_traces.py` was the reproducer and now completes on Windows: 14 traces loaded, 3 evaluators run, 0 errors.

## Related PRs
None. Related issue: #273 (evaluation SDK CLI), which this unblocks.

## Migrations (if applicable)
N/A

## Test environment
- OS: Windows 11 (10.0.26200)
- Python: 3.13.7
- Checks run locally, matching `amp-evaluation-package-pr-checks.yaml`: `ruff check` (0.15.22) clean, `ruff format --check` clean, `mypy src` clean across 25 source files, `pytest` 728 passed / 25 skipped.
- CI additionally covers Python 3.10–3.13 on Linux.

## Learning
Python's `open()` inherits `locale.getpreferredencoding()` when no encoding is given, which is why this class of bug is invisible on Linux and macOS but fatal on Windows. PEP 540 (UTF-8 mode) and PEP 686 (making UTF-8 mode the default in a future Python) exist precisely because of it; `PYTHONUTF8=1` is the workaround, and an explicit `encoding=` is the fix. The two-tier test approach came from noticing that a naive round-trip test would pass on this project's Linux CI whether or not the fix was present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when reading and writing datasets and traces containing non-ASCII characters by consistently using UTF-8 encoding.

* **Tests**
  * Added regression coverage for UTF-8 data handling across dataset and trace file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->