### PR TITLE
Add release promotion workflow

### DIFF
--- a/.github/scripts/assert-docs-version-published.sh
+++ b/.github/scripts/assert-docs-version-published.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# assert-docs-version-published.sh — fail unless the docs version this release
+# needs has already been cut and merged.
+#
+# update-helm-charts.sh enforces the same thing, but only once the release branch
+# and tags already exist. Running it in the promotion's validate job turns a
+# half-finished release into a fast, actionable failure.
+#
+# Usage: assert-docs-version-published.sh <docs-version> <versions-json> <target-version>
+set -euo pipefail
+
+DOCS_VERSION="${1-}"
+VERSIONS_FILE="${2:?usage: assert-docs-version-published.sh <docs-version> <versions-json> <target-version>}"
+TARGET_VERSION="${3:?usage: assert-docs-version-published.sh <docs-version> <versions-json> <target-version>}"
+
+if [ -z "$DOCS_VERSION" ]; then
+  echo "No documentation version is required for $TARGET_VERSION; the console will follow /docs/latest"
+  exit 0
+fi
+
+if [ ! -f "$VERSIONS_FILE" ]; then
+  echo "Error: documentation manifest $VERSIONS_FILE is missing, so $DOCS_VERSION cannot be verified." >&2
+  exit 1
+fi
+
+if ! grep -q "\"$DOCS_VERSION\"" "$VERSIONS_FILE"; then
+  {
+    echo "Error: documentation version $DOCS_VERSION is not published."
+    echo
+    echo "Run the \"Documentation Release\" workflow with:"
+    echo "  version=$DOCS_VERSION"
+    echo "  docker_tag=v$TARGET_VERSION"
+    echo "then merge the pull request it opens and re-run this promotion."
+  } >&2
+  exit 1
+fi
+
+echo "✅ Documentation version $DOCS_VERSION is published"

--- a/.github/scripts/resolve-docs-version.sh
+++ b/.github/scripts/resolve-docs-version.sh
@@ -6,6 +6,14 @@
 # sync: a divergence means the promotion passes its pre-flight and then fails
 # halfway through, after tags have been pushed.
 #
+# The two copies do not run from the same commit. This mirror runs from main (the
+# validate job), while update-helm-charts.sh runs from the release candidate's own
+# base commit (the prepare-promotion job) — an arbitrarily old tree. So editing
+# both files in one commit does not make them agree at run time: this file's rule
+# is checked against whatever update-helm-charts.sh said back when the rc was cut.
+# When they disagree, validate passes and the stamp fails after the branch and both
+# tags are pushed, requiring the cleanup runbook in release-promote.yml.
+#
 # Prints nothing (exit 0) for releases that cut no docs version.
 # Usage: resolve-docs-version.sh <target-version>
 set -euo pipefail

