### PR TITLE
Enable AgentID support in Agent Manager SAAS

### DIFF
--- a/agent-manager-service/app/app.go
+++ b/agent-manager-service/app/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/audit"
 	occlient "github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
+	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/config"
 	"github.com/wso2/agent-manager/agent-manager-service/db"
 	dbmigrations "github.com/wso2/agent-manager/agent-manager-service/db_migrations"
@@ -62,6 +63,13 @@ type Options struct {
 	// default) preserves the script-driven behavior; cloud deployments inject an
 	// implementation. See services.GatewayConfigApplier.
 	GatewayConfigApplier services.GatewayConfigApplier
+	// EnvThunderEndpointResolver optionally separates environment-Thunder
+	// management and OAuth endpoints. nil preserves on-premises behavior. Run
+	// automatically applies it to endpoint-aware provisioning implementations.
+	EnvThunderEndpointResolver thundersvc.EnvThunderEndpointResolver
+	// BackgroundContextDecorator optionally marks contexts created for trusted
+	// background workers. Request contexts never pass through this hook.
+	BackgroundContextDecorator func(context.Context) context.Context
 	// AgentThunderProvisioning is the deployment-specific AgentID provisioning
 	// implementation. A factory because the open-source impl is DB-backed and the
 	// DB is initialized inside Run. nil disables provisioning (identity endpoints
@@ -155,9 +163,12 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 			os.Exit(1)
 		}
 		agentThunderProvisioning = opts.AgentThunderProvisioning(database, secretMgmtClientForProvisioning, ocClientForProvisioning, encryptionKey)
+		if setter, ok := agentThunderProvisioning.(services.EnvThunderEndpointResolverSetter); ok {
+			setter.SetEnvThunderEndpointResolver(opts.EnvThunderEndpointResolver)
+		}
 	}
 
-	dependencies, err := wiring.InitializeAppParams(cfg, database, authProvider, secretProvider, opts.GatewayConfigApplier, agentThunderProvisioning, opts.BuildSecretProvisioner)
+	dependencies, err := wiring.InitializeAppParamsWithEnvThunderEndpoints(cfg, database, authProvider, secretProvider, opts.GatewayConfigApplier, agentThunderProvisioning, opts.BuildSecretProvisioner, opts.EnvThunderEndpointResolver)
 	if err != nil {
 		slog.Error("failed to initialize app dependencies", "error", err)
 		os.Exit(1)
@@ -183,6 +194,9 @@ func Run(authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Pro
 	// be lost — silently, which is the failure mode a context-carried recorder
 	// is most prone to.
 	backgroundCtx := audit.WithRecorder(context.Background(), dependencies.AuditRecorder)
+	if opts.BackgroundContextDecorator != nil {
+		backgroundCtx = opts.BackgroundContextDecorator(backgroundCtx)
+	}
 
 	// So a rotated agent's deferred pod rollout (see RefreshAfterRotation)
 	// stops waiting, or aborts an in-flight roll, once shutdown starts below

--- a/agent-manager-service/clients/thundersvc/client.go
+++ b/agent-manager-service/clients/thundersvc/client.go
@@ -87,18 +87,17 @@ type ThunderClient interface {
 }
 
 type thunderClient struct {
-	baseURL      string // Thunder API base URL (e.g. http://thunder:8090)
-	clientID     string // OAuth2 client ID of the system app (with Administrator role)
-	clientSecret string // OAuth2 client secret of the system app
-	// systemResource is the resource indicator (RFC 8707) sent with the client_credentials
-	// token request so the issued token is scoped to Thunder's built-in System resource
-	// server (identifier "<issuer>/mcp"), which owns the "system" permission. Admin APIs
-	// (/users, /applications, ...) require that permission, granted only when the token
-	// is scoped to the System RS. Without this, the server-wide default resource server
-	// (amp-resource-server) resolves the request instead, the "system" scope is dropped,
-	// and every admin call fails with AUTH-4030 Forbidden.
-	systemResource string
-	httpClient     *http.Client
+	baseURL          string // Thunder management API base URL (e.g. http://thunder:8090)
+	tokenURL         string // Complete OAuth2 token endpoint URL
+	clientID         string // OAuth2 client ID of the system app (with Administrator role)
+	clientSecret     string // OAuth2 client secret of the system app
+	systemTokenScope string
+	// systemResource is the optional RFC 8707 resource indicator sent with the
+	// system client token request. Empty deliberately lets Thunder select its
+	// configured default resource server.
+	systemResource  string
+	httpClient      *http.Client
+	tokenHTTPClient *http.Client
 
 	mu          sync.RWMutex
 	cachedToken string
@@ -125,12 +124,16 @@ func SystemResourceIdentifier(issuerURL string) string {
 // baseURL is the platform Thunder public/issuer URL, so it also derives the System
 // resource indicator used to obtain system-scoped tokens.
 func NewThunderClient(baseURL, clientID, clientSecret string) ThunderClient {
+	httpClient := &http.Client{Timeout: httpClientTimeout}
 	return &thunderClient{
-		baseURL:        baseURL,
-		clientID:       clientID,
-		clientSecret:   clientSecret,
-		systemResource: SystemResourceIdentifier(baseURL),
-		httpClient:     &http.Client{Timeout: httpClientTimeout},
+		baseURL:          baseURL,
+		tokenURL:         strings.TrimRight(baseURL, "/") + "/oauth2/token",
+		clientID:         clientID,
+		clientSecret:     clientSecret,
+		systemTokenScope: "system",
+		systemResource:   SystemResourceIdentifier(baseURL),
+		httpClient:       httpClient,
+		tokenHTTPClient:  httpClient,
 	}
 }
 
@@ -189,12 +192,67 @@ func newThunderClientWithDialOverride(baseURL, clientID, clientSecret, resolveTo
 		httpClient = ssrf.NewClient(httpClientTimeout)
 	}
 	return &thunderClient{
-		baseURL:        baseURL,
-		clientID:       clientID,
-		clientSecret:   clientSecret,
-		systemResource: systemResource,
-		httpClient:     httpClient,
+		baseURL:          baseURL,
+		tokenURL:         strings.TrimRight(baseURL, "/") + "/oauth2/token",
+		clientID:         clientID,
+		clientSecret:     clientSecret,
+		systemTokenScope: "system",
+		systemResource:   systemResource,
+		httpClient:       httpClient,
+		tokenHTTPClient:  httpClient,
 	}
+}
+
+// NewEnvThunderClientWithEndpoints creates a client whose management and token
+// traffic may use different endpoints. Existing constructors remain unchanged.
+func NewEnvThunderClientWithEndpoints(endpoints EnvThunderEndpoints, clientID, clientSecret string) (ThunderClient, error) {
+	managementURL := strings.TrimRight(strings.TrimSpace(endpoints.ManagementURL), "/")
+	tokenURL := strings.TrimSpace(endpoints.TokenURL)
+	if managementURL == "" || tokenURL == "" || strings.TrimSpace(endpoints.SystemTokenScope) == "" {
+		return nil, fmt.Errorf("management URL, token URL, and system token scope are required")
+	}
+	if err := validateThunderEndpointURL(managementURL); err != nil {
+		return nil, fmt.Errorf("invalid management URL: %w", err)
+	}
+	if err := validateThunderEndpointURL(tokenURL); err != nil {
+		return nil, fmt.Errorf("invalid token URL: %w", err)
+	}
+	managementURL, managementClient := thunderEndpointHTTPClient(managementURL, endpoints.ManagementResolveToHost, endpoints.ManagementURLTrusted)
+	tokenURL, tokenClient := thunderEndpointHTTPClient(tokenURL, endpoints.TokenResolveToHost, endpoints.TokenURLTrusted)
+	return &thunderClient{
+		baseURL: managementURL, tokenURL: tokenURL,
+		clientID: clientID, clientSecret: clientSecret,
+		systemTokenScope: endpoints.SystemTokenScope, systemResource: endpoints.SystemTokenResource,
+		httpClient: managementClient, tokenHTTPClient: tokenClient,
+	}, nil
+}
+
+func validateThunderEndpointURL(endpoint string) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return fmt.Errorf("must be an absolute HTTP(S) URL")
+	}
+	if parsed.User != nil || parsed.Fragment != "" {
+		return fmt.Errorf("must not contain user information or a fragment")
+	}
+	return nil
+}
+
+func thunderEndpointHTTPClient(endpoint, resolveToHost string, trusted bool) (string, *http.Client) {
+	httpClient := &http.Client{Timeout: httpClientTimeout}
+	if resolveToHost != "" {
+		httpClient.Transport = &http.Transport{DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, resolveToHost)
+		}}
+		endpoint = "http://" + strings.TrimPrefix(strings.TrimPrefix(endpoint, "https://"), "http://")
+	} else if !trusted {
+		httpClient = ssrf.NewClient(httpClientTimeout)
+	}
+	return endpoint, httpClient
 }
 
 // getSystemToken returns a cached system token or fetches a new one.
