### PR TITLE
Point releases at their exact documentation version

### DIFF
--- a/.github/scripts/resolve-docs-version.sh
+++ b/.github/scripts/resolve-docs-version.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 # resolve-docs-version.sh — print the documentation version a release points at.
 #
-# Mirrors the branch order in update-helm-charts.sh so the promotion workflow can
-# enforce the same rule *before* it cuts any branches or tags. Keep the two in
-# sync: a divergence means the promotion passes its pre-flight and then fails
-# halfway through, after tags have been pushed.
+# The value is consumed as the path segment after /docs/ (see the console's
+# DOCS_URL in the wso2-agent-manager chart), so it must match a directory in
+# documentation/versioned_docs/version-<docs-version> and an entry in
+# documentation/versions.json exactly. Docs versions are cut per release version,
+# so this is just "v" plus the release version.
 #
-# The two copies do not run from the same commit. This mirror runs from main (the
-# validate job), while update-helm-charts.sh runs from the release candidate's own
-# base commit (the prepare-promotion job) — an arbitrarily old tree. So editing
-# both files in one commit does not make them agree at run time: this file's rule
-# is checked against whatever update-helm-charts.sh said back when the rc was cut.
-# When they disagree, validate passes and the stamp fails after the branch and both
-# tags are pushed, requiring the cleanup runbook in release-promote.yml.
+# Prints nothing (exit 0) for releases that cut no docs version: release
+# candidates and nightlies follow /docs/latest.
 #
-# Prints nothing (exit 0) for releases that cut no docs version.
+# update-helm-charts.sh sources this to stamp the charts, and the promotion
+# workflow's validate job runs it to pre-flight the manifest before it cuts
+# anything.
+#
 # Usage: resolve-docs-version.sh <target-version>
 set -euo pipefail
 
@@ -24,8 +23,6 @@ if [[ "$TARGET_VERSION" =~ (-|\.)rc[0-9]+$ ]]; then
   : # release candidates follow /docs/latest
 elif [[ "$TARGET_VERSION" == *-dev* ]]; then
   : # nightlies follow /docs/latest