--- a/.github/scripts/resolve-docs-version.sh
+++ b/.github/scripts/resolve-docs-version.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# resolve-docs-version.sh — print the documentation version a release points at.
+#
+# Mirrors the branch order in update-helm-charts.sh so the promotion workflow can
+# enforce the same rule *before* it cuts any branches or tags. Keep the two in
+# sync: a divergence means the promotion passes its pre-flight and then fails
+# halfway through, after tags have been pushed.
+#
+# Prints nothing (exit 0) for releases that cut no docs version.
+# Usage: resolve-docs-version.sh <target-version>
+set -euo pipefail
+
+TARGET_VERSION="${1:?usage: resolve-docs-version.sh <target-version>}"
+
+if [[ "$TARGET_VERSION" =~ (-|\.)rc[0-9]+$ ]]; then
+  : # release candidates follow /docs/latest
+elif [[ "$TARGET_VERSION" == *-dev* ]]; then
+  : # nightlies follow /docs/latest
+elif [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "v${TARGET_VERSION%.*}.x"
+else
+  echo "v$TARGET_VERSION"
+fi

--- a/.github/scripts/resolve-source-commit.sh
+++ b/.github/scripts/resolve-source-commit.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# resolve-source-commit.sh — find the unstamped commit a release was cut from.
+#
+# A release tag points at the "chore: update versions..." commit, where the
+# 0.0.0-dev placeholders have already been replaced. Re-running the version
+# scripts there matches nothing and silently produces a release stamped with the
+# OLD version, so a promotion must start from that commit's parent instead.
+#
+# The subject match picks the candidate; the placeholder check is what makes it
+# safe. Run from a full checkout with HEAD at the source release tag.
+#
+# Prints the base commit SHA on stdout; all other output goes to stderr.
+# Usage: resolve-source-commit.sh <source-version>
+set -euo pipefail
+
+SOURCE_VERSION="${1:?usage: resolve-source-commit.sh <source-version>}"
+STAMP_SUBJECT="chore: update versions for release amp/v${SOURCE_VERSION}"
+
+if [ "$(git log -1 --format=%s HEAD)" = "$STAMP_SUBJECT" ]; then
+  BASE_COMMIT="$(git rev-parse HEAD^)"
+  echo "HEAD is the version-stamp commit; using its parent ${BASE_COMMIT:0:7}" >&2
+else
+  BASE_COMMIT="$(git rev-parse HEAD)"
+  echo "HEAD is not a version-stamp commit; using it directly (${BASE_COMMIT:0:7})" >&2
+fi
+
+if ! git grep -q '0\.0\.0-dev' "$BASE_COMMIT" -- deployments/helm-charts; then
+  {
+    echo "Error: could not locate the unstamped source commit for amp/v${SOURCE_VERSION}."
+    echo "Commit $BASE_COMMIT has no 0.0.0-dev placeholders under deployments/helm-charts,"
+    echo "so the version-stamping scripts would silently do nothing."
+  } >&2
+  exit 1
+fi
+
+echo "$BASE_COMMIT"

--- a/.github/scripts/retag-image.sh
+++ b/.github/scripts/retag-image.sh
@@ -18,7 +18,7 @@ DOCKER="${DOCKER:-docker}"
 "$DOCKER" buildx imagetools create -t "${IMAGE}:${TARGET_TAG}" "${IMAGE}:${SOURCE_TAG}"
 
 digest_of() {
-  "$DOCKER" buildx imagetools inspect --format '{{json .Manifest.Digest}}' "$1"
+  "$DOCKER" buildx imagetools inspect --format '{{.Manifest.Digest}}' "$1"
 }
 
 SOURCE_DIGEST="$(digest_of "${IMAGE}:${SOURCE_TAG}")"

--- a/.github/scripts/retag-image.sh
+++ b/.github/scripts/retag-image.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# retag-image.sh — publish an already-released image under a new tag.
+#
+# `imagetools create` copies the manifest list rather than the layers, so the
+# multi-arch structure survives, nothing is pulled or rebuilt, and the resulting
+# digest is identical by construction. The digest comparison afterwards is the
+# proof that a promoted release ships exactly the bits that were tested.
+#
+# Usage: retag-image.sh <image-ref-without-tag> <source-tag> <target-tag>
+set -euo pipefail
+
+IMAGE="${1:?usage: retag-image.sh <image-ref-without-tag> <source-tag> <target-tag>}"
+SOURCE_TAG="${2:?usage: retag-image.sh <image-ref-without-tag> <source-tag> <target-tag>}"
+TARGET_TAG="${3:?usage: retag-image.sh <image-ref-without-tag> <source-tag> <target-tag>}"
+
+DOCKER="${DOCKER:-docker}"
+
+"$DOCKER" buildx imagetools create -t "${IMAGE}:${TARGET_TAG}" "${IMAGE}:${SOURCE_TAG}"
+
+digest_of() {
+  "$DOCKER" buildx imagetools inspect --format '{{json .Manifest.Digest}}' "$1"
+}
+
+SOURCE_DIGEST="$(digest_of "${IMAGE}:${SOURCE_TAG}")"
+TARGET_DIGEST="$(digest_of "${IMAGE}:${TARGET_TAG}")"
+
+if [ "$SOURCE_DIGEST" != "$TARGET_DIGEST" ]; then
+  {
+    echo "Error: digest mismatch after retagging ${IMAGE}."
+    echo "  ${IMAGE}:${SOURCE_TAG} -> ${SOURCE_DIGEST}"
+    echo "  ${IMAGE}:${TARGET_TAG} -> ${TARGET_DIGEST}"
+  } >&2
+  exit 1
+fi
+
+echo "✅ ${IMAGE}:${TARGET_TAG} → ${SOURCE_DIGEST}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -7,6 +7,31 @@ name: WSO2 AI Agent Management Platform Release Promotion
 #
 # The documentation release for the target version must already be merged to main
 # before this runs; the validate job refuses to proceed otherwise.
+#
+# Recovering from a mid-way failure
+# ---------------------------------
+# validate hard-fails when amp/v<target> already exists, and prepare-promotion is
+# not idempotent (its `git push origin "$TAG"` is rejected against an existing
+# remote tag). So a run that failed after prepare-promotion cannot simply be
+# re-dispatched: delete what it created first, from a clone of this repo.
+#
+#   TARGET=1.0.0
+#   MAJOR="${TARGET%%.*}"
+#   git push origin ":refs/tags/amp/v${TARGET}"   # the release tag
+#   git push origin --delete "amp-${TARGET}"      # the release branch
+#   gh release delete "amp/v${TARGET}" --yes      # the draft GitHub release
+#   git ls-remote --tags origin "amp/v${MAJOR}"   # confirm the major tag
+#
+# Check that last one: "Create git tag" deletes and recreates amp/v<major> in a
+# single step, so an abort between the two operations leaves it missing. It
+# cannot point at the wrong release — the recreating push has no `|| true` and
+# git refuses to overwrite a tag without --force — but if it is gone, restore it
+# to the previous release's commit before re-running:
+#
+#   git tag -a "amp/v${MAJOR}" <previous-release-commit> -m "Latest release for major version ${MAJOR}"
+#   git push origin "amp/v${MAJOR}"
+#
+# Leave the retagged images alone: retagging is idempotent by digest.
 
 on:
   workflow_dispatch:
@@ -25,7 +50,7 @@ on:
         default: false
         type: boolean
 
-run-name: Promote amp/v${{ inputs.source_version }} to amp/v${{ inputs.target_version }}
+run-name: Promote amp/v${{ inputs.source_version }} → amp/v${{ inputs.target_version }}
 
 env:
   REGISTRY: ghcr.io
@@ -95,6 +120,9 @@ jobs:
           TARGET_VERSION: ${{ inputs.target_version }}
         shell: bash
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -102,15 +130,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The image list comes from the source tag, not this main checkout: retag-images
+      # reads its config from the release tree, and pre-flighting a different list
+      # would let an image the retag needs go unchecked.
       - name: Verify source images exist
         run: |
           MISSING=0
-          for name in $(jq -r '.images[].name' .github/release-config.json); do
+          for name in $(git show "amp/v${SOURCE_VERSION}:.github/release-config.json" | jq -r '.images[].name'); do
             REF="${REGISTRY}/${REGISTRY_ORG}/${name}:v${SOURCE_VERSION}"
-            if docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
+            if INSPECT_ERR="$(docker buildx imagetools inspect "$REF" 2>&1 >/dev/null)"; then
               echo "✅ $REF"
             else
               echo "❌ missing: $REF"
+              echo "$INSPECT_ERR" | sed 's/^/    /'
               MISSING=1
             fi
           done
@@ -144,6 +176,21 @@ jobs:
           fetch-depth: 0
           ref: amp/v${{ inputs.source_version }}
 
+      # The source tree predates this workflow, so it has no resolve-source-commit.sh.
+      # Tooling runs from the dispatched commit (no ref: = github.sha); the scripts that
+      # stamp the release's own content keep running from the checkout above.
+      - name: Checkout promotion tooling
+        uses: actions/checkout@v6
+        with:
+          path: .promotion-tools
+
+      # git add -A below would otherwise stage the whole tooling checkout into the
+      # release commit. info/exclude is local to the runner and never committed.
+      - name: Exclude promotion tooling from the release commit
+        run: |
+          echo ".promotion-tools/" >> .git/info/exclude
+        shell: bash
+
       - name: Configure Git
         run: |
           git config --local user.email "action@github.com"
@@ -153,7 +200,7 @@ jobs:
       - name: Resolve unstamped source commit
         id: resolve
         run: |
-          COMMIT_SHA="$(bash .github/scripts/resolve-source-commit.sh "$SOURCE_VERSION")"
+          COMMIT_SHA="$(bash .promotion-tools/.github/scripts/resolve-source-commit.sh "$SOURCE_VERSION")"
           echo "commit-sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "✅ Promoting from commit ${COMMIT_SHA:0:7}"
         env:
@@ -341,6 +388,14 @@ jobs:
         with:
           ref: amp/v${{ inputs.target_version }}
 
+      # The target tag is built from the source release's base commit, which predates
+      # this workflow and so carries no retag-image.sh. Tooling runs from the
+      # dispatched commit (no ref: = github.sha).
+      - name: Checkout promotion tooling
+        uses: actions/checkout@v6
+        with:
+          path: .promotion-tools
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -353,7 +408,7 @@ jobs:
 
       - name: Retag ${{ matrix.image.name }}
         run: |
-          bash .github/scripts/retag-image.sh \
+          bash .promotion-tools/.github/scripts/retag-image.sh \
             "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}" \
             "v${SOURCE_VERSION}" \
             "v${TARGET_VERSION}"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,288 @@
+name: WSO2 AI Agent Management Platform Release Promotion
+
+# Promotes an existing release to a new version without rebuilding it: images are
+# retagged by digest, and every version-stamped artifact (charts, amctl, install
+# bundle) is regenerated from the source release's own commit. See
+# docs/superpowers/specs/2026-09-07-release-promotion-design.md.
+#
+# The documentation release for the target version must already be merged to main
+# before this runs; the validate job refuses to proceed otherwise.
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_version:
+        description: "Existing release to promote from (e.g., 1.0.0-rc3)"
+        required: true
+        type: string
+      target_version:
+        description: "Target release version (e.g., 1.0.0)"
+        required: true
+        type: string
+      create_patch_branch:
+        description: "Create a patch branch (check only for production releases)"
+        required: false
+        default: false
+        type: boolean
+
+run-name: Promote amp/v${{ inputs.source_version }} to amp/v${{ inputs.target_version }}
+
+env:
+  REGISTRY: ghcr.io
+  REGISTRY_ORG: wso2
+  HELM_REGISTRY: oci://ghcr.io/wso2
+
+jobs:
+  validate:
+    name: Validate Promotion
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    concurrency:
+      group: release-${{ inputs.target_version }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      docs-version: ${{ steps.docs.outputs.docs-version }}
+    steps:
+      # main, not the source tag: the docs manifest and these scripts must be read
+      # from the current state of the repo, not from the release being promoted.
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate version inputs
+        run: |
+          SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'
+          for version in "$SOURCE_VERSION" "$TARGET_VERSION"; do
+            if [[ ! "$version" =~ $SEMVER ]]; then
+              echo "Error: invalid version '$version'. Expected: X.Y.Z or X.Y.Z-<pre-release>"
+              exit 1
+            fi
+          done
+
+          if [ "$SOURCE_VERSION" = "$TARGET_VERSION" ]; then
+            echo "Error: source_version and target_version must differ"
+            exit 1
+          fi
+
+          if ! git rev-parse -q --verify "refs/tags/amp/v${SOURCE_VERSION}" >/dev/null; then
+            echo "Error: source tag amp/v${SOURCE_VERSION} does not exist"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/amp/v${TARGET_VERSION}" >/dev/null; then
+            echo "Error: target tag amp/v${TARGET_VERSION} already exists"
+            exit 1
+          fi
+
+          echo "✅ Promoting amp/v${SOURCE_VERSION} to amp/v${TARGET_VERSION}"
+        env:
+          SOURCE_VERSION: ${{ inputs.source_version }}
+          TARGET_VERSION: ${{ inputs.target_version }}
+        shell: bash
+
+      - name: Verify documentation version is published
+        id: docs
+        run: |
+          DOCS_VERSION="$(bash .github/scripts/resolve-docs-version.sh "$TARGET_VERSION")"
+          echo "docs-version=$DOCS_VERSION" >> $GITHUB_OUTPUT
+          bash .github/scripts/assert-docs-version-published.sh \
+            "$DOCS_VERSION" \
+            "./documentation/versions.json" \
+            "$TARGET_VERSION"
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+        shell: bash
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify source images exist
+        run: |
+          MISSING=0
+          for name in $(jq -r '.images[].name' .github/release-config.json); do
+            REF="${REGISTRY}/${REGISTRY_ORG}/${name}:v${SOURCE_VERSION}"
+            if docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
+              echo "✅ $REF"
+            else
+              echo "❌ missing: $REF"
+              MISSING=1
+            fi
+          done
+
+          if [ "$MISSING" -ne 0 ]; then
+            echo "Error: one or more source images are missing; nothing was branched or tagged."
+            exit 1
+          fi
+        env:
+          SOURCE_VERSION: ${{ inputs.source_version }}
+        shell: bash
+
+  prepare-promotion:
+    name: Prepare Promotion
+    needs: validate
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      contents: write
+    outputs:
+      commit-sha: ${{ steps.resolve.outputs.commit-sha }}
+    steps:
+      - name: Checkout source release
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
+          fetch-depth: 0
+          ref: amp/v${{ inputs.source_version }}
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+        shell: bash
+
+      - name: Resolve unstamped source commit
+        id: resolve
+        run: |
+          COMMIT_SHA="$(bash .github/scripts/resolve-source-commit.sh "$SOURCE_VERSION")"
+          echo "commit-sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "✅ Promoting from commit ${COMMIT_SHA:0:7}"
+        env:
+          SOURCE_VERSION: ${{ inputs.source_version }}
+        shell: bash
+
+      - name: Create release branch
+        id: create-branch
+        run: |
+          BRANCH_NAME="amp-${TARGET_VERSION}"
+
+          if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+            git checkout "$BRANCH_NAME"
+            git reset --hard "$COMMIT_SHA"
+            echo "✅ Reset existing branch to commit ${COMMIT_SHA:0:7}"
+          else
+            git checkout -b "$BRANCH_NAME" "$COMMIT_SHA"
+            echo "✅ Created new branch from commit ${COMMIT_SHA:0:7}"
+          fi
+
+          echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+          COMMIT_SHA: ${{ steps.resolve.outputs.commit-sha }}
+        shell: bash
+
+      - name: Create patch branch
+        if: ${{ inputs.create_patch_branch }}
+        run: |
+          MAJOR=$(echo "$TARGET_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$TARGET_VERSION" | cut -d. -f2)
+          PATCH_BRANCH="amp-patch-${MAJOR}.${MINOR}.x"
+
+          if git ls-remote --exit-code --heads origin "$PATCH_BRANCH" >/dev/null; then
+            echo "⏭️ Patch branch $PATCH_BRANCH already exists, skipping creation"
+          else
+            git branch "$PATCH_BRANCH"
+            git push origin "$PATCH_BRANCH"
+            echo "✅ Created patch branch: $PATCH_BRANCH"
+          fi
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+        shell: bash
+
+      # The base commit predates the documentation release for this version, so
+      # update-helm-charts.sh would fail its own manifest check against a stale
+      # versions.json even though validate already confirmed the docs are live.
+      # Only the manifest is synced — versioned_docs/ is deliberately left alone.
+      - name: Sync documentation manifest from main
+        run: |
+          git fetch origin main
+          git checkout origin/main -- documentation/versions.json
+          echo "✅ Synced documentation/versions.json from main"
+        shell: bash
+
+      - name: Update Helm chart versions
+        run: |
+          bash .github/scripts/update-helm-charts.sh "$TARGET_VERSION"
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+        shell: bash
+
+      - name: Update install-helpers.sh
+        run: |
+          bash .github/scripts/update-install-helpers.sh \
+            "$TARGET_VERSION" \
+            "./deployments/quick-start/install-helpers.sh"
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+        shell: bash
+
+      - name: Update start.sh
+        run: |
+          bash .github/scripts/update-install-helpers.sh \
+            "$TARGET_VERSION" \
+            "./deployments/quick-start/start.sh"
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+        shell: bash
+
+      # A promotion that stamped nothing means the placeholders were already
+      # consumed, which resolve-source-commit.sh is supposed to make impossible.
+      - name: Commit version updates
+        run: |
+          git add -A
+
+          if git diff --staged --quiet; then
+            echo "Error: no version changes were produced from commit ${COMMIT_SHA:0:7}."
+            exit 1
+          fi
+
+          echo "Files to be committed:"
+          git diff --staged --name-only
+          git commit -m "chore: update versions for release amp/v${TARGET_VERSION}"
+          echo "✅ Committed version updates"
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+          COMMIT_SHA: ${{ steps.resolve.outputs.commit-sha }}
+        shell: bash
+
+      - name: Create git tag
+        run: |
+          TAG="amp/v${TARGET_VERSION}"
+          git tag -a "$TAG" -m "Release $TAG promoted from amp/v${SOURCE_VERSION} at commit ${COMMIT_SHA:0:7}"
+          git push origin "$TAG"
+          echo "✅ Created and pushed tag: $TAG"
+
+          MAJOR_VERSION=$(echo "$TARGET_VERSION" | cut -d. -f1)
+          MAJOR_TAG="amp/v${MAJOR_VERSION}"
+
+          if git rev-parse "$MAJOR_TAG" >/dev/null 2>&1; then
+            echo "Major tag $MAJOR_TAG already exists, updating..."
+            git tag -d "$MAJOR_TAG" || true
+            git push origin ":refs/tags/$MAJOR_TAG" || true
+          fi
+
+          git tag -a "$MAJOR_TAG" -m "Latest release for major version $MAJOR_VERSION"
+          git push origin "$MAJOR_TAG"
+          echo "✅ Created/updated major version tag: $MAJOR_TAG"
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+          SOURCE_VERSION: ${{ inputs.source_version }}
+          COMMIT_SHA: ${{ steps.resolve.outputs.commit-sha }}
+        shell: bash
+
+      - name: Push branch
+        run: |
+          git push origin "$BRANCH"
+          echo "✅ Pushed branch"
+        env:
+          BRANCH: ${{ steps.create-branch.outputs.branch }}
+        shell: bash

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -37,9 +37,6 @@ jobs:
     name: Validate Promotion
     runs-on:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
-    concurrency:
-      group: release-${{ inputs.target_version }}
-      cancel-in-progress: false
     permissions:
       contents: read
       packages: read
@@ -131,6 +128,9 @@ jobs:
     needs: validate
     runs-on:
       - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    concurrency:
+      group: release-${{ inputs.target_version }}
+      cancel-in-progress: false
     permissions:
       contents: write
     outputs:

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -12,8 +12,9 @@ name: WSO2 AI Agent Management Platform Release Promotion
 # ---------------------------------
 # validate hard-fails when amp/v<target> already exists, and prepare-promotion is
 # not idempotent (its `git push origin "$TAG"` is rejected against an existing
-# remote tag). So a run that failed after prepare-promotion cannot simply be
-# re-dispatched: delete what it created first, from a clone of this repo.
+# remote tag; "Create release branch" refuses outright when amp-<target> is
+# already on origin). So a run that failed after prepare-promotion cannot simply
+# be re-dispatched: delete what it created first, from a clone of this repo.
 #
 #   TARGET=1.0.0
 #   MAJOR="${TARGET%%.*}"
@@ -88,6 +89,17 @@ jobs:
 
           if [ "$SOURCE_VERSION" = "$TARGET_VERSION" ]; then
             echo "Error: source_version and target_version must differ"
+            exit 1
+          fi
+
+          if [[ "$TARGET_VERSION" == *-* ]]; then
+            echo "Error: target_version '$TARGET_VERSION' is a pre-release. Promotion targets a final release (X.Y.Z)."
+            exit 1
+          fi
+
+          if [ "${SOURCE_VERSION%%-*}" != "$TARGET_VERSION" ]; then
+            echo "Error: source_version '$SOURCE_VERSION' is not a pre-release of '$TARGET_VERSION'."
+            echo "Promotion runs within one release line, e.g. ${TARGET_VERSION}-rc1 → ${TARGET_VERSION}."
             exit 1
           fi
 
@@ -212,37 +224,19 @@ jobs:
         run: |
           BRANCH_NAME="amp-${TARGET_VERSION}"
 
-          if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-            git checkout "$BRANCH_NAME"
-            git reset --hard "$COMMIT_SHA"
-            echo "✅ Reset existing branch to commit ${COMMIT_SHA:0:7}"
-          else
-            git checkout -b "$BRANCH_NAME" "$COMMIT_SHA"
-            echo "✅ Created new branch from commit ${COMMIT_SHA:0:7}"
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null; then
+            echo "Error: branch $BRANCH_NAME already exists on origin, left over from a failed run."
+            echo "Delete it (see the recovery runbook at the top of this workflow) before re-dispatching."
+            exit 1
           fi
+
+          git checkout -b "$BRANCH_NAME" "$COMMIT_SHA"
+          echo "✅ Created new branch from commit ${COMMIT_SHA:0:7}"
 
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
         env:
           TARGET_VERSION: ${{ inputs.target_version }}
           COMMIT_SHA: ${{ steps.resolve.outputs.commit-sha }}
-        shell: bash
-
-      - name: Create patch branch
-        if: ${{ inputs.create_patch_branch }}
-        run: |
-          MAJOR=$(echo "$TARGET_VERSION" | cut -d. -f1)
-          MINOR=$(echo "$TARGET_VERSION" | cut -d. -f2)
-          PATCH_BRANCH="amp-patch-${MAJOR}.${MINOR}.x"
-
-          if git ls-remote --exit-code --heads origin "$PATCH_BRANCH" >/dev/null; then
-            echo "⏭️ Patch branch $PATCH_BRANCH already exists, skipping creation"
-          else
-            git branch "$PATCH_BRANCH"
-            git push origin "$PATCH_BRANCH"
-            echo "✅ Created patch branch: $PATCH_BRANCH"
-          fi
-        env:
-          TARGET_VERSION: ${{ inputs.target_version }}
         shell: bash
 
       # The base commit predates the documentation release for this version, so
@@ -283,11 +277,13 @@ jobs:
 
       # A promotion that stamped nothing means the placeholders were already
       # consumed, which resolve-source-commit.sh is supposed to make impossible.
+      # versions.json is excluded because the sync above always stages it, which
+      # would otherwise satisfy this check on its own.
       - name: Commit version updates
         run: |
           git add -A
 
-          if git diff --staged --quiet; then
+          if git diff --staged --quiet -- . ':(exclude)documentation/versions.json'; then
             echo "Error: no version changes were produced from commit ${COMMIT_SHA:0:7}."
             exit 1
           fi
@@ -299,6 +295,24 @@ jobs:
         env:
           TARGET_VERSION: ${{ inputs.target_version }}
           COMMIT_SHA: ${{ steps.resolve.outputs.commit-sha }}
+        shell: bash
+
+      - name: Create patch branch
+        if: ${{ inputs.create_patch_branch }}
+        run: |
+          MAJOR=$(echo "$TARGET_VERSION" | cut -d. -f1)
+          MINOR=$(echo "$TARGET_VERSION" | cut -d. -f2)
+          PATCH_BRANCH="amp-patch-${MAJOR}.${MINOR}.x"
+
+          if git ls-remote --exit-code --heads origin "$PATCH_BRANCH" >/dev/null; then
+            echo "⏭️ Patch branch $PATCH_BRANCH already exists, skipping creation"
+          else
+            git branch "$PATCH_BRANCH"
+            git push origin "$PATCH_BRANCH"
+            echo "✅ Created patch branch: $PATCH_BRANCH"
+          fi
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
         shell: bash
 
       - name: Create git tag
@@ -487,7 +501,6 @@ jobs:
           key: helm-charts-${{ hashFiles(format('{0}/Chart.lock', matrix.chart.path)) }}
 
       - name: Package and push ${{ matrix.chart.name }}
-        if: hashFiles(matrix.chart.chart-file) != ''
         run: |
           bash .github/scripts/package-helm-chart.sh \
             "$CHART_PATH" \

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -286,3 +286,368 @@ jobs:
         env:
           BRANCH: ${{ steps.create-branch.outputs.branch }}
         shell: bash
+
+  load-config:
+    name: Load Release Configuration
+    needs: prepare-promotion
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    outputs:
+      images: ${{ steps.set-matrix.outputs.images }}
+      charts: ${{ steps.set-matrix.outputs.charts }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: amp/v${{ inputs.target_version }}
+
+      - name: Load configuration and set matrix
+        id: set-matrix
+        run: |
+          CONFIG_FILE=".github/release-config.json"
+          CHARTS_BASE_PATH=$(jq -r '.config["charts-base-path"]' "$CONFIG_FILE")
+
+          IMAGES=$(jq -c '[.images[] | {name: .name}]' "$CONFIG_FILE")
+
+          CHARTS=$(jq -c --arg base "$CHARTS_BASE_PATH" '[.charts[] | {
+            name: .,
+            path: ($base + "/" + .),
+            "chart-file": ($base + "/" + . + "/Chart.yaml")
+          }]' "$CONFIG_FILE")
+
+          echo "images=$IMAGES" >> $GITHUB_OUTPUT
+          echo "charts=$CHARTS" >> $GITHUB_OUTPUT
+
+          echo "✅ Loaded configuration:"
+          echo "  - Images: $(echo "$IMAGES" | jq '. | length')"
+          echo "  - Charts: $(echo "$CHARTS" | jq '. | length')"
+        shell: bash
+
+  retag-images:
+    name: Retag ${{ matrix.image.name }}
+    needs: load-config
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        image: ${{ fromJson(needs.load-config.outputs.images) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: amp/v${{ inputs.target_version }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag ${{ matrix.image.name }}
+        run: |
+          bash .github/scripts/retag-image.sh \
+            "${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}" \
+            "v${SOURCE_VERSION}" \
+            "v${TARGET_VERSION}"
+        env:
+          IMAGE_NAME: ${{ matrix.image.name }}
+          SOURCE_VERSION: ${{ inputs.source_version }}
+          TARGET_VERSION: ${{ inputs.target_version }}
+        shell: bash
+
+  build-amctl:
+    name: Build amctl CLI
+    needs: prepare-promotion
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: amp/v${{ inputs.target_version }}
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6.1.0
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Run CLI tests
+        run: cd cli && go test ./...
+
+      - name: Build release artifacts
+        run: |
+          scripts/build-amctl.sh \
+            --version "${{ inputs.target_version }}" \
+            --commit "$(git rev-parse --short HEAD)" \
+            --date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --output-dir dist/
+
+      - name: Upload amctl artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: amctl-dist
+          path: dist/
+          retention-days: 7
+
+  package-charts:
+    name: Package ${{ matrix.chart.name }}
+    needs: [load-config, retag-images]
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        chart: ${{ fromJson(needs.load-config.outputs.charts) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: amp/v${{ inputs.target_version }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "3.14.0"
+
+      - name: Cache Helm chart dependencies
+        id: helm-cache
+        if: hashFiles(format('{0}/Chart.lock', matrix.chart.path)) != ''
+        uses: actions/cache@v5
+        with:
+          path: ${{ matrix.chart.path }}/charts
+          key: helm-charts-${{ hashFiles(format('{0}/Chart.lock', matrix.chart.path)) }}
+
+      - name: Package and push ${{ matrix.chart.name }}
+        if: hashFiles(matrix.chart.chart-file) != ''
+        run: |
+          bash .github/scripts/package-helm-chart.sh \
+            "$CHART_PATH" \
+            "$TARGET_RELEASE" \
+            "$HELM_REGISTRY" \
+            "$HELM_TOKEN"
+        env:
+          CHART_PATH: ${{ matrix.chart.path }}
+          TARGET_RELEASE: ${{ inputs.target_version }}
+          HELM_REGISTRY: ${{ env.HELM_REGISTRY }}
+          HELM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+
+  e2e:
+    name: E2E
+    needs: [retag-images, package-charts]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 130
+    permissions:
+      contents: read
+      checks: write
+    env:
+      K3D_VERSION: v5.8.3
+      K3D_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
+      YQ_VERSION: v4.45.4
+      YQ_SHA256: b96de04645707e14a12f52c37e6266832e03c29e95b9b139cddcae7314466e69
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+        with:
+          ref: amp/v${{ inputs.target_version }}
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install k3d
+        run: |
+          curl -fsSL -o /tmp/k3d "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
+          echo "${K3D_SHA256}  /tmp/k3d" | sha256sum -c -
+          sudo install /tmp/k3d /usr/local/bin/k3d
+          k3d version
+
+      - name: Install yq
+        run: |
+          curl -fsSL -o /tmp/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  /tmp/yq" | sha256sum -c -
+          sudo install /tmp/yq /usr/local/bin/yq
+
+      - name: Install platform
+        id: install-platform
+        env:
+          VERSION: ${{ inputs.target_version }}
+        run: |
+          cd deployments/quick-start && bash install.sh
+
+      - name: Run e2e tests
+        env:
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.INSTRUMENTATION_TEST_OPENAI_API_KEY }}
+          CHART_VERSION: ${{ inputs.target_version }}
+        run: |
+          set -o pipefail
+          cd test/e2e && go run github.com/onsi/ginkgo/v2/ginkgo -v --procs=2 --timeout 70m \
+            --poll-progress-after=600s --keep-going --junit-report=report.xml \
+            ./tests/... 2>&1 | tee e2e-output.log
+
+      - name: Run security conformance tests
+        if: ${{ !cancelled() && steps.install-platform.outcome == 'success' }}
+        env:
+          SECURITY_PROBE_REPOSITORY_URL: ${{ format('{0}/{1}', github.server_url, github.repository) }}
+          SECURITY_PROBE_REPOSITORY_BRANCH: amp/v${{ inputs.target_version }}
+        run: |
+          set -o pipefail
+          make security-test-live 2>&1 | tee test/e2e/security-output.log
+
+      - name: Dump pod logs on failure
+        if: failure()
+        run: |
+          mkdir -p /tmp/pod-logs
+          kubectl logs deployment/amp-api -n wso2-amp --tail=500 --all-containers=true > /tmp/pod-logs/amp-api.txt 2>&1 || true
+          kubectl logs deployment/openchoreo-api -n openchoreo-control-plane --tail=500 --all-containers=true > /tmp/pod-logs/openchoreo-api.txt 2>&1 || true
+          kubectl logs deployment/amp-observer -n openchoreo-observability-plane --tail=500 --all-containers=true > /tmp/pod-logs/amp-observer.txt 2>&1 || true
+          kubectl logs deployment/observer -n openchoreo-observability-plane --tail=500 --all-containers=true > /tmp/pod-logs/observer.txt 2>&1 || true
+          kubectl logs deployment/cluster-agent-workflowplane -n openchoreo-workflow-plane --tail=500 --all-containers=true > /tmp/pod-logs/cluster-agent-workflowplane.txt 2>&1 || true
+          for pod in $(kubectl get pods -n workflows-default --no-headers -o custom-columns=":metadata.name" 2>/dev/null); do
+            kubectl logs "$pod" -n workflows-default --all-containers=true --tail=200 > "/tmp/pod-logs/wf-pod-${pod}.txt" 2>&1 || true
+          done
+          kubectl get workflows -n workflows-default -o yaml > /tmp/pod-logs/argo-workflows-status.txt 2>&1 || true
+
+      - name: Upload pod logs
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pod-logs
+          path: /tmp/pod-logs/
+          retention-days: 7
+
+      - name: Publish test results
+        if: always()
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
+        with:
+          name: E2E Test Results (Promotion)
+          path: test/e2e/report.xml
+          reporter: java-junit
+
+      - name: Publish security test results
+        if: ${{ always() && hashFiles('test/e2e/security-report.xml') != '' }}
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
+        with:
+          name: Promotion Security Conformance Results
+          path: test/e2e/security-report.xml
+          reporter: java-junit
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: e2e-test-logs
+          path: |
+            test/e2e/e2e-output.log
+            test/e2e/security-output.log
+          retention-days: 7
+
+  create-release:
+    name: Create Release
+    # E2E is intentionally NOT a dependency here: it runs in parallel and reports
+    # red/green for the same run, but it does not gate the release.
+    needs: [prepare-promotion, retag-images, package-charts, build-amctl]
+    runs-on:
+      - codebuild-wso2_agent-manager-${{ github.run_id }}-${{ github.run_attempt }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: amp/v${{ inputs.target_version }}
+
+      - name: Generate release body
+        id: release-body
+        run: |
+          CONFIG_FILE=".github/release-config.json"
+
+          {
+            echo "## Release amp/v${VERSION}"
+            echo ""
+            echo "Promoted from \`amp/v${SOURCE_VERSION}\`. The container images below are the"
+            echo "same images published for \`amp/v${SOURCE_VERSION}\`, retagged by digest."
+            echo ""
+            echo "### Docker Images"
+
+            jq -r '.images[].name' "$CONFIG_FILE" | while read -r name; do
+              echo "- \`${REGISTRY}/${REGISTRY_ORG}/${name}:v${VERSION}\`"
+            done
+
+            jq -r '.["python-instrumentation-provider"][] | .instrumentation_version as $iv | .python_versions[] | "\($iv) \(.)"' "$CONFIG_FILE" | while read -r iv pyver; do
+              echo "- \`${REGISTRY}/${REGISTRY_ORG}/amp-python-instrumentation-provider:${iv}-python${pyver}\`"
+            done
+
+            echo ""
+            echo "### Helm Charts"
+            jq -r '.charts[]' "$CONFIG_FILE" | while read -r chart; do
+              echo "- \`${HELM_REGISTRY}/${chart}:${VERSION}\`"
+            done
+
+            echo ""
+            echo "### CLI (amctl)"
+            echo "Prebuilt \`amctl\` binaries (Linux, macOS, Windows) and \`checksums.txt\` are attached to this release."
+
+            echo ""
+            echo "### Install bundle"
+            echo "\`wso2-agent-manager-${VERSION}.tar.gz\` bundles both the VM and quick-start installers. \`bootstrap.sh\` and \`start.sh\` are also attached standalone as the one-command entry points:"
+            echo '```'
+            echo "# VM install"
+            echo "curl -fsSL https://github.com/${REGISTRY_ORG}/agent-manager/releases/download/amp/v${VERSION}/bootstrap.sh | sudo bash -s -- simple --host <PUBLIC_IP> --version ${VERSION}"
+            echo ""
+            echo "# Quick-start (local dev container)"
+            echo "curl -fsSL https://github.com/${REGISTRY_ORG}/agent-manager/releases/download/amp/v${VERSION}/start.sh -o start.sh && chmod +x start.sh && ./start.sh"
+            echo '```'
+          } > /tmp/release-body.md
+
+          {
+            echo "body<<RELEASE_BODY_EOF"
+            cat /tmp/release-body.md
+            echo "RELEASE_BODY_EOF"
+          } >> $GITHUB_OUTPUT
+        env:
+          VERSION: ${{ inputs.target_version }}
+          SOURCE_VERSION: ${{ inputs.source_version }}
+        shell: bash
+
+      - name: Download amctl artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: amctl-dist
+          path: dist/
+
+      - name: Package install bundle
+        run: |
+          bash .github/scripts/build-vm-bundle.sh \
+            "$TARGET_RELEASE" \
+            dist/
+        env:
+          TARGET_RELEASE: ${{ inputs.target_version }}
+        shell: bash
+
+      - name: Create GitHub release
+        id: create-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: amp/v${{ inputs.target_version }}
+          name: Release amp/v${{ inputs.target_version }}
+          body: ${{ steps.release-body.outputs.body }}
+          draft: true
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose
Promoting a release candidate to a final release currently means re-running `release.yml` against `main`. That rebuilds the container images from whatever `main` holds at the time, so the bits shipped as `1.0.0` are not the bits that were tested as `1.0.0-rc3`.

There is no way today to say "ship exactly what we tested, under the final version number".

## Goals
Add a promotion path that takes an existing release and republishes it under a new version, so the final release ships the same container images that were validated as the release candidate.

Only the container images can genuinely be identical under a new name. Everything else has the version baked in at build time, so it is regenerated from the release candidate's own source commit:

| Artifact | Version baked in | Promotion treatment |
|---|---|---|
| `amp-console`, `amp-api`, `amp-observer`, `amp-quick-start`, `amp-evaluation-monitor` | No | Retagged by manifest digest — identical bits |
| `amp-python-instrumentation-provider` | No (own `<version>-python<py>` scheme) | Untouched — already shared across releases |
| Helm charts | Yes (`Chart.yaml`, `values.yaml`) | Repackaged from the rc's source commit |
| `amctl` binaries + `checksums.txt` | Yes (ldflags) | Rebuilt from the rc's source commit |
| Install bundle, `start.sh`, `bootstrap.sh` | Yes (`update-install-helpers.sh`) | Regenerated from the rc's source commit |
| Documentation | Yes, asymmetric — `-rcN` cuts none; `X.Y.Z` requires `vX.Y.x` | Verified published before the promotion starts |

## Approach
New workflow `.github/workflows/release-promote.yml`, dispatched with `source_version` (e.g. `1.0.0-rc3`) and `target_version` (e.g. `1.0.0`). `release.yml` and `docs-release.yml` are not modified.

It is `release.yml` with one job swapped — `build-images` becomes `retag-images` — plus a validation gate on the front. `load-config`, `build-amctl`, `package-charts`, `e2e` and `create-release` are reused, since they already take a release tag as their only input.

**Retagging.** `docker buildx imagetools create` copies the manifest list, so multi-arch survives, no layer leaves the registry, and the digest is identical by construction. Each retag then compares source and target digests and fails on mismatch — that comparison is the proof the promotion shipped the tested bits.

**Finding the source commit.** The version-stamping scripts work by `sed`-ing the literal `0.0.0-dev`. A release tag points at the `chore: update versions for release amp/vX.Y.Z` commit, where those placeholders are already consumed — re-running the scripts there matches nothing, exits 0, and would produce a release full of the *old* version string. `resolve-source-commit.sh` walks back to the parent when the subject matches, then asserts the resulting commit still carries `0.0.0-dev` placeholders. The subject match picks the candidate; the assertion is what makes it safe.

**Docs gating.** `validate` derives the required docs version using the same rule as `update-helm-charts.sh`, reads `documentation/versions.json` from `origin/main`, and refuses to start if it is absent — naming the workflow to run and the PR to merge. This is the guard `update-helm-charts.sh` already enforces, hoisted to the front so it fails in seconds instead of after tags exist. The promotion never triggers the documentation release itself.

**Failure ordering.** Everything that can fail cheaply — input format, source tag present, target tag free, all five source images present, docs published — happens in `validate`, before any branch or tag exists.

**Tooling vs. historical scripts.** `prepare-promotion` and `retag-images` check out an older release tree, which predates the scripts this PR adds. Both jobs therefore check out the dispatched commit alongside it at `.promotion-tools/` and run `resolve-source-commit.sh` / `retag-image.sh` from there. The version-stamping scripts keep running from the release tree — they stamp that release's own content.

## User stories
As a release manager, I can promote `1.0.0-rc3` to `1.0.0` and know the container images are byte-identical to the ones that passed release testing, without re-running a build against a moving `main`.

## Release note
Added a Release Promotion workflow that promotes an existing release to a new version, retagging container images by digest instead of rebuilding them.

## Documentation
N/A — this is an internal release-engineering workflow with no user-facing surface. The recovery runbook lives in the workflow file's header comment, where a maintainer hitting a failed run will find it.

## Training
N/A — no user-facing behaviour change.

## Certification
N/A — internal release tooling, no impact on certification exams.

## Marketing
N/A — internal release tooling.

## Automation tests
 - Unit tests
   > None. The change is a GitHub Actions workflow plus four shell scripts; this repo has no shell test harness and none was added. Each script was verified by direct execution: the docs-version rule was checked across all six version shapes (`1.0.0`, `0.8.3`, `1.0.0-rc3`, `1.0.0-beta.rc1`, `1.0.0-dev`, `1.0.0-alpha1`), and `resolve-source-commit.sh` was run against the real `amp/v1.0.0-rc3` tag, correctly resolving `ea0bce564` to its parent `c9bd7f7be` with placeholders confirmed present.
 - Integration tests
   > The retag itself requires a registry and is verified by the first live promotion run, which checks that `imagetools inspect` reports the same digest for the source and target tags on all five images, that the packaged chart pins `tag: "v<target>"`, and that `amctl version` reports the target version.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A — no Java code in this change
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes — credentials are referenced only as `secrets.GITHUB_TOKEN`

## Samples
N/A — the workflow is run from the Actions tab with two version inputs.

## Related PRs
None.

## Migrations (if applicable)
N/A — no schema or data changes.

## Test environment
Scripts exercised locally on macOS (Darwin 25.0.0) with bash 3.2 and git 2.51, against the repo's real `amp/v1.0.0-rc3` tag. Workflow structure validated with `yq` v4. The workflow itself runs on the repo's existing CodeBuild runners and `ubuntu-24.04`, unchanged from `release.yml`.

## Learning
The non-obvious constraint is that a release tag is *not* a usable stamping base: it points at the commit where the `0.0.0-dev` placeholders were already consumed, so re-stamping there fails silently rather than loudly. That drove the parent-walk plus placeholder assertion in `resolve-source-commit.sh`.

The second was that a workflow checking out a historical tag cannot call scripts introduced by the same PR — they do not exist in that tree. `git ls-tree amp/v1.0.0-rc3 .github/scripts/` confirms it. Hence the separate `.promotion-tools/` checkout for tooling, kept distinct from the version-stamping scripts that must run from the release tree.

https://claude.ai/code/session_018hNbpaT4EbaVeg7ycLC1BC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered release promotion workflow for creating a new release from an existing version without rebuilding container images.
  - Container images are retagged while preserving their verified content.
  - Release artifacts, including Helm charts, command-line tools, and installation bundles, are regenerated and packaged automatically.
  - Added validation for version formats, source availability, documentation publication, and artifact integrity.
  - Automated end-to-end and security checks run before a draft release is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->