### PR TITLE
Fix NoNewPrivileges detection in runtime security probe

### DIFF
--- a/test/e2e/fixtures/security-probe-agent/probe/runtime.py
+++ b/test/e2e/fixtures/security-probe-agent/probe/runtime.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import ctypes
 import os
 import tempfile
 from pathlib import Path
+
+
+PR_GET_NO_NEW_PRIVS = 39
 
 
 def _proc_status() -> dict[str, str]:
@@ -17,6 +21,49 @@ def _proc_status() -> dict[str, str]:
     except OSError:
         return {}
     return values
+
+
+def _read_no_new_privileges() -> int | None:
+    """Read the process flag through prctl, independent of procfs rendering."""
+
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        prctl = libc.prctl
+    except (AttributeError, OSError):
+        return None
+
+    prctl.restype = ctypes.c_int
+    return int(
+        prctl(
+            ctypes.c_int(PR_GET_NO_NEW_PRIVS),
+            ctypes.c_ulong(0),
+            ctypes.c_ulong(0),
+            ctypes.c_ulong(0),
+            ctypes.c_ulong(0),
+        )
+    )
+
+
+def classify_no_new_privileges(
+    prctl_result: int | None,
+    proc_value: str | None,
+) -> tuple[bool, str]:
+    """Classify authoritative prctl evidence without failing open.
+
+    Older gVisor releases maintain the flag but omit NoNewPrivs from procfs.
+    Procfs is therefore diagnostic only when prctl itself is unavailable: an
+    unsupported direct query must never become a security pass.
+    """
+
+    if prctl_result == 1:
+        return True, "prctl_enabled"
+    if prctl_result == 0:
+        return False, "prctl_disabled"
+    if proc_value == "1":
+        return False, "prctl_unavailable_proc_enabled"
+    if proc_value == "0":
+        return False, "prctl_unavailable_proc_disabled"
+    return False, "prctl_unavailable_proc_missing"
 
 
 def runtime_posture() -> dict[str, object]:
@@ -43,7 +90,10 @@ def runtime_posture() -> dict[str, object]:
     status = _proc_status()
     cap_eff = status.get("CapEff", "")
     seccomp = status.get("Seccomp", "")
-    no_new_privileges = status.get("NoNewPrivs", "")
+    no_new_privileges, no_new_privileges_evidence = classify_no_new_privileges(
+        _read_no_new_privileges(),
+        status.get("NoNewPrivs"),
+    )
 
     return {
         "non_root": os.geteuid() != 0,
@@ -54,6 +104,7 @@ def runtime_posture() -> dict[str, object]:
         ).exists(),
         "effective_capabilities_dropped": bool(cap_eff)
         and int(cap_eff, 16) == 0,
-        "no_new_privileges": no_new_privileges == "1",
+        "no_new_privileges": no_new_privileges,
+        "no_new_privileges_evidence": no_new_privileges_evidence,
         "seccomp_enabled": seccomp == "2",
     }

