### PR TITLE
Make the image registry configurable and install from the release bundle

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -11,7 +11,6 @@ inputs:
   registry:
     description: 'Container registry URL'
     required: true
-    default: 'ghcr.io'
   registry-org:
     description: 'Registry organization/namespace'
     required: true
@@ -26,6 +25,29 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # required: true is documentation only — GitHub does not fail a run for a
+    # missing input. Without this, an unset registry or org silently yields a tag
+    # like "/wso2/amp-api:v1.0.0", and the build fails much later on an invalid
+    # image reference that says nothing about the cause.
+    - name: Verify the image reference is fully specified
+      run: |
+        missing=""
+        [ -n "${REGISTRY}" ]   || missing="${missing} registry"
+        [ -n "${REGISTRY_ORG}" ] || missing="${missing} registry-org"
+        [ -n "${IMAGE_NAME}" ] || missing="${missing} image-name"
+        [ -n "${TAG}" ]        || missing="${missing} tag"
+        if [ -n "${missing}" ]; then
+          echo "::error::Missing required input(s):${missing}. The caller must pass every part of the image reference." >&2
+          exit 1
+        fi
+        echo "Publishing to ${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${TAG}"
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        REGISTRY_ORG: ${{ inputs.registry-org }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        TAG: ${{ inputs.tag }}
+      shell: bash
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:

--- a/.github/actions/build-single-platform-docker-image/action.yaml
+++ b/.github/actions/build-single-platform-docker-image/action.yaml
@@ -11,7 +11,6 @@ inputs:
   registry:
     description: "Container registry URL"
     required: true
-    default: "ghcr.io"
   registry-org:
     description: "Registry organization/namespace"
     required: true
@@ -29,6 +28,29 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # required: true is documentation only — GitHub does not fail a run for a
+    # missing input. Without this, an unset registry or org silently yields a tag
+    # like "/wso2/amp-api:v1.0.0", and the build fails much later on an invalid
+    # image reference that says nothing about the cause.
+    - name: Verify the image reference is fully specified
+      run: |
+        missing=""
+        [ -n "${REGISTRY}" ]   || missing="${missing} registry"
+        [ -n "${REGISTRY_ORG}" ] || missing="${missing} registry-org"
+        [ -n "${IMAGE_NAME}" ] || missing="${missing} image-name"
+        [ -n "${TAG}" ]        || missing="${missing} tag"
+        if [ -n "${missing}" ]; then
+          echo "::error::Missing required input(s):${missing}. The caller must pass every part of the image reference." >&2
+          exit 1
+        fi
+        echo "Publishing to ${REGISTRY}/${REGISTRY_ORG}/${IMAGE_NAME}:${TAG}"
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        REGISTRY_ORG: ${{ inputs.registry-org }}
+        IMAGE_NAME: ${{ inputs.image-name }}
+        TAG: ${{ inputs.tag }}
+      shell: bash
+
     - name: Build Docker image
       run: |
         # Parse build-args into docker build format

--- a/.github/scripts/build-vm-bundle.sh
+++ b/.github/scripts/build-vm-bundle.sh
@@ -22,18 +22,71 @@ mkdir -p "$OUT_DIR"
 BUNDLE="${OUT_DIR}/wso2-agent-manager-${VERSION}.tar.gz"
 
 # Directories the installers read at runtime (see install.sh DEPLOYMENTS_DIR +
-# install-helpers.sh ../scripts). Charts are pulled from OCI registries at install
-# time, so helm-charts/ is intentionally excluded.
+# install-helpers.sh ../scripts). setup/ is here because install-kata.sh and
+# install-gvisor.sh resolve ../k8s/ relative to themselves, and fall back to
+# fetching those manifests over the network when they are not shipped alongside.
+# Charts are pulled from OCI registries at install time, so helm-charts/ is
+# intentionally excluded.
 tar -czf "$BUNDLE" \
   deployments/vm \
   deployments/quick-start \
   deployments/single-cluster \
   deployments/values \
   deployments/k8s \
-  deployments/scripts
+  deployments/scripts \
+  deployments/setup
 
 cp deployments/vm/bootstrap.sh "${OUT_DIR}/bootstrap.sh"
 cp deployments/quick-start/start.sh "${OUT_DIR}/start.sh"
+
+# MANIFEST.json — what this bundle expects to find at install time, in a form a
+# downstream publisher can read without parsing release notes. The download is
+# distributed outside GitHub, so "which images does this expect, and from where"
+# has to travel with the artifact rather than living in the workflow that built
+# it. Image digests are not included: they are only knowable after the push, and
+# recording a guess is worse than recording nothing.
+CONFIG_FILE="${CONFIG_FILE:-.github/release-config.json}"
+IMAGE_REGISTRY="${REGISTRY:-ghcr.io}/${REGISTRY_ORG:-wso2}"
+CHART_REGISTRY="${HELM_REGISTRY:-oci://ghcr.io/wso2}"
+BUILD_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+
+if [ -f "$CONFIG_FILE" ] && command -v jq >/dev/null 2>&1; then
+  jq -n \
+    --arg version "$VERSION" \
+    --arg buildCommit "$BUILD_COMMIT" \
+    --arg imageRegistry "$IMAGE_REGISTRY" \
+    --arg chartRegistry "$CHART_REGISTRY" \
+    --slurpfile config "$CONFIG_FILE" \
+    '{
+       version: $version,
+       buildCommit: $buildCommit,
+       imageRegistry: $imageRegistry,
+       chartRegistry: $chartRegistry,
+       images: [$config[0].images[] | { name: .name, tag: ("v" + $version) }],
+       charts: [$config[0].charts[] | { name: ., version: $version }]
+     }' > "${OUT_DIR}/MANIFEST.json"
+  echo "✅ Wrote manifest: ${OUT_DIR}/MANIFEST.json"
+else
+  echo "⚠️  Skipping MANIFEST.json (need jq and ${CONFIG_FILE})" >&2
+fi
+
+# SHA256SUMS — the integrity contract for a download served from somewhere other
+# than the GitHub release it was built in. Written last so it covers everything,
+# and in the format `sha256sum -c` reads, so verifying is one command.
+(
+  cd "$OUT_DIR"
+  # Basenames only: the file is consumed next to the artifacts, wherever they
+  # are republished, so an absolute build path would make it unusable.
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum ./* > SHA256SUMS.tmp 2>/dev/null || true
+  else
+    # macOS has shasum instead; -a 256 matches sha256sum's output format.
+    shasum -a 256 ./* > SHA256SUMS.tmp 2>/dev/null || true
+  fi
+  grep -v 'SHA256SUMS' SHA256SUMS.tmp | sed 's#\./##' > SHA256SUMS
+  rm -f SHA256SUMS.tmp
+)
+echo "✅ Wrote checksums: ${OUT_DIR}/SHA256SUMS"
 
 echo "✅ Built install bundle: $BUNDLE"
 echo "   Contents (top level):"

--- a/.github/scripts/check-no-raw-github-fetches.sh
+++ b/.github/scripts/check-no-raw-github-fetches.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Fail if an installer or a guide fetches this repository's own files over HTTP.
+# Run: bash .github/scripts/check-no-raw-github-fetches.sh
+#
+# Those fetches are what the release bundle exists to replace. They break in
+# three ways that are all invisible until an install is already running: GitHub
+# rate-limits unauthenticated requests per IP and `helm --values <url>` does not
+# retry on the 429, an egress-restricted cluster cannot reach the host at all,
+# and a private mirror of this repository serves no public raw URL. Without a
+# check they creep back in, because adding one is always the shortest diff.
+#
+# Two things are deliberately allowed:
+#   - a markdown link, [text](url), which a reader clicks to view a file rather
+#     than something an install fetches
+#   - a defaulted variable, ${AMP_SCRIPT_BASE_URL:-...}, which a fork or an
+#     air-gapped mirror can repoint in one place
+#   - a shell comment, which documents the curl | bash usage of a script rather
+#     than performing a fetch
+set -uo pipefail
+
+PATTERN='raw\.githubusercontent\.com/wso2/agent-manager'
+FAILURES=0
+
+check() {
+  local label="$1" hits
+  shift
+  # Skip markdown links and defaulted variables; flag everything else.
+  hits="$(grep -rn "$PATTERN" "$@" 2>/dev/null \
+    | grep -v '](https://raw\.githubusercontent' \
+    | grep -v ':-https://raw\.githubusercontent' \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' \
+    || true)"
+  if [[ -n "$hits" ]]; then
+    printf 'FAIL - %s fetches this repo over HTTP:\n' "$label"
+    printf '%s\n' "$hits" | sed 's/^/       /'
+    FAILURES=$((FAILURES + 1))
+  else
+    printf 'ok   - %s\n' "$label"
+  fi
+}
+
+check "installers under deployments/" \
+  --include='*.sh' --include='*.yaml' --include='*.yml' deployments
+check "guides under documentation/docs/" \
+  --include='*.mdx' --include='*.md' documentation/docs
+
+# The current version snapshot is what the docs site serves, so it needs the same
+# gate. Older snapshots are deliberately excluded: they are frozen records of
+# what shipped, they still contain these URLs, and rewriting them would be
+# falsifying history rather than fixing an install.
+LATEST_VERSION="$(sed -n 's/^[[:space:]]*"\(v[0-9][^"]*\)".*/\1/p' documentation/versions.json 2>/dev/null | head -1)"
+if [ -n "$LATEST_VERSION" ] && [ -d "documentation/versioned_docs/version-${LATEST_VERSION}" ]; then
+  # The isolation-tier guides are excluded: the tarball published for this
+  # version predates deployments/setup being added to the bundle, so those two
+  # node installers genuinely have to be fetched there. A snapshot cannot be
+  # pointed at files its own release asset does not contain.
+  check "guides in the current snapshot (${LATEST_VERSION})" \
+    --include='*.mdx' --include='*.md' \
+    --exclude-dir=isolation-tiers \
+    "documentation/versioned_docs/version-${LATEST_VERSION}"
+else
+  printf 'ok   - no current version snapshot to check\n'
+fi
+
+if ((FAILURES > 0)); then
+  printf '\nUse the bundled copy instead: ${AMP_DIST}/deployments/... in a guide,\n'
+  printf 'or a path relative to the script in an installer. If a fallback URL is\n'
+  printf 'genuinely needed, put it behind a defaulted variable.\n'
+  exit 1
+fi
+printf '\nNo raw-GitHub fetches of this repository\n'

--- a/.github/scripts/package-helm-chart.sh
+++ b/.github/scripts/package-helm-chart.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
 # Package and push a Helm chart
-# Usage: package-helm-chart.sh <chart-name> <chart-dir> <version> <helm-registry> <github-token>
+# Usage: package-helm-chart.sh <chart-dir> <version> <helm-registry> [<token>]
+#
+# Credentials: REGISTRY_USERNAME/REGISTRY_PASSWORD override the GitHub actor and
+# the positional token. A caller pushing to an authenticated registry should use
+# them rather than the argument, which `ps` exposes to every user on the host.
 
 set -euo pipefail
 
 CHART_DIR="${1:-}"
 VERSION="${2:-}"
 HELM_REGISTRY="${3:-}"
-GITHUB_TOKEN="${4:-}"
+REGISTRY_USER="${REGISTRY_USERNAME:-${GITHUB_ACTOR:-github-actions}}"
+REGISTRY_PASS="${REGISTRY_PASSWORD:-${4:-}}"
 
-if [ -z "$CHART_DIR" ] || [ -z "$VERSION" ] || [ -z "$HELM_REGISTRY" ] || [ -z "$GITHUB_TOKEN" ]; then
+if [ -z "$CHART_DIR" ] || [ -z "$VERSION" ] || [ -z "$HELM_REGISTRY" ] || [ -z "$REGISTRY_PASS" ]; then
   echo "Error: Missing required arguments"
-  echo "Usage: package-helm-chart.sh <chart-dir> <version> <helm-registry> <github-token>"
+  echo "Usage: package-helm-chart.sh <chart-dir> <version> <helm-registry> [<token>]"
+  echo "       The token may be supplied as REGISTRY_PASSWORD instead of the argument."
   exit 1
 fi
 
@@ -21,8 +27,7 @@ if [ ! -d "$CHART_DIR" ]; then
 fi
 
 # Log in to registry
-ACTOR="${GITHUB_ACTOR:-github-actions}"
-echo "$GITHUB_TOKEN" | helm registry login -u "$ACTOR" --password-stdin "${HELM_REGISTRY#oci://}"
+echo "$REGISTRY_PASS" | helm registry login -u "$REGISTRY_USER" --password-stdin "${HELM_REGISTRY#oci://}"
 
 # Update dependencies only if tarballs are missing
 if [ -f "$CHART_DIR/Chart.lock" ]; then

--- a/.github/scripts/rewrite-image-registry.sh
+++ b/.github/scripts/rewrite-image-registry.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Repoint the first-party image repositories in the shipped charts.
+# Usage: rewrite-image-registry.sh <from-prefix> <to-prefix>
+#   e.g. rewrite-image-registry.sh ghcr.io/wso2 registry.example.com/my-group
+#
+# Run from the repository root, after update-helm-charts.sh has stamped the
+# version. A build that publishes images somewhere other than the public
+# registry has to ship charts whose defaults point there, or the operator has to
+# override every image by hand.
+#
+# The rewrite is driven by an explicit allowlist of image names read from
+# .github/release-config.json, never by matching the registry prefix. That
+# distinction is the whole safety property here: the public org also hosts a
+# sibling product (ghcr.io/wso2/api-platform/*), and the charts additionally
+# reference ghcr.io/thunder-id and ghcr.io/openchoreo. Those images are not ours
+# to move, they are not mirrored to the private registry, and a prefix-based
+# sed would silently retag all of them into a registry that has never held them.
+#
+# amp-python-instrumentation-provider is deliberately NOT in scope even though it
+# is first-party. It runs as an init container in namespaces OpenChoreo creates
+# at deploy time, where no pull secret can be placed ahead of the pod, so it
+# stays on the public registry. See the instrumentation catalog guide for the
+# supported way to mirror it.
+set -euo pipefail
+
+FROM="${1:?usage: rewrite-image-registry.sh <from-prefix> <to-prefix>}"
+TO="${2:?usage: rewrite-image-registry.sh <from-prefix> <to-prefix>}"
+CONFIG_FILE="${CONFIG_FILE:-.github/release-config.json}"
+CHARTS_DIR="${CHARTS_DIR:-deployments/helm-charts}"
+
+[ -f "$CONFIG_FILE" ] || { echo "❌ Not found: $CONFIG_FILE (run from the repository root)" >&2; exit 1; }
+[ -d "$CHARTS_DIR" ] || { echo "❌ Not found: $CHARTS_DIR" >&2; exit 1; }
+
+# Trailing slashes would produce a doubled separator in the rewritten value.
+FROM="${FROM%/}"
+TO="${TO%/}"
+
+IMAGES="$(jq -r '.images[].name' "$CONFIG_FILE")"
+[ -n "$IMAGES" ] || { echo "❌ No images in $CONFIG_FILE" >&2; exit 1; }
+
+echo "Rewriting first-party image repositories: ${FROM} -> ${TO}"
+
+TOTAL=0
+while IFS= read -r image; do
+    [ -n "$image" ] || continue
+    count=0
+    # values.schema.json carries the same repository as a documented default, and
+    # the generated reference pages are built from it, so both move together or
+    # the chart and its documentation disagree.
+    while IFS= read -r file; do
+        # The image name must end the path segment: "amp-api" must not match
+        # "amp-api-client", and the anchor keeps the sibling product's nested
+        # paths (api-platform/gateway-controller) out of range entirely.
+        if grep -qE "${FROM}/${image}([\"':[:space:]]|$)" "$file" 2>/dev/null; then
+            perl -pi -e "s{\Q${FROM}/${image}\E(?=[\"':\\s]|\$)}{${TO}/${image}}g" "$file"
+            count=$((count + 1))
+        fi
+    done < <(find "$CHARTS_DIR" -type f \( -name values.yaml -o -name values.schema.json \))
+    if [ "$count" -gt 0 ]; then
+        echo "  ✅ ${image}: ${count} file(s)"
+        TOTAL=$((TOTAL + count))
+    else
+        echo "  –  ${image}: not referenced by any chart"
+    fi
+done <<< "$IMAGES"
+
+if [ "$TOTAL" -eq 0 ]; then
+    # Silence here means the prefix was wrong, or the charts moved. Either way a
+    # release that continues would publish charts still pointing at the public
+    # registry, which fails only later as an ImagePullBackOff on the customer's
+    # cluster. Fail now instead.
+    echo "❌ Nothing was rewritten. Is '${FROM}' the current prefix?" >&2
+    exit 1
+fi
+
+echo "Rewrote ${TOTAL} file reference(s)."
+
+# The images left on the public registry are load-bearing, so say so rather than
+# leaving the reader to diff the charts.
+echo "Deliberately unchanged:"
+grep -rhoE '(ghcr\.io|docker\.io|quay\.io|registry-1\.docker\.io)/[a-z0-9._/-]+' \
+    "$CHARTS_DIR"/*/values.yaml 2>/dev/null | sort -u | sed 's/^/  /'

--- a/.github/scripts/tests/rewrite-image-registry.sh
+++ b/.github/scripts/tests/rewrite-image-registry.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Unit tests for .github/scripts/rewrite-image-registry.sh.
+# Run: bash .github/scripts/tests/rewrite-image-registry.sh
+#
+# The fixtures deliberately include references the real charts do not have yet:
+# a sibling product under the same org (api-platform/*) and an image whose name
+# is a prefix of ours (amp-api-client). Those are the cases a prefix-matching
+# rewrite gets wrong, and getting them wrong retags someone else's image into a
+# registry that has never held it — which surfaces as an ImagePullBackOff on a
+# customer's cluster, not here.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/.github/scripts/rewrite-image-registry.sh"
+FAILURES=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_contains() {
+    local label="$1" file="$2" needle="$3"
+    if grep -qF -- "$needle" "$file"; then
+        printf 'ok   - %s\n' "$label"
+    else
+        printf 'FAIL - %s\n      expected %q in %s\n' "$label" "$needle" "$(basename "$file")"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_absent_re() {
+    local label="$1" file="$2" regex="$3"
+    if grep -qE -- "$regex" "$file"; then
+        printf 'FAIL - %s\n      did not expect /%s/ in %s\n' "$label" "$regex" "$(basename "$file")"
+        FAILURES=$((FAILURES + 1))
+    else
+        printf 'ok   - %s\n' "$label"
+    fi
+}
+
+assert_absent() {
+    local label="$1" file="$2" needle="$3"
+    if grep -qF -- "$needle" "$file"; then
+        printf 'FAIL - %s\n      did not expect %q in %s\n' "$label" "$needle" "$(basename "$file")"
+        FAILURES=$((FAILURES + 1))
+    else
+        printf 'ok   - %s\n' "$label"
+    fi
+}
+
+# A fixture tree the script can be pointed at, so the real charts are untouched.
+setup() {
+    rm -rf "$TMP/work"
+    mkdir -p "$TMP/work/.github" "$TMP/work/charts/demo"
+    cat > "$TMP/work/.github/release-config.json" <<'JSON'
+{
+  "images": [
+    { "name": "amp-api",  "dir": "agent-manager-service" },
+    { "name": "amp-observer", "dir": "agent-manager-observer" }
+  ]
+}
+JSON
+    cat > "$TMP/work/charts/demo/values.yaml" <<'YAML'
+agentManagerService:
+  image:
+    repository: ghcr.io/wso2/amp-api
+observer:
+  image:
+    repository: ghcr.io/wso2/amp-observer
+# Same organization, different product: not ours to move.
+gateway:
+  controller:
+    repository: ghcr.io/wso2/api-platform/gateway-controller
+# Name that merely starts with one of ours.
+authClient:
+  repository: ghcr.io/wso2/amp-api-client
+# Third-party.
+thunder:
+  registry: ghcr.io/thunder-id
+buildpack:
+  image: ghcr.io/openchoreo/buildpack/ballerina:18
+# First-party but deliberately out of scope.
+instrumentation:
+  imageRepository: ghcr.io/wso2/amp-python-instrumentation-provider
+YAML
+}
+
+run_rewrite() {
+    ( cd "$TMP/work" && CONFIG_FILE=".github/release-config.json" CHARTS_DIR="charts" \
+        bash "$SCRIPT" "$@" >"$TMP/out.txt" 2>&1 )
+}
+
+V="$TMP/work/charts/demo/values.yaml"
+
+setup
+if run_rewrite ghcr.io/wso2 registry.example.com/grp; then
+    printf 'ok   - rewrite succeeds\n'
+else
+    printf 'FAIL - rewrite failed:\n'; sed 's/^/       /' "$TMP/out.txt"; FAILURES=$((FAILURES + 1))
+fi
+assert_contains "amp-api is repointed"      "$V" "registry.example.com/grp/amp-api"
+assert_contains "amp-observer is repointed" "$V" "registry.example.com/grp/amp-observer"
+# The dangerous ones.
+assert_contains "the sibling product is left alone" "$V" "ghcr.io/wso2/api-platform/gateway-controller"
+assert_contains "a name that only starts with ours is left alone" "$V" "ghcr.io/wso2/amp-api-client"
+assert_contains "third-party thunder is left alone" "$V" "ghcr.io/thunder-id"
+assert_contains "third-party openchoreo is left alone" "$V" "ghcr.io/openchoreo/buildpack/ballerina:18"
+assert_contains "the instrumentation provider stays public" "$V" "ghcr.io/wso2/amp-python-instrumentation-provider"
+# Anchored: amp-api-client legitimately still starts with this prefix, so only
+# an exact end-of-value match means a first-party image was missed.
+assert_absent_re "no first-party image is left on the old prefix" "$V" "ghcr\\.io/wso2/amp-api$"
+assert_absent_re "amp-observer is not left behind either" "$V" "ghcr\\.io/wso2/amp-observer$"
+# Rerunning with the now-stale prefix must fail rather than quietly do nothing:
+# a release that continued would publish charts still pointing at the old
+# registry, and that only shows up as a failed pull on a customer's cluster.
+if run_rewrite ghcr.io/wso2 registry.example.com/grp; then
+    printf 'FAIL - a second run matched nothing yet reported success\n'; FAILURES=$((FAILURES + 1))
+else
+    printf 'ok   - a run that matches nothing fails loudly\n'
+fi
+
+# A trailing slash on either argument must not double the separator.
+setup
+run_rewrite ghcr.io/wso2/ registry.example.com/grp/ || true
+assert_contains "trailing slashes do not double the separator" "$V" "registry.example.com/grp/amp-api"
+assert_absent   "no doubled slash is produced" "$V" "grp//amp-api"
+
+if ((FAILURES > 0)); then
+    printf '\n%d assertion(s) failed\n' "$FAILURES"
+    exit 1
+fi
+printf '\nAll rewrite-image-registry assertions passed\n'

--- a/.github/workflows/deployments-pr-checks.yml
+++ b/.github/workflows/deployments-pr-checks.yml
@@ -1,0 +1,64 @@
+name: Deployments PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'deployments/**'
+      - 'documentation/docs/**'
+      - 'documentation/versioned_docs/**'
+      - 'documentation/versions.json'
+      - '.github/scripts/check-no-raw-github-fetches.sh'
+      - '.github/scripts/rewrite-image-registry.sh'
+      - '.github/scripts/build-vm-bundle.sh'
+      - '.github/scripts/tests/**'
+      - '.github/workflows/deployments-pr-checks.yml'
+
+# Everything here reads the checkout and runs bash; nothing needs write access.
+permissions:
+  contents: read
+
+jobs:
+  installer-checks:
+    name: Installer Scripts
+    # Plain bash and shellcheck only, so the shared runner pool is unnecessary.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # The release bundle exists so an install needs no network access to
+      # GitHub. Nothing else catches a fetch creeping back in, and adding one is
+      # always the shortest diff.
+      - name: Assert no raw-GitHub fetches of this repository
+        run: bash .github/scripts/check-no-raw-github-fetches.sh
+        shell: bash
+
+      # These suites existed but no workflow ran them, so a regression in the
+      # installer helpers reached a release unchallenged.
+      - name: Registry auth helper tests
+        run: bash deployments/scripts/tests/lib-registry-auth.sh
+        shell: bash
+
+      - name: VM helper preflight tests
+        run: bash deployments/vm/tests/preflight.sh
+        shell: bash
+
+      # The rewrite is the one script here that can quietly retag someone
+      # else's image, so its allowlist behaviour is worth a gate.
+      - name: Image registry rewrite tests
+        run: bash .github/scripts/tests/rewrite-image-registry.sh
+        shell: bash
+
+      - name: Shellcheck the installer scripts
+        run: |
+          # -S error matches what these scripts are already clean at; the
+          # info-level advice across the tree is a separate cleanup.
+          shellcheck -S error \
+            deployments/scripts/*.sh \
+            deployments/setup/*.sh \
+            deployments/quick-start/*.sh \
+            deployments/vm/*.sh \
+            .github/scripts/*.sh
+        shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REGISTRY: ghcr.io
-  REGISTRY_ORG: wso2
-  HELM_REGISTRY: oci://ghcr.io/wso2
+  REGISTRY: ${{ vars.AMP_REGISTRY || 'ghcr.io' }}
+  REGISTRY_ORG: ${{ vars.AMP_REGISTRY_ORG || 'wso2' }}
+  HELM_REGISTRY: ${{ vars.AMP_HELM_REGISTRY || 'oci://ghcr.io/wso2' }}
 
 jobs:
   # Compute the dated version string once; all jobs consume it via needs.
@@ -35,6 +35,9 @@ jobs:
   # before building new ones so stale dated tags don't accumulate.
   cleanup-images:
     name: Cleanup Previous Nightly Images
+    # Talks to the GHCR packages API directly, so it only applies when the
+    # registry is GHCR. A build publishing elsewhere has nothing to clean here.
+    if: ${{ vars.AMP_REGISTRY == '' || vars.AMP_REGISTRY == 'ghcr.io' }}
     needs: compute-version
     runs-on: ubuntu-latest
     permissions:
@@ -176,6 +179,14 @@ jobs:
   build-images:
     name: Build ${{ matrix.image.name }}
     needs: [compute-version, cleanup-images, load-config]
+    # cleanup-images is skipped when publishing somewhere other than GHCR, and a
+    # skipped dependency would otherwise skip this job and everything after it,
+    # turning the whole nightly into a silent no-op.
+    if: >-
+      always() &&
+      needs.compute-version.result == 'success' &&
+      needs.load-config.result == 'success' &&
+      (needs.cleanup-images.result == 'success' || needs.cleanup-images.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -194,8 +205,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
       - name: Build and push ${{ matrix.image.name }}
         if: hashFiles(matrix.image.dockerfile) != ''
@@ -259,6 +270,11 @@ jobs:
           DEV_VERSION: ${{ needs.compute-version.outputs.dev-version }}
           HELM_REGISTRY: ${{ env.HELM_REGISTRY }}
           HELM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # package-helm-chart.sh prefers these over the positional token, so a
+          # custom HELM_REGISTRY authenticates with its own credentials instead of
+          # a GITHUB_TOKEN that means nothing to it.
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
 
   update-dev-tag:
     name: Update Nightly Git Tag

--- a/.github/workflows/python_instrumentation_image_release.yaml
+++ b/.github/workflows/python_instrumentation_image_release.yaml
@@ -26,6 +26,11 @@ on:
 run-name: AMP Python Instrumentation Image Release ${{ inputs.instrumentation_version }} (from ${{ inputs.branch }})
 
 env:
+  # Deliberately NOT following vars.AMP_REGISTRY. This image is pulled as an
+  # init container inside namespaces created at deploy time, where no pull
+  # secret can be placed ahead of the pod, so it stays on the public registry
+  # and the control plane's baseline keeps pointing there. Publishing it
+  # privately would strand every agent deploy on ImagePullBackOff.
   REGISTRY: ghcr.io
   REGISTRY_ORG: wso2
 
@@ -93,8 +98,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
       - name: Build and push ${{ matrix.image.instrumentation_version }}-python${{ matrix.image.python_version }}
         uses: ./.github/actions/build-single-platform-docker-image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ on:
 run-name: Agent Manager Release ${{ inputs.target_version }}
 
 env:
-  REGISTRY: ghcr.io
-  REGISTRY_ORG: wso2
-  HELM_REGISTRY: oci://ghcr.io/wso2
+  REGISTRY: ${{ vars.AMP_REGISTRY || 'ghcr.io' }}
+  REGISTRY_ORG: ${{ vars.AMP_REGISTRY_ORG || 'wso2' }}
+  HELM_REGISTRY: ${{ vars.AMP_HELM_REGISTRY || 'oci://ghcr.io/wso2' }}
 
 jobs:
   prepare-release:
@@ -142,6 +142,14 @@ jobs:
         run: |
           bash .github/scripts/update-helm-charts.sh \
             "$TARGET_RELEASE"
+          # Images follow REGISTRY/REGISTRY_ORG, so the charts have to as well.
+          # Without this a build publishing elsewhere ships charts still
+          # defaulting to the public registry, and the install silently pulls
+          # someone else's image of that tag rather than the one just built.
+          if [ "${REGISTRY}/${REGISTRY_ORG}" != "ghcr.io/wso2" ]; then
+            bash .github/scripts/rewrite-image-registry.sh \
+              "ghcr.io/wso2" "${REGISTRY}/${REGISTRY_ORG}"
+          fi
         env:
           TARGET_RELEASE: ${{ inputs.target_version }}
         shell: bash
@@ -314,8 +322,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
       - name: Build and push ${{ matrix.image.name }}
         if: hashFiles(matrix.image.dockerfile) != ''
@@ -350,8 +358,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.REGISTRY_USERNAME || github.actor }}
+          password: ${{ secrets.REGISTRY_PASSWORD || secrets.GITHUB_TOKEN }}
 
       - name: Build and push instrumentation image ${{ matrix.image.instrumentation_version }}-python${{ matrix.image.python_version }}
         uses: ./.github/actions/build-single-platform-docker-image
@@ -448,6 +456,11 @@ jobs:
           TARGET_RELEASE: ${{ inputs.target_version }}
           HELM_REGISTRY: ${{ env.HELM_REGISTRY }}
           HELM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # package-helm-chart.sh prefers these over the positional token, so a
+          # custom HELM_REGISTRY authenticates with its own credentials instead of
+          # a GITHUB_TOKEN that means nothing to it.
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         shell: bash
 
   e2e:
@@ -494,6 +507,7 @@ jobs:
         id: install-platform
         env:
           VERSION: ${{ inputs.target_version }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           cd deployments/quick-start && bash install.sh
 
@@ -634,10 +648,10 @@ jobs:
             echo "\`wso2-agent-manager-${VERSION}.tar.gz\` bundles both the VM and quick-start installers. \`bootstrap.sh\` and \`start.sh\` are also attached standalone as the one-command entry points:"
             echo '```'
             echo "# VM install"
-            echo "curl -fsSL https://github.com/${REGISTRY_ORG}/agent-manager/releases/download/amp/v${VERSION}/bootstrap.sh | sudo bash -s -- simple --host <PUBLIC_IP> --version ${VERSION}"
+            echo "curl -fsSL https://github.com/${REPO_OWNER}/agent-manager/releases/download/amp/v${VERSION}/bootstrap.sh | sudo bash -s -- simple --host <PUBLIC_IP> --version ${VERSION}"
             echo ""
             echo "# Quick-start (local dev container)"
-            echo "curl -fsSL https://github.com/${REGISTRY_ORG}/agent-manager/releases/download/amp/v${VERSION}/start.sh -o start.sh && chmod +x start.sh && ./start.sh"
+            echo "curl -fsSL https://github.com/${REPO_OWNER}/agent-manager/releases/download/amp/v${VERSION}/start.sh -o start.sh && chmod +x start.sh && ./start.sh"
             echo '```'
           } > /tmp/release-body.md
 
@@ -648,6 +662,9 @@ jobs:
           } >> $GITHUB_OUTPUT
         env:
           VERSION: ${{ inputs.target_version }}
+          # The published URLs follow the repository, not REGISTRY_ORG, which
+          # names a registry namespace and need not match the GitHub owner.
+          REPO_OWNER: ${{ github.repository_owner }}
         shell: bash
 
       - name: Download amctl artifacts

--- a/agent-manager-service/clients/openchoreosvc/client/components.go
+++ b/agent-manager-service/clients/openchoreosvc/client/components.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/wso2/agent-manager/agent-manager-service/clients/openchoreosvc/gen"
 	"github.com/wso2/agent-manager/agent-manager-service/config"
+	"github.com/wso2/agent-manager/agent-manager-service/instrumentation"
 	"github.com/wso2/agent-manager/agent-manager-service/models"
 	"github.com/wso2/agent-manager/agent-manager-service/utils"
 )
@@ -2609,6 +2610,10 @@ func BuildInstrumentationImage(languageVersion, instrumentationVersion string) (
 // getInstrumentationImage builds the pre-built init-container image reference for
 // the given AMP instrumentation version and the agent's Python runtime version,
 // e.g. ghcr.io/wso2/amp-python-instrumentation-provider:0.3.0-python3.11.
+//
+// The repository comes from the instrumentation catalog so an operator-supplied
+// catalogExtension entry can redirect a version at an internal mirror; a version
+// the catalog does not know falls back to the public default.
 func getInstrumentationImage(languageVersion, instrumentationVersion string) (string, error) {
 	// Trim before splitting so the built tag matches the trimmed major.minor the
 	// service validates against the catalog (normalizePythonMinor also trims);
@@ -2619,7 +2624,8 @@ func getInstrumentationImage(languageVersion, instrumentationVersion string) (st
 		return "", fmt.Errorf("invalid languageVersion format: expected 'major.minor' but got '%s'", languageVersion)
 	}
 	pythonMajorMinor := strings.TrimSpace(parts[0]) + "." + strings.TrimSpace(parts[1])
-	return fmt.Sprintf("%s/%s:%s-python%s", InstrumentationImageRegistry, InstrumentationImageName, instrumentationVersion, pythonMajorMinor), nil
+	repository := instrumentation.ImageRepositoryFor(instrumentationVersion, DefaultInstrumentationImageRepository)
+	return fmt.Sprintf("%s:%s-python%s", repository, instrumentationVersion, pythonMajorMinor), nil
 }
 
 func (c *openChoreoClient) GetComponentEndpoints(ctx context.Context, ouID, projectName, componentName, environment string) (map[string]models.EndpointsResponse, error) {

--- a/agent-manager-service/clients/openchoreosvc/client/constants.go
+++ b/agent-manager-service/clients/openchoreosvc/client/constants.go
@@ -101,6 +101,10 @@ const (
 const (
 	InstrumentationImageRegistry = "ghcr.io/wso2"
 	InstrumentationImageName     = "amp-python-instrumentation-provider"
+
+	// DefaultInstrumentationImageRepository is the fallback used when the
+	// instrumentation catalog carries no entry for the requested version.
+	DefaultInstrumentationImageRepository = InstrumentationImageRegistry + "/" + InstrumentationImageName
 )
 
 // -----------------------------------------------------------------------------

--- a/agent-manager-service/clients/openchoreosvc/client/instrumentation_image_test.go
+++ b/agent-manager-service/clients/openchoreosvc/client/instrumentation_image_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/wso2/agent-manager/agent-manager-service/instrumentation"
+)
+
+// The catalog is process-wide, so install it once for every case below. Each
+// package gets its own test binary, so this does not leak to other packages.
+func TestGetInstrumentationImage(t *testing.T) {
+	const mirrorRepo = "mirror.test/amp-python-instrumentation-provider"
+	instrumentation.SetCatalog(instrumentation.NewForTest(
+		[]instrumentation.Version{
+			{Version: "0.4.1", PythonVersions: []string{"3.11"}, ImageRepository: mirrorRepo},
+		},
+		"0.4.1",
+	))
+
+	t.Run("catalog entry redirects the repository", func(t *testing.T) {
+		// The point of instrumentation.catalogExtension: an operator points a
+		// version at an internal mirror and the init container follows.
+		got, err := getInstrumentationImage("3.11", "0.4.1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := mirrorRepo + ":0.4.1-python3.11"; got != want {
+			t.Errorf("image = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("version absent from the catalog falls back to the public default", func(t *testing.T) {
+		got, err := getInstrumentationImage("3.12", "9.9.9")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := DefaultInstrumentationImageRepository + ":9.9.9-python3.12"; got != want {
+			t.Errorf("image = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("padded language version yields a clean tag", func(t *testing.T) {
+		got, err := getInstrumentationImage("  3.11.9  ", "0.4.1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := mirrorRepo + ":0.4.1-python3.11"; got != want {
+			t.Errorf("image = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("language version without a minor is rejected", func(t *testing.T) {
+		if _, err := getInstrumentationImage("3", "0.4.1"); err == nil {
+			t.Error("expected an error for a language version with no minor")
+		}
+	})
+}

--- a/agent-manager-service/instrumentation/catalog.go
+++ b/agent-manager-service/instrumentation/catalog.go
@@ -162,6 +162,18 @@ func (c *Catalog) Get(v string) (Version, bool) {
 	return cloneVersion(got), true
 }
 
+// ImageRepositoryFor returns the init-container image repository for version,
+// falling back when the version is absent or its entry carries no repository.
+// An extension entry that overrides a bundled version is how an operator
+// redirects the image at an internal mirror.
+func (c *Catalog) ImageRepositoryFor(version, fallback string) string {
+	got, ok := c.byVersion[version]
+	if !ok || got.ImageRepository == "" {
+		return fallback
+	}
+	return got.ImageRepository
+}
+
 // cloneVersion returns a Version whose slice fields are independent
 // copies of the input's.
 func cloneVersion(v Version) Version {
@@ -213,6 +225,21 @@ func GetCatalog() *Catalog {
 		panic("instrumentation.GetCatalog called before SetCatalog")
 	}
 	return c
+}
+
+// ImageRepositoryFor resolves version against the process-wide catalog,
+// returning fallback when the catalog is not installed or the version is
+// unknown. Unlike GetCatalog it never panics: image references are built on the
+// deploy path, where an un-booted catalog should degrade to the compiled-in
+// default rather than fail the request.
+func ImageRepositoryFor(version, fallback string) string {
+	pkgCatalogMu.RLock()
+	c := pkgCatalog
+	pkgCatalogMu.RUnlock()
+	if c == nil {
+		return fallback
+	}
+	return c.ImageRepositoryFor(version, fallback)
 }
 
 // NewForTest builds a catalog directly from versions. Use only in tests

--- a/agent-manager-service/instrumentation/catalog_test.go
+++ b/agent-manager-service/instrumentation/catalog_test.go
@@ -160,3 +160,51 @@ func TestSetCatalog_PanicsOnNil(t *testing.T) {
 	}()
 	SetCatalog(nil)
 }
+
+func TestImageRepositoryFor_Catalog(t *testing.T) {
+	const fallback = "fallback.test/amp-python-instrumentation-provider"
+	c := NewForTest([]Version{
+		{Version: "0.4.1", PythonVersions: []string{"3.11"}, ImageRepository: "mirror.test/provider"},
+		{Version: "0.5.0", PythonVersions: []string{"3.11"}},
+	}, "0.4.1")
+
+	if got := c.ImageRepositoryFor("0.4.1", fallback); got != "mirror.test/provider" {
+		t.Errorf("ImageRepositoryFor(0.4.1) = %q, want the catalog entry's repository", got)
+	}
+	// Entry present but carrying no repository, and an entirely unknown version,
+	// both degrade to the caller's default rather than an empty image prefix.
+	if got := c.ImageRepositoryFor("0.5.0", fallback); got != fallback {
+		t.Errorf("ImageRepositoryFor(0.5.0) = %q, want fallback for an empty repository", got)
+	}
+	if got := c.ImageRepositoryFor("9.9.9", fallback); got != fallback {
+		t.Errorf("ImageRepositoryFor(9.9.9) = %q, want fallback for an unknown version", got)
+	}
+}
+
+func TestImageRepositoryFor_ProcessWide(t *testing.T) {
+	const fallback = "fallback.test/amp-python-instrumentation-provider"
+
+	// Swap the process-wide catalog out and back so this test neither depends on
+	// nor leaks into the package-level state other tests share.
+	pkgCatalogMu.Lock()
+	saved := pkgCatalog
+	pkgCatalog = nil
+	pkgCatalogMu.Unlock()
+	t.Cleanup(func() {
+		pkgCatalogMu.Lock()
+		pkgCatalog = saved
+		pkgCatalogMu.Unlock()
+	})
+
+	// Unlike GetCatalog, this must not panic when the catalog was never installed.
+	if got := ImageRepositoryFor("0.4.1", fallback); got != fallback {
+		t.Errorf("ImageRepositoryFor with no catalog = %q, want fallback", got)
+	}
+
+	SetCatalog(NewForTest([]Version{
+		{Version: "0.4.1", PythonVersions: []string{"3.11"}, ImageRepository: "mirror.test/provider"},
+	}, "0.4.1"))
+	if got := ImageRepositoryFor("0.4.1", fallback); got != "mirror.test/provider" {
+		t.Errorf("ImageRepositoryFor = %q, want the installed catalog's repository", got)
+	}
+}

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -225,10 +225,15 @@ func TestNormalizePythonMinor(t *testing.T) {
 }
 
 func TestResolveInstrumentationImageOverride(t *testing.T) {
+	// A repository that is NOT the compiled-in default, so the assertions below
+	// prove the catalog entry drives the image reference rather than the constant.
+	const mirrorRepo = "mirror.test/amp-python-instrumentation-provider"
+	const wantImage = mirrorRepo + ":0.2.1-python3.11"
+
 	instrumentation.SetCatalog(instrumentation.NewForTest(
 		[]instrumentation.Version{
-			{Version: "0.2.1", PythonVersions: []string{"3.10", "3.11"}, ImageRepository: "x"},
-			{Version: "0.4.0", PythonVersions: []string{"3.12", "3.13"}, ImageRepository: "x"},
+			{Version: "0.2.1", PythonVersions: []string{"3.10", "3.11"}, ImageRepository: mirrorRepo},
+			{Version: "0.4.0", PythonVersions: []string{"3.12", "3.13"}, ImageRepository: mirrorRepo},
 		},
 		"0.2.1",
 	))
@@ -256,8 +261,8 @@ func TestResolveInstrumentationImageOverride(t *testing.T) {
 		if version == nil || *version != "0.2.1" {
 			t.Errorf("version = %v, want requested 0.2.1", version)
 		}
-		if !strings.HasSuffix(image, "0.2.1-python3.11") {
-			t.Errorf("image = %q, want suffix 0.2.1-python3.11", image)
+		if image != wantImage {
+			t.Errorf("image = %q, want %q", image, wantImage)
 		}
 	})
 
@@ -284,8 +289,8 @@ func TestResolveInstrumentationImageOverride(t *testing.T) {
 		if version == nil || *version != "0.2.1" {
 			t.Errorf("version = %v, want preserved 0.2.1", version)
 		}
-		if !strings.HasSuffix(image, "0.2.1-python3.11") {
-			t.Errorf("image = %q, want suffix 0.2.1-python3.11", image)
+		if image != wantImage {
+			t.Errorf("image = %q, want %q", image, wantImage)
 		}
 	})
 

--- a/console/apps/web-ui/public/config.template.js
+++ b/console/apps/web-ui/public/config.template.js
@@ -40,6 +40,7 @@ window.__RUNTIME_CONFIG__ = {
   gatewayControlPlaneUrl: '$GATEWAY_CONTROL_PLANE_URL',
   gatewayVersion: '$GATEWAY_VERSION',
   ampVersion: '$AMP_VERSION',
+  scriptBaseUrl: '$SCRIPT_BASE_URL',
   instrumentationUrl: '$INSTRUMENTATION_URL',
   agentManagerInternalBaseUrl: '$AGENT_MANAGER_INTERNAL_BASE_URL',
   agentManagerInternalCpHost: '$AGENT_MANAGER_INTERNAL_CP_HOST',

--- a/console/workspaces/libs/shared-component/src/utils/gatewayScripts.ts
+++ b/console/workspaces/libs/shared-component/src/utils/gatewayScripts.ts
@@ -70,9 +70,21 @@ export function getScriptRef(): string {
   return `amp/v${bare}`;
 }
 
-/** Full raw URL for a deployment script pinned to the current release ref. */
+/**
+ * Base URL the generated commands fetch deployment scripts from, without a
+ * trailing slash. Defaults to the public raw.githubusercontent.com path for the
+ * current release ref; `globalConfig.scriptBaseUrl` overrides it for a
+ * deployment where that host is not reachable or serves nothing.
+ */
+export function getScriptBaseUrl(): string {
+  const configured = globalConfig.scriptBaseUrl?.trim();
+  if (configured) return configured.replace(/\/+$/, "");
+  return `https://raw.githubusercontent.com/wso2/agent-manager/${getScriptRef()}/deployments/scripts`;
+}
+
+/** Full URL for a deployment script, pinned to the current release ref. */
 export function getRawScriptUrl(scriptName: string): string {
-  return `https://raw.githubusercontent.com/wso2/agent-manager/${getScriptRef()}/deployments/scripts/${scriptName}`;
+  return `${getScriptBaseUrl()}/${scriptName}`;
 }
 
 const DEFAULT_GATEWAY_CONTROL_PLANE_URL = "http://localhost:9243";

--- a/console/workspaces/libs/types/src/config/index.ts
+++ b/console/workspaces/libs/types/src/config/index.ts
@@ -36,6 +36,14 @@ export interface AppConfig {
    * git tag (amp/vX.Y.Z).
    */
   ampVersion?: string;
+  /**
+   * Base URL the console's generated commands fetch deployment scripts from.
+   * Empty (the default) derives the public raw.githubusercontent.com URL for
+   * the release ref. Set it where those raw URLs are not reachable — a private
+   * mirror of this repository serves none, so every generated command would
+   * fail — to any host serving deployments/scripts, without a trailing slash.
+   */
+  scriptBaseUrl?: string;
   disableAuth: boolean;
   instrumentationUrl: string;
   /**

--- a/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-agent-manager/templates/_helpers.tpl
@@ -328,3 +328,34 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+==============================================
+Images
+==============================================
+*/}}
+
+{{/*
+Image reference for a first-party image.
+
+global.ampImageRegistry, when set, replaces the registry and organization portion
+of the image's repository and keeps the trailing image name, so one value
+redirects every AMP image at a private registry. Left empty (the default) the
+fully-qualified repository is used exactly as written, which keeps existing
+installs and any per-image repository override working unchanged.
+
+Deliberately not named global.imageRegistry: that is a Bitnami convention, and
+Helm passes global values to subcharts, so the name would also rewrite the
+postgresql subchart's images and trip its unrecognized-container guard.
+
+Usage: include "agent-management-platform.image" (dict "image" .Values.console.image "ctx" .)
+*/}}
+{{- define "agent-management-platform.image" -}}
+{{- $image := .image -}}
+{{- $ctx := .ctx -}}
+{{- $repository := $image.repository -}}
+{{- with $ctx.Values.global.ampImageRegistry -}}
+{{- $repository = printf "%s/%s" (trimSuffix "/" .) (base $repository) -}}
+{{- end -}}
+{{- printf "%s:%s" $repository ($image.tag | default $ctx.Chart.AppVersion) -}}
+{{- end -}}