@@ -244,13 +302,12 @@ func (c *thunderClient) getSystemToken(ctx context.Context) (string, error) {
 	return result.(string), nil
 }
 
-// fetchSystemToken obtains a system-scoped access token from Thunder's OAuth2 token endpoint
-// using client_credentials grant with scope=system.
-// The system app must have the Administrator role assigned in Thunder.
+// fetchSystemToken obtains a management token from the configured OAuth2 token
+// endpoint using client_credentials and the deployment's system scope/resource.
 func (c *thunderClient) fetchSystemToken(ctx context.Context) (string, int, error) {
 	data := url.Values{
 		"grant_type": {"client_credentials"},
-		"scope":      {"system"},
+		"scope":      {c.systemTokenScope},
 	}
 	// Scope the token to Thunder's System resource server when the deployment has one.
 	// An empty value deliberately omits the RFC 8707 resource parameter so Thunder can
@@ -260,14 +317,14 @@ func (c *thunderClient) fetchSystemToken(ctx context.Context) (string, int, erro
 		data.Set("resource", c.systemResource)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/oauth2/token", strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tokenURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", 0, fmt.Errorf("thunder token request build: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(c.clientID, c.clientSecret)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.tokenHTTPClient.Do(req)
 	if err != nil {
 		return "", 0, fmt.Errorf("thunder token request: %w", err)
 	}

--- a/agent-manager-service/clients/thundersvc/env_endpoints.go
+++ b/agent-manager-service/clients/thundersvc/env_endpoints.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License, Version 2.0.
+
+package thundersvc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// EnvThunderEndpoints describes how Agent Manager reaches one environment's
+// Thunder instance. Management and OAuth token traffic normally share one
+// endpoint, but deployments may route them separately.
+type EnvThunderEndpoints struct {
+	ManagementURL           string
+	ManagementResolveToHost string
+	// ManagementURLTrusted permits direct access to a deployment-controlled
+	// internal endpoint. The safe zero value applies SSRF protection.
+	ManagementURLTrusted bool
+	TokenURL             string
+	TokenResolveToHost   string
+	// TokenURLTrusted permits direct access to a deployment-controlled token
+	// endpoint. Leave false for URLs derived from stored or user-supplied data.
+	TokenURLTrusted     bool
+	SystemTokenScope    string
+	SystemTokenResource string
+}
+
+// EnvThunderEndpointResolver is the deployment seam for selecting Thunder
+// management and token endpoints. The default implementation preserves the
+// existing on-premises URL probing and token semantics.
+type EnvThunderEndpointResolver interface {
+	ResolveEndpoints(ctx context.Context, ouID, orgNamespace, envName, storedURL string, callerSupplied bool) (EnvThunderEndpoints, error)
+}
+
+type defaultEnvThunderEndpointResolver struct {
+	resolveBaseURL resolveBaseURLFunc
+}
+
+// DefaultEnvThunderEndpointResolver returns the standard on-premises resolver.
+func DefaultEnvThunderEndpointResolver() EnvThunderEndpointResolver {
+	return defaultEnvThunderEndpointResolver{resolveBaseURL: ResolveThunderBaseURL}
+}
+
+func (r defaultEnvThunderEndpointResolver) ResolveEndpoints(ctx context.Context, _ string, orgNamespace, envName, storedURL string, callerSupplied bool) (EnvThunderEndpoints, error) {
+	baseURL, resolveToHost, ok := r.resolveBaseURL(ctx, orgNamespace, envName, storedURL, callerSupplied)
+	if !ok {
+		return EnvThunderEndpoints{}, fmt.Errorf("%w: %s/%s", ErrThunderUnreachable, orgNamespace, envName)
+	}
+	directCallerSupplied := callerSupplied && resolveToHost == "" && baseURL == storedURL
+	return EnvThunderEndpoints{
+		ManagementURL:           strings.TrimRight(baseURL, "/"),
+		ManagementResolveToHost: resolveToHost,
+		ManagementURLTrusted:    !directCallerSupplied,
+		TokenURL:                strings.TrimRight(baseURL, "/") + "/oauth2/token",
+		TokenResolveToHost:      resolveToHost,
+		TokenURLTrusted:         !directCallerSupplied,
+		SystemTokenScope:        "system",
+		SystemTokenResource:     SystemResourceIdentifier(ThunderIssuerURL(storedURL)),
+	}, nil
+}
+
+// ResolveEnvThunderTokenEndpoint resolves the token URL used inside an agent
+// workload without reading or exposing the environment's system credential.
+func ResolveEnvThunderTokenEndpoint(ctx context.Context, endpointResolver EnvThunderEndpointResolver, readThunderURL ReadThunderURLFunc, ouID, orgNamespace, envName string) (string, error) {
+	if endpointResolver == nil {
+		endpointResolver = DefaultEnvThunderEndpointResolver()
+	}
+	storedURL, callerSupplied, err := readThunderURL(ctx, ouID, envName)
+	if err != nil {
+		return "", fmt.Errorf("failed to read env-thunder url for %s/%s: %w", ouID, envName, err)
+	}
+	if storedURL == "" {
+		return "", ErrThunderNotProvisioned
+	}
+	endpoints, err := endpointResolver.ResolveEndpoints(ctx, ouID, orgNamespace, envName, storedURL, callerSupplied)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(endpoints.TokenURL) == "" {
+		return "", fmt.Errorf("env-thunder token URL is empty for %s/%s", ouID, envName)
+	}
+	if err := validateThunderEndpointURL(endpoints.TokenURL); err != nil {
+		return "", fmt.Errorf("invalid env-thunder token URL for %s/%s: %w", ouID, envName, err)
+	}
+	return endpoints.TokenURL, nil
+}

--- a/agent-manager-service/clients/thundersvc/env_endpoints_test.go
+++ b/agent-manager-service/clients/thundersvc/env_endpoints_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License, Version 2.0.
+
+package thundersvc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fixedEndpointResolver struct {
+	endpoints EnvThunderEndpoints
+	err       error
+}
+
+func (r fixedEndpointResolver) ResolveEndpoints(context.Context, string, string, string, string, bool) (EnvThunderEndpoints, error) {
+	return r.endpoints, r.err
+}
+
+func TestResolveEnvThunderTokenEndpointUsesDeploymentResolver(t *testing.T) {
+	t.Parallel()
+	readURL := func(context.Context, string, string) (string, bool, error) {
+		return "https://public.example.com", true, nil
+	}
+	got, err := ResolveEnvThunderTokenEndpoint(context.Background(), fixedEndpointResolver{endpoints: EnvThunderEndpoints{TokenURL: "https://public.example.com/oauth2/token"}}, readURL, "ou-id", "org", "customer-test")
+	require.NoError(t, err)
+	require.Equal(t, "https://public.example.com/oauth2/token", got)
+}
+
+func TestResolveEnvThunderTokenEndpointPreservesNotProvisioned(t *testing.T) {
+	t.Parallel()
+	readURL := func(context.Context, string, string) (string, bool, error) { return "", false, nil }
+	_, err := ResolveEnvThunderTokenEndpoint(context.Background(), nil, readURL, "ou-id", "org", "dev-eu")
+	require.ErrorIs(t, err, ErrThunderNotProvisioned)
+}
+
+func TestResolveEnvThunderTokenEndpointRejectsEmptyResolvedURL(t *testing.T) {
+	t.Parallel()
+	readURL := func(context.Context, string, string) (string, bool, error) {
+		return "https://public.example.com", true, nil
+	}
+	_, err := ResolveEnvThunderTokenEndpoint(context.Background(), fixedEndpointResolver{}, readURL, "ou-id", "org", "dev-eu")
+	require.ErrorContains(t, err, "token URL is empty")
+}
+
+func TestDefaultEnvThunderEndpointResolverPreservesOnPremisesSemantics(t *testing.T) {
+	t.Parallel()
+	resolver := defaultEnvThunderEndpointResolver{resolveBaseURL: func(context.Context, string, string, string, bool) (string, string, bool) {
+		return "https://issuer.example.com", "10.0.0.10:8090", true
+	}}
+	endpoints, err := resolver.ResolveEndpoints(context.Background(), "ou-id", "org", "dev-eu", "https://issuer.example.com", false)
+	require.NoError(t, err)
+	require.Equal(t, "https://issuer.example.com", endpoints.ManagementURL)
+	require.Equal(t, "10.0.0.10:8090", endpoints.ManagementResolveToHost)
+	require.True(t, endpoints.ManagementURLTrusted)
+	require.Equal(t, "https://issuer.example.com/oauth2/token", endpoints.TokenURL)
+	require.Equal(t, "10.0.0.10:8090", endpoints.TokenResolveToHost)
+	require.True(t, endpoints.TokenURLTrusted)
+	require.Equal(t, "system", endpoints.SystemTokenScope)
+	require.Equal(t, "https://issuer.example.com/mcp", endpoints.SystemTokenResource)
+}
+
+func TestEnvThunderClientUsesSeparateTokenAndManagementEndpoints(t *testing.T) {
+	t.Parallel()
+	tokenCalled := false
+	managementCalled := false
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenCalled = true
+		require.Equal(t, "/oauth2/token", r.URL.Path)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "tenant_instance:system", r.Form.Get("scope"))
+		require.Empty(t, r.Form.Get("resource"))
+		_, _ = io.WriteString(w, `{"access_token":"system-token","expires_in":300}`)
+	}))
+	defer tokenServer.Close()
+	managementServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		managementCalled = true
+		require.Equal(t, "/organization-units/tree/default", r.URL.Path)
+		require.Equal(t, "Bearer system-token", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, `{"id":"default-ou"}`)
+	}))
+	defer managementServer.Close()
+
+	client, err := NewEnvThunderClientWithEndpoints(EnvThunderEndpoints{
+		ManagementURL:        managementServer.URL,
+		ManagementURLTrusted: true,
+		TokenURL:             tokenServer.URL + "/oauth2/token",
+		TokenURLTrusted:      true,
+		SystemTokenScope:     "tenant_instance:system",
+	}, "client-id", "client-secret")
+	require.NoError(t, err)
+	ouID, err := client.GetDefaultOUID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "default-ou", ouID)
+	require.True(t, tokenCalled)
+	require.True(t, managementCalled)
+}
+
+func TestEnvThunderClientProtectsUntrustedTokenEndpointByDefault(t *testing.T) {
+	t.Parallel()
+	var tokenCalled atomic.Bool
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		tokenCalled.Store(true)
+	}))
+	defer tokenServer.Close()
+
+	client, err := NewEnvThunderClientWithEndpoints(EnvThunderEndpoints{
+		ManagementURL:        "https://management.example.com",
+		ManagementURLTrusted: true,
+		TokenURL:             tokenServer.URL + "/oauth2/token",
+		SystemTokenScope:     "tenant_instance:system",
+	}, "client-id", "client-secret")
+	require.NoError(t, err)
+	_, err = client.GetDefaultOUID(context.Background())
+	require.Error(t, err)
+	require.False(t, tokenCalled.Load(), "SSRF guard must reject loopback before credentials are sent")
+}
+
+func TestEnvThunderClientProtectsUntrustedManagementEndpointByDefault(t *testing.T) {
+	t.Parallel()
+	var managementCalled atomic.Bool
+	managementServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		managementCalled.Store(true)
+	}))
+	defer managementServer.Close()
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"access_token":"system-token","expires_in":300}`)
+	}))
+	defer tokenServer.Close()
+
+	client, err := NewEnvThunderClientWithEndpoints(EnvThunderEndpoints{
+		ManagementURL:    managementServer.URL,
+		TokenURL:         tokenServer.URL + "/oauth2/token",
+		TokenURLTrusted:  true,
+		SystemTokenScope: "tenant_instance:system",
+	}, "client-id", "client-secret")
+	require.NoError(t, err)
+	_, err = client.GetDefaultOUID(context.Background())
+	require.Error(t, err)
+	require.False(t, managementCalled.Load(), "SSRF guard must reject loopback management URL")
+}
+
+func TestEnvThunderClientRejectsUnsafeEndpointShapes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		managementURL string
+		tokenURL      string
+	}{
+		{name: "relative management URL", managementURL: "/thunder", tokenURL: "https://token.example.com/oauth2/token"},
+		{name: "non HTTP token URL", managementURL: "https://management.example.com", tokenURL: "file:///oauth2/token"},
+		{name: "credentials in token URL", managementURL: "https://user:YOUR_PASSWORD_HERE@management.example.com", tokenURL: "https://token.example.com/oauth2/token"},
+		{name: "fragment in token URL", managementURL: "https://management.example.com", tokenURL: "https://token.example.com/oauth2/token#fragment"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewEnvThunderClientWithEndpoints(EnvThunderEndpoints{
+				ManagementURL:    test.managementURL,
+				TokenURL:         test.tokenURL,
+				SystemTokenScope: "tenant_instance:system",
+			}, "client-id", "client-secret")
+			require.Error(t, err)
+		})
+	}
+}

--- a/agent-manager-service/clients/thundersvc/env_resolver.go
+++ b/agent-manager-service/clients/thundersvc/env_resolver.go
@@ -94,7 +94,7 @@ type (
 type envThunderResolver struct {
 	readSystemClient ReadSystemClientFunc
 	readThunderURL   ReadThunderURLFunc
-	resolveBaseURL   resolveBaseURLFunc
+	endpointResolver EnvThunderEndpointResolver
 	ttl              time.Duration
 	now              func() time.Time
 
@@ -112,16 +112,29 @@ type cachedThunderClient struct {
 // system-client reader (which decrypts the credential from AMS's Postgres) and
 // URL reader (which looks up the registered origin, if any, from the same DB).
 func NewEnvThunderResolver(readSystemClient ReadSystemClientFunc, readThunderURL ReadThunderURLFunc) EnvThunderResolver {
-	return newEnvThunderResolverWithReader(readSystemClient, readThunderURL, ResolveThunderBaseURL)
+	return NewEnvThunderResolverWithEndpoints(readSystemClient, readThunderURL, nil)
+}
+
+// NewEnvThunderResolverWithEndpoints creates a resolver with a deployment-specific
+// endpoint policy. A nil policy preserves the standard on-premises behavior.
+func NewEnvThunderResolverWithEndpoints(readSystemClient ReadSystemClientFunc, readThunderURL ReadThunderURLFunc, endpointResolver EnvThunderEndpointResolver) EnvThunderResolver {
+	if endpointResolver == nil {
+		endpointResolver = DefaultEnvThunderEndpointResolver()
+	}
+	return newEnvThunderResolverWithEndpointResolver(readSystemClient, readThunderURL, endpointResolver)
 }
 
 // newEnvThunderResolverWithReader builds a resolver from injected readers and a
 // base-URL resolver — real implementations in production, fakes in tests.
 func newEnvThunderResolverWithReader(readSystemClient ReadSystemClientFunc, readThunderURL ReadThunderURLFunc, resolveBaseURL resolveBaseURLFunc) *envThunderResolver {
+	return newEnvThunderResolverWithEndpointResolver(readSystemClient, readThunderURL, defaultEnvThunderEndpointResolver{resolveBaseURL: resolveBaseURL})
+}
+
+func newEnvThunderResolverWithEndpointResolver(readSystemClient ReadSystemClientFunc, readThunderURL ReadThunderURLFunc, endpointResolver EnvThunderEndpointResolver) *envThunderResolver {
 	return &envThunderResolver{
 		readSystemClient: readSystemClient,
 		readThunderURL:   readThunderURL,
-		resolveBaseURL:   resolveBaseURL,
+		endpointResolver: endpointResolver,
 		ttl:              envThunderClientCacheTTL,
 		now:              time.Now,
 		cache:            make(map[string]cachedThunderClient),
@@ -182,23 +195,14 @@ func (r *envThunderResolver) Resolve(ctx context.Context, ouID, orgNamespace, en
 			return nil, ErrThunderNotProvisioned
 		}
 
-		baseURL, resolveToHost, ok := r.resolveBaseURL(ctx, orgNamespace, envName, thunderURL, callerSupplied)
-		if !ok {
-			return nil, fmt.Errorf("%w: %s/%s", ErrThunderUnreachable, orgNamespace, envName)
+		endpoints, err := r.endpointResolver.ResolveEndpoints(ctx, ouID, orgNamespace, envName, thunderURL, callerSupplied)
+		if err != nil {
+			return nil, err
 		}
-		// The System RS identifier is "<issuer>/mcp", derived from the env-Thunder issuer
-		// URL — not the (possibly cluster-internal) dialable base URL selected above.
-		systemResource := SystemResourceIdentifier(ThunderIssuerURL(thunderURL))
-		// baseURL==thunderURL with no override identifies the plain-external
-		// candidate; callerSupplied says whether ITS VALUE is attacker-influenced
-		// (a SaaS row) rather than AMS's own trusted computation (an on-prem
-		// row, which can legitimately be a private address — see
-		// thunderURLCandidate's doc comment). Both must hold to harden the dial.
-		newClient := NewThunderClientWithDialOverride
-		if resolveToHost == "" && baseURL == thunderURL && callerSupplied {
-			newClient = NewEnvThunderClient
+		client, err := NewEnvThunderClientWithEndpoints(endpoints, clientID, clientSecret)
+		if err != nil {
+			return nil, fmt.Errorf("invalid env-thunder endpoints for %s/%s: %w", orgNamespace, envName, err)
 		}
-		client := newClient(baseURL, clientID, clientSecret, resolveToHost, systemResource)
 
 		r.mu.Lock()
 		r.cache[cacheKey] = cachedThunderClient{client: client, cachedAt: r.now()}

--- a/agent-manager-service/clients/thundersvc/identity_client.go
+++ b/agent-manager-service/clients/thundersvc/identity_client.go
@@ -135,12 +135,16 @@ type IdentityClient interface {
 // baseURL is the platform Thunder public/issuer URL, so it also derives the System
 // resource indicator used to obtain system-scoped tokens for the admin identity APIs.
 func NewIdentityClient(baseURL, clientID, clientSecret string) IdentityClient {
+	httpClient := &http.Client{Timeout: httpClientTimeout}
 	return &thunderClient{
-		baseURL:        baseURL,
-		clientID:       clientID,
-		clientSecret:   clientSecret,
-		systemResource: SystemResourceIdentifier(baseURL),
-		httpClient:     &http.Client{Timeout: httpClientTimeout},
+		baseURL:          baseURL,
+		tokenURL:         strings.TrimRight(baseURL, "/") + "/oauth2/token",
+		clientID:         clientID,
+		clientSecret:     clientSecret,
+		systemTokenScope: "system",
+		systemResource:   SystemResourceIdentifier(baseURL),
+		httpClient:       httpClient,
+		tokenHTTPClient:  httpClient,
 	}
 }
 

--- a/agent-manager-service/services/agent_identity_injection_service.go
+++ b/agent-manager-service/services/agent_identity_injection_service.go
@@ -208,12 +208,13 @@ type AgentIdentityShutdownContextSetter interface {
 }
 
 type agentIdentityInjectionService struct {
-	repo              repositories.AgentThunderClientRepository
-	agentConfigRepo   repositories.AgentConfigurationRepository
-	mcpProxyScopeRepo repositories.MCPProxyScopeRepository
-	ocClient          client.OpenChoreoClient
-	refreshInterval   string
-	logger            *slog.Logger
+	repo                 repositories.AgentThunderClientRepository
+	agentConfigRepo      repositories.AgentConfigurationRepository
+	mcpProxyScopeRepo    repositories.MCPProxyScopeRepository
+	ocClient             client.OpenChoreoClient
+	refreshInterval      string
+	logger               *slog.Logger
+	resolveTokenEndpoint func(context.Context, string, string, string) (string, error)
 	// now is injectable for tests; defaults to time.Now.
 	now func() time.Time
 	// after is injectable for tests; defaults to time.After. See
@@ -242,17 +243,33 @@ func NewAgentIdentityInjectionService(
 	refreshInterval string,
 	logger *slog.Logger,
 ) AgentIdentityInjectionService {
+	return NewAgentIdentityInjectionServiceWithTokenEndpointResolver(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, refreshInterval, logger, nil)
+}
+
+// NewAgentIdentityInjectionServiceWithTokenEndpointResolver creates the service
+// with an optional deployment-specific token endpoint lookup. A nil lookup
+// preserves the standard in-cluster on-premises endpoint.
+func NewAgentIdentityInjectionServiceWithTokenEndpointResolver(
+	repo repositories.AgentThunderClientRepository,
+	agentConfigRepo repositories.AgentConfigurationRepository,
+	mcpProxyScopeRepo repositories.MCPProxyScopeRepository,
+	ocClient client.OpenChoreoClient,
+	refreshInterval string,
+	logger *slog.Logger,
+	resolveTokenEndpoint func(context.Context, string, string, string) (string, error),
+) AgentIdentityInjectionService {
 	return &agentIdentityInjectionService{
-		repo:              repo,
-		agentConfigRepo:   agentConfigRepo,
-		mcpProxyScopeRepo: mcpProxyScopeRepo,
-		ocClient:          ocClient,
-		refreshInterval:   refreshInterval,
-		logger:            logger,
-		now:               time.Now,
-		after:             time.After,
-		rolloutTokens:     make(map[string]uint64),
-		shutdownCtx:       context.Background(),
+		repo:                 repo,
+		agentConfigRepo:      agentConfigRepo,
+		mcpProxyScopeRepo:    mcpProxyScopeRepo,
+		ocClient:             ocClient,
+		refreshInterval:      refreshInterval,
+		logger:               logger,
+		resolveTokenEndpoint: resolveTokenEndpoint,
+		now:                  time.Now,
+		after:                time.After,
+		rolloutTokens:        make(map[string]uint64),
+		shutdownCtx:          context.Background(),
 	}
 }
 
@@ -453,9 +470,9 @@ func (s *agentIdentityInjectionService) deleteSecretReference(ctx context.Contex
 	return nil
 }
 
-// buildEnvVars assembles the four identity env vars for one binding. The
-// token endpoint uses the cluster-internal env-Thunder URL: env-Thunder is not
-// published on the gateway vhost, so pods reach it by in-cluster address.
+// buildEnvVars assembles the four identity env vars for one binding. On-premises
+// deployments use the cluster-internal token endpoint; deployments with a
+// configured resolver may inject a separate public OAuth endpoint.
 //
 // The URL is built from ThunderOrgNamespace(), NOT binding.OUID: env-Thunder
 // is addressed by the org's namespace/handle (e.g. "default"), and binding.OUID
@@ -468,6 +485,13 @@ func (s *agentIdentityInjectionService) buildEnvVars(ctx context.Context, bindin
 	if err != nil {
 		return nil, err
 	}
+	tokenEndpoint := thundersvc.ThunderTokenURL(ThunderOrgNamespace(), binding.EnvironmentName)
+	if s.resolveTokenEndpoint != nil {
+		tokenEndpoint, err = s.resolveTokenEndpoint(ctx, binding.OUID, ThunderOrgNamespace(), binding.EnvironmentName)
+		if err != nil {
+			return nil, fmt.Errorf("resolve agent identity token endpoint: %w", err)
+		}
+	}
 	return []client.EnvVar{
 		{Key: client.EnvVarAgentIDClientID, Value: binding.ThunderClientID},
 		{
@@ -479,7 +503,7 @@ func (s *agentIdentityInjectionService) buildEnvVars(ctx context.Context, bindin
 				},
 			},
 		},
-		{Key: client.EnvVarAgentIDTokenEndpoint, Value: thundersvc.ThunderTokenURL(ThunderOrgNamespace(), binding.EnvironmentName)},
+		{Key: client.EnvVarAgentIDTokenEndpoint, Value: tokenEndpoint},
 		{Key: client.EnvVarAgentIDScopes, Value: strings.Join(scopes, " ")},
 	}, nil
 }

--- a/agent-manager-service/services/agent_identity_injection_service_unit_test.go
+++ b/agent-manager-service/services/agent_identity_injection_service_unit_test.go
@@ -171,6 +171,45 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecr
 	assert.Empty(t, byKey[client.EnvVarAgentIDScopes].Value, "no agent configuration means no MCP bindings, so no scopes to request")
 }
 
+func TestAgentIdentityInjection_EnvVarsForEnvironment_UsesDeploymentTokenEndpoint(t *testing.T) {
+	repo := identityRepoReturning(completedInternalBinding(), nil)
+	const publicTokenURL = "https://customer-test.example.com/oauth2/token"
+	resolverCalled := false
+	svc := NewAgentIdentityInjectionServiceWithTokenEndpointResolver(
+		repo, noMCPConfigRepo(), noMCPProxyScopeRepo(), injectableOCClient(), "1h", discardLogger(),
+		func(_ context.Context, ouID, orgNamespace, envName string) (string, error) {
+			resolverCalled = true
+			assert.Equal(t, testIdentityOrg, ouID)
+			assert.Equal(t, ThunderOrgNamespace(), orgNamespace)
+			assert.Equal(t, testIdentityEnv, envName)
+			return publicTokenURL, nil
+		},
+	)
+
+	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
+	require.NoError(t, err)
+	require.True(t, resolverCalled)
+	for _, envVar := range envVars {
+		if envVar.Key == client.EnvVarAgentIDTokenEndpoint {
+			assert.Equal(t, publicTokenURL, envVar.Value)
+			return
+		}
+	}
+	t.Fatal("Agent ID token endpoint env var was not injected")
+}
+
+func TestAgentIdentityInjection_EnvVarsForEnvironment_PropagatesTokenEndpointError(t *testing.T) {
+	expectedErr := errors.New("token endpoint unavailable")
+	svc := NewAgentIdentityInjectionServiceWithTokenEndpointResolver(
+		identityRepoReturning(completedInternalBinding(), nil), noMCPConfigRepo(), noMCPProxyScopeRepo(), injectableOCClient(), "1h", discardLogger(),
+		func(context.Context, string, string, string) (string, error) { return "", expectedErr },
+	)
+
+	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, envVars)
+}
+
 // TestAgentIdentityInjection_EnvVarsForEnvironment_CreateConflictFallsBackToUpdate
 // guards the concurrent-writer case: a create conflict (another request for
 // this same binding, or the reconciler, already created it) must fall back

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -172,11 +172,36 @@ type AgentThunderProvisioningService interface {
 	HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error
 }
 
+// EnvThunderEndpointResolverSetter lets app.Run apply one deployment endpoint
+// policy consistently to shared API services and DB-backed provisioning.
+type EnvThunderEndpointResolverSetter interface {
+	SetEnvThunderEndpointResolver(thundersvc.EnvThunderEndpointResolver)
+}
+
+type agentThunderEndpointResolver struct {
+	mu       sync.RWMutex
+	resolver thundersvc.EnvThunderEndpointResolver
+}
+
+func (r *agentThunderEndpointResolver) ResolveEndpoints(ctx context.Context, ouID, orgNamespace, envName, storedURL string, callerSupplied bool) (thundersvc.EnvThunderEndpoints, error) {
+	r.mu.RLock()
+	resolver := r.resolver
+	r.mu.RUnlock()
+	if resolver == nil {
+		resolver = thundersvc.DefaultEnvThunderEndpointResolver()
+	}
+	return resolver.ResolveEndpoints(ctx, ouID, orgNamespace, envName, storedURL, callerSupplied)
+}
+
+func (r *agentThunderEndpointResolver) set(resolver thundersvc.EnvThunderEndpointResolver) {
+	r.mu.Lock()
+	r.resolver = resolver
+	r.mu.Unlock()
+}
+
 // AgentThunderBindingState is a minimal, internal snapshot of one binding's
-// provisioning state — deliberately not the same type as
-// models.AgentIdentityEnvironmentView (the public API shape for GET
-// .../identities), since HasSecret exposes internal-agent secret presence
-// that view intentionally does not surface for every provisioning type.
+// provisioning state. It deliberately differs from the public API view because
+// HasSecret exposes internal-agent secret presence.
 type AgentThunderBindingState struct {
 	ProvisioningType models.AgentProvisioningType
 	Status           models.AgentThunderStatus
@@ -209,8 +234,17 @@ type agentThunderProvisioningService struct {
 	workloadInjectorMu sync.RWMutex
 	workloadInjector   AgentIdentityInjectionService
 	logger             *slog.Logger
+	endpointResolver   *agentThunderEndpointResolver
 	bindingLocks       keyedMutex
 }
+
+func (s *agentThunderProvisioningService) SetEnvThunderEndpointResolver(resolver thundersvc.EnvThunderEndpointResolver) {
+	if s.endpointResolver != nil {
+		s.endpointResolver.set(resolver)
+	}
+}
+
+var _ EnvThunderEndpointResolverSetter = (*agentThunderProvisioningService)(nil)
 
 // agentIdentitySecretLocation returns the secretmanagersvc.SecretLocation for
 // one binding's stored credential. Deterministic from (org, project, env,
@@ -467,17 +501,21 @@ func DBBackedAgentThunderProvisioning() func(db *gorm.DB, secretMgmtClient secre
 	return func(db *gorm.DB, secretMgmtClient secretmanagersvc.SecretManagementClient, ocClient client.OpenChoreoClient, encryptionKey []byte) AgentThunderProvisioningService {
 		envThunderRepo := repositories.NewEnvThunderSystemClientRepo(db)
 		envThunderURLRepo := repositories.NewEnvThunderURLRepo(db)
-		return NewAgentThunderProvisioningService(
+		endpointResolver := &agentThunderEndpointResolver{}
+		service := NewAgentThunderProvisioningService(
 			repositories.NewAgentThunderClientRepo(db),
-			thundersvc.NewEnvThunderResolver(
+			thundersvc.NewEnvThunderResolverWithEndpoints(
 				NewEnvThunderSecretReader(envThunderRepo, encryptionKey),
 				NewEnvThunderURLReader(envThunderURLRepo),
+				endpointResolver,
 			),
 			secretMgmtClient,
 			ocClient,
 			nil, // workload injector — see doc comment above
 			slog.Default(),
 		)
+		service.(*agentThunderProvisioningService).endpointResolver = endpointResolver
+		return service
 	}
 }
 

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -41,6 +41,28 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
 
+type endpointResolverStub struct {
+	managementURL string
+}
+
+func (r endpointResolverStub) ResolveEndpoints(context.Context, string, string, string, string, bool) (thundersvc.EnvThunderEndpoints, error) {
+	return thundersvc.EnvThunderEndpoints{
+		ManagementURL:    r.managementURL,
+		TokenURL:         "https://token.example.com/oauth2/token",
+		SystemTokenScope: "tenant_instance:system",
+	}, nil
+}
+
+func TestAgentThunderEndpointResolverCanBeConfiguredAfterFactoryConstruction(t *testing.T) {
+	holder := &agentThunderEndpointResolver{}
+	service := &agentThunderProvisioningService{endpointResolver: holder}
+	service.SetEnvThunderEndpointResolver(endpointResolverStub{managementURL: "http://internal.example.com"})
+
+	endpoints, err := holder.ResolveEndpoints(context.Background(), "ou-id", "org", "dev-eu", "https://public.example.com", true)
+	require.NoError(t, err)
+	require.Equal(t, "http://internal.example.com", endpoints.ManagementURL)
+}
+
 // testOCClientResolvingSecretRefs returns an OpenChoreoClientMock whose
 // GetSecretReference resolves ANY secret ref name to a "resolved/<name>" KV
 // key holding the agent-identity client-secret data source — standing in for

--- a/agent-manager-service/wiring/wire.go
+++ b/agent-manager-service/wiring/wire.go
@@ -20,6 +20,7 @@
 package wiring
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
@@ -63,7 +64,7 @@ var clientProviderSet = wire.NewSet(
 	// app.Options.AgentThunderProvisioning, built with its own reader — see app.Run.
 	ProvideEnvThunderSecretReader,
 	ProvideEnvThunderURLReader,
-	ProvideEnvThunderResolver,
+	ProvideEnvThunderResolverWithEndpoints,
 )
 
 var serviceProviderSet = wire.NewSet(
@@ -79,7 +80,7 @@ var serviceProviderSet = wire.NewSet(
 	services.NewMonitorSchedulerService,
 	// Provisioning service is injected (see InitializeAppParams); only the
 	// reconciler that consumes it is wired here.
-	ProvideAgentIdentityInjectionService,
+	ProvideAgentIdentityInjectionServiceWithEndpointResolver,
 	services.NewAgentThunderReconcilerService,
 	services.NewEvaluatorManagerService,
 	services.NewEnvironmentService,
@@ -564,6 +565,14 @@ func ProvideEnvThunderResolver(readSystemClient thundersvc.ReadSystemClientFunc,
 	return thundersvc.NewEnvThunderResolver(readSystemClient, readThunderURL)
 }
 
+func ProvideEnvThunderResolverWithEndpoints(readSystemClient thundersvc.ReadSystemClientFunc, readThunderURL thundersvc.ReadThunderURLFunc, endpointResolver thundersvc.EnvThunderEndpointResolver) thundersvc.EnvThunderResolver {
+	return thundersvc.NewEnvThunderResolverWithEndpoints(readSystemClient, readThunderURL, endpointResolver)
+}
+
+func ProvideDefaultEnvThunderEndpointResolver() thundersvc.EnvThunderEndpointResolver {
+	return thundersvc.DefaultEnvThunderEndpointResolver()
+}
+
 // ProvideAgentIdentityInjectionService creates the Gateway Binding service that
 // delivers AgentID credentials into internal agents' workloads. It reuses the
 // secret manager's SecretReference refresh interval so AgentID Secrets follow
@@ -577,6 +586,25 @@ func ProvideAgentIdentityInjectionService(
 	logger *slog.Logger,
 ) services.AgentIdentityInjectionService {
 	return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger)
+}
+
+func ProvideAgentIdentityInjectionServiceWithEndpointResolver(
+	repo repositories.AgentThunderClientRepository,
+	agentConfigRepo repositories.AgentConfigurationRepository,
+	mcpProxyScopeRepo repositories.MCPProxyScopeRepository,
+	ocClient occlient.OpenChoreoClient,
+	readThunderURL thundersvc.ReadThunderURLFunc,
+	endpointResolver thundersvc.EnvThunderEndpointResolver,
+	cfg config.Config,
+	logger *slog.Logger,
+) services.AgentIdentityInjectionService {
+	if endpointResolver == nil {
+		return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger)
+	}
+	resolveTokenEndpoint := func(ctx context.Context, ouID, orgNamespace, envName string) (string, error) {
+		return thundersvc.ResolveEnvThunderTokenEndpoint(ctx, endpointResolver, readThunderURL, ouID, orgNamespace, envName)
+	}
+	return services.NewAgentIdentityInjectionServiceWithTokenEndpointResolver(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger, resolveTokenEndpoint)
 }
 
 func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {
@@ -599,9 +627,14 @@ func ProvideOrgResolver(client thundersvc.IdentityClient) middleware.OrgResolver
 	return middleware.NewOrgResolver(client)
 }
 
-// InitializeAppParams wires up all application dependencies. agentThunderProvisioning
-// is the deployment-injected AgentID provisioning implementation (nil to disable).
+// InitializeAppParams preserves the standard on-premises dependency graph.
 func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier, agentThunderProvisioning services.AgentThunderProvisioningService, buildSecretProvisioner services.BuildSecretProvisioner) (*AppParams, error) {
+	return InitializeAppParamsWithEnvThunderEndpoints(cfg, db, authProvider, secretProvider, gatewayApplier, agentThunderProvisioning, buildSecretProvisioner, nil)
+}
+
+// InitializeAppParamsWithEnvThunderEndpoints wires dependencies with an
+// optional deployment-specific environment-Thunder endpoint resolver.
+func InitializeAppParamsWithEnvThunderEndpoints(cfg *config.Config, db *gorm.DB, authProvider occlient.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier, agentThunderProvisioning services.AgentThunderProvisioningService, buildSecretProvisioner services.BuildSecretProvisioner, endpointResolver thundersvc.EnvThunderEndpointResolver) (*AppParams, error) {
 	wire.Build(
 		configProviderSet,
 		clientProviderSet,
@@ -638,6 +671,7 @@ func InitializeTestAppParamsWithClientMocks(
 		configProviderSet,
 		ProvideJWTSigningConfig,
 		ProvideNilBuildSecretProvisioner,
+		ProvideDefaultEnvThunderEndpointResolver,
 		wire.Struct(new(AppParams), "*"),
 	)
 	return &AppParams{}, nil

--- a/agent-manager-service/wiring/wire_gen.go
+++ b/agent-manager-service/wiring/wire_gen.go
@@ -7,10 +7,8 @@
 package wiring
 
 import (
+	"context"
 	"fmt"
-	"log/slog"
-	"time"
-
 	"github.com/google/wire"
 	"github.com/wso2/agent-manager/agent-manager-service/audit"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/observersvc"
@@ -28,13 +26,15 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 	"github.com/wso2/agent-manager/agent-manager-service/websocket"
 	"gorm.io/gorm"
+	"log/slog"
+	"time"
 )
 
 // Injectors from wire.go:
 
-// InitializeAppParams wires up all application dependencies. agentThunderProvisioning
-// is the deployment-injected AgentID provisioning implementation (nil to disable).
-func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier, agentThunderProvisioning services.AgentThunderProvisioningService, buildSecretProvisioner services.BuildSecretProvisioner) (*AppParams, error) {
+// InitializeAppParamsWithEnvThunderEndpoints wires dependencies with an
+// optional deployment-specific environment-Thunder endpoint resolver.
+func InitializeAppParamsWithEnvThunderEndpoints(cfg *config.Config, db *gorm.DB, authProvider client.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier, agentThunderProvisioning services.AgentThunderProvisioningService, buildSecretProvisioner services.BuildSecretProvisioner, endpointResolver thundersvc.EnvThunderEndpointResolver) (*AppParams, error) {
 	configConfig := ProvideConfigFromPtr(cfg)
 	middleware := ProvideAuthMiddleware(configConfig)
 	logger := ProvideLogger()
@@ -85,12 +85,12 @@ func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.Au
 	infraResourceManager := services.NewInfraResourceManager(openChoreoClient, logger)
 	agentThunderClientRepository := ProvideAgentThunderClientRepository(db)
 	mcpProxyScopeRepository := repositories.NewMCPProxyScopeRepository(db)
-	agentIdentityInjectionService := ProvideAgentIdentityInjectionService(agentThunderClientRepository, agentConfigurationRepository, mcpProxyScopeRepository, openChoreoClient, configConfig, logger)
-	envThunderSystemClientRepository := ProvideEnvThunderSystemClientRepository(db)
-	readSystemClientFunc := ProvideEnvThunderSecretReader(envThunderSystemClientRepository, v)
 	envThunderURLRepository := ProvideEnvThunderURLRepository(db)
 	readThunderURLFunc := ProvideEnvThunderURLReader(envThunderURLRepository)
-	envThunderResolver := ProvideEnvThunderResolver(readSystemClientFunc, readThunderURLFunc)
+	agentIdentityInjectionService := ProvideAgentIdentityInjectionServiceWithEndpointResolver(agentThunderClientRepository, agentConfigurationRepository, mcpProxyScopeRepository, openChoreoClient, readThunderURLFunc, endpointResolver, configConfig, logger)
+	envThunderSystemClientRepository := ProvideEnvThunderSystemClientRepository(db)
+	readSystemClientFunc := ProvideEnvThunderSecretReader(envThunderSystemClientRepository, v)
+	envThunderResolver := ProvideEnvThunderResolverWithEndpoints(readSystemClientFunc, readThunderURLFunc, endpointResolver)
 	mcpProxyService := services.NewMCPProxyService(db, mcpProxyRepository, mcpProxyEndpointRepository, deploymentRepository, gatewayRepository, envAgentMCPMappingRepository, agentConfigurationRepository, gatewayEventsService, apiKeyRepository, infraResourceManager, agentIdentityInjectionService, logger, v, mcpProxyScopeRepository, envThunderResolver)
 	llmProxyDeploymentService := services.NewLLMProxyDeploymentService(deploymentRepository, llmProxyRepository, llmProviderRepository, gatewayRepository, gatewayEventsService)
 	llmProxyAPIKeyService := services.NewLLMProxyAPIKeyService(llmProxyRepository, gatewayRepository, gatewayEventsService, apiKeyRepository, openChoreoClient)
@@ -268,11 +268,12 @@ func InitializeTestAppParamsWithClientMocks(cfg *config.Config, db *gorm.DB, aut
 	infraResourceManager := services.NewInfraResourceManager(openChoreoClient, logger)
 	agentThunderClientRepository := ProvideAgentThunderClientRepository(db)
 	mcpProxyScopeRepository := repositories.NewMCPProxyScopeRepository(db)
-	agentIdentityInjectionService := ProvideAgentIdentityInjectionService(agentThunderClientRepository, agentConfigurationRepository, mcpProxyScopeRepository, openChoreoClient, configConfig, logger)
-	envThunderSystemClientRepository := ProvideEnvThunderSystemClientRepository(db)
-	readSystemClientFunc := ProvideEnvThunderSecretReader(envThunderSystemClientRepository, v)
 	envThunderURLRepository := ProvideEnvThunderURLRepository(db)
 	readThunderURLFunc := ProvideEnvThunderURLReader(envThunderURLRepository)
+	envThunderEndpointResolver := ProvideDefaultEnvThunderEndpointResolver()
+	agentIdentityInjectionService := ProvideAgentIdentityInjectionServiceWithEndpointResolver(agentThunderClientRepository, agentConfigurationRepository, mcpProxyScopeRepository, openChoreoClient, readThunderURLFunc, envThunderEndpointResolver, configConfig, logger)
+	envThunderSystemClientRepository := ProvideEnvThunderSystemClientRepository(db)
+	readSystemClientFunc := ProvideEnvThunderSecretReader(envThunderSystemClientRepository, v)
 	envThunderResolver := ProvideEnvThunderResolver(readSystemClientFunc, readThunderURLFunc)
 	mcpProxyService := services.NewMCPProxyService(db, mcpProxyRepository, mcpProxyEndpointRepository, deploymentRepository, gatewayRepository, envAgentMCPMappingRepository, agentConfigurationRepository, gatewayEventsService, apiKeyRepository, infraResourceManager, agentIdentityInjectionService, logger, v, mcpProxyScopeRepository, envThunderResolver)
 	llmProxyDeploymentService := services.NewLLMProxyDeploymentService(deploymentRepository, llmProxyRepository, llmProviderRepository, gatewayRepository, gatewayEventsService)
@@ -421,10 +422,10 @@ var clientProviderSet = wire.NewSet(
 	ProvideIdentityClient,
 	ProvideOrgResolver, thundersvc.NewProber, ProvideEnvThunderSecretReader,
 	ProvideEnvThunderURLReader,
-	ProvideEnvThunderResolver,
+	ProvideEnvThunderResolverWithEndpoints,
 )
 
-var serviceProviderSet = wire.NewSet(services.NewAgentManagerService, services.NewAgentKindService, services.NewInfraResourceManager, services.NewAgentTokenManagerService, ProvideGitCredentialsService, services.NewRepositoryService, services.NewMonitorExecutor, services.NewMonitorManagerService, ProvideThunderConfig, services.NewMonitorSchedulerService, ProvideAgentIdentityInjectionService, services.NewAgentThunderReconcilerService, services.NewEvaluatorManagerService, services.NewEnvironmentService, services.NewPlatformGatewayService, services.NewLLMProviderTemplateService, services.NewLLMProviderService, services.NewLLMProxyService, services.NewLLMProviderDeploymentService, services.NewLLMProviderAPIKeyService, services.NewLLMProxyAPIKeyService, services.NewAgentAPIKeyService, services.NewLLMProxyDeploymentService, services.NewMCPProxyService, services.NewMCPProxyScopeService, wire.Bind(new(services.MCPProxyRedeployer), new(*services.MCPProxyService)), wire.Bind(new(controllers.MCPResourceServerIdentifierResolver), new(*services.MCPProxyService)), services.NewGatewayInternalAPIService, services.NewMonitorScoresService, services.NewCatalogService, services.NewLLMProxyProvisioner, services.NewAgentConfigurationService, services.NewLLMTemplateStore, services.NewGitSecretService, services.NewAIApplicationService)
+var serviceProviderSet = wire.NewSet(services.NewAgentManagerService, services.NewAgentKindService, services.NewInfraResourceManager, services.NewAgentTokenManagerService, ProvideGitCredentialsService, services.NewRepositoryService, services.NewMonitorExecutor, services.NewMonitorManagerService, ProvideThunderConfig, services.NewMonitorSchedulerService, ProvideAgentIdentityInjectionServiceWithEndpointResolver, services.NewAgentThunderReconcilerService, services.NewEvaluatorManagerService, services.NewEnvironmentService, services.NewPlatformGatewayService, services.NewLLMProviderTemplateService, services.NewLLMProviderService, services.NewLLMProxyService, services.NewLLMProviderDeploymentService, services.NewLLMProviderAPIKeyService, services.NewLLMProxyAPIKeyService, services.NewAgentAPIKeyService, services.NewLLMProxyDeploymentService, services.NewMCPProxyService, services.NewMCPProxyScopeService, wire.Bind(new(services.MCPProxyRedeployer), new(*services.MCPProxyService)), wire.Bind(new(controllers.MCPResourceServerIdentifierResolver), new(*services.MCPProxyService)), services.NewGatewayInternalAPIService, services.NewMonitorScoresService, services.NewCatalogService, services.NewLLMProxyProvisioner, services.NewAgentConfigurationService, services.NewLLMTemplateStore, services.NewGitSecretService, services.NewAIApplicationService)
 
 var instrumentationProviderSet = wire.NewSet(
 	ProvideInstrumentationCatalog,
@@ -836,6 +837,14 @@ func ProvideEnvThunderResolver(readSystemClient thundersvc.ReadSystemClientFunc,
 	return thundersvc.NewEnvThunderResolver(readSystemClient, readThunderURL)
 }
 
+func ProvideEnvThunderResolverWithEndpoints(readSystemClient thundersvc.ReadSystemClientFunc, readThunderURL thundersvc.ReadThunderURLFunc, endpointResolver thundersvc.EnvThunderEndpointResolver) thundersvc.EnvThunderResolver {
+	return thundersvc.NewEnvThunderResolverWithEndpoints(readSystemClient, readThunderURL, endpointResolver)
+}
+
+func ProvideDefaultEnvThunderEndpointResolver() thundersvc.EnvThunderEndpointResolver {
+	return thundersvc.DefaultEnvThunderEndpointResolver()
+}
+
 // ProvideAgentIdentityInjectionService creates the Gateway Binding service that
 // delivers AgentID credentials into internal agents' workloads. It reuses the
 // secret manager's SecretReference refresh interval so AgentID Secrets follow
@@ -849,6 +858,25 @@ func ProvideAgentIdentityInjectionService(
 	logger *slog.Logger,
 ) services.AgentIdentityInjectionService {
 	return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger)
+}
+
+func ProvideAgentIdentityInjectionServiceWithEndpointResolver(
+	repo repositories.AgentThunderClientRepository,
+	agentConfigRepo repositories.AgentConfigurationRepository,
+	mcpProxyScopeRepo repositories.MCPProxyScopeRepository,
+	ocClient client.OpenChoreoClient,
+	readThunderURL thundersvc.ReadThunderURLFunc,
+	endpointResolver thundersvc.EnvThunderEndpointResolver,
+	cfg config.Config,
+	logger *slog.Logger,
+) services.AgentIdentityInjectionService {
+	if endpointResolver == nil {
+		return services.NewAgentIdentityInjectionService(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger)
+	}
+	resolveTokenEndpoint := func(ctx context.Context, ouID, orgNamespace, envName string) (string, error) {
+		return thundersvc.ResolveEnvThunderTokenEndpoint(ctx, endpointResolver, readThunderURL, ouID, orgNamespace, envName)
+	}
+	return services.NewAgentIdentityInjectionServiceWithTokenEndpointResolver(repo, agentConfigRepo, mcpProxyScopeRepo, ocClient, cfg.SecretManager.AgentIdentityRefreshInterval, logger, resolveTokenEndpoint)
 }
 
 func ProvideThunderConfig(cfg config.Config) config.ThunderConfig {
@@ -869,4 +897,9 @@ func ProvideIdentityClient(cfg config.ThunderConfig) thundersvc.IdentityClient {
 // ProvideOrgResolver creates the org resolver backed by Thunder, with a per-org OU ID cache.
 func ProvideOrgResolver(client2 thundersvc.IdentityClient) middleware.OrgResolver {
 	return middleware.NewOrgResolver(client2)
+}
+
+// InitializeAppParams preserves the standard on-premises dependency graph.
+func InitializeAppParams(cfg *config.Config, db *gorm.DB, authProvider client.AuthProvider, secretProvider secretmanagersvc.Provider, gatewayApplier services.GatewayConfigApplier, agentThunderProvisioning services.AgentThunderProvisioningService, buildSecretProvisioner services.BuildSecretProvisioner) (*AppParams, error) {
+	return InitializeAppParamsWithEnvThunderEndpoints(cfg, db, authProvider, secretProvider, gatewayApplier, agentThunderProvisioning, buildSecretProvisioner, nil)
 }


### PR DESCRIPTION
## Purpose

Enable AgentID functionality in the WSO2 Agent Manager SaaS deployment.

## Goals
- Route ThunderID management calls through the internal Cloud gateway.
- Use the public ThunderID URL for OAuth token requests.
- Support authenticated background AgentID operations.
- Continue using database-backed ThunderID provisioning.

## Approach
Added Cloud-specific ThunderID endpoint resolution and enabled `DBBackedAgentThunderProvisioning()`. Request-driven calls continue using the user JWT, while explicitly trusted background operations can use the Agent Manager service identity.

AMP RBAC remains disabled. No UI or database schema changes are included.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
- Unit tests
  - Added coverage for endpoint construction, URL validation, and restricted service-token fallback.
- Integration tests
  - To be verified in the WSO2 Cloud development environment using a provisioned ThunderID instance.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — this is a Go implementation
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment

- Go 1.26.6
- macOS
- WSO2 Cloud development environment for integration testing

## Learning
N/A