--- a/test/e2e/fixtures/security-probe-agent/tests/test_runtime.py
+++ b/test/e2e/fixtures/security-probe-agent/tests/test_runtime.py
@@ -1,0 +1,35 @@
+"""Tests for fail-closed runtime-hardening evidence classification."""
+
+import unittest
+
+from probe.runtime import classify_no_new_privileges
+
+
+class NoNewPrivilegesClassificationTests(unittest.TestCase):
+    def test_prctl_enabled_is_authoritative(self) -> None:
+        self.assertEqual(
+            classify_no_new_privileges(1, "0"),
+            (True, "prctl_enabled"),
+        )
+
+    def test_prctl_disabled_fails(self) -> None:
+        self.assertEqual(
+            classify_no_new_privileges(0, "1"),
+            (False, "prctl_disabled"),
+        )
+
+    def test_proc_enabled_is_only_diagnostic_when_prctl_is_unavailable(self) -> None:
+        self.assertEqual(
+            classify_no_new_privileges(None, "1"),
+            (False, "prctl_unavailable_proc_enabled"),
+        )
+
+    def test_missing_prctl_and_proc_evidence_fails_closed(self) -> None:
+        self.assertEqual(
+            classify_no_new_privileges(None, None),
+            (False, "prctl_unavailable_proc_missing"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/e2e/framework/types.go
+++ b/test/e2e/framework/types.go
@@ -793,13 +793,14 @@ type AgentIdentityAgentListResponse struct {
 }
 
 type SecurityRuntimeProbeResponse struct {
-	NonRoot                    bool `json:"non_root"`
-	RootFilesystemReadOnly     bool `json:"root_filesystem_read_only"`
-	TmpWritable                bool `json:"tmp_writable"`
-	ServiceAccountTokenPresent bool `json:"service_account_token_present"`
-	EffectiveCapabilitiesDrop  bool `json:"effective_capabilities_dropped"`
-	NoNewPrivileges            bool `json:"no_new_privileges"`
-	SeccompEnabled             bool `json:"seccomp_enabled"`
+	NonRoot                    bool   `json:"non_root"`
+	RootFilesystemReadOnly     bool   `json:"root_filesystem_read_only"`
+	TmpWritable                bool   `json:"tmp_writable"`
+	ServiceAccountTokenPresent bool   `json:"service_account_token_present"`
+	EffectiveCapabilitiesDrop  bool   `json:"effective_capabilities_dropped"`
+	NoNewPrivileges            bool   `json:"no_new_privileges"`
+	NoNewPrivilegesEvidence    string `json:"no_new_privileges_evidence"`
+	SeccompEnabled             bool   `json:"seccomp_enabled"`
 }
 
 type SecurityNetworkProbeResponse struct {

--- a/test/e2e/security/runtime/runtime_security_test.go
+++ b/test/e2e/security/runtime/runtime_security_test.go
@@ -198,7 +198,8 @@ var _ = Describe("SEC-RUNTIME-001: deployed agent sandbox and AgentID", Label("s
 		Expect(posture.TmpWritable).To(BeTrue(), "sandbox did not provide its bounded writable /tmp")
 		Expect(posture.ServiceAccountTokenPresent).To(BeFalse(), "agent pod received a Kubernetes service-account token")
 		Expect(posture.EffectiveCapabilitiesDrop).To(BeTrue(), "agent retained effective Linux capabilities")
-		Expect(posture.NoNewPrivileges).To(BeTrue(), "NoNewPrivs is not active")
+		Expect(posture.NoNewPrivileges).To(BeTrue(),
+			"NoNewPrivs is not active (evidence: %s)", posture.NoNewPrivilegesEvidence)
 		Expect(posture.SeccompEnabled).To(BeTrue(), "RuntimeDefault seccomp is not active")
 	})
 


### PR DESCRIPTION
## Purpose

The live runtime security suite incorrectly reported that `NoNewPrivileges` was disabled on gVisor (cloud version) because they did not expose the flag through `/proc/self/status`, even when the security control was active.

## Goals

Make the runtime security check reliable across both runc and gVisor without weakening the security assertion.

## Approach

Updated the security probe to query the process security flag directly through the Linux process-control interface. Procfs information is retained only as diagnostic evidence, and the check fails closed when authoritative evidence is unavailable.

The live-suite failure message now includes the detected evidence for easier diagnosis.

## User stories

As a platform engineer, I can run the live security suite across supported container runtimes without receiving false failures caused by differences in procfs rendering.

## Release note

Fixed incorrect `NoNewPrivileges` failures in live runtime security tests running under gVisor.

## Documentation

N/A 

## Training

N/A 

## Certification

N/A 

## Marketing

N/A 

## Automation tests

* **Unit tests**

  * Added four tests covering enabled, disabled, unavailable, and missing security evidence.
* **Integration tests**

  * Updated the existing live runtime security assertion to report the evidence used.
  * Verified E2E suite compilation and Go vet checks.

## Security checks

* Followed secure coding standards: **Yes**
* Ran FindSecurityBugs plugin and verified report: **N/A** 
* Confirmed that this PR doesn't commit secrets: **Yes**

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

* macOS
* Go E2E compilation and vet checks
* No JDK, database, or browser impact

## Learning

Reviewed the difference between querying the active process security flag directly and relying on its optional procfs representation. Older gVisor releases can enforce the flag without displaying it in `/proc/self/status`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of the container’s no-new-privileges security setting.
  - Security checks now fail safely when authoritative evidence is unavailable, preventing incorrect positive results.
  - Procfs information is used only as supporting diagnostic evidence when the primary check cannot be performed.

- **Tests**
  - Added coverage for enabled, disabled, unavailable, and incomplete security evidence scenarios.

- **Diagnostics**
  - Security check failures now include evidence explaining why the no-new-privileges setting was not confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->