--- a/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/deployment.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/agent-manager-service/deployment.yaml
@@ -71,7 +71,7 @@ spec:
               drop:
                 - ALL
           {{- end }}
-          image: "{{ .Values.agentManagerService.image.repository }}:{{ .Values.agentManagerService.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "agent-management-platform.image" (dict "image" .Values.agentManagerService.image "ctx" .) }}"
           imagePullPolicy: {{ .Values.agentManagerService.image.pullPolicy }}
           ports:
             - name: http

--- a/deployments/helm-charts/wso2-agent-manager/templates/console/configmap.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/console/configmap.yaml
@@ -24,6 +24,10 @@ data:
   GATEWAY_VERSION: {{ .Values.console.config.gatewayVersion | default "v1.0.0" | quote }}
   # Agent Manager release version — pins the deployment-script git tag (amp/vX.Y.Z)
   AMP_VERSION: {{ .Values.console.config.ampVersion | default "v1.0.0" | quote }}
+  # Base URL the console's generated commands fetch deployment scripts from.
+  # Empty derives the public raw.githubusercontent.com URL from AMP_VERSION; set
+  # it where that host is unreachable or serves nothing for this build.
+  SCRIPT_BASE_URL: {{ .Values.console.config.scriptBaseUrl | default "" | quote }}
   # Documentation base URL for the console's in-product doc links. Built from
   # the docs version so only the version segment varies per release.
   DOCS_URL: {{ printf "https://wso2.github.io/agent-manager/docs/%s" (.Values.console.config.docsVersion | default "latest") | quote }}

--- a/deployments/helm-charts/wso2-agent-manager/templates/console/deployment.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/console/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               drop:
                 - ALL
           {{- end }}
-          image: "{{ .Values.console.image.repository }}:{{ .Values.console.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "agent-management-platform.image" (dict "image" .Values.console.image "ctx" .) }}"
           imagePullPolicy: {{ .Values.console.image.pullPolicy }}
           ports:
             - name: http

