### PR TITLE
Backport VM installer fixes to the 1.0.0 release branch

### DIFF
--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -41,7 +41,8 @@ print_template() {
 # it serves is obtained with TLS_MODE — everything downstream is identical.
 
 # --- Required ---
-AMP_VERSION=0.15.0                 # amp/v* release tag (see github.com/wso2/agent-manager/releases)
+AMP_VERSION=                       # REQUIRED: amp/v* release tag, e.g. 1.0.0
+                                   # (see github.com/wso2/agent-manager/releases)
 DOMAIN_BASE=amp.mycompany.com      # service hosts derived as <svc>.<DOMAIN_BASE>
 
 # --- TLS mode: dns01 (default) or byoc ---

--- a/deployments/vm/lib-advanced.sh
+++ b/deployments/vm/lib-advanced.sh
@@ -50,7 +50,7 @@ load_config() {
 # validate_cert, which needs the derived hostnames and so runs after derive_hosts.
 validate_config() {
   CONFIG_ERRORS=()
-  [[ -n "${AMP_VERSION:-}" ]] || CONFIG_ERRORS+=("AMP_VERSION is required (an amp/v* release tag, e.g. 0.15.0)")
+  [[ -n "${AMP_VERSION:-}" ]] || CONFIG_ERRORS+=("AMP_VERSION is required (an amp/v* release tag, e.g. 1.0.0)")
   [[ -n "${DOMAIN_BASE:-}" ]] || CONFIG_ERRORS+=("DOMAIN_BASE is required (e.g. amp.mycompany.com)")
   local mode; mode="$(tls_mode)"
   case " ${SUPPORTED_TLS_MODES} " in

--- a/deployments/vm/lib-certmanager.sh
+++ b/deployments/vm/lib-certmanager.sh
@@ -75,6 +75,42 @@ cert_dns_names() {
   printf '*.%s\n' "$AMP_HOST_GATEWAY"
 }
 
+# acme_dns_names — cert_dns_names() reduced to the names an ACME CA will accept in a
+# SINGLE order. Let's Encrypt (Boulder) rejects an order carrying both a wildcard and a
+# name that wildcard already covers: "Domain name <host> is redundant with a wildcard
+# domain in the same request". That rejection is fatal at order creation, so the Order
+# goes straight to `errored` and NO Challenge is ever created — the install fails looking
+# like a DNS-01 problem while `kubectl get challenge -A` shows nothing at all.
+#
+# Every fixed host sits exactly one label under DOMAIN_BASE, so *.<DOMAIN_BASE> already
+# covers all of them and dropping them changes nothing about what the issued cert serves.
+# The wildcards are kept verbatim: *.agents.<base> and *.gateway.<base> are one label
+# deeper than *.<base> reaches, so none of the three is redundant with another.
+#
+# byoc deliberately keeps the full cert_dns_names() list — no ACME is involved there, and
+# validate_cert's coverage check is wildcard-aware, so a supplied certificate may carry
+# the explicit hosts, the wildcards, or both.
+acme_dns_names() {
+  local -a names=() wildcards=()
+  local n w base covered
+  while IFS= read -r n; do [[ -n "$n" ]] && names+=("$n"); done < <(cert_dns_names)
+  for n in "${names[@]}"; do
+    [[ "$n" == \*.* ]] && wildcards+=("$n")
+  done
+  for n in "${names[@]}"; do
+    if [[ "$n" != \*.* ]]; then
+      covered=false
+      for w in "${wildcards[@]}"; do
+        base="${w#\*.}"
+        # A wildcard matches exactly one label, so only a single-label child is covered.
+        if [[ "$n" == *."$base" && "${n%."$base"}" != *.* ]]; then covered=true; break; fi
+      done
+      [[ "$covered" == true ]] && continue
+    fi
+    printf '%s\n' "$n"
+  done
+}
+
 # _dns01_solver_block — print the cert-manager `dns01:` solver body for DNS_PROVIDER,
 # indented 10 spaces to sit under `solvers:\n  - dns01:` in render_acme_clusterissuer.
 # Credential values come from the config env vars; the referenced Secret is created by
@@ -180,7 +216,8 @@ EOF
 
 # render_wildcard_certificate <cert_name> <secret_name> <issuer_name> — print the
 # Certificate whose issued Secret the consolidated :443 Gateway references. dnsNames come
-# from cert_dns_names (fixed hosts + the agent/env-Thunder wildcards). Lives in GATEWAY_NS.
+# from acme_dns_names — cert_dns_names minus any host already covered by a wildcard in
+# the same list, which an ACME CA refuses to issue in one order. Lives in GATEWAY_NS.
 render_wildcard_certificate() {
   local name="$1" secret="$2" issuer="$3" d
   cat <<EOF
@@ -200,7 +237,7 @@ spec:
 EOF
   while IFS= read -r d; do
     [[ -n "$d" ]] && printf '    - %s\n' "$(_yaml_quote "$d")"
-  done < <(cert_dns_names)
+  done < <(acme_dns_names)
   cat <<EOF
   issuerRef:
     name: ${issuer}

--- a/deployments/vm/lib-vm.sh
+++ b/deployments/vm/lib-vm.sh
@@ -18,10 +18,18 @@ vm_host() {
 # amp_helm_args — hostname-driven core. Reads AMP_HOST_API/THUNDER/CONSOLE/OBSERVER/
 # GATEWAY/CP (CP empty => external gateways off). Emits one helm token per line.
 #
-# The service config lives under different top-level keys across chart versions:
-# `agentManager` (<=main) was renamed to `agentManagerService` (>=0.15.0). Emit
-# both; helm silently ignores whichever key the installed chart doesn't define,
-# so the right one always wins regardless of the --version pulled.
+# Only `agentManagerService` is emitted. The service config used to live under
+# `agentManager` too (renamed in 0.15.0) and both keys were emitted on the theory
+# that helm ignores keys the installed chart doesn't define — true until the chart
+# gained a values.schema.json (1.0.0-rc3), which sets additionalProperties:false
+# at the root and rejects the whole install with "additional properties
+# 'agentManager' not allowed".
+#
+# That schema also types agentsHttpPort/agentsHttpsPort/gatewayVhostPort and
+# console.config.tlsEnabled as strings (the templates `| quote` them), and helm's
+# --set coerces 443 to a number and true to a boolean. Those four need
+# --set-string; agentManagerService.config.tlsEnabled is a real boolean and must
+# stay on --set.
 #
 # config.tlsEnabled (env TLS_ENABLED) selects which advertised endpoint variant
 # amp-api hands the console for deployed agents: when true it emits the https URL
@@ -52,24 +60,21 @@ vm_host() {
 # call (users/roles/groups).
 # shellcheck disable=SC2154  # AMP_HOST_* come from the caller's scope by design.
 amp_helm_args() {
-  local k
-  for k in agentManager agentManagerService; do
-    printf '%s\n' \
-      "--set" "${k}.config.serverPublicURL=https://${AMP_HOST_API}" \
-      "--set" "${k}.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
-      "--set" "${k}.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
-      "--set" "${k}.config.keyManager.audience=urn:wso2:amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/mcp" \
-      "--set" "${k}.config.thunder.baseURL=https://${AMP_HOST_THUNDER}" \
-      "--set" "${k}.config.thunder.resolveToHost=amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090" \
-      "--set" "${k}.config.tlsEnabled=true" \
-      "--set" "${k}.config.idpHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
-      "--set" "${k}.config.agentsBaseDomain=${AMP_AGENTS_BASE}" \
-      "--set" "${k}.config.agentsHttpPort=443" \
-      "--set" "${k}.config.agentsHttpsPort=443" \
-      "--set" "${k}.config.gatewayBaseDomain=${AMP_HOST_GATEWAY}" \
-      "--set" "${k}.config.gatewayVhostScheme=https" \
-      "--set" "${k}.config.gatewayVhostPort=443"
-  done
+  printf '%s\n' \
+    "--set" "agentManagerService.config.serverPublicURL=https://${AMP_HOST_API}" \
+    "--set" "agentManagerService.config.oauthAuthorizationServers=https://${AMP_HOST_THUNDER}" \
+    "--set" "agentManagerService.config.keyManager.issuer=https://${AMP_HOST_THUNDER}" \
+    "--set" "agentManagerService.config.keyManager.audience=urn:wso2:amp\,amp-console-client\,amp-api-client\,amp-publisher-*\,amctl\,am-mcp\,https://${AMP_HOST_API}/mcp" \
+    "--set" "agentManagerService.config.thunder.baseURL=https://${AMP_HOST_THUNDER}" \
+    "--set" "agentManagerService.config.thunder.resolveToHost=amp-thunder-extension-service.amp-thunder.svc.cluster.local:8090" \
+    "--set" "agentManagerService.config.tlsEnabled=true" \
+    "--set" "agentManagerService.config.idpHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
+    "--set" "agentManagerService.config.agentsBaseDomain=${AMP_AGENTS_BASE}" \
+    "--set-string" "agentManagerService.config.agentsHttpPort=443" \
+    "--set-string" "agentManagerService.config.agentsHttpsPort=443" \
+    "--set" "agentManagerService.config.gatewayBaseDomain=${AMP_HOST_GATEWAY}" \
+    "--set" "agentManagerService.config.gatewayVhostScheme=https" \
+    "--set-string" "agentManagerService.config.gatewayVhostPort=443"
 
   printf '%s\n' \
     "--set" "console.config.auth.baseUrl=https://${AMP_HOST_THUNDER}" \
@@ -79,11 +84,10 @@ amp_helm_args() {
     "--set" "agentManagerService.config.amObserverPublicURL=https://${AMP_HOST_OBSERVER}" \
     "--set" "console.config.instrumentationUrl=https://${AMP_HOST_GATEWAY}/otel" \
     "--set" "console.config.idpHostBaseDomain=${AMP_HOST_THUNDER#thunder.}" \
-    "--set" "console.config.tlsEnabled=true"
+    "--set-string" "console.config.tlsEnabled=true"
 
   # Console and API are ClusterIP behind the OC control-plane kgateway; their
   # HTTPRoutes must match the public hosts Caddy forwards (Host is preserved).
-  # Older charts (agentManager key era) predate ocIngress and ignore these.
   printf '%s\n' \
     "--set" "console.ocIngress.hostname=${AMP_HOST_CONSOLE}" \
     "--set" "agentManagerService.ocIngress.hostname=${AMP_HOST_API}"

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -41,6 +41,30 @@ assert_eq "cert SANs include env-Thunder wild" "yes" "$(grep -qxF '*.amp.mycompa
 AMP_HOST_CP="" sans_nocp="$(AMP_HOST_CP="" cert_dns_names)"
 assert_eq "cert SANs omit cp when unset"       "no"  "$(grep -qxF 'cp.amp.mycompany.com' <<<"$sans_nocp" && echo yes || echo no)"
 
+# --- acme_dns_names: the ACME order must carry NO name a wildcard in it already covers ---
+# Boulder rejects such an order outright ("redundant with a wildcard domain in the same
+# request"), and the Order errors before any Challenge exists — so this is what keeps
+# TLS_MODE=dns01 issuable at all, not a cosmetic trim.
+# The cp assertion above leaks AMP_HOST_CP="" into the shell (two assignments in one
+# command), so restore it — otherwise the cp cases below would pass vacuously.
+AMP_HOST_CP=cp.amp.mycompany.com
+acme="$(acme_dns_names)"
+assert_eq "acme names keep the base wildcard"   "yes" "$(grep -qxF '*.amp.mycompany.com' <<<"$acme" && echo yes || echo no)"
+assert_eq "acme names keep agents wildcard"     "yes" "$(grep -qxF '*.agents.amp.mycompany.com' <<<"$acme" && echo yes || echo no)"
+assert_eq "acme names keep gateway wildcard"    "yes" "$(grep -qxF '*.gateway.amp.mycompany.com' <<<"$acme" && echo yes || echo no)"
+# Each of these is one label under the base domain, so *.amp.mycompany.com covers it.
+for h in console api thunder observer gateway cp; do
+  assert_eq "acme names drop redundant ${h}"    "no"  "$(grep -qxF "${h}.amp.mycompany.com" <<<"$acme" && echo yes || echo no)"
+done
+assert_eq "acme names are exactly the 3 wildcards" "3" "$(grep -c . <<<"$acme")"
+# A host NOT covered by any wildcard in the list must survive the filter: an operator
+# override can put a service outside DOMAIN_BASE, and dropping it would silently issue a
+# cert that does not serve that host.
+acme_off="$(AMP_HOST_CONSOLE=console.elsewhere.example acme_dns_names)"
+assert_eq "acme names keep an off-base host"    "yes" "$(grep -qxF 'console.elsewhere.example' <<<"$acme_off" && echo yes || echo no)"
+# The byoc requirement list is deliberately unfiltered — validate_cert accepts either shape.
+assert_eq "cert_dns_names still lists all 9"    "9"   "$(grep -c . <<<"$(cert_dns_names)")"
+
 # --- validate_dns01_config: provider + credential presence (appends to CONFIG_ERRORS) ---
 run_validate() { CONFIG_ERRORS=(); validate_dns01_config; echo "${#CONFIG_ERRORS[@]}"; }
 
@@ -219,7 +243,7 @@ assert_eq "platform CA cm PEM round-trips" "yes" \
 # cannot tell a valid block scalar from an invalid header (an explicit indentation
 # indicator, say), so on its own it would pass on YAML that no parser accepts.
 if command -v kubectl >/dev/null 2>&1; then
-  ca_parsed="$(printf '%s\n' "$ca_cm" | kubectl create --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
+  ca_parsed="$(printf '%s\n' "$ca_cm" | kubectl create --validate=false --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
   assert_eq "platform CA cm is valid YAML" "yes" \
     "$(printf '%s' "$ca_parsed" | grep -q 'BEGIN CERTIFICATE' && echo yes || echo no)"
   assert_eq "platform CA cm PEM is not indented" "no" \
@@ -228,12 +252,12 @@ if command -v kubectl >/dev/null 2>&1; then
   # the inferred block indentation.
   tmp_messy="$(mktemp)"
   { printf '\n  Certificate:\n    Data:\n'; cat "$tmp_cert"; } > "$tmp_messy"
-  messy_parsed="$(render_platform_ca_configmap "$tmp_messy" | kubectl create --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
+  messy_parsed="$(render_platform_ca_configmap "$tmp_messy" | kubectl create --validate=false --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
   assert_eq "indented-preamble CA still renders valid YAML" "yes" \
     "$(printf '%s' "$messy_parsed" | openssl x509 -noout -subject >/dev/null 2>&1 && echo yes || echo no)"
   rm -f "$tmp_messy"
   # The byoc Secret must parse too.
-  sec_type="$(render_byoc_tls_secret amp-wildcard-tls "$tmp_cert" "$tmp_key" | kubectl create --dry-run=client -o jsonpath='{.type}' -f - 2>/dev/null || true)"
+  sec_type="$(render_byoc_tls_secret amp-wildcard-tls "$tmp_cert" "$tmp_key" | kubectl create --validate=false --dry-run=client -o jsonpath='{.type}' -f - 2>/dev/null || true)"
   assert_eq "byoc secret is valid YAML" "kubernetes.io/tls" "$sec_type"
 else
   printf 'ok   - rendered YAML parses (skipped: kubectl not installed)\n'

--- a/deployments/vm/tests/run.sh
+++ b/deployments/vm/tests/run.sh
@@ -35,6 +35,10 @@ assert_eq() {
 # has <haystack> <needle> -> "yes" if needle present, else "no"
 # (-- so needles starting with '-' aren't parsed as grep options)
 has() { grep -qF -- "$2" <<<"$1" && echo yes || echo no; }
+# flag_for <helm-args> <key=value> -> the flag token emitted just before that
+# KEY=VALUE line. The builders print one token per line, so --set vs --set-string
+# (which decides whether helm coerces 443 to a number) is the preceding line.
+flag_for() { grep -B1 -F -- "$2" <<<"$1" | head -1; }
 
 # --- vm_host ---
 assert_eq "vm_host console" "console.amp.203.0.113.10.sslip.io" "$(vm_host console 203.0.113.10)"
@@ -42,13 +46,14 @@ assert_eq "vm_host thunder" "thunder.amp.203.0.113.10.sslip.io" "$(vm_host thund
 
 # --- build_amp_helm_args (external gateways on by default) ---
 amp="$(build_amp_helm_args 203.0.113.10 true)"
-# Service settings are emitted under BOTH chart keys (agentManager + agentManagerService).
+# Service settings are emitted under `agentManagerService` only. The chart's
+# values.schema.json sets additionalProperties:false at the root, so the legacy
+# pre-0.15.0 `agentManager` key fails the whole install rather than being ignored.
 assert_eq "amp serverPublicURL (service key)" \
   "agentManagerService.config.serverPublicURL=https://api.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.serverPublicURL' <<<"$amp")"
-assert_eq "amp serverPublicURL (legacy key)" \
-  "agentManager.config.serverPublicURL=https://api.amp.203.0.113.10.sslip.io" \
-  "$(grep -F 'agentManager.config.serverPublicURL' <<<"$amp")"
+assert_eq "amp emits no legacy agentManager key" "no" \
+  "$(has "$amp" 'agentManager.config.')"
 assert_eq "amp oauthAuthorizationServers (service key)" \
   "agentManagerService.config.oauthAuthorizationServers=https://thunder.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'agentManagerService.config.oauthAuthorizationServers' <<<"$amp")"
@@ -62,16 +67,16 @@ assert_eq "amp keyManager.audience carries the public API URL (service key)" "ye
   "$(has "$amp" 'agentManagerService.config.keyManager.audience=urn:wso2:amp\,')"
 assert_eq "amp keyManager.audience ends with the public API URL (service key)" "yes" \
   "$(has "$amp" 'am-mcp\,https://api.amp.203.0.113.10.sslip.io/mcp')"
-assert_eq "amp keyManager.audience carries the public API URL (legacy key)" "yes" \
-  "$(has "$amp" 'agentManager.config.keyManager.audience=urn:wso2:amp\,')"
-# tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant;
-# emitted under both keys (old agentManager + new agentManagerService).
+# tlsEnabled=true makes amp-api advertise the https deployed-agent endpoint variant.
+# The schema types the service-side flag as a boolean and the console-side one as a
+# string, so they must go out on different helm flags.
 assert_eq "amp tlsEnabled (service key)" \
   "agentManagerService.config.tlsEnabled=true" \
   "$(grep -F 'agentManagerService.config.tlsEnabled' <<<"$amp")"
-assert_eq "amp tlsEnabled (legacy key)" \
-  "agentManager.config.tlsEnabled=true" \
-  "$(grep -F 'agentManager.config.tlsEnabled' <<<"$amp")"
+assert_eq "amp tlsEnabled stays a boolean for the service" "--set" \
+  "$(flag_for "$amp" 'agentManagerService.config.tlsEnabled=true')"
+assert_eq "amp tlsEnabled is a string for the console" "--set-string" \
+  "$(flag_for "$amp" 'console.config.tlsEnabled=true')"
 assert_eq "amp console apiBaseUrl" \
   "console.config.apiBaseUrl=https://api.amp.203.0.113.10.sslip.io" \
   "$(grep -F 'config.apiBaseUrl' <<<"$amp")"
@@ -124,6 +129,12 @@ assert_eq "amp gatewayVhostScheme (service key)" \
 assert_eq "amp gatewayVhostPort (service key)" \
   "agentManagerService.config.gatewayVhostPort=443" \
   "$(grep -F 'agentManagerService.config.gatewayVhostPort' <<<"$amp")"
+# The schema types all three ports as strings; plain --set would hand helm the
+# number 443 and fail validation before anything is installed.
+for port_key in agentsHttpPort agentsHttpsPort gatewayVhostPort; do
+  assert_eq "amp ${port_key} is set as a string" "--set-string" \
+    "$(flag_for "$amp" "agentManagerService.config.${port_key}=443")"
+done
 
 # --- build_amp_helm_args (external gateways disabled) ---
 amp_nocp="$(build_amp_helm_args 203.0.113.10 false)"
@@ -767,6 +778,68 @@ assert_eq "inotify watches floor"             "524288" "$(inotify_bump_target 81
   assert_eq "_public_ip offline exit status"  "0" "$rc"
   assert_eq "_public_ip offline output empty" ""  "$out"
 )
+
+# --- every builder's output passes the target chart's values.schema.json ---
+# The assertions above check the tokens; they cannot see that helm rejects them.
+# 1.0.0-rc3 shipped the first values.schema.json and its simple install failed at
+# the last step on a value type and a stale top-level key, so render each builder's
+# args against the in-repo charts. Rendering (not just linting) is what runs schema
+# validation, and it needs no cluster.
+if command -v helm >/dev/null 2>&1; then
+  CHARTS_DIR="$(cd "${SCRIPT_DIR}/../../helm-charts" && pwd)"
+  assert_schema_accepts() {
+    local label="$1" chart="$2" out; shift 2
+    if out="$(helm template schema-check "${CHARTS_DIR}/${chart}" "$@" 2>&1 >/dev/null)"; then
+      printf 'ok   - %s\n' "$label"
+    else
+      printf 'FAIL - %s\n%s\n' "$label" "$out"
+      echo 1 >>"$FAILLOG"
+    fi
+  }
+  (
+    IP=203.0.113.10
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_amp_helm_args "$IP" true)
+    assert_schema_accepts "amp args pass the chart schema" wso2-agent-manager "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_amp_helm_args "$IP" false)
+    assert_schema_accepts "amp args (no cp) pass the chart schema" wso2-agent-manager "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_thunder_helm_args "$IP")
+    assert_schema_accepts "thunder args pass the chart schema" wso2-amp-thunder-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_observability_helm_args "$IP")
+    assert_schema_accepts "observability args pass the chart schema" wso2-amp-observability-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_gateway_helm_args "$IP")
+    assert_schema_accepts "gateway args pass the chart schema" wso2-amp-api-platform-gateway-extension "${args[@]}"
+    AMP_AGENTS_BASE="agents.${IP}.sslip.io"
+    AMP_HOST_GATEWAY="$(vm_host gateway "$IP")"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_platform_resources_helm_args)
+    assert_schema_accepts "platform-resources args pass the chart schema" \
+      wso2-amp-platform-resources-extension "${args[@]}"
+  )
+  # The advanced installer calls the bare cores with derive_hosts' custom-domain
+  # hostnames instead of the sslip.io wrappers above, so cover that path too — a
+  # value added on only one of the two would otherwise ship unvalidated.
+  (
+    DOMAIN_BASE="amp.example.com"
+    AMP_HOST_CONSOLE="" AMP_HOST_API="" AMP_HOST_THUNDER="" AMP_HOST_OBSERVER=""
+    AMP_HOST_GATEWAY="" AMP_HOST_CP="" AMP_AGENTS_BASE=""
+    derive_hosts
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(amp_helm_args)
+    assert_schema_accepts "advanced amp args pass the chart schema" wso2-agent-manager "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(thunder_helm_args)
+    assert_schema_accepts "advanced thunder args pass the chart schema" \
+      wso2-amp-thunder-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(observability_helm_args)
+    assert_schema_accepts "advanced observability args pass the chart schema" \
+      wso2-amp-observability-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(gateway_helm_args)
+    assert_schema_accepts "advanced gateway args pass the chart schema" \
+      wso2-amp-api-platform-gateway-extension "${args[@]}"
+    args=(); while IFS= read -r l; do args+=("$l"); done < <(build_platform_resources_helm_args)
+    assert_schema_accepts "advanced platform-resources args pass the chart schema" \
+      wso2-amp-platform-resources-extension "${args[@]}"
+  )
+else
+  echo "skip - chart schema checks (helm not installed)"
+fi
 
 if [[ -s "$FAILLOG" ]]; then echo "TESTS FAILED"; exit 1; fi
 echo "ALL TESTS PASSED"

--- a/documentation/docs/guides/on-a-vm.mdx
+++ b/documentation/docs/guides/on-a-vm.mdx
@@ -219,7 +219,7 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 ## Prerequisites {#adv-prerequisites}
 
 - **Docker, k3d, kubectl, Helm, curl, and `lsof`** must already be installed on the VM. The installer **verifies** they are present and exits with install hints if any are missing. It does **not** install them for you.
-- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works.
+- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works. Those figures cover the platform plus the **default environment**. Every environment you add runs its own Thunder and API Platform Gateway, and evaluation runs are scheduled as extra pods, so on 4 vCPUs a second environment can consume nearly all allocatable CPU — after which evaluation jobs stay `Pending` (`0/1 nodes are available: 1 Insufficient cpu`) instead of reporting a capacity error. Plan on **8 vCPUs** if you intend to add environments or run evaluations.
 - **A domain you control.** With `TLS_MODE=dns01` it must additionally be hosted on one of the supported DNS providers — **Cloudflare**, **AWS Route 53**, **Google Cloud DNS**, or **Azure DNS** — and you need **a DNS-provider API credential** scoped to edit that zone's records, which cert-manager uses to write the `_acme-challenge` TXT record. You do **not** create TXT records by hand. With `TLS_MODE=byoc` neither the provider nor the credential matters; you need only [a certificate covering the right names](#adv-byoc).
 
 ## Configure {#adv-configure}
@@ -487,6 +487,20 @@ Per-environment Thunder does **not** have this problem: its handles sit directly
 
 Verify the fixed hosts resolve before installing:
 
+:::note A freshly delegated zone reads as broken for a few minutes
+If you have only just pointed the parent zone's `NS` records at your DNS provider, the loop below can return **empty answers for some hosts and addresses for others**, changing from run to run. That is the parent zone's negative cache (typically 300 s, per the zone's SOA), not a misconfiguration — public resolvers are anycast fleets, so each edge expires its cached `NXDOMAIN` at a different moment. Confirm the zone itself is correct by querying its authoritative nameservers directly, which never serve a stale negative:
+
+```bash
+# 1. the delegation itself — this prints your DNS provider's nameservers
+dig +short NS amp.mycompany.com
+
+# 2. ask one of those nameservers directly, substituting a name from step 1
+dig +short console.amp.mycompany.com A @<nameserver-from-step-1>
+```
+
+Certificate issuance does not depend on these A records at all — it turns on the `_acme-challenge` TXT record cert-manager writes, so a service host that has not finished propagating can still be certified. It does depend on the delegation being correct: if the parent zone still points at the wrong nameservers, the CA follows that stale delegation and never sees the TXT record, so confirm the `NS` answer above before suspecting issuance.
+:::
+
 ```bash
 for h in console.amp.mycompany.com thunder.amp.mycompany.com gateway.amp.mycompany.com \
          x-y.agents.amp.mycompany.com x-y.gateway.amp.mycompany.com; do
@@ -639,7 +653,11 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 - **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER` or `TLS_MODE`, a missing provider credential, or `byoc` without `TLS_CERT_FILE`). Fix `amp-config.env` and re-run.
 - **Certificate rejected before install (`byoc`).** The pre-flight found that the certificate and key don't match, the certificate has expired, or its SANs don't cover a required name. The message names the specific problem. The most common one is a missing `*.agents` or `*.gateway` wildcard: those tiers sit one label deeper than `*.<DOMAIN_BASE>` reaches, so they each need their own explicit wildcard SAN (see [Bring your own certificate](#adv-byoc)). Reissue with the full SAN list.
 - **Certificate never becomes Ready (`dns01`).** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
-- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
+- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)). For `amctl` specifically, which fails with `x509: certificate signed by unknown authority`, you can point it at the CA for a single command instead of changing the host's trust store — no root required:
+
+  ```bash
+  SSL_CERT_FILE=/path/to/ca.pem amctl project list --org <org>
+  ```
 - **Login to an agent environment fails while the console works (`byoc` with a private CA).** That environment's Thunder cannot validate the chain when it fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`. Environment creation reports success regardless, so this only ever surfaces at login. Check whether the CA is published in the cluster:
 
   ```bash

--- a/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
+++ b/documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx
@@ -219,7 +219,7 @@ If you just want a quick IP-based demo with automatic TLS, prefer the **Simple**
 ## Prerequisites {#adv-prerequisites}
 
 - **Docker, k3d, kubectl, Helm, curl, and `lsof`** must already be installed on the VM. The installer **verifies** they are present and exits with install hints if any are missing. It does **not** install them for you.
-- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works.
+- A **Linux VM** with at least **4 vCPUs**, **8 GB RAM**, and **50 GB of disk**, and **outbound** internet access to pull images and charts. Inbound `:443` is needed only for clients to reach the services, **not** for certificate issuance, so a fully private VM works. Those figures cover the platform plus the **default environment**. Every environment you add runs its own Thunder and API Platform Gateway, and evaluation runs are scheduled as extra pods, so on 4 vCPUs a second environment can consume nearly all allocatable CPU — after which evaluation jobs stay `Pending` (`0/1 nodes are available: 1 Insufficient cpu`) instead of reporting a capacity error. Plan on **8 vCPUs** if you intend to add environments or run evaluations.
 - **A domain you control.** With `TLS_MODE=dns01` it must additionally be hosted on one of the supported DNS providers — **Cloudflare**, **AWS Route 53**, **Google Cloud DNS**, or **Azure DNS** — and you need **a DNS-provider API credential** scoped to edit that zone's records, which cert-manager uses to write the `_acme-challenge` TXT record. You do **not** create TXT records by hand. With `TLS_MODE=byoc` neither the provider nor the credential matters; you need only [a certificate covering the right names](#adv-byoc).
 
 ## Configure {#adv-configure}
@@ -487,6 +487,20 @@ Per-environment Thunder does **not** have this problem: its handles sit directly
 
 Verify the fixed hosts resolve before installing:
 
+:::note A freshly delegated zone reads as broken for a few minutes
+If you have only just pointed the parent zone's `NS` records at your DNS provider, the loop below can return **empty answers for some hosts and addresses for others**, changing from run to run. That is the parent zone's negative cache (typically 300 s, per the zone's SOA), not a misconfiguration — public resolvers are anycast fleets, so each edge expires its cached `NXDOMAIN` at a different moment. Confirm the zone itself is correct by querying its authoritative nameservers directly, which never serve a stale negative:
+
+```bash
+# 1. the delegation itself — this prints your DNS provider's nameservers
+dig +short NS amp.mycompany.com
+
+# 2. ask one of those nameservers directly, substituting a name from step 1
+dig +short console.amp.mycompany.com A @<nameserver-from-step-1>
+```
+
+Certificate issuance does not depend on these A records at all — it turns on the `_acme-challenge` TXT record cert-manager writes, so a service host that has not finished propagating can still be certified. It does depend on the delegation being correct: if the parent zone still points at the wrong nameservers, the CA follows that stale delegation and never sees the TXT record, so confirm the `NS` answer above before suspecting issuance.
+:::
+
 ```bash
 for h in console.amp.mycompany.com thunder.amp.mycompany.com gateway.amp.mycompany.com \
          x-y.agents.amp.mycompany.com x-y.gateway.amp.mycompany.com; do
@@ -639,7 +653,11 @@ The control-plane endpoint `https://cp.<DOMAIN_BASE>` is exposed by default. Gen
 - **Config rejected before install.** The installer names the missing/invalid key (e.g. an unsupported `DNS_PROVIDER` or `TLS_MODE`, a missing provider credential, or `byoc` without `TLS_CERT_FILE`). Fix `amp-config.env` and re-run.
 - **Certificate rejected before install (`byoc`).** The pre-flight found that the certificate and key don't match, the certificate has expired, or its SANs don't cover a required name. The message names the specific problem. The most common one is a missing `*.agents` or `*.gateway` wildcard: those tiers sit one label deeper than `*.<DOMAIN_BASE>` reaches, so they each need their own explicit wildcard SAN (see [Bring your own certificate](#adv-byoc)). Reissue with the full SAN list.
 - **Certificate never becomes Ready (`dns01`).** cert-manager could not complete the DNS-01 challenge. Inspect it with `kubectl describe certificate amp-wildcard-tls -n openchoreo-control-plane` and `kubectl get challenge -A`. Common causes: the provider credential can't write the zone, the zone isn't delegated to that provider, or a production rate limit. Re-run with `ACME_SERVER` pointed at Let's Encrypt staging to iterate.
-- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)).
+- **Untrusted-certificate warnings everywhere (`byoc` with a private CA).** Expected on any client that doesn't hold your CA. Import the CA into the client's trust store. If browsers also report the chain as incomplete, `TLS_CERT_FILE` is probably leaf-only — rebuild it as the full chain and rotate (see [Rotating a `byoc` certificate](#adv-byoc-rotate)). For `amctl` specifically, which fails with `x509: certificate signed by unknown authority`, you can point it at the CA for a single command instead of changing the host's trust store — no root required:
+
+  ```bash
+  SSL_CERT_FILE=/path/to/ca.pem amctl project list --org <org>
+  ```
 - **Login to an agent environment fails while the console works (`byoc` with a private CA).** That environment's Thunder cannot validate the chain when it fetches platform Thunder's JWKS over `https://thunder.<DOMAIN_BASE>`. Environment creation reports success regardless, so this only ever surfaces at login. Check whether the CA is published in the cluster:
 
   ```bash


### PR DESCRIPTION
## Purpose

The `amp/v1.0.0` release was cut from this branch before the two VM installer fixes landed on `main`, so the branch still carries a defect that breaks every VM install — simple and advanced alike — at the final step:

```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
wso2-agent-manager:
- at '/agentManagerService/config': validation failed
  - at '/agentManagerService/config/gatewayVhostPort': got number, want string
  - at '/agentManagerService/config/agentsHttpsPort': got number, want string
  - at '/agentManagerService/config/agentsHttpPort': got number, want string
- at '/console/config/tlsEnabled': got boolean, want string
- at '': additional properties 'agentManager' not allowed
```

Reproduced by extracting the published `wso2-agent-manager-1.0.0.tar.gz` and rendering its `build_amp_helm_args` output against the `1.0.0` chart. The install bundle attached to the release has since been rebuilt with these fixes, but this branch had not, so any patch release cut from here would regress straight back to the same failure. This PR closes that gap.

Backports #1808 and #1816.

## Goals

Bring the release branch in line with the install bundle now attached to `amp/v1.0.0`, so the branch is a faithful source for the shipped artifact and future patch cuts do not reintroduce the defect.

## Approach

Straight cherry-picks of `2ff9d783b` (#1808) and `ddd7df0b9` (#1816), both of which applied cleanly.

`2ff9d783b` stops `amp_helm_args` emitting the legacy top-level `agentManager` key — harmless before the chart gained a `values.schema.json`, fatal now that the schema sets `additionalProperties: false` at the root — and moves the four string-typed values (`agentsHttpPort`, `agentsHttpsPort`, `gatewayVhostPort`, `console.config.tlsEnabled`) onto `--set-string`, since plain `--set` hands helm the number `443` and the boolean `true`. `agentManagerService.config.tlsEnabled` is a genuine boolean in the schema and deliberately stays on `--set`. It also adds schema-render coverage to the VM test suite, which previously asserted the emitted tokens and so could not see helm rejecting them.

`ddd7df0b9` fixes DNS-01 certificate issuance on advanced installs and updates the VM guide accordingly.

One deliberate deviation from a pure cherry-pick: the `documentation/package.json` and `documentation/package-lock.json` changes in `ddd7df0b9` (a `fast-uri` transitive bump, 3.1.5 to 3.1.7) are unrelated churn that happened to be committed alongside the fix on `main`, and are excluded here rather than shipped onto a GA release branch. Everything else from both commits is carried over verbatim.

## User stories

N/A — installer defect fix with no user-facing feature change.

## Release note

Fixed VM installs failing at the Agent Management Platform step because the installer's Helm values did not conform to the `wso2-agent-manager` chart's values schema, and fixed DNS-01 certificate issuance on advanced VM installs.

## Documentation

The VM guide changes from #1816 are carried over: `documentation/docs/guides/on-a-vm.mdx` and `documentation/versioned_docs/version-v1.0.0-rc3/guides/on-a-vm.mdx`. No further documentation impact — no documented flag or installation step changes.

## Training

N/A — no training content covers the VM installer internals.

## Certification

N/A — internal installer wiring, not exam material.

## Marketing

N/A — bug fix.

## Automation tests

- Unit tests
  > `bash deployments/vm/tests/run.sh` passes on this branch, including the 13 schema-render checks added by #1808. Those cover `wso2-agent-manager`, `wso2-amp-thunder-extension`, `wso2-amp-observability-extension`, `wso2-amp-platform-resources-extension` and `wso2-amp-api-platform-gateway-extension`, for both the sslip.io host path used by the simple installer and the `derive_hosts` custom-domain path used by the advanced one.
  > Note that no CI workflow currently runs this suite, which is why the original defect reached a release. Wiring it in is worth a follow-up but is deliberately out of scope here.
- Integration tests
  > No automated integration coverage exists for the VM installer. The schema fix was verified by a full documented install on a clean cloud VM when it landed on `main`.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — shell and docs only, no Java in this change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A — no samples relate to installer helm arguments.

## Related PRs

- #1808 — original schema fix on `main`
- #1816 — original DNS-01 fix on `main`

## Migrations (if applicable)

N/A — no data or resource migration. Existing installations are unaffected; this only changes how a fresh install passes values to helm.

## Test environment

Verified that each of the six installer files on this branch is byte-identical to its counterpart in the install bundle now published on the `amp/v1.0.0` release, so the branch and the shipped artifact agree exactly.

Schema conformance was checked by rendering every builder's arguments against the in-repo charts on this branch, and the fixed arguments were additionally rendered against the published `1.0.0` chart with external gateways both enabled and disabled. Helm v3.21.4 on macOS; the original end-to-end install validation for the schema fix ran on Ubuntu 26.04.1 LTS with Docker 29.7.2, k3d v5.9.0, kubectl v1.37.0 and Helm v3.21.4.

## Learning

Adding a `values.schema.json` to a chart retroactively tightens the contract for every existing caller. Two consequences are easy to miss: helm's `--set` infers types, so `443` becomes a number and `true` a boolean, which makes a string-typed field an immediate violation and `--set-string` the only way to pass such values; and a root `additionalProperties: false` turns the common "emit both the old and new key so any chart version works" pattern from harmless into fatal.

The broader lesson for release hygiene is that a release branch cut before a fix merges will keep shipping the defect even after the attached artifact is rebuilt, so the branch needs the backport too.
