### PR TITLE
Resolve org context for background AgentID workload injection

### DIFF
--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/orgctx"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -463,10 +464,19 @@ func reconcileWorkloadInjection(ctx context.Context, injector AgentIdentityInjec
 			"ouID", binding.OUID, "bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName)
 		return
 	}
+	// Provisioning can finish after the originating HTTP request has returned, or
+	// during the periodic reconciler where there is no user token at all. Preserve
+	// the binding's trusted OU identity in the context so deployments that use an
+	// M2M service token can send the target organization to OpenChoreo.
+	ctx = agentThunderBindingOrgContext(ctx, binding)
 	if err := injector.ReconcileForEnvironment(ctx, binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName); err != nil {
 		logger.Warn("Failed to reconcile agent identity credentials into workload",
 			"ouID", binding.OUID, "bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName, "error", err)
 	}
+}
+
+func agentThunderBindingOrgContext(ctx context.Context, binding models.AgentThunderClient) context.Context {
+	return orgctx.WithResolvedOrg(ctx, orgctx.ResolvedOrg{OUID: binding.OUID})
 }
 
 // DBBackedAgentThunderProvisioning returns a constructor to be called

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/wso2/agent-manager/agent-manager-service/clients/secretmanagersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/thundersvc"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
+	"github.com/wso2/agent-manager/agent-manager-service/orgctx"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories"
 	"github.com/wso2/agent-manager/agent-manager-service/repositories/repomocks"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
@@ -2052,12 +2053,15 @@ func TestAttemptProvision_Success_InternalAgent_InjectsWorkloadCredentials(t *te
 
 	reconciledCalls := 0
 	injector := &agentIdentityInjectorStub{
-		ReconcileForEnvironmentFunc: func(_ context.Context, orgName, projectName, agentName, envName string) error {
+		ReconcileForEnvironmentFunc: func(ctx context.Context, orgName, projectName, agentName, envName string) error {
 			reconciledCalls++
 			assert.Equal(t, "acme", orgName)
 			assert.Equal(t, "proj1", projectName)
 			assert.Equal(t, "my-agent", agentName)
 			assert.Equal(t, "staging", envName)
+			resolvedOrg, ok := orgctx.GetResolvedOrg(ctx)
+			require.True(t, ok, "workload reconciliation must carry an organization context")
+			assert.Equal(t, "acme", resolvedOrg.OUID)
 			return nil
 		},
 	}

--- a/agent-manager-service/services/agent_thunder_reconciler.go
+++ b/agent-manager-service/services/agent_thunder_reconciler.go
@@ -244,12 +244,13 @@ func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx conte
 			return
 		}
 		for _, binding := range recent {
+			bindingCtx := agentThunderBindingOrgContext(ctx, binding)
 			if healSecretRefs {
-				if err := s.provisioning.HealSecretRef(ctx, binding); err != nil {
+				if err := s.provisioning.HealSecretRef(bindingCtx, binding); err != nil {
 					s.logger.Warn("Failed to heal agent thunder binding secret ref", "ouID", binding.OUID, "bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName, "error", err)
 				}
 			}
-			reconcileWorkloadInjection(ctx, s.injector, binding, s.logger)
+			reconcileWorkloadInjection(bindingCtx, s.injector, binding, s.logger)
 		}
 		if len(recent) < reconcilerBatchSize {
 			return


### PR DESCRIPTION
## Purpose
Background AgentID work (the periodic reconciler, or provisioning that finishes after its request has already returned) has no request to resolve an org from. When it authenticates to OpenChoreo with the M2M service token, no org is attached to the call, so Platform API can't tell which org's agent workload to inject credentials into.

## Goals
Every background AgentID call should carry the correct org, whether it's authenticated with a user token or the M2M service token.

## Approach
`reconcileWorkloadInjection` (used by both the post-provisioning path and the periodic reconciler) now sets the binding's OUID on the context via `orgctx.WithResolvedOrg` before calling the injector — the same thing `middleware.RequireOrgMatch` already does for real HTTP requests.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   Added a test asserting the injector receives the resolved org from context.
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A

## Learning
N/A