--- a/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/jobs/db-migration-job.yaml
@@ -53,7 +53,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.dbMigration.image.repository }}:{{ .Values.dbMigration.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "agent-management-platform.image" (dict "image" .Values.dbMigration.image "ctx" .) }}"
           imagePullPolicy: {{ .Values.dbMigration.image.pullPolicy }}
           command:
             - /go/bin/agent-manager-service

--- a/deployments/helm-charts/wso2-agent-manager/templates/jobs/tls-certs-job.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/templates/jobs/tls-certs-job.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/component: tls-cert-generator
     spec:
       restartPolicy: Never
+      {{- if .Values.global.imagePullSecrets }}
+      {{- include "agent-management-platform.imagePullSecrets" . | trim | nindent 6 }}
+      {{- end }}
       {{- if .Values.tlsCertsGeneration.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.tlsCertsGeneration.podSecurityContext | nindent 8 }}

--- a/deployments/helm-charts/wso2-agent-manager/tests/render.sh
+++ b/deployments/helm-charts/wso2-agent-manager/tests/render.sh
@@ -351,6 +351,91 @@ assert_ca_mount "a private CA volume reaches the API" "$API_TMPL" yes "${CA_VOLU
 assert_ca_mount "a private CA volume reaches the migration job" "$MIG_TMPL" yes "${CA_VOLUME[@]}"
 assert_ca_mount "no CA volume is invented for the migration job by default" "$MIG_TMPL" no
 
+# --- global.ampImageRegistry -------------------------------------------------
+# The knob exists so a private-registry install redirects every first-party image
+# with one value. Two things have to hold, and neither is visible from a plain
+# `helm template` with defaults.
+
+# image_of <template-path> <container-name> [helm --set args...] -> that
+# container's image. Selected by name, never by position: these pod specs put a
+# postgres wait-for-db initContainer ahead of the app container, so "the first
+# image:" would silently assert the wrong thing.
+image_of() {
+  local tmpl="$1" container="$2" rendered
+  shift 2
+  if ! rendered="$(helm template test-release "$CHART_DIR" --show-only "$tmpl" "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$rendered" >&2
+    return 1
+  fi
+  awk -v c="$container" '
+    $1 == "-" && $2 == "name:" && $3 == c { found = 1; next }
+    found && $1 == "image:" { gsub(/^"|"$/, "", $2); print $2; exit }
+  ' <<<"$rendered"
+}
+
+assert_image() {
+  local label="$1" tmpl="$2" container="$3" expected="$4"
+  shift 4
+  local actual
+  actual="$(image_of "$tmpl" "$container" "$@")"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected: %q\n      actual:   %q\n' "$label" "$expected" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+CONSOLE_TMPL=templates/console/deployment.yaml
+APP_VERSION="$(awk '/^appVersion:/ {gsub(/"/, "", $2); print $2}' "$CHART_DIR/Chart.yaml")"
+
+# Unset must leave the fully-qualified public repository exactly as written, so
+# existing installs and quick-start (which passes no overrides) are untouched.
+assert_image "default keeps the public api repository" \
+  "$API_TMPL" agent-manager-service "ghcr.io/wso2/amp-api:${APP_VERSION}"
+assert_image "default keeps the public console repository" \
+  "$CONSOLE_TMPL" console "ghcr.io/wso2/amp-console:${APP_VERSION}"
+assert_image "default keeps the public migration-job repository" \
+  "$MIG_TMPL" db-migration "ghcr.io/wso2/amp-api:${APP_VERSION}"
+
+# Set, it must replace the registry and org but keep the image name, for every
+# first-party image including the migration job (which runs as an install hook,
+# so missing it fails the install rather than a later request).
+assert_image "override redirects the api image" \
+  "$API_TMPL" agent-manager-service "registry.example.com/my-org/amp-api:${APP_VERSION}" \
+  --set global.ampImageRegistry=registry.example.com/my-org
+assert_image "override redirects the console image" \
+  "$CONSOLE_TMPL" console "registry.example.com/my-org/amp-console:${APP_VERSION}" \
+  --set global.ampImageRegistry=registry.example.com/my-org
+assert_image "override redirects the migration-job image" \
+  "$MIG_TMPL" db-migration "registry.example.com/my-org/amp-api:${APP_VERSION}" \
+  --set global.ampImageRegistry=registry.example.com/my-org
+assert_image "a trailing slash does not double up" \
+  "$API_TMPL" agent-manager-service "registry.example.com/my-org/amp-api:${APP_VERSION}" \
+  --set global.ampImageRegistry=registry.example.com/my-org/
+# A per-image repository override still wins, so the escape hatch keeps working.
+assert_image "an explicit repository is still redirected by name only" \
+  "$API_TMPL" agent-manager-service "registry.example.com/my-org/custom-api:${APP_VERSION}" \
+  --set global.ampImageRegistry=registry.example.com/my-org \
+  --set agentManagerService.image.repository=somewhere.else/team/custom-api
+
+# The name is NOT global.imageRegistry on purpose: that is a Bitnami convention,
+# and Helm passes global values into subcharts, so that name would rewrite the
+# postgresql images too and trip its unrecognized-container guard. Third-party
+# images must stay on their own registries.
+if rendered="$(helm template test-release "$CHART_DIR" \
+     --set global.ampImageRegistry=registry.example.com/my-org 2>&1)"; then
+  if grep -E '^\s+image: ' <<<"$rendered" | grep -q 'registry.example.com/my-org/bitnami'; then
+    printf 'FAIL - the override leaked into the postgresql subchart\n'
+    FAILURES=$((FAILURES + 1))
+  else
+    printf 'ok   - the override does not leak into third-party subchart images\n'
+  fi
+else
+  printf 'FAIL - chart does not render with ampImageRegistry set: %s\n' "$rendered"
+  FAILURES=$((FAILURES + 1))
+fi
+
 if ((FAILURES > 0)); then
   printf '\n%d assertion(s) failed\n' "$FAILURES"
   exit 1