-elif [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "v${TARGET_VERSION%.*}.x"
 else
   echo "v$TARGET_VERSION"
 fi

--- a/.github/scripts/update-helm-charts.sh
+++ b/.github/scripts/update-helm-charts.sh
@@ -12,21 +12,11 @@ if [ -z "$TARGET_VERSION" ]; then
   exit 1
 fi
 
-# Work out which versioned documentation this release should point at.
-#
-# Docs versions are cut per minor line (vX.Y.x) for final releases, and pinned
-# exactly for pre-releases such as v1.0.0-alpha1. No docs version is cut for a
-# release candidate (X.Y.Z-rcN or X.Y.Z-<pre>.rcN) or for a nightly, so those
-# keep whatever the chart defaults to and follow /docs/latest instead.
-if [[ "$TARGET_VERSION" =~ (-|\.)rc[0-9]+$ ]]; then
-  DOCS_VERSION=""
-elif [[ "$TARGET_VERSION" == *-dev* ]]; then
-  DOCS_VERSION=""
-elif [[ "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  DOCS_VERSION="v${TARGET_VERSION%.*}.x"
-else
-  DOCS_VERSION="v$TARGET_VERSION"
-fi
+# Which versioned documentation this release points at. The rule lives in
+# resolve-docs-version.sh so the promotion workflow can pre-flight it; empty
+# means no docs version was cut and the chart keeps /docs/latest.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCS_VERSION="$(bash "$SCRIPT_DIR/resolve-docs-version.sh" "$TARGET_VERSION")"
 
 # A release must not ship a console pinned to documentation that was never
 # published, so fail early rather than emitting links that 404. The manifest is

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -190,7 +190,8 @@ jobs:
 
       # The source tree predates this workflow, so it has no resolve-source-commit.sh.
       # Tooling runs from the dispatched commit (no ref: = github.sha); the scripts that
-      # stamp the release's own content keep running from the checkout above.
+      # stamp the release's own content keep running from the checkout above, except
+      # update-helm-charts.sh — see the docs-version note on that step.
       - name: Checkout promotion tooling
         uses: actions/checkout@v6
         with:
@@ -250,9 +251,13 @@ jobs:
           echo "✅ Synced documentation/versions.json from main"
         shell: bash
 
+      # From the tooling checkout, not the release tree: the docs-version rule is
+      # policy about the target version, and the rc's frozen copy of it would
+      # decide where this release's console doc links point. The seds still run
+      # against the release tree, which is the working directory.
       - name: Update Helm chart versions
         run: |
-          bash .github/scripts/update-helm-charts.sh "$TARGET_VERSION"
+          bash .promotion-tools/.github/scripts/update-helm-charts.sh "$TARGET_VERSION"
         env:
           TARGET_VERSION: ${{ inputs.target_version }}
         shell: bash

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -515,9 +515,9 @@ console:
     # Documentation version the console's in-product doc links point at, used as
     # the path segment after /docs/. "latest" tracks the newest released docs.
     # The release pipeline (.github/scripts/update-helm-charts.sh) pins this to
-    # the matching versioned docs (vX.Y.x, or the exact version for a
-    # pre-release) for final and pre-release builds. Release candidates and
-    # nightlies keep "latest", because no docs version is cut for them.
+    # the release's own versioned docs (v plus the release version). Release
+    # candidates and nightlies keep "latest", because no docs version is cut
+    # for them.
     docsVersion: "latest"
     # Trace-export URL shown to external agent developers. kgateway-routed
     # vhost — independent of the gateway runtime's namespace; no port-forward.


### PR DESCRIPTION
## Purpose
The release pipeline pins the console's in-product documentation links to a docs version that does not exist for final releases.

`update-helm-charts.sh` collapsed a final release to `v${TARGET%.*}.x` (`1.0.0` → `v1.0.x`). That string is used verbatim as the path segment after `/docs/` (`DOCS_URL` in `deployments/helm-charts/wso2-agent-manager/templates/console/configmap.yaml`), so it has to match an entry in `documentation/versions.json` and a `documentation/versioned_docs/version-<docs-version>` directory. Docs versions have always been cut per exact release version — `v1.0.0-alpha1`, `v1.0.0-beta`, `v1.0.0-rc1..rc3`, and now `v1.0.0` (#1830) — so `v1.0.x` matches nothing.

Consequences before this fix:
- `1.0.0` cannot be released or promoted at all: the manifest guard in `update-helm-charts.sh` fails on `v1.0.x`, telling the operator to run Documentation Release for a version that should not be cut.
- If that guard were satisfied, the charts would ship `docsVersion: "v1.0.x"` and every in-product doc link would 404.

## Goals
Resolve a release's docs version to `v` plus its own release version, keep one copy of that rule, and make sure a promotion evaluates the current rule rather than the one frozen in the release candidate's tree.

## Approach
1. `.github/scripts/resolve-docs-version.sh` — dropped the `vX.Y.x` branch for final releases. Release candidates (`X.Y.Z-rcN`, `X.Y.Z.rcN`) and nightlies (`*-dev*`) still resolve to empty, i.e. keep `/docs/latest`; everything else resolves to `v<version>`.
2. `.github/scripts/update-helm-charts.sh` — sources `resolve-docs-version.sh` instead of carrying a second copy of the ladder, so the rule cannot drift between the promotion's pre-flight and its stamping step.
3. `.github/workflows/release-promote.yml` — the stamping step runs `update-helm-charts.sh` from the promotion tooling checkout (the dispatched commit) rather than from the release tree. This is load-bearing: `amp/v1.0.0-rc3`'s tree contains a byte-identical copy of the old script, so fixing `main` alone would leave a promotion computing `v1.0.x` from the frozen copy. The `sed` calls still run against the release tree, which remains the working directory.
4. `deployments/helm-charts/wso2-agent-manager/values.yaml` — the `docsVersion` comment no longer documents the `vX.Y.x` form.

`release.yml` is unchanged: it runs the scripts from the tree it is releasing, which is current.

## User stories
N/A — release tooling; no user-facing feature.

## Release note
Fixed the console's in-product documentation links being pinned to a non-existent `vX.Y.x` documentation version for final releases.

## Documentation
N/A — no documentation content changes. The change makes releases point at the documentation versions that are already published under `documentation/versioned_docs/`.

## Training
N/A — no training impact.

## Certification
N/A — release tooling change, no impact on certification exams.

## Marketing
N/A — internal release tooling.

## Automation tests
 - Unit tests
   > N/A — the repository has no test harness for `.github/scripts`. Verified by running the real scripts against the `amp/v1.0.0-rc3` tree in a scratch copy: with `v1.0.0` absent from the manifest, both the `validate` pre-flight and the stamping step fail naming `v1.0.0`; with it present, the charts stamp `docsVersion: "v1.0.0"`, `ampVersion: "v1.0.0"`, `tag: "v1.0.0"`, `Chart.yaml` `version: v1.0.0` / `appVersion: "v1.0.0"`. Target `1.0.0-rc4` leaves `docsVersion: "latest"`. Resolver spot-checks match `versioned_docs/` exactly: `1.0.0-alpha1` → `v1.0.0-alpha1`, `1.0.0-beta` → `v1.0.0-beta`, `1.0.0-rc3` / `1.0.0.rc3` / `0.0.0-dev` → empty.
 - Integration tests
   > N/A — exercised by the next release/promotion run. `shellcheck` is clean on both scripts and the workflow parses.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no — not applicable, the change is Bash and YAML with no Java code
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
- #1829 (Add release promotion workflow) — introduced the promotion workflow and the mirrored docs-version rule this PR corrects and de-duplicates.
- #1830 (docs: release documentation version v1.0.0) — cuts `v1.0.0`, the docs version this change expects. Both need to land before the 1.0.0 promotion is dispatched.

## Migrations (if applicable)
N/A — no data or schema migration.

## Test environment
macOS 25.0.0 (darwin), Bash 3.2 / GNU coreutils via Homebrew, shellcheck; scripts also run on the workflow's Ubuntu and CodeBuild runners.

## Learning
The duplicated rule was written deliberately, because the promotion has to evaluate it from `main` before cutting tags while the stamping script runs from the release candidate's own (arbitrarily old) tree. That framing is what hid the bug: keeping the two copies "in sync" was treated as the problem, when the rule itself was wrong. Running the stamping script from the tooling checkout removes the two-commit problem, which is what made a single shared copy safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected documentation links for released versions so they point to the matching versioned documentation.
  - Ensured release candidates and nightly builds continue linking to the latest documentation.
  - Improved release promotion handling to consistently determine the appropriate documentation version.
- **Documentation**
  - Clarified documentation-versioning guidance for release, release-candidate, and nightly builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->