### PR TITLE
fix(console): correct OpenAI provider logo display inconsistency

### DIFF
--- a/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/AddLLMProviderForm.tsx
@@ -501,8 +501,9 @@ export const AddLLMProviderForm: React.FC<AddLLMProviderFormProps> = ({
                             width: 28,
                             height: 28,
                             objectFit: "contain",
-                            backgroundColor: "grey.100",
+                            backgroundColor: "common.white",
                             borderRadius: "20%",
+                            flexShrink: 0,
                           }}
                         />
                       ) : (

--- a/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderTable.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/LLMProviderTable.tsx
@@ -225,7 +225,7 @@ export function LLMProviderTable() {
                               width: 14,
                               height: 14,
                               objectFit: "contain",
-                              bgcolor: "grey.200",
+                              bgcolor: "common.white",
                               flexShrink: 0,
                               borderRadius: 1,
                             }}

--- a/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
+++ b/console/workspaces/pages/llm-providers/src/subComponents/ViewLLMProvider.tsx
@@ -146,10 +146,11 @@ export const ViewLLMProvider: React.FC = () => {
       backLabel="Back to LLM Providers"
       isLoading={isLoading}
       // The template's own logo identifies the provider better than a letter
-      // tile; `transparent` keeps the logo on the card surface.
+      // tile; use a white background so dark logos (e.g. OpenAI's black mark)
+      // remain visible in both light and dark themes.
       avatar={
         templateLogoUrl
-          ? { src: templateLogoUrl, alt: templateDisplayName, color: "transparent" }
+          ? { src: templateLogoUrl, alt: templateDisplayName, color: "common.white" }
           : undefined
       }
       titleTail={
@@ -166,6 +167,11 @@ export const ViewLLMProvider: React.FC = () => {
                     sx={{
                       width: 14,
                       height: 14,
+                      objectFit: "contain",
+                      bgcolor: "common.white",
+                      borderRadius: "2px",
+                      p: "1px",
+                      flexShrink: 0,
                     }}
                   />
                 ) : undefined

--- a/console/workspaces/pages/overview/src/AgentOverview/providerAvatar.ts
+++ b/console/workspaces/pages/overview/src/AgentOverview/providerAvatar.ts
@@ -22,9 +22,9 @@ import { getEntityAvatarColor } from "@agent-management-platform/views";
 // likely to see here; anything else falls back to a deterministic hash color
 // so it's still stable across renders instead of random.
 const KNOWN_PROVIDER_COLORS: Record<string, string> = {
+    "azure-openai": "#0078D4",
     openai: "#10a37f",
     azure: "#0078D4",
-    "azure-openai": "#0078D4",
     anthropic: "#B45AF2",
     claude: "#B45AF2",
     google: "#4285F4",
@@ -38,12 +38,21 @@ const KNOWN_PROVIDER_COLORS: Record<string, string> = {
     llama: "#0668E1",
 };
 
+// Sort candidate keys by descending length so specific/longer keys (e.g. "azure-openai")
+// are matched before generic/shorter keys (e.g. "openai" or "azure").
+const KNOWN_PROVIDER_KEYS = Object.keys(KNOWN_PROVIDER_COLORS).sort(
+    (a, b) => b.length - a.length,
+);
+
 /** Picks a stable avatar color for a provider/config name — a curated brand
  * color when recognized, otherwise the platform-wide deterministic fallback. */
 export function getProviderAvatarColor(name?: string): string {
     if (!name) return getEntityAvatarColor();
     const key = name.trim().toLowerCase();
-    const known = Object.keys(KNOWN_PROVIDER_COLORS).find((k) => key.includes(k));
+    if (Object.prototype.hasOwnProperty.call(KNOWN_PROVIDER_COLORS, key)) {
+        return KNOWN_PROVIDER_COLORS[key];
+    }
+    const known = KNOWN_PROVIDER_KEYS.find((k) => key.includes(k));
     if (known) return KNOWN_PROVIDER_COLORS[known];
     return getEntityAvatarColor(key);
 }

--- a/console/workspaces/pages/overview/src/AgentOverview/providerAvatar.ts
+++ b/console/workspaces/pages/overview/src/AgentOverview/providerAvatar.ts
@@ -22,7 +22,7 @@ import { getEntityAvatarColor } from "@agent-management-platform/views";
 // likely to see here; anything else falls back to a deterministic hash color
 // so it's still stable across renders instead of random.
 const KNOWN_PROVIDER_COLORS: Record<string, string> = {
-    openai: "#000000",
+    openai: "#10a37f",
     azure: "#0078D4",
     "azure-openai": "#0078D4",
     anthropic: "#B45AF2",


### PR DESCRIPTION
The OpenAI logo is a black picture that blends into the dark card background when it is shown with a transparent backdrop, which makes it invisible in dark mode.

Fixes #1785

- ViewLLMProvider: set the background to common.white instead of making it transparent so the dark OpenAI mark shows on the card header no matter what theme is used.

- ViewLLMProvider: give the template Chip icon (14x14) a white background and padding so it remains visible as well.

- AddLLMProviderForm: replace grey.100 with common.white for the provider selection card logo so it stays visible consistently.

- LLMProviderTable: change the Chip icon color in the providers list table from grey.200 to common.white to keep it consistent across locations.

- providerAvatar.ts: change the fallback color from pure black (#000000) to the OpenAI brand green (#10a37f) so the letter avatar matches the brand and stays visible on dark backgrounds.

## Purpose

Purpose: This section explains the problems or needs that caused this feature or fix. It also lists issues in the format: Resolves issue1, issue2, etc.

## Goals

Goals: This part describes the solutions that the feature or fix will bring to solve the problems mentioned earlier.

## Approach

Approach: This section explains how the solutions will be implemented. If the UI changes, include an animated GIF or screenshot. Send it to documentation@wso2.com for review. If the write‑up is too long link to a file or a Google document.

## User stories

User Stories: A summary of the user stories that this change addresses.

## Release note

Release Note: A description of the new feature or bug fix that will be shown in the release notes.

## Documentation

Documentation: Provide links to the product documentation that covers the changes in this PR. If there is no impact on documentation write 'N/A'. Give a brief explanation of why.

## Training

Training: Link to the PR that updates the training content at https://github.com/wso2/WSO2-Training if this change applies.

## Certification

Certification: Write 'Sent' if you have supplied updated certification questions, including four answers for each question with the correct answer in bold. Send the questions and answers to certification@wso2.com. Do not paste them in this PR. If this change does not affect certification exams write 'N/A' and explain why.

## Marketing

Marketing: Provide links to any draft marketing content that will describe and promote this feature, such as changes to the product page technical articles, blog posts, videos and so on, if relevant.

## Automation tests

- Unit tests

> Code coverage information

- Integration tests

> Details about the test cases and coverage

## Security checks

- Followed coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no

- Ran FindSecurityBugs. Verified report? yes/no

- Confirmed that this PR doesn't commit any keys passwords, tokens, usernames or other secrets? yes/no

## Samples

Samples: Provide a high‑level overview of the samples that relate to this feature.

## PRs

Related PRs: List any pull requests that are related.

## Migrations (if applicable)

Migrations (if Describe the steps, for migration and the platforms on which the migration has been tested.

## Test environment

Test Environment: List the JDK versions, operating systems, databases and browser versions that were used to test this feature or fix.

## Learning

Learning: Describe the research phase and any blog posts, patterns, libraries or add‑ons that were used to solve the problem.

<img width="1870" height="667" alt="Screenshot 2026-09-06 192409" src="https://github.com/user-attachments/assets/adb8ce3f-7e32-4921-83e9-0bf75955dd39" />
<img width="1868" height="680" alt="Screenshot 2026-09-06 192415" src="https://github.com/user-attachments/assets/62e58485-a116-4d79-81b4-acc045dece8b" />
<img width="1877" height="722" alt="Screenshot 2026-09-06 192425" src="https://github.com/user-attachments/assets/cdbef5c9-21e2-4d70-8bd5-8974486708e3" />
<img width="1882" height="322" alt="Screenshot 2026-09-06 192433" src="https://github.com/user-attachments/assets/3aa32532-3c6e-4c61-9619-5cd020efc0d9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved LLM provider logos with consistent white backgrounds, rounded corners, and spacing.
  - Prevented provider images from shrinking and ensured logos remain fully visible.
  - Updated the curated OpenAI provider avatar to use OpenAI’s green brand color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->