--- a/deployments/helm-charts/wso2-agent-manager/values.schema.json
+++ b/deployments/helm-charts/wso2-agent-manager/values.schema.json
@@ -8,10 +8,19 @@
       "additionalProperties": false,
       "description": "Default values for agent-management-platform",
       "properties": {
+        "ampImageRegistry": {
+          "default": "",
+          "description": "Registry and organization that replaces the registry portion of every first-party AMP image repository, keeping the image name. Set this to pull the AMP images from a private registry (e.g. registry.example.com/my-org) without overriding each image individually. Third-party subchart images (PostgreSQL) are deliberately unaffected. Empty leaves each image.repository exactly as configured. Deliberately not named global.imageRegistry, which Bitnami subcharts consume.",
+          "title": "ampImageRegistry",
+          "type": "string"
+        },
         "imagePullSecrets": {
           "default": [],
           "description": "Secrets used to pull images from a private registry",
-          "items": {},
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
           "title": "imagePullSecrets",
           "type": "array"
         },
@@ -1562,6 +1571,30 @@
           "additionalProperties": false,
           "description": "Frontend configuration",
           "properties": {
+            "agentManagerInternalBaseUrl": {
+              "default": "http://amp-api.wso2-amp.svc.cluster.local:9000",
+              "description": "Cluster-internal URLs the API Platform Gateway uses to reach Agent Manager when add-environment.sh installs a new gateway. The Create Environment drawer pipes these into the rendered curl|bash command so the gateway is configured for in-cluster service discovery.",
+              "title": "agentManagerInternalBaseUrl",
+              "type": "string"
+            },
+            "agentManagerInternalCpHost": {
+              "default": "amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243",
+              "description": "In-cluster address the console's server-side calls use.",
+              "title": "agentManagerInternalCpHost",
+              "type": "string"
+            },
+            "ampVersion": {
+              "default": "0.0.0-dev",
+              "description": "Agent Manager release version \u2014 pins the deployment-script git tag (amp/vX.Y.Z). Placeholder is substituted with the real release version by the release pipeline (.github/scripts/update-helm-charts.sh); dev builds fall back to main.",
+              "title": "ampVersion",
+              "type": "string"
+            },
+            "apiBaseUrl": {
+              "default": "http://api.amp.localhost:8080",
+              "description": "Backend API URLs (will be auto-configured if empty) Routed through the OpenChoreo control-plane gateway (see ocIngress).",
+              "title": "apiBaseUrl",
+              "type": "string"
+            },
             "auth": {
               "additionalProperties": false,
               "description": "Authentication (set to \"\" to disable)",
@@ -1625,11 +1658,44 @@
               "title": "disableAuth",
               "type": "string"
             },
-            "apiBaseUrl": {
-              "default": "http://api.amp.localhost:8080",
-              "description": "Backend API URLs (will be auto-configured if empty) Routed through the OpenChoreo control-plane gateway (see ocIngress).",
-              "title": "apiBaseUrl",
+            "docsVersion": {
+              "default": "latest",
+              "description": "Documentation version the console's in-product doc links point at, used as the path segment after /docs/. \"latest\" tracks the newest released docs. The release pipeline (.github/scripts/update-helm-charts.sh) pins this to the matching versioned docs (vX.Y.x, or the exact version for a pre-release) for final and pre-release builds. Release candidates and nightlies keep \"latest\", because no docs version is cut for them.",
+              "title": "docsVersion",
               "type": "string"
+            },
+            "featureFlags": {
+              "additionalProperties": false,
+              "description": "Feature flags.",
+              "properties": {
+                "enablePrivateRepoSupport": {
+                  "default": true,
+                  "description": "Shows the private Git repository option when building agents from source.",
+                  "title": "enablePrivateRepoSupport",
+                  "type": "boolean"
+                },
+                "enableIdentityProviderManagedMode": {
+                  "default": false,
+                  "description": "When true, identity provider management calls the REST API directly instead of rendering the self-hosted manage-identity-provider.sh script snippet.",
+                  "title": "enableIdentityProviderManagedMode",
+                  "type": "boolean"
+                },
+                "enableProfileManagement": {
+                  "default": true,
+                  "description": "When false, the Profile Settings text fields and Save Changes button are hidden/disabled, and the Change Password tab is disabled.",
+                  "title": "enableProfileManagement",
+                  "type": "boolean"
+                },
+                "enableUserManagement": {
+                  "default": true,
+                  "description": "When false, the Add User, Invite User, Create Role, and Create Group buttons on the Settings page are disabled.",
+                  "title": "enableUserManagement",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "featureFlags",
+              "type": "object"
             },
             "gatewayControlPlaneUrl": {
               "default": "http://host.docker.internal:8080",
@@ -1641,60 +1707,6 @@
               "default": "v1.0.0",
               "description": "Gateway version for setup commands (default: v1.0.0)",
               "title": "gatewayVersion",
-              "type": "string"
-            },
-            "ampVersion": {
-              "default": "0.0.0-dev",
-              "description": "Agent Manager release version \u2014 pins the deployment-script git tag (amp/vX.Y.Z). Placeholder is substituted with the real release version by the release pipeline (.github/scripts/update-helm-charts.sh); dev builds fall back to main.",
-              "title": "ampVersion",
-              "type": "string"
-            },
-            "docsVersion": {
-              "default": "latest",
-              "description": "Documentation version the console's in-product doc links point at, used as the path segment after /docs/. \"latest\" tracks the newest released docs. The release pipeline (.github/scripts/update-helm-charts.sh) pins this to the matching versioned docs (vX.Y.x, or the exact version for a pre-release) for final and pre-release builds. Release candidates and nightlies keep \"latest\", because no docs version is cut for them.",
-              "title": "docsVersion",
-              "type": "string"
-            },
-            "instrumentationUrl": {
-              "default": "http://default-default.gateway.localhost:19080/otel",
-              "description": "Trace-export URL shown to external agent developers. kgateway-routed vhost \u2014 independent of the gateway runtime's namespace; no port-forward.",
-              "title": "instrumentationUrl",
-              "type": "string"
-            },
-            "agentManagerInternalBaseUrl": {
-              "default": "http://amp-api.wso2-amp.svc.cluster.local:9000",
-              "description": "Cluster-internal URLs the API Platform Gateway uses to reach Agent Manager when add-environment.sh installs a new gateway. The Create Environment drawer pipes these into the rendered curl|bash command so the gateway is configured for in-cluster service discovery.",
-              "title": "agentManagerInternalBaseUrl",
-              "type": "string"
-            },
-            "agentManagerInternalCpHost": {
-              "default": "amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243",
-              "description": "In-cluster address the console's server-side calls use.",
-              "title": "agentManagerInternalCpHost",
-              "type": "string"
-            },
-            "idpHostBaseDomain": {
-              "default": "amp.localhost",
-              "description": "Base domain env-Thunder instances are hosted under, and whether this deployment serves them over TLS. Mirrors agentManagerService.config's own idpHostBaseDomain/tlsEnabled \u2014 kept in sync so the Create Environment drawer's rendered command matches this deployment. VM/production installs override both (see deployments/vm/lib-vm.sh).",
-              "title": "idpHostBaseDomain",
-              "type": "string"
-            },
-            "tlsEnabled": {
-              "default": "false",
-              "description": "Serve the console over HTTPS.",
-              "title": "tlsEnabled",
-              "type": "string"
-            },
-            "guardrailsCatalogUrl": {
-              "default": "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=AI,Guardrails&limit=50",
-              "description": "Guardrails catalog URL for fetching available guardrail policies",
-              "title": "guardrailsCatalogUrl",
-              "type": "string"
-            },
-            "guardrailsDefinitionBaseUrl": {
-              "default": "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies",
-              "description": "Guardrails definition base URL for fetching policy definitions",
-              "title": "guardrailsDefinitionBaseUrl",
               "type": "string"
             },
             "guardrailCapabilities": {
@@ -1736,38 +1748,41 @@
               "title": "guardrailCapabilities",
               "type": "object"
             },
-            "featureFlags": {
-              "additionalProperties": false,
-              "description": "Feature flags.",
-              "properties": {
-                "enablePrivateRepoSupport": {
-                  "default": true,
-                  "description": "Shows the private Git repository option when building agents from source.",
-                  "title": "enablePrivateRepoSupport",
-                  "type": "boolean"
-                },
-                "enableIdentityProviderManagedMode": {
-                  "default": false,
-                  "description": "When true, identity provider management calls the REST API directly instead of rendering the self-hosted manage-identity-provider.sh script snippet.",
-                  "title": "enableIdentityProviderManagedMode",
-                  "type": "boolean"
-                },
-                "enableProfileManagement": {
-                  "default": true,
-                  "description": "When false, the Profile Settings text fields and Save Changes button are hidden/disabled, and the Change Password tab is disabled.",
-                  "title": "enableProfileManagement",
-                  "type": "boolean"
-                },
-                "enableUserManagement": {
-                  "default": true,
-                  "description": "When false, the Add User, Invite User, Create Role, and Create Group buttons on the Settings page are disabled.",
-                  "title": "enableUserManagement",
-                  "type": "boolean"
-                }
-              },
-              "required": [],
-              "title": "featureFlags",
-              "type": "object"
+            "guardrailsCatalogUrl": {
+              "default": "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=AI,Guardrails&limit=50",
+              "description": "Guardrails catalog URL for fetching available guardrail policies",
+              "title": "guardrailsCatalogUrl",
+              "type": "string"
+            },
+            "guardrailsDefinitionBaseUrl": {
+              "default": "https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies",
+              "description": "Guardrails definition base URL for fetching policy definitions",
+              "title": "guardrailsDefinitionBaseUrl",
+              "type": "string"
+            },
+            "idpHostBaseDomain": {
+              "default": "amp.localhost",
+              "description": "Base domain env-Thunder instances are hosted under, and whether this deployment serves them over TLS. Mirrors agentManagerService.config's own idpHostBaseDomain/tlsEnabled \u2014 kept in sync so the Create Environment drawer's rendered command matches this deployment. VM/production installs override both (see deployments/vm/lib-vm.sh).",
+              "title": "idpHostBaseDomain",
+              "type": "string"
+            },
+            "instrumentationUrl": {
+              "default": "http://default-default.gateway.localhost:19080/otel",
+              "description": "Trace-export URL shown to external agent developers. kgateway-routed vhost \u2014 independent of the gateway runtime's namespace; no port-forward.",
+              "title": "instrumentationUrl",
+              "type": "string"
+            },
+            "scriptBaseUrl": {
+              "default": "",
+              "description": "Base URL the console's generated commands fetch deployment scripts from, without a trailing slash. Empty derives the public raw.githubusercontent.com URL from ampVersion. Set it where that host is unreachable from the operator's machine, or where this build's scripts are served from somewhere else.",
+              "title": "scriptBaseUrl",
+              "type": "string"
+            },
+            "tlsEnabled": {
+              "default": "false",
+              "description": "Serve the console over HTTPS.",
+              "title": "tlsEnabled",
+              "type": "string"
             }
           },
           "required": [],

--- a/deployments/helm-charts/wso2-agent-manager/values.yaml
+++ b/deployments/helm-charts/wso2-agent-manager/values.yaml
@@ -1,6 +1,7 @@
 # Default values for agent-management-platform
 global:
   imagePullSecrets: []
+  ampImageRegistry: ""
   storageClass: ""
 
 # PostgreSQL Database Configuration
@@ -512,6 +513,9 @@ console:
     # Placeholder is substituted with the real release version by the release
     # pipeline (.github/scripts/update-helm-charts.sh); dev builds fall back to main.
     ampVersion: "0.0.0-dev"
+    # -- Base URL for the console's generated deployment-script commands.
+    # Empty derives the public raw.githubusercontent.com URL from ampVersion.
+    scriptBaseUrl: ""
     # Documentation version the console's in-product doc links point at, used as
     # the path segment after /docs/. "latest" tracks the newest released docs.
     # The release pipeline (.github/scripts/update-helm-charts.sh) pins this to

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/_helpers.tpl
@@ -48,6 +48,24 @@ Otherwise returns the repository:tag as-is for external registries
   {{- $registry := include "amp-evaluation-extension.registryEndpoint" . -}}
   {{- printf "%s/%s:%s" $registry $repository $tag -}}
 {{- else -}}
+  {{- with .Values.global.ampImageRegistry -}}
+    {{- $repository = printf "%s/%s" (trimSuffix "/" .) (base $repository) -}}
+  {{- end -}}
   {{- printf "%s:%s" $repository $tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Image pull secrets for the evaluation job pod.
+
+The pod runs in the workflow namespace ("workflows-<environment>"), not this
+chart's release namespace, so the named secrets have to exist there. The chart
+does not create them: that keeps registry credentials out of Helm values and
+the release secret, and matches how the installer provisions them per namespace.
+*/}}
+{{- define "amp-evaluation-extension.imagePullSecrets" -}}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/cluster-workflow-monitor-evaluation.yaml
@@ -9,6 +9,9 @@ metadata:
 {{- include "amp-evaluation-extension.labels" . | nindent 4 }}
 spec:
   entrypoint: run-monitor
+  {{- if .Values.global.imagePullSecrets }}
+  {{- include "amp-evaluation-extension.imagePullSecrets" . | trim | nindent 2 }}
+  {{- end }}
   # Stamped onto the actual pod (unlike metadata.labels above, which only labels the CR) —
   # the podSelector evaluation-job-networkpolicy.yaml targets.
   podMetadata:

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/workflow-monitor-evaluation.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/templates/workflow-templates/workflow-monitor-evaluation.yaml
@@ -142,6 +142,9 @@ spec:
         amp.wso2.com/component: ${parameters.agent.name}
     spec:
       serviceAccountName: workflow-sa
+      {{- if .Values.global.imagePullSecrets }}
+      {{- include "amp-evaluation-extension.imagePullSecrets" . | trim | nindent 6 }}
+      {{- end }}
       # main gets no token; only the wait sidecar does, via workflow-sa-bound-token below.
       automountServiceAccountToken: false
       executor:

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/tests/render.sh
@@ -106,6 +106,69 @@ else
   FAILURES=$((FAILURES + 1))
 fi
 
+# --- global.ampImageRegistry / global.imagePullSecrets -----------------------
+# The evaluation image is the awkward one: its pod runs as an Argo workflow in
+# the workflow namespace, not this chart's release namespace, and the repository
+# is assembled by a helper with two branches. Both branches need pinning.
+
+job_image() {
+  local rendered
+  if ! rendered="$(helm template test-release "$CHART_DIR" "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$rendered" >&2
+    return 1
+  fi
+  awk '$1 == "image:" { v = $2; gsub(/^['"'"'"]|['"'"'"]$/, "", v); print v; exit }' <<<"$rendered"
+}
+
+assert_image() {
+  local label="$1" expected="$2"
+  shift 2
+  local actual
+  actual="$(job_image "$@")"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected: %q\n      actual:   %q\n' "$label" "$expected" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+TAG="$(awk '/^    tag:/ {gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/values.yaml")"
+
+assert_image "default keeps the public evaluation repository" \
+  "ghcr.io/wso2/amp-evaluation-monitor:${TAG}"
+assert_image "override redirects the evaluation image" \
+  "registry.example.com/my-org/amp-evaluation-monitor:${TAG}" \
+  --set global.ampImageRegistry=registry.example.com/my-org
+assert_image "a trailing slash does not double up" \
+  "registry.example.com/my-org/amp-evaluation-monitor:${TAG}" \
+  --set global.ampImageRegistry=registry.example.com/my-org/
+# useLocalRegistry prefixes the in-cluster build registry instead; a remote
+# override there would defeat the point of importing a locally built image.
+assert_image "useLocalRegistry ignores the override" \
+  "host.k3d.internal:10082/ghcr.io/wso2/amp-evaluation-monitor:${TAG}" \
+  --set ampEvaluation.useLocalRegistry=true \
+  --set global.ampImageRegistry=registry.example.com/my-org
+
+# The pull secret has to reach BOTH specs: the ClusterWorkflowTemplate (used on a
+# direct submission) and the Workflow's runTemplate (the production path, whose
+# spec wins over the referenced template).
+if helm template test-release "$CHART_DIR" | grep -q "imagePullSecrets"; then
+  printf 'FAIL - default render should not mention imagePullSecrets\n'
+  FAILURES=$((FAILURES + 1))
+else
+  printf 'ok   - default render omits imagePullSecrets entirely\n'
+fi
+PULL_COUNT="$(helm template test-release "$CHART_DIR" \
+  --set 'global.imagePullSecrets[0]=wso2-registry-credentials' \
+  | grep -c -- '- name: wso2-registry-credentials' || true)"
+if [[ "$PULL_COUNT" == "2" ]]; then
+  printf 'ok   - the pull secret reaches both workflow specs\n'
+else
+  printf 'FAIL - expected the pull secret in 2 specs, found %s\n' "$PULL_COUNT"
+  FAILURES=$((FAILURES + 1))
+fi
+
 if [[ $FAILURES -gt 0 ]]; then
   printf '\nwso2-amp-evaluation-extension: %d render assertion(s) failed\n' "$FAILURES"
   exit 1

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/values.schema.json
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/values.schema.json
@@ -8,11 +8,27 @@
       "additionalProperties": false,
       "description": "Global configuration (inherited from parent chart)",
       "properties": {
+        "ampImageRegistry": {
+          "default": "",
+          "description": "Registry and organization that replaces the registry portion of the first-party AMP image repository, keeping the image name. Ignored when ampEvaluation.useLocalRegistry is true, which prefixes the in-cluster build registry instead. Deliberately not named global.imageRegistry, which Bitnami subcharts consume.",
+          "title": "ampImageRegistry",
+          "type": "string"
+        },
         "baseDomain": {
           "default": "",
           "description": "Base domain for external access",
           "title": "baseDomain",
           "type": "string"
+        },
+        "imagePullSecrets": {
+          "default": [],
+          "description": "Names of existing docker-registry secrets used to pull the evaluation image. The secrets must exist in the workflow namespace (workflows-<environment>), not this chart's release namespace, because that is where the evaluation job pod runs.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
         },
         "registry": {
           "additionalProperties": false,

--- a/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-evaluation-extension/values.yaml
@@ -6,6 +6,17 @@ global:
   # -- Base domain for external access
   baseDomain: ""
 
+  # -- Registry and organization replacing the registry portion of the
+  # first-party AMP image repository, keeping the image name. Ignored when
+  # useLocalRegistry is true. Not named imageRegistry: Bitnami subcharts
+  # consume that name.
+  ampImageRegistry: ""
+
+  # -- Names of existing docker-registry secrets used to pull the evaluation
+  # image. These must exist in the workflow namespace ("workflows-<env>"), not
+  # this chart's release namespace, because that is where the job pod runs.
+  imagePullSecrets: []
+
   # -- Container registry configuration
   registry:
     # -- Registry endpoint for pushing and pulling images

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/_helpers.tpl
@@ -75,3 +75,35 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Image reference for the observer.
+
+global.ampImageRegistry, when set, replaces the registry and organization
+portion of the repository and keeps the image name, so one value redirects the
+AMP images across all the AMP charts at a private registry. Left empty (the
+default) the fully-qualified repository is used exactly as written.
+
+Deliberately not named global.imageRegistry: that is a Bitnami convention, and
+Helm passes global values into subcharts, so the name collides wherever a
+Bitnami chart is a dependency.
+*/}}
+{{- define "amp-observability-extension.image" -}}
+{{- $repository := .Values.amObserver.image.repository -}}
+{{- with .Values.global.ampImageRegistry -}}
+{{- $repository = printf "%s/%s" (trimSuffix "/" .) (base $repository) -}}
+{{- end -}}
+{{- printf "%s:%s" $repository (.Values.amObserver.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+
+{{/*
+Image pull secrets
+*/}}
+{{- define "amp-observability-extension.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/templates/deployment.yaml
@@ -32,13 +32,16 @@ spec:
         app: amp-observer
         app.kubernetes.io/component: observer
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      {{- include "amp-observability-extension.imagePullSecrets" . | trim | nindent 6 }}
+      {{- end }}
       containers:
         - name: observer
           # if developmentMode is true, use latest image for easier debugging
           {{- if .Values.amObserver.developmentMode }}
           image: amp-observer:0.0.0-dev
           {{- else }}
-          image: {{ .Values.amObserver.image.repository }}:{{ .Values.amObserver.image.tag }}
+          image: {{ include "amp-observability-extension.image" . }}
           {{- end }}
           imagePullPolicy: {{ .Values.amObserver.image.pullPolicy }}
           ports:

--- a/deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh
+++ b/deployments/helm-charts/wso2-amp-observability-extension/tests/render.sh
@@ -91,6 +91,70 @@ assert_env "a stray comma in the audience does not produce an empty entry" \
   --set amObserver.publicUrl=https://traces.example.com \
   --set 'amObserver.auth.audience=amp\,'
 
+# --- global.ampImageRegistry / global.imagePullSecrets -----------------------
+# A private-registry install needs both: the image redirected, and a pull secret
+# on the pod. Neither is visible from a default `helm template`.
+
+# rendered_field <awk-pattern> [helm --set args...] -> first matching field value
+observer_image() {
+  local rendered
+  if ! rendered="$(helm template test-release "$CHART_DIR" "$@" 2>&1)"; then
+    printf 'helm template failed: %s\n' "$rendered" >&2
+    return 1
+  fi
+  awk '$1 == "-" && $2 == "name:" && $3 == "observer" { f = 1; next }
+       f && $1 == "image:" { gsub(/^"|"$/, "", $2); print $2; exit }' <<<"$rendered"
+}
+
+assert_image() {
+  local label="$1" expected="$2"
+  shift 2
+  local actual
+  actual="$(observer_image "$@")"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   - %s\n' "$label"
+  else
+    printf 'FAIL - %s\n      expected: %q\n      actual:   %q\n' "$label" "$expected" "$actual"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+APP_VERSION="$(awk '/^appVersion:/ {gsub(/"/, "", $2); print $2}' "$CHART_DIR/Chart.yaml")"
+IMAGE_TAG="$(awk '/^  *tag:/ {gsub(/"/, "", $2); print $2; exit}' "$CHART_DIR/values.yaml")"
+: "${IMAGE_TAG:=$APP_VERSION}"
+
+assert_image "default keeps the public observer repository" \
+  "ghcr.io/wso2/amp-observer:${IMAGE_TAG}"
+assert_image "override redirects the observer image" \
+  "registry.example.com/my-org/amp-observer:${IMAGE_TAG}" \
+  --set global.ampImageRegistry=registry.example.com/my-org
+assert_image "a trailing slash does not double up" \
+  "registry.example.com/my-org/amp-observer:${IMAGE_TAG}" \
+  --set global.ampImageRegistry=registry.example.com/my-org/
+# developmentMode deliberately bypasses the registry: it uses a locally built
+# image, so redirecting it at a remote registry would break local debugging.
+assert_image "developmentMode is not redirected" \
+  "amp-observer:0.0.0-dev" \
+  --set amObserver.developmentMode=true \
+  --set global.ampImageRegistry=registry.example.com/my-org
+
+# The pod must carry no imagePullSecrets key at all by default: an empty one is
+# a rendered zero value that GitOps diffs pick up on every existing install.
+if helm template test-release "$CHART_DIR" | grep -q "imagePullSecrets"; then
+  printf 'FAIL - default render should not mention imagePullSecrets\n'
+  FAILURES=$((FAILURES + 1))
+else
+  printf 'ok   - default render omits imagePullSecrets entirely\n'
+fi
+if helm template test-release "$CHART_DIR" \
+     --set 'global.imagePullSecrets[0]=wso2-registry-credentials' \
+   | grep -A1 'imagePullSecrets:' | grep -q -- '- name: wso2-registry-credentials'; then
+  printf 'ok   - a configured pull secret reaches the pod spec\n'
+else
+  printf 'FAIL - a configured pull secret did not reach the pod spec\n'
+  FAILURES=$((FAILURES + 1))
+fi
+
 if ((FAILURES > 0)); then
   printf '\n%d assertion(s) failed\n' "$FAILURES"
   exit 1

--- a/deployments/helm-charts/wso2-amp-observability-extension/values.schema.json
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.schema.json
@@ -277,6 +277,55 @@
       "title": "amObserver",
       "type": "object"
     },
+    "global": {
+      "additionalProperties": false,
+      "description": "Values shared with the other AMP charts",
+      "properties": {
+        "ampImageRegistry": {
+          "default": "",
+          "description": "Registry and organization that replaces the registry portion of the first-party AMP image repository, keeping the image name. Set this to pull the observer image from a private registry (e.g. registry.example.com/my-org). Empty leaves image.repository exactly as configured. Deliberately not named global.imageRegistry, which Bitnami subcharts consume.",
+          "title": "ampImageRegistry",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "default": [],
+          "description": "Secrets used to pull images from a private registry",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "networkPolicy": {
+      "additionalProperties": false,
+      "description": "Network restrictions applied to the pods this chart runs.",
+      "properties": {
+        "otelCollector": {
+          "additionalProperties": false,
+          "description": "Traffic the collector is allowed to accept.",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "No-op on clusters whose CNI doesn't enforce NetworkPolicy.",
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "otelCollector",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "networkPolicy",
+      "type": "object"
+    },
     "otelCollector": {
       "additionalProperties": false,
       "description": "OpenTelemetry collector extras",
@@ -323,30 +372,6 @@
       },
       "required": [],
       "title": "otelCollector",
-      "type": "object"
-    },
-    "networkPolicy": {
-      "additionalProperties": false,
-      "description": "Network restrictions applied to the pods this chart runs.",
-      "properties": {
-        "otelCollector": {
-          "additionalProperties": false,
-          "description": "Traffic the collector is allowed to accept.",
-          "properties": {
-            "enabled": {
-              "default": true,
-              "description": "No-op on clusters whose CNI doesn't enforce NetworkPolicy.",
-              "title": "enabled",
-              "type": "boolean"
-            }
-          },
-          "required": [],
-          "title": "otelCollector",
-          "type": "object"
-        }
-      },
-      "required": [],
-      "title": "networkPolicy",
       "type": "object"
     }
   }

--- a/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
+++ b/deployments/helm-charts/wso2-amp-observability-extension/values.yaml
@@ -1,3 +1,7 @@
+global:
+  imagePullSecrets: []
+  ampImageRegistry: ""
+
 # Agent Manager Observer Service config
 amObserver:
   enabled: true

--- a/deployments/quick-start/install-helpers.sh
+++ b/deployments/quick-start/install-helpers.sh
@@ -14,6 +14,23 @@ VERSION="${VERSION:-0.0.0-dev}"
 # Helm chart registry and versions
 HELM_CHART_REGISTRY="${HELM_CHART_REGISTRY:-ghcr.io/wso2}"
 
+# Registry authentication helpers: the single source of truth for the registry
+# host, the pull-secret name and the helm flags a private-registry install
+# needs. Resolved the same two ways as DEPLOYMENTS_DIR in install.sh — one level
+# up in a repo checkout, flat alongside in the dev-container image.
+_amp_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for _candidate in \
+    "${DEPLOYMENTS_DIR:-}/scripts/lib-registry-auth.sh" \
+    "${_amp_lib_dir}/../scripts/lib-registry-auth.sh" \
+    "${_amp_lib_dir}/scripts/lib-registry-auth.sh"; do
+    if [[ -n "$_candidate" && -f "$_candidate" ]]; then
+        # shellcheck source=../scripts/lib-registry-auth.sh
+        source "$_candidate"
+        break
+    fi
+done
+unset _amp_lib_dir _candidate
+
 # Chart names
 AMP_CHART_NAME="wso2-agent-manager"
 OBSERVABILITY_CHART_NAME="wso2-amp-observability-extension"
@@ -61,6 +78,20 @@ if [[ -z "${GATEWAY_HELM_ARGS+x}" ]]; then
 fi
 if [[ -z "${CP_HELM_ARGS+x}" ]]; then
     CP_HELM_ARGS=()
+fi
+
+# A private-registry install has to tell each chart that runs a first-party
+# image where to pull it from and which pull secret to use. amp_pull_secret_helm_args
+# prints nothing for a public install, so these arrays are left untouched there
+# and every existing helm invocation stays byte-identical.
+if declare -F amp_pull_secret_helm_args >/dev/null 2>&1; then
+    while IFS= read -r _reg_arg; do
+        [[ -n "$_reg_arg" ]] || continue
+        AMP_HELM_ARGS+=("$_reg_arg")
+        OBSERVABILITY_HELM_ARGS+=("$_reg_arg")
+        EVALUATION_HELM_ARGS+=("$_reg_arg")
+    done < <(amp_pull_secret_helm_args)
+    unset _reg_arg
 fi
 
 # Timeouts (in seconds)
@@ -152,6 +183,28 @@ install_amp_helm_chart() {
 # ============================================================================
 
 # Install Agent Management Platform
+# Create the image pull secret in every namespace that runs a first-party image.
+# A no-op for a public install. Called before the first chart install, because a
+# secret that arrives after the pod does still leaves it in ImagePullBackOff.
+#
+# The evaluation job is the reason workflows-default is here: its pod runs in the
+# workflow namespace, not the chart's release namespace.
+install_registry_credentials() {
+    if ! declare -F amp_registry_is_private >/dev/null 2>&1; then
+        return 0
+    fi
+    if ! amp_registry_is_private; then
+        return 0
+    fi
+    log_info "Creating image pull secret for $(amp_registry_host)..."
+    if amp_create_pull_secret "${AMP_NS}" "${OBSERVABILITY_NS}" "workflows-default"; then
+        log_success "Image pull secret created"
+        return 0
+    fi
+    log_error "Failed to create the image pull secret"
+    return 1
+}
+
 install_agent_management_platform() {
     local chart_ref="oci://${HELM_CHART_REGISTRY}/${AMP_CHART_NAME}"
     local chart_version="${VERSION}"
@@ -265,7 +318,7 @@ install_default_env_thunder() {
     if [[ -n "${DEPLOYMENTS_DIR:-}" && -f "${bundled_script}" ]]; then
         script_path="${bundled_script}"
     else
-        local script_url="https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts/add-environment-thunder.sh"
+        local script_url="${AMP_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts}/add-environment-thunder.sh"
         tmp_script="$(mktemp)"
         if ! curl -fsSL --connect-timeout 30 "${script_url}" -o "${tmp_script}" 2>/dev/null; then
             echo "Failed to download add-environment-thunder.sh from ${script_url}"

--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -622,11 +622,39 @@ if k3d cluster list 2>/dev/null | grep -q "${CLUSTER_NAME}"; then
         exit 1
     }
     log_success "Using existing cluster"
+    # k3d writes the node's registries.yaml at creation time only, so a re-run
+    # against an existing cluster cannot add it. That file is the only mechanism
+    # covering images pulled into namespaces OpenChoreo creates later, so say so
+    # rather than letting agent deploys fail with no explanation.
+    if declare -F amp_registry_is_private >/dev/null 2>&1 && amp_registry_is_private; then
+        log_warning "Reusing an existing cluster: its node has no registry credentials."
+        log_warning "Agent image pulls will fail. Delete the cluster and re-run to add them."
+    fi
 else
     log_info "Creating k3d cluster..."
 
     # Create shared directory for OpenChoreo
     mkdir -p /tmp/k3d-shared
+
+    # A private registry needs credentials inside the node: its containerd sees
+    # neither the host's docker config nor a namespace's imagePullSecrets for the
+    # namespaces OpenChoreo creates later. k3d writes registries.config through to
+    # the node's registries.yaml verbatim, so append the auth block there.
+    # Written to a 0600 temp file because it contains the registry token; the
+    # credential still ends up in the node's /etc/rancher/k3s/registries.yaml.
+    if declare -F amp_registry_is_private >/dev/null 2>&1 && amp_registry_is_private; then
+        log_info "Adding registry credentials to the k3d node configuration..."
+        _k3d_config_with_auth="$(mktemp)"
+        chmod 600 "${_k3d_config_with_auth}"
+        if ! { cat "${K3D_CONFIG}"; amp_registries_yaml_fragment; } > "${_k3d_config_with_auth}"; then
+            rm -f "${_k3d_config_with_auth}"
+            log_error "Failed to render the k3d registry credentials"
+            exit 1
+        fi
+        K3D_CONFIG="${_k3d_config_with_auth}"
+        # Remove it as soon as the cluster is up; k3d has copied the content in.
+        trap 'rm -f "${_k3d_config_with_auth:-}"' EXIT
+    fi
 
     # Create k3d cluster
     if k3d cluster create --config "${K3D_CONFIG}"; then
@@ -1508,6 +1536,10 @@ log_step "Step 12/13: Installing WSO2 AMP Thunder Extension"
 
 log_info "Installing WSO2 AMP Thunder Extension..."
 log_info "Gateway API CRDs and Gateway Operator are now available"
+if ! install_registry_credentials; then
+    exit 1
+fi
+
 if ! install_amp_thunder_extension; then
     log_warning "AMP Thunder Extension installation failed (non-fatal)"
     echo "The installation will continue but thunder extension features may not work."
@@ -1604,7 +1636,7 @@ if ! install_default_env_thunder; then
     if [[ -f "${env_thunder_script}" ]]; then
         echo "  bash ${env_thunder_script}"
     else
-        env_thunder_base="https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts"
+        env_thunder_base="${AMP_SCRIPT_BASE_URL:-https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts}"
         echo "  SCRIPT_BASE_URL=${env_thunder_base} \\"
         echo "  bash <(curl -fsSL ${env_thunder_base}/add-environment-thunder.sh)"
     fi

--- a/deployments/quick-start/start.sh
+++ b/deployments/quick-start/start.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # Stamped to the release version at build time (see .github/scripts/update-install-helpers.sh
 # for the equivalent 0.0.0-dev -> version substitution pattern applied to this file).
 DEFAULT_VERSION="0.0.0-dev"
-IMAGE="${QUICK_START_IMAGE:-ghcr.io/wso2/amp-quick-start}"
+IMAGE="${QUICK_START_IMAGE:-${AMP_IMAGE_REGISTRY:-ghcr.io/wso2}/amp-quick-start}"
 
 log() { printf '\033[0;34m[start]\033[0m %s\n' "$*"; }
 warn() { printf '\033[0;33m[start] WARNING:\033[0m %s\n' "$*" >&2; }
@@ -64,9 +64,53 @@ case "$ARCH" in
   *) warn "Unrecognized architecture '${ARCH}' — the quick-start image is published for amd64/arm64 only" ;;
 esac
 
+# This image is pulled by the HOST's Docker daemon, so it needs credentials of
+# its own: a cluster-side pull secret does not apply, and the cryptic
+# "denied: requested access to the resource is denied" is what a missing login
+# looks like. Kept self-contained rather than sourcing
+# deployments/scripts/lib-registry-auth.sh, because start.sh is fetched and run
+# as a standalone release asset with no siblings on disk.
+REGISTRY_PREFIX="${AMP_IMAGE_REGISTRY:-ghcr.io/wso2}"
+if [[ "$REGISTRY_PREFIX" != "ghcr.io/wso2" ]]; then
+  REGISTRY_HOST="${REGISTRY_PREFIX%%/*}"
+  if [[ -n "${AMP_REGISTRY_USERNAME:-}" && -n "${AMP_REGISTRY_PASSWORD:-}" ]]; then
+    log "Authenticating to ${REGISTRY_HOST}"
+    printf '%s' "$AMP_REGISTRY_PASSWORD" \
+      | docker login "$REGISTRY_HOST" -u "$AMP_REGISTRY_USERNAME" --password-stdin >/dev/null \
+      || die "docker login to ${REGISTRY_HOST} failed. Check AMP_REGISTRY_USERNAME and AMP_REGISTRY_PASSWORD."
+  else
+    log "Using the Docker credentials already on this host for ${REGISTRY_HOST}"
+    log "If the pull is denied, run: docker login ${REGISTRY_HOST}"
+  fi
+fi
+
 log "Starting quick-start dev container (${IMAGE}:v${VERSION})"
 log "Run ./install.sh from the container shell to install the platform (~15-20 minutes)."
+# install.sh runs inside the container and reads these, so a private-registry
+# install has to carry them across. Without this the container defaulted back to
+# the public registry and installed charts with no pull secret at all.
+#
+# A credentials file is mounted read-only rather than passed as environment,
+# because `docker inspect` shows a container's environment to anyone who can
+# reach the daemon.
+DOCKER_ARGS=()
+if [[ "$REGISTRY_PREFIX" != "ghcr.io/wso2" ]]; then
+  DOCKER_ARGS+=(-e "AMP_IMAGE_REGISTRY=${REGISTRY_PREFIX}")
+  if [[ -n "${AMP_REGISTRY_CREDENTIALS_FILE:-}" && -f "${AMP_REGISTRY_CREDENTIALS_FILE}" ]]; then
+    DOCKER_ARGS+=(-v "${AMP_REGISTRY_CREDENTIALS_FILE}:/run/amp-registry.creds:ro"
+                  -e "AMP_REGISTRY_CREDENTIALS_FILE=/run/amp-registry.creds")
+  elif [[ -n "${AMP_REGISTRY_USERNAME:-}" && -n "${AMP_REGISTRY_PASSWORD:-}" ]]; then
+    warn "Passing registry credentials as container environment variables; 'docker inspect' will show them. Set AMP_REGISTRY_CREDENTIALS_FILE to mount a file instead."
+    DOCKER_ARGS+=(-e "AMP_REGISTRY_USERNAME=${AMP_REGISTRY_USERNAME}"
+                  -e "AMP_REGISTRY_PASSWORD=${AMP_REGISTRY_PASSWORD}")
+  fi
+  if [[ "${AMP_REGISTRY_ALLOW_INSECURE:-false}" == "true" ]]; then
+    DOCKER_ARGS+=(-e "AMP_REGISTRY_ALLOW_INSECURE=true")
+  fi
+fi
+
 exec docker run --rm -it --name amp-quick-start \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --network=host \
+  ${DOCKER_ARGS[@]+"${DOCKER_ARGS[@]}"} \
   "${IMAGE}:v${VERSION}"

--- a/deployments/scripts/add-environment.sh
+++ b/deployments/scripts/add-environment.sh
@@ -142,7 +142,7 @@ case "$IDP_SKIP_TLS_VERIFY" in
         ;;
 esac
 
-CHART_REF="oci://ghcr.io/wso2/wso2-amp-api-platform-gateway-extension"
+CHART_REF="${CHART_REF:-oci://ghcr.io/wso2/wso2-amp-api-platform-gateway-extension}"
 
 # GATEWAY_CHART: optional path or ref to an alternative chart (e.g. a private OCI registry
 # or a tarball). When unset, the published OCI chart at CHART_REF is used.
@@ -230,6 +230,30 @@ else
   unset _ams_auth_lib_url _ams_auth_lib_tmp
 fi
 
+# Load the shared registry auth helpers (deployments/scripts/lib-registry-auth.sh)
+# so a private-registry environment gets its image pull secret. Optional, unlike
+# the two libs above: a public install needs nothing from it, so a missing or
+# unreachable copy must not block adding an environment. Only fetched when a
+# registry is actually configured, to avoid a pointless network call.
+if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "$(dirname "${BASH_SOURCE[0]}")/lib-registry-auth.sh" ]; then
+  # shellcheck source=lib-registry-auth.sh
+  source "$(dirname "${BASH_SOURCE[0]}")/lib-registry-auth.sh"
+elif [ -n "${AMP_IMAGE_REGISTRY:-}" ]; then
+  # Deliberately not fetched over the network. This helper handles registry
+  # credentials, so sourcing a copy pulled from a configurable URL would execute
+  # unverified code in the very context that holds them. A private-registry
+  # install runs from the extracted release bundle, where this file sits next to
+  # this script, so require it rather than downloading a substitute.
+  #
+  # Fatal, not a warning: without it amp_create_pull_secret never runs, the
+  # environment comes up with no pull secret in its workflow namespace, and the
+  # first evaluation run fails to pull with nothing pointing back to here.
+  echo "❌ AMP_IMAGE_REGISTRY is set, but lib-registry-auth.sh was not found next" >&2
+  echo "   to this script. Run add-environment.sh from the extracted release" >&2
+  echo "   bundle so the image pull secret can be created in workflows-${ENV_NAME}." >&2
+  exit 1
+fi
+
 echo "=== Adding Environment: ${DISPLAY_NAME} (${ENV_NAME}) ==="
 echo ""
 
@@ -243,6 +267,22 @@ if ! kubectl version > /dev/null 2>&1; then
     echo "     - give your user a context:"
     echo "         sudo k3d kubeconfig merge amp-local --kubeconfig-merge-default --kubeconfig-switch-context"
     exit 1
+fi
+
+# A private-registry environment needs the image pull secret in the namespace
+# OpenChoreo runs THIS environment's evaluation workflows in ("workflows-<env>"),
+# because the evaluation job's pod runs there rather than in the extension
+# chart's release namespace. The chart references the secret but does not create
+# it, so each new environment needs its own copy. Idempotent, and a no-op for a
+# public install.
+if declare -F amp_registry_is_private >/dev/null 2>&1 && amp_registry_is_private; then
+    echo "⏳ Creating image pull secret in workflows-${ENV_NAME}..."
+    if amp_create_pull_secret "workflows-${ENV_NAME}"; then
+        echo "✅ Image pull secret created in workflows-${ENV_NAME}"
+    else
+        echo "❌ Failed to create the image pull secret in workflows-${ENV_NAME}" >&2
+        exit 1
+    fi
 fi
 
 # --- Step 0: Verify Agent Manager is reachable ---

--- a/deployments/scripts/lib-registry-auth.sh
+++ b/deployments/scripts/lib-registry-auth.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# Registry authentication helpers — the SINGLE source of truth for how the
+# installers name the image registry and turn registry credentials into the
+# artifacts an image pull needs. Meant to be sourced, not executed directly.
+#
+# Why this is one file: the registry host has to appear in three unrelated
+# places — a `docker login` on the host, a containerd `configs:` entry inside
+# the k3d node, and a kubernetes.io/dockerconfigjson Secret in every namespace
+# that runs a first-party image. Getting them out of step does not fail loudly:
+# a secret scoped to a different host than the image tag is simply ignored, the
+# pull falls back to anonymous and 401s. So the host is derived here once and
+# never spelled out again.
+#
+# Credentials are read from the environment or a file, or prompted for. They are
+# deliberately NOT accepted as command-line arguments: argv is readable by every
+# user on the host through ps, and lands in shell history.
+
+# Registry prefix (host and organization/project) the first-party AMP images are
+# pulled from. Matches the charts' global.ampImageRegistry.
+AMP_PUBLIC_IMAGE_REGISTRY="ghcr.io/wso2"
+AMP_IMAGE_REGISTRY="${AMP_IMAGE_REGISTRY:-$AMP_PUBLIC_IMAGE_REGISTRY}"
+
+# Name of the docker-registry Secret the installers create and the charts
+# reference. One name everywhere, so a chart value and a kubectl invocation in a
+# different script cannot disagree.
+AMP_REGISTRY_SECRET_NAME="${AMP_REGISTRY_SECRET_NAME:-wso2-registry-credentials}"
+
+# amp_registry_host -> the registry hostname alone, without the organization.
+# `docker login`, the containerd configs: key and --docker-server all key on the
+# host; the organization belongs only in the image reference. Keeps any port.
+amp_registry_host() {
+    printf '%s' "${AMP_IMAGE_REGISTRY%%/*}"
+}
+
+# amp_registry_is_private -> true when images come from somewhere other than the
+# public registry, which is what makes credentials and a pull secret necessary.
+amp_registry_is_private() {
+    [ "$AMP_IMAGE_REGISTRY" != "$AMP_PUBLIC_IMAGE_REGISTRY" ]
+}
+
+# amp_registry_verify_tls
+# Confirm the registry answers over HTTPS with a certificate this host already
+# trusts, before any credential is sent to it.
+#
+# This cannot be left to docker. A daemon configured with insecure-registries
+# will send the token to a plain-HTTP endpoint without complaint, and
+# AMP_IMAGE_REGISTRY is operator-supplied, so the check belongs here.
+#
+# Any HTTP status at all means the handshake succeeded and the chain verified —
+# 401 is the expected answer from an authenticated registry. curl reports 000
+# when TLS itself failed.
+#
+# AMP_REGISTRY_ALLOW_INSECURE=true opts out, for a mirror deliberately served
+# over plain HTTP on a trusted network.
+amp_registry_verify_tls() {
+    if [ "${AMP_REGISTRY_ALLOW_INSECURE:-false}" = "true" ]; then
+        return 0
+    fi
+    local host code
+    host="$(amp_registry_host)"
+    code="$(curl -sS -o /dev/null --max-time 15 -w '%{http_code}' "https://${host}/v2/" 2>/dev/null || true)"
+    case "$code" in
+        [1-5][0-9][0-9]) return 0 ;;
+    esac
+    echo "❌ ${host} did not answer over HTTPS with a trusted certificate." >&2
+    echo "   Refusing to send registry credentials in cleartext." >&2
+    echo "   Set AMP_REGISTRY_ALLOW_INSECURE=true only if that is intended." >&2
+    return 1
+}
+
+# amp_registry_load_credentials
+# Populates AMP_REGISTRY_USERNAME / AMP_REGISTRY_PASSWORD from, in order:
+#   1. the environment, when already set
+#   2. AMP_REGISTRY_CREDENTIALS_FILE, a KEY=value file (expected mode 600)
+#   3. an interactive prompt, when stdin is a terminal
+# Returns non-zero when it cannot obtain both without a terminal, so a
+# non-interactive install fails with a clear message instead of hanging.
+amp_registry_load_credentials() {
+    local file="${AMP_REGISTRY_CREDENTIALS_FILE:-}"
+
+    if [ -n "$file" ] && { [ -z "${AMP_REGISTRY_USERNAME:-}" ] || [ -z "${AMP_REGISTRY_PASSWORD:-}" ]; }; then
+        if [ ! -f "$file" ]; then
+            echo "❌ Registry credentials file not found: $file" >&2
+            return 1
+        fi
+        # Warn rather than refuse: the file may be on a filesystem that cannot
+        # represent modes, but a world-readable credential is worth saying out loud.
+        local mode
+        mode="$(stat -f '%OLp' "$file" 2>/dev/null || stat -c '%a' "$file" 2>/dev/null || echo '')"
+        case "$mode" in
+            ''|600|400) ;;
+            *) echo "⚠️  $file is mode $mode; 600 is expected for a credentials file" >&2 ;;
+        esac
+        # Parsed, never sourced: a credentials file must not be able to run code.
+        # IFS='=' with two targets keeps any '=' inside the password intact.
+        local key value
+        while IFS='=' read -r key value || [ -n "$key" ]; do
+            case "$key" in
+                AMP_REGISTRY_USERNAME) [ -n "${AMP_REGISTRY_USERNAME:-}" ] || AMP_REGISTRY_USERNAME="${value%$'\r'}" ;;
+                AMP_REGISTRY_PASSWORD) [ -n "${AMP_REGISTRY_PASSWORD:-}" ] || AMP_REGISTRY_PASSWORD="${value%$'\r'}" ;;
+            esac
+        done < "$file"
+    fi
+
+    if [ -z "${AMP_REGISTRY_USERNAME:-}" ]; then
+        if [ -t 0 ]; then
+            printf 'Registry username for %s: ' "$(amp_registry_host)" >&2
+            IFS= read -r AMP_REGISTRY_USERNAME
+        else
+            echo "❌ No registry username. Set AMP_REGISTRY_USERNAME or AMP_REGISTRY_CREDENTIALS_FILE." >&2
+            return 1
+        fi
+    fi
+
+    if [ -z "${AMP_REGISTRY_PASSWORD:-}" ]; then
+        if [ -t 0 ]; then
+            # read -s so the token never reaches the terminal or a transcript.
+            printf 'Registry token for %s: ' "$(amp_registry_host)" >&2
+            IFS= read -rs AMP_REGISTRY_PASSWORD
+            printf '\n' >&2
+        else
+            echo "❌ No registry token. Set AMP_REGISTRY_PASSWORD or AMP_REGISTRY_CREDENTIALS_FILE." >&2
+            return 1
+        fi
+    fi
+
+    [ -n "${AMP_REGISTRY_USERNAME:-}" ] && [ -n "${AMP_REGISTRY_PASSWORD:-}" ] || return 1
+
+    # Checked here rather than in one caller, because this is the single point
+    # every credential-emitting path goes through: the docker login, the
+    # dockerconfigjson Secret, and the containerd fragment. Guarding only the
+    # login would have left the other two sending the token unchecked.
+    amp_registry_verify_tls
+}
+
+# _amp_yaml_escape <value> -> the value safe to place inside a double-quoted
+# YAML scalar.
+#
+# Backslash first, or it would double-escape every escape added after it. Tab,
+# carriage return and line feed are escaped too: a double-quoted scalar cannot
+# carry them literally, so one in a credential would either change the value the
+# node receives or invalidate the generated k3d configuration outright.
+_amp_yaml_escape() {
+    local v="$1"
+    v="${v//\\/\\\\}"
+    v="${v//\"/\\\"}"
+    v="${v//$'\t'/\\t}"
+    v="${v//$'\r'/\\r}"
+    v="${v//$'\n'/\\n}"
+    printf '%s' "$v"
+}
+
+# amp_registry_docker_login
+# Authenticates the LOCAL docker daemon. Needed for images the host pulls
+# itself (the quick-start container) — this does NOT authenticate pulls made by
+# a cluster node, which has its own credential store.
+amp_registry_docker_login() {
+    amp_registry_load_credentials || return 1
+    printf '%s' "$AMP_REGISTRY_PASSWORD" \
+        | docker login "$(amp_registry_host)" -u "$AMP_REGISTRY_USERNAME" --password-stdin
+}
+
+# amp_create_pull_secret <namespace>...
+# Creates or updates the docker-registry Secret in each namespace. Idempotent,
+# so it is safe to re-run on an upgrade.
+amp_create_pull_secret() {
+    amp_registry_load_credentials || return 1
+    # Build the docker config here rather than letting kubectl take the token as
+    # --docker-password: argv is readable by any user on the host through ps,
+    # which is the same reason these credentials are not accepted as a flag.
+    # base64 output is alphanumeric, so neither value can break the JSON.
+    local cfg ns rc=0
+    cfg="$(mktemp)"
+    chmod 600 "$cfg"
+    if ! printf '{"auths":{"%s":{"auth":"%s"}}}' \
+        "$(amp_registry_host)" \
+        "$(printf '%s:%s' "$AMP_REGISTRY_USERNAME" "$AMP_REGISTRY_PASSWORD" | base64 | tr -d '\n')" \
+        > "$cfg"; then
+        rm -f "$cfg"
+        return 1
+    fi
+    for ns in "$@"; do
+        # Create the namespace only when absent. Several of these namespaces are
+        # owned by a Helm release or by OpenChoreo, and applying a bare Namespace
+        # over one of those would fight its ownership metadata.
+        # --ignore-not-found so an absent namespace exits zero with no output,
+        # which separates it from a real failure. Without that, a permissions or
+        # connectivity error fell through to create and surfaced as "cannot
+        # create" rather than naming what actually went wrong.
+        local found
+        if ! found="$(kubectl get namespace "$ns" --ignore-not-found -o name 2>&1)"; then
+            echo "❌ Cannot query namespace ${ns}: ${found}" >&2
+            rc=1
+            continue
+        fi
+        if [ -z "$found" ]; then
+            kubectl create namespace "$ns" >/dev/null || { rc=1; continue; }
+        fi
+        kubectl create secret generic "$AMP_REGISTRY_SECRET_NAME" \
+            --namespace "$ns" \
+            --type=kubernetes.io/dockerconfigjson \
+            --from-file=.dockerconfigjson="$cfg" \
+            --dry-run=client -o yaml | kubectl apply -f - >/dev/null || rc=1
+    done
+    rm -f "$cfg"
+    # Return the failure explicitly. Both callers test this in an `if`, which
+    # disables errexit inside the function, so the cleanup above would otherwise
+    # be the last command and report success over a Secret that was never
+    # created — leaving the pull to fail much later with nothing pointing here.
+    return "$rc"
+}
+
+# amp_registries_yaml_fragment
+# Prints the containerd `configs:` block for the k3d node's registries.yaml,
+# indented to sit inside the `registries.config: |` literal of k3d-config.yaml.
+#
+# This is the only mechanism that covers pulls into dynamically created
+# namespaces: a cluster node's containerd sees neither the host's docker config
+# nor a namespace's imagePullSecrets when the namespace did not exist at install
+# time. k3d passes registries.config through verbatim (verified against v5.8.3),
+# and the VM installer's rewrite of the mirror endpoint does not match these
+# lines, so the block survives both.
+amp_registries_yaml_fragment() {
+    amp_registry_load_credentials || return 1
+    cat <<EOF
+    configs:
+      "$(amp_registry_host)":
+        auth:
+          username: "$(_amp_yaml_escape "$AMP_REGISTRY_USERNAME")"
+          password: "$(_amp_yaml_escape "$AMP_REGISTRY_PASSWORD")"
+EOF
+}
+
+# amp_pull_secret_helm_args
+# Prints the helm flags that point a chart at the private registry, one token per
+# line so a caller can read them into an array. Prints nothing for a public
+# install, which keeps every existing invocation byte-identical.
+amp_pull_secret_helm_args() {
+    amp_registry_is_private || return 0
+    printf '%s\n' \
+        "--set" "global.ampImageRegistry=${AMP_IMAGE_REGISTRY}" \
+        "--set" "global.imagePullSecrets[0]=${AMP_REGISTRY_SECRET_NAME}"
+}

--- a/deployments/scripts/remove-environment.sh
+++ b/deployments/scripts/remove-environment.sh
@@ -122,7 +122,22 @@ if [ "${DEPROVISION_THUNDER:-true}" = "true" ]; then
     SCRIPT_BASE_URL="${SCRIPT_BASE_URL:-https://raw.githubusercontent.com/wso2/agent-manager/main/deployments/scripts}"
     THUNDER_SCRIPT_URL="${THUNDER_SCRIPT_URL:-${SCRIPT_BASE_URL}/remove-environment-thunder.sh}"
     script_tmp="$(mktemp)"
-    if curl -fsSL "${THUNDER_SCRIPT_URL}" -o "$script_tmp"; then
+    # Prefer the sibling on disk, as every other script in this directory does:
+    # in a release bundle or a checkout it is right there, and fetching it needs
+    # egress this install may not have. The URL stays the fallback for curl | bash.
+    _local_thunder_script=""
+    if [ -n "${BASH_SOURCE[0]:-}" ]; then
+        _local_thunder_script="$(dirname "${BASH_SOURCE[0]}")/remove-environment-thunder.sh"
+    fi
+    if [ -n "$_local_thunder_script" ] && [ -f "$_local_thunder_script" ]; then
+        cp "$_local_thunder_script" "$script_tmp"
+    else
+        # Non-fatal: the emptiness check below drives the same warning path the
+        # fetch failure used to, so a missing script still degrades rather than
+        # aborting the gateway removal that follows.
+        curl -fsSL "${THUNDER_SCRIPT_URL}" -o "$script_tmp" || true
+    fi
+    if [ -s "$script_tmp" ]; then
       # Forward the API URL and token already validated by this script so the
       # chained cleanup updates the same Agent Manager deployment.
       if ENV_NAME="${ENV_NAME}" ORG_NAME="${ORG_NAME}" SCRIPT_BASE_URL="${SCRIPT_BASE_URL}" \

--- a/deployments/scripts/tests/lib-registry-auth.sh
+++ b/deployments/scripts/tests/lib-registry-auth.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Unit tests for deployments/scripts/lib-registry-auth.sh.
+# Run: bash deployments/scripts/tests/lib-registry-auth.sh
+#
+# Covers the parts that are silent when wrong: the host derivation (a pull
+# secret scoped to the wrong host is ignored rather than rejected), the
+# credentials-file parser (which must not execute its input), and the public
+# default emitting no helm flags at all.
+set -uo pipefail
+
+LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/lib-registry-auth.sh"
+FAILURES=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        printf 'ok   - %s\n' "$label"
+    else
+        printf 'FAIL - %s\n      expected: %q\n      actual:   %q\n' "$label" "$expected" "$actual"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Each case runs in a subshell so one case's exports cannot leak into the next.
+host_for() { ( unset AMP_IMAGE_REGISTRY; export AMP_IMAGE_REGISTRY="$1"; . "$LIB"; amp_registry_host ); }
+
+assert_eq "public default host" "ghcr.io" "$( ( unset AMP_IMAGE_REGISTRY; . "$LIB"; amp_registry_host ) )"
+assert_eq "host is split from the organization" "registry.example.com" "$(host_for registry.example.com/my-org)"
+assert_eq "a nested project path keeps only the host" "registry.example.com" "$(host_for registry.example.com/a/b/c)"
+assert_eq "a host-only value is returned as-is" "registry.example.com" "$(host_for registry.example.com)"
+assert_eq "a port survives the split" "localhost:5000" "$(host_for localhost:5000/org)"
+
+# The public default must produce no helm flags, so every existing install
+# command stays byte-identical.
+assert_eq "public registry emits no helm args" "" \
+  "$( ( unset AMP_IMAGE_REGISTRY; . "$LIB"; amp_pull_secret_helm_args ) )"
+assert_eq "private registry emits both helm args" \
+  "--set global.ampImageRegistry=registry.example.com/my-org --set global.imagePullSecrets[0]=wso2-registry-credentials" \
+  "$( ( export AMP_IMAGE_REGISTRY=registry.example.com/my-org; . "$LIB"; amp_pull_secret_helm_args | tr '\n' ' ' | sed 's/ $//' ) )"
+# The charts take imagePullSecrets as a list of plain strings, not objects, so
+# the flag must be [0]=name. [0].name= renders an empty entry and no secret.
+assert_eq "the pull-secret flag targets a string list, not an object" \
+  "global.imagePullSecrets[0]=wso2-registry-credentials" \
+  "$( ( export AMP_IMAGE_REGISTRY=r.example.com/org; . "$LIB"; amp_pull_secret_helm_args | tail -1 ) )"
+
+# Credentials file: parsed, not sourced.
+printf 'AMP_REGISTRY_USERNAME=robot$proj+ci\nAMP_REGISTRY_PASSWORD=tok=with=equals\n' > "$TMP/creds"
+chmod 600 "$TMP/creds"
+read -r U P < <( ( export AMP_REGISTRY_ALLOW_INSECURE=true AMP_REGISTRY_CREDENTIALS_FILE="$TMP/creds"
+                   unset AMP_REGISTRY_USERNAME AMP_REGISTRY_PASSWORD
+                   . "$LIB"; amp_registry_load_credentials >/dev/null 2>&1
+                   printf '%s %s\n' "$AMP_REGISTRY_USERNAME" "$AMP_REGISTRY_PASSWORD" ) )
+assert_eq "username is read from the credentials file" 'robot$proj+ci' "$U"
+assert_eq "a password containing '=' survives parsing" "tok=with=equals" "$P"
+
+# `read` returns non-zero on a final line with no trailing newline, so a naive
+# loop drops it — and the dropped one is whichever the operator wrote last.
+printf 'AMP_REGISTRY_USERNAME=u1\nAMP_REGISTRY_PASSWORD=p-no-newline' > "$TMP/nonl"
+chmod 600 "$TMP/nonl"
+assert_eq "a final line without a newline is still read" "p-no-newline" \
+  "$( ( export AMP_REGISTRY_ALLOW_INSECURE=true AMP_REGISTRY_CREDENTIALS_FILE="$TMP/nonl"
+        unset AMP_REGISTRY_USERNAME AMP_REGISTRY_PASSWORD
+        . "$LIB"; amp_registry_load_credentials >/dev/null 2>&1
+        printf '%s' "$AMP_REGISTRY_PASSWORD" ) )"
+
+# The containerd fragment puts these into double-quoted YAML scalars, so a
+# password containing a quote or a backslash would either break the document or
+# silently reach the node altered. Asserted one character at a time: a combined
+# case is unreadable through two layers of shell quoting.
+frag_password() {
+  ( export AMP_REGISTRY_ALLOW_INSECURE=true AMP_IMAGE_REGISTRY=registry.example.com/org \
+           AMP_REGISTRY_USERNAME='u' AMP_REGISTRY_PASSWORD="$1"
+    . "$LIB"; amp_registries_yaml_fragment ) | grep 'password:'
+}
+assert_eq "a double quote is escaped for YAML" \
+  '          password: "a\"b"' "$(frag_password 'a"b')"
+assert_eq "a backslash is doubled for YAML" \
+  '          password: "a\\b"' "$(frag_password 'a\b')"
+
+# A double-quoted YAML scalar cannot carry these literally: one in a credential
+# would change the value the node receives, or invalidate the k3d config.
+assert_eq "a tab is escaped for YAML" \
+  '          password: "a\tb"' "$(frag_password "$(printf 'a\tb')")"
+assert_eq "a carriage return is escaped for YAML" \
+  '          password: "a\rb"' "$(frag_password "$(printf 'a\rb')")"
+
+# A credentials file written on Windows leaves a trailing CR, which would
+# otherwise be an invisible character in the password that simply fails to
+# authenticate.
+printf 'AMP_REGISTRY_USERNAME=u\r\nAMP_REGISTRY_PASSWORD=p-crlf\r\n' > "$TMP/crlf"
+chmod 600 "$TMP/crlf"
+assert_eq "a CRLF credentials file yields a clean password" "p-crlf" \
+  "$( ( export AMP_REGISTRY_ALLOW_INSECURE=true AMP_REGISTRY_CREDENTIALS_FILE="$TMP/crlf"
+        unset AMP_REGISTRY_USERNAME AMP_REGISTRY_PASSWORD
+        . "$LIB"; amp_registry_load_credentials >/dev/null 2>&1
+        printf '%s' "$AMP_REGISTRY_PASSWORD" ) )"
+
+
+# A credentials file must never be able to run code.
+printf 'AMP_REGISTRY_USERNAME=safe\nAMP_REGISTRY_PASSWORD=safe\n' > "$TMP/evil"
+printf 'touch %q/PWNED\n' "$TMP" >> "$TMP/evil"
+chmod 600 "$TMP/evil"
+( export AMP_REGISTRY_ALLOW_INSECURE=true AMP_REGISTRY_CREDENTIALS_FILE="$TMP/evil"
+  unset AMP_REGISTRY_USERNAME AMP_REGISTRY_PASSWORD
+  . "$LIB"; amp_registry_load_credentials >/dev/null 2>&1 ) || true
+if [[ -e "$TMP/PWNED" ]]; then
+    printf 'FAIL - a credentials file executed its contents\n'
+    FAILURES=$((FAILURES + 1))
+else
+    printf 'ok   - a credentials file is parsed, not executed\n'
+fi
+
+# The environment wins over the file, so a CI secret is not silently overridden.
+assert_eq "environment credentials win over the file" "from-env" \
+  "$( ( export AMP_REGISTRY_ALLOW_INSECURE=true AMP_REGISTRY_CREDENTIALS_FILE="$TMP/creds" AMP_REGISTRY_USERNAME=from-env AMP_REGISTRY_PASSWORD=x
+        . "$LIB"; amp_registry_load_credentials >/dev/null 2>&1; printf '%s' "$AMP_REGISTRY_USERNAME" ) )"
+
+# Non-interactive and no credentials must fail, not block on a prompt.
+if ( unset AMP_REGISTRY_USERNAME AMP_REGISTRY_PASSWORD AMP_REGISTRY_CREDENTIALS_FILE
+     . "$LIB"; amp_registry_load_credentials </dev/null >/dev/null 2>&1 ); then
+    printf 'FAIL - missing credentials should fail without a terminal\n'
+    FAILURES=$((FAILURES + 1))
+else
+    printf 'ok   - missing credentials fail without a terminal\n'
+fi
+
+# The containerd fragment must sit at the indentation of the k3d config's
+# `config: |` literal, or the node's registries.yaml is malformed.
+FRAG="$( ( export AMP_REGISTRY_ALLOW_INSECURE=true AMP_IMAGE_REGISTRY=registry.example.com/my-org \
+                  AMP_REGISTRY_USERNAME='robot$proj+ci' AMP_REGISTRY_PASSWORD=tok
+           . "$LIB"; amp_registries_yaml_fragment ) )"
+assert_eq "the fragment is keyed on the host alone" '    configs:
+      "registry.example.com":
+        auth:
+          username: "robot$proj+ci"
+          password: "tok"' "$FRAG"
+
+# Both installers test amp_create_pull_secret in an `if`, which disables errexit
+# inside it, so a cleanup step as the last command would report success over a
+# Secret that was never created. Stub kubectl to fail and require a non-zero rc.
+STUB="$TMP/stub"; mkdir -p "$STUB"
+printf '#!/bin/sh\nexit 1\n' > "$STUB/kubectl"; chmod +x "$STUB/kubectl"
+if ( export PATH="$STUB:$PATH" AMP_REGISTRY_ALLOW_INSECURE=true \
+            AMP_IMAGE_REGISTRY=registry.example.com/org \
+            AMP_REGISTRY_USERNAME=u AMP_REGISTRY_PASSWORD=p
+     . "$LIB"; amp_create_pull_secret ns-a ns-b >/dev/null 2>&1 ); then
+    printf 'FAIL - a failed kubectl was reported as success\n'
+    FAILURES=$((FAILURES + 1))
+else
+    printf 'ok   - a failed secret create returns non-zero\n'
+fi
+
+# A credential must not be sent to an endpoint whose TLS this host does not
+# trust. docker cannot be relied on for that: a daemon with insecure-registries
+# configured sends it to plain HTTP without complaint.
+STUB2="$TMP/stub2"; mkdir -p "$STUB2"
+# curl reports 000 when the handshake itself failed.
+printf '#!/bin/sh\nprintf 000\nexit 35\n' > "$STUB2/curl"; chmod +x "$STUB2/curl"
+if ( export PATH="$STUB2:$PATH" AMP_IMAGE_REGISTRY=registry.example.com/org
+     . "$LIB"; amp_registry_verify_tls >/dev/null 2>&1 ); then
+    printf 'FAIL - an untrusted TLS endpoint was accepted\n'
+    FAILURES=$((FAILURES + 1))
+else
+    printf 'ok   - an untrusted TLS endpoint is refused\n'
+fi
+# 401 is what an authenticated registry answers; the handshake still verified.
+printf '#!/bin/sh\nprintf 401\nexit 22\n' > "$STUB2/curl"; chmod +x "$STUB2/curl"
+if ( export PATH="$STUB2:$PATH" AMP_IMAGE_REGISTRY=registry.example.com/org
+     . "$LIB"; amp_registry_verify_tls >/dev/null 2>&1 ); then
+    printf 'ok   - a 401 over verified TLS is accepted\n'
+else
+    printf 'FAIL - a 401 over verified TLS was refused\n'
+    FAILURES=$((FAILURES + 1))
+fi
+# The opt-out exists for a mirror deliberately served over plain HTTP.
+printf '#!/bin/sh\nprintf 000\nexit 35\n' > "$STUB2/curl"; chmod +x "$STUB2/curl"
+if ( export PATH="$STUB2:$PATH" AMP_IMAGE_REGISTRY=registry.example.com/org \
+            AMP_REGISTRY_ALLOW_INSECURE=true
+     . "$LIB"; amp_registry_verify_tls >/dev/null 2>&1 ); then
+    printf 'ok   - the explicit insecure opt-out is honoured\n'
+else
+    printf 'FAIL - the insecure opt-out did not work\n'
+    FAILURES=$((FAILURES + 1))
+fi
+
+if ((FAILURES > 0)); then
+    printf '\n%d assertion(s) failed\n' "$FAILURES"
+    exit 1
+fi
+printf '\nAll lib-registry-auth assertions passed\n'

