### PR TITLE
fix(console): correct cURL command shown in LLM provider configuration

### DIFF
--- a/console/workspaces/libs/api-client/src/apis/agent-model-configs.ts
+++ b/console/workspaces/libs/api-client/src/apis/agent-model-configs.ts
@@ -234,7 +234,7 @@ export function normalizeAgentModelConfigResponse(
                   ? {
                       type: "apikey",
                       in: "header",
-                      name: "Authorization",
+                      name: "api-key",
                       value: mapping.llmProxy.apiKey,
                     }
                   : undefined,

--- a/console/workspaces/pages/configure-agent/src/ViewLLMProvider.Component.tsx
+++ b/console/workspaces/pages/configure-agent/src/ViewLLMProvider.Component.tsx
@@ -863,7 +863,7 @@ export const ViewLLMProviderComponent: React.FC = () => {
           {(() => {
             const authEntry = authInfoByEnv?.[selectedEnvName];
             const apiKeyEnvVar = config.environmentVariables?.find((ev) => ev.key === "apikey");
-            const headerName = authEntry?.name || "Authorization";
+            const headerName = authEntry?.name || providerConfig?.authInfo?.name || "api-key";
             const headerValue = authEntry?.value || (apiKeyEnvVar ? `$${apiKeyEnvVar.name}` : "<api-key>");
             const curlCode = [
               `curl -X POST ${providerConfig.url || "<endpoint-url>"}/chat/completions`,


### PR DESCRIPTION
### Purpose

Resolves #1813

The cURL command shown in the "Connect to LLM Provider" drawer under LLM provider configurations was always showing `Authorization` as the auth header name, no matter what header was actually set for the provider. This led users to copy a command that didn't match their setup making it hard to test the integration properly.

### Goals

Show the authentication header name in the generated cURL example. The header name should match the one configured for the provider or fall back to a default like `api-key` so users can copy and paste a working command without issues.

### Approach

- In `agent-model-configs.ts` changed the normalized API key auth header name from the hardcoded `"Authorization"` to `"api-key"` to match the default used by the LLM provider integration.

- In `ViewLLMProvider.Component.tsx` updated how the `headerName` is resolved. It now checks `providerConfig?.authInfo?.name` first. This is the header name set for the provider. And only uses `"api-key"` if no custom name is set. It no longer defaults to `"Authorization"`.

- This change ensures the `curl -X POST...` example in the drawer always reflects the authentication header used by the provider.

### Release note

Fixed an issue where the sample cURL command in the LLM provider "Connect" drawer showed an authentication header name.

### Documentation

N/A – no user-facing documentation describes the text inside the drawer. The behavior now matches the actual provider configuration.

### Automation tests

Manually verified: opened the LLM provider configuration page and checked the "Connect to LLM Provider" drawer. Confirmed the example now shows the correct header name for both providers, with a custom auth header and those using the default setting.

### Security checks

- Followed coding standards: yes

- Ran FindSecurityBugs plugin and verified report: N/A (frontend TypeScript change, not

- Confirmed no keys, passwords, tokens, usernames or secrets committed: yes## Purpose

> Explain the problems, issues or needs that motivate this feature or fix. Include links to issues using the format: Resolves issue1 issue2, etc.

## Goals

> Explain the solutions that this feature or fix will provide to solve the problems described above.

## Approach

> Explain how you will implement the solutions. Add an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a file or Google doc if the feature write-up is too long to paste here.

## User stories

> Summary of user stories addressed by this change.

## Release note

> description of the new feature or bug fix as it will appear in the release notes.

## Documentation

> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter "N/A" plus brief explanation of why there is no doc impact.

## Training

> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable.

## Certification

> Type "Sent" when you have provided /updated certification questions, plus four answers for each question (correct answer highlighted in bold) based on this change. Certification questions/answers should be sent to certification@wso2.com. Not pasted in this PR. If there is no impact on certification exams, type "N/A". Explain why.

## Marketing

> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc. if applicable.

## Automation tests

Unit tests

> Code coverage information

Integration tests

> Details about the test cases and coverage

## Security checks

Followed coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no

Ran FindSecurityBugs plugin and verified report? yes/no

Confirmed that this PR does not commit any keys, passwords, tokens, usernames or other secrets? yes/no

## Samples

> Provide high-level details about the samples related to this feature.

## Related PRs

> List any related PRs.

## Migrations (if applicable)

> Describe migration steps and platforms on which migration has been tested.

## Test environment

> List all JDK versions, operating systems, databases and browser/versions on which this feature/fix was tested.

## Learning

> Describe the research phase and any blog posts, patterns, libraries or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**

Corrected API key authentication headers for configured agent model providers.

Updated the example in the "Connect to LLM Provider" drawer to show the appropriate saved authentication header with `api-key` used as the fallback.

This improves consistency between provider configuration and the connection example helping ensure generated requests authenticate correctly.

<!-- end of auto-generated comment: release notes, by coderabbit.ai -->


  <img width="1836" height="727" alt="Screenshot 2026-09-05 185757" src="https://github.com/user-attachments/assets/9d182e85-e7b4-4543-89ad-be46548b98dd" />
