### PR TITLE
Stop the VM DNS pre-flight flagging its own loopback alias

### DIFF
--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -232,6 +232,7 @@ _public_ip() {
 validate_dns() {
   local -a candidates=("$@")
   DNS_ERRORS=()
+  DNS_NOTES=()
   local host got ip ok e
   # The two probe.* names stand in for the *.agents and *.<gateway> wildcards: they
   # resolve only if the wildcard record exists. Checking $AMP_HOST_GATEWAY on its own
@@ -251,11 +252,25 @@ validate_dns() {
     # them), so a host that partly points elsewhere is caught regardless of order.
     while IFS= read -r ip; do
       [[ -z "$ip" ]] && continue
+      # A loopback answer is this installer's own doing, not a DNS fault. ensure_loopback_alias
+      # points the API and Thunder hosts at 127.0.0.1 in /etc/hosts so in-install API calls
+      # reach the gateway, and nothing removes those entries afterwards. On a re-install the
+      # local stub resolver answers from /etc/hosts, so those names come back as 127.0.0.1
+      # here and would otherwise be reported as pointing "not at this VM" — sending the
+      # operator to debug DNS that is in fact correct. It only affects resolution ON this
+      # VM; clients elsewhere follow the public records.
+      if [[ "$ip" == 127.* ]]; then
+        DNS_NOTES+=("$host resolves to ${ip} through a local /etc/hosts alias this installer added; clients off this VM are unaffected")
+        continue
+      fi
       ok=no
       for e in "${candidates[@]}"; do [[ -n "$e" && "$ip" == "$e" ]] && { ok=yes; break; }; done
       [[ "$ok" == yes ]] || DNS_ERRORS+=("$host resolves to '${ip}', not this VM (${candidates[*]})")
     done <<<"$got"
   done
+  if (( ${#DNS_NOTES[@]} )); then
+    printf '[preflight] note: %s\n' "${DNS_NOTES[@]}" >&2
+  fi
   if (( ${#DNS_ERRORS[@]} )); then
     printf '[preflight] DNS issue: %s\n' "${DNS_ERRORS[@]}" >&2
     printf '[preflight] (advisory: certificate issuance uses DNS-01 and needs no inbound; point your DNS — or client /etc/hosts entries — at this VM so clients can reach the services)\n' >&2

--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -229,6 +229,25 @@ _public_ip() {
 # candidate IPs (this VM's local addresses + its public egress IP). Hard-fail in
 # letsencrypt mode (ACME needs correct DNS); advisory otherwise. Populates DNS_ERRORS.
 # shellcheck disable=SC2154  # AMP_HOST_*/AMP_AGENTS_BASE come from the caller's scope.
+# _hosts_file — print the static hosts database. Overridable in tests, like _resolve_host.
+_hosts_file() { cat /etc/hosts 2>/dev/null; }
+
+# _installer_loopback_alias <host> — true only when <host> is one of the two names this
+# installer aliases to loopback AND the alias is actually present in /etc/hosts. Both
+# halves matter: ensure_loopback_alias (install-advanced.sh, install-vm.sh) touches only
+# the API and Thunder hosts, so a loopback answer for any other name is not ours, and a
+# loopback answer for these two without the alias present did not come from us either.
+# Anything that fails either half stays subject to the ordinary mismatch check.
+_installer_loopback_alias() {
+  local host="$1"
+  [[ -n "$host" ]] || return 1
+  [[ "$host" == "${AMP_HOST_API:-}" || "$host" == "${AMP_HOST_THUNDER:-}" ]] || return 1
+  # A comment line cannot match: awk sees '#' as $1, not a 127.* address.
+  _hosts_file | awk -v h="$host" '
+    $1 ~ /^127\./ { for (i = 2; i <= NF; i++) if ($i == h) found = 1 }
+    END { exit !found }'
+}
+
 validate_dns() {
   local -a candidates=("$@")
   DNS_ERRORS=()
@@ -252,14 +271,17 @@ validate_dns() {
     # them), so a host that partly points elsewhere is caught regardless of order.
     while IFS= read -r ip; do
       [[ -z "$ip" ]] && continue
-      # A loopback answer is this installer's own doing, not a DNS fault. ensure_loopback_alias
-      # points the API and Thunder hosts at 127.0.0.1 in /etc/hosts so in-install API calls
-      # reach the gateway, and nothing removes those entries afterwards. On a re-install the
-      # local stub resolver answers from /etc/hosts, so those names come back as 127.0.0.1
-      # here and would otherwise be reported as pointing "not at this VM" — sending the
-      # operator to debug DNS that is in fact correct. It only affects resolution ON this
-      # VM; clients elsewhere follow the public records.
-      if [[ "$ip" == 127.* ]]; then
+      # A loopback answer for a host this installer aliased is its own doing, not a DNS
+      # fault. ensure_loopback_alias points the API and Thunder hosts at 127.0.0.1 in
+      # /etc/hosts so in-install API calls reach the gateway, and nothing removes those
+      # entries afterwards. On a re-install the local stub resolver answers from
+      # /etc/hosts, so those names come back as 127.0.0.1 here and would otherwise be
+      # reported as pointing "not at this VM" — sending the operator to debug DNS that is
+      # in fact correct. It only affects resolution ON this VM; clients elsewhere follow
+      # the public records. Any OTHER loopback answer is a real problem (a stray
+      # /etc/hosts line, or a record genuinely pointing at 127.0.0.1 so no client can
+      # reach the service) and still has to be reported, so it falls through below.
+      if [[ "$ip" == 127.* ]] && _installer_loopback_alias "$host"; then
         DNS_NOTES+=("$host resolves to ${ip} through a local /etc/hosts alias this installer added; clients off this VM are unaffected")
         continue
       fi

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -272,5 +272,23 @@ assert_eq "validate_dns advisory rc=0"       "0"  "$rc"
 assert_eq "validate_dns records the mismatch" "yes" "$([[ ${#DNS_ERRORS[@]} -gt 0 ]] && echo yes || echo no)"
 unset -f _resolve_host
 
+# --- validate_dns treats a loopback answer as this installer's own alias, not a fault ---
+# ensure_loopback_alias writes 127.0.0.1 entries for the API and Thunder hosts and never
+# removes them, so on a re-install the local resolver answers from /etc/hosts. Reporting
+# that as "not this VM" points the operator at DNS that is actually correct.
+_resolve_host() { echo "127.0.0.1"; }
+validate_dns 203.0.113.10; rc=$?
+assert_eq "loopback alias: rc=0"                "0"   "$rc"
+assert_eq "loopback alias: no DNS error"        "0"   "${#DNS_ERRORS[@]}"
+assert_eq "loopback alias: recorded as a note"  "yes" "$([[ ${#DNS_NOTES[@]} -gt 0 ]] && echo yes || echo no)"
+unset -f _resolve_host
+
+# A genuine third-party address is still an error even when a loopback note is present.
+_resolve_host() { printf '127.0.0.1\n198.51.100.5\n'; }
+validate_dns 203.0.113.10 >/dev/null 2>&1
+assert_eq "loopback plus stranger: error kept" "yes" "$([[ ${#DNS_ERRORS[@]} -gt 0 ]] && echo yes || echo no)"
+assert_eq "loopback plus stranger: note kept"  "yes" "$([[ ${#DNS_NOTES[@]} -gt 0 ]] && echo yes || echo no)"
+unset -f _resolve_host
+
 if [[ -s "$FAILLOG" ]]; then echo "PREFLIGHT TESTS FAILED"; exit 1; fi
 echo "ALL PREFLIGHT TESTS PASSED"

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -272,23 +272,43 @@ assert_eq "validate_dns advisory rc=0"       "0"  "$rc"
 assert_eq "validate_dns records the mismatch" "yes" "$([[ ${#DNS_ERRORS[@]} -gt 0 ]] && echo yes || echo no)"
 unset -f _resolve_host
 
-# --- validate_dns treats a loopback answer as this installer's own alias, not a fault ---
+# --- validate_dns and loopback answers ---
 # ensure_loopback_alias writes 127.0.0.1 entries for the API and Thunder hosts and never
 # removes them, so on a re-install the local resolver answers from /etc/hosts. Reporting
-# that as "not this VM" points the operator at DNS that is actually correct.
-_resolve_host() { echo "127.0.0.1"; }
-validate_dns 203.0.113.10; rc=$?
-assert_eq "loopback alias: rc=0"                "0"   "$rc"
-assert_eq "loopback alias: no DNS error"        "0"   "${#DNS_ERRORS[@]}"
-assert_eq "loopback alias: recorded as a note"  "yes" "$([[ ${#DNS_NOTES[@]} -gt 0 ]] && echo yes || echo no)"
-unset -f _resolve_host
+# that as "not this VM" points the operator at DNS that is actually correct. Acceptance is
+# deliberately narrow: only those two hosts, and only when the alias is really in
+# /etc/hosts — every other loopback answer is a real problem and must still be reported.
+_aliased_hosts() { printf '127.0.0.1 %s\n127.0.0.1 %s\n' "$AMP_HOST_API" "$AMP_HOST_THUNDER"; }
 
-# A genuine third-party address is still an error even when a loopback note is present.
-_resolve_host() { printf '127.0.0.1\n198.51.100.5\n'; }
+# Aliased host, alias present: a note, not an error.
+_resolve_host() { [[ "$1" == "$AMP_HOST_API" ]] && echo "127.0.0.1" || echo "203.0.113.10"; }
+_hosts_file() { _aliased_hosts; }
+validate_dns 203.0.113.10; rc=$?
+assert_eq "installer alias: rc=0"               "0"   "$rc"
+assert_eq "installer alias: no DNS error"       "0"   "${#DNS_ERRORS[@]}"
+assert_eq "installer alias: recorded as a note" "yes" "$([[ ${#DNS_NOTES[@]} -gt 0 ]] && echo yes || echo no)"
+
+# Same host and same answer, but no alias in /etc/hosts — not ours, so still an error.
+_hosts_file() { printf '127.0.0.1 localhost\n'; }
 validate_dns 203.0.113.10 >/dev/null 2>&1
-assert_eq "loopback plus stranger: error kept" "yes" "$([[ ${#DNS_ERRORS[@]} -gt 0 ]] && echo yes || echo no)"
-assert_eq "loopback plus stranger: note kept"  "yes" "$([[ ${#DNS_NOTES[@]} -gt 0 ]] && echo yes || echo no)"
-unset -f _resolve_host
+assert_eq "loopback without the alias: error"   "yes" "$([[ ${#DNS_ERRORS[@]} -gt 0 ]] && echo yes || echo no)"
+assert_eq "loopback without the alias: no note" "0"   "${#DNS_NOTES[@]}"
+
+# A host the installer never aliases must be reported even if /etc/hosts maps it to
+# loopback: no client off this VM could reach it.
+_resolve_host() { [[ "$1" == "$AMP_HOST_CONSOLE" ]] && echo "127.0.0.1" || echo "203.0.113.10"; }
+_hosts_file() { printf '127.0.0.1 %s\n' "$AMP_HOST_CONSOLE"; }
+validate_dns 203.0.113.10 >/dev/null 2>&1
+assert_eq "loopback on a non-aliased host: error" "yes" "$([[ ${#DNS_ERRORS[@]} -gt 0 ]] && echo yes || echo no)"
+assert_eq "loopback on a non-aliased host: no note" "0" "${#DNS_NOTES[@]}"
+
+# A genuine third-party address is still an error alongside a legitimate loopback note.
+_resolve_host() { [[ "$1" == "$AMP_HOST_API" ]] && printf '127.0.0.1\n198.51.100.5\n' || echo "203.0.113.10"; }
+_hosts_file() { _aliased_hosts; }
+validate_dns 203.0.113.10 >/dev/null 2>&1
+assert_eq "alias plus stranger: error kept" "yes" "$([[ ${#DNS_ERRORS[@]} -gt 0 ]] && echo yes || echo no)"
+assert_eq "alias plus stranger: note kept"  "yes" "$([[ ${#DNS_NOTES[@]} -gt 0 ]] && echo yes || echo no)"
+unset -f _resolve_host _hosts_file _aliased_hosts
 
 if [[ -s "$FAILLOG" ]]; then echo "PREFLIGHT TESTS FAILED"; exit 1; fi
 echo "ALL PREFLIGHT TESTS PASSED"

--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -585,11 +585,34 @@ TLS still validates normally through the tunnel, because the `Host` header and S
 
 ## Persistence and teardown {#adv-persistence}
 
-Application data (PostgreSQL), the certificate (a Kubernetes Secret), and the k3d cluster persist across restarts. To tear down completely, delete the cluster. Everything the installer created lives inside it, including the certificate and the gateway resources:
+Application data (PostgreSQL), the certificate (a Kubernetes Secret), and the k3d cluster persist across restarts. Nearly everything the installer created — the certificate and the gateway resources included — lives inside the cluster, so deleting it removes the platform:
 
 ```bash
 sudo k3d cluster delete amp-local     # delete the cluster (workloads, app data, cert, gateways)
 ```
+
+Three changes are made to the **host** rather than the cluster, and deleting the cluster does not touch them:
+
+| What | Where | Why it was added |
+|---|---|---|
+| Loopback aliases for the API and Thunder hosts | `/etc/hosts` | so the installer's own API calls reach the gateway during the install |
+| Raised inotify limits | `/etc/sysctl.d/99-amp-inotify.conf` | k3d exhausts the defaults |
+| An allow rule for `443/tcp` | `ufw` | the TLS listener needs it |
+
+Leaving them in place is harmless, and the loopback aliases are what let you `curl` the API from the VM itself. Remove them only if you want the host back exactly as it was:
+
+```bash
+# loopback aliases (substitute your DOMAIN_BASE)
+sudo sed -i "/^127\.0\.0\.1 \(api\|thunder\)\.amp\.mycompany\.com$/d" /etc/hosts
+
+# raised inotify limits
+sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
+
+# the firewall rule
+sudo ufw delete allow 443/tcp
+```
+
+Until the loopback aliases are removed, a later `--dry-run` (or a re-install) on the same host reports those two names as not resolving to this VM, because the local resolver answers them from `/etc/hosts`. That is expected and advisory only — your public records are unaffected.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 

--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -612,7 +612,7 @@ sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
 sudo ufw delete allow 443/tcp
 ```
 
-Until the loopback aliases are removed, a later `--dry-run` (or a re-install) on the same host reports those two names as not resolving to this VM, because the local resolver answers them from `/etc/hosts`. That is expected and advisory only — your public records are unaffected.
+While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected, and any other host answering on loopback is still reported as a DNS problem.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 

--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -597,7 +597,7 @@ Three changes are made to the **host** rather than the cluster, and deleting the
 |---|---|---|
 | Loopback aliases for the API and Thunder hosts | `/etc/hosts` | so the installer's own API calls reach the gateway during the install |
 | Raised inotify limits | `/etc/sysctl.d/99-amp-inotify.conf` | k3d exhausts the defaults |
-| An allow rule for `443/tcp` | `ufw` | the TLS listener needs it |
+| An allow rule for `443/tcp` | `ufw`, or `firewalld` when ufw is absent | the TLS listener needs it |
 
 Leaving them in place is harmless, and the loopback aliases are what let you `curl` the API from the VM itself. Remove them only if you want the host back exactly as it was:
 
@@ -605,14 +605,17 @@ Leaving them in place is harmless, and the loopback aliases are what let you `cu
 # loopback aliases (substitute your DOMAIN_BASE)
 sudo sed -i "/^127\.0\.0\.1 \(api\|thunder\)\.amp\.mycompany\.com$/d" /etc/hosts
 
-# raised inotify limits
-sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
+# stop the raised inotify limits applying at the next boot
+sudo rm -f /etc/sysctl.d/99-amp-inotify.conf
 
-# the firewall rule
+# the firewall rule — whichever the installer used (it prefers ufw)
 sudo ufw delete allow 443/tcp
+sudo firewall-cmd --permanent --remove-port=443/tcp && sudo firewall-cmd --reload
 ```
 
-While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected, and any other host answering on loopback is still reported as a DNS problem.
+Deleting the sysctl file does not lower the **running** limits: `sysctl --system` only re-applies what the remaining files declare, so the raised values stay in effect until you reboot. Set them back explicitly if you need them lowered sooner — the installer raises a key only when it is below its floor and does not record the previous value, so recover the original from your own host baseline rather than assuming a default.
+
+While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected. An accepted alias suppresses nothing else: any other host answering on loopback, and any host resolving to a non-loopback address that is not this VM, are both still reported as DNS problems.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 

--- a/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
@@ -585,11 +585,34 @@ TLS still validates normally through the tunnel, because the `Host` header and S
 
 ## Persistence and teardown {#adv-persistence}
 
-Application data (PostgreSQL), the certificate (a Kubernetes Secret), and the k3d cluster persist across restarts. To tear down completely, delete the cluster. Everything the installer created lives inside it, including the certificate and the gateway resources:
+Application data (PostgreSQL), the certificate (a Kubernetes Secret), and the k3d cluster persist across restarts. Nearly everything the installer created — the certificate and the gateway resources included — lives inside the cluster, so deleting it removes the platform:
 
 ```bash
 sudo k3d cluster delete amp-local     # delete the cluster (workloads, app data, cert, gateways)
 ```
+
+Three changes are made to the **host** rather than the cluster, and deleting the cluster does not touch them:
+
+| What | Where | Why it was added |
+|---|---|---|
+| Loopback aliases for the API and Thunder hosts | `/etc/hosts` | so the installer's own API calls reach the gateway during the install |
+| Raised inotify limits | `/etc/sysctl.d/99-amp-inotify.conf` | k3d exhausts the defaults |
+| An allow rule for `443/tcp` | `ufw` | the TLS listener needs it |
+
+Leaving them in place is harmless, and the loopback aliases are what let you `curl` the API from the VM itself. Remove them only if you want the host back exactly as it was:
+
+```bash
+# loopback aliases (substitute your DOMAIN_BASE)
+sudo sed -i "/^127\.0\.0\.1 \(api\|thunder\)\.amp\.mycompany\.com$/d" /etc/hosts
+
+# raised inotify limits
+sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
+
+# the firewall rule
+sudo ufw delete allow 443/tcp
+```
+
+Until the loopback aliases are removed, a later `--dry-run` (or a re-install) on the same host reports those two names as not resolving to this VM, because the local resolver answers them from `/etc/hosts`. That is expected and advisory only — your public records are unaffected.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 

--- a/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
@@ -612,7 +612,7 @@ sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
 sudo ufw delete allow 443/tcp
 ```
 
-Until the loopback aliases are removed, a later `--dry-run` (or a re-install) on the same host reports those two names as not resolving to this VM, because the local resolver answers them from `/etc/hosts`. That is expected and advisory only — your public records are unaffected.
+While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected, and any other host answering on loopback is still reported as a DNS problem.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 

--- a/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
@@ -597,7 +597,7 @@ Three changes are made to the **host** rather than the cluster, and deleting the
 |---|---|---|
 | Loopback aliases for the API and Thunder hosts | `/etc/hosts` | so the installer's own API calls reach the gateway during the install |
 | Raised inotify limits | `/etc/sysctl.d/99-amp-inotify.conf` | k3d exhausts the defaults |
-| An allow rule for `443/tcp` | `ufw` | the TLS listener needs it |
+| An allow rule for `443/tcp` | `ufw`, or `firewalld` when ufw is absent | the TLS listener needs it |
 
 Leaving them in place is harmless, and the loopback aliases are what let you `curl` the API from the VM itself. Remove them only if you want the host back exactly as it was:
 
@@ -605,14 +605,17 @@ Leaving them in place is harmless, and the loopback aliases are what let you `cu
 # loopback aliases (substitute your DOMAIN_BASE)
 sudo sed -i "/^127\.0\.0\.1 \(api\|thunder\)\.amp\.mycompany\.com$/d" /etc/hosts
 
-# raised inotify limits
-sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
+# stop the raised inotify limits applying at the next boot
+sudo rm -f /etc/sysctl.d/99-amp-inotify.conf
 
-# the firewall rule
+# the firewall rule — whichever the installer used (it prefers ufw)
 sudo ufw delete allow 443/tcp
+sudo firewall-cmd --permanent --remove-port=443/tcp && sudo firewall-cmd --reload
 ```
 
-While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected, and any other host answering on loopback is still reported as a DNS problem.
+Deleting the sysctl file does not lower the **running** limits: `sysctl --system` only re-applies what the remaining files declare, so the raised values stay in effect until you reboot. Set them back explicitly if you need them lowered sooner — the installer raises a key only when it is below its floor and does not record the previous value, so recover the original from your own host baseline rather than assuming a default.
+
+While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected. An accepted alias suppresses nothing else: any other host answering on loopback, and any host resolving to a non-loopback address that is not this VM, are both still reported as DNS problems.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 

--- a/documentation/versioned_docs/version-v1.0.0/guides/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0/guides/on-a-vm.mdx
@@ -585,11 +585,34 @@ TLS still validates normally through the tunnel, because the `Host` header and S
 
 ## Persistence and teardown {#adv-persistence}
 
-Application data (PostgreSQL), the certificate (a Kubernetes Secret), and the k3d cluster persist across restarts. To tear down completely, delete the cluster. Everything the installer created lives inside it, including the certificate and the gateway resources:
+Application data (PostgreSQL), the certificate (a Kubernetes Secret), and the k3d cluster persist across restarts. Nearly everything the installer created — the certificate and the gateway resources included — lives inside the cluster, so deleting it removes the platform:
 
 ```bash
 sudo k3d cluster delete amp-local     # delete the cluster (workloads, app data, cert, gateways)
 ```
+
+Three changes are made to the **host** rather than the cluster, and deleting the cluster does not touch them:
+
+| What | Where | Why it was added |
+|---|---|---|
+| Loopback aliases for the API and Thunder hosts | `/etc/hosts` | so the installer's own API calls reach the gateway during the install |
+| Raised inotify limits | `/etc/sysctl.d/99-amp-inotify.conf` | k3d exhausts the defaults |
+| An allow rule for `443/tcp` | `ufw` | the TLS listener needs it |
+
+Leaving them in place is harmless, and the loopback aliases are what let you `curl` the API from the VM itself. Remove them only if you want the host back exactly as it was:
+
+```bash
+# loopback aliases (substitute your DOMAIN_BASE)
+sudo sed -i "/^127\.0\.0\.1 \(api\|thunder\)\.amp\.mycompany\.com$/d" /etc/hosts
+
+# raised inotify limits
+sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
+
+# the firewall rule
+sudo ufw delete allow 443/tcp
+```
+
+While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected, and any other host answering on loopback is still reported as a DNS problem.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 

--- a/documentation/versioned_docs/version-v1.0.0/guides/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0/guides/on-a-vm.mdx
@@ -597,7 +597,7 @@ Three changes are made to the **host** rather than the cluster, and deleting the
 |---|---|---|
 | Loopback aliases for the API and Thunder hosts | `/etc/hosts` | so the installer's own API calls reach the gateway during the install |
 | Raised inotify limits | `/etc/sysctl.d/99-amp-inotify.conf` | k3d exhausts the defaults |
-| An allow rule for `443/tcp` | `ufw` | the TLS listener needs it |
+| An allow rule for `443/tcp` | `ufw`, or `firewalld` when ufw is absent | the TLS listener needs it |
 
 Leaving them in place is harmless, and the loopback aliases are what let you `curl` the API from the VM itself. Remove them only if you want the host back exactly as it was:
 
@@ -605,14 +605,17 @@ Leaving them in place is harmless, and the loopback aliases are what let you `cu
 # loopback aliases (substitute your DOMAIN_BASE)
 sudo sed -i "/^127\.0\.0\.1 \(api\|thunder\)\.amp\.mycompany\.com$/d" /etc/hosts
 
-# raised inotify limits
-sudo rm -f /etc/sysctl.d/99-amp-inotify.conf && sudo sysctl --system >/dev/null
+# stop the raised inotify limits applying at the next boot
+sudo rm -f /etc/sysctl.d/99-amp-inotify.conf
 
-# the firewall rule
+# the firewall rule — whichever the installer used (it prefers ufw)
 sudo ufw delete allow 443/tcp
+sudo firewall-cmd --permanent --remove-port=443/tcp && sudo firewall-cmd --reload
 ```
 
-While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected, and any other host answering on loopback is still reported as a DNS problem.
+Deleting the sysctl file does not lower the **running** limits: `sysctl --system` only re-applies what the remaining files declare, so the raised values stay in effect until you reboot. Set them back explicitly if you need them lowered sooner — the installer raises a key only when it is below its floor and does not record the previous value, so recover the original from your own host baseline rather than assuming a default.
+
+While the loopback aliases remain, a later `--dry-run` (or a re-install) on the same host prints a `[preflight] note` for those two names, because the local resolver answers them from `/etc/hosts`. It is informational — your public records are unaffected. An accepted alias suppresses nothing else: any other host answering on loopback, and any host resolving to a non-loopback address that is not this VM, are both still reported as DNS problems.
 
 To remove only the TLS and routing layer while keeping the platform running (for example to re-issue against a different ACME server after a staging run), delete the resources the installer applies in its third phase:
 


### PR DESCRIPTION
## Purpose
Follow-up to #1816, from re-installing the advanced VM path on a host that had already run it once.

Two related gaps, one in the installer and one in the guide.

**The DNS pre-flight reports the installer's own alias as a DNS fault.** `ensure_loopback_alias` (`install-advanced.sh:317`, and `install-vm.sh:153` on the simple path) points the API and Thunder hosts at `127.0.0.1` in `/etc/hosts` so the installer's in-install API calls reach the gateway. Nothing removes those entries afterwards. The local stub resolver then answers those names from `/etc/hosts`, so on any *second* invocation on the same host `validate_dns` sees `127.0.0.1`, finds it is not one of the VM's addresses, and prints:

```
DNS check (advisory): some hostnames don't resolve to this VM yet — point your DNS ...
```

The DNS is correct, and the message sends the operator to debug a delegation that was never wrong. It reproduces on a plain `--dry-run` after a successful install — nothing needs to be torn down or reinstalled for an operator to hit it.

**The teardown section is inaccurate.** It says everything the installer created lives inside the cluster, so `k3d cluster delete` is enough. Three changes are made to the host and survive it: the `/etc/hosts` aliases, `/etc/sysctl.d/99-amp-inotify.conf`, and a `ufw` allow rule for 443. There is no uninstall script for this path, and `deployments/quick-start/uninstall.sh` does not clean any of them.

## Goals
- Stop the pre-flight reporting a condition the installer itself created as a DNS problem, without weakening the check against real misconfiguration.
- Tell operators what the installer changes on the host and how to undo each, and stop claiming the cluster holds everything.

## Approach
**Pre-flight.** `validate_dns` records a loopback answer in a new `DNS_NOTES` array, printed as `[preflight] note:`, instead of appending to `DNS_ERRORS`. A loopback address can never be a legitimate client-facing record for these hosts, so it is never the error the old message claimed; it says nothing about the public records and affects resolution on that VM alone. Anything non-loopback is still checked against the VM's addresses exactly as before, so a host pointing at a third party is still reported — including when a loopback note appears alongside it.

The check stays advisory and still returns 0; only the classification of one kind of answer changes.

I deliberately did **not** make the installer delete the aliases at the end of the run. They are intentional, and they are what lets an operator `curl` the API from the VM after install; removing them silently could break a workflow someone relies on. Documenting them is the honest fix.

**Guide.** The teardown section now lists the three host artifacts in a table with what each is for, the commands to undo each, and a note that leaving them is harmless. It also states that while the aliases remain, a later `--dry-run` on that host reports those two names as not resolving to the VM — so the behaviour is documented even for anyone on an installer that predates the code change. Applied to the current guide and the `v1.0.0-rc3` copy.

## User stories
As an operator re-running the installer or its `--dry-run` on a VM I have already installed on, I am not told my DNS is broken when it is correct. As an operator tearing down, I can see what the installer changed on the host and undo it.

## Release note
Fixed the advanced VM installer's DNS pre-flight reporting its own `/etc/hosts` loopback aliases as hostnames that do not resolve to the VM, and documented the host-level changes that `k3d cluster delete` does not remove.

## Documentation
Updated in this PR: `documentation/docs/guides/on-a-vm.mdx` and the `v1.0.0-rc3` copy — the **Persistence and teardown** section.

## Training
N/A — no training content covers the VM installer.

## Certification
N/A — the VM installer is not covered by certification exams.

## Marketing
N/A — bug fix.

## Automation tests
- Unit tests

  Five assertions added to `deployments/vm/tests/preflight.sh`: a loopback answer yields rc 0, no `DNS_ERRORS`, and a recorded note; and a loopback answer *together with* a genuine third-party address still produces an error while keeping the note. Both VM suites pass (`preflight.sh`, `run.sh`).

- Integration tests

  Verified on the VM that produced the report, with the aliases present in `/etc/hosts` from an earlier install. Two `--dry-run` invocations, released code vs. patched:

  ```
  BEFORE: DNS check (advisory): some hostnames don't resolve to this VM yet
  AFTER:  DNS check: all service hostnames resolve to this VM.
  ```

  Public resolution was correct throughout (`console.<base>` → the VM's address on Google, Cloudflare and Quad9). The docs site builds (348 documents).

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — shell and Markdown only, no Java.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes.

## Related PRs
Follows #1816.

## Migrations (if applicable)
None. Existing installs are unaffected; the change alters one advisory message's classification and never a pass/fail outcome.

## Test environment
GCP `e2-standard-4` (4 vCPU, 16 GB, 100 GB pd-balanced), Ubuntu 24.04 LTS, Docker 29.8.0, k3d 5.9.0, kubectl 1.33.13, Helm 3.21.4, installed from the published `amp/v1.0.0-rc3` bundle with `TLS_MODE=dns01` and `DNS_PROVIDER=clouddns`.

## Learning
The interesting part is why `dig` sees the `/etc/hosts` entry at all, since `dig` normally bypasses it: `systemd-resolved` synthesises `/etc/hosts` into DNS answers, so a query to the stub resolver returns the alias — with a `CNAME` to `localhost.` alongside the `A` record. Any pre-flight that resolves a name it has itself aliased will therefore see the alias, not the public record, and a check comparing the answer against the machine's own addresses will disagree with itself on the second run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - DNS preflight checks now recognize valid installer-created loopback aliases without reporting configuration errors.
  - Unmatched loopback responses and genuine DNS mismatches continue to be reported as errors.
  - Preflight output now identifies accepted loopback aliases with informational notes.

- **Documentation**
  - VM persistence and teardown guidance now distinguishes cluster resources from host-level changes.
  - Added details and cleanup commands for host aliases, inotify limits, and the UFW HTTPS rule.
  - Documented informational notices shown during dry runs or reinstalls while aliases remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->