--- a/deployments/setup/env.sh
+++ b/deployments/setup/env.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared cluster environment variables — sourced by all scripts in this directory.
 OPENCHOREO_VERSION="1.2.0"
 CLUSTER_NAME="${CLUSTER_NAME:-openchoreo-local-setup}"

--- a/deployments/setup/install-gvisor.sh
+++ b/deployments/setup/install-gvisor.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# Resolved the same way as install-kata.sh: the RuntimeClass manifest is applied
+# from the sibling k8s/ directory when this script travels with it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # install-gvisor.sh — Install gVisor (runsc) on a Linux Kubernetes node.
 #
 # Run this script directly on each node you want to use for gVisor agents.
@@ -155,7 +159,13 @@ echo ""
 echo "Next steps — from a machine with kubectl access to your cluster:"
 echo ""
 echo "  1. Apply the RuntimeClass (once per cluster):"
-echo "     kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/main/deployments/k8s/gvisor-runtimeclass.yaml"
+if [ -f "$SCRIPT_DIR/../k8s/gvisor-runtimeclass.yaml" ]; then
+    # Point at the copy already on disk: telling the reader to curl a different
+    # one invites a version mismatch with the install they just ran.
+    echo "     kubectl apply -f \"$SCRIPT_DIR/../k8s/gvisor-runtimeclass.yaml\""
+else
+    echo "     kubectl apply -f ${AMP_MANIFEST_BASE_URL:-https://raw.githubusercontent.com/wso2/agent-manager/${AMP_RELEASE_REF:-main}/deployments/k8s}/gvisor-runtimeclass.yaml"
+fi
 echo ""
 echo "  2. Label and taint this node (replace <node-name> with: kubectl get nodes):"
 echo "     kubectl label node <node-name> gvisor=true --overwrite"

