### PR TITLE
Raise the Argo workflow controller resource requests

### DIFF
--- a/deployments/quick-start/install.sh
+++ b/deployments/quick-start/install.sh
@@ -1108,7 +1108,8 @@ helm_install_idempotent \
     "oci://ghcr.io/openchoreo/helm-charts/openchoreo-workflow-plane" \
     "${BUILD_CI_NS}" \
     "${TIMEOUT_BUILD_PLANE}" \
-    --version "${OPENCHOREO_VERSION}"
+    --version "${OPENCHOREO_VERSION}" \
+    --values "${DEPLOYMENTS_DIR}/single-cluster/values-wp.yaml"
 
 
 # Register Workflow Plane with Control Plane

--- a/deployments/setup/setup-openchoreo.sh
+++ b/deployments/setup/setup-openchoreo.sh
@@ -229,7 +229,8 @@ install_workflow_plane() {
     helm upgrade --install openchoreo-workflow-plane oci://ghcr.io/openchoreo/helm-charts/openchoreo-workflow-plane \
     --version ${OPENCHOREO_VERSION} \
     --namespace openchoreo-workflow-plane \
-    --create-namespace
+    --create-namespace \
+    --values "${SCRIPT_DIR}/../single-cluster/values-wp.yaml"
 
     echo "⏳ Waiting for Workflow Plane pods to be ready..."
     kubectl wait -n openchoreo-workflow-plane --for=condition=available --timeout=300s deployment --all

--- a/deployments/single-cluster/values-wp.yaml
+++ b/deployments/single-cluster/values-wp.yaml
@@ -1,0 +1,14 @@
+# Helm values for OpenChoreo Workflow Plane in k3d single-cluster setup
+
+# The chart ships the controller at 25m/32Mi requests, which leaves it starved
+# once several builds queue up at once. The chart's limits sat at the new
+# request values, so they move up too to leave the controller burst headroom.
+argo-workflows:
+  controller:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi

--- a/documentation/docs/guides/on-k3d.mdx
+++ b/documentation/docs/guides/on-k3d.mdx
@@ -479,6 +479,10 @@ helm install openchoreo-workflow-plane \
   --version 1.2.0 \
   --namespace openchoreo-workflow-plane \
   --create-namespace \
+  --set argo-workflows.controller.resources.requests.cpu=50m \
+  --set argo-workflows.controller.resources.requests.memory=64Mi \
+  --set argo-workflows.controller.resources.limits.cpu=200m \
+  --set argo-workflows.controller.resources.limits.memory=128Mi \
   --timeout 600s
 ```
 

--- a/documentation/docs/guides/on-your-environment.mdx
+++ b/documentation/docs/guides/on-your-environment.mdx
@@ -1038,6 +1038,10 @@ helm install openchoreo-workflow-plane \
   --namespace openchoreo-workflow-plane \
   --create-namespace \
   --set clusterAgent.tls.generateCerts=true \
+  --set argo-workflows.controller.resources.requests.cpu=50m \
+  --set argo-workflows.controller.resources.requests.memory=64Mi \
+  --set argo-workflows.controller.resources.limits.cpu=200m \
+  --set argo-workflows.controller.resources.limits.memory=128Mi \
   --timeout 600s
 
 kubectl wait --for=condition=Available \


### PR DESCRIPTION
## Purpose

The `openchoreo-workflow-plane` chart ships its Argo workflow controller at 25m CPU / 32Mi memory requests, which leaves it starved once several builds queue at once. We install that chart in two places and neither passed any values override.

Resolves: N/A — no tracked issue.

## Goals

Install the workflow plane with the controller requesting 50m CPU / 64Mi memory, in every path we document or script.

## Approach

The chart is installed from `oci://ghcr.io/openchoreo/helm-charts/openchoreo-workflow-plane` in two scripts and two guides:

- `deployments/setup/setup-openchoreo.sh` and `deployments/quick-start/install.sh` now pass a new `deployments/single-cluster/values-wp.yaml`, following the existing `values-cp.yaml` / `values-dp.yaml` / `values-op.yaml` convention. The quick-start Dockerfile already copies `deployments/single-cluster/` into the image, so the containerised install resolves the same path.
- `documentation/docs/guides/on-k3d.mdx` and `documentation/docs/guides/on-your-environment.mdx` are standalone copy-paste blocks with no repo file to reference, so they get the same values as inline `--set` flags — matching how `clusterAgent.tls.generateCerts` is already passed there.

The limits move too. The chart's limits were 50m / 64Mi, so the new requests would sit exactly at the limit on both axes — legal, but it leaves the controller no burst headroom at all. They go to 200m / 128Mi, giving the controller room to burst above its reservation when a batch of builds lands at once.

The `versioned_docs` snapshots are deliberately untouched — they describe already-released versions, and this is a tuning change rather than a correction to broken instructions.

## User stories

As an operator installing the workflow plane, the Argo controller is not CPU-starved when several builds run concurrently.

## Release note

The OpenChoreo workflow plane is now installed with higher Argo workflow controller resource requests (50m CPU / 64Mi memory).

## Documentation

Updated in this PR: the workflow plane install step in the `on-k3d` and `on-your-environment` guides.

## Training

N/A — no training content covers workflow plane chart values.

## Certification

N/A — no certification exam covers chart resource values.

## Marketing

N/A — a resource tuning change with no user-visible feature.

## Automation tests

- Unit tests
  > N/A — no code paths changed; the diff is Helm values, two shell install invocations and two docs blocks.
- Integration tests
  > N/A for automation. Verified by rendering the chart both ways: `helm template ... --values deployments/single-cluster/values-wp.yaml` and with the four `--set` flags from the guides each produce `quay.io/argoproj/workflow-controller:v4.0.6` with requests 50m/64Mi and limits 200m/128Mi. Both install scripts pass `bash -n`. The docs site build was not run — the Docusaurus dependencies are not installed in this environment; the doc edits are four added lines inside existing fenced `bash` blocks and touch no MDX structure.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — FindSecurityBugs analyses Java bytecode; this change touches only YAML, shell invocations and Markdown.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

None. Existing installs are unaffected until the workflow plane chart is reinstalled or upgraded; `helm upgrade` with the new values rolls the controller pod.

## Test environment

Helm 3 rendering the chart at version 1.2.0 against `oci://ghcr.io/openchoreo/helm-charts/openchoreo-workflow-plane`, on Linux.

## Learning

The chart nests the controller under an `argo-workflows` subchart, so the values path is `argo-workflows.controller.resources` — the dash is fine in a `--set` key.

https://claude.ai/code/session_01GQUWyDosXAE61LXdesohSN
