### PR TITLE
Show agentID creation button 

### DIFF
--- a/agent-manager-service/controllers/agent_controller.go
+++ b/agent-manager-service/controllers/agent_controller.go
@@ -1260,10 +1260,9 @@ func (c *agentController) RevokeAgentIdentitySecret(w http.ResponseWriter, r *ht
 // ProvisionAgentIdentity handles
 // PUT /orgs/{orgName}/projects/{projName}/agents/{agentName}/identities?environment={envID}
 //
-// Provisions an AgentID for an External agent in an environment that doesn't
-// have one yet — e.g. one created (or added to this project's pipeline) after
-// the agent already existed. Internal agents are rejected: they receive their
-// AgentID automatically during promotion instead. Idempotent (PUT semantics):
+// Provisions an AgentID for an agent in an environment that doesn't have one
+// yet — e.g. one created (or added to this project's pipeline) after the agent
+// already existed. Idempotent (PUT semantics):
 // if a binding already exists, it is left untouched and the current state is
 // returned rather than provisioning again.
 func (c *agentController) ProvisionAgentIdentity(w http.ResponseWriter, r *http.Request) {

--- a/agent-manager-service/docs/api_v1_openapi.yaml
+++ b/agent-manager-service/docs/api_v1_openapi.yaml
@@ -3656,10 +3656,11 @@ paths:
         - Agent Identity
       summary: Provision an AgentID for a missing environment
       description: |
-        Creates an AgentID for an externally hosted agent in an environment
-        that was added after the agent already existed. Platform-hosted
-        agents get an AgentID automatically when promoted, so they are
-        rejected here.
+        Creates an AgentID for an internal or externally hosted agent in an
+        environment that was added after the agent already existed. Internal
+        agents normally get an AgentID automatically during deployment or
+        promotion; this operation provides an idempotent repair path when the
+        binding is missing.
 
         Safe to call more than once: if a binding already exists it is left
         as is and returned with `200`. A genuinely missing binding is
@@ -3686,7 +3687,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/AgentIdentityEnvironmentView"
         "400":
-          description: Missing `environment` query parameter, or the agent is a Platform-Hosted agent (use promotion instead)
+          description: Missing `environment` query parameter
           content:
             application/json:
               schema:

--- a/agent-manager-service/services/agent_manager.go
+++ b/agent-manager-service/services/agent_manager.go
@@ -4147,12 +4147,10 @@ func (s *agentManagerService) RevokeAgentIdentitySecret(ctx context.Context, ouI
 }
 
 // ProvisionAgentIdentity provisions an AgentID for one environment that doesn't
-// have one yet — for an External agent that existed before this environment
-// did (or before it entered the project's pipeline). Internal agents get their
-// AgentIDs automatically during PromoteAgent instead; this endpoint rejects
-// them with a clear pointer to that flow rather than silently doing nothing
-// useful (an Internal agent's identity is meaningless without also deploying
-// its workload there, which only promotion does).
+// have one yet — for example, an agent that existed before this environment
+// did (or before it entered the project's pipeline). Internal agents normally
+// get their AgentIDs automatically during deployment/promotion, but this
+// idempotent repair path also covers older agents whose binding is missing.
 //
 // alreadyExisted is true when a binding for this environment was already
 // present (any status) — the caller uses this to choose between 200 (nothing
@@ -4167,10 +4165,16 @@ func (s *agentManagerService) ProvisionAgentIdentity(ctx context.Context, ouID s
 		s.logger.Error("Failed to fetch agent for identity provisioning", "agentName", agentName, "error", err)
 		return models.AgentIdentityEnvironmentView{}, false, translateAgentError(err)
 	}
-	if agent.Provisioning.Type != string(utils.ExternalAgent) {
+	var provisioningType models.AgentProvisioningType
+	switch agent.Provisioning.Type {
+	case string(utils.InternalAgent):
+		provisioningType = models.AgentProvisioningTypeInternal
+	case string(utils.ExternalAgent):
+		provisioningType = models.AgentProvisioningTypeExternal
+	default:
 		return models.AgentIdentityEnvironmentView{}, false, fmt.Errorf(
-			"%w: agent %q is an internal agent — internal agents receive an AgentID automatically when promoted to a new environment, not via this endpoint",
-			utils.ErrInvalidInput, agentName,
+			"%w: agent %q has unsupported provisioning type %q",
+			utils.ErrInvalidInput, agentName, agent.Provisioning.Type,
 		)
 	}
 
@@ -4185,7 +4189,7 @@ func (s *agentManagerService) ProvisionAgentIdentity(ctx context.Context, ouID s
 	}
 
 	alreadyExisted, err := s.agentThunderProvisioning.ProvisionForEnvironmentIfMissing(
-		ctx, ouID, projectName, agentName, environmentName, models.AgentProvisioningTypeExternal, requestedBy,
+		ctx, ouID, projectName, agentName, environmentName, provisioningType, requestedBy,
 	)
 	if err != nil {
 		return models.AgentIdentityEnvironmentView{}, false, err

--- a/agent-manager-service/services/agent_manager_test.go
+++ b/agent-manager-service/services/agent_manager_test.go
@@ -49,12 +49,13 @@ import (
 // this stub never call them.
 type stubAgentThunderProvisioning struct {
 	AgentThunderProvisioningService
-	RegenerateFunc       func(ctx context.Context, orgName, projectName, agentName, envName string) (models.AgentProvisioningType, string, string, error)
-	RevokeFunc           func(ctx context.Context, orgName, projectName, agentName, envName string) (string, error)
-	GetBindingStateFunc  func(ctx context.Context, orgName, projectName, agentName, envName string) (*AgentThunderBindingState, error)
-	GetAgentRolesFunc    func(ctx context.Context, orgName, projectName, agentName, envName string) ([]thundersvc.ThunderRole, error)
-	GetAgentGroupsFunc   func(ctx context.Context, orgName, projectName, agentName, envName string) ([]thundersvc.ThunderGroup, error)
-	GetIdentityViewsFunc func(ctx context.Context, ouID, projectName, agentName string) ([]models.AgentIdentityEnvironmentView, error)
+	RegenerateFunc                       func(ctx context.Context, orgName, projectName, agentName, envName string) (models.AgentProvisioningType, string, string, error)
+	RevokeFunc                           func(ctx context.Context, orgName, projectName, agentName, envName string) (string, error)
+	GetBindingStateFunc                  func(ctx context.Context, orgName, projectName, agentName, envName string) (*AgentThunderBindingState, error)
+	GetAgentRolesFunc                    func(ctx context.Context, orgName, projectName, agentName, envName string) ([]thundersvc.ThunderRole, error)
+	GetAgentGroupsFunc                   func(ctx context.Context, orgName, projectName, agentName, envName string) ([]thundersvc.ThunderGroup, error)
+	GetIdentityViewsFunc                 func(ctx context.Context, ouID, projectName, agentName string) ([]models.AgentIdentityEnvironmentView, error)
+	ProvisionForEnvironmentIfMissingFunc func(ctx context.Context, ouID, projectName, agentName, envName string, ownership models.AgentProvisioningType, requestedBy string) (bool, error)
 }
 
 func (s *stubAgentThunderProvisioning) GetBindingState(ctx context.Context, orgName, projectName, agentName, envName string) (*AgentThunderBindingState, error) {
@@ -79,6 +80,52 @@ func (s *stubAgentThunderProvisioning) GetAgentGroups(ctx context.Context, orgNa
 
 func (s *stubAgentThunderProvisioning) GetIdentityViews(ctx context.Context, ouID, projectName, agentName string) ([]models.AgentIdentityEnvironmentView, error) {
 	return s.GetIdentityViewsFunc(ctx, ouID, projectName, agentName)
+}
+
+func (s *stubAgentThunderProvisioning) ProvisionForEnvironmentIfMissing(ctx context.Context, ouID, projectName, agentName, envName string, ownership models.AgentProvisioningType, requestedBy string) (bool, error) {
+	return s.ProvisionForEnvironmentIfMissingFunc(ctx, ouID, projectName, agentName, envName, ownership, requestedBy)
+}
+
+func TestProvisionAgentIdentity_UsesAgentProvisioningType(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		agentType utils.AgentProvisioningType
+		want      models.AgentProvisioningType
+	}{
+		{name: "internal", agentType: utils.InternalAgent, want: models.AgentProvisioningTypeInternal},
+		{name: "external", agentType: utils.ExternalAgent, want: models.AgentProvisioningTypeExternal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got models.AgentProvisioningType
+			provisioning := &stubAgentThunderProvisioning{
+				ProvisionForEnvironmentIfMissingFunc: func(_ context.Context, _, _, _, _ string, ownership models.AgentProvisioningType, _ string) (bool, error) {
+					got = ownership
+					return false, nil
+				},
+				GetIdentityViewsFunc: func(context.Context, string, string, string) ([]models.AgentIdentityEnvironmentView, error) {
+					return []models.AgentIdentityEnvironmentView{{EnvironmentName: "development", ProvisioningType: tc.want, Status: models.AgentThunderStatusPending}}, nil
+				},
+			}
+			svc := &agentManagerService{
+				ocClient: &clientmocks.OpenChoreoClientMock{
+					GetComponentFunc: func(context.Context, string, string, string) (*models.AgentResponse, error) {
+						return &models.AgentResponse{Provisioning: models.Provisioning{Type: string(tc.agentType)}}, nil
+					},
+					GetEnvironmentFunc: func(context.Context, string, string) (*models.EnvironmentResponse, error) {
+						return &models.EnvironmentResponse{}, nil
+					},
+				},
+				agentThunderProvisioning: provisioning,
+				logger:                   discardLogger(),
+			}
+
+			view, existed, err := svc.ProvisionAgentIdentity(context.Background(), "ou-1", "default", "agent-1", "development")
+			require.NoError(t, err)
+			assert.False(t, existed)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, "development", view.EnvironmentName)
+		})
+	}
 }
 
 func TestValidateInstrumentationVersion_UsesCatalog(t *testing.T) {

--- a/agent-manager-service/spec/api_agent_identity.go
+++ b/agent-manager-service/spec/api_agent_identity.go
@@ -2411,10 +2411,11 @@ func (r ApiProvisionAgentIdentityRequest) Execute() (*AgentIdentityEnvironmentVi
 /*
 ProvisionAgentIdentity Provision an AgentID for a missing environment
 
-Creates an AgentID for an externally hosted agent in an environment
-that was added after the agent already existed. Platform-hosted
-agents get an AgentID automatically when promoted, so they are
-rejected here.
+Creates an AgentID for an internal or externally hosted agent in an
+environment that was added after the agent already existed. Internal
+agents normally get an AgentID automatically during deployment or
+promotion; this operation provides an idempotent repair path when the
+binding is missing.
 
 Safe to call more than once: if a binding already exists it is left
 as is and returned with `200`. A genuinely missing binding is

--- a/console/workspaces/libs/api-client/src/apis/agents.ts
+++ b/console/workspaces/libs/api-client/src/apis/agents.ts
@@ -296,9 +296,9 @@ export async function getAgentIdentity(
   return res.json();
 }
 
-// Creates an AgentID for an externally hosted agent in an environment that
-// was added after the agent already existed. Idempotent: an existing binding
-// is left as is and returned unchanged.
+// Creates an AgentID for an internal or externally hosted agent in an
+// environment whose binding is missing. Idempotent: an existing binding is
+// left as is and returned unchanged.
 export async function provisionAgentIdentity(
   params: ProvisionAgentIdentityPathParams,
   query: ProvisionAgentIdentityQuery,

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvAgentRolesGroupsSection.tsx
@@ -36,14 +36,6 @@ interface EnvAgentRolesGroupsSectionProps {
   projectId: string;
   agentId: string;
   envId: string;
-  /**
-   * Only Externally-Hosted agents can self-serve provisioning for an
-   * environment added after the agent already existed (see the "Create
-   * Agent ID" action below) — Internal agents get theirs automatically when
-   * promoted to a new environment, and the backend rejects this action for
-   * them, so the action is hidden entirely rather than shown and left to fail.
-   */
-  external?: boolean;
 }
 
 /**
@@ -57,7 +49,7 @@ interface EnvAgentRolesGroupsSectionProps {
  * response.
  */
 export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProps> = ({
-  orgId, projectId, agentId, envId, external,
+  orgId, projectId, agentId, envId,
 }) => {
   // useAgentIdentityBinding has no `enabled` option, so the ids are withheld
   // when Agent ID is disabled to keep the identity request from firing.
@@ -70,12 +62,11 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
   const isFailed = binding?.status === "failed";
   // No binding row exists for this environment at all yet — distinct from
   // "pending"/"in_progress" (already attempted, still running) or "failed"
-  // (attempted, didn't work). This is the state an Externally-Hosted agent is
-  // stuck in forever if its environment was added to the pipeline after the
-  // agent was created: nothing ever attempts provisioning on its own for that
-  // combination, so it needs an explicit action (see canSelfProvision below).
+  // (attempted, didn't work). Older internal and external agents can both
+  // reach this state when an environment is added later, so the idempotent
+  // action below repairs only this genuinely missing binding.
   const hasNoBinding = !isLoadingIdentity && !binding;
-  const canSelfProvision = Boolean(external) && hasNoBinding;
+  const canSelfProvision = hasNoBinding;
 
   const { mutate: retryProvisioning, isPending: isRetrying } = useRetryAgentIdentityProvisioning();
   const handleRetry = () => {
@@ -267,7 +258,7 @@ export const EnvAgentRolesGroupsSection: React.FC<EnvAgentRolesGroupsSectionProp
         >
           {isProvisionError
             ? "Couldn't create the Agent ID for this environment. Check that the environment is reachable, then try again."
-            : "This environment was added after the agent was created, so it has no Agent ID yet."}
+            : "This agent has no Agent ID for this environment yet."}
         </Alert>
       )}
     </OverviewSectionCard>

--- a/console/workspaces/pages/overview/src/AgentOverview/EnvironmentSectionsContent.tsx
+++ b/console/workspaces/pages/overview/src/AgentOverview/EnvironmentSectionsContent.tsx
@@ -72,7 +72,6 @@ export function EnvironmentSectionsContent({
                             projectId={projectId}
                             agentId={agentId}
                             envId={envId}
-                            external={external}
                         />
                     </Grid>
                 )}


### PR DESCRIPTION
## Purpose
Existing agents without an Agent ID need a way to create one.

## Goals
Support Agent ID creation for internal and external agents in the selected environment.

## Approach
Add a Create Agent ID action to the Agent ID card and extend the existing provisioning API to support internal agents.

## User stories
Users can create a missing Agent ID without recreating the agent.

## Release note
Support creating missing Agent IDs for existing internal and external agents.

## Documentation
N/A — existing Agent ID workflow extended.

## Training
N/A

## Certification
N/A — no certification impact.

## Marketing
N/A

## Automation tests
- Unit tests: Backend provisioning tests pass for both agent types.
- Integration tests: End-to-end verification pending.

## Security checks
- Followed secure coding standards? Not independently verified.
- Ran FindSecurityBugs plugin and verified report? No.
- Confirmed no secrets committed? Pending final diff review.

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
None.

## Test environment
Local backend tests and console build/lint checks.

## Learning
Reuse the existing environment-specific identity provisioning flow.