--- a/deployments/setup/install-kata.sh
+++ b/deployments/setup/install-kata.sh
@@ -271,7 +271,11 @@ echo "🧩 Registering the '${KATA_RUNTIME_CLASS}' RuntimeClass..."
 if [ -f "$SCRIPT_DIR/../k8s/kata-runtimeclass.yaml" ]; then
     kubectl apply -f "$SCRIPT_DIR/../k8s/kata-runtimeclass.yaml"
 else
-    kubectl apply -f "https://raw.githubusercontent.com/wso2/agent-manager/main/deployments/k8s/kata-runtimeclass.yaml"
+    # Release-pinned, not main: a versioned install applying a manifest from the
+    # tip of main is how a cluster ends up running something the rest of the
+    # install has never been tested against. AMP_MANIFEST_BASE_URL lets a fork or
+    # an air-gapped mirror repoint this without editing the script.
+    kubectl apply -f "${AMP_MANIFEST_BASE_URL:-https://raw.githubusercontent.com/wso2/agent-manager/${AMP_RELEASE_REF:-main}/deployments/k8s}/kata-runtimeclass.yaml"
 fi
 
 echo "🏷️  Tainting the Kata node(s) so only Kata pods schedule there..."

--- a/deployments/setup/utils.sh
+++ b/deployments/setup/utils.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Util: Check if a port is in use
 #
 # On Linux a published container port is held by a root-owned docker-proxy,

--- a/deployments/vm/install-advanced.sh
+++ b/deployments/vm/install-advanced.sh
@@ -14,6 +14,10 @@
 #   sudo ./install-advanced.sh --config amp-config.env
 #   ./install-advanced.sh --init > amp-config.env      # emit annotated template
 #   sudo ./install-advanced.sh --config amp-config.env --dry-run   # validate + render only
+#
+# To install from a private image registry, set AMP_IMAGE_REGISTRY,
+# AMP_REGISTRY_USERNAME and AMP_REGISTRY_PASSWORD in the config file (see the
+# template --init writes). --dry-run reports the registry without the token.
 set -euo pipefail
 
 VM_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -44,6 +48,25 @@ print_template() {
 AMP_VERSION=                       # REQUIRED: amp/v* release tag, e.g. 1.0.0
                                    # (see github.com/wso2/agent-manager/releases)
 DOMAIN_BASE=amp.mycompany.com      # service hosts derived as <svc>.<DOMAIN_BASE>
+
+# --- Private image registry (optional) ---
+# Leave both unset to pull the AMP images from the public registry. When set, the
+# installer redirects every first-party image, gives the cluster node registry
+# credentials, and creates the image pull secret in each namespace that needs one.
+# Third-party images (OpenChoreo, cert-manager, kgateway, PostgreSQL) always come
+# from their own public registries.
+#
+# AMP_REGISTRY_PASSWORD is a live credential: keep this file mode 600, as the
+# DNS-01 provider tokens below already require. --dry-run never prints it.
+#
+# QUOTE the username if it contains a '$' — some registries name machine
+# accounts that way, e.g. robot$project+name. This file is sourced, so an
+# unquoted '$' is expanded by the
+# shell and the install fails with an unrelated "unbound variable" error (or, if
+# that name happens to be set, silently authenticates as the wrong user).
+#AMP_IMAGE_REGISTRY=registry.example.com/my-org
+#AMP_REGISTRY_USERNAME='robot$my-org+installer'
+#AMP_REGISTRY_PASSWORD=
 
 # --- TLS mode: dns01 (default) or byoc ---
 TLS_MODE=dns01
@@ -364,6 +387,18 @@ if [[ "$DRY_RUN" == "true" ]]; then
     "$AMP_HOST_CONSOLE" "$AMP_HOST_API" "$AMP_HOST_THUNDER" "$AMP_HOST_OBSERVER" \
     "$AMP_HOST_GATEWAY" "${AMP_HOST_CP:-<none>}" "$AMP_AGENTS_BASE"
   log "DRY RUN — TLS mode: ${TLS_MODE_RESOLVED}"
+  # Confirm the registry wiring without echoing the token: dry-run goes to stdout
+  # (terminal scrollback, CI logs), same reasoning as the Secret placeholders below.
+  if [[ -n "${AMP_IMAGE_REGISTRY:-}" ]]; then
+    log "DRY RUN — image registry: ${AMP_IMAGE_REGISTRY}"
+    if [[ -n "${AMP_REGISTRY_USERNAME:-}" && -n "${AMP_REGISTRY_PASSWORD:-}" ]]; then
+      printf '  credentials: user=%s token=<omitted in dry-run>\n' "$AMP_REGISTRY_USERNAME"
+    else
+      printf '  credentials: <none configured — set AMP_REGISTRY_USERNAME and AMP_REGISTRY_PASSWORD>\n'
+    fi
+  else
+    log "DRY RUN — image registry: public default"
+  fi
   log "DRY RUN — amp helm args:"; amp_helm_args
   log "DRY RUN — required cert SANs:"; cert_dns_names
   if [[ "$TLS_MODE_RESOLVED" == "byoc" ]]; then

--- a/deployments/vm/install-vm.sh
+++ b/deployments/vm/install-vm.sh
@@ -2,7 +2,8 @@
 # install-vm.sh — run ON the target VM (with sudo) to install Agent Manager.
 # Usage:
 #   sudo ./install-vm.sh --host <PUBLIC_IP> --version <amp-release> \
-#                        [--email <addr>] [--no-external-gateways]
+#                        [--email <addr>] [--no-external-gateways] \
+#                        [--registry <host/org>] [--registry-credentials <file>]
 #
 # --host: the VM's PUBLIC IPv4 address. Public URLs are derived as
 #   *.amp.<IP>.sslip.io, and a cloud VM usually can't read its own public IP
@@ -10,6 +11,12 @@
 #   SSH in).
 # --version: the amp/v* release to install (e.g. 0.15.0). Required — the charts
 #   and manifests are pulled per-release; there is no sensible default.
+#
+# --registry / --registry-credentials: install from a private image registry
+#   instead of the public default. The credentials file holds
+#   AMP_REGISTRY_USERNAME=... and AMP_REGISTRY_PASSWORD=... and should be mode
+#   600; they are read from the file rather than the command line because argv
+#   is readable by every user on the VM through ps.
 #
 # TLS is always Let's Encrypt, 443-only: certificates issue via the TLS-ALPN-01
 # challenge inside the :443 handshake, so only inbound 443 is required (no port
@@ -39,12 +46,16 @@ log() { printf '\033[0;34m[install-vm]\033[0m %s\n' "$*"; }
 die() { printf '\033[0;31m[install-vm] ERROR:\033[0m %s\n' "$*" >&2; exit 1; }
 require_value() { [[ -n "${2:-}" && "${2:-}" != --* ]] || die "$1 requires a value"; }
 
+REGISTRY_PREFIX=""
+REGISTRY_CREDENTIALS_FILE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --host) require_value "$1" "${2:-}"; VM_IP="$2"; shift 2 ;;
     --version) require_value "$1" "${2:-}"; AMP_VERSION="$2"; shift 2 ;;
     --email) require_value "$1" "${2:-}"; ACME_EMAIL="$2"; shift 2 ;;
     --no-external-gateways) EXTERNAL_GATEWAYS="false"; shift ;;
+    --registry) require_value "$1" "${2:-}"; REGISTRY_PREFIX="$2"; shift 2 ;;
+    --registry-credentials) require_value "$1" "${2:-}"; REGISTRY_CREDENTIALS_FILE="$2"; shift 2 ;;
     -h|--help) grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) die "unknown flag: $1" ;;
   esac
@@ -52,6 +63,9 @@ done
 
 [[ "$(id -u)" -eq 0 ]] || \
   die "run with sudo — this installs Docker, opens the firewall and creates the cluster: sudo $0 --host <IP> --version <release>"
