### PR TITLE
Fix DNS-01 certificate issuance on the advanced VM installer

### DIFF
--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -41,7 +41,8 @@ print_template() {
 # it serves is obtained with TLS_MODE — everything downstream is identical.
 
 # --- Required ---
-AMP_VERSION=0.15.0                 # amp/v* release tag (see github.com/wso2/agent-manager/releases)
+AMP_VERSION=                       # REQUIRED: amp/v* release tag, e.g. 1.0.0
+                                   # (see github.com/wso2/agent-manager/releases)
 DOMAIN_BASE=amp.mycompany.com      # service hosts derived as <svc>.<DOMAIN_BASE>
 
 # --- TLS mode: dns01 (default) or byoc ---

--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -50,7 +50,7 @@ load_config() {
 # validate_cert, which needs the derived hostnames and so runs after derive_hosts.
 validate_config() {
   CONFIG_ERRORS=()
-  [[ -n "${AMP_VERSION:-}" ]] || CONFIG_ERRORS+=("AMP_VERSION is required (an amp/v* release tag, e.g. 0.15.0)")
+  [[ -n "${AMP_VERSION:-}" ]] || CONFIG_ERRORS+=("AMP_VERSION is required (an amp/v* release tag, e.g. 1.0.0)")
   [[ -n "${DOMAIN_BASE:-}" ]] || CONFIG_ERRORS+=("DOMAIN_BASE is required (e.g. amp.mycompany.com)")
   local mode; mode="$(tls_mode)"
   case " ${SUPPORTED_TLS_MODES} " in

--- a/deployments/vm/lib-certmanager.sh
+++ b/deployments/vm/lib-certmanager.sh
@@ -75,6 +75,42 @@ cert_dns_names() {
   printf '*.%s\n' "$AMP_HOST_GATEWAY"
 }
 
+# acme_dns_names — cert_dns_names() reduced to the names an ACME CA will accept in a
+# SINGLE order. Let's Encrypt (Boulder) rejects an order carrying both a wildcard and a
+# name that wildcard already covers: "Domain name <host> is redundant with a wildcard
+# domain in the same request". That rejection is fatal at order creation, so the Order
+# goes straight to `errored` and NO Challenge is ever created — the install fails looking
+# like a DNS-01 problem while `kubectl get challenge -A` shows nothing at all.
+#
+# Every fixed host sits exactly one label under DOMAIN_BASE, so *.<DOMAIN_BASE> already
+# covers all of them and dropping them changes nothing about what the issued cert serves.
+# The wildcards are kept verbatim: *.agents.<base> and *.gateway.<base> are one label
+# deeper than *.<base> reaches, so none of the three is redundant with another.
+#
+# byoc deliberately keeps the full cert_dns_names() list — no ACME is involved there, and
+# validate_cert's coverage check is wildcard-aware, so a supplied certificate may carry
+# the explicit hosts, the wildcards, or both.
+acme_dns_names() {
+  local -a names=() wildcards=()
+  local n w base covered
+  while IFS= read -r n; do [[ -n "$n" ]] && names+=("$n"); done < <(cert_dns_names)
+  for n in "${names[@]}"; do
+    [[ "$n" == \*.* ]] && wildcards+=("$n")
+  done
+  for n in "${names[@]}"; do
+    if [[ "$n" != \*.* ]]; then
+      covered=false
+      for w in "${wildcards[@]}"; do
+        base="${w#\*.}"
+        # A wildcard matches exactly one label, so only a single-label child is covered.
+        if [[ "$n" == *."$base" && "${n%."$base"}" != *.* ]]; then covered=true; break; fi
+      done
+      [[ "$covered" == true ]] && continue
+    fi
+    printf '%s\n' "$n"
+  done
+}
+
 # _dns01_solver_block — print the cert-manager `dns01:` solver body for DNS_PROVIDER,
 # indented 10 spaces to sit under `solvers:\n  - dns01:` in render_acme_clusterissuer.
 # Credential values come from the config env vars; the referenced Secret is created by
@@ -180,7 +216,8 @@ EOF
 
 # render_wildcard_certificate <cert_name> <secret_name> <issuer_name> — print the
 # Certificate whose issued Secret the consolidated :443 Gateway references. dnsNames come
-# from cert_dns_names (fixed hosts + the agent/env-Thunder wildcards). Lives in GATEWAY_NS.
+# from acme_dns_names — cert_dns_names minus any host already covered by a wildcard in
+# the same list, which an ACME CA refuses to issue in one order. Lives in GATEWAY_NS.
 render_wildcard_certificate() {
   local name="$1" secret="$2" issuer="$3" d
   cat <<EOF
@@ -200,7 +237,7 @@ spec:
 EOF
   while IFS= read -r d; do
     [[ -n "$d" ]] && printf '    - %s\n' "$(_yaml_quote "$d")"
-  done < <(cert_dns_names)
+  done < <(acme_dns_names)
   cat <<EOF
   issuerRef:
     name: ${issuer}

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -41,6 +41,30 @@ assert_eq "cert SANs include env-Thunder wild" "yes" "$(grep -qxF '*.amp.mycompa
 AMP_HOST_CP="" sans_nocp="$(AMP_HOST_CP="" cert_dns_names)"
 assert_eq "cert SANs omit cp when unset"       "no"  "$(grep -qxF 'cp.amp.mycompany.com' <<<"$sans_nocp" && echo yes || echo no)"
 
+# --- acme_dns_names: the ACME order must carry NO name a wildcard in it already covers ---
+# Boulder rejects such an order outright ("redundant with a wildcard domain in the same
+# request"), and the Order errors before any Challenge exists — so this is what keeps
+# TLS_MODE=dns01 issuable at all, not a cosmetic trim.
+# The cp assertion above leaks AMP_HOST_CP="" into the shell (two assignments in one
+# command), so restore it — otherwise the cp cases below would pass vacuously.
+AMP_HOST_CP=cp.amp.mycompany.com
+acme="$(acme_dns_names)"
+assert_eq "acme names keep the base wildcard"   "yes" "$(grep -qxF '*.amp.mycompany.com' <<<"$acme" && echo yes || echo no)"
+assert_eq "acme names keep agents wildcard"     "yes" "$(grep -qxF '*.agents.amp.mycompany.com' <<<"$acme" && echo yes || echo no)"
+assert_eq "acme names keep gateway wildcard"    "yes" "$(grep -qxF '*.gateway.amp.mycompany.com' <<<"$acme" && echo yes || echo no)"
+# Each of these is one label under the base domain, so *.amp.mycompany.com covers it.
+for h in console api thunder observer gateway cp; do
+  assert_eq "acme names drop redundant ${h}"    "no"  "$(grep -qxF "${h}.amp.mycompany.com" <<<"$acme" && echo yes || echo no)"
+done
+assert_eq "acme names are exactly the 3 wildcards" "3" "$(grep -c . <<<"$acme")"
+# A host NOT covered by any wildcard in the list must survive the filter: an operator
+# override can put a service outside DOMAIN_BASE, and dropping it would silently issue a
+# cert that does not serve that host.
+acme_off="$(AMP_HOST_CONSOLE=console.elsewhere.example acme_dns_names)"
+assert_eq "acme names keep an off-base host"    "yes" "$(grep -qxF 'console.elsewhere.example' <<<"$acme_off" && echo yes || echo no)"
+# The byoc requirement list is deliberately unfiltered — validate_cert accepts either shape.
+assert_eq "cert_dns_names still lists all 9"    "9"   "$(grep -c . <<<"$(cert_dns_names)")"
+
 # --- validate_dns01_config: provider + credential presence (appends to CONFIG_ERRORS) ---
 run_validate() { CONFIG_ERRORS=(); validate_dns01_config; echo "${#CONFIG_ERRORS[@]}"; }
 
@@ -219,7 +243,7 @@ assert_eq "platform CA cm PEM round-trips" "yes" \
 # cannot tell a valid block scalar from an invalid header (an explicit indentation
 # indicator, say), so on its own it would pass on YAML that no parser accepts.
 if command -v kubectl >/dev/null 2>&1; then
-  ca_parsed="$(printf '%s\n' "$ca_cm" | kubectl create --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
+  ca_parsed="$(printf '%s\n' "$ca_cm" | kubectl create --validate=false --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
   assert_eq "platform CA cm is valid YAML" "yes" \
     "$(printf '%s' "$ca_parsed" | grep -q 'BEGIN CERTIFICATE' && echo yes || echo no)"
   assert_eq "platform CA cm PEM is not indented" "no" \
@@ -228,12 +252,12 @@ if command -v kubectl >/dev/null 2>&1; then
   # the inferred block indentation.
   tmp_messy="$(mktemp)"
   { printf '\n  Certificate:\n    Data:\n'; cat "$tmp_cert"; } > "$tmp_messy"
-  messy_parsed="$(render_platform_ca_configmap "$tmp_messy" | kubectl create --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
+  messy_parsed="$(render_platform_ca_configmap "$tmp_messy" | kubectl create --validate=false --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
   assert_eq "indented-preamble CA still renders valid YAML" "yes" \
     "$(printf '%s' "$messy_parsed" | openssl x509 -noout -subject >/dev/null 2>&1 && echo yes || echo no)"
   rm -f "$tmp_messy"
   # The byoc Secret must parse too.
-  sec_type="$(render_byoc_tls_secret amp-wildcard-tls "$tmp_cert" "$tmp_key" | kubectl create --dry-run=client -o jsonpath='{.type}' -f - 2>/dev/null || true)"
+  sec_type="$(render_byoc_tls_secret amp-wildcard-tls "$tmp_cert" "$tmp_key" | kubectl create --validate=false --dry-run=client -o jsonpath='{.type}' -f - 2>/dev/null || true)"
   assert_eq "byoc secret is valid YAML" "kubernetes.io/tls" "$sec_type"
 else
   printf 'ok   - rendered YAML parses (skipped: kubectl not installed)\n'

--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -219,7 +219,7 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 ## Prerequisites {#adv-prerequisites}
 
 - **Docker, k3d, kubectl, Helm, curl, and `lsof`** must already be installed on the VM. The installer **verifies** they are present and exits with install hints if any are missing. It does **not** install them for you.
-- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works.
+- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works. Those figures cover the platform plus the **default environment**. Every environment you add runs its own Thunder and API Platform Gateway, and evaluation runs are scheduled as extra pods, so on 4 vCPUs a second environment can consume nearly all allocatable CPU — after which evaluation jobs stay `Pending` (`0/1 nodes are available: 1 Insufficient cpu`) instead of reporting a capacity error. Plan on **8 vCPUs** if you intend to add environments or run evaluations.
 - **A domain you control.** With `TLS_MODE=dns01` it must additionally be hosted on one of the supported DNS providers — **Cloudflare**, **AWS Route 53**, **Google Cloud DNS**, or **Azure DNS** — and you need **a DNS-provider API credential** scoped to edit that zone's records, which cert-manager uses to write the `_acme-challenge` TXT record. You do **not** create TXT records by hand. With `TLS_MODE=byoc` neither the provider nor the credential matters; you need only [a certificate covering the right names](#adv-byoc).
 
 ## Configure {#adv-configure}
@@ -487,6 +487,20 @@ Per-environment Thunder does **not** have this problem: its handles sit directly
 
 Verify the fixed hosts resolve before installing:
 
+:::note A freshly delegated zone reads as broken for a few minutes
+If you have only just pointed the parent zone's `NS` records at your DNS provider, the loop below can return **empty answers for some hosts and addresses for others**, changing from run to run. That is the parent zone's negative cache (typically 300 s, per the zone's SOA), not a misconfiguration — public resolvers are anycast fleets, so each edge expires its cached `NXDOMAIN` at a different moment. Confirm the zone itself is correct by querying its authoritative nameservers directly, which never serve a stale negative:
+
+```bash
+# 1. the delegation itself — this prints your DNS provider's nameservers
+dig +short NS amp.mycompany.com
+
+# 2. ask one of those nameservers directly, substituting a name from step 1
+dig +short console.amp.mycompany.com A @<nameserver-from-step-1>
+```
+
+Certificate issuance does not depend on these A records at all — it turns on the `_acme-challenge` TXT record cert-manager writes, so a service host that has not finished propagating can still be certified. It does depend on the delegation being correct: if the parent zone still points at the wrong nameservers, the CA follows that stale delegation and never sees the TXT record, so confirm the `NS` answer above before suspecting issuance.
+:::
+
 ```bash
 for h in console.amp.mycompany.com thunder.amp.mycompany.com gateway.amp.mycompany.com \
          x-y.agents.amp.mycompany.com x-y.gateway.amp.mycompany.com; do
@@ -639,7 +653,11 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 - **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER` or `TLS_MODE`, a missing provider credential, or `byoc` without `TLS_CERT_FILE`). Fix `amp-config.env` and re-run.
 - **Certificate rejected before install (`byoc`).** The pre-flight found that the certificate and key don't match, the certificate has expired, or its SANs don't cover a required name. The message names the specific problem. The most common one is a missing `*.agents` or `*.gateway` wildcard: those tiers sit one label deeper than `*.<DOMAIN_BASE>` reaches, so they each need their own explicit wildcard SAN (see [Bring your own certificate](#adv-byoc)). Reissue with the full SAN list.
 - **Certificate never becomes Ready (`dns01`).** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
-- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
+- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)). For `amctl` specifically, which fails with `x509: certificate signed by unknown authority`, you can point it at the CA for a single command instead of changing the host's trust store — no root required:
+
+  ```bash
+  SSL_CERT_FILE=/path/to/ca.pem amctl project list --org <org>
+  ```
 - **Login to an agent environment fails while the console works (`byoc` with a private CA).** That environment's Thunder cannot validate the chain when it fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`. Environment creation reports success regardless, so this only ever surfaces at login. Check whether the CA is published in the cluster:
 
   ```bash

--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -10126,9 +10126,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -59,7 +59,7 @@
     "ws": "^8.21.1",
     "body-parser": "^1.20.6",
     "brace-expansion": "^5.0.9",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "js-yaml": "^4.3.1",
     "mermaid": "^11.16.1",
     "nanoid": "^3.3.17",

--- a/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
@@ -219,7 +219,7 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 ## Prerequisites {#adv-prerequisites}
 
 - **Docker, k3d, kubectl, Helm, curl, and `lsof`** must already be installed on the VM. The installer **verifies** they are present and exits with install hints if any are missing. It does **not** install them for you.
-- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works.
+- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works. Those figures cover the platform plus the **default environment**. Every environment you add runs its own Thunder and API Platform Gateway, and evaluation runs are scheduled as extra pods, so on 4 vCPUs a second environment can consume nearly all allocatable CPU — after which evaluation jobs stay `Pending` (`0/1 nodes are available: 1 Insufficient cpu`) instead of reporting a capacity error. Plan on **8 vCPUs** if you intend to add environments or run evaluations.
 - **A domain you control.** With `TLS_MODE=dns01` it must additionally be hosted on one of the supported DNS providers — **Cloudflare**, **AWS Route 53**, **Google Cloud DNS**, or **Azure DNS** — and you need **a DNS-provider API credential** scoped to edit that zone's records, which cert-manager uses to write the `_acme-challenge` TXT record. You do **not** create TXT records by hand. With `TLS_MODE=byoc` neither the provider nor the credential matters; you need only [a certificate covering the right names](#adv-byoc).
 
 ## Configure {#adv-configure}
@@ -487,6 +487,20 @@ Per-environment Thunder does **not** have this problem: its handles sit directly
 
 Verify the fixed hosts resolve before installing:
 
+:::note A freshly delegated zone reads as broken for a few minutes
+If you have only just pointed the parent zone's `NS` records at your DNS provider, the loop below can return **empty answers for some hosts and addresses for others**, changing from run to run. That is the parent zone's negative cache (typically 300 s, per the zone's SOA), not a misconfiguration — public resolvers are anycast fleets, so each edge expires its cached `NXDOMAIN` at a different moment. Confirm the zone itself is correct by querying its authoritative nameservers directly, which never serve a stale negative:
+
+```bash
+# 1. the delegation itself — this prints your DNS provider's nameservers
+dig +short NS amp.mycompany.com
+
+# 2. ask one of those nameservers directly, substituting a name from step 1
+dig +short console.amp.mycompany.com A @<nameserver-from-step-1>
+```
+
+Certificate issuance does not depend on these A records at all — it turns on the `_acme-challenge` TXT record cert-manager writes, so a service host that has not finished propagating can still be certified. It does depend on the delegation being correct: if the parent zone still points at the wrong nameservers, the CA follows that stale delegation and never sees the TXT record, so confirm the `NS` answer above before suspecting issuance.
+:::
+
 ```bash
 for h in console.amp.mycompany.com thunder.amp.mycompany.com gateway.amp.mycompany.com \
          x-y.agents.amp.mycompany.com x-y.gateway.amp.mycompany.com; do
@@ -639,7 +653,11 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 - **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER` or `TLS_MODE`, a missing provider credential, or `byoc` without `TLS_CERT_FILE`). Fix `amp-config.env` and re-run.
 - **Certificate rejected before install (`byoc`).** The pre-flight found that the certificate and key don't match, the certificate has expired, or its SANs don't cover a required name. The message names the specific problem. The most common one is a missing `*.agents` or `*.gateway` wildcard: those tiers sit one label deeper than `*.<DOMAIN_BASE>` reaches, so they each need their own explicit wildcard SAN (see [Bring your own certificate](#adv-byoc)). Reissue with the full SAN list.
 - **Certificate never becomes Ready (`dns01`).** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
-- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
+- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)). For `amctl` specifically, which fails with `x509: certificate signed by unknown authority`, you can point it at the CA for a single command instead of changing the host's trust store — no root required:
+
+  ```bash
+  SSL_CERT_FILE=/path/to/ca.pem amctl project list --org <org>
+  ```
 - **Login to an agent environment fails while the console works (`byoc` with a private CA).** That environment's Thunder cannot validate the chain when it fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`. Environment creation reports success regardless, so this only ever surfaces at login. Check whether the CA is published in the cluster:
 
   ```bash


### PR DESCRIPTION
## Purpose
`TLS_MODE=dns01` — the default and documented TLS mode of the advanced VM installer — cannot obtain a certificate from Let's Encrypt. Found while validating the v1.0.0-rc3 advanced VM install on a public-network GCP VM with Google Cloud DNS.

Let's Encrypt rejects an ACME order that carries both a wildcard and a name that wildcard already covers:

```
400 urn:ietf:params:acme:error:malformed: Error creating new order ::
Domain name "api.<base>" is redundant with a wildcard domain in the same request.
Remove one or the other from the certificate request.
```

`cert_dns_names()` requests the six fixed hosts (`console`, `api`, `thunder`, `observer`, `gateway`, `cp`) alongside `*.<DOMAIN_BASE>`, and each fixed host is exactly one label under the base domain, so all six are redundant. The rejection happens at order creation, so the Order goes straight to `errored` and **no Challenge is ever created** — the installer reports that cert-manager did not issue the certificate and points at `kubectl get challenge -A`, which shows nothing, sending the operator to debug DNS that was never involved.

This regressed when the env-Thunder wildcard was broadened from `*.thunder.<base>` to `*.<base>` for the handle-only hostname shape. Before that, no fixed host was covered by any wildcard (`*.thunder.<base>` does not cover `thunder.<base>` itself), so the order was accepted. The change is tagged in **RC1, rc2 and rc3** — all three ship a DNS-01 path that cannot complete.

Two smaller gaps found in the same run are fixed here as well, and the guide gains notes for two things that cost real debugging time.

## Goals
- Make `TLS_MODE=dns01` installs able to issue a certificate again, without changing what the served certificate covers.
- Keep `byoc` behaviour and its documented SAN requirements exactly as they are.
- Stop the `--init` template from handing operators a stale release version.
- Make the VM preflight test suite pass on a developer workstation regardless of its kubeconfig.
- Record the DNS-delegation and node-sizing surprises in the guide.

## Approach
**ACME order (the fix).** New `acme_dns_names()` in `lib-certmanager.sh` filters `cert_dns_names()` down to the names an ACME CA will accept in one order, dropping any non-wildcard name that a wildcard in the same list already covers (matching a single label, per RFC 4592). The ACME `Certificate` now requests that list; for a default install it is exactly the three wildcards `*.<base>`, `*.agents.<base>` and `*.gateway.<base>`, which between them cover every host the nine-name list did.

`cert_dns_names()` is untouched, so `byoc` keeps the full required-SAN list documented in the guide and shown by `--dry-run`. That is safe because no ACME is involved in `byoc` and `validate_cert`'s coverage check is already wildcard-aware — a supplied certificate may carry the explicit hosts, the wildcards, or both. A host placed outside `DOMAIN_BASE` by a `HOST_*` override is not covered by any wildcard and so survives the filter; there is a test for it.

**Config template.** `AMP_VERSION` ships empty, so config validation fails with `AMP_VERSION is required` before anything touches the cluster, instead of silently installing `0.15.0`.

**Test hermeticity.** The three YAML assertions parsed rendered manifests with `kubectl create --dry-run=client`, which fetches the OpenAPI schema from the *current kubeconfig context*. On a workstation whose context is unreachable this fails with an HTML error body and reported three failures unrelated to the code under test. Added `--validate=false`, which keeps the parse and drops the schema fetch.

**Documentation.** A note that a freshly delegated zone returns inconsistent empty answers until the parent's negative cache expires (public resolvers are anycast, so each edge expires at a different moment) with the authoritative-nameserver query that settles it; and a note that the stated 4 vCPU minimum covers the platform plus the default environment only.

### Related findings not addressed here
Found in the same run, in other components, so deliberately out of scope for this PR:

| Finding | Component |
|---|---|
| A buildpack build reports `Completed` for an image with no runtime when the app path contains no project for the declared language; the agent then crash-loops with `python: command not found` | build pipeline |
| `amctl login --client-secret` requests no scopes, so the only headless login yields 403 on every call while still printing `✓ Logged in` | amctl |
| `agent create` auto-triggers a build, so an explicit `agent build create` races a second concurrent build with no indication one is already running | amctl / API |
| `POST .../environments/{envID}/api-keys` 404s for the UUID returned by the environments listing; only the environment *name* works, though the spec documents "Environment name or UUID" | API |
| `monitors/{name}/scores/breakdown` accepts only `level=agent|llm`, so trace-level evaluator explanations are unreachable | API |
| A monitor payload missing the required `llmProvider.providerName` is reported as `LLM provider not found` rather than a validation error | API |

## User stories
As an operator installing Agent Manager on a VM with my own domain, I can use the default `dns01` TLS mode and get a publicly-trusted wildcard certificate without the install failing at the TLS phase.

## Release note
Fixed the advanced VM installer's `TLS_MODE=dns01` path, which could not obtain a certificate because the ACME order included hostnames already covered by a wildcard in the same request.

## Documentation
Updated in this PR: `documentation/docs/guides/on-a-vm.mdx` and the `v1.0.0-rc3` copy — DNS-delegation propagation note and node-sizing guidance for additional environments.

## Training
N/A — no training content covers the VM installer.

## Certification
N/A — the VM installer is not covered by certification exams.

## Marketing
N/A — bug fix.

## Automation tests
- Unit tests

  `deployments/vm/tests/preflight.sh` gains 12 assertions on `acme_dns_names()`: the three wildcards are kept, each of the six redundant fixed hosts is dropped, the result is exactly three names, a host outside `DOMAIN_BASE` survives the filter, and `cert_dns_names()` still returns all nine for `byoc`. Both VM suites pass with no failures (`preflight.sh`, `run.sh`); before this change `preflight.sh` reported three failures on an unreachable kubeconfig context.

- Integration tests

  Verified on a real GCP VM against **production** Let's Encrypt with Google Cloud DNS. Before: Order `errored`, zero Challenges, install aborted at Phase 3/3. After: three Challenges created, Order `valid`, certificate `Ready`, and `:443` serves a publicly-trusted wildcard (`Verify return code: 0`). All six fixed hosts answer over TLS (`api /healthz` 200, Thunder OIDC discovery 200, observer 200, cp 200, OTel ingest 401 as expected), and a full agent lifecycle — create, buildpack build, deploy, invoke, traces — completes over the issued certificate. A second environment added afterwards brought up per-env Thunder, an API Platform Gateway and an agent endpoint, all three serving valid TLS off the **same** three-wildcard certificate with no re-issuance and no new DNS records, which confirms the trimmed list covers everything the nine-name request did.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — shell and Markdown only, no Java.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes.

## Related PRs
None.

## Migrations (if applicable)
None. Existing installs are unaffected: the change alters only what a new ACME order requests. An install whose certificate was already issued keeps it, and a renewal simply requests the filtered list.

## Test environment
GCP `e2-standard-4` (4 vCPU, 16 GB, 100 GB pd-balanced), Ubuntu 24.04 LTS, Docker 29.8.0, k3d 5.9.0, kubectl 1.33.13, Helm 3.21.4. Installed from the published `amp/v1.0.0-rc3` bundle. TLS via cert-manager DNS-01 with `DNS_PROVIDER=clouddns` against production Let's Encrypt.

## Learning
Boulder's redundancy rule is a CA policy rather than anything in RFC 8555, so it does not surface in the cert-manager or Gateway API docs and only appears as an `urn:ietf:params:acme:error:malformed` at order creation. The failure mode is deceptive in a specific way worth remembering: because the order is refused before any authorization exists, every DNS-01 diagnostic an operator would reach for — the challenge list, the `_acme-challenge` TXT record, the provider credential — is empty or absent, which all points at DNS while the actual complaint is about the requested name list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wildcard DNS certificate handling to prevent redundant hostname errors during ACME validation.
  - Kubernetes configuration checks now work reliably during preflight validation.

- **Documentation**
  - Clarified VM sizing guidance for additional environments and evaluation workloads.
  - Added guidance for DNS propagation delays after delegating a new zone.
  - Documented using `SSL_CERT_FILE` with `amctl` for private-CA certificates.

- **Configuration**
  - VM installations now require an explicit AMP release tag instead of using a default version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->