### PR TITLE
Fix AgentID secret injection and Cloud issuer registration

### DIFF
--- a/agent-manager-service/clients/thundersvc/env_endpoints.go
+++ b/agent-manager-service/clients/thundersvc/env_endpoints.go
@@ -1,6 +1,18 @@
 // Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
 //
-// WSO2 LLC. licenses this file to you under the Apache License, Version 2.0.
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package thundersvc
 

--- a/agent-manager-service/clients/thundersvc/env_endpoints_test.go
+++ b/agent-manager-service/clients/thundersvc/env_endpoints_test.go
@@ -1,6 +1,18 @@
 // Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
 //
-// WSO2 LLC. licenses this file to you under the Apache License, Version 2.0.
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package thundersvc
 

--- a/agent-manager-service/controllers/gateway_identity_provider_controller.go
+++ b/agent-manager-service/controllers/gateway_identity_provider_controller.go
@@ -135,10 +135,24 @@ func (c *gatewayController) ListGatewayIdentityProviders(w http.ResponseWriter, 
 // deploy-time validation checks the mirror, so a mirror-only issuer passes validation
 // while the gateway rejects its tokens at runtime. Use manage-identity-provider.sh.
 func (c *gatewayController) UpsertGatewayIdentityProvider(w http.ResponseWriter, r *http.Request) {
-	log := logger.GetLogger(r.Context())
+	ctx := r.Context()
+	log := logger.GetLogger(ctx)
 	ouID := middleware.OUIDFromRequest(r)
 	gatewayID := strings.TrimSpace(r.PathValue("gatewayID"))
 	name := strings.TrimSpace(r.PathValue("name"))
+
+	// WSO2 Cloud provisions the environment Thunder identity provider with a
+	// control-plane M2M token, so the tenant OU is carried in
+	// X-Impersonate-Org. Keep ordinary user-token requests unchanged when the
+	// header is absent, matching the Thunder URL and system-client endpoints.
+	if impersonated, ok := impersonatedOUID(r); ok && impersonated != ouID {
+		log.Warn("UpsertGatewayIdentityProvider: org impersonation header overrides token org",
+			"tokenOuID", ouID, "impersonatedOuID", impersonated)
+		ouID = impersonated
+		org, _ := middleware.GetResolvedOrg(ctx)
+		org.OUID = impersonated
+		ctx = middleware.WithResolvedOrg(ctx, org)
+	}
 
 	var req spec.UpsertIdentityProviderRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -153,7 +167,6 @@ func (c *gatewayController) UpsertGatewayIdentityProvider(w http.ResponseWriter,
 	// because they decide where the signing keys come from and whether that
 	// fetch validates TLS — an issuer on its own does not say who can actually
 	// mint an accepted token.
-	ctx := r.Context()
 	attempt, ok := beginAuditOrFail(
 		w, r, "UpsertGatewayIdentityProvider", "Failed to upsert identity provider", audit.ActionGatewaySetIdentityProvider,
 		audit.Org(ouID),

--- a/agent-manager-service/models/agent_thunder_client.go
+++ b/agent-manager-service/models/agent_thunder_client.go
@@ -57,8 +57,9 @@ type AgentThunderClient struct {
 	ProvisioningType AgentProvisioningType `gorm:"column:provisioning_type;not null"`
 	ThunderAgentID   string                `gorm:"column:thunder_agent_id;not null;default:''"`
 	ThunderClientID  string                `gorm:"column:thunder_client_id;not null;default:''"`
-	// SecretRefPath is the OpenBao KV path holding the credential (internal agents only).
-	// Read directly by services.AgentIdentityInjectionService.
+	// SecretRefPath stores the provider-managed SecretReference name for the
+	// credential (internal agents only). The column name is retained for schema
+	// compatibility.
 	SecretRefPath string             `gorm:"column:secret_ref_path;not null;default:''"`
 	Status        AgentThunderStatus `gorm:"column:status;not null;default:'pending'"`
 	// RequestedBy is the calling user's own subject (from AMS's existing

--- a/agent-manager-service/services/agent_identity_injection_service.go
+++ b/agent-manager-service/services/agent_identity_injection_service.go
@@ -118,14 +118,9 @@ func mergeAgentIdentityEnvVarKeys(dst map[string]bool) map[string]bool {
 // "Gateway Binding" phase of the AgentID feature. It never handles the secret
 // VALUE itself: the pod receives the client secret through a SecretKeyRef
 // into a Kubernetes Secret that OpenChoreo materializes, in the agent's own
-// workload namespace, from a data-plane SecretReference this service owns
-// (ensureSecretReference) — pointed at the remote KV key
-// agentThunderProvisioningService.storeCredential resolved once, at
-// credential creation/rotation, and persisted in binding.SecretRefPath (see
-// its doc comment). This service never independently resolves or guesses
-// that KV key — it only ever reads binding.SecretRefPath, so it never repeats
-// a live OpenChoreo round trip on its own (much more frequent) injection
-// path.
+// workload namespace, from the provider-managed SecretReference whose name
+// agentThunderProvisioningService stores in binding.SecretRefPath. Injection
+// uses that name directly and never reads or reconstructs the backing KV path.
 //
 // This service is wired unconditionally (see wiring.ProvideAgentIdentityInjectionService),
 // independent of which AgentThunderProvisioningService implementation a
@@ -136,13 +131,11 @@ func mergeAgentIdentityEnvVarKeys(dst map[string]bool) map[string]bool {
 // silently no-ops for them.
 type AgentIdentityInjectionService interface {
 	// EnvVarsForEnvironment returns the identity env vars for one internal
-	// agent in one environment, ensuring the backing data-plane
-	// SecretReference exists first. Returns (nil, nil) when there is nothing
+	// agent in one environment. Returns (nil, nil) when there is nothing
 	// to inject: no binding, provisioning not completed, an external agent,
 	// or a revoked credential. Callers treat nil as "skip identity
 	// injection" — a normal state, not an error. A non-nil error means the
-	// current state could not be determined (or the SecretReference could
-	// not be ensured) and the caller must NOT proceed with an env-var
+	// current state could not be determined and the caller must NOT proceed with an env-var
 	// rewrite that would silently drop the vars.
 	EnvVarsForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) ([]client.EnvVar, error)
 
@@ -166,18 +159,14 @@ type AgentIdentityInjectionService interface {
 	// revoked bindings and for not-yet-deployed environments.
 	ReconcileForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) error
 
-	// RefreshAfterRotation re-asserts the data-plane SecretReference with a
-	// fresh rotated-at annotation and rolls the pod once the secret-store sync
-	// has had time to catch up. Rotation never changes the SecretReference's
-	// remote KV key (storeCredential's resolved location is stable — a
-	// rotation only updates the value in place), so this never touches
-	// binding.SecretRefPath itself. No-op for external agents and
+	// RefreshAfterRotation waits for the provider-managed SecretReference to
+	// synchronize the rotated value, then rolls the pod. Rotation keeps the same
+	// SecretReference name, so this never changes binding.SecretRefPath. No-op for external agents and
 	// unprovisioned bindings.
 	RefreshAfterRotation(ctx context.Context, ouID, projectName, agentName, envName string) error
 
 	// RemoveForEnvironment removes the identity env vars from the agent's
-	// workload for one environment and deletes the backing data-plane
-	// SecretReference — used after a revoke, so the pod does not keep
+	// workload for one environment — used after a revoke, so the pod does not keep
 	// serving a credential that can no longer mint tokens.
 	// includeWorkloadLevel additionally removes the vars from the shared
 	// Workload CR; callers set it only when envName is the pipeline's lowest
@@ -187,10 +176,8 @@ type AgentIdentityInjectionService interface {
 	// pod).
 	RemoveForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string, includeWorkloadLevel bool) error
 
-	// CleanupForEnvironment deletes the AgentID data-plane SecretReference
-	// for one (agent, environment) — used on agent deletion, where the
-	// workload itself is being deleted so env var removal is pointless but
-	// the SecretReference would leak. Best-effort: not-found is success.
+	// CleanupForEnvironment removes any injection-owned resources. The backing
+	// SecretReference is owned and deleted by the secret management provider.
 	CleanupForEnvironment(ctx context.Context, ouID, agentName, envName string) error
 }
 
@@ -215,8 +202,6 @@ type agentIdentityInjectionService struct {
 	refreshInterval      string
 	logger               *slog.Logger
 	resolveTokenEndpoint func(context.Context, string, string, string) (string, error)
-	// now is injectable for tests; defaults to time.Now.
-	now func() time.Time
 	// after is injectable for tests; defaults to time.After. See
 	// RefreshAfterRotation's doc comment for why it waits at all.
 	after func(time.Duration) <-chan time.Time
@@ -266,7 +251,6 @@ func NewAgentIdentityInjectionServiceWithTokenEndpointResolver(
 		refreshInterval:      refreshInterval,
 		logger:               logger,
 		resolveTokenEndpoint: resolveTokenEndpoint,
-		now:                  time.Now,
 		after:                time.After,
 		rolloutTokens:        make(map[string]uint64),
 		shutdownCtx:          context.Background(),
@@ -411,55 +395,6 @@ func (s *agentIdentityInjectionService) injectableBinding(ctx context.Context, o
 	return binding, nil
 }
 
-// secretRotatedAtAnnotation/secretRotatedAtFormat stamp a fresh value on the
-// SecretReference's Secret template on every rotation, marking its spec as
-// changed. This alone does not force the secret-store sync ahead of its own
-// refresh cadence — see RefreshAfterRotation for how the wait is handled.
-const (
-	secretRotatedAtAnnotation = "amp.wso2.com/secret-rotated-at"
-	secretRotatedAtFormat     = time.RFC3339Nano
-)
-
-// ensureSecretReference creates or updates the data-plane SecretReference CR
-// that lets OpenChoreo materialize the stored credential as a Kubernetes
-// Secret in the agent's own workload namespace. templateAnnotations may be
-// nil; see secretRotatedAtAnnotation for when it is not.
-//
-// KVPath comes directly from binding.SecretRefPath — the remote key
-// agentThunderProvisioningService.storeCredential resolved once, at
-// credential creation/rotation, by reading the SecretReference CreateSecret
-// itself manages back from OpenChoreo (see storeCredential's doc comment).
-// This method never independently computes or re-resolves that value; it
-// only ever asserts the CR's spec from whatever's already in the DB, so it
-// carries no live-read dependency of its own — safe to call on every
-// deploy/promote/config-update, and from the reconciler on every tick.
-func (s *agentIdentityInjectionService) ensureSecretReference(ctx context.Context, binding *models.AgentThunderClient, templateAnnotations map[string]string) (string, error) {
-	location := agentIdentitySecretLocation(binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName)
-	refName := location.SecretRefName()
-	req := client.CreateSecretReferenceRequest{
-		Namespace:           binding.OUID,
-		Name:                refName,
-		ProjectName:         binding.ProjectName,
-		ComponentName:       binding.AgentName,
-		KVPath:              binding.SecretRefPath,
-		SecretKeys:          []string{thundersvc.AgentSecretKeyClientSecret},
-		RefreshInterval:     s.refreshInterval,
-		TemplateAnnotations: templateAnnotations,
-	}
-	if _, err := s.ocClient.CreateSecretReference(ctx, binding.OUID, req); err != nil {
-		// A concurrent caller (another request for this same binding, or the
-		// reconciler) may have already created it — fall back to asserting
-		// the same spec via update rather than treating this as fatal.
-		if !errors.Is(err, utils.ErrConflict) {
-			return "", fmt.Errorf("create agent identity SecretReference %q: %w", refName, err)
-		}
-		if _, err := s.ocClient.UpdateSecretReference(ctx, binding.OUID, refName, req); err != nil {
-			return "", fmt.Errorf("update agent identity SecretReference %q after create conflict: %w", refName, err)
-		}
-	}
-	return refName, nil
-}
-
 // deleteSecretReference deletes the data-plane SecretReference for one
 // binding. Best-effort by convention of every caller: not-found is success.
 func (s *agentIdentityInjectionService) deleteSecretReference(ctx context.Context, ouID, projectName, agentName, envName string) error {
@@ -508,20 +443,25 @@ func (s *agentIdentityInjectionService) buildEnvVars(ctx context.Context, bindin
 	}, nil
 }
 
-func (s *agentIdentityInjectionService) envVarsForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string, templateAnnotations map[string]string) ([]client.EnvVar, error) {
+func (s *agentIdentityInjectionService) envVarsForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) ([]client.EnvVar, error) {
 	binding, err := s.injectableBinding(ctx, ouID, projectName, agentName, envName)
 	if err != nil || binding == nil {
 		return nil, err
 	}
-	refName, err := s.ensureSecretReference(ctx, binding, templateAnnotations)
-	if err != nil {
-		return nil, err
+	secretRefName := binding.SecretRefPath
+	if strings.Contains(secretRefName, "/") {
+		// Rows created before SecretReference-name persistence stored the backing
+		// KV path here. The SecretReference itself used this deterministic name,
+		// so existing deployments can continue without a database migration.
+		secretRefName = agentIdentitySecretLocation(
+			binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName,
+		).SecretRefName()
 	}
-	return s.buildEnvVars(ctx, binding, refName)
+	return s.buildEnvVars(ctx, binding, secretRefName)
 }
 
 func (s *agentIdentityInjectionService) EnvVarsForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) ([]client.EnvVar, error) {
-	return s.envVarsForEnvironment(ctx, ouID, projectName, agentName, envName, nil)
+	return s.envVarsForEnvironment(ctx, ouID, projectName, agentName, envName)
 }
 
 func (s *agentIdentityInjectionService) InjectForEnvironment(ctx context.Context, ouID, projectName, agentName, envName string) error {
@@ -621,10 +561,7 @@ func identityEnvVarsInSync(desired []client.EnvVar, current []models.EnvVars) bo
 // otherwise every rotation restarts the pod, even ones already superseded by
 // a later rotation before their own wait finished.
 func (s *agentIdentityInjectionService) RefreshAfterRotation(ctx context.Context, ouID, projectName, agentName, envName string) error {
-	annotations := map[string]string{
-		secretRotatedAtAnnotation: s.now().UTC().Format(secretRotatedAtFormat),
-	}
-	envVars, err := s.envVarsForEnvironment(ctx, ouID, projectName, agentName, envName, annotations)
+	envVars, err := s.envVarsForEnvironment(ctx, ouID, projectName, agentName, envName)
 	if err != nil {
 		return err
 	}

--- a/agent-manager-service/services/agent_identity_injection_service_unit_test.go
+++ b/agent-manager-service/services/agent_identity_injection_service_unit_test.go
@@ -48,20 +48,11 @@ const (
 	testIdentityEnv     = "staging"
 )
 
-// testIdentitySecretRefName is the deterministic SecretReference name
-// agentIdentitySecretLocation computes for the fixed (org, project, agent,
-// env) tuple above — the same value storeCredential now persists into
-// SecretRefPath (CreateSecret's own returned name, not a locally-computed
-// path; see storeCredential's doc comment).
+// testIdentitySecretRefName represents the provider-managed SecretReference
+// name returned by CreateSecret and persisted in SecretRefPath.
 func testIdentitySecretRefName() string {
-	return agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv).SecretRefName()
+	return "cred-agent-identity-a1b2c3d4"
 }
-
-// testIdentityKVPath is a remote KV path distinct from
-// testIdentitySecretRefName(), so tests asserting createdReq.KVPath actually
-// exercise "value came from binding.SecretRefPath" rather than passing
-// vacuously because both happened to be the same string.
-const testIdentityKVPath = "openbao/agent-identities/test-agent/dev"
 
 func completedInternalBinding() *models.AgentThunderClient {
 	return &models.AgentThunderClient{
@@ -73,7 +64,7 @@ func completedInternalBinding() *models.AgentThunderClient {
 		Status:           models.AgentThunderStatusCompleted,
 		ThunderAgentID:   "thunder-agent-1",
 		ThunderClientID:  "client-abc",
-		SecretRefPath:    testIdentityKVPath,
+		SecretRefPath:    testIdentitySecretRefName(),
 	}
 }
 
@@ -113,34 +104,23 @@ func newTestIdentityInjectionService(
 	return NewAgentIdentityInjectionService(repo, noMCPConfigRepo(), noMCPProxyScopeRepo(), oc, "1h", discardLogger())
 }
 
-// injectableOCClient returns an OpenChoreoClientMock with CreateSecretReferenceFunc
-// stubbed to succeed — the data-plane SecretReference write every injectable
-// binding now makes via ensureSecretReference on every EnvVarsForEnvironment
-// call. Tests that also exercise other OpenChoreo calls set their own funcs
-// on the returned mock before use.
+// injectableOCClient returns a base OpenChoreo client mock. SecretReference
+// creation is deliberately not stubbed: injection must use the stored
+// provider-managed reference directly and must not create another one.
 func injectableOCClient() *clientmocks.OpenChoreoClientMock {
 	return &clientmocks.OpenChoreoClientMock{
-		CreateSecretReferenceFunc: func(_ context.Context, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-			return &client.SecretReferenceInfo{Name: req.Name}, nil
+		CreateSecretReferenceFunc: func(context.Context, string, client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
+			panic("injection must not create a second SecretReference")
 		},
 	}
 }
 
-// TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecretReference
-// guards the core fix: the SecretKeyRef's Name comes from ensureSecretReference
-// asserting the data-plane SecretReference from binding.SecretRefPath — the
-// remote KV key agentThunderProvisioningService.storeCredential resolved
-// once, at creation/rotation (see its doc comment) — never independently
-// recomputed or guessed here.
-func TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecretReference(t *testing.T) {
+// TestAgentIdentityInjection_EnvVarsForEnvironment_UsesStoredSecretReference
+// guards the core flow: the pod SecretKeyRef uses the exact provider-managed
+// reference name persisted in binding.SecretRefPath.
+func TestAgentIdentityInjection_EnvVarsForEnvironment_UsesStoredSecretReference(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 	oc := injectableOCClient()
-	var createdReq client.CreateSecretReferenceRequest
-	oc.CreateSecretReferenceFunc = func(_ context.Context, ouID string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-		assert.Equal(t, testIdentityOrg, ouID)
-		createdReq = req
-		return &client.SecretReferenceInfo{Name: req.Name}, nil
-	}
 	svc := newTestIdentityInjectionService(repo, oc)
 
 	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
@@ -148,10 +128,6 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecr
 	require.Len(t, envVars, 4)
 
 	expectedRefName := testIdentitySecretRefName()
-	assert.Equal(t, testIdentityKVPath, createdReq.KVPath,
-		"KVPath must come from binding.SecretRefPath, never recomputed independently")
-	assert.Equal(t, []string{thundersvc.AgentSecretKeyClientSecret}, createdReq.SecretKeys)
-	assert.Empty(t, createdReq.TemplateAnnotations, "a plain read must not stamp a rotated-at annotation")
 
 	byKey := map[string]client.EnvVar{}
 	for _, ev := range envVars {
@@ -169,6 +145,27 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_BuildsVarsFromResolvedSecr
 	assert.Equal(t, thundersvc.ThunderTokenURL(ThunderOrgNamespace(), testIdentityEnv), byKey[client.EnvVarAgentIDTokenEndpoint].Value,
 		"token endpoint must be built from the org's Thunder namespace, NOT the raw ouID")
 	assert.Empty(t, byKey[client.EnvVarAgentIDScopes].Value, "no agent configuration means no MCP bindings, so no scopes to request")
+}
+
+func TestAgentIdentityInjection_EnvVarsForEnvironment_UsesExistingReferenceForLegacyPath(t *testing.T) {
+	binding := completedInternalBinding()
+	binding.SecretRefPath = "wc-secrets/org/generic/credential"
+	svc := newTestIdentityInjectionService(identityRepoReturning(binding, nil), injectableOCClient())
+
+	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
+	require.NoError(t, err)
+	for _, envVar := range envVars {
+		if envVar.Key == client.EnvVarAgentIDClientSecret {
+			require.NotNil(t, envVar.ValueFrom)
+			require.NotNil(t, envVar.ValueFrom.SecretKeyRef)
+			assert.Equal(t,
+				agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv).SecretRefName(),
+				envVar.ValueFrom.SecretKeyRef.Name,
+			)
+			return
+		}
+	}
+	t.Fatal("Agent ID client secret env var was not injected")
 }
 
 func TestAgentIdentityInjection_EnvVarsForEnvironment_UsesDeploymentTokenEndpoint(t *testing.T) {
@@ -208,29 +205,6 @@ func TestAgentIdentityInjection_EnvVarsForEnvironment_PropagatesTokenEndpointErr
 	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
 	require.ErrorIs(t, err, expectedErr)
 	require.Nil(t, envVars)
-}
-
-// TestAgentIdentityInjection_EnvVarsForEnvironment_CreateConflictFallsBackToUpdate
-// guards the concurrent-writer case: a create conflict (another request for
-// this same binding, or the reconciler, already created it) must fall back
-// to asserting the same spec via update rather than failing.
-func TestAgentIdentityInjection_EnvVarsForEnvironment_CreateConflictFallsBackToUpdate(t *testing.T) {
-	repo := identityRepoReturning(completedInternalBinding(), nil)
-	oc := injectableOCClient()
-	updated := false
-	oc.CreateSecretReferenceFunc = func(_ context.Context, _ string, _ client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-		return nil, utils.ErrConflict
-	}
-	oc.UpdateSecretReferenceFunc = func(_ context.Context, _, _ string, _ client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-		updated = true
-		return &client.SecretReferenceInfo{}, nil
-	}
-	svc := newTestIdentityInjectionService(repo, oc)
-
-	envVars, err := svc.EnvVarsForEnvironment(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
-	require.NoError(t, err)
-	assert.Len(t, envVars, 4)
-	assert.True(t, updated, "create conflict must fall back to update, not fail")
 }
 
 // mcpProxyBinding is one EnvAgentMCPMapping's worth of fixture data: a proxy
@@ -636,21 +610,14 @@ func TestAgentIdentityInjection_ReconcileForEnvironment_ConfigReadError_Propagat
 	assert.Error(t, err, "an unreadable current state must not silently proceed to a blind write")
 }
 
-// TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
-// guards rotation's contract: the SecretReference gets a fresh rotated-at
-// annotation, and the pod rolls only after waiting out the refresh cadence
-// (see RefreshAfterRotation for why the roll is deferred and detached).
-func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod(t *testing.T) {
+// TestAgentIdentityInjection_RefreshAfterRotation_WaitsAndRollsPod guards
+// rotation's contract: the provider updates the existing SecretReference, then
+// the pod rolls only after waiting out the refresh cadence.
+func TestAgentIdentityInjection_RefreshAfterRotation_WaitsAndRollsPod(t *testing.T) {
 	repo := identityRepoReturning(completedInternalBinding(), nil)
 
-	fixedNow := time.Date(2026, 7, 8, 10, 30, 0, 0, time.UTC)
-	var createdReq client.CreateSecretReferenceRequest
 	rolled := make(chan struct{})
 	oc := injectableOCClient()
-	oc.CreateSecretReferenceFunc = func(_ context.Context, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-		createdReq = req
-		return &client.SecretReferenceInfo{Name: req.Name}, nil
-	}
 	oc.UpdateReleaseBindingEnvVarsFunc = func(_ context.Context, _, _, _, _ string, envVars []client.EnvVar) error {
 		assert.Len(t, envVars, 4)
 		close(rolled)
@@ -660,7 +627,6 @@ func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
 	svc := newTestIdentityInjectionService(repo, oc)
 	impl, ok := svc.(*agentIdentityInjectionService)
 	require.True(t, ok)
-	impl.now = func() time.Time { return fixedNow }
 	var slept time.Duration
 	impl.after = func(d time.Duration) <-chan time.Time {
 		slept = d
@@ -670,10 +636,6 @@ func TestAgentIdentityInjection_RefreshAfterRotation_StampsAnnotationAndRollsPod
 	}
 
 	require.NoError(t, svc.RefreshAfterRotation(context.Background(), testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv))
-	require.NotNil(t, createdReq.TemplateAnnotations)
-	assert.Equal(t, fixedNow.Format(secretRotatedAtFormat), createdReq.TemplateAnnotations[secretRotatedAtAnnotation],
-		"rotation must stamp a fresh annotation marking the SecretReference spec as changed")
-	assert.Equal(t, testIdentityKVPath, createdReq.KVPath, "rotation must not change the resolved KV path")
 
 	select {
 	case <-rolled:
@@ -914,10 +876,8 @@ func TestAgentIdentitySecretLocation_EntityNameIsAgentScoped(t *testing.T) {
 	assert.Contains(t, locA.EntityName, "agent-a")
 }
 
-// TestAgentIdentitySecretLocation_IsDeterministic guards the property
-// agentThunderProvisioningService.HealSecretRef relies on: the same (org,
-// project, agent, env) tuple must always compute the exact same
-// SecretReference name, with no stored or round-tripped state required.
+// TestAgentIdentitySecretLocation_IsDeterministic guards stable secret naming
+// for create, rotate, and delete operations.
 func TestAgentIdentitySecretLocation_IsDeterministic(t *testing.T) {
 	loc1 := agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)
 	loc2 := agentIdentitySecretLocation(testIdentityOrg, testIdentityProject, testIdentityAgent, testIdentityEnv)

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -81,13 +81,6 @@ func (s *stubAgentThunderProvisioning) GetIdentityViews(ctx context.Context, ouI
 	return s.GetIdentityViewsFunc(ctx, ouID, projectName, agentName)
 }
 
-// HealSecretRef is a no-op override: no test using this stub exercises the
-// reconciler's startup heal pass, but leaving it unimplemented would panic on
-// the nil embedded interface if that ever changes.
-func (s *stubAgentThunderProvisioning) HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error {
-	return nil
-}
-
 func TestValidateInstrumentationVersion_UsesCatalog(t *testing.T) {
 	instrumentation.SetCatalog(instrumentation.NewForTest(
 		[]instrumentation.Version{

--- a/agent-manager-service/services/agent_thunder_provisioning_service.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -162,15 +161,6 @@ type AgentThunderProvisioningService interface {
 	// in one environment. Returns utils.ErrAgentIdentityNotProvisioned if the
 	// binding doesn't exist or hasn't completed yet.
 	GetAgentGroups(ctx context.Context, ouID, projectName, agentName, envName string) ([]thundersvc.ThunderGroup, error)
-
-	// HealSecretRef corrects binding.SecretRefPath when it doesn't match the
-	// credential's actual remote KV key, by re-resolving it via the same
-	// GetSecretReference lookup storeCredential itself uses (see its doc
-	// comment) — one bounded OpenChoreo read per call, no writes. No-op for
-	// external agents, unprovisioned bindings, and bindings already holding
-	// the correct value. Called once per completed internal binding from the
-	// reconciler's unbounded startup sweep.
-	HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error
 }
 
 // EnvThunderEndpointResolverSetter lets app.Run apply one deployment endpoint
@@ -217,13 +207,6 @@ type agentThunderProvisioningService struct {
 	repo             repositories.AgentThunderClientRepository
 	envResolver      thundersvc.EnvThunderResolver
 	secretMgmtClient secretmanagersvc.SecretManagementClient
-	// ocClient resolves the REAL remote KV key for a stored credential — the
-	// SecretReference secretMgmtClient.CreateSecret manages internally is not
-	// itself reachable from the agent's own workload namespace, only whatever
-	// the secret provider decides as its physical location; storeCredential
-	// reads that back once, at credential creation/rotation, rather than
-	// guessing it locally. See storeCredential's doc comment.
-	ocClient client.OpenChoreoClient
 	// workloadInjector pushes an internal agent's credential into its live
 	// workload (Gateway Binding). Optional (nil skips injection). Used by the
 	// post-provisioning reconcile hook to cover agents whose workload comes up
@@ -266,28 +249,8 @@ func agentIdentitySecretLocation(ouID, projectName, agentName, envName string) s
 	}
 }
 
-// createSecretConflictRetryMarker is the exact substring secretmanagersvc's
-// OpenChoreo provider includes only when a create conflict's own fallback
-// update then also fails (PushSecret's "failed to update secret after create
-// conflict" wrap in clients/secretmanagersvc/providers/openchoreo/client.go).
-// The secret manager doesn't expose a distinct sentinel for this exact shape,
-// so this is the only way to tell it apart from other, unrelated not-found
-// errors without changing the secret manager itself.
-const createSecretConflictRetryMarker = "after create conflict"
-
-// storeCredential writes the client ID/secret pair for one binding via the
-// shared secret management client and returns the remote KV key to persist
-// in AgentThunderClient.SecretRefPath.
-//
-// CreateSecret's own return value is only the name of the tracking
-// SecretReference it manages internally (see
-// SecretManagementClient.CreateSecret's doc comment) — that resource is not
-// reachable from the agent's own workload namespace. The actual remote KV
-// location is decided by whichever secret provider is plugged in and is only
-// ever learned by reading it back via GetSecretReference, once, here — never
-// guessed locally, and never re-verified by AgentIdentityInjectionService on
-// its own (much more frequent) injection path. Same resolve-don't-guess
-// pattern as agentManagerService.storeAgentAPIKey.
+// storeCredential writes the client ID/secret pair for one binding and returns
+// the provider-managed SecretReference name to persist in SecretRefPath.
 func (s *agentThunderProvisioningService) storeCredential(ctx context.Context, ouID, projectName, agentName, envName, clientID, clientSecret string) (string, error) {
 	location := agentIdentitySecretLocation(ouID, projectName, agentName, envName)
 	data := map[string]string{
@@ -296,106 +259,10 @@ func (s *agentThunderProvisioningService) storeCredential(ctx context.Context, o
 	}
 	refName, err := s.secretMgmtClient.CreateSecret(ctx, location, data)
 	if err != nil {
-		if !errors.Is(err, utils.ErrNotFound) || !strings.Contains(err.Error(), createSecretConflictRetryMarker) {
-			return "", err
-		}
-		// An already-provisioned internal agent already has a data-plane
-		// SecretReference for this name, owned by the identity injection
-		// service rather than by this code, which is why the create above
-		// failed here. Delete it and create again: the retry succeeds
-		// because it's now a plain create with nothing in the way, same as
-		// a brand-new agent's first credential.
-		injector := s.getWorkloadInjector()
-		if injector == nil {
-			return "", err
-		}
-		if cleanupErr := injector.CleanupForEnvironment(ctx, ouID, agentName, envName); cleanupErr != nil {
-			return "", fmt.Errorf("clear existing SecretReference before retry: %w: %w", cleanupErr, err)
-		}
-		refName, err = s.secretMgmtClient.CreateSecret(ctx, location, data)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	kvPath, err := s.resolveClientSecretKVPath(ctx, ouID, refName)
-	if err != nil {
 		return "", err
 	}
-	return kvPath, nil
-}
 
-// resolveClientSecretKVPath reads back the real remote KV key for refName's
-// AgentSecretKeyClientSecret data source. The one place both storeCredential
-// (at creation/rotation) and HealSecretRef (the one-time startup backfill)
-// learn where a credential actually lives — never guessed, never computed
-// from agentIdentitySecretLocation.
-func (s *agentThunderProvisioningService) resolveClientSecretKVPath(ctx context.Context, ouID, refName string) (string, error) {
-	if s.ocClient == nil {
-		return "", fmt.Errorf("resolve stored KV path for SecretReference %q: OpenChoreo client not configured", refName)
-	}
-	ref, err := s.ocClient.GetSecretReference(ctx, ouID, refName)
-	if err != nil {
-		return "", fmt.Errorf("resolve stored KV path for SecretReference %q: %w", refName, err)
-	}
-	for _, ds := range ref.Data {
-		if ds.SecretKey == thundersvc.AgentSecretKeyClientSecret {
-			return ds.RemoteRef.Key, nil
-		}
-	}
-	return "", fmt.Errorf("SecretReference %q has no %q data source", refName, thundersvc.AgentSecretKeyClientSecret)
-}
-
-// HealSecretRef corrects a binding's SecretRefPath if its stored value
-// doesn't match the credential's actual remote KV key. Re-resolves via the
-// same GetSecretReference lookup storeCredential itself uses — the binding's
-// deterministic SecretReference name is a pure function of (ouID,
-// projectName, agentName, envName), so re-deriving it locally and reading it
-// back is always safe regardless of how the stored value got stale. Called
-// once per completed internal binding from the reconciler's unbounded
-// startup sweep; a no-op on every run after the first successful heal for a
-// given binding.
-//
-// The OpenChoreo resolve runs BEFORE the binding lock (never hold a lock
-// across I/O), but the write is gated on a fresh re-read taken INSIDE the
-// same bindingLocks key every other SecretRefPath writer (RegenerateSecret,
-// RevokeSecret, DeleteAllBindings) already holds. The sweep that calls this
-// runs concurrently with the HTTP server from process startup (Start()
-// backgrounds it and returns immediately) — without the re-read, a revoke or
-// delete landing on this binding between the sweep's initial snapshot and
-// this call's resolve would have its SecretRefPath="" clear silently
-// overwritten with a resolved-but-now-orphaned path, which the injection
-// reconciler would then treat as a live credential and re-inject.
-func (s *agentThunderProvisioningService) HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error {
-	if binding.ProvisioningType != models.AgentProvisioningTypeInternal || binding.SecretRefPath == "" {
-		return nil
-	}
-	refName := agentIdentitySecretLocation(binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName).SecretRefName()
-	kvPath, err := s.resolveClientSecretKVPath(ctx, binding.OUID, refName)
-	if err != nil {
-		return fmt.Errorf("heal secret ref for binding %s: %w", binding.ID, err)
-	}
-	if binding.SecretRefPath == kvPath {
-		return nil
-	}
-
-	release, lockErr := s.bindingLocks.Lock(ctx, bindingLockKey(binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName))
-	if lockErr != nil {
-		return fmt.Errorf("heal secret ref for binding %s: %w", binding.ID, lockErr)
-	}
-	defer release()
-
-	current, err := s.repo.Get(ctx, binding.OUID, binding.ProjectName, binding.AgentName, binding.EnvironmentName)
-	if err != nil {
-		if errors.Is(err, repositories.ErrAgentThunderClientNotFound) {
-			return nil // deleted while this heal was resolving — nothing left to heal
-		}
-		return fmt.Errorf("heal secret ref for binding %s: %w", binding.ID, err)
-	}
-	if current.SecretRefPath == "" || current.SecretRefPath == kvPath {
-		return nil // revoked/cleared for deletion since the snapshot, or already healed
-	}
-	return s.repo.UpdateSecretRef(ctx, current.ID, kvPath)
+	return refName, nil
 }
 
 // deleteCredential permanently removes the stored credential (and its
@@ -535,7 +402,7 @@ func NewAgentThunderProvisioningService(
 	repo repositories.AgentThunderClientRepository,
 	envResolver thundersvc.EnvThunderResolver,
 	secretMgmtClient secretmanagersvc.SecretManagementClient,
-	ocClient client.OpenChoreoClient,
+	_ client.OpenChoreoClient, // retained for deployment-constructor compatibility
 	workloadInjector AgentIdentityInjectionService,
 	logger *slog.Logger,
 ) AgentThunderProvisioningService {
@@ -543,7 +410,6 @@ func NewAgentThunderProvisioningService(
 		repo:             repo,
 		envResolver:      envResolver,
 		secretMgmtClient: secretMgmtClient,
-		ocClient:         ocClient,
 		workloadInjector: workloadInjector,
 		logger:           logger,
 	}

--- a/agent-manager-service/services/agent_thunder_provisioning_service_test.go
+++ b/agent-manager-service/services/agent_thunder_provisioning_service_test.go
@@ -161,8 +161,8 @@ func TestAttemptProvision_Success_CreatesIdentityAndStoresSecret(t *testing.T) {
 	require.NotNil(t, recorded.ThunderClientID)
 	assert.Equal(t, "client-abc", *recorded.ThunderClientID)
 	require.NotNil(t, recorded.SecretRefPath)
-	assert.Equal(t, "resolved/ref", *recorded.SecretRefPath,
-		"the persisted SecretRefPath is resolved by reading the SecretReference back from OpenChoreo, never CreateSecret's bare name or a locally-computed path")
+	assert.Equal(t, "ref", *recorded.SecretRefPath,
+		"the provider-managed SecretReference name returned by CreateSecret must be persisted directly")
 	assert.Empty(t, recorded.LastError)
 }
 
@@ -254,8 +254,8 @@ func TestAttemptProvision_AlreadyHasThunderAgentID_SkipsCreate(t *testing.T) {
 		"a binding with a Thunder identity but no stored secret must recover one before completing")
 	require.NotNil(t, recorded.SecretRefPath,
 		"the recovered secret's storage location must be persisted, not left empty")
-	assert.Equal(t, "resolved/ref", *recorded.SecretRefPath,
-		"the persisted SecretRefPath is resolved by reading the SecretReference back from OpenChoreo, never CreateSecret's bare name or a locally-computed path")
+	assert.Equal(t, "ref", *recorded.SecretRefPath,
+		"the provider-managed SecretReference name returned by CreateSecret must be persisted directly")
 }
 
 // TestAttemptProvision_AlreadyHasSecretRef_SkipsRecovery guards the inverse of
@@ -738,18 +738,13 @@ func TestRegenerateSecret_Internal_StoresSecret(t *testing.T) {
 	assert.Equal(t, "client-abc", clientID)
 	assert.Equal(t, "new-secret", newSecret)
 	assert.Equal(t, "new-secret", storedSecret)
-	assert.Equal(t, "resolved/ref", updatedPath,
-		"the persisted SecretRefPath is resolved by reading the SecretReference back from OpenChoreo, never CreateSecret's bare name or a locally-computed path")
+	assert.Equal(t, "ref", updatedPath,
+		"the provider-managed SecretReference name returned by CreateSecret must be persisted directly")
 }
 
-// TestRegenerateSecret_Internal_CreateSecretErrorPropagatesDirectly_NoInjector
-// guards the no-workload-injector case: even when CreateSecret's error
-// matches the "after create conflict" marker storeCredential otherwise
-// retries on (see TestStoreCredential_ConflictMarker_CleansUpAndRetries),
-// there is nothing to clean up without an injector configured, so the
-// original error propagates on the first and only attempt instead of
-// panicking or retrying blind. newTestProvisioningService (used here) wires
-// no injector; newTestProvisioningServiceWithInjector is the variant that does.
+// TestRegenerateSecret_Internal_CreateSecretErrorPropagatesDirectly verifies
+// that a provider failure is returned without attempting to replace or
+// recreate the provider-managed SecretReference.
 func TestRegenerateSecret_Internal_CreateSecretErrorPropagatesDirectly_NoInjector(t *testing.T) {
 	tc := fakeThunderClientMock()
 	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
@@ -780,106 +775,6 @@ func TestRegenerateSecret_Internal_CreateSecretErrorPropagatesDirectly_NoInjecto
 	require.Error(t, err)
 	assert.ErrorIs(t, err, utils.ErrNotFound)
 	assert.Equal(t, 1, createCalls, "no retry — the error propagates on the first and only attempt")
-}
-
-// TestStoreCredential_ConflictMarker_CleansUpAndRetries guards the actual
-// recovery path the marker above exists for: an already-provisioned internal
-// agent's stray SecretReference (owned by AgentIdentityInjectionService, not
-// this code) collides with a fresh CreateSecret. With a workload injector
-// configured, storeCredential clears that stray reference and retries once,
-// succeeding on a now-unobstructed create.
-func TestStoreCredential_ConflictMarker_CleansUpAndRetries(t *testing.T) {
-	tc := fakeThunderClientMock()
-	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
-		return "new-secret", nil
-	}
-	resolver := &clientmocks.EnvThunderResolverMock{
-		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
-	}
-	var createCalls int
-	store := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
-			createCalls++
-			if createCalls == 1 {
-				return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
-			}
-			return "ref", nil
-		},
-	}
-	var cleanupCalls int
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(_ context.Context, orgName, agentName, envName string) error {
-			cleanupCalls++
-			assert.Equal(t, "acme", orgName)
-			assert.Equal(t, "my-agent", agentName)
-			assert.Equal(t, "staging", envName)
-			return nil
-		},
-	}
-	var updatedPath string
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
-				ProvisioningType: models.AgentProvisioningTypeInternal,
-			}, nil
-		},
-		UpdateSecretRefFunc: func(_ context.Context, _ uuid.UUID, secretRefPath string) error {
-			updatedPath = secretRefPath
-			return nil
-		},
-	}
-
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
-	_, _, newSecret, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
-
-	require.NoError(t, err)
-	assert.Equal(t, "new-secret", newSecret)
-	assert.Equal(t, 2, createCalls, "the first create hits the stray reference; the retry succeeds")
-	assert.Equal(t, 1, cleanupCalls)
-	assert.Equal(t, "resolved/ref", updatedPath)
-}
-
-// TestStoreCredential_ConflictMarker_CleanupFails_WrapsBothErrors guards the
-// double-failure case: if the stray SecretReference can't even be cleaned up,
-// the original CreateSecret error must not be silently dropped — both are
-// wrapped together so the real cause (the cleanup failure blocking recovery)
-// is visible alongside what triggered the recovery attempt in the first place.
-func TestStoreCredential_ConflictMarker_CleanupFails_WrapsBothErrors(t *testing.T) {
-	tc := fakeThunderClientMock()
-	tc.RegenerateAgentSecretFunc = func(context.Context, string) (string, error) {
-		return "new-secret", nil
-	}
-	resolver := &clientmocks.EnvThunderResolverMock{
-		ResolveFunc: func(_ context.Context, _, _, _ string) (thundersvc.ThunderClient, error) { return tc, nil },
-	}
-	var createCalls int
-	store := &clientmocks.SecretManagementClientMock{
-		CreateSecretFunc: func(context.Context, secretmanagersvc.SecretLocation, map[string]string) (string, error) {
-			createCalls++
-			return "", fmt.Errorf("failed to upsert secret: failed to update secret after create conflict: %w", utils.ErrNotFound)
-		},
-	}
-	cleanupErr := errors.New("cleanup boom")
-	injector := &agentIdentityInjectorStub{
-		CleanupForEnvironmentFunc: func(context.Context, string, string, string) error { return cleanupErr },
-	}
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return &models.AgentThunderClient{
-				ID: uuid.New(), ThunderAgentID: "thunder-agent-1", ThunderClientID: "client-abc",
-				ProvisioningType: models.AgentProvisioningTypeInternal,
-			}, nil
-		},
-	}
-
-	svc := newTestProvisioningServiceWithInjector(repo, resolver, store, injector)
-	_, _, _, err := svc.RegenerateSecret(context.Background(), "acme", "proj1", "my-agent", "staging")
-
-	require.Error(t, err)
-	assert.ErrorIs(t, err, cleanupErr)
-	assert.ErrorIs(t, err, utils.ErrNotFound, "the original CreateSecret error must still be reachable, not replaced by the cleanup error")
-	assert.Equal(t, 1, createCalls, "no retry attempted once cleanup itself failed")
 }
 
 // TestRegenerateSecret_External_NeverStoresSecret guards the invariant that an
@@ -2460,164 +2355,4 @@ func TestAttemptProvision_SerializesWithRegenerateSecret(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("RegenerateSecret never unblocked after AttemptProvision released the binding lock")
 	}
-}
-
-// TestHealSecretRef_CorrectsStaleRow guards the one-time backfill: a binding
-// whose SecretRefPath still holds the old locally-computed KV-path guess
-// (from before storeCredential was fixed) gets corrected to the real remote
-// KV key, read back through GetSecretReference — never recomputed locally.
-// The secret management mock has every func nil, so a CreateSecret or
-// DeleteSecret call would panic: healing is a read plus one DB write.
-func TestHealSecretRef_CorrectsStaleRow(t *testing.T) {
-	svc := newTestProvisioningService(
-		&repomocks.AgentThunderClientRepositoryMock{},
-		&clientmocks.EnvThunderResolverMock{},
-		&clientmocks.SecretManagementClientMock{},
-	)
-	impl := svc.(*agentThunderProvisioningService)
-
-	refName := agentIdentitySecretLocation("acme", "proj1", "my-agent", "staging").SecretRefName()
-	binding := models.AgentThunderClient{
-		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
-		ProvisioningType: models.AgentProvisioningTypeInternal,
-		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity", // the old, wrong KV-path-shaped guess
-	}
-
-	var updatedID uuid.UUID
-	var updatedPath string
-	impl.repo = &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			// The fresh re-read taken under the binding lock — still stale,
-			// matching the snapshot, so the write is expected to proceed.
-			return &binding, nil
-		},
-		UpdateSecretRefFunc: func(_ context.Context, id uuid.UUID, secretRefPath string) error {
-			updatedID = id
-			updatedPath = secretRefPath
-			return nil
-		},
-	}
-
-	require.NoError(t, impl.HealSecretRef(context.Background(), binding))
-	assert.Equal(t, binding.ID, updatedID)
-	assert.Equal(t, "resolved/"+refName, updatedPath, "must heal to the value resolved via GetSecretReference, never a locally-computed name")
-}
-
-// TestHealSecretRef_RevokedAfterSnapshot_DoesNotResurrectCredential guards the
-// race a background startup sweep is exposed to: if a RevokeSecret or
-// DeleteAllBindings call clears SecretRefPath to "" for this binding between
-// the sweep's initial snapshot and this call's own GetSecretReference resolve
-// completing, the resolved (but now orphaned) path must never be written back
-// over the fresh, empty value — that would resurrect a revoked/deleted
-// credential for the injection reconciler to re-inject.
-func TestHealSecretRef_RevokedAfterSnapshot_DoesNotResurrectCredential(t *testing.T) {
-	svc := newTestProvisioningService(
-		&repomocks.AgentThunderClientRepositoryMock{},
-		&clientmocks.EnvThunderResolverMock{},
-		&clientmocks.SecretManagementClientMock{},
-	)
-	impl := svc.(*agentThunderProvisioningService)
-
-	staleBinding := models.AgentThunderClient{
-		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
-		ProvisioningType: models.AgentProvisioningTypeInternal,
-		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity", // the sweep's stale snapshot
-	}
-
-	impl.repo = &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			// A concurrent revoke/delete landed and cleared it since the snapshot.
-			revoked := staleBinding
-			revoked.SecretRefPath = ""
-			return &revoked, nil
-		},
-		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
-			t.Fatal("must not write a resolved path back over a binding that was revoked/cleared since the snapshot")
-			return nil
-		},
-	}
-
-	require.NoError(t, impl.HealSecretRef(context.Background(), staleBinding))
-}
-
-// TestHealSecretRef_DeletedAfterSnapshot_NoOp guards the sibling case: the
-// binding row was deleted entirely (agent deletion) between the sweep's
-// snapshot and this call's resolve completing.
-func TestHealSecretRef_DeletedAfterSnapshot_NoOp(t *testing.T) {
-	svc := newTestProvisioningService(
-		&repomocks.AgentThunderClientRepositoryMock{},
-		&clientmocks.EnvThunderResolverMock{},
-		&clientmocks.SecretManagementClientMock{},
-	)
-	impl := svc.(*agentThunderProvisioningService)
-
-	staleBinding := models.AgentThunderClient{
-		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
-		ProvisioningType: models.AgentProvisioningTypeInternal,
-		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity",
-	}
-
-	impl.repo = &repomocks.AgentThunderClientRepositoryMock{
-		GetFunc: func(context.Context, string, string, string, string) (*models.AgentThunderClient, error) {
-			return nil, repositories.ErrAgentThunderClientNotFound
-		},
-		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
-			t.Fatal("must not write for a binding deleted since the snapshot")
-			return nil
-		},
-	}
-
-	require.NoError(t, impl.HealSecretRef(context.Background(), staleBinding))
-}
-
-// TestHealSecretRef_NoOpWhenAlreadyCorrect guards against a needless DB write
-// on every restart once a binding has already been healed (or was always
-// correct, e.g. provisioned after the fix shipped).
-func TestHealSecretRef_NoOpWhenAlreadyCorrect(t *testing.T) {
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
-			t.Fatal("must not write when the stored ref is already correct")
-			return nil
-		},
-	}
-	svc := newTestProvisioningService(repo, &clientmocks.EnvThunderResolverMock{}, &clientmocks.SecretManagementClientMock{})
-	impl := svc.(*agentThunderProvisioningService)
-
-	refName := agentIdentitySecretLocation("acme", "proj1", "my-agent", "staging").SecretRefName()
-	binding := models.AgentThunderClient{
-		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
-		ProvisioningType: models.AgentProvisioningTypeInternal,
-		SecretRefPath:    "resolved/" + refName, // already the resolved value HealSecretRef would derive
-	}
-
-	require.NoError(t, impl.HealSecretRef(context.Background(), binding))
-}
-
-// TestHealSecretRef_SkipsExternalAndRevoked guards the two states that must
-// never be touched: external agents never have a stored secret at all, and a
-// revoked binding's empty SecretRefPath must stay empty, not be "healed"
-// into a name pointing at a secret that no longer exists.
-func TestHealSecretRef_SkipsExternalAndRevoked(t *testing.T) {
-	repo := &repomocks.AgentThunderClientRepositoryMock{
-		UpdateSecretRefFunc: func(context.Context, uuid.UUID, string) error {
-			t.Fatal("must not write for an external agent or a revoked (empty SecretRefPath) binding")
-			return nil
-		},
-	}
-	svc := newTestProvisioningService(repo, &clientmocks.EnvThunderResolverMock{}, &clientmocks.SecretManagementClientMock{})
-	impl := svc.(*agentThunderProvisioningService)
-
-	external := models.AgentThunderClient{
-		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
-		ProvisioningType: models.AgentProvisioningTypeExternal,
-		SecretRefPath:    "acme/proj1/staging/my-agent/my-agent-agent-identity",
-	}
-	revoked := models.AgentThunderClient{
-		ID: uuid.New(), OUID: "acme", ProjectName: "proj1", AgentName: "my-agent", EnvironmentName: "staging",
-		ProvisioningType: models.AgentProvisioningTypeInternal,
-		SecretRefPath:    "",
-	}
-
-	require.NoError(t, impl.HealSecretRef(context.Background(), external))
-	require.NoError(t, impl.HealSecretRef(context.Background(), revoked))
 }

--- a/agent-manager-service/services/agent_thunder_reconciler.go
+++ b/agent-manager-service/services/agent_thunder_reconciler.go
@@ -194,7 +194,7 @@ const identityInjectionReconcileWindow = 2 * time.Hour
 // lock; concurrent instances converge on the same desired state, so the worst
 // case is a duplicate content-identical write.
 func (s *agentThunderReconcilerService) runIdentityInjectionReconcile(ctx context.Context) {
-	s.pageIdentityInjectionReconcile(ctx, time.Now().Add(-identityInjectionReconcileWindow), false)
+	s.pageIdentityInjectionReconcile(ctx, time.Now().Add(-identityInjectionReconcileWindow))
 }
 
 // runInitialIdentityInjectionBackfill runs once per process start (see Start)
@@ -217,7 +217,7 @@ func (s *agentThunderReconcilerService) runIdentityInjectionReconcile(ctx contex
 // on every one-minute tick forever, not just once (or a few times) per
 // restart.
 func (s *agentThunderReconcilerService) runInitialIdentityInjectionBackfill(ctx context.Context) {
-	s.pageIdentityInjectionReconcile(ctx, time.Time{}, true)
+	s.pageIdentityInjectionReconcile(ctx, time.Time{})
 }
 
 // pageIdentityInjectionReconcile reconciles every COMPLETED internal binding
@@ -229,13 +229,7 @@ func (s *agentThunderReconcilerService) runInitialIdentityInjectionBackfill(ctx 
 // newest ones — the same oldest page would be reselected every call until
 // enough of them aged out of the (periodic caller's) window, and a newer
 // binding could miss its entire window without ever being reconciled.
-//
-// healSecretRefs is true only for the unbounded startup pass
-// (runInitialIdentityInjectionBackfill): HealSecretRef is cheap (one bounded
-// OpenChoreo read) and idempotent (a no-op once a binding's SecretRefPath
-// already matches), but there is no reason to re-run it against every
-// already-healed row on every one-minute periodic tick too.
-func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx context.Context, createdAfter time.Time, healSecretRefs bool) {
+func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx context.Context, createdAfter time.Time) {
 	var cursor *repositories.ReconcileCursor
 	for {
 		recent, err := s.repo.FindRecentlyCompletedInternal(ctx, createdAfter, cursor, reconcilerBatchSize)
@@ -245,11 +239,6 @@ func (s *agentThunderReconcilerService) pageIdentityInjectionReconcile(ctx conte
 		}
 		for _, binding := range recent {
 			bindingCtx := agentThunderBindingOrgContext(ctx, binding)
-			if healSecretRefs {
-				if err := s.provisioning.HealSecretRef(bindingCtx, binding); err != nil {
-					s.logger.Warn("Failed to heal agent thunder binding secret ref", "ouID", binding.OUID, "bindingID", binding.ID, "agentName", binding.AgentName, "envName", binding.EnvironmentName, "error", err)
-				}
-			}
 			reconcileWorkloadInjection(bindingCtx, s.injector, binding, s.logger)
 		}
 		if len(recent) < reconcilerBatchSize {

--- a/agent-manager-service/services/agent_thunder_reconciler_test.go
+++ b/agent-manager-service/services/agent_thunder_reconciler_test.go
@@ -338,10 +338,6 @@ func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_CoversBindin
 			return nil
 		},
 	}
-	// provisioning must be set (even with no healFunc) because
-	// runInitialIdentityInjectionBackfill below calls HealSecretRef on every
-	// binding it reconciles — unset would panic on the nil interface, not
-	// silently skip it.
 	s := &agentThunderReconcilerService{injector: injector, provisioning: &fakeProvisioningService{}, repo: repo, logger: slog.Default(), stopCh: make(chan struct{})}
 
 	s.runIdentityInjectionReconcile(ctx)
@@ -355,111 +351,10 @@ func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_CoversBindin
 	assert.True(t, reconciled, "the one-time backfill must reconcile a binding regardless of age")
 }
 
-// TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealsEveryBinding
-// verifies the startup pass actually invokes HealSecretRef for each binding it
-// covers, and that a periodic (non-startup) sweep does not.
-func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealsEveryBinding(t *testing.T) {
-	ctx := context.Background()
-	repo := repositories.NewAgentThunderClientRepo(db.GetDB())
-	const org, project, agent, env = "test-org", "test-proj", "reconcile-heal-agent", "production"
-	t.Cleanup(func() { _ = repo.DeleteByAgent(ctx, org, project, agent) })
-
-	require.NoError(t, repo.Upsert(ctx, &models.AgentThunderClient{
-		OUID: org, ProjectName: project, AgentName: agent, EnvironmentName: env,
-		ProvisioningType: models.AgentProvisioningTypeInternal, Status: models.AgentThunderStatusCompleted,
-		ThunderAgentID: "thunder-heal", ThunderClientID: "client-heal", SecretRefPath: "path/heal",
-	}))
-
-	var mu sync.Mutex
-	var healed, reconciled int
-	provisioning := &fakeProvisioningService{
-		healFunc: func(_ context.Context, binding models.AgentThunderClient) error {
-			if binding.OUID != org || binding.ProjectName != project || binding.AgentName != agent {
-				return nil // a stray binding from an unrelated concurrent test
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			healed++
-			return nil
-		},
-	}
-	injector := &agentIdentityInjectorStub{
-		ReconcileForEnvironmentFunc: func(_ context.Context, ouID, projectName, agentName, envName string) error {
-			if ouID != org || projectName != project || agentName != agent {
-				return nil
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			reconciled++
-			return nil
-		},
-	}
-	s := &agentThunderReconcilerService{injector: injector, provisioning: provisioning, repo: repo, logger: slog.Default(), stopCh: make(chan struct{})}
-
-	s.runIdentityInjectionReconcile(ctx)
-	mu.Lock()
-	assert.Equal(t, 0, healed, "the periodic sweep must not call HealSecretRef — only the startup backfill does")
-	assert.Equal(t, 1, reconciled, "the periodic sweep must still reconcile the workload")
-	mu.Unlock()
-
-	s.runInitialIdentityInjectionBackfill(ctx)
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Equal(t, 1, healed, "the startup backfill must call HealSecretRef for the binding it covers")
-	assert.Equal(t, 2, reconciled, "the startup backfill must still reconcile the workload after healing")
-}
-
-// TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealFailureDoesNotBlockReconcile
-// verifies a HealSecretRef failure is logged and swallowed rather than
-// aborting the binding's workload reconcile — matching HealSecretRef's own
-// doc comment ("best-effort... a failed heal on one binding just means that
-// binding's pod keeps failing exactly as it does today until the next sweep
-// retries it; no regression versus current behavior").
-func TestAgentThunderReconciler_RunInitialIdentityInjectionBackfill_HealFailureDoesNotBlockReconcile(t *testing.T) {
-	ctx := context.Background()
-	repo := repositories.NewAgentThunderClientRepo(db.GetDB())
-	const org, project, agent, env = "test-org", "test-proj", "reconcile-heal-fail-agent", "production"
-	t.Cleanup(func() { _ = repo.DeleteByAgent(ctx, org, project, agent) })
-
-	require.NoError(t, repo.Upsert(ctx, &models.AgentThunderClient{
-		OUID: org, ProjectName: project, AgentName: agent, EnvironmentName: env,
-		ProvisioningType: models.AgentProvisioningTypeInternal, Status: models.AgentThunderStatusCompleted,
-		ThunderAgentID: "thunder-heal-fail", ThunderClientID: "client-heal-fail", SecretRefPath: "path/heal-fail",
-	}))
-
-	provisioning := &fakeProvisioningService{
-		healFunc: func(context.Context, models.AgentThunderClient) error {
-			return fmt.Errorf("simulated heal failure")
-		},
-	}
-	var mu sync.Mutex
-	var reconciled bool
-	injector := &agentIdentityInjectorStub{
-		ReconcileForEnvironmentFunc: func(_ context.Context, ouID, projectName, agentName, envName string) error {
-			if ouID != org || projectName != project || agentName != agent {
-				return nil
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			reconciled = true
-			return nil
-		},
-	}
-	s := &agentThunderReconcilerService{injector: injector, provisioning: provisioning, repo: repo, logger: slog.Default(), stopCh: make(chan struct{})}
-
-	require.NotPanics(t, func() { s.runInitialIdentityInjectionBackfill(ctx) })
-	mu.Lock()
-	defer mu.Unlock()
-	assert.True(t, reconciled, "a HealSecretRef failure must not prevent the binding's workload from still being reconciled")
-}
-
 // fakeProvisioningService is a minimal hand-written test double for
-// AgentThunderProvisioningService — only AttemptProvision and HealSecretRef
-// are exercised by the reconciler, so those are the only methods given a
-// real implementation.
+// AgentThunderProvisioningService.
 type fakeProvisioningService struct {
 	attemptFunc func(ctx context.Context, binding models.AgentThunderClient)
-	healFunc    func(ctx context.Context, binding models.AgentThunderClient) error
 }
 
 func (f *fakeProvisioningService) ProvisionForAgent(context.Context, string, string, string, models.AgentProvisioningType, []string, string) {
@@ -508,13 +403,6 @@ func (f *fakeProvisioningService) GetAgentRoles(context.Context, string, string,
 
 func (f *fakeProvisioningService) GetAgentGroups(context.Context, string, string, string, string) ([]thundersvc.ThunderGroup, error) {
 	return nil, nil
-}
-
-func (f *fakeProvisioningService) HealSecretRef(ctx context.Context, binding models.AgentThunderClient) error {
-	if f.healFunc == nil {
-		return nil
-	}
-	return f.healFunc(ctx, binding)
 }
 
 // compile-time interface check

--- a/agent-manager-service/tests/promote_agent_test.go
+++ b/agent-manager-service/tests/promote_agent_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/wso2/agent-manager/agent-manager-service/clients/clientmocks"
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/client"
 	"github.com/wso2/agent-manager/agent-manager-service/db"
 	"github.com/wso2/agent-manager/agent-manager-service/middleware/jwtassertion"
@@ -102,23 +101,28 @@ func seedReadyAgentIdentityRow(t *testing.T, orgName, projectName, agentName, en
 	require.NoError(t, db.DB(context.Background()).Create(binding).Error)
 }
 
-// stubReadyAgentIdentitySecretReference stubs the OpenChoreo mock's
-// SecretReference methods for the "not found yet, create it" path —
-// EnvVarsForEnvironment calls these once per invocation, and each subtest
-// constructs its own fresh ocClient mock (unlike the DB row, which is
-// shared), so this must be called once per subtest.
-func stubReadyAgentIdentitySecretReference(ocClient *clientmocks.OpenChoreoClientMock) {
-	ocClient.GetSecretReferenceFunc = func(_ context.Context, _, _ string) (*client.SecretReferenceInfo, error) {
-		return nil, utils.ErrNotFound
-	}
-	ocClient.CreateSecretReferenceFunc = func(_ context.Context, _ string, req client.CreateSecretReferenceRequest) (*client.SecretReferenceInfo, error) {
-		return &client.SecretReferenceInfo{Name: req.Name}, nil
-	}
+// seedEnvironmentThunderURL mirrors the URL registration performed by the
+// cloud environment-provisioning flow. Completed AgentID bindings need this
+// public URL to construct the token endpoint injected during promotion.
+func seedEnvironmentThunderURL(t *testing.T, ouID, envName, thunderURL string) {
+	t.Helper()
+	handle := "test-" + envName
+	require.NoError(t, db.DB(context.Background()).Create(&models.EnvThunderURL{
+		OUID:          ouID,
+		EnvName:       envName,
+		ThunderHandle: &handle,
+		ThunderURL:    thunderURL,
+	}).Error)
 }
 
 func TestPromoteAgent(t *testing.T) {
 	authMiddleware := jwtassertion.NewMockMiddleware(t)
 	agentName := fmt.Sprintf("agent-%s", uuid.New().String()[:8])
+	thunderServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA"}]}`))
+	}))
+	t.Cleanup(thunderServer.Close)
 
 	// PromoteAgent hard-blocks promotion when the target environment's
 	// AgentID identity isn't ready (see agent_manager.go) — seed a completed
@@ -133,6 +137,7 @@ func TestPromoteAgent(t *testing.T) {
 	// org handle in the URL path (see its doc comment), and PromoteAgent's
 	// identity lookup is keyed by that token OUID — not the path org.
 	seedReadyAgentIdentityRow(t, jwtassertion.MockOUID, "my-project", agentName, "production")
+	seedEnvironmentThunderURL(t, jwtassertion.MockOUID, "production", thunderServer.URL+"/production")
 
 	promoteURL := func(org string) string {
 		return fmt.Sprintf("/api/v1/orgs/%s/projects/my-project/agents/%s/promote", org, agentName)
@@ -140,7 +145,6 @@ func TestPromoteAgent(t *testing.T) {
 
 	t.Run("promoting along a valid path returns 202", func(t *testing.T) {
 		ocClient := apitestutils.CreateMockOpenChoreoClient()
-		stubReadyAgentIdentitySecretReference(ocClient)
 		ocClient.GetProjectDeploymentPipelineFunc = pipelineWithPath("development", "production")
 		// System-managed env var resolution parses the environment UUID, so it must be valid.
 		ocClient.GetEnvironmentFunc = func(ctx context.Context, namespaceName, environmentName string) (*models.EnvironmentResponse, error) {
@@ -167,7 +171,6 @@ func TestPromoteAgent(t *testing.T) {
 
 	t.Run("with useConfigFromSourceEnv=true clones the source env overrides", func(t *testing.T) {
 		ocClient := apitestutils.CreateMockOpenChoreoClient()
-		stubReadyAgentIdentitySecretReference(ocClient)
 		ocClient.GetProjectDeploymentPipelineFunc = pipelineWithPath("development", "production")
 		ocClient.GetEnvironmentFunc = func(ctx context.Context, namespaceName, environmentName string) (*models.EnvironmentResponse, error) {
 			return &models.EnvironmentResponse{UUID: uuid.New().String(), Name: environmentName}, nil
@@ -222,7 +225,6 @@ func TestPromoteAgent(t *testing.T) {
 
 	t.Run("with useConfigFromSourceEnv=false forwards the provided env overrides", func(t *testing.T) {
 		ocClient := apitestutils.CreateMockOpenChoreoClient()
-		stubReadyAgentIdentitySecretReference(ocClient)
 		ocClient.GetProjectDeploymentPipelineFunc = pipelineWithPath("development", "production")
 		ocClient.GetEnvironmentFunc = func(ctx context.Context, namespaceName, environmentName string) (*models.EnvironmentResponse, error) {
 			return &models.EnvironmentResponse{UUID: uuid.New().String(), Name: environmentName}, nil
@@ -359,9 +361,9 @@ func TestPromoteAgent(t *testing.T) {
 		// be seeded here — otherwise promotion proceeds and panics on the
 		// unconfigured PromoteComponentFunc mock below.
 		seedReadyAgentIdentityRow(t, jwtassertion.MockOUID, "my-project", agentName, "development")
+		seedEnvironmentThunderURL(t, jwtassertion.MockOUID, "development", thunderServer.URL+"/development")
 
 		ocClient := apitestutils.CreateMockOpenChoreoClient()
-		stubReadyAgentIdentitySecretReference(ocClient)
 		ocClient.GetProjectDeploymentPipelineFunc = pipelineWithPath("development", "unready-env")
 		ocClient.GetEnvironmentFunc = func(ctx context.Context, namespaceName, environmentName string) (*models.EnvironmentResponse, error) {
 			return &models.EnvironmentResponse{UUID: uuid.New().String(), Name: environmentName}, nil


### PR DESCRIPTION
## Purpose
Fix AgentID credential injection and allow Cloud provisioning to register the environment Thunder issuer for the correct organization.

## Goals
Ensure AgentID credentials work for new and existing agents without requiring a database migration.

## Approach
- Store and inject the SecretReference returned by Secret Manager directly.
- Support existing database rows containing legacy Vault paths.
- Apply the validated impersonated organization to gateway identity-provider updates.
- Update AgentID and promotion test coverage.

## User stories
- AgentID credentials are injected into deployed agent workloads.
- Cloud provisioning can register `ThunderKeyManager` for the correct organization.

## Release note
Fixed AgentID credential injection and environment Thunder issuer registration in Agent Manager SaaS.

## Documentation
N/A — internal implementation fix with no public API changes.

## Training
N/A — no training impact.

## Certification
N/A — no certification impact.

## Marketing
N/A — no marketing impact.

## Automation tests
- Unit tests
  > Full unit suite passed, including new SecretReference and organization impersonation tests.
- Integration tests
  > Full integration suite passed, including agent promotion coverage.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A — this is a Go service; repository lint checks passed.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A — no sample changes.

## Related PRs
N/A 

## Migrations (if applicable)
N/A 

## Test environment
Go, macOS, PostgreSQL 15, and Linux container build.

## Learning
Reused the SecretReference returned by Secret Manager and followed the existing Cloud organization impersonation pattern.