+if [[ -n "${REGISTRY_CREDENTIALS_FILE:-}" && ! -r "$REGISTRY_CREDENTIALS_FILE" ]]; then
+  die "--registry-credentials file not readable: ${REGISTRY_CREDENTIALS_FILE}"
+fi
 [[ -n "$VM_IP" ]] || die "--host <PUBLIC_IP> is required (the VM's public IPv4 — sslip.io hostnames embed it)"
 [[ "$VM_IP" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || \
   die "--host must be an IPv4 address (got '${VM_IP}')"
@@ -117,6 +131,16 @@ run_install() {
   # install.sh builds chart refs + raw manifest URLs from amp/v${VERSION}; export it
   # only now, after bootstrap, so the piped installers above never saw it.
   export VERSION="$AMP_VERSION"
+
+  # Private-registry handoff: install.sh sources lib-registry-auth.sh, which reads
+  # these. Exported only when given, so a public install sees an unchanged
+  # environment and keeps its existing behaviour exactly.
+  if [[ -n "${REGISTRY_PREFIX:-}" ]]; then
+    export AMP_IMAGE_REGISTRY="$REGISTRY_PREFIX"
+  fi
+  if [[ -n "${REGISTRY_CREDENTIALS_FILE:-}" ]]; then
+    export AMP_REGISTRY_CREDENTIALS_FILE="$REGISTRY_CREDENTIALS_FILE"
+  fi
 
   # Suppress install.sh's localhost completion URLs — they are unreachable on a VM
   # (k3d ports are loopback-bound). This script prints the public sslip.io URLs below.

--- a/deployments/vm/tests/preflight.sh
+++ b/deployments/vm/tests/preflight.sh
@@ -242,7 +242,20 @@ assert_eq "platform CA cm PEM round-trips" "yes" \
 # Parse the rendered YAML for real when kubectl is available. The manual de-indent above
 # cannot tell a valid block scalar from an invalid header (an explicit indentation
 # indicator, say), so on its own it would pass on YAML that no parser accepts.
+# Having the binary is not the same as being able to use it: a CI runner can ship
+# kubectl with no usable configuration, and then every parse below returns empty
+# and these assertions fail for a reason the swallowed stderr never shows. Probe
+# the capability once with a trivial manifest, and if it does not come back, skip
+# visibly and print why rather than reporting four confusing failures.
+kubectl_probe_err="$(mktemp)"
+kubectl_can_parse=no
 if command -v kubectl >/dev/null 2>&1; then
+  probe_out="$(printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: probe\ndata:\n  k: v\n' \
+    | kubectl create --validate=false --dry-run=client -o jsonpath='{.data.k}' -f - 2>"$kubectl_probe_err" || true)"
+  [ "$probe_out" = "v" ] && kubectl_can_parse=yes
+fi
+
+if [ "$kubectl_can_parse" = "yes" ]; then
   ca_parsed="$(printf '%s\n' "$ca_cm" | kubectl create --validate=false --dry-run=client -o jsonpath='{.data.ca\.crt}' -f - 2>/dev/null || true)"
   assert_eq "platform CA cm is valid YAML" "yes" \
     "$(printf '%s' "$ca_parsed" | grep -q 'BEGIN CERTIFICATE' && echo yes || echo no)"
@@ -259,9 +272,13 @@ if command -v kubectl >/dev/null 2>&1; then
   # The byoc Secret must parse too.
   sec_type="$(render_byoc_tls_secret amp-wildcard-tls "$tmp_cert" "$tmp_key" | kubectl create --validate=false --dry-run=client -o jsonpath='{.type}' -f - 2>/dev/null || true)"
   assert_eq "byoc secret is valid YAML" "kubernetes.io/tls" "$sec_type"
+elif command -v kubectl >/dev/null 2>&1; then
+  printf 'ok   - rendered YAML parses (skipped: kubectl cannot client-dry-run here: %s)\n' \
+    "$(head -1 "$kubectl_probe_err" 2>/dev/null || echo 'no error reported')"
 else
   printf 'ok   - rendered YAML parses (skipped: kubectl not installed)\n'
 fi
+rm -f "$kubectl_probe_err"
 
 rm -f "$tmp_cert" "$tmp_key" "$tmp_c2" "$tmp_k2" "$tmp_c3" "$tmp_k3"
 

--- a/documentation/docs/guides/_partials/_amp-installation.mdx
+++ b/documentation/docs/guides/_partials/_amp-installation.mdx
@@ -632,7 +632,7 @@ Correcting it after the fact means deleting the gateway registration and re-regi
 The extension already renders an OTLP ingest route for its own gateway (`<release>-otel-restapi` in the data-plane namespace), so nothing further is needed for the default environment. The standalone manifest below targets the per-environment namespace `<org>-<env>`, which does not exist until the first agent is deployed there — apply it only if you need that variant, and only after a deployment has created the namespace:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/otel-collector-rest-api.yaml
+kubectl apply -f "${AMP_DIST}/deployments/values/otel-collector-rest-api.yaml"
 ```
 
 :::tip Verify

--- a/documentation/docs/guides/isolation-tiers/gvisor.mdx
+++ b/documentation/docs/guides/isolation-tiers/gvisor.mdx
@@ -42,6 +42,22 @@ Agent Manager builds agent images for **amd64**, and gVisor cannot emulate a for
 
 ## Set Up a gVisor Node
 
+:::note `${AMP_DIST}`
+The commands below run scripts and manifests from the release bundle. If you do
+not already have it extracted, fetch it first and point `AMP_DIST` at it — the
+same bundle the install guides use:
+
+```bash
+export VERSION="0.0.0-dev"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
+On a node-side step, extract it on that node: the installer script runs there,
+not on your workstation.
+:::
+
 ### Step 1: Add a new node to the cluster
 
 Provision a new Linux node matching the requirements above and join it to your cluster using your platform's standard mechanism (node pool / node group / `kubeadm join` / k3s agent). Leave it empty — do not schedule workloads on it yet.
@@ -59,8 +75,7 @@ Google Kubernetes Engine offers gVisor as a built-in option (**GKE Sandbox**): c
 Run the installer **on the node** as root. It downloads the `runsc` binary and containerd shim, registers the `runsc` runtime in containerd, and restarts containerd (only containerd restarts — the kubelet is unaffected):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/setup/install-gvisor.sh \
-  | sudo bash
+sudo bash "${AMP_DIST}/deployments/setup/install-gvisor.sh"
 ```
 
 The script is idempotent — safe to re-run.
@@ -94,7 +109,7 @@ From any machine with kubectl access to the cluster:
 
 ```bash
 # 1. Apply the RuntimeClass (once per cluster)
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/k8s/gvisor-runtimeclass.yaml
+kubectl apply -f "${AMP_DIST}/deployments/k8s/gvisor-runtimeclass.yaml"
 
 # 2. Label and taint the node (find the name with: kubectl get nodes)
 kubectl label node <node-name> gvisor=true --overwrite
@@ -135,14 +150,11 @@ Isolation tier is set at environment creation time. Open the **Create Environmen
 If you script environment creation directly, set the variable yourself:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/scripts/add-environment.sh \
-  -o add-environment.sh
-
 ISOLATION_TIER=gvisor \
   ENV_NAME=secure-dev \
   DISPLAY_NAME="Secure Dev" \
   AGENT_MANAGER_TOKEN=<token> \
-  bash add-environment.sh
+  bash "${AMP_DIST}/deployments/scripts/add-environment.sh"
 ```
 
 The tier appears as a **Sandboxing T2** shield chip in the environment list, and as a shield icon next to the environment name on the agent's Deploy and Overview pages — hover over it to confirm *Sandboxing Tier 2 — gVisor*. Deploy or promote an agent to the environment as usual — no agent-side changes are needed.
@@ -191,7 +203,7 @@ If DNS or connectivity fails, re-run the installer in host-network passthrough m
 
 ```bash
 # on the node
-GVISOR_NETWORK_HOST=true sudo -E bash install-gvisor.sh
+GVISOR_NETWORK_HOST=true sudo -E bash "${AMP_DIST}/deployments/setup/install-gvisor.sh"
 # local k3d
 GVISOR_NETWORK_HOST=true make setup-gvisor
 ```

--- a/documentation/docs/guides/isolation-tiers/kata.mdx
+++ b/documentation/docs/guides/isolation-tiers/kata.mdx
@@ -49,6 +49,22 @@ Like gVisor, Kata uses a **dedicated node** labeled `kata=true` and tainted `kat
 
 ## Set Up a Kata Node
 
+:::note `${AMP_DIST}`
+The commands below run scripts and manifests from the release bundle. If you do
+not already have it extracted, fetch it first and point `AMP_DIST` at it — the
+same bundle the install guides use:
+
+```bash
+export VERSION="0.0.0-dev"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
+On a node-side step, extract it on that node: the installer script runs there,
+not on your workstation.
+:::
+
 ### Step 1: Add a new node to the cluster
 
 Provision a KVM-capable Linux node matching the requirements above and join it to your cluster using your platform's standard mechanism. Leave it empty.
@@ -62,10 +78,7 @@ If your platform lets you set taints at node-pool creation, apply `kata=true:NoS
 Unlike the gVisor installer (which runs on the node), the Kata installer runs from **any machine with kubectl access** and does everything through the Kubernetes API:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/setup/install-kata.sh \
-  -o install-kata.sh
-
-KATA_NODES="<node-name>" bash install-kata.sh
+KATA_NODES="<node-name>" bash "${AMP_DIST}/deployments/setup/install-kata.sh"
 ```
 
 What it does:
@@ -137,14 +150,11 @@ Isolation tier is set at environment creation time. Open the **Create Environmen
 If you script environment creation directly, set the variable yourself:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/scripts/add-environment.sh \
-  -o add-environment.sh
-
 ISOLATION_TIER=kata \
   ENV_NAME=secure-prod \
   DISPLAY_NAME="Secure Prod" \
   AGENT_MANAGER_TOKEN=<token> \
-  bash add-environment.sh
+  bash "${AMP_DIST}/deployments/scripts/add-environment.sh"
 ```
 
 The tier appears as a **Sandboxing T3** shield chip in the environment list, and as a shield icon next to the environment name on the agent's Deploy and Overview pages — hover over it to confirm *Sandboxing Tier 3 — Kata Containers*. Then deploy or promote an agent to the environment as usual.

--- a/documentation/docs/guides/on-k3d.mdx
+++ b/documentation/docs/guides/on-k3d.mdx
@@ -96,13 +96,26 @@ OpenChoreo organises its infrastructure into four planes, each handling a differ
 
 This phase installs all four with Agent Manager-specific configuration. **Estimated time: ~15-20 minutes.**
 
+### Step 0: Download the Release Bundle
+
+Download the release bundle once. Every manifest, values file and script this
+guide applies comes from it, so the install needs no further network access to
+GitHub — which also sidesteps the per-IP rate limiting that makes
+`helm --values <url>` fail with HTTP 429 behind shared or corporate NAT.
+
+```bash
+export VERSION="0.0.0-dev"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
 ### Step 1: Create k3d Cluster
 
 Create the cluster using the Agent Manager cluster configuration, which includes all required port mappings:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/quick-start/k3d-config.yaml \
-  | k3d cluster create --config=-
+k3d cluster create --config="${AMP_DIST}/deployments/quick-start/k3d-config.yaml"
 ```
 
 Set the kubectl context:
@@ -132,7 +145,7 @@ kubectl cluster-info --context k3d-amp-local
 Enables `*.openchoreo.localhost`, `*.amp.localhost`, `*.agentmanager.localhost`, `*.am-gateway.localhost`, and `*.gateway.localhost` DNS resolution inside the cluster — required for in-cluster lookups of the Console/API/Thunder hostnames as well as agent-to-agent and AI gateway traffic:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/k8s/coredns-amp-custom.yaml
+kubectl apply -f "${AMP_DIST}/deployments/k8s/coredns-amp-custom.yaml"
 ```
 
 CoreDNS's reload plugin can miss the override if the ConfigMap mounts after the pod's initial parse, so restart it to make sure the rewrite rules are active before anything depends on them:
@@ -199,7 +212,7 @@ helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
   --namespace openbao \
   --create-namespace \
   --version 0.25.6 \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/single-cluster/values-openbao.yaml \
+  --values "${AMP_DIST}/deployments/single-cluster/values-openbao.yaml" \
   --timeout 180s
 
 kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=openbao -n openbao --timeout=120s
@@ -325,7 +338,7 @@ helm install openchoreo-control-plane \
   --namespace openchoreo-control-plane \
   --create-namespace \
   --timeout 600s \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/single-cluster/values-cp.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-cp.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-control-plane --timeout=600s
@@ -395,7 +408,7 @@ helm install openchoreo-data-plane \
   --namespace openchoreo-data-plane \
   --create-namespace \
   --timeout 600s \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/single-cluster/values-dp.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-dp.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-data-plane --timeout=600s
@@ -574,7 +587,7 @@ kubectl wait -n openchoreo-observability-plane \
 Apply the custom OpenTelemetry Collector ConfigMap (required for trace ingestion):
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/values/oc-collector-configmap.yaml \
+kubectl apply -f "${AMP_DIST}/deployments/values/oc-collector-configmap.yaml" \
   -n openchoreo-observability-plane
 ```
 
@@ -587,7 +600,7 @@ helm install openchoreo-observability-plane \
   --namespace openchoreo-observability-plane \
   --create-namespace \
   --timeout 25m \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/single-cluster/values-op.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-op.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-observability-plane --timeout=300s
@@ -717,9 +730,6 @@ With OpenChoreo running, you can now install the Agent Manager components — th
 Every Environment needs its own dedicated Thunder ID instance. This is separate from the platform Thunder installed in Phase 1, which only handles console and API login. This instance is what issues each agent its own OAuth2 credential (AgentID) in that Environment. Agents can still be created without it, but they will never get an AgentID there — Agent Manager keeps retrying and failing in the background, and the API Platform Gateway Extension silently skips registering its ThunderKeyManager identity provider, so the Identity Providers page stays empty with no error anywhere in the platform. Run this once the Agent Manager API is reachable at `${API_PUBLIC_URL}`:
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/wso2/agent-manager/amp/v0.0.0-dev/deployments/scripts/add-environment-thunder.sh" \
-  -o add-environment-thunder.sh
-
 ENV_NAME=default \
 DISPLAY_NAME="Default" \
 ORG_NAME=default \
@@ -727,7 +737,7 @@ THUNDER_HANDLE=default-idp \
 AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
 IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
 THUNDER_HOST_BASE_DOMAIN="amp.localhost" \
-bash add-environment-thunder.sh
+bash "${AMP_DIST}/deployments/scripts/add-environment-thunder.sh"
 ```
 
 The script registers an unguessable handle with Agent Manager before it creates

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -109,8 +109,21 @@ Pick a base domain you control (a delegated subdomain like `amp.yourdomain.com` 
 
 Concretely: `console`/`api-amp`/`thunder`/`cp` all point at the control-plane gateway — via a single required `*.<base>` wildcard, not four separate records (per-environment Thunder hostnames are created after install and are only reachable through that wildcard) — `traces` points at the observability-plane gateway, and `*.agents.<base>` plus the `agents.<base>` apex point at the data-plane gateway. [Step 10](#step-10-publish-dns-records) lists the exact records once the LoadBalancer addresses exist.
 
+Download the release bundle first. Every manifest, values file and script this
+guide applies comes from it, so the install needs no further network access to
+GitHub — which also sidesteps the per-IP rate limiting that makes
+`helm --values <url>` fail with HTTP 429 behind shared or corporate NAT.
+
 ```bash
 export VERSION="0.0.0-dev"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
+Then the rest of the configuration:
+
+```bash
 export HELM_CHART_REGISTRY="ghcr.io/wso2"
 export AMP_NS="wso2-amp"
 export BUILD_CI_NS="openchoreo-workflow-plane"
@@ -396,7 +409,7 @@ helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
   --namespace openbao \
   --create-namespace \
   --version 0.25.6 \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-openbao.yaml \
+  --values "${AMP_DIST}/deployments/single-cluster/values-openbao.yaml" \
   --timeout 180s
 
 kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=openbao -n openbao --timeout=120s
@@ -933,7 +946,7 @@ helm install openchoreo-data-plane \
   --set "gateway.tls.certificateRefs[0].name=dp-gateway-tls" \
   --set gateway.httpPort=80 \
   --set gateway.httpsPort=443 \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-dp.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-dp.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-data-plane --timeout=600s
@@ -1145,7 +1158,7 @@ kubectl wait -n openchoreo-observability-plane \
 Apply the custom OpenTelemetry Collector ConfigMap (required for trace ingestion):
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/oc-collector-configmap.yaml \
+kubectl apply -f "${AMP_DIST}/deployments/values/oc-collector-configmap.yaml" \
   -n openchoreo-observability-plane
 ```
 
@@ -1190,7 +1203,7 @@ helm install openchoreo-observability-plane \
   --set observer.extraEnv.AUTH_SERVER_BASE_URL="${THUNDER_PUBLIC_URL}" \
   --set security.oidc.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set security.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-op.yaml \
+  --values "${AMP_DIST}/deployments/single-cluster/values-op.yaml" \
   --timeout 25m
 
 kubectl wait --for=condition=Available \
@@ -1450,11 +1463,6 @@ That needs a `*.otel.${BASE_DOMAIN}` DNS record and gateway certificate coverage
 
 Every Environment needs its own dedicated Thunder ID instance. This is separate from the platform Thunder installed in Phase 1, which only handles console and API login. This instance is what issues each agent its own OAuth2 credential (AgentID) in that Environment. Run this once for the default Environment: agents can still be created without it, but they will never get an AgentID there, since there is no Thunder instance to provision one against, and Agent Manager will keep retrying and failing in the background. Run it after Agent Manager (`amp`) is installed and reachable at `API_PUBLIC_URL`, since this step registers the generated credential with the Agent Manager API.
 
-```bash
-curl -fsSL "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts/add-environment-thunder.sh" \
-  -o add-environment-thunder.sh
-```
-
 Pick the tab matching your [Step 3](#step-3-setup-tls-issuer) issuer choice — the CA trust setting below only differs by that choice, nothing else changes.
 
 :::note Pass the platform client secret
@@ -1481,7 +1489,7 @@ PLATFORM_THUNDER_JWKS_URL="${THUNDER_PUBLIC_URL}/oauth2/jwks" \
 THUNDER_HOST_BASE_DOMAIN="${BASE_DOMAIN}" \
 TLS_ENABLED=true \
 SKIP_CA_BUNDLE_TRUST=true \
-bash add-environment-thunder.sh
+bash "${AMP_DIST}/deployments/scripts/add-environment-thunder.sh"
 ```
 
   </TabItem>
@@ -1529,7 +1537,7 @@ PLATFORM_THUNDER_JWKS_URL="${THUNDER_PUBLIC_URL}/oauth2/jwks" \
 PLATFORM_THUNDER_CA_PEM="${PLATFORM_THUNDER_CA_PEM}" \
 THUNDER_HOST_BASE_DOMAIN="${BASE_DOMAIN}" \
 TLS_ENABLED=true \
-bash add-environment-thunder.sh
+bash "${AMP_DIST}/deployments/scripts/add-environment-thunder.sh"
 ```
 
   </TabItem>

--- a/documentation/docs/reference/helm-charts/index.mdx
+++ b/documentation/docs/reference/helm-charts/index.mdx
@@ -11,11 +11,11 @@ generated from that chart's `values.schema.json`.
 
 | Chart | Purpose | Parameters |
 |---|---|---|
-| [Agent Manager](./wso2-agent-manager.mdx) | Helm chart for WSO2 Agent Management Platform - Deploy, manage, and govern AI agents at scale | 345 |
+| [Agent Manager](./wso2-agent-manager.mdx) | Helm chart for WSO2 Agent Management Platform - Deploy, manage, and govern AI agents at scale | 347 |
 | [API Platform Gateway Extension](./wso2-amp-api-platform-gateway-extension.mdx) | A Helm chart to deploy and auto-register the unified API Platform Gateway for the Agent Management Platform. | 83 |
 | [Thunder Extension](./wso2-amp-thunder-extension.mdx) | A Helm chart to add Thunder Identity Provider functionality for the Agent Management Platform. | 367 |
-| [Evaluation Extension](./wso2-amp-evaluation-extension.mdx) | A Helm chart to add Evaluation functionality for the Agent Management Platform, by Deploying and Configuring Monitor evaluation workflows. | 43 |
-| [Observability Extension](./wso2-amp-observability-extension.mdx) | A Helm chart to add Tracing functionality for the Agent Management Platform, by Deploying and Configuring the Agent Manager Observer. | 51 |
+| [Evaluation Extension](./wso2-amp-evaluation-extension.mdx) | A Helm chart to add Evaluation functionality for the Agent Management Platform, by Deploying and Configuring Monitor evaluation workflows. | 45 |
+| [Observability Extension](./wso2-amp-observability-extension.mdx) | A Helm chart to add Tracing functionality for the Agent Management Platform, by Deploying and Configuring the Agent Manager Observer. | 54 |
 | [Platform Resources Extension](./wso2-amp-platform-resources-extension.mdx) | Default platform resources for WSO2 AI Agent Management Platform on OpenChoreo | 76 |
 
 Because the pages are generated from the schema, `helm lint` and this reference cannot

--- a/documentation/docs/reference/helm-charts/wso2-agent-manager.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-agent-manager.mdx
@@ -7,7 +7,7 @@ title: Agent Manager
 Helm chart for WSO2 Agent Management Platform - Deploy, manage, and govern AI agents at scale
 
 ```bash
-helm install agent-manager oci://ghcr.io/wso2/helm-charts/wso2-agent-manager \
+helm install agent-manager oci://ghcr.io/wso2/wso2-agent-manager \
   --namespace <namespace> --create-namespace \
   --values my-values.yaml
 ```
@@ -223,6 +223,10 @@ helm install agent-manager oci://ghcr.io/wso2/helm-charts/wso2-agent-manager \
 | `console.livenessProbe` | Health checks | null | `null` |
 | `console.readinessProbe` | Readiness probe for the console. Unset uses the image default. | null | `null` |
 | `console.config` | Frontend configuration | object |  |
+| `console.config.agentManagerInternalBaseUrl` | Cluster-internal URLs the API Platform Gateway uses to reach Agent Manager when add-environment.sh installs a new gateway. The Create Environment drawer pipes these into the rendered curl\|bash command so the gateway is configured for in-cluster service discovery. | string | `"http://amp-api.wso2-amp.svc.cluster.local:9000"` |
+| `console.config.agentManagerInternalCpHost` | In-cluster address the console's server-side calls use. | string | `"amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243"` |
+| `console.config.ampVersion` | Agent Manager release version — pins the deployment-script git tag (amp/vX.Y.Z). Placeholder is substituted with the real release version by the release pipeline (.github/scripts/update-helm-charts.sh); dev builds fall back to main. | string | `"0.0.0-dev"` |
+| `console.config.apiBaseUrl` | Backend API URLs (will be auto-configured if empty) Routed through the OpenChoreo control-plane gateway (see ocIngress). | string | `"http://api.amp.localhost:8080"` |
 | `console.config.auth` | Authentication (set to "" to disable) | object |  |
 | `console.config.auth.clientId` | OAuth 2.0 client ID the console authenticates with. | string | `"amp-console-client"` |
 | `console.config.auth.baseUrl` | Identity provider the console redirects users to. | string | `"http://thunder.amp.localhost:8080"` |
@@ -233,29 +237,26 @@ helm install agent-manager oci://ghcr.io/wso2/helm-charts/wso2-agent-manager \
 | `console.config.auth.validateIDToken` | Verify the ID token signature in the browser. | string | `"false"` |
 | `console.config.auth.clockTolerance` | Clock skew tolerated when validating tokens, in seconds. | integer | `300` |
 | `console.config.disableAuth` | Disable auth for development | string | `"false"` |
-| `console.config.apiBaseUrl` | Backend API URLs (will be auto-configured if empty) Routed through the OpenChoreo control-plane gateway (see ocIngress). | string | `"http://api.amp.localhost:8080"` |
+| `console.config.docsVersion` | Documentation version the console's in-product doc links point at, used as the path segment after /docs/. "latest" tracks the newest released docs. The release pipeline (.github/scripts/update-helm-charts.sh) pins this to the matching versioned docs (vX.Y.x, or the exact version for a pre-release) for final and pre-release builds. Release candidates and nightlies keep "latest", because no docs version is cut for them. | string | `"latest"` |
+| `console.config.featureFlags` | Feature flags. | object |  |
+| `console.config.featureFlags.enablePrivateRepoSupport` | Shows the private Git repository option when building agents from source. | boolean | `true` |
+| `console.config.featureFlags.enableIdentityProviderManagedMode` | When true, identity provider management calls the REST API directly instead of rendering the self-hosted manage-identity-provider.sh script snippet. | boolean | `false` |
+| `console.config.featureFlags.enableProfileManagement` | When false, the Profile Settings text fields and Save Changes button are hidden/disabled, and the Change Password tab is disabled. | boolean | `true` |
+| `console.config.featureFlags.enableUserManagement` | When false, the Add User, Invite User, Create Role, and Create Group buttons on the Settings page are disabled. | boolean | `true` |
 | `console.config.gatewayControlPlaneUrl` | Gateway control plane URL rendered into external-gateway setup commands. Routed through the OpenChoreo control-plane gateway (see agentManagerService.ocIngress.gatewayMgmt); host.docker.internal lets a gateway container on the same machine reach it. | string | `"http://host.docker.internal:8080"` |
 | `console.config.gatewayVersion` | Gateway version for setup commands (default: v1.0.0) | string | `"v1.0.0"` |
-| `console.config.ampVersion` | Agent Manager release version — pins the deployment-script git tag (amp/vX.Y.Z). Placeholder is substituted with the real release version by the release pipeline (.github/scripts/update-helm-charts.sh); dev builds fall back to main. | string | `"0.0.0-dev"` |
-| `console.config.docsVersion` | Documentation version the console's in-product doc links point at, used as the path segment after /docs/. "latest" tracks the newest released docs. The release pipeline (.github/scripts/update-helm-charts.sh) pins this to the matching versioned docs (vX.Y.x, or the exact version for a pre-release) for final and pre-release builds. Release candidates and nightlies keep "latest", because no docs version is cut for them. | string | `"latest"` |
-| `console.config.instrumentationUrl` | Trace-export URL shown to external agent developers. kgateway-routed vhost — independent of the gateway runtime's namespace; no port-forward. | string | `"http://default-default.gateway.localhost:19080/otel"` |
-| `console.config.agentManagerInternalBaseUrl` | Cluster-internal URLs the API Platform Gateway uses to reach Agent Manager when add-environment.sh installs a new gateway. The Create Environment drawer pipes these into the rendered curl\|bash command so the gateway is configured for in-cluster service discovery. | string | `"http://amp-api.wso2-amp.svc.cluster.local:9000"` |
-| `console.config.agentManagerInternalCpHost` | In-cluster address the console's server-side calls use. | string | `"amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243"` |
-| `console.config.idpHostBaseDomain` | Base domain env-Thunder instances are hosted under, and whether this deployment serves them over TLS. Mirrors agentManagerService.config's own idpHostBaseDomain/tlsEnabled — kept in sync so the Create Environment drawer's rendered command matches this deployment. VM/production installs override both (see deployments/vm/lib-vm.sh). | string | `"amp.localhost"` |
-| `console.config.tlsEnabled` | Serve the console over HTTPS. | string | `"false"` |
-| `console.config.guardrailsCatalogUrl` | Guardrails catalog URL for fetching available guardrail policies | string | `"https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=AI,Guardrails&limit=50"` |
-| `console.config.guardrailsDefinitionBaseUrl` | Guardrails definition base URL for fetching policy definitions | string | `"https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies"` |
 | `console.config.guardrailCapabilities` | Guardrail capability flags — enable policies that require external system configuration. OOTB policies are always shown regardless of these flags. | object |  |
 | `console.config.guardrailCapabilities.awsBedrock` | Offer AWS Bedrock guardrails. Allowed values: Unlocks: aws-bedrock-guardrail. | boolean | `false` |
 | `console.config.guardrailCapabilities.azureContentSafety` | Offer Azure AI Content Safety guardrails. Allowed values: Unlocks: azure-content-safety-content-moderation. | boolean | `false` |
 | `console.config.guardrailCapabilities.graniteGuardian` | Offer Granite Guardian guardrails. Allowed values: Unlocks: granite-guardian-prompt-injection. | boolean | `false` |
 | `console.config.guardrailCapabilities.nemoGuard` | Offer NVIDIA NeMo Guardrails. Allowed values: Unlocks: nvidia-nemoguard-content-safety. | boolean | `false` |
 | `console.config.guardrailCapabilities.semanticGuardrails` | Offer semantic guardrails. Allowed values: Unlocks: semantic-prompt-guard, semantic-cache. | boolean | `false` |
-| `console.config.featureFlags` | Feature flags. | object |  |
-| `console.config.featureFlags.enablePrivateRepoSupport` | Shows the private Git repository option when building agents from source. | boolean | `true` |
-| `console.config.featureFlags.enableIdentityProviderManagedMode` | When true, identity provider management calls the REST API directly instead of rendering the self-hosted manage-identity-provider.sh script snippet. | boolean | `false` |
-| `console.config.featureFlags.enableProfileManagement` | When false, the Profile Settings text fields and Save Changes button are hidden/disabled, and the Change Password tab is disabled. | boolean | `true` |
-| `console.config.featureFlags.enableUserManagement` | When false, the Add User, Invite User, Create Role, and Create Group buttons on the Settings page are disabled. | boolean | `true` |
+| `console.config.guardrailsCatalogUrl` | Guardrails catalog URL for fetching available guardrail policies | string | `"https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies?categories=AI,Guardrails&limit=50"` |
+| `console.config.guardrailsDefinitionBaseUrl` | Guardrails definition base URL for fetching policy definitions | string | `"https://db720294-98fd-40f4-85a1-cc6a3b65bc9a-prod.e1-us-east-azure.choreoapis.dev/api-platform/policy-hub-api/policy-hub-public/v1.0/policies"` |
+| `console.config.idpHostBaseDomain` | Base domain env-Thunder instances are hosted under, and whether this deployment serves them over TLS. Mirrors agentManagerService.config's own idpHostBaseDomain/tlsEnabled — kept in sync so the Create Environment drawer's rendered command matches this deployment. VM/production installs override both (see deployments/vm/lib-vm.sh). | string | `"amp.localhost"` |
+| `console.config.instrumentationUrl` | Trace-export URL shown to external agent developers. kgateway-routed vhost — independent of the gateway runtime's namespace; no port-forward. | string | `"http://default-default.gateway.localhost:19080/otel"` |
+| `console.config.scriptBaseUrl` | Base URL the console's generated commands fetch deployment scripts from, without a trailing slash. Empty derives the public raw.githubusercontent.com URL from ampVersion. Set it where that host is unreachable from the operator's machine, or where this build's scripts are served from somewhere else. | string | `""` |
+| `console.config.tlsEnabled` | Serve the console over HTTPS. | string | `"false"` |
 | `console.podAnnotations` | Pod-level configurations | object | `{}` |
 | `console.podLabels` | Labels added to the pod | object | `{}` |
 | `console.podSecurityContext` | Pod security context - optional, no defaults to allow image to use its own user If you need to set fsGroup or other pod-level security settings, specify them here | object | `{}` |
@@ -290,6 +291,7 @@ helm install agent-manager oci://ghcr.io/wso2/helm-charts/wso2-agent-manager \
 | Parameter | Description | Type | Default |
 |---|---|---|---|
 | `global` | Default values for agent-management-platform | object |  |
+| `global.ampImageRegistry` | Registry and organization that replaces the registry portion of every first-party AMP image repository, keeping the image name. Set this to pull the AMP images from a private registry (e.g. registry.example.com/my-org) without overriding each image individually. Third-party subchart images (PostgreSQL) are deliberately unaffected. Empty leaves each image.repository exactly as configured. Deliberately not named global.imageRegistry, which Bitnami subcharts consume. | string | `""` |
 | `global.imagePullSecrets` | Secrets used to pull images from a private registry | array | `[]` |
 | `global.storageClass` | StorageClass applied to every chart component that needs storage | string | `""` |
 

--- a/documentation/docs/reference/helm-charts/wso2-amp-api-platform-gateway-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-api-platform-gateway-extension.mdx
@@ -7,7 +7,7 @@ title: API Platform Gateway Extension
 A Helm chart to deploy and auto-register the unified API Platform Gateway for the Agent Management Platform.
 
 ```bash
-helm install amp-api-platform-gateway-extension oci://ghcr.io/wso2/helm-charts/wso2-amp-api-platform-gateway-extension \
+helm install amp-api-platform-gateway-extension oci://ghcr.io/wso2/wso2-amp-api-platform-gateway-extension \
   --namespace <namespace> --create-namespace \
   --values my-values.yaml
 ```
@@ -37,7 +37,7 @@ helm install amp-api-platform-gateway-extension oci://ghcr.io/wso2/helm-charts/w
 | `apiGateway.controlPlane.host` | In-cluster address of the control plane. | string | `"amp-api-gateway-manager.wso2-amp.svc.cluster.local:9243"` |
 | `apiGateway.controlPlane.tls` | TLS settings for the control-plane connection. | object |  |
 | `apiGateway.controlPlane.tls.enabled` | Use TLS when connecting to the control plane. | boolean | `true` |
-| `apiGateway.controlPlane.tls.insecureSkipVerify` | Skip verification of the control plane's TLS certificate. True by default because the control plane serves a self-signed certificate in-cluster. Note: the template applies `\| default true`, and Go templates treat false as empty, so setting this to false here does not currently disable it. | boolean | `true` |
+| `apiGateway.controlPlane.tls.insecureSkipVerify` | Skip verification of the control plane's TLS certificate. True because the control plane serves a self-signed certificate in-cluster; set to false only where the gateway can trust the control plane's certificate chain. | boolean | `true` |
 | `apiGateway.config` | ConfigMap containing full Helm values for the gateway Helm chart. The gateway-operator reads this and passes it when deploying the gateway stack. | object |  |
 | `apiGateway.config.configMapName` | Name of the ConfigMap to create with gateway Helm values. Defaults to "&lt;release-name&gt;-config" if empty. | string | `""` |
 | `apiGateway.config.policyConfigurations` | Policy configurations rendered under [policy_configurations.*] in config.toml. Consumed by policies that reference $&#123;config.policy_configurations.&lt;section&gt;.&lt;key&gt;&#125;. | object |  |

--- a/documentation/docs/reference/helm-charts/wso2-amp-evaluation-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-evaluation-extension.mdx
@@ -7,7 +7,7 @@ title: Evaluation Extension
 A Helm chart to add Evaluation functionality for the Agent Management Platform, by Deploying and Configuring Monitor evaluation workflows.
 
 ```bash
-helm install amp-evaluation-extension oci://ghcr.io/wso2/helm-charts/wso2-amp-evaluation-extension \
+helm install amp-evaluation-extension oci://ghcr.io/wso2/wso2-amp-evaluation-extension \
   --namespace <namespace> --create-namespace \
   --values my-values.yaml
 ```
@@ -34,7 +34,9 @@ helm install amp-evaluation-extension oci://ghcr.io/wso2/helm-charts/wso2-amp-ev
 | Parameter | Description | Type | Default |
 |---|---|---|---|
 | `global` | Global configuration (inherited from parent chart) | object |  |
+| `global.ampImageRegistry` | Registry and organization that replaces the registry portion of the first-party AMP image repository, keeping the image name. Ignored when ampEvaluation.useLocalRegistry is true, which prefixes the in-cluster build registry instead. Deliberately not named global.imageRegistry, which Bitnami subcharts consume. | string | `""` |
 | `global.baseDomain` | Base domain for external access | string | `""` |
+| `global.imagePullSecrets` | Names of existing docker-registry secrets used to pull the evaluation image. The secrets must exist in the workflow namespace (workflows-&lt;environment&gt;), not this chart's release namespace, because that is where the evaluation job pod runs. | array | `[]` |
 | `global.registry` | Container registry configuration | object |  |
 | `global.registry.endpoint` | Registry endpoint for pushing and pulling images For local registry: "host.k3d.internal:10082" For external registry with baseDomain: automatically uses "registry.&lt;baseDomain&gt;" | string | `"host.k3d.internal:10082"` |
 

--- a/documentation/docs/reference/helm-charts/wso2-amp-observability-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-observability-extension.mdx
@@ -7,7 +7,7 @@ title: Observability Extension
 A Helm chart to add Tracing functionality for the Agent Management Platform, by Deploying and Configuring the Agent Manager Observer.
 
 ```bash
-helm install amp-observability-extension oci://ghcr.io/wso2/helm-charts/wso2-amp-observability-extension \
+helm install amp-observability-extension oci://ghcr.io/wso2/wso2-amp-observability-extension \
   --namespace <namespace> --create-namespace \
   --values my-values.yaml
 ```
@@ -57,6 +57,14 @@ helm install amp-observability-extension oci://ghcr.io/wso2/helm-charts/wso2-amp
 | `amObserver.oauth` | OAuth 2.0 discovery metadata for MCP clients (RFC 9728). Consumed by the /mcp route's protected-resource well-known endpoint. | object |  |
 | `amObserver.oauth.authorizationServers` | Comma-separated list of OAuth 2.0 authorization server URLs advertised in RFC 9728 protected resource metadata. Left empty on purpose: it defaults to auth.issuer above, which is the same authorization server. Only set it when the advertised URL must differ from the token issuer. To suppress the metadata endpoint instead, empty publicUrl — the handler checks that first, and an empty auth.issuer fails startup validation. | string | `""` |
 | `amObserver.oauth.scopesSupported` | Comma-separated list of OAuth 2.0 scopes supported by this resource, advertised in RFC 9728 protected resource metadata. | string | `"amp:observability:log-read,amp:observability:trace-read,amp:observability:metric-read,amp:observability:build-log-read"` |
+
+## global
+
+| Parameter | Description | Type | Default |
+|---|---|---|---|
+| `global` | Values shared with the other AMP charts | object |  |
+| `global.ampImageRegistry` | Registry and organization that replaces the registry portion of the first-party AMP image repository, keeping the image name. Set this to pull the observer image from a private registry (e.g. registry.example.com/my-org). Empty leaves image.repository exactly as configured. Deliberately not named global.imageRegistry, which Bitnami subcharts consume. | string | `""` |
+| `global.imagePullSecrets` | Secrets used to pull images from a private registry | array | `[]` |
 
 ## networkPolicy
 

--- a/documentation/docs/reference/helm-charts/wso2-amp-platform-resources-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-platform-resources-extension.mdx
@@ -7,7 +7,7 @@ title: Platform Resources Extension
 Default platform resources for WSO2 AI Agent Management Platform on OpenChoreo
 
 ```bash
-helm install amp-platform-resources-extension oci://ghcr.io/wso2/helm-charts/wso2-amp-platform-resources-extension \
+helm install amp-platform-resources-extension oci://ghcr.io/wso2/wso2-amp-platform-resources-extension \
   --namespace <namespace> --create-namespace \
   --values my-values.yaml
 ```

--- a/documentation/docs/reference/helm-charts/wso2-amp-thunder-extension.mdx
+++ b/documentation/docs/reference/helm-charts/wso2-amp-thunder-extension.mdx
@@ -7,7 +7,7 @@ title: Thunder Extension
 A Helm chart to add Thunder Identity Provider functionality for the Agent Management Platform.
 
 ```bash
-helm install amp-thunder-extension oci://ghcr.io/wso2/helm-charts/wso2-amp-thunder-extension \
+helm install amp-thunder-extension oci://ghcr.io/wso2/wso2-amp-thunder-extension \
   --namespace <namespace> --create-namespace \
   --values my-values.yaml
 ```

--- a/documentation/scripts/gen-helm-reference.mjs
+++ b/documentation/scripts/gen-helm-reference.mjs
@@ -14,6 +14,10 @@ import path from "node:path";
 const ROOT = path.resolve(import.meta.dirname, "..", "..");
 const CHARTS = path.join(ROOT, "deployments", "helm-charts");
 const OUT = path.join(import.meta.dirname, "..", "docs", "reference", "helm-charts");
+// Charts are published flat at oci://<registry>/<chart> (see
+// .github/scripts/package-helm-chart.sh), so the install command must carry no
+// extra path segment. Overridable so a private-registry build documents its own.
+const CHART_REGISTRY = process.env.HELM_CHART_REGISTRY || "ghcr.io/wso2";
 const CHECK = process.argv.includes("--check");
 
 const TITLES = {
@@ -79,7 +83,7 @@ for (const name of Object.keys(TITLES)) {
     `# ${TITLES[name]}`, "",
     chartDescription(name), "",
     "```bash",
-    `helm install ${name.replace("wso2-", "")} oci://ghcr.io/wso2/helm-charts/${name} \\`,
+    `helm install ${name.replace("wso2-", "")} oci://${CHART_REGISTRY}/${name} \\`,
     "  --namespace <namespace> --create-namespace \\",
     "  --values my-values.yaml",
     "```", "",

--- a/documentation/versioned_docs/version-v1.0.0/guides/_partials/_amp-installation.mdx
+++ b/documentation/versioned_docs/version-v1.0.0/guides/_partials/_amp-installation.mdx
@@ -632,7 +632,7 @@ Correcting it after the fact means deleting the gateway registration and re-regi
 The extension already renders an OTLP ingest route for its own gateway (`<release>-otel-restapi` in the data-plane namespace), so nothing further is needed for the default environment. The standalone manifest below targets the per-environment namespace `<org>-<env>`, which does not exist until the first agent is deployed there — apply it only if you need that variant, and only after a deployment has created the namespace:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/otel-collector-rest-api.yaml
+kubectl apply -f "${AMP_DIST}/deployments/values/otel-collector-rest-api.yaml"
 ```
 
 :::tip Verify

--- a/documentation/versioned_docs/version-v1.0.0/guides/isolation-tiers/gvisor.mdx
+++ b/documentation/versioned_docs/version-v1.0.0/guides/isolation-tiers/gvisor.mdx
@@ -42,6 +42,22 @@ Agent Manager builds agent images for **amd64**, and gVisor cannot emulate a for
 
 ## Set Up a gVisor Node
 
+:::note `${AMP_DIST}`
+The commands below run scripts and manifests from the release bundle. If you do
+not already have it extracted, fetch it first and point `AMP_DIST` at it — the
+same bundle the install guides use:
+
+```bash
+export VERSION="1.0.0"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
+On a node-side step, extract it on that node: the installer script runs there,
+not on your workstation.
+:::
+
 ### Step 1: Add a new node to the cluster
 
 Provision a new Linux node matching the requirements above and join it to your cluster using your platform's standard mechanism (node pool / node group / `kubeadm join` / k3s agent). Leave it empty — do not schedule workloads on it yet.
@@ -94,7 +110,7 @@ From any machine with kubectl access to the cluster:
 
 ```bash
 # 1. Apply the RuntimeClass (once per cluster)
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/k8s/gvisor-runtimeclass.yaml
+kubectl apply -f "${AMP_DIST}/deployments/k8s/gvisor-runtimeclass.yaml"
 
 # 2. Label and taint the node (find the name with: kubectl get nodes)
 kubectl label node <node-name> gvisor=true --overwrite
@@ -135,14 +151,11 @@ Isolation tier is set at environment creation time. Open the **Create Environmen
 If you script environment creation directly, set the variable yourself:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/scripts/add-environment.sh \
-  -o add-environment.sh
-
 ISOLATION_TIER=gvisor \
   ENV_NAME=secure-dev \
   DISPLAY_NAME="Secure Dev" \
   AGENT_MANAGER_TOKEN=<token> \
-  bash add-environment.sh
+  bash "${AMP_DIST}/deployments/scripts/add-environment.sh"
 ```
 
 The tier appears as a **Sandboxing T2** shield chip in the environment list, and as a shield icon next to the environment name on the agent's Deploy and Overview pages — hover over it to confirm *Sandboxing Tier 2 — gVisor*. Deploy or promote an agent to the environment as usual — no agent-side changes are needed.

--- a/documentation/versioned_docs/version-v1.0.0/guides/isolation-tiers/kata.mdx
+++ b/documentation/versioned_docs/version-v1.0.0/guides/isolation-tiers/kata.mdx
@@ -49,6 +49,22 @@ Like gVisor, Kata uses a **dedicated node** labeled `kata=true` and tainted `kat
 
 ## Set Up a Kata Node
 
+:::note `${AMP_DIST}`
+The commands below run scripts and manifests from the release bundle. If you do
+not already have it extracted, fetch it first and point `AMP_DIST` at it — the
+same bundle the install guides use:
+
+```bash
+export VERSION="1.0.0"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
+On a node-side step, extract it on that node: the installer script runs there,
+not on your workstation.
+:::
+
 ### Step 1: Add a new node to the cluster
 
 Provision a KVM-capable Linux node matching the requirements above and join it to your cluster using your platform's standard mechanism. Leave it empty.
@@ -137,14 +153,11 @@ Isolation tier is set at environment creation time. Open the **Create Environmen
 If you script environment creation directly, set the variable yourself:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/scripts/add-environment.sh \
-  -o add-environment.sh
-
 ISOLATION_TIER=kata \
   ENV_NAME=secure-prod \
   DISPLAY_NAME="Secure Prod" \
   AGENT_MANAGER_TOKEN=<token> \
-  bash add-environment.sh
+  bash "${AMP_DIST}/deployments/scripts/add-environment.sh"
 ```
 
 The tier appears as a **Sandboxing T3** shield chip in the environment list, and as a shield icon next to the environment name on the agent's Deploy and Overview pages — hover over it to confirm *Sandboxing Tier 3 — Kata Containers*. Then deploy or promote an agent to the environment as usual.

--- a/documentation/versioned_docs/version-v1.0.0/guides/on-k3d.mdx
+++ b/documentation/versioned_docs/version-v1.0.0/guides/on-k3d.mdx
@@ -96,13 +96,26 @@ OpenChoreo organises its infrastructure into four planes, each handling a differ
 
 This phase installs all four with Agent Manager-specific configuration. **Estimated time: ~15-20 minutes.**
 
+### Step 0: Download the Release Bundle
+
+Download the release bundle once. Every manifest, values file and script this
+guide applies comes from it, so the install needs no further network access to
+GitHub — which also sidesteps the per-IP rate limiting that makes
+`helm --values <url>` fail with HTTP 429 behind shared or corporate NAT.
+
+```bash
+export VERSION="1.0.0"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
 ### Step 1: Create k3d Cluster
 
 Create the cluster using the Agent Manager cluster configuration, which includes all required port mappings:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/quick-start/k3d-config.yaml \
-  | k3d cluster create --config=-
+k3d cluster create --config="${AMP_DIST}/deployments/quick-start/k3d-config.yaml"
 ```
 
 Set the kubectl context:
@@ -132,7 +145,7 @@ kubectl cluster-info --context k3d-amp-local
 Enables `*.openchoreo.localhost`, `*.amp.localhost`, `*.agentmanager.localhost`, `*.am-gateway.localhost`, and `*.gateway.localhost` DNS resolution inside the cluster — required for in-cluster lookups of the Console/API/Thunder hostnames as well as agent-to-agent and AI gateway traffic:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/k8s/coredns-amp-custom.yaml
+kubectl apply -f "${AMP_DIST}/deployments/k8s/coredns-amp-custom.yaml"
 ```
 
 CoreDNS's reload plugin can miss the override if the ConfigMap mounts after the pod's initial parse, so restart it to make sure the rewrite rules are active before anything depends on them:
@@ -199,7 +212,7 @@ helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
   --namespace openbao \
   --create-namespace \
   --version 0.25.6 \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/single-cluster/values-openbao.yaml \
+  --values "${AMP_DIST}/deployments/single-cluster/values-openbao.yaml" \
   --timeout 180s
 
 kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=openbao -n openbao --timeout=120s
@@ -325,7 +338,7 @@ helm install openchoreo-control-plane \
   --namespace openchoreo-control-plane \
   --create-namespace \
   --timeout 600s \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/single-cluster/values-cp.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-cp.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-control-plane --timeout=600s
@@ -395,7 +408,7 @@ helm install openchoreo-data-plane \
   --namespace openchoreo-data-plane \
   --create-namespace \
   --timeout 600s \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/single-cluster/values-dp.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-dp.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-data-plane --timeout=600s
@@ -574,7 +587,7 @@ kubectl wait -n openchoreo-observability-plane \
 Apply the custom OpenTelemetry Collector ConfigMap (required for trace ingestion):
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/values/oc-collector-configmap.yaml \
+kubectl apply -f "${AMP_DIST}/deployments/values/oc-collector-configmap.yaml" \
   -n openchoreo-observability-plane
 ```
 
@@ -587,7 +600,7 @@ helm install openchoreo-observability-plane \
   --namespace openchoreo-observability-plane \
   --create-namespace \
   --timeout 25m \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/single-cluster/values-op.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-op.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-observability-plane --timeout=300s
@@ -717,9 +730,6 @@ With OpenChoreo running, you can now install the Agent Manager components — th
 Every Environment needs its own dedicated Thunder ID instance. This is separate from the platform Thunder installed in Phase 1, which only handles console and API login. This instance is what issues each agent its own OAuth2 credential (AgentID) in that Environment. Agents can still be created without it, but they will never get an AgentID there — Agent Manager keeps retrying and failing in the background, and the API Platform Gateway Extension silently skips registering its ThunderKeyManager identity provider, so the Identity Providers page stays empty with no error anywhere in the platform. Run this once the Agent Manager API is reachable at `${API_PUBLIC_URL}`:
 
 ```bash
-curl -fsSL "https://raw.githubusercontent.com/wso2/agent-manager/amp/v1.0.0/deployments/scripts/add-environment-thunder.sh" \
-  -o add-environment-thunder.sh
-
 ENV_NAME=default \
 DISPLAY_NAME="Default" \
 ORG_NAME=default \
@@ -727,7 +737,7 @@ THUNDER_HANDLE=default-idp \
 AMP_API_URL="${API_PUBLIC_URL}/api/v1" \
 IDP_TOKEN_URL="${THUNDER_PUBLIC_URL}/oauth2/token" \
 THUNDER_HOST_BASE_DOMAIN="amp.localhost" \
-bash add-environment-thunder.sh
+bash "${AMP_DIST}/deployments/scripts/add-environment-thunder.sh"
 ```
 
 The script registers an unguessable handle with Agent Manager before it creates

--- a/documentation/versioned_docs/version-v1.0.0/guides/on-your-environment.mdx
+++ b/documentation/versioned_docs/version-v1.0.0/guides/on-your-environment.mdx
@@ -109,8 +109,21 @@ Pick a base domain you control (a delegated subdomain like `amp.yourdomain.com` 
 
 Concretely: `console`/`api-amp`/`thunder`/`cp` all point at the control-plane gateway — via a single required `*.<base>` wildcard, not four separate records (per-environment Thunder hostnames are created after install and are only reachable through that wildcard) — `traces` points at the observability-plane gateway, and `*.agents.<base>` plus the `agents.<base>` apex point at the data-plane gateway. [Step 10](#step-10-publish-dns-records) lists the exact records once the LoadBalancer addresses exist.
 
+Download the release bundle once. Every manifest, values file and script this
+guide applies comes from it, so the install needs no further network access to
+GitHub — which also sidesteps the per-IP rate limiting that makes
+`helm --values <url>` fail with HTTP 429 behind shared or corporate NAT.
+
 ```bash
 export VERSION="1.0.0"
+curl -fsSL -O "https://github.com/wso2/agent-manager/releases/download/amp/v${VERSION}/wso2-agent-manager-${VERSION}.tar.gz"
+tar xzf "wso2-agent-manager-${VERSION}.tar.gz"
+export AMP_DIST="$PWD"
+```
+
+Then the rest of the configuration:
+
+```bash
 export HELM_CHART_REGISTRY="ghcr.io/wso2"
 export AMP_NS="wso2-amp"
 export BUILD_CI_NS="openchoreo-workflow-plane"
@@ -396,7 +409,7 @@ helm upgrade --install openbao oci://ghcr.io/openbao/charts/openbao \
   --namespace openbao \
   --create-namespace \
   --version 0.25.6 \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-openbao.yaml \
+  --values "${AMP_DIST}/deployments/single-cluster/values-openbao.yaml" \
   --timeout 180s
 
 kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=openbao -n openbao --timeout=120s
@@ -933,7 +946,7 @@ helm install openchoreo-data-plane \
   --set "gateway.tls.certificateRefs[0].name=dp-gateway-tls" \
   --set gateway.httpPort=80 \
   --set gateway.httpsPort=443 \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-dp.yaml
+  --values "${AMP_DIST}/deployments/single-cluster/values-dp.yaml"
 
 kubectl wait --for=condition=Available \
   deployment --all -n openchoreo-data-plane --timeout=600s
@@ -1145,7 +1158,7 @@ kubectl wait -n openchoreo-observability-plane \
 Apply the custom OpenTelemetry Collector ConfigMap (required for trace ingestion):
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/values/oc-collector-configmap.yaml \
+kubectl apply -f "${AMP_DIST}/deployments/values/oc-collector-configmap.yaml" \
   -n openchoreo-observability-plane
 ```
 
@@ -1190,7 +1203,7 @@ helm install openchoreo-observability-plane \
   --set observer.extraEnv.AUTH_SERVER_BASE_URL="${THUNDER_PUBLIC_URL}" \
   --set security.oidc.jwksUrl="${THUNDER_INTERNAL_URL}/oauth2/jwks" \
   --set security.oidc.tokenUrl="${THUNDER_INTERNAL_URL}/oauth2/token" \
-  --values https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/single-cluster/values-op.yaml \
+  --values "${AMP_DIST}/deployments/single-cluster/values-op.yaml" \
   --timeout 25m
 
 kubectl wait --for=condition=Available \
@@ -1450,11 +1463,6 @@ That needs a `*.otel.${BASE_DOMAIN}` DNS record and gateway certificate coverage
 
 Every Environment needs its own dedicated Thunder ID instance. This is separate from the platform Thunder installed in Phase 1, which only handles console and API login. This instance is what issues each agent its own OAuth2 credential (AgentID) in that Environment. Run this once for the default Environment: agents can still be created without it, but they will never get an AgentID there, since there is no Thunder instance to provision one against, and Agent Manager will keep retrying and failing in the background. Run it after Agent Manager (`amp`) is installed and reachable at `API_PUBLIC_URL`, since this step registers the generated credential with the Agent Manager API.
 
-```bash
-curl -fsSL "https://raw.githubusercontent.com/wso2/agent-manager/amp/v${VERSION}/deployments/scripts/add-environment-thunder.sh" \
-  -o add-environment-thunder.sh
-```
-
 Pick the tab matching your [Step 3](#step-3-setup-tls-issuer) issuer choice — the CA trust setting below only differs by that choice, nothing else changes.
 
 :::note Pass the platform client secret
@@ -1481,7 +1489,7 @@ PLATFORM_THUNDER_JWKS_URL="${THUNDER_PUBLIC_URL}/oauth2/jwks" \
 THUNDER_HOST_BASE_DOMAIN="${BASE_DOMAIN}" \
 TLS_ENABLED=true \
 SKIP_CA_BUNDLE_TRUST=true \
-bash add-environment-thunder.sh
+bash "${AMP_DIST}/deployments/scripts/add-environment-thunder.sh"
 ```
 
   </TabItem>
@@ -1529,7 +1537,7 @@ PLATFORM_THUNDER_JWKS_URL="${THUNDER_PUBLIC_URL}/oauth2/jwks" \
 PLATFORM_THUNDER_CA_PEM="${PLATFORM_THUNDER_CA_PEM}" \
 THUNDER_HOST_BASE_DOMAIN="${BASE_DOMAIN}" \
 TLS_ENABLED=true \
-bash add-environment-thunder.sh
+bash "${AMP_DIST}/deployments/scripts/add-environment-thunder.sh"
 ```
 
   </TabItem>

--- a/python-instrumentation-provider/Makefile
+++ b/python-instrumentation-provider/Makefile
@@ -6,7 +6,8 @@ PYTHON_VERSION ?= 3.11
 # locks/traceloop-$(TRACELOOP_VERSION)-python$(PYTHON_VERSION).txt.
 TRACELOOP_VERSION ?= 0.62.3
 TAG ?= dev-python$(PYTHON_VERSION)
-APP_NAME = ghcr.io/wso2/amp-python-instrumentation-provider
+REGISTRY_ENDPOINT ?= ghcr.io/wso2
+APP_NAME = $(REGISTRY_ENDPOINT)/amp-python-instrumentation-provider
 DOCKER_IMAGE = $(APP_NAME):$(TAG)
 K3D_CLUSTER_NAME = openchoreo-local-setup
 KIND_CLUSTER_NAME = openchoreo-local


### PR DESCRIPTION
## Purpose

Installing Agent Manager needs two public hosts reachable at install time, and there is no single way to redirect either of them.

Every first-party image repository is hard-coded to `ghcr.io/wso2` in the shipped charts, and only one of the six charts supports `imagePullSecrets` at all — so an install that pulls images from an internal mirror has to override each image individually, and the observer and evaluation job cannot be authenticated to a private registry by any means. Separately, the install guides fetch 19 manifests, values files and scripts from `raw.githubusercontent.com` as the reader works through them. That one is not theoretical: GitHub rate-limits unauthenticated requests per IP, `helm --values <url>` does not retry the 429, and a single throttled response aborts an install partway through. Behind shared or corporate NAT that is common, and a cluster with restricted egress cannot complete an install at all.

Four defects surfaced while working on this and are fixed alongside it:

- `instrumentation.catalogExtension[].imageRepository` is documented as the way to point the OTEL init container at an internal mirror, and it silently does nothing. The field is validated on load and never read; the image reference is built from a compiled-in constant.
- All six generated Helm reference pages tell the reader to install from `oci://ghcr.io/wso2/helm-charts/<chart>`. Charts are published flat, with no `helm-charts/` segment, so that path has never existed.
- `remove-environment.sh` always fetches its sibling script over HTTP even when it is on disk next to it, unlike every other script in that directory.
- `deployments/setup` is not shipped in the release bundle, so `install-kata.sh` and `install-gvisor.sh` — which resolve `../k8s/` relative to themselves — always fall back to fetching those manifests from the network.

Resolves: N/A — no tracked issue; raised from installing on restricted-egress clusters.

## Goals

One value redirects every first-party image; every chart that runs one can authenticate to a private registry; and an install reads its manifests, values files and scripts from the release bundle it already downloads rather than from GitHub. Public installs behave exactly as they do today, byte for byte.

## Approach

**`global.ampImageRegistry`** replaces the registry-and-organization portion of a first-party image repository and keeps the image name, so one value moves them all. Replacing rather than prefixing keeps an existing per-image `repository` override working. It is deliberately not named `global.imageRegistry`: that is a Bitnami convention, and Helm passes global values into subcharts, so that name also rewrites the `postgresql` subchart's images and trips its unrecognized-container guard, failing the render outright. A render assertion pins that third-party images stay on their own registries.

**`global.imagePullSecrets`** is extended to the observability and evaluation charts. The evaluation one is the awkward case: its pod runs as an Argo workflow in the workflow namespace rather than the chart's release namespace, so the named secrets have to exist there, and both the `ClusterWorkflowTemplate` and the `Workflow` runTemplate carry the setting since the latter's spec wins over the referenced template. The chart references the secrets rather than creating them, which keeps registry credentials out of Helm values and out of the release secret.

**`deployments/scripts/lib-registry-auth.sh`** is the single definition of the registry host and the pull-secret name. That matters because a private-registry install needs the host in three unrelated places — a `docker login` on the host, a containerd `configs:` entry inside the cluster node, and a `dockerconfigjson` Secret per namespace — and getting them out of step does not fail loudly: a pull secret scoped to a host that does not match the image tag is ignored rather than rejected, so the pull falls back to anonymous and 401s. Credentials come from the environment, a file, or a prompt, never from a command-line argument, since argv is readable by any user on the host through `ps`. The credentials file is parsed rather than sourced, so it cannot execute code.

The containerd fragment is the only mechanism that covers images pulled into namespaces created after install time, because a node's containerd sees neither the host's docker config nor a namespace's `imagePullSecrets` for a namespace that did not exist yet. It was verified against the pinned k3d version: the block passes through into the node's `registries.yaml` unchanged, keeps the existing local build-registry mirror, and survives the VM installer's rewrite of that mirror's endpoint.

**Registry and organization in CI** now come from repository variables with the public values inline as defaults, and the login steps fall through to the `GITHUB_TOKEN` when no registry secret is set. An unset variable or secret is the empty string, so a repository that sets neither stays zero-secret and behaves as before. `REGISTRY_ORG` had to be split first: besides naming the registry namespace it stood in for the GitHub organization in the release body's download URLs, which now follow `github.repository_owner`.

**The guides** read from the bundle through `${AMP_DIST}`, which the two install guides establish in a download step up front and the isolation-tier guides explain in a note. Rewriting the URL was not sufficient on its own — a command built around fetching a remote file does not become correct by pointing it at a local one, so a k3d config piped through `curl` is now passed as `--config`, four download-then-run pairs lost the download half, and `install-gvisor.sh` is invoked rather than piped into `sudo bash`. Markdown links in the on-k3d reference table are untouched: those are for viewing a file, not fetching one during an install.

`.github/scripts/check-no-raw-github-fetches.sh` enforces this, because adding a fetch back is always the shortest diff. It allows markdown links, defaulted variables and shell comments, and runs from a new workflow alongside the installer helper tests and shellcheck — nothing ran any `deployments/**/tests` script before.

The same guide fixes are applied to the `v1.0.0` snapshot as well, since that is the version the docs site serves and so the instructions people actually follow. That is a change to a shipped guide, which is normally left alone; it is justified here because it corrects instructions rather than describing something new — `wso2-agent-manager-1.0.0.tar.gz` has been attached to the `amp/v1.0.0` release since GA. It is a separate commit and can be dropped if that call goes the other way.

## User stories

- As an operator on a cluster with restricted egress, I can complete an install without any host reaching `raw.githubusercontent.com`.
- As an operator behind shared or corporate NAT, my install is not aborted partway through by a GitHub rate-limit response.
- As an operator mirroring images into an internal registry, I redirect every Agent Manager image with one Helm value, and authenticate the pull, without overriding each image by hand.
- As an operator following the published `v1.0.0` guides, the install commands I copy work.

## Release note

The image registry for Agent Manager's own images is now configurable with `global.ampImageRegistry`, and `global.imagePullSecrets` is supported by every chart that runs one. Installs read manifests, values files and scripts from the release bundle instead of fetching them from GitHub. Fixes the documented `instrumentation.catalogExtension[].imageRepository` override, which previously had no effect, and corrects the chart install path in the generated Helm reference pages.

## Documentation

Updated in this PR: the `on-k3d`, `on-your-environment`, gVisor and Kata guides and the shared installation partial, in both the unversioned docs and the `v1.0.0` snapshot. The generated Helm chart reference pages are regenerated, and their install command is corrected to the path charts are actually published at.

## Training

N/A — no training content covers the install guides or chart values.

## Certification

N/A — no certification exam covers chart values, installer scripts, or the install guides.

## Marketing

N/A — a portability and robustness fix with no user-visible feature to promote.

## Automation tests

- Unit tests
  > New: 4 subtests for the instrumentation image reference (`clients/openchoreosvc/client`), 2 for the catalog resolver (`instrumentation`), 14 for `lib-registry-auth.sh`, 13 for `rewrite-image-registry.sh`, and 20 Helm render assertions across the three charts that carry a first-party image. Two pre-existing assertions in `services/agent_manager_test.go` were tightened from a suffix match to the full image reference — that looseness is why the `imageRepository` defect survived review, and both now fail without the fix. Coverage: `instrumentation` 85.7%.
- Integration tests
  > N/A for automation. Verified manually instead, because the parts that matter need a registry and a cluster: charts rendered against a private registry with third-party images confirmed unmoved, the containerd auth block validated against the pinned k3d version and through the VM config renderer, the docs site built, and `--dry-run` on the advanced VM installer confirmed to report the registry without printing the token. Each chart's default render was diffed against the previous commit to confirm no public install changes.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs analyses Java bytecode; this change touches Go, shell, TypeScript and Helm templates. `shellcheck -S error` is clean across every installer script and `go vet` is clean.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — no credential is committed. Credentials are read from the environment, a file, or an interactive prompt, never from argv, and the credentials file is parsed rather than sourced so it cannot execute code. `--dry-run` output and the advanced installer's config template omit the token, and a test asserts the token does not appear in dry-run output.

## Samples

N/A — no sample applications are affected. The advanced VM installer's `--init` config template gains the optional registry keys, with the credential documented as needing mode 600 and the username quoted if it contains a `$`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added private container-registry support for VM, quick-start, and Kubernetes installations, including credential handling and image pull secrets.
  * Added configurable image registry overrides for Helm charts and deployment-script sources for private mirrors or offline environments.
  * Release bundles now include setup files, metadata, and checksums.
  * Instrumentation images can resolve from catalog-provided repositories.
* **Documentation**
  * Updated installation guides and Helm references for release bundles, private registries, and OCI chart locations.
* **Quality**
  * Added automated deployment checks and registry configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->